### PR TITLE
[Parameter Packs] Add an execution test for building and importing a library using parameter packs.

### DIFF
--- a/test/Interpreter/Inputs/variadic_generic_library.swift
+++ b/test/Interpreter/Inputs/variadic_generic_library.swift
@@ -1,0 +1,57 @@
+public struct Key: Hashable {
+  static var index = 0
+
+  public let id: Int
+
+  init() {
+    self.id = Self.index
+    Self.index += 1
+  }
+}
+
+public struct Variable<Value> {
+  public let key = Key()
+}
+
+public struct Bindings {
+  private var storage: [Key : Any] = [:]
+
+  public init<each T>(
+    _ value: repeat (Variable<each T>, each T)
+  ) {
+    _ = (repeat storage[(each value).0.key] = (each value).1)
+  }
+}
+
+public protocol Expression<Result> {
+  associatedtype Result
+  func evaluate(_ bindings: Bindings) throws -> Result
+}
+
+public struct True: Expression {
+  public init() {}
+
+  public func evaluate(_ bindings: Bindings) throws -> Bool {
+    true
+  }
+}
+
+public struct Predicate<each Input> {
+  var variables: (repeat Variable<each Input>)
+  var expression: any Expression<Bool>
+
+  public init<Expr>(
+    builder: (repeat Variable<each Input>) -> Expr
+  ) where Expr: Expression<Bool> {
+    self.variables = (repeat Variable<each Input>())
+    self.expression = builder(repeat each variables.element)
+  }
+
+  public func evaluate(
+    _ input: repeat each Input
+  ) throws -> Bool  {
+    return try expression.evaluate(
+      .init(repeat (each variables.element, each input))
+    )
+  }
+}

--- a/test/Interpreter/import_parameter_pack_library.swift
+++ b/test/Interpreter/import_parameter_pack_library.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(variadic_generic_library)) -Xfrontend -disable-availability-checking -enable-experimental-feature VariadicGenerics -enable-library-evolution %S/Inputs/variadic_generic_library.swift -emit-module -emit-module-path %t/variadic_generic_library.swiftmodule -module-name variadic_generic_library
+// RUN: %target-codesign %t/%target-library-name(variadic_generic_library)
+
+// RUN: %target-build-swift %s -Xfrontend -disable-availability-checking -enable-experimental-feature VariadicGenerics -lvariadic_generic_library -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+
+// RUN: %target-run %t/main %t/%target-library-name(variadic_generic_library)
+
+// REQUIRES: executable_test
+
+// FIXME: Optimizations disabled for all parameter pack tests in test/Interpreter/
+// REQUIRES: swift_test_mode_optimize_none
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+
+
+import variadic_generic_library
+import StdlibUnittest
+
+var ImportParameterPackTests = TestSuite("ImportParameterPackTests")
+
+ImportParameterPackTests.test("basic") {
+  let closure: (Variable<Int>) -> _ = { a in
+    True()
+  }
+
+  let predicate = Predicate.init(builder: closure)
+  let result = try! predicate.evaluate(1)
+  expectEqual(result, true)
+}
+
+ImportParameterPackTests.test("no inputs") {
+  let closure: () -> _ = {
+    True()
+  }
+
+  let predicate = Predicate.init(builder: closure)
+  let result = try! predicate.evaluate()
+  expectEqual(result, true)
+}
+
+
+ImportParameterPackTests.test("multi-input") {
+  let closure: (Variable<Int>, Variable<String>, Variable<Bool>) -> _ = { a, b, c in
+    True()
+  }
+
+  let predicate = Predicate<Int, String, Bool>(builder: closure)
+  let result = try! predicate.evaluate(1, "hello", true)
+  expectEqual(result, true)
+}
+
+runAllTests()


### PR DESCRIPTION
This example is reduced from the API proposed in https://forums.swift.org/t/pitch-swift-predicates/62000, which is the most involved use of variadic generics on the forums so far.