### PR TITLE
[5.9][Serialization] Load non-public transitive dependencies on @testable imports

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1041,6 +1041,11 @@ REMARK(module_loaded,none,
        "%select{| (overlay for a clang dependency)}1"
        "; source: '%2', loaded: '%3'",
        (Identifier, unsigned, StringRef, StringRef))
+
+REMARK(transitive_dependency_behavior,none,
+       "%1 has %select{a required|an optional|an ignored}2 "
+       "transitive dependency on '%0'",
+       (StringRef, Identifier, unsigned))
        
 REMARK(explicit_interface_build_skipped,none,
        "Skipped rebuilding module at %0 - up-to-date",

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -294,6 +294,9 @@ public:
   virtual void
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const {}
 
+  /// Load extra dependencies of this module to satisfy a testable import.
+  virtual void loadDependenciesForTestable(SourceLoc diagLoc) const {}
+
   /// Returns the path of the file or directory that defines the module
   /// represented by this \c FileUnit, or empty string if there is none.
   /// Cross-import overlay specifiers are found relative to this path.

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -454,6 +454,8 @@ public:
   virtual void
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;
 
+  virtual void loadDependenciesForTestable(SourceLoc diagLoc) const override;
+
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D) const override;
 
   virtual StringRef getFilename() const override;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -251,6 +251,23 @@ void diagnoseSerializedASTLoadFailure(
     StringRef moduleBufferID, StringRef moduleDocBufferID,
     ModuleFile *loadedModuleFile, Identifier ModuleName);
 
+/// Emit diagnostics explaining a failure to load a serialized AST,
+/// this version only supports diagnostics relevant to transitive dependencies:
+/// missing dependency, missing underlying module, or circular dependency.
+///
+/// \see diagnoseSerializedASTLoadFailure that supports all diagnostics.
+///
+/// - \p Ctx is an AST context through which any diagnostics are surfaced.
+/// - \p diagLoc is the (possibly invalid) location used in the diagnostics.
+/// - \p status describes the issue with loading the AST. It must not be
+///   Status::Valid.
+/// - \p loadedModuleFile is an invalid loaded module.
+/// - \p ModuleName is the name used to refer to the module in diagnostics.
+/// - \p forTestable indicates if we loaded the AST for a @testable import.
+void diagnoseSerializedASTLoadFailureTransitive(
+    ASTContext &Ctx, SourceLoc diagLoc, const serialization::Status status,
+    ModuleFile *loadedModuleFile, Identifier ModuleName, bool forTestable);
+
 } // end namespace serialization
 } // end namespace swift
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -326,8 +326,11 @@ void ImportResolver::bindImport(UnboundImport &&I) {
 
   // Load more dependencies for testable imports.
   if (I.import.options.contains(ImportFlags::Testable)) {
+    SourceLoc diagLoc;
+    if (ID) diagLoc = ID.get()->getStartLoc();
+
     for (auto file: M->getFiles())
-      file->loadDependenciesForTestable(ID.get()->getStartLoc());
+      file->loadDependenciesForTestable(diagLoc);
   }
 
   auto topLevelModule = I.getTopLevelModule(M, SF);

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -324,6 +324,12 @@ void ImportResolver::bindImport(UnboundImport &&I) {
     return;
   }
 
+  // Load more dependencies for testable imports.
+  if (I.import.options.contains(ImportFlags::Testable)) {
+    for (auto file: M->getFiles())
+      file->loadDependenciesForTestable(ID.get()->getStartLoc());
+  }
+
   auto topLevelModule = I.getTopLevelModule(M, SF);
 
   I.validateOptions(topLevelModule, SF);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -17,6 +17,7 @@
 #include "ModuleFormat.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Subsystems.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericSignature.h"
@@ -196,6 +197,14 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
 
     ModuleLoadingBehavior transitiveBehavior =
       getTransitiveLoadingBehavior(dependency);
+
+    if (ctx.LangOpts.EnableModuleLoadingRemarks) {
+      ctx.Diags.diagnose(diagLoc,
+                         diag::transitive_dependency_behavior,
+                         dependency.Core.getPrettyPrintedPath(),
+                         M->getName(),
+                         unsigned(transitiveBehavior));
+    }
 
     // Skip this dependency?
     if (transitiveBehavior == ModuleLoadingBehavior::Ignored)

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -133,6 +133,9 @@ ModuleFile::loadDependenciesForFileContext(const FileUnit *file,
 
   bool missingDependency = false;
   for (auto &dependency : Dependencies) {
+    if (forTestable && dependency.isLoaded())
+      continue;
+
     assert(!dependency.isLoaded() && "already loaded?");
 
     if (dependency.isHeader()) {
@@ -156,7 +159,7 @@ ModuleFile::loadDependenciesForFileContext(const FileUnit *file,
     }
 
     ModuleLoadingBehavior transitiveBehavior =
-      getTransitiveLoadingBehavior(dependency);
+      getTransitiveLoadingBehavior(dependency, forTestable);
 
     if (ctx.LangOpts.EnableModuleLoadingRemarks) {
       ctx.Diags.diagnose(diagLoc,
@@ -282,7 +285,8 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
 }
 
 ModuleLoadingBehavior
-ModuleFile::getTransitiveLoadingBehavior(const Dependency &dependency) const {
+ModuleFile::getTransitiveLoadingBehavior(const Dependency &dependency,
+    bool forTestable) const {
   ASTContext &ctx = getContext();
   ModuleDecl *mod = FileContext->getParentModule();
 
@@ -293,7 +297,8 @@ ModuleFile::getTransitiveLoadingBehavior(const Dependency &dependency) const {
   return Core->getTransitiveLoadingBehavior(dependency.Core,
                                             ctx.LangOpts.DebuggerSupport,
                                             isPartialModule,
-                                            ctx.LangOpts.PackageName);
+                                            ctx.LangOpts.PackageName,
+                                            forTestable);
 }
 
 bool ModuleFile::mayHaveDiagnosticsPointingAtBuffer() const {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -664,7 +664,8 @@ public:
 
   /// How should \p dependency be loaded for a transitive import via \c this?
   ModuleLoadingBehavior
-  getTransitiveLoadingBehavior(const Dependency &dependency) const;
+  getTransitiveLoadingBehavior(const Dependency &dependency,
+                               bool forTestable) const;
 
   /// Returns `true` if there is a buffer that might contain source code where
   /// other parts of the compiler could have emitted diagnostics, to indicate

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -649,6 +649,19 @@ public:
   Status associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
                                   bool recoverFromIncompatibility);
 
+  /// Load dependencies of this module.
+  ///
+  /// \param file The FileUnit that represents this file's place in the AST.
+  /// \param diagLoc A location used for diagnostics that occur during loading.
+  /// This does not include diagnostics about \e this file failing to load,
+  /// but rather other things that might be imported as part of bringing the
+  /// file into the AST.
+  ///
+  /// \returns any error that occurred during loading dependencies.
+  Status
+  loadDependenciesForFileContext(const FileUnit *file, SourceLoc diagLoc,
+                               bool forTestable);
+
   /// How should \p dependency be loaded for a transitive import via \c this?
   ModuleLoadingBehavior
   getTransitiveLoadingBehavior(const Dependency &dependency) const;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1688,7 +1688,8 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
                                           const Dependency &dependency,
                                           bool debuggerMode,
                                           bool isPartialModule,
-                                          StringRef packageName) const {
+                                          StringRef packageName,
+                                          bool forTestable) const {
   if (isPartialModule) {
     // Keep the merge-module behavior for legacy support. In that case
     // we load all transitive dependencies from partial modules and
@@ -1717,7 +1718,7 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
     // Non-public imports are similar to implementation-only, the module
     // loading behavior differs on loading those dependencies
     // on testable imports.
-    if (isTestable() || !moduleIsResilient) {
+    if (forTestable || !moduleIsResilient) {
       return ModuleLoadingBehavior::Required;
     } else if (debuggerMode) {
       return ModuleLoadingBehavior::Optional;
@@ -1730,6 +1731,7 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
     // Package dependencies are usually loaded only for import from the same
     // package.
     if ((!packageName.empty() && packageName == getModulePackageName()) ||
+        forTestable ||
         !moduleIsResilient) {
       return ModuleLoadingBehavior::Required;
     } else if (debuggerMode) {

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -614,11 +614,17 @@ public:
   ///
   /// If \p packageName is set, transitive package dependencies are loaded if
   /// loaded from the same package.
+  ///
+  /// If \p forTestable, get the desired loading behavior for a @testable
+  /// import. Reports non-public dependencies as required for a testable
+  /// client so it can access internal details, which in turn can reference
+  /// those non-public dependencies.
   ModuleLoadingBehavior
   getTransitiveLoadingBehavior(const Dependency &dependency,
                                bool debuggerMode,
                                bool isPartialModule,
-                               StringRef packageName) const;
+                               StringRef packageName,
+                               bool forTestable) const;
 };
 
 template <typename T, typename RawData>

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1479,10 +1479,9 @@ void SerializedASTFile::loadDependenciesForTestable(SourceLoc diagLoc) const {
     File.loadDependenciesForFileContext(this, diagLoc, /*forTestable=*/true);
 
   if (status != serialization::Status::Valid) {
-    if (diagLoc)
-      serialization::diagnoseSerializedASTLoadFailureTransitive(
-          getASTContext(), diagLoc, status, &File,
-          getParentModule()->getName(), /*forTestable*/true);
+    serialization::diagnoseSerializedASTLoadFailureTransitive(
+        getASTContext(), diagLoc, status, &File,
+        getParentModule()->getName(), /*forTestable*/true);
   }
 }
 

--- a/test/Index/index_only_sdk_system_modules.swift
+++ b/test/Index/index_only_sdk_system_modules.swift
@@ -58,3 +58,10 @@ module LocalSystemModule [system] { }
 
 @testable import LocalSystemModule // expected-error {{module 'LocalSystemModule' was not compiled for testing}}
 // expected-remark @-1 {{LocalSystemModule.swiftinterface}}
+// expected-remark @-2 {{'LocalSystemModule' has a required transitive dependency on 'LocalSystemModule'}}
+// expected-remark @-3 {{'LocalSystemModule' has a required transitive dependency on 'Swift'}}
+// expected-remark @-4 {{'LocalSystemModule' has a required transitive dependency on 'SwiftOnoneSupport'}}
+// expected-remark @-5 {{'LocalSystemModule' has a required transitive dependency on '_Concurrency'}}
+// expected-remark @-6 {{'LocalSystemModule' has a required transitive dependency on '_StringProcessing'}}
+// expected-remark @-7 {{'LocalSystemModule' has a required transitive dependency on '_SwiftConcurrencyShims'}}
+

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -49,8 +49,10 @@ import SwiftDependency
 import SwiftNonResilientDependency
 import DirectMixedDependency
 
+// CHECK: remark: 'Swift' has a required transitive dependency on 'SwiftShims'
 // CHECK: remark: loaded module 'SwiftShims'; source: '{{.*}}module.modulemap', loaded: '{{.*}}SwiftShims-{{.*}}.pcm'
 // CHECK: remark: loaded module 'Swift'; source: '{{.*}}Swift.swiftmodule{{.*}}.swiftinterface', loaded: '{{.*}}Swift.swiftmodule{{.*}}.swiftmodule'
+// CHECK: remark: 'SwiftDependency' has a required transitive dependency on 'Swift'
 // CHECK: remark: loaded module 'SwiftDependency'; source: '{{.*}}SwiftDependency.swiftinterface', loaded: '{{.*}}SwiftDependency-{{.*}}.swiftmodule'
 // CHECK: remark: loaded module 'SwiftNonResilientDependency'; source: '{{.*}}SwiftNonResilientDependency.swiftmodule', loaded: '{{.*}}SwiftNonResilientDependency.swiftmodule'
 // CHECK: remark: loaded module 'IndirectMixedDependency' (overlay for a clang dependency); source: '{{.*}}IndirectMixedDependency.swiftinterface', loaded: '{{.*}}IndirectMixedDependency-{{.*}}.swiftmodule'

--- a/test/Serialization/package-dependencies.swift
+++ b/test/Serialization/package-dependencies.swift
@@ -25,13 +25,13 @@ package import PackageDep
 // RUN:   -package-name MyPackage -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
-// VISIBLE-PACKAGE-DEP: source: '{{.*}}PackageDep.swiftmodule'
+// VISIBLE-PACKAGE-DEP: loaded module 'PackageDep'
 
 // RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift \
 // RUN:   -package-name NotMyPackage -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-PACKAGE-DEP %s
-// HIDDEN-PACKAGE-DEP-NOT: PackageDep
+// HIDDEN-PACKAGE-DEP-NOT: loaded module 'PackageDep'
 
 //--- ResilientClient.swift
 import ResilientDep


### PR DESCRIPTION
A `@testable` import allows a client to call internal decls which may refer to non-public dependencies. To support such a use case, load non-public transitive dependencies of a module when it's imported `@testable` from the main module.

We apply this behavior only to `@testable` imports from the main module being built, not transitively trough `@testable` imports of a library. It should support the vast majority of `@testable` uses and provide a reasonable behavior without surprises.

This replaces the previous behavior where we loaded those dependencies for any modules built for testing. This would load more modules for any debug build, opening the door to a different behavior between debug and release builds. In contrast, applying this logic to `@testable` clients will only change the behavior of test targets.

rdar://107329303

---

Cherry-pick of the feature from #64693, plus as support: #64516 and #64522.

This affects only the new kind of imports using access level, as it's still behind a flag it should be low risk and not affect existing projects.