### PR TITLE
[shims] ensure that _SwiftConcurrency has the same Swift interface re…

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/_SwiftConcurrency.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftConcurrency.h
@@ -25,13 +25,16 @@ typedef struct _SwiftContext {
   struct _SwiftContext *parentContext;
 } _SwiftContext;
 
-void exit(int);
-
-#define EXIT_SUCCESS 0
-
 #ifdef __cplusplus
 } // extern "C"
 } // namespace swift
 #endif
+
+#ifdef __cplusplus
+extern "C" [[noreturn]]
+#endif
+void exit(int);
+
+#define EXIT_SUCCESS 0
 
 #endif // SWIFT_CONCURRENCY_H

--- a/test/Interop/Cxx/stdlib/print-swiftconcurrencyshims-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-swiftconcurrencyshims-interface.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=_SwiftConcurrencyShims -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=_SwiftConcurrencyShims -source-filename=x | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Ensure that _SwiftConcurrencyShims defines the same `exit` regardless of whether
+// C++ interoperability is enabled.
+
+// CHECK: func exit(_: Int32) -> Never
+// CHECK: var EXIT_SUCCESS: Int32 { get }


### PR DESCRIPTION
…gardless of whether C++ interop is enabled

This ensures that a module built from Swift interface file (and as such interop is disabled), that references 'exit' (from _SwiftConcurrencyShims module) can resolve the module reference to 'exit' even when it's being imported when interop is enabled (and thus it loads a different underlying _SwiftConcurrencyShims).
