### PR TITLE
[SourceKit] Return the original location for decls within generated code

### DIFF
--- a/include/swift/AST/DiagnosticsRefactoring.def
+++ b/include/swift/AST/DiagnosticsRefactoring.def
@@ -46,6 +46,8 @@ ERROR(decl_no_accessibility, none, "cannot rename as accessibility could not be 
 
 ERROR(decl_from_clang, none, "cannot rename a Clang symbol from its Swift reference", ())
 
+ERROR(decl_in_macro, none, "cannot rename a symbol defined in a macro", ())
+
 ERROR(value_decl_referenced_out_of_range, none, "value decl '%0' is referenced out of range", (DeclName))
 
 ERROR(multi_entry_range, none, "selected range has more than one entry point", ())

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -410,6 +410,11 @@ public:
   /// the given location isn't in this module.
   bool isInGeneratedBuffer(SourceLoc loc);
 
+  // Retrieve the buffer ID and source location of the outermost location that
+  // caused the generation of the buffer containing \p loc. \p loc and its
+  // buffer if it isn't in a generated buffer or has no original location.
+  std::pair<unsigned, SourceLoc> getOriginalLocation(SourceLoc loc) const;
+
   /// Creates a map from \c #filePath strings to corresponding \c #fileID
   /// strings, diagnosing any conflicts.
   ///

--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -79,6 +79,7 @@ enum class RefactorAvailableKind {
   Unavailable_has_no_name,
   Unavailable_has_no_accessibility,
   Unavailable_decl_from_clang,
+  Unavailable_decl_in_macro,
 };
 
 struct RefactorAvailabilityInfo {

--- a/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
+++ b/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
@@ -3,56 +3,60 @@
 
 // RUN: %sourcekitd-test \
 // RUN:   -shell -- echo '## State 1' == \
-// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=5:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 2' == \
 // RUN:   -shell -- cp %t/State2.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=6:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 3' == \
 // RUN:   -shell -- cp %t/State3.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 4' == \
 // RUN:   -shell -- cp %t/State4.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 5' == \
 // RUN:   -shell -- cp %t/State5.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 6' == \
 // RUN:   -shell -- cp %t/State6.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift > %t/response.txt
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift > %t/response.txt
 // RUN: %FileCheck %s < %t/response.txt
 
 // CHECK-LABEL: ## State 1
-// CHECK: source.lang.swift.decl.var.local (3:7-3:18)
+// CHECK: source.lang.swift.decl.var.local (5:7-5:18)
 // CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 0
 // CHECK-LABEL: ## State 2
-// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
+// CHECK: source.lang.swift.decl.var.local (6:7-6:18)
 // CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 3
-// CHECK: source.lang.swift.decl.var.local (2:7-2:18)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
 // CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 4
-// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
 // CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 5
-// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
 // CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 0
 // CHECK-LABEL: ## State 6
-// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
 // CHECK: <Declaration>let myNewName: <Type usr="s:Si">Int</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 
 //--- file.swift
+func unrelated() {}
+
 func foo() {
   let inFunctionA = 1
   let inFunctionB = "hi"
 }
 
 //--- State2.swift
+func unrelated() {}
+
 func foo() {
   let newlyAddedMember = 3
   let inFunctionA = 1
@@ -60,21 +64,29 @@ func foo() {
 }
 
 //--- State3.swift
+func unrelated() {}
+
 func foo() {
   let inFunctionB = "hi"
 }
 
 //--- State4.swift
+func unrelated() {}
+
 func foo() {
   let myNewName = "hi"
 }
 
 //--- State5.swift
+func unrelated() {}
+
 func foo(param: Int) {
   let myNewName = "hi"
 }
 
 //--- State6.swift
+func unrelated() {}
+
 func foo(param: Int) {
   let myNewName = 7
 }

--- a/test/SourceKit/Macros/macro_across_modules.swift
+++ b/test/SourceKit/Macros/macro_across_modules.swift
@@ -1,0 +1,78 @@
+// REQUIRES: swift_swift_parser
+// TODO: This shouldn't be required
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mods)
+// RUN: split-file --leading-lines %s %t
+
+// Check that indexing and cursor info both point to the expansion site rather
+// than generated macro buffer.
+
+// Create a plugin that adds a new function as a member
+// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+
+// Prepare a test module that uses the macro in a struct
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name TestModule -o %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -I %swift-host-lib-dir %t/TestModule.swift -index-store-path %t/idx
+
+// Check we correctly output the added `newFunc` on the line of the attached
+// macro.
+// RUN: c-index-test core -print-record %t/idx | %FileCheck %s --check-prefix=INDEX
+
+//--- MacroPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddNamedFuncMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let newFunc: DeclSyntax =
+      """
+      public func newFunc() {}
+      """
+    return [
+      newFunc,
+    ]
+  }
+}
+
+//--- TestModule.swift
+@attached(
+  member,
+  names: named(newFunc)
+)
+public macro AddNamedFunc() = #externalMacro(module: "MacroPlugin", type: "AddNamedFuncMacro")
+
+// INDEX: [[@LINE+2]]:1 | instance-method/Swift | s:10TestModule9ModStructV7newFuncyyF
+// INDEX-SAME: Def,Impl
+@AddNamedFunc
+// MOD_CURSOR: source.lang.swift.ref.function.method.instance
+// MOD_CURSOR-SAME: TestModule.swift:[[@LINE-2]]:1
+// MOD_CURSOR: newFunc()
+public struct ModStruct {
+  public func existingFunc() {}
+}
+
+//--- test.swift
+import TestModule
+
+@AddNamedFunc
+// LOCAL_CURSOR: source.lang.swift.ref.function.method.instance
+// LOCAL_CURSOR-SAME: [[@LINE-2]]:1
+// LOCAL_CURSOR: newFunc()
+public struct LocalStruct {
+  public func existingFunc() {}
+}
+
+// Check the location in cursor info is the attached macro.
+func test(l: LocalStruct, m: ModStruct) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -I %swift-host-lib-dir %t/test.swift | %FileCheck %s --check-prefix=LOCAL_CURSOR
+  l.newFunc()
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods %t/test.swift | %FileCheck %s --check-prefix=MOD_CURSOR
+  m.newFunc()
+}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -104,7 +104,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_MACRO_EXPR-NEXT: Expand Macro
 // CURSOR_MACRO_EXPR: ACTIONS END
 
-//##-- Refactoring on macro expression
+//##-- Expansion on macro expression
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=4:7 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=4:8 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=EXPAND %s
 // EXPAND: source.edit.kind.active:
@@ -129,7 +129,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_MACRO_DECL-NEXT: Expand Macro
 // CURSOR_MACRO_DECL: ACTIONS END
 
-//##-- Refactoring on macro declaration
+//##-- Expansion on macro declaration
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=57:1 %s -- ${COMPILER_ARGS[@]} -parse-as-library -enable-experimental-feature FreestandingMacros | %FileCheck -check-prefix=EXPAND_MACRO_DECL %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=57:2 %s -- ${COMPILER_ARGS[@]} -parse-as-library -enable-experimental-feature FreestandingMacros | %FileCheck -check-prefix=EXPAND_MACRO_DECL %s
 // EXPAND_MACRO_DECL: source.edit.kind.active:
@@ -166,7 +166,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_ATTACHED-NEXT: Expand Macro
 // CURSOR_ATTACHED: ACTIONS END
 
-//##-- Refactoring on attached macro
+//##-- Expansion on attached macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:1 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // ATTACHED_EXPAND: source.edit.kind.active:
@@ -196,11 +196,11 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_CURSOR-NEXT: },
 // NESTED_ATTACHED_CURSOR: SYMBOL GRAPH END
 // NESTED_ATTACHED_CURSOR-LABEL: ACTIONS BEGIN
-// NESTED_ATTACHED_CURSOR: source.refactoring.kind.expand.macro
+// NESTED_ATTACHED_CURSOR-NEXT: source.refactoring.kind.expand.macro
 // NESTED_ATTACHED_CURSOR-NEXT: Expand Macro
-// NESTED_ATTACHED_CURSOR:ACTIONS END
+// NESTED_ATTACHED_CURSOR-NEXT: ACTIONS END
 
-//##-- Refactoring on the attribute expanded by @myTypeWrapper
+//##-- Expansion on the attribute expanded by @myTypeWrapper
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
 // NESTED_ATTACHED_EXPAND: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1xSivp16accessViaStoragefMa_.swift) "{
@@ -211,7 +211,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: 1:1-1:18 ""
 
-//##-- Refactoring expanding the first accessor macro
+//##-- Expansion on the first accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s
 // ACCESSOR1_EXPAND: source.edit.kind.active:
 // ACCESSOR1_EXPAND-NEXT: 31:13-31:13 (@__swiftmacro_9MacroUser2S2V1xSivp16accessViaStoragefMa_.swift) "{
@@ -222,7 +222,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // ACCESSOR1_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR1_EXPAND-NEXT: 30:3-30:20 ""
 
-//##-- Refactoring expanding the second accessor macro
+//##-- Expansion on the second accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=33:13 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR2_EXPAND %s
 // ACCESSOR2_EXPAND: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 34:14-34:18 (@__swiftmacro_9MacroUser2S2V1ySivp16accessViaStoragefMa_.swift) "{
@@ -233,7 +233,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // ACCESSOR2_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 33:3-33:20 ""
 
-//##-- Refactoring expanding the addCompletionHandler macro.
+//##-- Expansion on the addCompletionHandler macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=42:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=PEER_EXPAND %s
 // PEER_EXPAND: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift) "
@@ -247,7 +247,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // PEER_EXPAND-NEXT: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 42:3-42:24 ""
 
-//##-- Refactoring expanding a conformance macro.
+//##-- Expansion on a conformance macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=51:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CONFORMANCE_EXPAND %s
 // CONFORMANCE_EXPAND: source.edit.kind.active:
 // CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S4V8HashablefMc_.swift) "

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -899,12 +899,13 @@ static void setLocationInfo(const ValueDecl *VD,
       NameLen = getCharLength(SM, Loc);
     }
 
-    unsigned DeclBufID = SM.findBufferContainingLoc(Loc);
+    auto [DeclBufID, DeclLoc] =
+        VD->getModuleContext()->getOriginalLocation(Loc);
     Location.Filename = SM.getIdentifierForBuffer(DeclBufID);
-    Location.Offset = SM.getLocOffsetInBuffer(Loc, DeclBufID);
+    Location.Offset = SM.getLocOffsetInBuffer(DeclLoc, DeclBufID);
     Location.Length = NameLen;
-    std::tie(Location.Line, Location.Column) = SM.getLineAndColumnInBuffer(
-        Loc, DeclBufID);
+    std::tie(Location.Line, Location.Column) =
+        SM.getLineAndColumnInBuffer(DeclLoc, DeclBufID);
     if (auto GeneratedSourceInfo = SM.getGeneratedSourceInfo(DeclBufID)) {
       if (GeneratedSourceInfo->kind ==
           GeneratedSourceInfo::ReplacedFunctionBody) {
@@ -918,9 +919,8 @@ static void setLocationInfo(const ValueDecl *VD,
         auto GeneratedStartOffset = SM.getLocOffsetInBuffer(
             GeneratedSourceInfo->generatedSourceRange.getStart(), DeclBufID);
         Location.Offset += OriginalStartOffset - GeneratedStartOffset;
-        assert(SM.findBufferContainingLoc(Loc) == DeclBufID);
         std::tie(Location.Line, Location.Column) =
-            SM.getPresumedLineAndColumnForLoc(Loc, DeclBufID);
+            SM.getPresumedLineAndColumnForLoc(DeclLoc, DeclBufID);
       }
     }
   } else if (ClangNode) {


### PR DESCRIPTION
Pass back the original location (ie. where the macro was expanded, not the location that the generated code would be inserted) for cursor info and indexing. Also mark any declarations/references within generated source as implicit.

Resolves rdar://107209132.