### PR TITLE
tests: fix the SILOptimizer/specialize.sil test file

### DIFF
--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -757,3 +757,5 @@ bb0:
   return %r : $()
 }
 
+sil @$s7closures5UInt8V_Tg5 : $@convention(thin) (UInt8) -> ()
+


### PR DESCRIPTION
This is a follow up of https://github.com/apple/swift/pull/64632

The missing line in the test caused the test to always pass, even if the compiler bug fix is not in place.
