### PR TITLE
Tests: Fix and re-enable `@_spi_available` tests

### DIFF
--- a/test/ModuleInterface/spi-available.swift
+++ b/test/ModuleInterface/spi-available.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %s -emit-module -library-level=api -emit-module-path %t/Foo.swiftmodule -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface -emit-private-module-interface-path %t/Foo.private.swiftinterface
+// RUN: %target-swift-emit-module-interfaces(%t/Foo.swiftinterface, %t/Foo.private.swiftinterface) -parse-as-library %s -library-level api
 
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.public.swiftmodule -module-name Foo
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.private.swiftinterface -o %t/Foo.private.swiftmodule -module-name Foo
+// RUN: %FileCheck %s --check-prefix=CHECK-PUBLIC < %t/Foo.swiftinterface
+// RUN: %FileCheck %s --check-prefix=CHECK-PRIVATE < %t/Foo.private.swiftinterface
 
 @_spi_available(macOS 10.10, tvOS 14.0, *)
 @available(iOS 8.0, *)

--- a/test/Sema/spi-available-context.swift
+++ b/test/Sema/spi-available-context.swift
@@ -1,13 +1,23 @@
-// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9 -library-level api
+// RUN: %target-typecheck-verify-swift -library-level api
 
-@_spi_available(macOS 10.4, *)
+@_spi_available(macOS 10.10, *)
 @available(iOS 8.0, *)
-public protocol Foo { }
+public protocol MacOSSPIProto {} // expected-note {{type declared here}}
 
-@_spi_available(macOS 10.4, *)
+@_spi_available(iOS 8.0, *)
+@available(macOS 10.10, *)
+public protocol iOSSPIProto {}
+
+@_spi_available(macOS 10.10, *)
 @available(iOS 8.0, *)
 public class Bar {
-    public var foo: Foo?
+  public var macos: MacOSSPIProto?
+  public var ios: iOSSPIProto?
+}
+
+@available(macOS 10.10, iOS 8.0, *)
+public class Baz {
+  public var macos: MacOSSPIProto? // expected-error {{cannot use protocol 'MacOSSPIProto' here; it is SPI}}
+  public var ios: iOSSPIProto?
 }

--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -1,16 +1,16 @@
-// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9 -library-level api
+// RUN: %target-typecheck-verify-swift -library-level api
 
-@_spi_available(macOS 10.4, *)
+@_spi_available(macOS 10.10, *)
 @available(iOS 8.0, *)
 public class MacOSSPIClass { public init() {} }
 
 @_spi_available(iOS 8.0, *)
-@available(macOS 10.4, *)
+@available(macOS 10.10, *)
 public class iOSSPIClass { public init() {} }
 
-@inlinable public func foo() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
+@available(macOS 10.10, iOS 8.0, *)
+@inlinable public func foo() {
 	_ = MacOSSPIClass() // expected-error {{class 'MacOSSPIClass' cannot be used in an '@inlinable' function because it is SPI}}
 	_ = iOSSPIClass()
 }

--- a/test/Sema/spi-available-local.swift
+++ b/test/Sema/spi-available-local.swift
@@ -1,15 +1,16 @@
-// REQUIRES: OS=ios
-// REQUIRES: rdar91325474
-// RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -target x86_64-apple-macosx11.9 -parse-as-library %s -typecheck -library-level=api >& %t/macos.txt
-// RUN: %FileCheck %s < %t/macos.txt
-
-// RUN: %target-swift-frontend -target arm64-apple-ios13.0  -parse-as-library %s -typecheck -library-level=api
+// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -parse-as-library -library-level api
 
 @_spi_available(macOS 10.10, *)
 @available(iOS 8.0, *)
-public class SPIClass {}
+public class MacOSSPIClass {} // expected-note {{type declared here}}
 
-public func foo(_ c: SPIClass) {}
+@_spi_available(iOS 8.0, *)
+@available(macOS 10.10, *)
+public class iOSSPIClass {}
 
-// CHECK: cannot use class 'SPIClass' here; it is SPI
+@available(macOS 10.10, iOS 8.0, *)
+public class MacOSDerived: MacOSSPIClass {} // expected-error {{cannot use class 'MacOSSPIClass' here; it is SPI}}
+
+@available(macOS 10.10, iOS 8.0, *)
+public class iOSDerived: iOSSPIClass {}


### PR DESCRIPTION
The main issue was that the tests specified `-library-level=api` in `swift-frontend` invocations instead of `-library-level api`. The former seems to have no effect and therefore expected diagnostics were not being emitted.

Additional clean up:
- Make every test require `OS=macosx` for ease of local testing.
- Avoid unnecessarily specifying target arches (this makes tests slow).
- Add missing `FileCheck` invocation.
- Add some missing test coverage.

Resolves rdar://91325474
