### PR TITLE
[Immediate] Use the large code model

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -326,6 +326,7 @@ int swift::RunImmediately(CompilerInstance &CI,
         .setJITTargetMachineBuilder(
             llvm::orc::JITTargetMachineBuilder(llvm::Triple(Triple))
               .setRelocationModel(llvm::Reloc::PIC_)
+              .setCodeModel(llvm::CodeModel::Large)
               .setOptions(std::move(TargetOpt))
               .setCPU(std::move(CPU))
               .addFeatures(Features)


### PR DESCRIPTION
The default 'small' code model assumes that code and data sections are allocated less than 2 GiB apart so that RIP-relative displacements can be 32-bit. On UNIX this produces ELF object code with R_X86_64_PC32 relocations. However, the default SectionMemoryManager for LLJIT simply makes mmap() allocations which, depending on the platform's implementation, may end up far apart.

While LLVM provides an alternate JITLinkMemoryManager which aims to provide support for the small code model, it is still a work in progress: https://llvm.org/docs/JITLink.html#jitlink-availability-and-feature-status

This change instead ensures the large code model is used instead, which makes no assumptions about memory offset sizes and produces R_X86_64_64 relocations. Additional information about x64 code models can be found at: https://eli.thegreenplace.net/2012/01/03/understanding-the-x64-code-models

Fixes #60673