### PR TITLE
🍒[cxx-interop] Do not try linking with swiftstd

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -490,15 +490,13 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
     if (!getSwiftModule()->getName().is("Cxx"))
       this->addLinkLibrary(LinkLibrary("swiftCxx", LibraryKind::Library));
 
-    // Only link with std on platforms where the overlay is available.
-    // Do not try to link std with itself.
+    // Only link with CxxStdlib on platforms where the overlay is available.
+    // Do not try to link CxxStdlib with itself.
     if ((target.isOSDarwin() || (target.isOSLinux() && !target.isAndroid())) &&
         !getSwiftModule()->getName().is("Cxx") &&
         !getSwiftModule()->getName().is("CxxStdlib") &&
         !getSwiftModule()->getName().is("std")) {
       this->addLinkLibrary(LinkLibrary("swiftCxxStdlib", LibraryKind::Library));
-      if (target.isOSDarwin())
-        this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
     }
   }
 


### PR DESCRIPTION
This fixes an ld warning:
```
ld: warning: Could not find or use auto-linked library ‘swiftstd’
```

`swiftstd` was renamed to `swiftCxxStdlib`. We were still trying to link with `swiftstd` for some time to allow building with hosttools and to keep the CI green, however a new toolchain was released since the module was renamed, so this is no longer needed.

rdar://107412807
(cherry picked from commit 00b327f1edae2ff282755533cbd5d2dffd10dd41)