### PR TITLE
[5.9] Sema: Relax `@backDeployed` availability conflict diagnostics.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4320,15 +4320,19 @@ void AttributeChecker::checkBackDeployedAttrs(
     // Unavailable decls cannot be back deployed.
     if (auto unavailableAttrPair = VD->getSemanticUnavailableAttr()) {
       auto unavailableAttr = unavailableAttrPair.value().first;
-      DeclName name;
-      unsigned accessorKind;
-      std::tie(accessorKind, name) = getAccessorKindAndNameForDiagnostics(VD);
-      diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr,
-               accessorKind, name, prettyPlatformString(Platform));
-      diagnose(unavailableAttr->AtLoc, diag::availability_marked_unavailable,
-               accessorKind, name)
-          .highlight(unavailableAttr->getRange());
-      continue;
+
+      if (unavailableAttr->Platform == PlatformKind::none ||
+          unavailableAttr->Platform == Attr->Platform) {
+        DeclName name;
+        unsigned accessorKind;
+        std::tie(accessorKind, name) = getAccessorKindAndNameForDiagnostics(VD);
+        diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr,
+                 accessorKind, name, prettyPlatformString(Platform));
+        diagnose(unavailableAttr->AtLoc, diag::availability_marked_unavailable,
+                 accessorKind, name)
+            .highlight(unavailableAttr->getRange());
+        continue;
+      }
     }
 
     // Verify that the decl is available before the back deployment boundary.

--- a/test/attr/attr_backDeployed_availability_extension.swift
+++ b/test/attr/attr_backDeployed_availability_extension.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library
+// RUN: %target-typecheck-verify-swift -parse-as-library -application-extension
+
+@available(macOS 11, *)
+@available(macOSApplicationExtension, unavailable)
+public struct UnavailableMacOSExtensionsStruct {
+  @backDeployed(before: macOS 12)
+  public func memberFunc() {}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64750.

Only diagnose `@backDeployed` as conflicting with unavailability if the attribute that is making the declaration unavailable is unconditional or it is for the same base platform. For example, it should be allowed to back deploy a function on macOS while making that function unavailable for application extensions on macOS.

Resolves rdar://107291474
