### PR TITLE
Fix test failure on Windows due to path separators being treated as escapes

### DIFF
--- a/test/ModuleInterface/ModuleCache/module-cache-bad-version.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-bad-version.swift
@@ -20,7 +20,7 @@
 // RUN: not %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module  -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err.txt 2>&1
 // RUN: test ! -f %t/TestModule.swiftmodule
 // This avoids a problem in Windows with test ! -f 'foo*' for a file that doesn't exist
-// RUN: %{python} -c "import sys; import glob; sys.exit(len(glob.glob('%t/modulecache/LeafModule-*.swiftmodule')) != 0)"
+// RUN: %{python} -c "import sys; import glob; sys.exit(len(glob.glob(r'%t/modulecache/LeafModule-*.swiftmodule')) != 0)"
 // RUN: %FileCheck %s -check-prefix=CHECK-ERR <%t/err.txt
 // CHECK-ERR: {{error: unsupported version of module interface '.*[/\\]LeafModule.swiftinterface': '9999.999'}}
 // CHECK-ERR: error: no such module 'LeafModule


### PR DESCRIPTION
The `test/ModuleInterface/ModuleCache/module-cache-bad-version.swift` test was failing on Windows because it evaluates a Python code string containing a path, which on Windows would have backslashes and be interpreted as escapes. The fix is to use a Python raw string which doesn't process backslash escapes.
