### PR TITLE
[🍒][cxx-interop] Mark clang-related requests as un-cached.

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -413,12 +413,9 @@ SourceLoc extractNearestSourceLoc(SafeUseOfCxxDeclDescriptor desc);
 
 class IsSafeUseOfCxxDecl
     : public SimpleRequest<IsSafeUseOfCxxDecl, bool(SafeUseOfCxxDeclDescriptor),
-                           RequestFlags::Cached> {
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
-
-  // Caching
-  bool isCached() const { return true; }
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };


### PR DESCRIPTION
Pointers from clang appear to be unstable in some capacity. My theory is that clang loads one module, then frees its AST when it's done, or maybe just re-allocates the AST at some point. In any case, we cannot cache requests on clang pointers.

This should fix the flakeyness issue that we've been seeing for a while.