### PR TITLE
[cxx-interop] Rename `swift-interop-support.h` -> `swift/bridging`.

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -43,20 +43,20 @@ add_dependencies(swiftClangImporter
 
 set_swift_llvm_is_available(swiftClangImporter)
 
-# Mark - copy "swift-interop-support.h" into the local include directory and install it
-# into the compiler toolchain.
+# Mark - copy "bridging" (support header) into the local include directory and
+# install it into the compiler toolchain.
 set(SWIFTINC_DIR
     "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/include/swift")
 
 add_custom_command(
-    OUTPUT "${SWIFTINC_DIR}/swift-interop-support.h"
-    COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/swift-interop-support.h" "${SWIFTINC_DIR}")
+    OUTPUT "${SWIFTINC_DIR}/bridging"
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/bridging" "${SWIFTINC_DIR}")
 
 add_custom_target("copy_cxxInterop_support_header"
-    DEPENDS "${SWIFTINC_DIR}/swift-interop-support.h"
+    DEPENDS "${SWIFTINC_DIR}/bridging"
     COMMENT "Copying C++ interop support header to ${SWIFTINC_DIR}")
 
-swift_install_in_component(FILES "${CMAKE_CURRENT_SOURCE_DIR}/swift-interop-support.h"
+swift_install_in_component(FILES "${CMAKE_CURRENT_SOURCE_DIR}/bridging"
                            DESTINATION "include/swift"
                            COMPONENT compiler)
 

--- a/lib/ClangImporter/bridging
+++ b/lib/ClangImporter/bridging
@@ -1,4 +1,4 @@
-//===--- swift-interop-support.h - C++ and Swift Interop --------*- C++ -*-===//
+//===------------------ bridging - C++ and Swift Interop --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
There are some updates to the contents as well. Those will be a different patch.