### PR TITLE
[5.9][ModuleInterface] Guard layout based prespecializations in swiftinter…

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3160,7 +3160,13 @@ static bool usesFeatureVariadicGenerics(Decl *decl) {
 }
 
 static bool usesFeatureLayoutPrespecialization(Decl *decl) {
-  return false;
+  auto &attrs = decl->getAttrs();
+  return std::any_of(attrs.begin(), attrs.end(), [](auto *attr) {
+    if (auto *specialize = dyn_cast<SpecializeAttr>(attr)) {
+      return !specialize->getTypeErasedParams().empty();
+    }
+    return false;
+  });
 }
 
 static bool usesFeatureLayoutStringValueWitnesses(Decl *decl) {

--- a/test/ModuleInterface/layout_pre_specialization.swift
+++ b/test/ModuleInterface/layout_pre_specialization.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/LayoutPrespec.swiftinterface) %s -enable-experimental-feature LayoutPrespecialization -module-name LayoutPrespec -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/LayoutPrespec.swiftinterface) -module-name LayoutPrespec -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/LayoutPrespec.swiftinterface) -module-name LayoutPrespec -enable-experimental-feature LayoutPrespecialization -disable-availability-checking
+// RUN: %FileCheck %s < %t/LayoutPrespec.swiftinterface
+
+// CHECK: #if compiler(>=5.3) && $LayoutPrespecialization
+// CHECK-NEXT: @_specialize(exported: true, kind: full, where @_noMetadata A : _Class)
+// CHECK-NEXT: public func test<A>(a: A) -> A
+// CHECK-NEXT: #endif
+@_specialize(exported: true, where @_noMetadata A : _Class)
+public func test<A>(a: A) -> A {
+    return a
+}


### PR DESCRIPTION
Cherry-pick of: #64695

* [ModuleInterface] Guard layout based prespecializations in swiftinterface files

rdar://107269447

To allow compilers that don't have this feature enabled to parse interface files that contain declarations that use layout based prespecializations, it has to be guarded.
