### PR TITLE
[Observation] Restrict tests for observation to only use built stdlib's and not test in back-deployment

### DIFF
--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -5,6 +5,8 @@
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import StdlibUnittest
 import _Observation


### PR DESCRIPTION
This limits the observation tests such that it requires a built sodlib and tests only on systems that can support it.

Resolves: rdar://107399372