### PR TITLE
[CSSimplify] Exploaded tuple argument should assume param's label if …

### DIFF
--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -331,11 +331,18 @@ func test_pack_expansions_with_closures() {
 // rdar://107151854 - crash on invalid due to specialized pack expansion
 func test_pack_expansion_specialization() {
   struct Data<each T> {
-    init(_: repeat each T) {} // expected-note {{'init(_:)' declared here}}
+    init(_: repeat each T) {} // expected-note 2 {{'init(_:)' declared here}}
+    init(vals: repeat each T) {} // expected-note 2 {{'init(vals:)' declared here}}
   }
 
   _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}
   _ = Data<Int>(0) // Ok
   _ = Data<Int, String>(42, "") // Ok
   _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
+  _ = Data<Int, String>((42, ""))
+  // expected-error@-1 {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  _ = Data<Int, String, Float>(vals: (42, "", 0))
+  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  _ = Data<Int, String, Float>((vals: 42, "", 0))
+  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1799,3 +1799,9 @@ func variadicSplat() {
     _ = y.count
   }
 }
+
+func tuple_splat_with_a_label() {
+  func test(vals: Int, _: String, _: Float) {} // expected-note 2 {{'test(vals:_:_:)' declared here}}
+  test(vals: (23, "hello", 3.14)) // expected-error {{local function 'test' expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  test((vals: 23, "hello", 3.14)) // expected-error {{local function 'test' expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+}


### PR DESCRIPTION
…first element doesn't have one

If tuple doesn't have a label for its first element and parameter does, 
let's assume parameter's label to aid argument matching. 

For example:

```swift
func test(val: Int, _: String) {}

test(val: (42, "")) // expands into `(val: 42, "")`
```

Resolves: rdar://106775969

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
