### PR TITLE
[5.9] [AST] add a source location for GenericTypeParamDecls

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3050,7 +3050,8 @@ createOpaqueParameterGenericParams(GenericContext *genericContext, GenericParamL
       // Allocate a new generic parameter to represent this opaque type.
       auto *gp = GenericTypeParamDecl::createImplicit(
           dc, Identifier(), GenericTypeParamDecl::InvalidDepth, index++,
-          /*isParameterPack*/ false, /*isOpaqueType*/ true, repr);
+          /*isParameterPack*/ false, /*isOpaqueType*/ true, repr,
+          /*nameLoc*/ repr->getStartLoc());
 
       // Use the underlying constraint as the constraint on the generic parameter.
       //  The underlying constraint is only present for OpaqueReturnTypeReprs

--- a/test/SymbolGraph/Symbols/OpaqueParams.swift
+++ b/test/SymbolGraph/Symbols/OpaqueParams.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 %s -emit-module -emit-module-path %t/OpaqueParams.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %{python} -m json.tool %t/OpaqueParams.symbols.json %t/OpaqueParams.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/OpaqueParams.formatted.symbols.json
+
+// CHECK: "precise": "s:12OpaqueParams7MyClassC6myFunc5param10otherParamyq__xtAA0C8ProtocolRzAaGR_r0_lF"
+
+public protocol MyProtocol {}
+
+public class MyClass {
+    public func myFunc<S: MyProtocol>(
+        param: some MyProtocol,
+        otherParam: S
+    ) {}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64688

- **Explanation**: Functions with a mix of generic type parameters and existential types crash SymbolGraphGen and any other users of SourceEntityWalker.
- **Scope**: The change introduces a source location for GenericTypeParamDecl, which previously had none. This doesn't seem to affect any consumers of it (i checked SourceKit's cursor info, `-dump-ast`, and SymbolGraphGen), but the change may affect other internals of the compiler.
- **Issue**: rdar://105982860
- **Risk**: Low. The addition of the source location for GenericTypeParamDecl seems to be unused, and this change should not affect normal compilation.
- **Testing**: An automated test has been added to ensure that SymbolGraphGen's use of SourceEntityWalker no longer trips an assertion on a reproduction. Existing automated tests still pass.
- **Reviewer**: @slavapestov