### PR TITLE
[Serialization] Attempt to load transitive implementation-only dependencies on testable imports

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1702,7 +1702,7 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
   if (dependency.isImplementationOnly()) {
     // Implementation-only dependencies are not usually loaded from
     // transitive imports.
-    if (debuggerMode) {
+    if (debuggerMode || forTestable) {
       // In the debugger, try to load the module if possible.
       // Same in the case of a testable import, try to load the dependency
       // but don't fail if it's missing as this could be source breaking.

--- a/test/Serialization/implementation-only-testable.swift
+++ b/test/Serialization/implementation-only-testable.swift
@@ -1,0 +1,61 @@
+/// Implementation-only dependencies of modules imported as testable are
+/// optional, we attempt to load them but don't error if they are missing.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build the hidden implementation-only dependency and the testable module.
+// RUN: %target-swift-frontend -emit-module %t/HiddenDep.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/TestedLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution -I %t \
+// RUN:   -enable-testing
+
+/// A client should ignore the transitive implementation-only dependency for a
+/// normal import.
+// RUN: %target-swift-frontend -typecheck %t/ClientNormalImport.swift -o %t \
+// RUN:   -swift-version 5 -I %t -Rmodule-loading 2>&1 | \
+// RUN:   %FileCheck --check-prefix=CHECK-NOT-LOADED %s
+
+/// A client should load the transitive implementation-only dependency of
+/// a module imported @testable.
+// RUN: %target-swift-frontend -typecheck %t/ClientTestableImport.swift -o %t \
+// RUN:   -swift-version 5 -I %t -Rmodule-loading 2>&1 | %FileCheck %s
+
+/// If the dependency is missing we don't fail at loading, but we may still
+/// fail later accessing decls missing because of references to the not-loaded module.
+// RUN: rm %t/HiddenDep.swiftmodule
+
+/// The transitive dependency is not loaded but a client can still build fine.
+// RUN: %target-swift-frontend -typecheck %t/ClientNormalImport.swift -o %t \
+// RUN:   -swift-version 5 -I %t -Rmodule-loading 2>&1 | \
+// RUN:   %FileCheck %s --check-prefix=CHECK-NOT-LOADED
+
+/// Clients referencing a decl that depends on the hidden module don't see the
+/// decl, it is dropped by deserialization recovery.
+// RUN: %target-swift-frontend -typecheck %t/ClientTestableImport.swift -o %t \
+// RUN:   -swift-version 5 -I %t -verify
+
+//--- HiddenDep.swift
+
+public struct HiddenType {}
+
+//--- TestedLib.swift
+
+@_implementationOnly import HiddenDep
+
+internal func dependsOnHiddenType() -> HiddenType { fatalError() }
+
+//--- ClientNormalImport.swift
+
+/// Note that the import doesn't have to be testable, only the imported module
+/// needs to enable testing. We may want to improve upon this in the future.
+import TestedLib
+// CHECK-NOT-LOADED-NOT: remark: loaded module 'HiddenDep'
+
+//--- ClientTestableImport.swift
+
+@testable import TestedLib
+// CHECK: remark: loaded module 'HiddenDep'
+
+let _ = dependsOnHiddenType() // expected-error {{cannot find 'dependsOnHiddenType' in scope}}


### PR DESCRIPTION
Implementation-only dependencies may be referenced from internal decls. When that module is imported as `@testable`, clients see the internal decls and may fail accessing them if the transitive implementation-only dependencies are not loaded.

Let's consider such transitive implementation-only dependencies as optional for `@testable` clients. As such, the compiler will attempt to load them for test targets, and won't fail if the dependency is missing.

We can make these dependencies required for non-public imports, but it could be project breaking to do so for implementation-only dependencies. Considering them as optional is a decent compromise.

rdar://79459263