### PR TITLE
[5.9][interop][SwiftToCxx] do not error out on -Wnon-modular-include-in-fr…

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -378,24 +378,29 @@ void ClangSyntaxPrinter::printPrimaryCxxTypeName(
 }
 
 void ClangSyntaxPrinter::printIncludeForShimHeader(StringRef headerName) {
-  os << "// Look for the C++ interop support header relative to clang's "
-        "resource dir:\n";
-  os << "//  "
-        "'<toolchain>/usr/lib/clang/<version>/include/../../../swift/"
-        "swiftToCxx'.\n";
-  os << "#if __has_include(<../../../swift/swiftToCxx/" << headerName << ">)\n";
-  os << "#include <../../../swift/swiftToCxx/" << headerName << ">\n";
-  os << "#elif __has_include(<../../../../../lib/swift/swiftToCxx/"
-     << headerName << ">)\n";
-  os << "//  "
-        "'<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/"
-        "swift/swiftToCxx'.\n";
-  os << "#include <../../../../../lib/swift/swiftToCxx/" << headerName << ">\n";
-  os << "// Alternatively, allow user to find the header using additional "
-        "include path into '<toolchain>/lib/swift'.\n";
-  os << "#elif __has_include(<swiftToCxx/" << headerName << ">)\n";
-  os << "#include <swiftToCxx/" << headerName << ">\n";
-  os << "#endif\n";
+  printIgnoredDiagnosticBlock("non-modular-include-in-framework-module", [&] {
+    os << "// Look for the C++ interop support header relative to clang's "
+          "resource dir:\n";
+    os << "//  "
+          "'<toolchain>/usr/lib/clang/<version>/include/../../../swift/"
+          "swiftToCxx'.\n";
+    os << "#if __has_include(<../../../swift/swiftToCxx/" << headerName
+       << ">)\n";
+    os << "#include <../../../swift/swiftToCxx/" << headerName << ">\n";
+    os << "#elif __has_include(<../../../../../lib/swift/swiftToCxx/"
+       << headerName << ">)\n";
+    os << "//  "
+          "'<toolchain>/usr/local/lib/clang/<version>/include/../../../../../"
+          "lib/"
+          "swift/swiftToCxx'.\n";
+    os << "#include <../../../../../lib/swift/swiftToCxx/" << headerName
+       << ">\n";
+    os << "// Alternatively, allow user to find the header using additional "
+          "include path into '<toolchain>/lib/swift'.\n";
+    os << "#elif __has_include(<swiftToCxx/" << headerName << ">)\n";
+    os << "#include <swiftToCxx/" << headerName << ">\n";
+    os << "#endif\n";
+  });
 }
 
 void ClangSyntaxPrinter::printDefine(StringRef macroName) {

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -67,6 +67,9 @@ static void writePtrauthPrologue(raw_ostream &os) {
           os << "# ifndef __ptrauth_swift_value_witness_function_pointer\n";
           os << "#  define __ptrauth_swift_value_witness_function_pointer(x)\n";
           os << "# endif\n";
+          os << "# ifndef __ptrauth_swift_class_method_pointer\n";
+          os << "#  define __ptrauth_swift_class_method_pointer(x)\n";
+          os << "# endif\n";
         });
     os << "#endif\n";
   });

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -59,12 +59,15 @@ static void emitObjCConditional(raw_ostream &out,
 
 static void writePtrauthPrologue(raw_ostream &os) {
   emitCxxConditional(os, [&]() {
-    os << "#if __has_include(<ptrauth.h>)\n";
+    os << "#if defined(__arm64e__) && __has_include(<ptrauth.h>)\n";
     os << "# include <ptrauth.h>\n";
     os << "#else\n";
-    os << "# ifndef __ptrauth_swift_value_witness_function_pointer\n";
-    os << "#  define __ptrauth_swift_value_witness_function_pointer(x)\n";
-    os << "# endif\n";
+    ClangSyntaxPrinter(os).printIgnoredDiagnosticBlock(
+        "reserved-macro-identifier", [&]() {
+          os << "# ifndef __ptrauth_swift_value_witness_function_pointer\n";
+          os << "#  define __ptrauth_swift_value_witness_function_pointer(x)\n";
+          os << "# endif\n";
+        });
     os << "#endif\n";
   });
 }

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-imported-into-framework-module.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-imported-into-framework-module.swift
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/TestFmSwift.swift -typecheck -module-name TestFm -enable-experimental-cxx-interop -emit-clang-header-path %t/TestFm.framework/Headers/TestFm-Swift.h
+
+// RUN: %target-swift-frontend -typecheck %t/SecondSwift.swift -typecheck -module-name Second -enable-experimental-cxx-interop -emit-clang-header-path %t/Second.framework/Headers/Second-Swift.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++17 -fmodules -fcxx-modules -c %t/consumer.cpp -F %t -fsyntax-only -Werror=non-modular-include-in-framework-module
+
+// Check that a client C++ file can use Swift stdlib APIs from two
+// mixed-language C++ and Swift frameworks.
+
+// This will only pass on Darwin with -Werror=non-modular-include-in-framework-module,
+// as the SDK is not modularized on other platforms.
+// REQUIRES: OS=macosx
+
+//--- TestFm.framework/Headers/TestFm.h
+#pragma once
+
+class CxxClass {
+public:
+    int testMethod() const {
+        return 42;
+    }
+};
+
+//--- TestFm.framework/Modules/module.modulemap
+framework module TestFm {
+    umbrella header "TestFm.h"
+
+    export *
+    module * { export * }
+}
+
+module TestFm.Swift {
+    header "TestFm-Swift.h"
+}
+
+//--- TestFmSwift.swift
+
+public func testSwiftFunc() -> String {
+    return ""
+}
+
+//--- Second.framework/Headers/Second.h
+#pragma once
+
+class CxxSecondClass {
+public:
+    int testMethodTwo() const {
+        return 42;
+    }
+};
+
+//--- Second.framework/Modules/module.modulemap
+framework module Second {
+    umbrella header "Second.h"
+
+    export *
+    module * { export * }
+}
+
+module Second.Swift {
+    header "Second-Swift.h"
+}
+
+//--- SecondSwift.swift
+
+public func testSwiftFuncTwo() -> String {
+    return ""
+}
+
+//--- consumer.cpp
+
+#pragma clang module import TestFm
+#pragma clang module import Second
+
+void testUseSwiftStdlibAPIsFromTwoFrameworksImportedViaModules() {
+    auto swiftString = TestFm::testSwiftFunc();
+    auto c1 = swiftString.getCount();
+    auto swiftString2 = Second::testSwiftFuncTwo();
+    auto c2 = swiftString.getCount();
+}

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -90,6 +90,8 @@
 // CHECK-EMPTY:
 // CHECK-NEXT:  #endif
 // CHECK-NEXT: #define SWIFT_CXX_INTEROP_STRING_MIXIN
+// CHECK-NEXT: #pragma clang diagnostic push
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
 // CHECK-NEXT: // Look for the C++ interop support header relative to clang's resource dir:
 // CHECK-NEXT: //  '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
 // CHECK-NEXT: #if __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
@@ -101,6 +103,7 @@
 // CHECK-NEXT: #elif __has_include(<swiftToCxx/_SwiftStdlibCxxOverlay.h>)
 // CHECK-NEXT: #include <swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #endif
+// CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: private:
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) UTF8View final {
@@ -114,6 +117,8 @@
 // CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
+// CHECK: #pragma clang diagnostic push
+// CHECK: #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
 // CHECK: #if __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
 // CHECK-NEXT: #include <../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #elif __has_include(<../../../../../lib/swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
@@ -123,5 +128,6 @@
 // CHECK-NEXT: #elif __has_include(<swiftToCxx/_SwiftStdlibCxxOverlay.h>)
 // CHECK-NEXT: #include <swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #endif
+// CHECK-NEXTZ: #pragma clang diagnostic pop
 
 // CHECK: } // namespace swift

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -47,6 +47,9 @@
 // CHECK-NEXT:  # ifndef __ptrauth_swift_value_witness_function_pointer
 // CHECK-NEXT:  #  define __ptrauth_swift_value_witness_function_pointer(x)
 // CHECK-NEXT:  # endif
+// CHECK-NEXT:  # ifndef __ptrauth_swift_class_method_pointer
+// CHECK-NEXT:  # define __ptrauth_swift_class_method_pointer(x)
+// CHECK-NEXT:  # endif
 // CHECK-NEXT:  #pragma clang diagnostic pop
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #endif

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -39,12 +39,15 @@
 // CHECK-NEXT:  #include <string.h>
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #if defined(__cplusplus)
-// CHECK-NEXT:  #if __has_include(<ptrauth.h>)
+// CHECK-NEXT:  #if defined(__arm64e__) && __has_include(<ptrauth.h>)
 // CHECK-NEXT:  # include <ptrauth.h>
 // CHECK-NEXT:  #else
+// CHECK-NEXT:  #pragma clang diagnostic push
+// CHECK-NEXT:  #pragma clang diagnostic ignored "-Wreserved-macro-identifier"
 // CHECK-NEXT:  # ifndef __ptrauth_swift_value_witness_function_pointer
 // CHECK-NEXT:  #  define __ptrauth_swift_value_witness_function_pointer(x)
 // CHECK-NEXT:  # endif
+// CHECK-NEXT:  #pragma clang diagnostic pop
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #endif
 
@@ -87,6 +90,8 @@
 // CHECK-LABEL: #if defined(__OBJC__)
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #if defined(__cplusplus)
+// CHECK-NEXT:  #pragma clang diagnostic push
+// CHECK-NEXT:  #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
 // CHECK-NEXT:  // Look for the C++ interop support header relative to clang's resource dir:
 // CHECK-NEXT:  //  '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
 // CHECK-NEXT:  #if __has_include(<../../../swift/swiftToCxx/_SwiftCxxInteroperability.h>)
@@ -98,6 +103,7 @@
 // CHECK-NEXT:  #elif __has_include(<swiftToCxx/_SwiftCxxInteroperability.h>)
 // CHECK-NEXT:  #include <swiftToCxx/_SwiftCxxInteroperability.h>
 // CHECK-NEXT:  #endif
+// CHECK-NEXT:  #pragma clang diagnostic pop
 // CHECK-NEXT:  #if __has_feature(objc_modules)
 // CHECK:       #ifndef SWIFT_PRINTED_CORE
 // CHECK:       } // namespace swift


### PR DESCRIPTION
…amework-module clang diagnostic when importing the generated header as part of a framework back into C++ via a Clang module

ptrauth.h isn't modularized in Apple/github/clang due to some SDK issues, so avoid importing it for non-arm64e code.

