### PR TITLE
[SourceKit] Refactor collection of available refactorings

### DIFF
--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -72,7 +72,7 @@ struct RenameRangeDetail {
   Optional<unsigned> Index;
 };
 
-enum class RenameAvailableKind {
+enum class RefactorAvailableKind {
   Available,
   Unavailable_system_symbol,
   Unavailable_has_no_location,
@@ -81,14 +81,14 @@ enum class RenameAvailableKind {
   Unavailable_decl_from_clang,
 };
 
-struct RenameAvailabilityInfo {
+struct RefactorAvailabilityInfo {
   RefactoringKind Kind;
-  RenameAvailableKind AvailableKind;
-  RenameAvailabilityInfo(RefactoringKind Kind,
-                         RenameAvailableKind AvailableKind)
+  RefactorAvailableKind AvailableKind;
+  RefactorAvailabilityInfo(RefactoringKind Kind,
+                           RefactorAvailableKind AvailableKind)
       : Kind(Kind), AvailableKind(AvailableKind) {}
-  RenameAvailabilityInfo(RefactoringKind Kind)
-      : RenameAvailabilityInfo(Kind, RenameAvailableKind::Available) {}
+  RefactorAvailabilityInfo(RefactoringKind Kind)
+      : RefactorAvailabilityInfo(Kind, RefactorAvailableKind::Available) {}
 };
 
 class FindRenameRangesConsumer {
@@ -112,7 +112,7 @@ public:
 
 StringRef getDescriptiveRefactoringKindName(RefactoringKind Kind);
 
-StringRef getDescriptiveRenameUnavailableReason(RenameAvailableKind Kind);
+StringRef getDescriptiveRenameUnavailableReason(RefactorAvailableKind Kind);
 
 bool refactorSwiftModule(ModuleDecl *M, RefactoringOptions Opts,
                          SourceEditConsumer &EditConsumer,
@@ -131,25 +131,13 @@ int findLocalRenameRanges(SourceFile *SF, RangeConfig Range,
                           FindRenameRangesConsumer &RenameConsumer,
                           DiagnosticConsumer &DiagConsumer);
 
-void collectAvailableRefactorings(
-    SourceFile *SF, RangeConfig Range, bool &RangeStartMayNeedRename,
-    llvm::SmallVectorImpl<RefactoringKind> &Kinds,
-    llvm::ArrayRef<DiagnosticConsumer *> DiagConsumers);
+SmallVector<RefactorAvailabilityInfo, 0>
+collectRefactorings(SourceFile *SF, RangeConfig Range,
+                    bool &RangeStartMayNeedRename,
+                    llvm::ArrayRef<DiagnosticConsumer *> DiagConsumers);
 
-void collectAvailableRefactorings(ResolvedCursorInfoPtr CursorInfo,
-                                  llvm::SmallVectorImpl<RefactoringKind> &Kinds,
-                                  bool ExcludeRename);
-
-/// Stores information about the reference that rename availability is being
-/// queried on.
-struct RenameRefInfo {
-  SourceFile *SF; ///< The source file containing the reference.
-  SourceLoc Loc; ///< The reference's source location.
-  bool IsArgLabel; ///< Whether Loc is on an arg label, rather than base name.
-};
-
-Optional<RenameAvailabilityInfo>
-renameAvailabilityInfo(const ValueDecl *VD, Optional<RenameRefInfo> RefInfo);
+SmallVector<RefactorAvailabilityInfo, 0>
+collectRefactorings(ResolvedCursorInfoPtr CursorInfo, bool ExcludeRename);
 
 } // namespace ide
 } // namespace swift

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -702,30 +702,22 @@ static bool passCursorInfoForModule(ModuleEntity Mod,
   return false;
 }
 
-static Optional<RefactoringInfo>
-collectAvailableRenameInfo(const ValueDecl *VD,
-                           Optional<RenameRefInfo> RefInfo) {
-  Optional<RenameAvailabilityInfo> Info = renameAvailabilityInfo(VD, RefInfo);
-  if (!Info)
-    return None;
+static void addRefactorings(
+    SmallVectorImpl<RefactoringInfo> &intoLangInfos,
+    const SmallVectorImpl<RefactorAvailabilityInfo> &availableInfos) {
+  for (auto info : availableInfos) {
+    auto uid = SwiftLangSupport::getUIDForRefactoringKind(info.Kind);
+    bool hasRefactoringWithSameUID =
+        llvm::any_of(intoLangInfos, [&](RefactoringInfo &existing) {
+          return uid == existing.Kind;
+        });
+    if (hasRefactoringWithSameUID)
+      continue;
 
-  return RefactoringInfo(
-      SwiftLangSupport::getUIDForRefactoringKind(Info->Kind),
-      ide::getDescriptiveRefactoringKindName(Info->Kind),
-      ide::getDescriptiveRenameUnavailableReason(Info->AvailableKind));
-}
-
-static SmallVector<RefactoringInfo>
-collectAvailableRefactoringsOtherThanRename(ResolvedCursorInfoPtr CursorInfo) {
-  SmallVector<RefactoringKind, 8> Kinds;
-  collectAvailableRefactorings(CursorInfo, Kinds, /*ExcludeRename*/ true);
-  SmallVector<RefactoringInfo> Refactorings;
-  for (auto Kind : Kinds) {
-    Refactorings.emplace_back(SwiftLangSupport::getUIDForRefactoringKind(Kind),
-                              ide::getDescriptiveRefactoringKindName(Kind),
-                              StringRef());
+    intoLangInfos.emplace_back(
+        uid, ide::getDescriptiveRefactoringKindName(info.Kind),
+        ide::getDescriptiveRenameUnavailableReason(info.AvailableKind));
   }
-  return Refactorings;
 }
 
 static Optional<unsigned>
@@ -1211,27 +1203,8 @@ addCursorInfoForDecl(CursorInfoData &Data, ResolvedValueRefCursorInfoPtr Info,
   }
 
   if (AddRefactorings) {
-    Optional<RenameRefInfo> RefInfo;
-    if (Info->isRef())
-      RefInfo = {Info->getSourceFile(), Info->getLoc(),
-                 Info->isKeywordArgument()};
-
-    /// Adds an action to \c Data if no action with the same UID exists.
-    auto AddAction = [&Data](const RefactoringInfo &NewRefactoring) {
-      bool HasRefactoringWithSameUID = llvm::any_of(
-          Data.AvailableActions, [&](RefactoringInfo &ExistingRefactoring) {
-            return ExistingRefactoring.Kind == NewRefactoring.Kind;
-          });
-      if (HasRefactoringWithSameUID) {
-        return;
-      }
-      Data.AvailableActions.push_back(NewRefactoring);
-    };
-    if (auto Rename = collectAvailableRenameInfo(MainInfo.VD, RefInfo)) {
-      AddAction(*Rename);
-    }
-    llvm::for_each(collectAvailableRefactoringsOtherThanRename(Info),
-                   AddAction);
+    addRefactorings(Data.AvailableActions,
+                    collectRefactorings(Info, /*ExcludeRename=*/false));
   }
 
   return true;
@@ -1584,7 +1557,6 @@ static void resolveCursor(
       // Retrieve relevant actions on the code under selection.
       llvm::SmallVector<RefactoringInfo, 8> Actions;
       if (Actionables && Length) {
-        SmallVector<RefactoringKind, 8> Kinds;
         RangeConfig Range;
         Range.BufferID = BufferID;
         auto Pair = SM.getLineAndColumnInBuffer(Loc);
@@ -1592,13 +1564,9 @@ static void resolveCursor(
         Range.Column = Pair.second;
         Range.Length = Length;
         bool CollectRangeStartRefactorings = false;
-        collectAvailableRefactorings(SF, Range, CollectRangeStartRefactorings,
-                                     Kinds, {});
-        for (RefactoringKind Kind : Kinds) {
-          Actions.emplace_back(SwiftLangSupport::getUIDForRefactoringKind(Kind),
-                               getDescriptiveRefactoringKindName(Kind),
-                               /*UnavailableReason*/ StringRef());
-        }
+        addRefactorings(
+            Actions,
+            collectRefactorings(SF, Range, CollectRangeStartRefactorings, {}));
         if (!CollectRangeStartRefactorings) {
           // If Length is given then this request is only for refactorings,
           // return straight away unless we need cursor based refactorings as
@@ -1652,8 +1620,8 @@ static void resolveCursor(
       case CursorInfoKind::ExprStart:
       case CursorInfoKind::StmtStart: {
         if (Actionables) {
-          Actions.append(
-              collectAvailableRefactoringsOtherThanRename(CursorInfo));
+          addRefactorings(
+              Actions, collectRefactorings(CursorInfo, /*ExcludeRename=*/true));
           if (!Actions.empty()) {
             CursorInfoData Data;
             Data.AvailableActions = Actions;

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -421,13 +421,14 @@ int main(int argc, char *argv[]) {
   RangeConfig Range = getRange(BufferID, SM, StartLoc, EndLoc);
 
   if (options::Action == RefactoringKind::None) {
-    llvm::SmallVector<RefactoringKind, 32> Kinds;
     bool CollectRangeStartRefactorings = false;
-    collectAvailableRefactorings(SF, Range, CollectRangeStartRefactorings,
-                                 Kinds, {&PrintDiags});
+    auto Refactorings = collectRefactorings(
+        SF, Range, CollectRangeStartRefactorings, {&PrintDiags});
     llvm::outs() << "Action begins\n";
-    for (auto Kind : Kinds) {
-      llvm::outs() << getDescriptiveRefactoringKindName(Kind) << "\n";
+    for (auto Info : Refactorings) {
+      if (Info.AvailableKind == RefactorAvailableKind::Available) {
+        llvm::outs() << getDescriptiveRefactoringKindName(Info.Kind) << "\n";
+      }
     }
     llvm::outs() << "Action ends\n";
     return 0;


### PR DESCRIPTION
Update to have a single refactoring collection method for cursor refactorings and another for ranges. The various functions were only needed because of the extra availability information on renames, so just give that to all refactorings.