### PR TITLE
[Macros] Unpack DiagnosticsError into separate diagnostics

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -373,6 +373,14 @@ func expandFreestandingMacroInProcess(
       print("not an expression macro or a declaration macro")
       return nil
     }
+  } catch let diagsError as DiagnosticsError {
+    for diag in diagsError.diagnostics {
+      sourceManager.diagnose(
+        diagnostic: diag,
+        messageSuffix: " (from macro '\(macroName)')"
+      )
+    }
+    return nil
   } catch {
     // Record the error
     sourceManager.diagnose(
@@ -805,6 +813,15 @@ func expandAttachedMacroInProcess(
       print("\(macroPtr) does not conform to any known attached macro protocol")
       return nil
     }
+  } catch let diagsError as DiagnosticsError {
+    for diag in diagsError.diagnostics {
+      sourceManager.diagnose(
+        diagnostic: diag,
+        messageSuffix: " (from macro '\(macroName)')"
+      )
+    }
+
+    return nil
   } catch {
     // Record the error
     // FIXME: Need to decide where to diagnose the error:

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -310,23 +310,35 @@ func expandFreestandingMacroInProcess(
     discriminator: discriminator
   )
 
+  guard let parentExpansion = macroSyntax.asProtocol(
+    FreestandingMacroExpansionSyntax.self
+  ) else {
+    print("not on a macro expansion node: \(macroSyntax.recursiveDescription)")
+    return nil
+  }
+
+  let macroName = parentExpansion.macro.text
+
+  // Make sure we emit all of the diagnostics from the context.
+  defer {
+    // Emit diagnostics accumulated in the context.
+    for diag in context.diagnostics {
+      sourceManager.diagnose(
+        diagnostic: diag,
+        messageSuffix: " (from macro '\(macroName)')"
+      )
+    }
+
+    context.diagnostics = []
+  }
+
   let macroPtr = macroPtr.bindMemory(to: ExportedMacro.self, capacity: 1)
 
-  let macroName: String
   let evaluatedSyntax: Syntax
   do {
     switch macroPtr.pointee.macro {
     // Handle expression macro.
     case let exprMacro as ExpressionMacro.Type:
-      guard let parentExpansion = macroSyntax.asProtocol(
-        FreestandingMacroExpansionSyntax.self
-      ) else {
-        print("not on a macro expansion node: \(macroSyntax.recursiveDescription)")
-        return nil
-      }
-
-      macroName = parentExpansion.macro.text
-
       func expandExpressionMacro<Node: FreestandingMacroExpansionSyntax>(
         _ node: Node
       ) throws -> ExprSyntax {
@@ -346,14 +358,6 @@ func expandFreestandingMacroInProcess(
     // Handle declaration macro. The resulting decls are wrapped in a
     // `CodeBlockItemListSyntax`.
     case let declMacro as DeclarationMacro.Type:
-      guard let parentExpansion = macroSyntax.asProtocol(
-        FreestandingMacroExpansionSyntax.self
-      ) else {
-        print("not on a macro expansion decl: \(macroSyntax.recursiveDescription)")
-        return nil
-      }
-      macroName = parentExpansion.macro.text
-
       func expandDeclarationMacro<Node: FreestandingMacroExpansionSyntax>(
         _ node: Node
       ) throws -> [DeclSyntax] {
@@ -373,32 +377,9 @@ func expandFreestandingMacroInProcess(
       print("not an expression macro or a declaration macro")
       return nil
     }
-  } catch let diagsError as DiagnosticsError {
-    for diag in diagsError.diagnostics {
-      sourceManager.diagnose(
-        diagnostic: diag,
-        messageSuffix: " (from macro '\(macroName)')"
-      )
-    }
-    return nil
   } catch {
-    // Record the error
-    sourceManager.diagnose(
-      diagnostic: Diagnostic(
-        node: macroSyntax,
-        message: ThrownErrorDiagnostic(message: String(describing: error))
-      ),
-      messageSuffix: " (from macro '\(macroName)')"
-    )
+    context.addDiagnostics(from: error, node: macroSyntax)
     return nil
-  }
-
-  // Emit diagnostics accumulated in the context.
-  for diag in context.diagnostics {
-    sourceManager.diagnose(
-      diagnostic: diag,
-      messageSuffix: " (from macro '\(macroName)')"
-    )
   }
 
   return evaluatedSyntax.trimmedDescription
@@ -678,6 +659,20 @@ func expandAttachedMacroInProcess(
   )
 
   let macroName = customAttrNode.attributeName.trimmedDescription
+
+  // Emit all of the accumulated diagnostics before we exit.
+  defer {
+    // Emit diagnostics accumulated in the context.
+    for diag in context.diagnostics {
+      sourceManager.diagnose(
+        diagnostic: diag,
+        messageSuffix: " (from macro '\(macroName)')"
+      )
+    }
+
+    context.diagnostics = []
+  }
+
   var expandedSources: [String]
   do {
     switch (macro, macroRole) {
@@ -813,35 +808,9 @@ func expandAttachedMacroInProcess(
       print("\(macroPtr) does not conform to any known attached macro protocol")
       return nil
     }
-  } catch let diagsError as DiagnosticsError {
-    for diag in diagsError.diagnostics {
-      sourceManager.diagnose(
-        diagnostic: diag,
-        messageSuffix: " (from macro '\(macroName)')"
-      )
-    }
-
-    return nil
   } catch {
-    // Record the error
-    // FIXME: Need to decide where to diagnose the error:
-    sourceManager.diagnose(
-      diagnostic: Diagnostic(
-        node: Syntax(declarationNode),
-        message: ThrownErrorDiagnostic(message: String(describing: error))
-      ),
-      messageSuffix: " (from macro '\(macroName)')"
-    )
-
+    context.addDiagnostics(from: error, node: declarationNode)
     return nil
-  }
-
-  // Emit diagnostics accumulated in the context.
-  for diag in context.diagnostics {
-    sourceManager.diagnose(
-      diagnostic: diag,
-      messageSuffix: " (from macro '\(macroName)')"
-    )
   }
 
   return expandedSources

--- a/test/Macros/macro_expand_throwing.swift
+++ b/test/Macros/macro_expand_throwing.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Make sure the diagnostic comes through...
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
 
 // Make sure the diagnostic doesn't crash in SILGen
 // RUN: not %target-swift-frontend -swift-version 5 -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g
@@ -12,9 +12,22 @@
 
 @freestanding(expression) macro myWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "WarningMacro")
 
+@freestanding(expression) macro myError(_ message: String) = #externalMacro(module: "MacroDefinition", type: "ErrorMacro")
+
 func testThrownError() {
   let name = "hello"
   #myWarning (name) // expected-error{{#myWarning macro requires a string literal (from macro 'myWarning')}}
 
   #myWarning("experimental features ahead") // expected-warning{{experimental features ahead}}
 }
+
+#if TEST_DIAGNOSTICS
+func testThrownErrors() {
+  let name = "hello"
+  #myError(
+    name
+  ) // expected-error@-1{{macro requires a string literal (from macro 'myError')}}
+
+  #myError("experimental features ahead") // expected-error{{experimental features ahead}}
+}
+#endif


### PR DESCRIPTION
* *Explanation*: When a macro throws a `DiagnosticsError`, which can bundle together multiple diagnostics, make sure to "unpack" those into separate diagnostics. We were flattening them into one error diagnostic that lots all of the specific locations / highlights / Fix-Its of the originals.
* Scope: Only affects macros that produce diagnostics.
* Issue: rdar://107289985.
* Risk: Very low; it's replacing some bespoke code with the use of a common entry point.
* Testing: Additional tests added.
* Reviewer: @bnbarham
* Main branch PR: #64744