### PR TITLE
[Tests] Disable path lookup test for OS stdlib.

### DIFF
--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -11,6 +11,9 @@
 // RUN: env %env-SWIFT_ROOT=%t/swift-root %target-run %t/paths-test | %FileCheck %s --check-prefix CHECK-FR
 // REQUIRES: executable_test
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // This can't be done in unittests, because that statically links the runtime
 // so we get the wrong paths.  We explicitly want to test that we get the
 // path we expect (that is, the path to the runtime, and paths relative to


### PR DESCRIPTION
Path lookup needs the new stdlib.

rdar://107399270
