### PR TITLE
[5.9] don't print macro definitions in symbol graphs

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -484,6 +484,9 @@ struct PrintOptions {
   /// of the alias.
   bool PrintTypeAliasUnderlyingType = false;
 
+  /// Print the definition of a macro, e.g. `= #externalMacro(...)`.
+  bool PrintMacroDefinitions = true;
+
   /// Use aliases when printing references to modules to avoid ambiguities
   /// with types sharing a name with a module.
   bool AliasModuleNames = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4709,38 +4709,40 @@ void PrintAST::visitMacroDecl(MacroDecl *decl) {
     Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
   }
 
-  if (decl->definition) {
-    ASTContext &ctx = decl->getASTContext();
-    SmallString<64> scratch;
-    Printer << " = "
-            << extractInlinableText(ctx.SourceMgr, decl->definition, scratch);
-  } else {
-    auto def = decl->getDefinition();
-    switch (def.kind) {
-    case MacroDefinition::Kind::Invalid:
-    case MacroDefinition::Kind::Undefined:
-      // Nothing to do.
-      break;
+  if (Options.PrintMacroDefinitions) {
+    if (decl->definition) {
+      ASTContext &ctx = decl->getASTContext();
+      SmallString<64> scratch;
+      Printer << " = "
+              << extractInlinableText(ctx.SourceMgr, decl->definition, scratch);
+    } else {
+      auto def = decl->getDefinition();
+      switch (def.kind) {
+      case MacroDefinition::Kind::Invalid:
+      case MacroDefinition::Kind::Undefined:
+        // Nothing to do.
+        break;
 
-    case MacroDefinition::Kind::External: {
-      auto external = def.getExternalMacro();
-      Printer << " = #externalMacro(module: \"" << external.moduleName
-              << "\", " << "type: \"" << external.macroTypeName << "\")";
-      break;
-    }
-
-    case MacroDefinition::Kind::Builtin:
-      Printer << " = Builtin.";
-      switch (def.getBuiltinKind()) {
-      case BuiltinMacroKind::ExternalMacro:
-        Printer << "ExternalMacro";
+      case MacroDefinition::Kind::External: {
+        auto external = def.getExternalMacro();
+        Printer << " = #externalMacro(module: \"" << external.moduleName
+                << "\", " << "type: \"" << external.macroTypeName << "\")";
         break;
       }
-      break;
 
-    case MacroDefinition::Kind::Expanded:
-      Printer << " = " << def.getExpanded().getExpansionText();
-      break;
+      case MacroDefinition::Kind::Builtin:
+        Printer << " = Builtin.";
+        switch (def.getBuiltinKind()) {
+        case BuiltinMacroKind::ExternalMacro:
+          Printer << "ExternalMacro";
+          break;
+        }
+        break;
+
+      case MacroDefinition::Kind::Expanded:
+        Printer << " = " << def.getExpanded().getExpansionText();
+        break;
+      }
     }
   }
 

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -69,6 +69,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   Opts.PrintInherited = false;
   Opts.ExplodeEnumCaseDecls = true;
   Opts.PrintFactoryInitializerComment = false;
+  Opts.PrintMacroDefinitions = false;
 
   Opts.ExclusiveAttrList.clear();
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Inputs/stringify_macro.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Inputs/stringify_macro.swift
@@ -1,0 +1,18 @@
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.argumentList.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "(\(argument), \(StringLiteralExprSyntax(content: argument.description)))"
+  }
+}

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
@@ -1,0 +1,152 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/stringify_macro.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %target-swift-frontend -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name Macros -emit-module -emit-module-path %t/Macros.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %{python} -m json.tool %t/Macros.symbols.json %t/Macros.formatted.symbols.json
+
+// Make sure that the `= #externalMacro(...)` doesn't show up in declaration fragments and in names fragments.
+
+// RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json --check-prefix NAMES
+
+// '-enable-experimental-feature Macros' requires an asserts build.
+// REQUIRES: asserts
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+// CHECK:      "declarationFragments": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "attribute",
+// CHECK-NEXT:         "spelling": "@freestanding"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": "(expression) "
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "keyword",
+// CHECK-NEXT:         "spelling": "macro"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": " "
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "identifier",
+// CHECK-NEXT:         "spelling": "stringify"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": "<"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "genericParameter",
+// CHECK-NEXT:         "spelling": "T"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": ">("
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "externalParam",
+// CHECK-NEXT:         "spelling": "_"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": " "
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "internalParam",
+// CHECK-NEXT:         "spelling": "value"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": ": "
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "typeIdentifier",
+// CHECK-NEXT:         "spelling": "T",
+// CHECK-NEXT:         "preciseIdentifier": "s:6Macros1TL_xmfp"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": ") -> ("
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "typeIdentifier",
+// CHECK-NEXT:         "spelling": "T",
+// CHECK-NEXT:         "preciseIdentifier": "s:6Macros1TL_xmfp"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": ", "
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "typeIdentifier",
+// CHECK-NEXT:         "spelling": "String",
+// CHECK-NEXT:         "preciseIdentifier": "s:SS"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:         "kind": "text",
+// CHECK-NEXT:         "spelling": ")"
+// CHECK-NEXT:     }
+// CHECK-NEXT: ],
+
+// NAMES:      "names": {
+// NAMES-NEXT:     "title": "stringify(_:)",
+// NAMES-NEXT:     "subHeading": [
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "keyword",
+// NAMES-NEXT:             "spelling": "macro"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "text",
+// NAMES-NEXT:             "spelling": " "
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "identifier",
+// NAMES-NEXT:             "spelling": "stringify"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "text",
+// NAMES-NEXT:             "spelling": "<"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "genericParameter",
+// NAMES-NEXT:             "spelling": "T"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "text",
+// NAMES-NEXT:             "spelling": ">("
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "typeIdentifier",
+// NAMES-NEXT:             "spelling": "T",
+// NAMES-NEXT:             "preciseIdentifier": "s:6Macros1TL_xmfp"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "text",
+// NAMES-NEXT:             "spelling": ") -> ("
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "typeIdentifier",
+// NAMES-NEXT:             "spelling": "T",
+// NAMES-NEXT:             "preciseIdentifier": "s:6Macros1TL_xmfp"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "text",
+// NAMES-NEXT:             "spelling": ", "
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "typeIdentifier",
+// NAMES-NEXT:             "spelling": "String",
+// NAMES-NEXT:             "preciseIdentifier": "s:SS"
+// NAMES-NEXT:         },
+// NAMES-NEXT:         {
+// NAMES-NEXT:             "kind": "text",
+// NAMES-NEXT:             "spelling": ")"
+// NAMES-NEXT:         }
+// NAMES-NEXT:     ]
+// NAMES-NEXT: },


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64732

rdar://106862694

- **Explanation**: The symbol-graph representation of macros includes the macro definition, which is not useful for a user of a macro.
- **Scope**: Affects users of macros who are reading documentation of those macros.
- **Issue**: rdar://106862694
- **Risk**: Low. This is a very light modification of the AST Printer code to optionally skip printing macro definitions, which is only turned on in SymbolGraphGen.
- **Testing**: A test has been added to test the new behavior. Existing automated tests pass.
- **Reviewer**: @DougGregor 