### PR TITLE
[ConstraintSystem] `openOpaqueType`: remove logic that duplicates `bindArchetypesFromContext`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1009,21 +1009,10 @@ Type ConstraintSystem::openOpaqueType(OpaqueTypeArchetypeType *opaque,
   // underlying return type.
   auto opaqueLocator = locator.withPathElement(
       LocatorPathElt::OpenedOpaqueArchetype(opaqueDecl));
+
   OpenedTypeMap replacements;
   openGeneric(DC, opaqueDecl->getOpaqueInterfaceGenericSignature(),
               opaqueLocator, replacements);
-
-  // If there is an outer generic signature, bind the outer parameters based
-  // on the substitutions in the opaque type.
-  auto subs = opaque->getSubstitutions();
-  if (auto genericSig = subs.getGenericSignature()) {
-    for (auto *genericParamPtr : genericSig.getGenericParams()) {
-      Type genericParam(genericParamPtr);
-      addConstraint(
-          ConstraintKind::Bind, openType(genericParam, replacements),
-          genericParam.subst(subs), opaqueLocator);
-    }
-  }
 
   recordOpenedTypes(opaqueLocatorKey, replacements);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1762,6 +1762,8 @@ static void bindArchetypesFromContext(
     auto genericSig = parentDC->getGenericSignatureOfContext();
     for (auto *paramTy : genericSig.getGenericParams()) {
       Type contextTy = cs.DC->mapTypeIntoContext(paramTy);
+      if (paramTy->isParameterPack())
+        contextTy = PackType::getSingletonPackExpansion(contextTy);
       bindPrimaryArchetype(paramTy, contextTy);
     }
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature VariadicGenerics
 
 // REQUIRES: asserts
 
@@ -317,4 +317,19 @@ func test_pack_expansion_specialization() {
   _ = Data<Int>(0) // Ok
   _ = Data<Int, String>(42, "") // Ok
   _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
+}
+
+// rdar://107280056 - "Ambiguous without more context" with opaque return type + variadics
+protocol Q {
+  associatedtype B
+}
+
+do {
+  struct G<each T>: Q {
+    typealias B = (repeat each T)
+  }
+
+  func f<each T>(_: repeat each T) -> some Q {
+    return G<repeat each T>() // Ok
+  }
 }


### PR DESCRIPTION
`openGenericParameters` calls `bindArchetypesFromContext` which would bind all of the
external generic parameters in the opaque type signature.

Resolves: rdar://107280056

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
