### PR TITLE
🍒[cxx-interop] Add operators for comparing and concatenating `std::string`s

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -53,6 +53,40 @@ extension std.u16string: ExpressibleByStringLiteral {
   }
 }
 
+// MARK: Concatenating and comparing C++ strings
+
+extension std.string: Equatable {
+  public static func ==(lhs: std.string, rhs: std.string) -> Bool {
+    return lhs.compare(rhs) == 0
+  }
+
+  public static func +=(lhs: inout std.string, rhs: std.string) {
+    lhs.__appendUnsafe(rhs) // ignore the returned pointer
+  }
+
+  public static func +(lhs: std.string, rhs: std.string) -> std.string {
+    var copy = lhs
+    copy += rhs
+    return copy
+  }
+}
+
+extension std.u16string: Equatable {
+  public static func ==(lhs: std.u16string, rhs: std.u16string) -> Bool {
+    return lhs.compare(rhs) == 0
+  }
+
+  public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
+    lhs.__appendUnsafe(rhs) // ignore the returned pointer
+  }
+
+  public static func +(lhs: std.u16string, rhs: std.u16string) -> std.u16string {
+    var copy = lhs
+    copy += rhs
+    return copy
+  }
+}
+
 // MARK: Getting a Swift description of a C++ string
 
 extension std.string: CustomDebugStringConvertible {

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -45,6 +45,46 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
   expectEqual(swift7, "���")
 }
 
+StdStringOverlayTestSuite.test("std::string operators") {
+  var s1 = std.string("something")
+  let s2 = std.string("123")
+  let sum = s1 + s2
+  expectEqual(sum, std.string("something123"))
+
+  expectFalse(s1 == s2)
+  let s3 = std.string("something123")
+  expectFalse(s1 == s3)
+  expectFalse(s2 == s3)
+
+  s1 += s2
+  expectTrue(s1 == std.string("something123"))
+  expectTrue(s1 == s3)
+
+  // Make sure the operators work together with ExpressibleByStringLiteral conformance.
+  s1 += "literal"
+  expectTrue(s1 == "something123literal")
+}
+
+StdStringOverlayTestSuite.test("std::u16string operators") {
+  var s1 = std.u16string("something")
+  let s2 = std.u16string("123")
+  let sum = s1 + s2
+  expectEqual(sum, std.u16string("something123"))
+
+  expectFalse(s1 == s2)
+  let s3 = std.u16string("something123")
+  expectFalse(s1 == s3)
+  expectFalse(s2 == s3)
+
+  s1 += s2
+  expectTrue(s1 == std.u16string("something123"))
+  expectTrue(s1 == s3)
+
+  // Make sure the operators work together with ExpressibleByStringLiteral conformance.
+  s1 += "literal"
+  expectTrue(s1 == "something123literal")
+}
+
 StdStringOverlayTestSuite.test("std::u16string <=> Swift.String") {
   let cxx1 = std.u16string()
   let swift1 = String(cxx1)


### PR DESCRIPTION
The original C++ operators are not currently imported into Swift because they are defined as a non-member templated functions.

This change adds the operators as Swift extension functions. This also adds an `Equatable` conformance for `std::string`.

rdar://107017882
(cherry picked from commit 62cb187a3bde2c85a980662588e952b0b5105616)