### PR TITLE
[Test] Re-enable previously failing ASAN test

### DIFF
--- a/test/Frontend/clang-args-diags.swift
+++ b/test/Frontend/clang-args-diags.swift
@@ -1,9 +1,6 @@
 // RUN: not %swift -Xcc -fake-argument -typecheck %s 2>&1 | %FileCheck %s -check-prefix=CHECK-UNKNOWN-ARG
 // CHECK-UNKNOWN-ARG: unknown argument: '-fake-argument'
 
-// Temporarily disable this test on ASAN bots.
-// UNSUPPORTED: asan
-
 // RUN: not %swift -Xcc -ivfsoverlay -Xcc %t.nonexistent -typecheck %s 2>&1 | %FileCheck %s -check-prefix=CHECK-VFS-NONEXISTENT
 // CHECK-VFS-NONEXISTENT: virtual filesystem overlay file '{{.*}}' not found
 


### PR DESCRIPTION
This was fixed by https://github.com/apple/swift/pull/63881, ie. a stack use after scope.

Resolves rdar://100508951.