### PR TITLE
[Attr] Refactor retrieving original attributes

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -851,12 +851,11 @@ SourceLoc DeclAttributes::getStartLoc(bool forModifiers) const {
   return lastAttr ? lastAttr->getRangeWithAt().Start : SourceLoc();
 }
 
-OrigDeclAttributes::OrigDeclAttributes(DeclAttributes allAttributes, ModuleDecl *mod) {
-  for (auto *attr : allAttributes) {
-    if (!mod->isInGeneratedBuffer(attr->AtLoc)) {
-      attributes.emplace_back(attr);
-    }
-  }
+Optional<const DeclAttribute *>
+OrigDeclAttrFilter::operator()(const DeclAttribute *Attr) const {
+  if (!mod || mod->isInGeneratedBuffer(Attr->AtLoc))
+    return None;
+  return Attr;
 }
 
 static void printAvailableAttr(const AvailableAttr *Attr, ASTPrinter &Printer,


### PR DESCRIPTION
`decl->getOriginalAttrs()->getAttributes<...>` isn't safe in the current API. Update `OrigDeclAttributes` to filter its attributes to the original ones on demand, rather than filtering and storing a vector inline.

Resolves rdar://107342658.