### PR TITLE
Support all BorrowedValueKind in hasPointerEscape(BorrowedValue) api

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -25,59 +25,44 @@
 
 using namespace swift;
 
-bool swift::hasPointerEscape(BorrowedValue value) {
-  assert(value.kind == BorrowedValueKind::BeginBorrow ||
-         value.kind == BorrowedValueKind::LoadBorrow);
-  GraphNodeWorklist<Operand *, 8> worklist;
-  for (Operand *use : value->getUses()) {
-    if (use->getOperandOwnership() != OperandOwnership::NonUse)
-      worklist.insert(use);
+bool swift::hasPointerEscape(BorrowedValue original) {
+  ValueWorklist worklist(original->getFunction());
+  worklist.push(*original);
+
+  if (auto *phi = SILArgument::asPhi(*original)) {
+    phi->visitTransitiveIncomingPhiOperands([&](auto *phi, auto *operand) {
+      worklist.pushIfNotVisited(operand->get());
+      return true;
+    });
   }
 
-  while (Operand *op = worklist.pop()) {
-    switch (op->getOperandOwnership()) {
-    case OperandOwnership::NonUse:
-    case OperandOwnership::TrivialUse:
-    case OperandOwnership::ForwardingConsume:
-    case OperandOwnership::DestroyingConsume:
-      llvm_unreachable("this operand cannot handle an inner guaranteed use");
-
-    case OperandOwnership::ForwardingUnowned:
-    case OperandOwnership::PointerEscape:
-      return true;
-
-    case OperandOwnership::Borrow:
-    case OperandOwnership::EndBorrow:
-    case OperandOwnership::InstantaneousUse:
-    case OperandOwnership::UnownedInstantaneousUse:
-    case OperandOwnership::InteriorPointer:
-    case OperandOwnership::BitwiseEscape:
-      break;
-    case OperandOwnership::Reborrow: {
-      SILArgument *phi = cast<BranchInst>(op->getUser())
-                             ->getDestBB()
-                             ->getArgument(op->getOperandNumber());
-      for (auto *use : phi->getUses()) {
-        if (use->getOperandOwnership() != OperandOwnership::NonUse)
-          worklist.insert(use);
-      }
-      break;
-    }
-    case OperandOwnership::GuaranteedForwarding: {
-      // This may follow a guaranteed phis.
-      ForwardingOperand(op).visitForwardedValues([&](SILValue result) {
-        // Do not include transitive uses with 'none' ownership
-        if (result->getOwnershipKind() == OwnershipKind::None)
-          return true;
-        for (auto *resultUse : result->getUses()) {
-          if (resultUse->getOperandOwnership() != OperandOwnership::NonUse) {
-            worklist.insert(resultUse);
-          }
-        }
+  while (auto value = worklist.pop()) {
+    for (auto *op : value->getUses()) {
+      switch (op->getOperandOwnership()) {
+      case OperandOwnership::ForwardingUnowned:
+      case OperandOwnership::PointerEscape:
         return true;
-      });
-      break;
-    }
+
+      case OperandOwnership::Reborrow: {
+        SILArgument *phi = PhiOperand(op).getValue();
+        worklist.pushIfNotVisited(phi);
+        break;
+      }
+
+      case OperandOwnership::GuaranteedForwarding: {
+        // This may follow guaranteed phis.
+        ForwardingOperand(op).visitForwardedValues([&](SILValue result) {
+          // Do not include transitive uses with 'none' ownership
+          if (result->getOwnershipKind() == OwnershipKind::None)
+            return true;
+          worklist.pushIfNotVisited(result);
+          return true;
+        });
+        break;
+      }
+      default:
+        break;
+      }
     }
   }
   return false;

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -283,8 +283,8 @@ void DCE::markLive() {
       }
       case SILInstructionKind::EndBorrowInst: {
         auto phi = PhiValue(I.getOperand(0));
-        // If there is a pointer escape, disable DCE.
-        if (phi && hasPointerEscape(phi)) {
+        // If there is a pointer escape or phi is lexical, disable DCE.
+        if (phi && (hasPointerEscape(phi) || phi->isLexical())) {
           markInstructionLive(&I);
         }
         // The instruction is live only if it's operand value is also live
@@ -319,10 +319,6 @@ void DCE::markLive() {
           for (auto root : roots) {
             disableBorrowDCE(root);
           }
-        }
-        // If we have a lexical borrow scope, disable DCE.
-        if (borrowInst->isLexical()) {
-          disableBorrowDCE(borrowInst);
         }
         break;
       }


### PR DESCRIPTION
https://github.com/apple/swift/pull/64190 added a new hasPointerEscape(SILValue) which delegates BorrowedValue to hasPointerEscape(BorrowedValue) which previously did not support reborrows. 

Add the reborrow support here, and use the updated utility in DCE.