### PR TITLE
[Frontend] Accept the frontend arg `-library-level=`

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -501,6 +501,10 @@ def library_level : Separate<["-"], "library-level">,
   MetaVarName<"<level>">,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Library distribution level 'api', 'spi' or 'other' (the default)">;
+def library_level_EQ : Joined<["-"], "library-level=">,
+  MetaVarName<"<level>">,
+  Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
+  Alias<library_level>;
 
 def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption,

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -16,6 +16,9 @@
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/PublicImports.swift \
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ -module-cache-path %t \
 // RUN:   -library-level api -verify -module-name MainLib
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/PublicImports.swift \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ -module-cache-path %t \
+// RUN:   -library-level=api -verify -module-name MainLib
 
 /// Expect no errors when building an SPI client.
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/PublicImports.swift \
@@ -71,9 +74,14 @@ import LocalClang // expected-error{{private module 'LocalClang' is imported pub
 @_spiOnly import LocalClang
 
 /// Test error message on an unknown library level name.
-// RUN: not %target-swift-frontend -typecheck %s -library-level ThatsNotALibraryLevel 2>&1 \
+// RUN: not %target-swift-frontend -typecheck %t/Empty.swift \
+// RUN:   -library-level ThatsNotALibraryLevel 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix CHECK-ARG
+// RUN: not %target-swift-frontend -typecheck %t/Empty.swift \
+// RUN:   -library-level=ThatsNotALibraryLevel 2>&1 \
 // RUN:   | %FileCheck %s --check-prefix CHECK-ARG
 // CHECK-ARG: error: unknown library level 'ThatsNotALibraryLevel', expected one of 'api', 'spi', 'ipi', or 'other'
+//--- Empty.swift
 
 /// Expect no errors in swiftinterfaces.
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \


### PR DESCRIPTION
Add proper support for `-library-level=`. As seen in #64724, it used to be accepted but ignored silently.