### PR TITLE
Don't build and install libcxx when generating a macOS toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1265,7 +1265,6 @@ swift-driver
 swiftsyntax
 swiftformat
 playgroundsupport
-libcxx
 indexstore-db
 sourcekit-lsp
 swiftdocc
@@ -1308,7 +1307,6 @@ install-swiftpm
 install-swift-driver
 install-swiftsyntax
 install-playgroundsupport
-install-libcxx
 install-sourcekit-lsp
 install-swiftformat
 install-swiftdocc


### PR DESCRIPTION
Libcxx is already part of the macOS SDKs shipped since Xcode 12.5, so there is no need for us to rebuild it.
This will also prevent compilation issues in the presets that builds the standard library using a prebuilt toolchain, so the clang compiler that ships in that toolchain does not pickup libcxx headers that do not match the tbd shipped in the underlying macOS SDK.

This change would be desirable for all macOS presets, focusing for now on the toolchain presets.

Addresses rdar://106817494