### PR TITLE
[Constraint System]  Fix covariant erasure for constrained existentials

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5532,7 +5532,8 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// variable and anything that depends on it to their non-dependent bounds.
 Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
                                          TypeVariableType *openedTypeVar,
-                                         TypePosition outermostPosition);
+                                         TypePosition outermostPosition,
+                                         bool wantNonDependentBound = true);
 
 Type transformFn(Type type, Type existentialBaseType,
                             TypePosition initialPos);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5534,6 +5534,10 @@ Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
                                          TypeVariableType *openedTypeVar,
                                          TypePosition outermostPosition);
 
+Type transformFn(Type type, Type existentialBaseType,
+                            TypePosition initialPos);
+
+
 /// Returns true if a reference to a member on a given base type will apply
 /// its curried self parameter, assuming it has one.
 ///

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -635,19 +635,91 @@ Type GenericSignatureImpl::getNonDependentUpperBounds(Type type) const {
     // If the class contains a type parameter, try looking for a non-dependent
     // superclass.
     while (superclass && superclass->hasTypeParameter()) {
+//      auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
+//      if (!primaryAssocTypes.empty()) {
+//        SmallVector<Type, 2> argTypes;
+//
+//        // Attempt to recover same-type requirements on primary associated types.
+//        for (auto *assocType : primaryAssocTypes) {
+//          // For each primary associated type A of P, compute the reduced type
+//          // of T.[P]A.
+//          auto *memberType = DependentMemberType::get(type, assocType);
+//          auto reducedType = getReducedType(memberType);
+//
+//        }
+//      }
+      
       superclass = superclass->getSuperclass();
     }
-
     if (superclass) {
       types.push_back(superclass);
       hasExplicitAnyObject = false;
     }
   }
+  
+  // Protocol Inheritence
+  // Change here too! if there is a reduced type, erase to it othererwise keep goign until we hit something that has unresolved components
   for (auto *proto : getRequiredProtocols(type)) {
     if (proto->requiresClass())
       hasExplicitAnyObject = false;
+    
+    auto *baseType = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
 
-    types.push_back(proto->getDeclaredInterfaceType());
+    auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
+    if (!primaryAssocTypes.empty()) {
+      SmallVector<Type, 2> argTypes;
+
+      // Attempt to recover same-type requirements on primary associated types.
+      for (auto *assocType : primaryAssocTypes) {
+        // For each primary associated type A of P, compute the reduced type
+        // of T.[P]A.
+        auto *memberType = DependentMemberType::get(type, assocType);
+        auto reducedType = getReducedType(memberType);
+
+        // If the reduced type is at a lower depth than the root generic
+        // parameter of T, then it's constrained.
+        bool hasOuterGenericParam = false;
+        bool hasInnerGenericParam = false;
+        reducedType.visit([&](Type t) {
+          if (auto *paramTy = t->getAs<GenericTypeParamType>()) {
+            unsigned rootDepth = type->getRootGenericParam()->getDepth();
+            if (paramTy->getDepth() == rootDepth)
+              hasInnerGenericParam = true;
+            else {
+              assert(paramTy->getDepth() < rootDepth);
+              hasOuterGenericParam = true;
+            }
+          }
+        });
+
+        if (hasInnerGenericParam && hasOuterGenericParam) {
+          llvm::errs() << "Weird same-type requirements?\n";
+          llvm::errs() << "Interface type: " << type << "\n";
+          llvm::errs() << "Member type: " << memberType << "\n";
+          llvm::errs() << "Reduced member type: " << reducedType << "\n";
+          llvm::errs() << GenericSignature(this) << "\n";
+          abort();
+        }
+
+        if (!hasInnerGenericParam)
+          argTypes.push_back(reducedType);
+      }
+      // We should have either constrained all primary associated types,
+      // or none of them.
+      if (!argTypes.empty()) {
+        if (argTypes.size() != primaryAssocTypes.size()) {
+          llvm::errs() << "Not all primary associated types constrained?\n";
+          llvm::errs() << "Interface type: " << type << "\n";
+          llvm::errs() << GenericSignature(this) << "\n";
+          abort();
+        }
+
+        types.push_back(ParameterizedProtocolType::get(getASTContext(), baseType, argTypes));
+        continue;
+      }
+    }
+
+    types.push_back(baseType);
   }
 
   auto constraint = ProtocolCompositionType::get(

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -631,9 +631,11 @@ Type GenericSignatureImpl::getNonDependentUpperBounds(Type type) const {
   bool hasExplicitAnyObject = requiresClass(type);
 
   llvm::SmallVector<Type, 2> types;
+
+  // Class Inheritence
+  // If the class contains a type parameter that cannot be reduced,
+  // try looking for a non-dependent superclass.
   if (Type superclass = getSuperclassBound(type)) {
-    // If the class contains a type parameter that cannot be reduced,
-    // try looking for a non-dependent superclass.
     while (superclass &&
            superclass->hasTypeParameter()) { // check if the current protocol
                                              // has an associated type]
@@ -661,7 +663,8 @@ Type GenericSignatureImpl::getNonDependentUpperBounds(Type type) const {
   }
   
   // Protocol Inheritence
-  // Change here too! if there is a reduced type, erase to it othererwise keep goign until we hit something that has unresolved components
+  // If there is a reduced type, erase to it.
+  // Otherwise keep going until we hit a type that has unresolved components.
   for (auto *proto : getRequiredProtocols(type)) {
     if (proto->requiresClass())
       hasExplicitAnyObject = false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8760,6 +8760,10 @@ bool MissingExplicitExistentialCoercion::fixItRequiresParens() const {
 
 void MissingExplicitExistentialCoercion::fixIt(
     InFlightDiagnostic &diagnostic) const {
+
+  if (ErasedResultType->hasDependentMember())
+    return;
+
   bool requiresParens = fixItRequiresParens();
 
   auto callRange = getSourceRange();

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2506,6 +2506,14 @@ bool AddExplicitExistentialCoercion::isRequired(
           RequiresCoercion = true;
           return Action::Stop;
         }
+        
+        if (auto *const nominal = erasedMemberTy->getAs<NominalOrBoundGenericNominalType>()) {
+          // Bound Generic Nominals 
+          if (!hasConstrainedAssociatedTypes(member, *existentialType)) {
+            RequiresCoercion = true;
+            return Action::Stop;
+          }
+        }
 
         return Action::SkipChildren;
       }
@@ -2554,6 +2562,7 @@ bool AddExplicitExistentialCoercion::isRequired(
         case RequirementKind::Layout: {
           if (isAnchoredOn(req.getFirstType(), member->getAssocType()))
             return true;
+          
           break;
         }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12653,6 +12653,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
       // `as` coercion.
       if (AddExplicitExistentialCoercion::isRequired(
               *this, func2->getResult(), openedExistentials, locator)) {
+
         if (!shouldAttemptFixes())
           return SolutionKind::Error;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2103,7 +2103,7 @@ typeEraseExistentialSelfReferences(
       if (t->is<GenericTypeParamType>()) {
         erasedTy = baseTy;
       } else {
-        erasedTy = existentialSig->getDependentUpperBounds(t);
+        erasedTy = existentialSig->getNonDependentUpperBounds(t);
       }
 
       if (metatypeDepth) {
@@ -2114,8 +2114,7 @@ typeEraseExistentialSelfReferences(
       return erasedTy;
     });
   };
-
-  return transformFn(refTy, outermostPosition);
+  return transformFn(refTy, outermostPosition);    
 }
 
 Type constraints::typeEraseOpenedExistentialReference(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2103,7 +2103,7 @@ typeEraseExistentialSelfReferences(
       if (t->is<GenericTypeParamType>()) {
         erasedTy = baseTy;
       } else {
-        erasedTy = existentialSig->getNonDependentUpperBounds(t);
+        erasedTy = existentialSig->getDependentUpperBounds(t);
       }
 
       if (metatypeDepth) {

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -305,3 +305,55 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   getP((getC(v) as any P))   // Ok - parens avoid opening suppression
   getP((v.getC() as any P))  // Ok - parens avoid opening suppression
 }
+
+// Generic Class Types
+class C1 {}
+class C2<T>: C1 {}
+
+// Protocols With Associated Types
+protocol P1 {
+  associatedtype A
+  associatedtype B: C2<A>
+
+  func returnAssocTypeB() -> B
+}
+
+func testAssocReturn(p: any P1) { // should return C1
+  let _ = p.returnAssocTypeB() // expected-error {{inferred result type 'C2<(any T).A>' requires explicit coercion due to loss of generic requirements}} {{29-29=as C2<(any P1).A>}}
+}
+
+
+// Protocols With Associated Types
+protocol P2<A> {
+  associatedtype A
+  associatedtype B: C2<A>
+
+  func returnAssocTypeB() -> B
+}
+
+func testAssocReturn(p: any P2<Int>) { // should return C2<A>
+  let _ = p.returnAssocTypeB() // expected-error {{inferred result type 'C2<(any P2).A>' requires explicit coercion due to loss of generic requirements}} {{29-29=as C2<(any P2).A>}}
+}
+
+// Protocols With Primary Associated Types
+protocol U<A> {
+  associatedtype A
+  associatedtype B: C2<A>
+
+  func returnAssocTypeB() -> B
+  func returnPrimaryAssocTypeA() -> A
+  func returnAssocTypeCollection() -> any Collection<A>
+}
+
+func testPrimaryAssocReturn(p: any U<String>) {
+  let _ = p.returnAssocTypeB() // expected-error {{inferred result type 'C2<(any U<String>).A>' requires explicit coercion due to loss of generic requirements}} {{29-29=as C2<(any U<String>).A>}}
+}
+
+func testPrimaryAssocReturn(p: any U<Int>) {
+  let _ = p.returnPrimaryAssocTypeA()
+}
+
+func testPrimaryAssocCollection(p: any U<Float>) -> any Collection {
+  let x = p.returnAssocTypeCollection()
+  return x
+}

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -637,6 +637,7 @@ do {
   let exist: any InvalidTypeParameters
 
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
+  // expected-error@-1 {{inferred result type '(any InvalidTypeParameters).A.A' requires explicit coercion due to loss of generic requirements}}{{16-16=as (any InvalidTypeParameters).A.A}}
   exist.method2(false) // expected-error {{instance method 'method2' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method3(false, false) // expected-error {{instance method 'method3' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   // expected-error@-1 {{member 'method3' cannot be used on value of type 'any InvalidTypeParameters'; consider using a generic constraint instead}}
@@ -794,14 +795,14 @@ do {
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
-    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4
+    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4 // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}{{74-74=as any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes}}
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
     ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.property4
 
     let _: any Class<Struct<Bool>.Inner> & ConcreteAssocTypes =
-      arg[
+      arg[ // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}{{7-7=(}} {{807:8-8=as any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes)}}
         subscript4: Struct<Bool>(), (any ConcreteAssocTypes).self, { true }
       ]
   }
@@ -914,31 +915,45 @@ do {
   let _: Any = exist.method1()
   let _: AnyObject = exist.method2()
   let _: any CovariantAssocTypeErasure = exist.method3()
-  let _: Class2Base = exist.method4() // expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}
-  let _: Class2Base = exist.method5() // expected-error {{inferred result type 'Class2Derived<any CovariantAssocTypeErasure>' requires explicit coercion due to loss of generic requirements}}
+  let _: Class2Base = exist.method4()
+  let _: Class2Base = exist.method5()
   let _: any Class2Base & CovariantAssocTypeErasure = exist.method6()
   let _: any Class2Base & CovariantAssocTypeErasure = exist.method7()
-
-  let _: Any? = exist.method8() // expected-error {{inferred result type 'Optional<Any>' requires explicit coercion due to loss of generic requirements}}
+  let _: Any? = exist.method8()
   let _: (AnyObject, Bool) = exist.method9()
   let _: any CovariantAssocTypeErasure.Type = exist.method10()
-  let _: Array<Class2Base> = exist.method11() // expected-error {{inferred result type 'Array<Class2Base>' requires explicit coercion due to loss of generic requirements}}
-  let _: Dictionary<String, Class2Base> = exist.method12() //expected-error {{inferred result type 'Dictionary<String, Class2Derived<any CovariantAssocTypeErasure>>' requires explicit coercion due to loss of generic requirements}}
+  let _: Array<Class2Base> = exist.method11()
+  let _: Dictionary<String, Class2Base> = exist.method12()
+
+  let _ = exist.method1()
+  let _ = exist.method2()
+  let _ = exist.method3()
+  let _ = exist.method4()
+  let _ = exist.method5() // expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}{{24-24=as Class2Base}}
+  let _ = exist.method6()
+  let _ = exist.method7() // expected-error {{inferred result type 'any Class2Base & CovariantAssocTypeErasure' requires explicit coercion due to loss of generic requirements}}{{24-24=as any Class2Base & CovariantAssocTypeErasure}}
+  let _ = exist.method8()
+  let _ = exist.method9()
+  let _ = exist.method10()
+  let _ = exist.method11()
+  let _ = exist.method12() // expected-error {{inferred result type 'Dictionary<String, Class2Base>' requires explicit coercion due to loss of generic requirements}}{{25-25=as Dictionary<String, Class2Base>}}
+  
+
 }
 do {
   let exist: any CovariantAssocTypeErasureDerived
 
   let _: any CovariantAssocTypeErasureDerived = exist.method1()
-  let _: Class2Base = exist.method2() //expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}
+  let _: Class2Base = exist.method2()
   let _: any CovariantAssocTypeErasureDerived = exist.method3()
   let _: any Class2Base & CovariantAssocTypeErasureDerived = exist.method4()
   let _: any Class2Base & CovariantAssocTypeErasureDerived = exist.method5()
   let _: any Class2Base & CovariantAssocTypeErasureDerived = exist.method6()
   let _: any Class2Base & CovariantAssocTypeErasure & Sequence = exist.method7()
 
-  let _: (any CovariantAssocTypeErasureDerived)? = exist.method8() //expected-error {{inferred result type 'Optional<any CovariantAssocTypeErasureDerived>' requires explicit coercion due to loss of generic requirements}}
+  let _: (any CovariantAssocTypeErasureDerived)? = exist.method8()
   let _: (Class2Base, Bool) = exist.method9()
   let _: any CovariantAssocTypeErasureDerived.Type = exist.method10()
-  let _: Array<any Class2Base & CovariantAssocTypeErasureDerived> = exist.method11() //expected-error {{inferred result type 'Array<any Class2Base & CovariantAssocTypeErasureDerived>' requires explicit coercion due to loss of generic requirements}}
-  let _: Dictionary<String, any Class2Base & CovariantAssocTypeErasureDerived> = exist.method12() //expected-error {{inferred result type 'Dictionary<String, any Class2Derived<any CovariantAssocTypeErasureDerived> & CovariantAssocTypeErasureDerived>' requires explicit coercion due to loss of generic requirements}}
+  let _: Array<any Class2Base & CovariantAssocTypeErasureDerived> = exist.method11()
+  let _: Dictionary<String, any Class2Base & CovariantAssocTypeErasureDerived> = exist.method12()
 }

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -637,7 +637,7 @@ do {
   let exist: any InvalidTypeParameters
 
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
-  // expected-error@-1 {{inferred result type '(any InvalidTypeParameters).A.A' requires explicit coercion due to loss of generic requirements}}{{16-16=as (any InvalidTypeParameters).A.A}}
+  // expected-error@-1 {{inferred result type '(any InvalidTypeParameters).A.A' requires explicit coercion due to loss of generic requirements}}
   exist.method2(false) // expected-error {{instance method 'method2' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method3(false, false) // expected-error {{instance method 'method3' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   // expected-error@-1 {{member 'method3' cannot be used on value of type 'any InvalidTypeParameters'; consider using a generic constraint instead}}
@@ -795,14 +795,14 @@ do {
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
-    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4 // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}{{74-74=as any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes}}
+    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4 // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
     ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.property4
 
     let _: any Class<Struct<Bool>.Inner> & ConcreteAssocTypes =
-      arg[ // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}{{7-7=(}} {{807:8-8=as any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes)}}
+      arg[ // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}
         subscript4: Struct<Bool>(), (any ConcreteAssocTypes).self, { true }
       ]
   }

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -914,31 +914,31 @@ do {
   let _: Any = exist.method1()
   let _: AnyObject = exist.method2()
   let _: any CovariantAssocTypeErasure = exist.method3()
-  let _: Class2Base = exist.method4()
-  let _: Class2Base = exist.method5()
+  let _: Class2Base = exist.method4() // expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}
+  let _: Class2Base = exist.method5() // expected-error {{inferred result type 'Class2Derived<any CovariantAssocTypeErasure>' requires explicit coercion due to loss of generic requirements}}
   let _: any Class2Base & CovariantAssocTypeErasure = exist.method6()
   let _: any Class2Base & CovariantAssocTypeErasure = exist.method7()
 
-  let _: Any? = exist.method8()
+  let _: Any? = exist.method8() // expected-error {{inferred result type 'Optional<Any>' requires explicit coercion due to loss of generic requirements}}
   let _: (AnyObject, Bool) = exist.method9()
   let _: any CovariantAssocTypeErasure.Type = exist.method10()
-  let _: Array<Class2Base> = exist.method11()
-  let _: Dictionary<String, Class2Base> = exist.method12()
+  let _: Array<Class2Base> = exist.method11() // expected-error {{inferred result type 'Array<Class2Base>' requires explicit coercion due to loss of generic requirements}}
+  let _: Dictionary<String, Class2Base> = exist.method12() //expected-error {{inferred result type 'Dictionary<String, Class2Derived<any CovariantAssocTypeErasure>>' requires explicit coercion due to loss of generic requirements}}
 }
 do {
   let exist: any CovariantAssocTypeErasureDerived
 
   let _: any CovariantAssocTypeErasureDerived = exist.method1()
-  let _: Class2Base = exist.method2()
+  let _: Class2Base = exist.method2() //expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}
   let _: any CovariantAssocTypeErasureDerived = exist.method3()
   let _: any Class2Base & CovariantAssocTypeErasureDerived = exist.method4()
   let _: any Class2Base & CovariantAssocTypeErasureDerived = exist.method5()
   let _: any Class2Base & CovariantAssocTypeErasureDerived = exist.method6()
   let _: any Class2Base & CovariantAssocTypeErasure & Sequence = exist.method7()
 
-  let _: (any CovariantAssocTypeErasureDerived)? = exist.method8()
+  let _: (any CovariantAssocTypeErasureDerived)? = exist.method8() //expected-error {{inferred result type 'Optional<any CovariantAssocTypeErasureDerived>' requires explicit coercion due to loss of generic requirements}}
   let _: (Class2Base, Bool) = exist.method9()
   let _: any CovariantAssocTypeErasureDerived.Type = exist.method10()
-  let _: Array<any Class2Base & CovariantAssocTypeErasureDerived> = exist.method11()
-  let _: Dictionary<String, any Class2Base & CovariantAssocTypeErasureDerived> = exist.method12()
+  let _: Array<any Class2Base & CovariantAssocTypeErasureDerived> = exist.method11() //expected-error {{inferred result type 'Array<any Class2Base & CovariantAssocTypeErasureDerived>' requires explicit coercion due to loss of generic requirements}}
+  let _: Dictionary<String, any Class2Base & CovariantAssocTypeErasureDerived> = exist.method12() //expected-error {{inferred result type 'Dictionary<String, any Class2Derived<any CovariantAssocTypeErasureDerived> & CovariantAssocTypeErasureDerived>' requires explicit coercion due to loss of generic requirements}}
 }

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -92,8 +92,14 @@ func protocolCompositionNotSupported1(_: SomeProto & Sequence<Int>) {}
 func protocolCompositionNotSupported2(_: any SomeProto & Sequence<Int>) {}
 // expected-error@-1 {{non-protocol, non-class type 'Sequence<Int>' cannot be used within a protocol-constrained type}}
 
-func increment(n : any Sequence<Float>) {
+func increment(_ n : any Collection<Float>) {
   for value in n {
       _ = value + 1
+  }
+}
+
+func genericIncrement<T: Numeric>(_ n : any Collection<T>) {
+  for value in n {
+    _ = value + 1
   }
 }

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -91,3 +91,9 @@ func protocolCompositionNotSupported1(_: SomeProto & Sequence<Int>) {}
 
 func protocolCompositionNotSupported2(_: any SomeProto & Sequence<Int>) {}
 // expected-error@-1 {{non-protocol, non-class type 'Sequence<Int>' cannot be used within a protocol-constrained type}}
+
+func increment(n : any Sequence<Float>) {
+  for value in n {
+      _ = value + 1
+  }
+}


### PR DESCRIPTION
Constrained existentials should be type erased to an upper bound that is dependent on other type parameters.

```swift
let t: (any Sequence<Int>) = [1, 2]

for value in t {
    let v = value + 1 // the existential is opened so that `value` is generic parameter Int instead of Any
}
```

Fixes rdar://101343646