### PR TITLE
[5.9] Handle null package context when returning access scope

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3934,10 +3934,15 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
   case AccessLevel::Package: {
     auto pkg = resultDC->getPackageContext(/*lookupIfNotCurrent*/ true);
     if (!pkg) {
+      // No package context was found; show diagnostics
       auto &d = VD->getASTContext().Diags;
       d.diagnose(VD->getLoc(), diag::access_control_requires_package_name);
+      // Instead of reporting and failing early, return the scope of
+      // resultDC to allow continuation (should still non-zero exit later)
+      return AccessScope(resultDC);
+    } else {
+      return AccessScope(pkg);
     }
-    return AccessScope(pkg);
   }
   case AccessLevel::Public:
   case AccessLevel::Open:

--- a/test/diagnostics/package-name-diagnostics.swift
+++ b/test/diagnostics/package-name-diagnostics.swift
@@ -1,23 +1,19 @@
 // RUN: %empty-directory(%t)
-// REQUIRES: rdar106819422
 
 // Package name should have valid characters
-// RUN: not --crash %target-swift-frontend -module-name Logging -package-name My-Logging%Pkg %s -emit-module -emit-module-path %t/Logging.swiftmodule 2> %t/resultA.output
+// RUN: not %target-swift-frontend -module-name Logging -package-name My-Logging%Pkg %s -emit-module -emit-module-path %t/Logging.swiftmodule 2> %t/resultA.output
 // RUN: %FileCheck %s -input-file %t/resultA.output -check-prefix CHECK-BAD
-// CHECK-BAD: package name "My-Logging%Pkg" is not a valid identifier
-// CHECK-BAD: decl has a package access level but no -package-name was passed
-// CHECK-BAD: non-public decl has no formal access scope
+// CHECK-BAD: error: package name "My-Logging%Pkg" is not a valid identifier
+// CHECK-BAD: error: decl has a package access level but no -package-name was passed
 
 // Package name should not be empty
-// RUN: not --crash %target-swift-frontend -typecheck %s -package-name "" 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
-// CHECK-EMPTY: package name "" is not a valid identifier
-// CHECK-EMPTY: decl has a package access level but no -package-name was passed
-// CHECK-EMPTY: non-public decl has no formal access scope
+// RUN: not %target-swift-frontend -typecheck %s -package-name "" 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
+// CHECK-EMPTY: error: package name "" is not a valid identifier
+// CHECK-EMPTY: error: decl has a package access level but no -package-name was passed
 
 // If package access level is used but no package-name is passed, it should error
-// RUN: not --crash %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s -check-prefix CHECK-MISSING
-// CHECK-MISSING: decl has a package access level but no -package-name was passed
-// CHECK-MISSING: non-public decl has no formal access scope
+// RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s -check-prefix CHECK-MISSING
+// CHECK-MISSING: error: decl has a package access level but no -package-name was passed
 
 // Package name can be same as the module name
 // RUN: %target-swift-frontend -module-name Logging -package-name Logging %s -emit-module -emit-module-path %t/Logging.swiftmodule


### PR DESCRIPTION
Handle null package context when returning access scope
Resolves rdar://106819422
