### PR TITLE
[RemoteMirror] Fix demangle node corruption caused by excessively eager clearing of the NodeFactory.

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -93,6 +93,7 @@ valid_type_ref:
 /// Load and normalize a mangled name so it can be matched with string equality.
 llvm::Optional<std::string>
 TypeRefBuilder::normalizeReflectionName(RemoteRef<char> reflectionName) {
+  ScopedNodeFactoryCheckpoint checkpoint(this);
   // Remangle the reflection name to resolve symbolic references.
   if (auto node = demangleTypeRef(reflectionName,
                                   /*useOpaqueTypeSymbolicReferences*/ false)) {
@@ -104,7 +105,6 @@ TypeRefBuilder::normalizeReflectionName(RemoteRef<char> reflectionName) {
       return {};
     default:
       auto mangling = mangleNode(node);
-      clearNodeFactory();
       if (!mangling.isSuccess()) {
         return {};
       }
@@ -159,11 +159,11 @@ lookupTypeWitness(const std::string &MangledTypeName,
             0)
           continue;
 
+        ScopedNodeFactoryCheckpoint checkpoint(this);
         auto SubstitutedTypeName = readTypeRef(AssocTy,
                                                AssocTy->SubstitutedTypeName);
         auto Demangled = demangleTypeRef(SubstitutedTypeName);
         auto *TypeWitness = decodeMangledType(Demangled);
-        clearNodeFactory();
 
         AssociatedTypeCache.insert(std::make_pair(key, TypeWitness));
         return TypeWitness;
@@ -181,9 +181,9 @@ const TypeRef *TypeRefBuilder::lookupSuperclass(const TypeRef *TR) {
   if (!FD->hasSuperclass())
     return nullptr;
 
+  ScopedNodeFactoryCheckpoint checkpoint(this);
   auto Demangled = demangleTypeRef(readTypeRef(FD, FD->Superclass));
   auto Unsubstituted = decodeMangledType(Demangled);
-  clearNodeFactory();
   if (!Unsubstituted)
     return nullptr;
 
@@ -367,9 +367,9 @@ bool TypeRefBuilder::getFieldTypeRefs(
       continue;
     }
 
+    ScopedNodeFactoryCheckpoint checkpoint(this);
     auto Demangled = demangleTypeRef(readTypeRef(Field,Field->MangledTypeName));
     auto Unsubstituted = decodeMangledType(Demangled);
-    clearNodeFactory();
     if (!Unsubstituted)
       return false;
 
@@ -486,10 +486,10 @@ TypeRefBuilder::getClosureContextInfo(RemoteRef<CaptureDescriptor> CD) {
     auto CR = CD.getField(*i);
     
     if (CR->hasMangledTypeName()) {
+      ScopedNodeFactoryCheckpoint checkpoint(this);
       auto MangledName = readTypeRef(CR, CR->MangledTypeName);
       auto DemangleTree = demangleTypeRef(MangledName);
       TR = decodeMangledType(DemangleTree);
-      clearNodeFactory();
     }
     Info.CaptureTypes.push_back(TR);
   }
@@ -499,10 +499,10 @@ TypeRefBuilder::getClosureContextInfo(RemoteRef<CaptureDescriptor> CD) {
     auto MSR = CD.getField(*i);
     
     if (MSR->hasMangledTypeName()) {
+      ScopedNodeFactoryCheckpoint checkpoint(this);
       auto MangledName = readTypeRef(MSR, MSR->MangledTypeName);
       auto DemangleTree = demangleTypeRef(MangledName);
       TR = decodeMangledType(DemangleTree);
-      clearNodeFactory();
     }
 
     const MetadataSource *MS = nullptr;
@@ -526,11 +526,11 @@ TypeRefBuilder::getClosureContextInfo(RemoteRef<CaptureDescriptor> CD) {
 
 void TypeRefBuilder::dumpTypeRef(RemoteRef<char> MangledName,
                                  std::ostream &stream, bool printTypeName) {
+  ScopedNodeFactoryCheckpoint checkpoint(this);
   auto DemangleTree = demangleTypeRef(MangledName);
   auto TypeName = nodeToString(DemangleTree);
   stream << TypeName << "\n";
   auto Result = swift::Demangle::decodeMangledType(*this, DemangleTree);
-  clearNodeFactory();
   if (Result.isError()) {
     auto *Error = Result.getError();
     char *ErrorStr = Error->copyErrorString();
@@ -549,10 +549,14 @@ FieldTypeCollectionResult TypeRefBuilder::collectFieldTypes(
   FieldTypeCollectionResult result;
   for (const auto &sections : ReflectionInfos) {
     for (auto descriptor : sections.Field) {
-      auto typeRef = readTypeRef(descriptor, descriptor->MangledTypeName);
-      auto typeName = nodeToString(demangleTypeRef(typeRef));
-      auto optionalMangledTypeName = normalizeReflectionName(typeRef);
-      clearNodeFactory();
+      llvm::Optional<std::string> optionalMangledTypeName;
+      std::string typeName;
+      {
+        ScopedNodeFactoryCheckpoint checkpoint(this);
+        auto typeRef = readTypeRef(descriptor, descriptor->MangledTypeName);
+        typeName = nodeToString(demangleTypeRef(typeRef));
+        optionalMangledTypeName = normalizeReflectionName(typeRef);
+      }
       if (optionalMangledTypeName.has_value()) {
         auto mangledTypeName =
           optionalMangledTypeName.value();
@@ -618,10 +622,10 @@ void TypeRefBuilder::dumpFieldSection(std::ostream &stream) {
 void TypeRefBuilder::dumpBuiltinTypeSection(std::ostream &stream) {
   for (const auto &sections : ReflectionInfos) {
     for (auto descriptor : sections.Builtin) {
+      ScopedNodeFactoryCheckpoint checkpoint(this);
       auto typeNode =
           demangleTypeRef(readTypeRef(descriptor, descriptor->TypeName));
       auto typeName = nodeToString(typeNode);
-      clearNodeFactory();
 
       stream << "\n- " << typeName << ":\n";
       stream << "Size: " << descriptor->Size << "\n";
@@ -670,10 +674,10 @@ void TypeRefBuilder::dumpCaptureSection(std::ostream &stream) {
 void TypeRefBuilder::dumpMultiPayloadEnumSection(std::ostream &stream) {
   for (const auto &sections : ReflectionInfos) {
     for (const auto descriptor : sections.MultiPayloadEnum) {
+      ScopedNodeFactoryCheckpoint checkpoint(this);
       auto typeNode =
           demangleTypeRef(readTypeRef(descriptor, descriptor->TypeName));
       auto typeName = nodeToString(typeNode);
-      clearNodeFactory();
 
       stream << "\n- " << typeName << ":\n";
       stream << "  Descriptor Size: " << descriptor->getSizeInBytes() << "\n";


### PR DESCRIPTION
We clear the NodeFactory to prevent unbounded buildup of allocated memory, but this is done too eagerly. In particular, normalizeReflectionName can end up clearing the factory while the calling code is still using nodes that were allocated from it.

To keep peak memory usage low while avoiding this problem, we introduce a checkpoint mechanism in NodeFactory. A checkpoint can be pushed and then subsequently popped. When a checkpoint is popped, only the nodes allocated since the checkpoint was pushed are invalidated and the memory reclaimed. This allows us to quickly clear short-lived nodes like those created in normalizeReflectionName, while preserving longer-lived nodes used in code calling it. Uses of clearNodeFactory are replaced with this checkpoint mechanism.

rdar://106547092