### PR TITLE
[5.9][AST] Do not copy SearchPathOptions in updateNonUserModule

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -630,7 +630,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -680,11 +680,7 @@ protected:
 
     /// If the map from @objc provided name to top level swift::Decl in this
     /// module is populated
-    ObjCNameLookupCachePopulated : 1,
-
-    /// Whether the module is contained in the SDK or stdlib, or its a system
-    /// module and no SDK was specified.
-    IsNonUserModule : 1
+    ObjCNameLookupCachePopulated : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -661,15 +661,9 @@ public:
   void setIsSystemModule(bool flag = true);
 
   /// \returns true if this module is part of the stdlib or contained within
-  /// the SDK. If no SDK was specified, also falls back to whether the module
-  /// was specified as a system module (ie. it's on the system search path).
-  bool isNonUserModule() const { return Bits.ModuleDecl.IsNonUserModule; }
-
-private:
-  /// Update whether this module is a non-user module, see \c isNonUserModule.
-  /// \p newUnit is the added unit that caused this update, or \c nullptr if
-  /// the update wasn't caused by adding a new unit.
-  void updateNonUserModule(FileUnit *newUnit);
+  /// the SDK. If no SDK was specified, falls back to whether the module was
+  /// specified as a system module (ie. it's on the system search path).
+  bool isNonUserModule() const;
 
 public:
   /// Returns true if the module was rebuilt from a module interface instead

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4194,6 +4194,25 @@ void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);
 void simple_display(llvm::raw_ostream &out, ResultBuilderBodyPreCheck pck);
 
+/// Computes whether a module is part of the stdlib or contained within the
+/// SDK. If no SDK was specified, falls back to whether the module was
+/// specified as a system module (ie. it's on the system search path).
+class IsNonUserModuleRequest
+    : public SimpleRequest<IsNonUserModuleRequest,
+                           bool(ModuleDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, ModuleDecl *mod) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -466,6 +466,9 @@ SWIFT_REQUEST(TypeChecker, GetRuntimeDiscoverableAttributes,
 SWIFT_REQUEST(TypeChecker, LocalDiscriminatorsRequest,
               unsigned(DeclContext *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsNonUserModuleRequest,
+              bool(ModuleDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckObjCImplementationRequest,
               unsigned(ExtensionDecl *),
               Cached, NoLocationInfo)

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -291,6 +291,7 @@ void CompletionLookup::addSubModuleNames(
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResultKind::Declaration, SemanticContextKind::None);
     auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
+    MD->setFailedToLoad();
     Builder.setAssociatedDecl(MD);
     Builder.addBaseName(MD->getNameStr());
     Builder.addTypeAnnotation("Module");
@@ -365,6 +366,8 @@ void CompletionLookup::addImportModuleNames() {
       continue;
 
     auto MD = ModuleDecl::create(ModuleName, Ctx);
+    MD->setFailedToLoad();
+
     Optional<ContextualNotRecommendedReason> Reason = None;
 
     // Imported modules are not recommended.

--- a/test/IDE/complete_diagnostics.swift
+++ b/test/IDE/complete_diagnostics.swift
@@ -77,7 +77,7 @@ import MyModule
 import #^IMPORT^#;
 // IMPORT-DAG: Decl[Module]/None/NotRecommended:   MyModule[#Module#]; name=MyModule; diagnostics=warning:module 'MyModule' is already imported{{$}}
 // IMPORT-DAG: Decl[Module]/None/NotRecommended:   OtherModule[#Module#]; name=OtherModule; diagnostics=note:module 'OtherModule' is already imported via another module import{{$}}
-// IMPORT-DAG: Decl[Module]/None/NotRecommended:   Swift[#Module#]; name=Swift; diagnostics=warning:module 'Swift' is already imported{{$}}
+// IMPORT-DAG: Decl[Module]/None/NotRecommended/IsSystem:   Swift[#Module#]; name=Swift; diagnostics=warning:module 'Swift' is already imported{{$}}
 
 func test(foo: Foo) {
   foo.#^MEMBER^#


### PR DESCRIPTION
* Explanation: Fixes a major performance regression caused by an accidental copy of `SearchPathOptions` when a file is added to a module.
* Scope: All module loading
* Risk: Low; replaces the previously-always-called check with a cached request instead
* Testing: Checked performance regression was fixed
* Original PR: https://github.com/apple/swift/pull/64593