### PR TITLE
[5.9][Attr] Refactor retrieving original attributes

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -851,12 +851,11 @@ SourceLoc DeclAttributes::getStartLoc(bool forModifiers) const {
   return lastAttr ? lastAttr->getRangeWithAt().Start : SourceLoc();
 }
 
-OrigDeclAttributes::OrigDeclAttributes(DeclAttributes allAttributes, ModuleDecl *mod) {
-  for (auto *attr : allAttributes) {
-    if (!mod->isInGeneratedBuffer(attr->AtLoc)) {
-      attributes.emplace_back(attr);
-    }
-  }
+Optional<const DeclAttribute *>
+OrigDeclAttrFilter::operator()(const DeclAttribute *Attr) const {
+  if (!mod || mod->isInGeneratedBuffer(Attr->AtLoc))
+    return None;
+  return Attr;
 }
 
 static void printAvailableAttr(const AvailableAttr *Attr, ASTPrinter &Printer,


### PR DESCRIPTION
* Explanation: Fixes a stack use after free that could be hit by calling `getAttributes` on `OrigDeclAttributes` within a foreach loop.
* Scope:  Extract function and formatting requests were the only uses of this, but it's possible other uses could be added later.
* Risk: Low; only used by extract function and formatting.
* Testing: ASAN results now green
* Original PR: https://github.com/apple/swift/pull/64701