### PR TITLE
[5.9] [SymbolGraphGen] allow SourceKit to print declarations for private stdlib symbols

### DIFF
--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -57,6 +57,12 @@ struct SymbolGraphOptions {
   /// along with "extensionTo" relationships instead of directly associating
   /// members and conformances with the extended nominal.
   bool EmitExtensionBlockSymbols = false;
+
+  /// Whether to print information for private symbols in the standard library.
+  /// This should be left as `false` when printing a full-module symbol graph,
+  /// but SourceKit should be able to load the information when pulling symbol
+  /// information for individual queries.
+  bool PrintPrivateStdlibSymbols = false;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -63,8 +63,8 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   Opts.PrintFunctionRepresentationAttrs =
     PrintOptions::FunctionRepresentationMode::None;
   Opts.PrintUserInaccessibleAttrs = false;
-  Opts.SkipPrivateStdlibDecls = true;
-  Opts.SkipUnderscoredStdlibProtocols = true;
+  Opts.SkipPrivateStdlibDecls = !Walker.Options.PrintPrivateStdlibSymbols;
+  Opts.SkipUnderscoredStdlibProtocols = !Walker.Options.PrintPrivateStdlibSymbols;
   Opts.PrintGenericRequirements = true;
   Opts.PrintInherited = false;
   Opts.ExplodeEnumCaseDecls = true;

--- a/test/SourceKit/CursorInfo/issue-62457-symbol-graph-crash.swift
+++ b/test/SourceKit/CursorInfo/issue-62457-symbol-graph-crash.swift
@@ -1,0 +1,48 @@
+struct AnyError: Swift.Error {
+  let error: Swift.Error
+}
+
+func test(lhs: AnyError) {
+  // RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=%(line + 1):13 %s -- %s | %FileCheck %s
+  lhs.error._code
+}
+
+// CHECK: SYMBOL GRAPH BEGIN
+
+// CHECK:      "declarationFragments": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "keyword",
+// CHECK-NEXT:     "spelling": "var"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "identifier",
+// CHECK-NEXT:     "spelling": "_code"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": ": "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "typeIdentifier",
+// CHECK-NEXT:     "preciseIdentifier": "s:Si",
+// CHECK-NEXT:     "spelling": "Int"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " { "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "keyword",
+// CHECK-NEXT:     "spelling": "get"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " }"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+
+// CHECK: SYMBOL GRAPH END

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1020,6 +1020,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
     Options.MinimumAccessLevel = AccessLevel::Private;
     Options.IncludeSPISymbols = true;
     Options.IncludeClangDocs = true;
+    Options.PrintPrivateStdlibSymbols = true;
 
     symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,
                                             DInfo.InSynthesizedExtension,


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64556

- **Explanation**: If SourceKit tries to access a cursor symbol graph for a symbol that's private in the stdlib (e.g. `String.index` or `Error._code`), SymbolGraphGen trips an assertion and crashes.
- **Scope**: Affects projects that use internal stdlib APIs and develop with sourcekit-lsp.
- **Issue**: #62457, rdar://103112656
- **Risk**: Low. This change only allows SourceKit to gain more information for its cursor info symbol graphs. Full-module symbol graphs are unaffected, as well as normal compilation.
- **Testing**: An automated test has been added. Existing automated tests pass.
- **Reviewer**: @bnbarham, @ahoppen 