### PR TITLE
[AST] add a source location for GenericTypeParamDecls

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3050,7 +3050,8 @@ createOpaqueParameterGenericParams(GenericContext *genericContext, GenericParamL
       // Allocate a new generic parameter to represent this opaque type.
       auto *gp = GenericTypeParamDecl::createImplicit(
           dc, Identifier(), GenericTypeParamDecl::InvalidDepth, index++,
-          /*isParameterPack*/ false, /*isOpaqueType*/ true, repr);
+          /*isParameterPack*/ false, /*isOpaqueType*/ true, repr,
+          /*nameLoc*/ repr->getStartLoc());
 
       // Use the underlying constraint as the constraint on the generic parameter.
       //  The underlying constraint is only present for OpaqueReturnTypeReprs

--- a/test/SymbolGraph/Symbols/OpaqueParams.swift
+++ b/test/SymbolGraph/Symbols/OpaqueParams.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-module -emit-module-path %t/OpaqueParams.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %{python} -m json.tool %t/OpaqueParams.symbols.json %t/OpaqueParams.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/OpaqueParams.formatted.symbols.json
+
+// CHECK: "precise": "s:12OpaqueParams7MyClassC6myFunc5param10otherParamyq__xtAA0C8ProtocolRzAaGR_r0_lF"
+
+public protocol MyProtocol {}
+
+public class MyClass {
+    public func myFunc<S: MyProtocol>(
+        param: some MyProtocol,
+        otherParam: S
+    ) {}
+}


### PR DESCRIPTION
Resolves rdar://105982860

When a method contains both a generic type parameter and a parameter with an existential type (`some MyProtocol`), the mixture creates a situation where the SourceEntityWalker tries to calculate the source range of the existential, which trips an assertion. This is because GenericTypeParamDecls are not given a source location for their "name", but are given an "inherited" constraint, which is used to calculate the source range:

https://github.com/apple/swift/blob/a9491f6bfe0f83c7d05e06dc0523fbade0b39de4/lib/AST/NameLookup.cpp#L3054-L3072

https://github.com/apple/swift/blob/9f38648b789787e1b5963b6c4d193c45e7111bb6/lib/AST/Decl.cpp#L5001-L5012

This combination of "invalid start location" with "valid end location" fails an assertion in the construction of a SourceRange for the resulting GenericTypeParamDecl.

This PR attempts to resolve this issue by providing a source location for the decl, that points to the beginning of the `some`/`any` keyword, so that the source range can cover the whole `some MyProtocol` span.