### PR TITLE
[Assertions] Provide the flag to dodge the "type reconstruction" assertions

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -921,6 +921,9 @@ private:
         Ty->dump(llvm::errs());
         if (Sig)
           llvm::errs() << "Generic signature: " << Sig << "\n";
+        llvm::errs() << SWIFT_CRASH_BUG_REPORT_MESSAGE << "\n"
+          << "Pass '-Xfrontend -disable-round-trip-debug-types' to disable "
+             "this assertion.\n";
         abort();
       } else if (!Reconstructed->isEqual(Ty) &&
                  // FIXME: Some existential types are reconstructed without
@@ -935,6 +938,9 @@ private:
         Reconstructed->dump(llvm::errs());
         if (Sig)
           llvm::errs() << "Generic signature: " << Sig << "\n";
+        llvm::errs() << SWIFT_CRASH_BUG_REPORT_MESSAGE << "\n"
+          << "Pass '-Xfrontend -disable-round-trip-debug-types' to disable "
+             "this assertion.\n";
         abort();
       }
     }


### PR DESCRIPTION
When the compiler aborts due to a type reconstruction error, ask the user to submit a bug report and provide the flag needed to disable this check.
