### PR TITLE
[Executors] Clean up how we unwrap the local executor of distributed custom actor

### DIFF
--- a/include/swift/AST/KnownSDKDecls.def
+++ b/include/swift/AST/KnownSDKDecls.def
@@ -21,6 +21,7 @@
 
 KNOWN_SDK_FUNC_DECL(Distributed, IsRemoteDistributedActor, "__isRemoteActor")
 KNOWN_SDK_FUNC_DECL(Distributed, IsLocalDistributedActor, "__isLocalActor")
+KNOWN_SDK_FUNC_DECL(Distributed, GetUnwrapLocalDistributedActorUnownedExecutor, "_getUnwrapLocalDistributedActorUnownedExecutor")
 
 #undef KNOWN_SDK_FUNC_DECL
 

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -278,19 +278,15 @@ public protocol DistributedActor: AnyActor, Identifiable, Hashable
   /// - Parameter system: `system` which should be used to resolve the `identity`, and be associated with the returned actor
   static func resolve(id: ID, using system: ActorSystem) throws -> Self
 
-  // FIXME: figure out how to remove this so LowerHopToActor can call the extension method directly on the protocol
-  @available(SwiftStdlib 5.9, *)
-  var _unwrapLocalUnownedExecutor: UnownedSerialExecutor { get }
 }
 
-
 @available(SwiftStdlib 5.9, *)
-extension DistributedActor {
-
-  @available(SwiftStdlib 5.9, *)
-  public var _unwrapLocalUnownedExecutor: UnownedSerialExecutor {
-    self.localUnownedExecutor!
+public func _getUnwrapLocalDistributedActorUnownedExecutor(_ actor: some DistributedActor) -> UnownedSerialExecutor {
+  guard let executor = actor.localUnownedExecutor else {
+    fatalError("Expected distributed actor executor to be not nil!")
   }
+
+  return executor
 }
 
 // ==== Hashable conformance ---------------------------------------------------


### PR DESCRIPTION
The previous implementation relied on a hacky `_` protocol requirement. 
This is a proper implementation of the "we want to unwrap and offer a nice error" and removes the temporary workaround.

Thank you @slavapestov for the help here!