### PR TITLE
[Macros] Allow macro parameters to have default arguments.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2028,8 +2028,6 @@ ERROR(foreign_diagnostic,none,
 //------------------------------------------------------------------------------
 ERROR(expected_macro_value_type,PointsToFirstBadToken,
       "expected macro value type following ':'", ())
-ERROR(no_default_arg_macro,none,
-      "default arguments are not allowed in macros", ())
 ERROR(expected_lparen_macro,PointsToFirstBadToken,
       "expected '(' for macro parameters or ':' for a value-like macro", ())
 ERROR(expected_type_macro_result,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6970,8 +6970,6 @@ ERROR(macro_definition_unsupported,none,
 ERROR(external_macro_arg_not_type_name,none,
       "argument to `#externalMacro` must be a string literal naming "
       "the external macro's %select{module|type}0", (unsigned))
-ERROR(attached_declaration_macro_not_supported,none,
-      "attached declaration macros are not yet supported", ())
 ERROR(invalid_decl_in_macro_expansion,none,
       "macro expansion cannot introduce %0",
       (DescriptiveDeclKind))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9595,9 +9595,10 @@ ParserResult<MacroDecl> Parser::parseDeclMacro(DeclAttributes &attributes) {
   DeclName macroFullName;
 
   // Parameter list.
+  DefaultArgumentInfo defaultArgs;
   SmallVector<Identifier, 2> namePieces;
   auto parameterResult = parseSingleParameterClause(
-      ParameterContextKind::Macro, &namePieces, nullptr);
+      ParameterContextKind::Macro, &namePieces, &defaultArgs);
   status |= parameterResult;
   parameterList = parameterResult.getPtrOrNull();
 
@@ -9639,6 +9640,8 @@ ParserResult<MacroDecl> Parser::parseDeclMacro(DeclAttributes &attributes) {
     }
     status |= whereStatus;
   }
+
+  defaultArgs.setFunctionContext(macro, macro->getParameterList());
 
   return dcc.fixupParserResult(status, macro);
 }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -109,15 +109,13 @@ static ParserStatus parseDefaultArgument(
   case Parser::ParameterContextKind::Initializer:
   case Parser::ParameterContextKind::EnumElement:
   case Parser::ParameterContextKind::Subscript:
+  case Parser::ParameterContextKind::Macro:
     break;
   case Parser::ParameterContextKind::Closure:
     diagID = diag::no_default_arg_closure;
     break;
   case Parser::ParameterContextKind::Curried:
     diagID = diag::no_default_arg_curried;
-    break;
-  case Parser::ParameterContextKind::Macro:
-    diagID = diag::no_default_arg_macro;
     break;
   }
   
@@ -704,7 +702,8 @@ mapParsedParameters(Parser &parser,
              paramContext == Parser::ParameterContextKind::Operator ||
              paramContext == Parser::ParameterContextKind::Initializer ||
              paramContext == Parser::ParameterContextKind::EnumElement ||
-             paramContext == Parser::ParameterContextKind::Subscript) &&
+             paramContext == Parser::ParameterContextKind::Subscript ||
+             paramContext == Parser::ParameterContextKind::Macro) &&
             "Default arguments are only permitted on the first param clause");
 
     if (param.DefaultArg) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2043,6 +2043,7 @@ public:
       MD->diagnose(diag::macro_without_role, MD->getName());
 
     TypeChecker::checkParameterList(MD->getParameterList(), MD);
+    checkDefaultArguments(MD->getParameterList());
 
     // Check the macro definition.
     switch (auto macroDef = MD->getDefinition()) {

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -146,8 +146,13 @@ func testExternalMacroOutOfPlace() {
 
 @freestanding(expression)
 public macro macroWithDefaults(_: Int = 17) = #externalMacro(module: "A", type: "B")
-// expected-error@-1{{default arguments are not allowed in macros}}
-// expected-warning@-2{{external macro implementation type 'A.B' could not be found for macro 'macroWithDefaults'}}
+// expected-warning@-1{{external macro implementation type 'A.B' could not be found for macro 'macroWithDefaults'}}
+// expected-note@-2{{'macroWithDefaults' declared here}}
+
+func callMacroWithDefaults() {
+  _ = #macroWithDefaults()
+  // expected-error@-1 {{external macro implementation type 'A.B' could not be found for macro 'macroWithDefaults'}}
+}
 
 // Make sure we don't allow macros to prevent type folding.
 @attached(member)

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -1,4 +1,4 @@
-@freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+@freestanding(expression) public macro publicStringify<T>(_ value: T, label: String? = nil) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -13,6 +13,7 @@ import def_macros
 
 func test(a: Int, b: Int) {
   _ = #publicStringify(a + b)
+  _ = #publicStringify(a + b, label: "hello")
 
   _ = #internalStringify(a + b)
   // expected-error@-1{{no macro named 'internalStringify'}}


### PR DESCRIPTION
SE-0382 allows macro parameters to have default arguments. Enable these default arguments, with the normal type checking rules. One significant quirk to this implementation is that the actual default argument values don't make it to the macro implementation. This is a previously-unconsidered design problem we'll need to address.

Tracked by rdar://104043987.

(cherry picked from commit 9d9f8326c829cd4ec3ca38e7ec40f04ad81daf68, https://github.com/apple/swift/pull/64631)
