### PR TITLE
Ban building runtimes using compilers without SwiftCC/SwiftAsyncCC

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -198,20 +198,24 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define SWIFT_CC_c
 
 // SWIFT_CC(swift) is the Swift calling convention.
-// FIXME: the next comment is false.
-// Functions outside the stdlib or runtime that include this file may be built 
-// with a compiler that doesn't support swiftcall; don't define these macros
-// in that case so any incorrect usage is caught.
-#if __has_attribute(swiftcall)
+
+#if __has_attribute(swiftcall) && __has_attribute(swift_context) &&            \
+    __has_attribute(swift_error_result) &&                                     \
+    __has_attribute(swift_indirect_result)
 #define SWIFT_CC_swift __attribute__((swiftcall))
 #define SWIFT_CONTEXT __attribute__((swift_context))
 #define SWIFT_ERROR_RESULT __attribute__((swift_error_result))
 #define SWIFT_INDIRECT_RESULT __attribute__((swift_indirect_result))
 #else
-#define SWIFT_CC_swift
-#define SWIFT_CONTEXT
-#define SWIFT_ERROR_RESULT
-#define SWIFT_INDIRECT_RESULT
+
+#if _MSC_VER && !__INTEL_COMPILER
+#pragma message(                                                               \
+    "Warning: C++ Compiler does not support swiftcall calling conventions. SWIFT_CC_swift macros not defined!")
+#else
+#warning                                                                       \
+    "C++ Compiler does not support swiftcall calling conventions. SWIFT_CC_swift macros not defined!"
+#endif
+
 #endif
 
 #if __has_attribute(swift_async_context)
@@ -231,7 +235,15 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #if __has_feature(swiftasynccc) && __has_attribute(swiftasynccall)
 #define SWIFT_CC_swiftasync __attribute__((swiftasynccall))
 #else
-#define SWIFT_CC_swiftasync SWIFT_CC_swift
+
+#if _MSC_VER && !__INTEL_COMPILER
+#pragma message(                                                               \
+    "Warning: C++ Compiler does not support swiftcall calling conventions. SWIFT_CC_swiftasync macros not defined!")
+#else
+#warning                                                                       \
+    "C++ Compiler does not support async-swift calling conventions. SWIFT_CC_swiftasync macros not defined!"
+#endif
+
 #endif
 
 // SWIFT_CC(PreserveMost) is used in the runtime implementation to prevent

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -47,6 +47,13 @@
 #include <dlfcn.h>
 #endif
 
+// Check for valid Swift-async calling convention support here to ensure that
+// the concurrency runtime is being built correctly.
+#if !__has_feature(swiftasynccc) || !__has_attribute(swiftasynccall) ||        \
+    !__has_attribute(swift_async_context)
+#error "The Swift concurrency runtime must be built with a C++ compiler that supports swiftasynccall calling conventions."
+#endif
+
 #if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT)
 #include <Availability.h>
 #include <TargetConditionals.h>


### PR DESCRIPTION
Building the runtime with a compiler that doesn't understand swift calling conventions is playing with fire, and not a fun fire. Also, swapping out swift async calling conventions with normal swift CC is not a great idea either. Emit an error message saying stopping folks from burning themselves.

Folks keep seeing this and thinking that they can build without the right compiler and arguing with me about not being able to use a random compiler to build the runtime "because it's just normal C++". The Swift async calling conventions are different enough that just falling back on synchronous calling conventions (especially without telling the Swift compiler) is a risky endeavor, if it works at all.