### PR TITLE
[5.9][Dependency Scanning] Do not track source module dependencies separately in `SwiftDependencyScanningService`

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -567,14 +567,6 @@ class SwiftDependencyScanningService {
       clang::tooling::dependencies::DependencyScanningFilesystemSharedCache>
       SharedFilesystemCache;
 
-  /// All cached Swift source module dependencies, in the order in which they
-  /// were encountered
-  std::vector<ModuleDependencyID> AllSourceModules;
-
-  /// Dependencies for all Swift source-based modules discovered. Each one is
-  /// the main module of a prior invocation of the scanner.
-  ModuleNameToDependencyMap SwiftSourceModuleDependenciesMap;
-
   /// A map from a String representing the target triple of a scanner invocation
   /// to the corresponding cached dependencies discovered so far when using this
   /// triple.
@@ -650,10 +642,6 @@ private:
   ContextSpecificGlobalCacheState *
   getCacheForScanningContextHash(StringRef scanContextHash) const;
 
-  /// Look for source-based module dependency details
-  Optional<const ModuleDependencyInfo*>
-  findSourceModuleDependency(StringRef moduleName) const;
-
   /// Look for module dependencies for a module with the given name
   ///
   /// \returns the cached result, or \c None if there is no cached entry.
@@ -667,28 +655,17 @@ private:
                                                ModuleDependencyInfo dependencies,
                                                StringRef scanContextHash);
 
-  /// Record source-module dependencies for the given module.
-  const ModuleDependencyInfo *recordSourceDependency(StringRef moduleName,
-                                                     ModuleDependencyInfo dependencies);
-
   /// Update stored dependencies for the given module.
   const ModuleDependencyInfo *updateDependency(ModuleDependencyID moduleID,
                                                ModuleDependencyInfo dependencies,
                                                StringRef scanContextHash);
 
-  /// Reference the list of all module dependencies that are not source-based
-  /// modules (i.e. interface dependencies, binary dependencies, clang
-  /// dependencies).
+  /// Reference the list of all module dependency infos for a given scanning context
   const std::vector<ModuleDependencyID> &
-  getAllNonSourceModules(StringRef scanningContextHash) const {
+  getAllModules(StringRef scanningContextHash) const {
     auto contextSpecificCache =
         getCacheForScanningContextHash(scanningContextHash);
     return contextSpecificCache->AllModules;
-  }
-
-  /// Return the list of all source-based modules discovered by this cache
-  const std::vector<ModuleDependencyID> &getAllSourceModules() const {
-    return AllSourceModules;
   }
 };
 
@@ -756,10 +733,6 @@ public:
   /// to a kind-qualified set of module IDs.
   void resolveDependencyImports(ModuleDependencyID moduleID,
                                 const std::vector<ModuleDependencyID> &dependencyIDs);
-
-  const std::vector<ModuleDependencyID> &getAllSourceModules() const {
-    return globalScanningService.getAllSourceModules();
-  }
   
   StringRef getMainModuleName() const {
     return mainScanModuleName;

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -386,7 +386,8 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
       for (const auto &mod : *bridgingModuleDeps)
         moduleDep.addBridgingModuleDependency(mod, alreadyAdded);
 
-      cache.recordSourceDependency(currentModuleName, std::move(moduleDep));
+      cache.recordDependency(currentModuleName, std::move(moduleDep),
+                             getContextHash());
       hasCurrentModule = false;
       break;
     }
@@ -991,37 +992,9 @@ unsigned ModuleDependenciesCacheSerializer::getArrayID(ModuleDependencyID module
 
 void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
     const SwiftDependencyScanningService &cache) {
-  for (auto &moduleID : cache.getAllSourceModules()) {
-    assert(moduleID.second == ModuleDependencyKind::SwiftSource &&
-           "Expected source-based dependency");
-    auto optionalDependencyInfo =
-        cache.findSourceModuleDependency(moduleID.first);
-    assert(optionalDependencyInfo.has_value() && "Expected dependency info.");
-    auto dependencyInfo = optionalDependencyInfo.value();
-    // Add the module's name
-    addIdentifier(moduleID.first);
-    // Add the module's dependencies
-    addStringArray(moduleID, ModuleIdentifierArrayKind::DependencyImports,
-                   dependencyInfo->getModuleImports());
-    addDependencyIDArray(moduleID, ModuleIdentifierArrayKind::QualifiedModuleDependencyIDs,
-                         dependencyInfo->getModuleDependencies());
-    auto swiftSourceDeps = dependencyInfo->getAsSwiftSourceModule();
-    assert(swiftSourceDeps);
-    addStringArray(moduleID, ModuleIdentifierArrayKind::ExtraPCMArgs,
-                   swiftSourceDeps->textualModuleDetails.extraPCMArgs);
-    if (swiftSourceDeps->textualModuleDetails.bridgingHeaderFile.has_value())
-      addIdentifier(swiftSourceDeps->textualModuleDetails.bridgingHeaderFile.value());
-    addStringArray(moduleID, ModuleIdentifierArrayKind::SourceFiles,
-                   swiftSourceDeps->sourceFiles);
-    addStringArray(moduleID, ModuleIdentifierArrayKind::BridgingSourceFiles,
-                   swiftSourceDeps->textualModuleDetails.bridgingSourceFiles);
-    addStringArray(moduleID, ModuleIdentifierArrayKind::BridgingModuleDependencies,
-                   swiftSourceDeps->textualModuleDetails.bridgingModuleDependencies);
-  }
-
   for (auto &contextHash : cache.getAllContextHashes()) {
     addIdentifier(contextHash);
-    for (auto &moduleID : cache.getAllNonSourceModules(contextHash)) {
+    for (auto &moduleID : cache.getAllModules(contextHash)) {
       auto optionalDependencyInfo = cache.findDependency(moduleID.first,
                                                          moduleID.second,
                                                          contextHash);
@@ -1076,6 +1049,21 @@ void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
           addIdentifier(swiftPHDeps->compiledModulePath);
           addIdentifier(swiftPHDeps->moduleDocPath);
           addIdentifier(swiftPHDeps->sourceInfoPath);
+          break;
+        }
+        case swift::ModuleDependencyKind::SwiftSource: {
+          auto swiftSourceDeps = dependencyInfo->getAsSwiftSourceModule();
+          assert(swiftSourceDeps);
+          addStringArray(moduleID, ModuleIdentifierArrayKind::ExtraPCMArgs,
+                         swiftSourceDeps->textualModuleDetails.extraPCMArgs);
+          if (swiftSourceDeps->textualModuleDetails.bridgingHeaderFile.has_value())
+            addIdentifier(swiftSourceDeps->textualModuleDetails.bridgingHeaderFile.value());
+          addStringArray(moduleID, ModuleIdentifierArrayKind::SourceFiles,
+                         swiftSourceDeps->sourceFiles);
+          addStringArray(moduleID, ModuleIdentifierArrayKind::BridgingSourceFiles,
+                         swiftSourceDeps->textualModuleDetails.bridgingSourceFiles);
+          addStringArray(moduleID, ModuleIdentifierArrayKind::BridgingModuleDependencies,
+                         swiftSourceDeps->textualModuleDetails.bridgingModuleDependencies);
           break;
         }
         case swift::ModuleDependencyKind::Clang: {
@@ -1135,17 +1123,8 @@ void ModuleDependenciesCacheSerializer::writeInterModuleDependenciesCache(
   writeArraysOfIdentifiers();
 
   // Write the core graph
-  // First, write the source modules we've encountered
-  for (auto &moduleID : cache.getAllSourceModules()) {
-    auto dependencyInfo = cache.findSourceModuleDependency(moduleID.first);
-    assert(dependencyInfo.has_value() && "Expected dependency info.");
-    writeModuleInfo(moduleID, llvm::Optional<std::string>(), **dependencyInfo);
-  }
-
-  // Write all non-source modules, for each of the context hashes this scanner
-  // has been used with
   for (auto &contextHash : cache.getAllContextHashes()) {
-    for (auto &moduleID : cache.getAllNonSourceModules(contextHash)) {
+    for (auto &moduleID : cache.getAllModules(contextHash)) {
       auto dependencyInfo = cache.findDependency(moduleID.first,
                                                  moduleID.second,
                                                  contextHash);


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64778
--------------------------------------------
Instead, treat them like any other module that is specific to the scanning context hash of the scan it originates from. Otherwise we may actually have simultaneous scans happening for the same source module but with different context hashes, and the current scheme leads to collisions.
