### PR TITLE
[Backtracing] Support specifying a hard-coded path for swift-backtrace.

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -234,3 +234,8 @@ option(SWIFT_STDLIB_CONCURRENCY_TRACING
 option(SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES
        "Use relative protocol witness tables"
        FALSE)
+
+set(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH "" CACHE STRING
+  "If set, provides a fixed path to the swift-backtrace binary.  This
+   will disable dynamic determination of the path and will also disable
+   the setting in SWIFT_BACKTRACE.")

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -18,6 +18,11 @@ if(SWIFT_RUNTIME_ENABLE_LEAK_CHECKER)
   set(swift_runtime_leaks_sources Leaks.mm)
 endif()
 
+if(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
+  list(APPEND swift_runtime_compile_flags
+    "-DSWIFT_RUNTIME_FIXED_BACKTRACER_PATH=\"${SWIFT_RUNTIME_FIXED_BACKTRACER_PATH}\"")
+endif()
+
 set(swift_runtime_objc_sources
     ErrorObject.mm
     SwiftObject.mm

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -236,6 +236,7 @@ KNOWN_SETTINGS=(
     swift-enable-experimental-string-processing   "1"               "whether to build experimental string processing feature"
     swift-earlyswiftsyntax                        "0"               "use the early SwiftSyntax"
     swift-enable-backtracing                      "1"               "whether to build the backtracing support"
+    swift-runtime-fixed-backtracer-path           ""                "if set, use a fixed path for the backtracer"
 
     ## FREESTANDING Stdlib Options
     swift-freestanding-flavor                     ""                "when building the FREESTANDING stdlib, which build style to use (options: apple, linux)"
@@ -1622,6 +1623,13 @@ for host in "${ALL_HOSTS[@]}"; do
         )
     fi
 
+    if [[ "${SWIFT_RUNTIME_FIXED_BACKTRACER_PATH}" ]] ; then
+        swift_cmake_options=(
+            "${swift_cmake_options[@]}"
+            -DSWIFT_RUNTIME_FIXED_BACKTRACER_PATH:STRING="${SWIFT_RUNTIME_FIXED_BACKTRACER_PATH}"
+        )
+    fi
+
     if [[ "${EXTRA_SWIFT_ARGS}" ]] ; then
         swift_cmake_options=(
             "${swift_cmake_options[@]}"
@@ -2047,6 +2055,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES:BOOL=$(true_false "${SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES}")
+                    )
+                fi
+
+                if [[ "${SWIFT_RUNTIME_FIXED_BACKTRACER_PATH}" ]] ; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_RUNTIME_FIXED_BACKTRACER_PATH:STRING="${SWIFT_RUNTIME_FIXED_BACKTRACER_PATH}"
                     )
                 fi
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -455,6 +455,8 @@ def create_argument_parser():
     option('--swift-enable-backtracing', toggle_true,
            default=True,
            help='enable backtracing support')
+    option('--swift-runtime-fixed-backtracer-path', store,
+           help='if set, provide a fixed path for the Swift backtracer')
 
     option('--compiler-vendor', store,
            choices=['none', 'apple'],

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -239,6 +239,7 @@ EXPECTED_DEFAULTS = {
     'swift_darwin_supported_archs': None,
     'swift_freestanding_is_darwin': False,
     'swift_profile_instr_use': None,
+    'swift_runtime_fixed_backtracer_path': None,
     'swift_stdlib_assertions': True,
     'swift_stdlib_build_variant': 'Debug',
     'swift_tools_ld64_lto_codegen_only_for_supporting_targets': False,
@@ -752,6 +753,7 @@ EXPECTED_OPTIONS = [
     PathOption('--cmake-c-launcher'),
     PathOption('--cmake-cxx-launcher'),
     PathOption('--swift-profile-instr-use'),
+    PathOption('--swift-runtime-fixed-backtracer-path'),
 
     IntOption('--benchmark-num-o-iterations'),
     IntOption('--benchmark-num-onone-iterations'),

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -386,6 +386,13 @@ class BuildScriptInvocation(object):
         if args.maccatalyst_ios_tests:
             impl_args += ["--darwin-test-maccatalyst-ios-like=1"]
 
+        # Provide a fixed backtracer path, if required
+        if args.swift_runtime_fixed_backtracer_path is not None:
+            impl_args += [
+                '--swift-runtime-fixed-backtracer-path=%s' %
+                args.swift_runtime_fixed_backtracer_path
+            ]
+
         # If we have extra_cmake_options, combine all of them together and then
         # add them as one command.
         if args.extra_cmake_options:


### PR DESCRIPTION
Add a way to disable dynamic lookup of the backtracer path, for situations where a hard-coded path makes more sense.

rdar://107360391
