### PR TITLE
[5.9] Cherry-pick macro indexing/cursor info fixes

### DIFF
--- a/include/swift/AST/DiagnosticsRefactoring.def
+++ b/include/swift/AST/DiagnosticsRefactoring.def
@@ -46,6 +46,8 @@ ERROR(decl_no_accessibility, none, "cannot rename as accessibility could not be 
 
 ERROR(decl_from_clang, none, "cannot rename a Clang symbol from its Swift reference", ())
 
+ERROR(decl_in_macro, none, "cannot rename a symbol defined in a macro", ())
+
 ERROR(value_decl_referenced_out_of_range, none, "value decl '%0' is referenced out of range", (DeclName))
 
 ERROR(multi_entry_range, none, "selected range has more than one entry point", ())

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -410,6 +410,11 @@ public:
   /// the given location isn't in this module.
   bool isInGeneratedBuffer(SourceLoc loc);
 
+  // Retrieve the buffer ID and source location of the outermost location that
+  // caused the generation of the buffer containing \p loc. \p loc and its
+  // buffer if it isn't in a generated buffer or has no original location.
+  std::pair<unsigned, SourceLoc> getOriginalLocation(SourceLoc loc) const;
+
   /// Creates a map from \c #filePath strings to corresponding \c #fileID
   /// strings, diagnosing any conflicts.
   ///

--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -79,6 +79,7 @@ enum class RefactorAvailableKind {
   Unavailable_has_no_name,
   Unavailable_has_no_accessibility,
   Unavailable_decl_from_clang,
+  Unavailable_decl_in_macro,
 };
 
 struct RefactorAvailabilityInfo {

--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -72,7 +72,7 @@ struct RenameRangeDetail {
   Optional<unsigned> Index;
 };
 
-enum class RenameAvailableKind {
+enum class RefactorAvailableKind {
   Available,
   Unavailable_system_symbol,
   Unavailable_has_no_location,
@@ -81,14 +81,14 @@ enum class RenameAvailableKind {
   Unavailable_decl_from_clang,
 };
 
-struct RenameAvailabilityInfo {
+struct RefactorAvailabilityInfo {
   RefactoringKind Kind;
-  RenameAvailableKind AvailableKind;
-  RenameAvailabilityInfo(RefactoringKind Kind,
-                         RenameAvailableKind AvailableKind)
+  RefactorAvailableKind AvailableKind;
+  RefactorAvailabilityInfo(RefactoringKind Kind,
+                           RefactorAvailableKind AvailableKind)
       : Kind(Kind), AvailableKind(AvailableKind) {}
-  RenameAvailabilityInfo(RefactoringKind Kind)
-      : RenameAvailabilityInfo(Kind, RenameAvailableKind::Available) {}
+  RefactorAvailabilityInfo(RefactoringKind Kind)
+      : RefactorAvailabilityInfo(Kind, RefactorAvailableKind::Available) {}
 };
 
 class FindRenameRangesConsumer {
@@ -112,7 +112,7 @@ public:
 
 StringRef getDescriptiveRefactoringKindName(RefactoringKind Kind);
 
-StringRef getDescriptiveRenameUnavailableReason(RenameAvailableKind Kind);
+StringRef getDescriptiveRenameUnavailableReason(RefactorAvailableKind Kind);
 
 bool refactorSwiftModule(ModuleDecl *M, RefactoringOptions Opts,
                          SourceEditConsumer &EditConsumer,
@@ -131,25 +131,13 @@ int findLocalRenameRanges(SourceFile *SF, RangeConfig Range,
                           FindRenameRangesConsumer &RenameConsumer,
                           DiagnosticConsumer &DiagConsumer);
 
-void collectAvailableRefactorings(
-    SourceFile *SF, RangeConfig Range, bool &RangeStartMayNeedRename,
-    llvm::SmallVectorImpl<RefactoringKind> &Kinds,
-    llvm::ArrayRef<DiagnosticConsumer *> DiagConsumers);
+SmallVector<RefactorAvailabilityInfo, 0>
+collectRefactorings(SourceFile *SF, RangeConfig Range,
+                    bool &RangeStartMayNeedRename,
+                    llvm::ArrayRef<DiagnosticConsumer *> DiagConsumers);
 
-void collectAvailableRefactorings(ResolvedCursorInfoPtr CursorInfo,
-                                  llvm::SmallVectorImpl<RefactoringKind> &Kinds,
-                                  bool ExcludeRename);
-
-/// Stores information about the reference that rename availability is being
-/// queried on.
-struct RenameRefInfo {
-  SourceFile *SF; ///< The source file containing the reference.
-  SourceLoc Loc; ///< The reference's source location.
-  bool IsArgLabel; ///< Whether Loc is on an arg label, rather than base name.
-};
-
-Optional<RenameAvailabilityInfo>
-renameAvailabilityInfo(const ValueDecl *VD, Optional<RenameRefInfo> RefInfo);
+SmallVector<RefactorAvailabilityInfo, 0>
+collectRefactorings(ResolvedCursorInfoPtr CursorInfo, bool ExcludeRename);
 
 } // namespace ide
 } // namespace swift

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -816,6 +816,49 @@ bool ModuleDecl::isInGeneratedBuffer(SourceLoc loc) {
   return file->Kind == SourceFileKind::MacroExpansion;
 }
 
+std::pair<unsigned, SourceLoc>
+ModuleDecl::getOriginalLocation(SourceLoc loc) const {
+  assert(loc.isValid());
+
+  SourceManager &SM = getASTContext().SourceMgr;
+  unsigned bufferID = SM.findBufferContainingLoc(loc);
+
+  SourceLoc startLoc = loc;
+  unsigned startBufferID = bufferID;
+  while (Optional<GeneratedSourceInfo> info =
+             SM.getGeneratedSourceInfo(bufferID)) {
+    switch (info->kind) {
+    case GeneratedSourceInfo::ExpressionMacroExpansion:
+    case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
+    case GeneratedSourceInfo::AccessorMacroExpansion:
+    case GeneratedSourceInfo::MemberAttributeMacroExpansion:
+    case GeneratedSourceInfo::MemberMacroExpansion:
+    case GeneratedSourceInfo::PeerMacroExpansion:
+    case GeneratedSourceInfo::ConformanceMacroExpansion: {
+      // Location was within a macro expansion, return the expansion site, not
+      // the insertion location.
+      if (info->attachedMacroCustomAttr) {
+        loc = info->attachedMacroCustomAttr->getLocation();
+      } else {
+        ASTNode expansionNode = ASTNode::getFromOpaqueValue(info->astNode);
+        loc = expansionNode.getStartLoc();
+      }
+      bufferID = SM.findBufferContainingLoc(loc);
+      break;
+    }
+    case GeneratedSourceInfo::ReplacedFunctionBody:
+      // There's not really any "original" location for locations within
+      // replaced function bodies. The body is actually different code to the
+      // original file.
+    case GeneratedSourceInfo::PrettyPrinted:
+      // No original location, return the original buffer/location
+      return {startBufferID, startLoc};
+    }
+  }
+
+  return {bufferID, loc};
+}
+
 ArrayRef<SourceFile *>
 PrimarySourceFilesRequest::evaluate(Evaluator &evaluator,
                                     ModuleDecl *mod) const {
@@ -1353,14 +1396,24 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
     return None;
   }
 
-  SourceLoc Loc = D->getLoc(/*SerializedOK=*/false);
-  if (Loc.isInvalid())
+  SourceLoc MainLoc = D->getLoc(/*SerializedOK=*/false);
+  if (MainLoc.isInvalid())
     return None;
 
+  // TODO: Rather than grabbing the location of the macro expansion, we should
+  // instead add the generated buffer tree - that would need to include source
+  // if we want to be able to retrieve documentation within generated buffers.
   SourceManager &SM = getASTContext().SourceMgr;
-  auto BufferID = SM.findBufferContainingLoc(Loc);
+  bool InGeneratedBuffer =
+      !SM.rangeContainsTokenLoc(SM.getRangeForBuffer(BufferID), MainLoc);
+  if (InGeneratedBuffer) {
+    int UnderlyingBufferID;
+    std::tie(UnderlyingBufferID, MainLoc) =
+        D->getModuleContext()->getOriginalLocation(MainLoc);
+    if (BufferID != UnderlyingBufferID)
+      return None;
+  }
 
-  ExternalSourceLocs::RawLocs Result;
   auto setLoc = [&](ExternalSourceLocs::RawLoc &RawLoc, SourceLoc Loc) {
     if (!Loc.isValid())
       return;
@@ -1379,15 +1432,20 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
     RawLoc.Directive.Name = StringRef(VF->Name);
   };
 
+  ExternalSourceLocs::RawLocs Result;
+
   Result.SourceFilePath = SM.getIdentifierForBuffer(BufferID);
-  for (const auto &SRC : D->getRawComment(/*SerializedOK=*/false).Comments) {
-    Result.DocRanges.emplace_back(ExternalSourceLocs::RawLoc(),
-                                  SRC.Range.getByteLength());
-    setLoc(Result.DocRanges.back().first, SRC.Range.getStart());
+  setLoc(Result.Loc, MainLoc);
+  if (!InGeneratedBuffer) {
+    for (const auto &SRC : D->getRawComment(/*SerializedOK=*/false).Comments) {
+      Result.DocRanges.emplace_back(ExternalSourceLocs::RawLoc(),
+                                    SRC.Range.getByteLength());
+      setLoc(Result.DocRanges.back().first, SRC.Range.getStart());
+    }
+    setLoc(Result.StartLoc, D->getStartLoc());
+    setLoc(Result.EndLoc, D->getEndLoc());
   }
-  setLoc(Result.Loc, D->getLoc(/*SerializedOK=*/false));
-  setLoc(Result.StartLoc, D->getStartLoc());
-  setLoc(Result.EndLoc, D->getEndLoc());
+
   return Result;
 }
 

--- a/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
+++ b/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
@@ -3,56 +3,60 @@
 
 // RUN: %sourcekitd-test \
 // RUN:   -shell -- echo '## State 1' == \
-// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=5:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 2' == \
 // RUN:   -shell -- cp %t/State2.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=6:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 3' == \
 // RUN:   -shell -- cp %t/State3.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 4' == \
 // RUN:   -shell -- cp %t/State4.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 5' == \
 // RUN:   -shell -- cp %t/State5.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 6' == \
 // RUN:   -shell -- cp %t/State6.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift > %t/response.txt
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift > %t/response.txt
 // RUN: %FileCheck %s < %t/response.txt
 
 // CHECK-LABEL: ## State 1
-// CHECK: source.lang.swift.decl.var.local (3:7-3:18)
+// CHECK: source.lang.swift.decl.var.local (5:7-5:18)
 // CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 0
 // CHECK-LABEL: ## State 2
-// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
+// CHECK: source.lang.swift.decl.var.local (6:7-6:18)
 // CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 3
-// CHECK: source.lang.swift.decl.var.local (2:7-2:18)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
 // CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 4
-// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
 // CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 5
-// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
 // CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 0
 // CHECK-LABEL: ## State 6
-// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
 // CHECK: <Declaration>let myNewName: <Type usr="s:Si">Int</Type></Declaration>
 // CHECK: DID REUSE AST CONTEXT: 1
 
 //--- file.swift
+func unrelated() {}
+
 func foo() {
   let inFunctionA = 1
   let inFunctionB = "hi"
 }
 
 //--- State2.swift
+func unrelated() {}
+
 func foo() {
   let newlyAddedMember = 3
   let inFunctionA = 1
@@ -60,21 +64,29 @@ func foo() {
 }
 
 //--- State3.swift
+func unrelated() {}
+
 func foo() {
   let inFunctionB = "hi"
 }
 
 //--- State4.swift
+func unrelated() {}
+
 func foo() {
   let myNewName = "hi"
 }
 
 //--- State5.swift
+func unrelated() {}
+
 func foo(param: Int) {
   let myNewName = "hi"
 }
 
 //--- State6.swift
+func unrelated() {}
+
 func foo(param: Int) {
   let myNewName = 7
 }

--- a/test/SourceKit/Macros/macro_across_modules.swift
+++ b/test/SourceKit/Macros/macro_across_modules.swift
@@ -1,0 +1,78 @@
+// REQUIRES: swift_swift_parser
+// TODO: This shouldn't be required
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mods)
+// RUN: split-file --leading-lines %s %t
+
+// Check that indexing and cursor info both point to the expansion site rather
+// than generated macro buffer.
+
+// Create a plugin that adds a new function as a member
+// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+
+// Prepare a test module that uses the macro in a struct
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name TestModule -o %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -I %swift-host-lib-dir %t/TestModule.swift -index-store-path %t/idx
+
+// Check we correctly output the added `newFunc` on the line of the attached
+// macro.
+// RUN: c-index-test core -print-record %t/idx | %FileCheck %s --check-prefix=INDEX
+
+//--- MacroPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddNamedFuncMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let newFunc: DeclSyntax =
+      """
+      public func newFunc() {}
+      """
+    return [
+      newFunc,
+    ]
+  }
+}
+
+//--- TestModule.swift
+@attached(
+  member,
+  names: named(newFunc)
+)
+public macro AddNamedFunc() = #externalMacro(module: "MacroPlugin", type: "AddNamedFuncMacro")
+
+// INDEX: [[@LINE+2]]:1 | instance-method/Swift | s:10TestModule9ModStructV7newFuncyyF
+// INDEX-SAME: Def,Impl
+@AddNamedFunc
+// MOD_CURSOR: source.lang.swift.ref.function.method.instance
+// MOD_CURSOR-SAME: TestModule.swift:[[@LINE-2]]:1
+// MOD_CURSOR: newFunc()
+public struct ModStruct {
+  public func existingFunc() {}
+}
+
+//--- test.swift
+import TestModule
+
+@AddNamedFunc
+// LOCAL_CURSOR: source.lang.swift.ref.function.method.instance
+// LOCAL_CURSOR-SAME: [[@LINE-2]]:1
+// LOCAL_CURSOR: newFunc()
+public struct LocalStruct {
+  public func existingFunc() {}
+}
+
+// Check the location in cursor info is the attached macro.
+func test(l: LocalStruct, m: ModStruct) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -I %swift-host-lib-dir %t/test.swift | %FileCheck %s --check-prefix=LOCAL_CURSOR
+  l.newFunc()
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods %t/test.swift | %FileCheck %s --check-prefix=MOD_CURSOR
+  m.newFunc()
+}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -181,6 +181,25 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 21:1-21:15 ""
 
+//##-- Cursor info on the attribute expanded by @myTypeWrapper
+// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
+// NESTED_ATTACHED_CURSOR: source.lang.swift.ref.macro
+// NESTED_ATTACHED_CURSOR-SAME: macro_basic.swift:10:27-10:43
+// NESTED_ATTACHED_CURSOR-LABEL: SYMBOL GRAPH BEGIN
+// NESTED_ATTACHED_CURSOR: "identifier": {
+// NESTED_ATTACHED_CURSOR-NEXT:   "interfaceLanguage": "swift",
+// NESTED_ATTACHED_CURSOR-NEXT:   "precise": "s:9MacroUser16accessViaStorageyycfm"
+// NESTED_ATTACHED_CURSOR-NEXT: },
+// NESTED_ATTACHED_CURSOR-NEXT: "kind": {
+// NESTED_ATTACHED_CURSOR-NEXT:   "displayName": "Macro",
+// NESTED_ATTACHED_CURSOR-NEXT:   "identifier": "swift.macro"
+// NESTED_ATTACHED_CURSOR-NEXT: },
+// NESTED_ATTACHED_CURSOR: SYMBOL GRAPH END
+// NESTED_ATTACHED_CURSOR-LABEL: ACTIONS BEGIN
+// NESTED_ATTACHED_CURSOR: source.refactoring.kind.expand.macro
+// NESTED_ATTACHED_CURSOR-NEXT: Expand Macro
+// NESTED_ATTACHED_CURSOR:ACTIONS END
+
 //##-- Refactoring on the attribute expanded by @myTypeWrapper
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
 // NESTED_ATTACHED_EXPAND: source.edit.kind.active:

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -104,7 +104,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_MACRO_EXPR-NEXT: Expand Macro
 // CURSOR_MACRO_EXPR: ACTIONS END
 
-//##-- Refactoring on macro expression
+//##-- Expansion on macro expression
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=4:7 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=4:8 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=EXPAND %s
 // EXPAND: source.edit.kind.active:
@@ -129,7 +129,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_MACRO_DECL-NEXT: Expand Macro
 // CURSOR_MACRO_DECL: ACTIONS END
 
-//##-- Refactoring on macro declaration
+//##-- Expansion on macro declaration
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=57:1 %s -- ${COMPILER_ARGS[@]} -parse-as-library -enable-experimental-feature FreestandingMacros | %FileCheck -check-prefix=EXPAND_MACRO_DECL %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=57:2 %s -- ${COMPILER_ARGS[@]} -parse-as-library -enable-experimental-feature FreestandingMacros | %FileCheck -check-prefix=EXPAND_MACRO_DECL %s
 // EXPAND_MACRO_DECL: source.edit.kind.active:
@@ -166,7 +166,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_ATTACHED-NEXT: Expand Macro
 // CURSOR_ATTACHED: ACTIONS END
 
-//##-- Refactoring on attached macro
+//##-- Expansion on attached macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:1 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // ATTACHED_EXPAND: source.edit.kind.active:
@@ -196,11 +196,11 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_CURSOR-NEXT: },
 // NESTED_ATTACHED_CURSOR: SYMBOL GRAPH END
 // NESTED_ATTACHED_CURSOR-LABEL: ACTIONS BEGIN
-// NESTED_ATTACHED_CURSOR: source.refactoring.kind.expand.macro
+// NESTED_ATTACHED_CURSOR-NEXT: source.refactoring.kind.expand.macro
 // NESTED_ATTACHED_CURSOR-NEXT: Expand Macro
-// NESTED_ATTACHED_CURSOR:ACTIONS END
+// NESTED_ATTACHED_CURSOR-NEXT: ACTIONS END
 
-//##-- Refactoring on the attribute expanded by @myTypeWrapper
+//##-- Expansion on the attribute expanded by @myTypeWrapper
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
 // NESTED_ATTACHED_EXPAND: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1xSivp16accessViaStoragefMa_.swift) "{
@@ -211,7 +211,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: 1:1-1:18 ""
 
-//##-- Refactoring expanding the first accessor macro
+//##-- Expansion on the first accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s
 // ACCESSOR1_EXPAND: source.edit.kind.active:
 // ACCESSOR1_EXPAND-NEXT: 31:13-31:13 (@__swiftmacro_9MacroUser2S2V1xSivp16accessViaStoragefMa_.swift) "{
@@ -222,7 +222,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // ACCESSOR1_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR1_EXPAND-NEXT: 30:3-30:20 ""
 
-//##-- Refactoring expanding the second accessor macro
+//##-- Expansion on the second accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=33:13 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR2_EXPAND %s
 // ACCESSOR2_EXPAND: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 34:14-34:18 (@__swiftmacro_9MacroUser2S2V1ySivp16accessViaStoragefMa_.swift) "{
@@ -233,7 +233,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // ACCESSOR2_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 33:3-33:20 ""
 
-//##-- Refactoring expanding the addCompletionHandler macro.
+//##-- Expansion on the addCompletionHandler macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=42:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=PEER_EXPAND %s
 // PEER_EXPAND: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift) "
@@ -247,7 +247,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // PEER_EXPAND-NEXT: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 42:3-42:24 ""
 
-//##-- Refactoring expanding a conformance macro.
+//##-- Expansion on a conformance macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=51:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CONFORMANCE_EXPAND %s
 // CONFORMANCE_EXPAND: source.edit.kind.active:
 // CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S4V8HashablefMc_.swift) "

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -640,10 +640,10 @@ enum class SemanticRefactoringKind {
 
 struct SemanticRefactoringInfo {
   SemanticRefactoringKind Kind;
-  // The name of the source file to start the refactoring in. Empty if it is
-  // the primary file (in which case the primary file from the AST is used).
-  // This must match the buffer identifier stored in the source manager.
-  StringRef SourceFile;
+  // The name of the input buffer to start the refactoring in. This must either
+  // be empty (in which case the primary file for the AST is used), or exactly
+  // match the buffer identifier stored in the source manager.
+  StringRef InputBufferName;
   unsigned Line;
   unsigned Column;
   unsigned Length;
@@ -982,14 +982,15 @@ public:
                                        EditorConsumer &Consumer) = 0;
 
   virtual void getCursorInfo(
-      StringRef Filename, unsigned Offset, unsigned Length, bool Actionables,
-      bool SymbolGraph, bool CancelOnSubsequentRequest,
-      ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+      StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+      unsigned Length, bool Actionables, bool SymbolGraph,
+      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+      Optional<VFSOptions> vfsOptions,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<CursorInfoData> &)> Receiver) = 0;
 
   virtual void
-  getDiagnostics(StringRef InputFile, ArrayRef<const char *> Args,
+  getDiagnostics(StringRef PrimaryFilePath, ArrayRef<const char *> Args,
                  Optional<VFSOptions> VfsOptions,
                  SourceKitCancellationToken CancellationToken,
                  std::function<void(const RequestResult<DiagnosticsResult> &)>
@@ -1003,26 +1004,28 @@ public:
                   Receiver) = 0;
 
   virtual void getRangeInfo(
-      StringRef Filename, unsigned Offset, unsigned Length,
-      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
-      SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+      unsigned Length, bool CancelOnSubsequentRequest,
+      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<RangeInfo> &)> Receiver) = 0;
 
   virtual void getCursorInfoFromUSR(
-      StringRef Filename, StringRef USR, bool CancelOnSubsequentRequest,
-      ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+      StringRef PrimaryFilePath, StringRef InputBufferName, StringRef USR,
+      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+      Optional<VFSOptions> vfsOptions,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<CursorInfoData> &)> Receiver) = 0;
 
   virtual void findRelatedIdentifiersInFile(
-      StringRef Filename, unsigned Offset, bool CancelOnSubsequentRequest,
-      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+      SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<RelatedIdentsInfo> &)>
           Receiver) = 0;
 
   virtual void findActiveRegionsInFile(
-      StringRef Filename, ArrayRef<const char *> Args,
-      SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName,
+      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ActiveRegionsInfo> &)>
           Receiver) = 0;
 
@@ -1052,16 +1055,17 @@ public:
                         SourceKitCancellationToken CancellationToken,
                         CategorizedRenameRangesReceiver Receiver) = 0;
 
-  virtual void semanticRefactoring(StringRef PrimaryFile,
+  virtual void semanticRefactoring(StringRef PrimaryFilePath,
                                    SemanticRefactoringInfo Info,
                                    ArrayRef<const char *> Args,
                                    SourceKitCancellationToken CancellationToken,
                                    CategorizedEditsReceiver Receiver) = 0;
 
   virtual void collectExpressionTypes(
-      StringRef FileName, ArrayRef<const char *> Args,
-      ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
-      bool CanonicalType, SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName,
+      ArrayRef<const char *> Args, ArrayRef<const char *> ExpectedProtocols,
+      bool FullyQualified, bool CanonicalType,
+      SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ExpressionTypesInFile> &)>
           Receiver) = 0;
 
@@ -1069,8 +1073,9 @@ public:
   /// the source file. If `Offset` or `Length` are empty, variable types for
   /// the entire document are collected.
   virtual void collectVariableTypes(
-      StringRef FileName, ArrayRef<const char *> Args,
-      Optional<unsigned> Offset, Optional<unsigned> Length, bool FullyQualified,
+      StringRef PrimaryFilePath, StringRef InputBufferName,
+      ArrayRef<const char *> Args, Optional<unsigned> Offset,
+      Optional<unsigned> Length, bool FullyQualified,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<VariableTypesInFile> &)>
           Receiver) = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -632,9 +632,9 @@ public:
   void editorExpandPlaceholder(StringRef Name, unsigned Offset, unsigned Length,
                                EditorConsumer &Consumer) override;
 
-  void getCursorInfo(StringRef Filename, unsigned Offset, unsigned Length,
-                     bool Actionables, bool SymbolGraph,
-                     bool CancelOnSubsequentRequest,
+  void getCursorInfo(StringRef PrimaryFilePath, StringRef InputBufferName,
+                     unsigned Offset, unsigned Length, bool Actionables,
+                     bool SymbolGraph, bool CancelOnSubsequentRequest,
                      ArrayRef<const char *> Args,
                      Optional<VFSOptions> vfsOptions,
                      SourceKitCancellationToken CancellationToken,
@@ -642,7 +642,7 @@ public:
                          Receiver) override;
 
   void
-  getDiagnostics(StringRef InputFile, ArrayRef<const char *> Args,
+  getDiagnostics(StringRef PrimaryFilePath, ArrayRef<const char *> Args,
                  Optional<VFSOptions> VfsOptions,
                  SourceKitCancellationToken CancellationToken,
                  std::function<void(const RequestResult<DiagnosticsResult> &)>
@@ -655,27 +655,29 @@ public:
       override;
 
   void getRangeInfo(
-      StringRef Filename, unsigned Offset, unsigned Length,
-      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
-      SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+      unsigned Length, bool CancelOnSubsequentRequest,
+      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<RangeInfo> &)> Receiver) override;
 
   void getCursorInfoFromUSR(
-      StringRef Filename, StringRef USR, bool CancelOnSubsequentRequest,
-      ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+      StringRef PrimaryFilePath, StringRef InputBufferName, StringRef USR,
+      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+      Optional<VFSOptions> vfsOptions,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<CursorInfoData> &)> Receiver)
       override;
 
   void findRelatedIdentifiersInFile(
-      StringRef Filename, unsigned Offset, bool CancelOnSubsequentRequest,
-      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+      bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+      SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver)
       override;
 
   void findActiveRegionsInFile(
-      StringRef Filename, ArrayRef<const char *> Args,
-      SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName,
+      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ActiveRegionsInfo> &)> Receiver)
       override;
 
@@ -695,20 +697,23 @@ public:
                              CategorizedRenameRangesReceiver Receiver) override;
 
   void collectExpressionTypes(
-      StringRef FileName, ArrayRef<const char *> Args,
-      ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
-      bool CanonicalType, SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName,
+      ArrayRef<const char *> Args, ArrayRef<const char *> ExpectedProtocols,
+      bool FullyQualified, bool CanonicalType,
+      SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ExpressionTypesInFile> &)>
           Receiver) override;
 
   void collectVariableTypes(
-      StringRef FileName, ArrayRef<const char *> Args,
-      Optional<unsigned> Offset, Optional<unsigned> Length, bool FullyQualified,
+      StringRef PrimaryFilePath, StringRef InputBufferName,
+      ArrayRef<const char *> Args, Optional<unsigned> Offset,
+      Optional<unsigned> Length, bool FullyQualified,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver)
       override;
 
-  void semanticRefactoring(StringRef PrimaryFile, SemanticRefactoringInfo Info,
+  void semanticRefactoring(StringRef PrimaryFilePath,
+                           SemanticRefactoringInfo Info,
                            ArrayRef<const char *> Args,
                            SourceKitCancellationToken CancellationToken,
                            CategorizedEditsReceiver Receiver) override;

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -899,12 +899,13 @@ static void setLocationInfo(const ValueDecl *VD,
       NameLen = getCharLength(SM, Loc);
     }
 
-    unsigned DeclBufID = SM.findBufferContainingLoc(Loc);
+    auto [DeclBufID, DeclLoc] =
+        VD->getModuleContext()->getOriginalLocation(Loc);
     Location.Filename = SM.getIdentifierForBuffer(DeclBufID);
-    Location.Offset = SM.getLocOffsetInBuffer(Loc, DeclBufID);
+    Location.Offset = SM.getLocOffsetInBuffer(DeclLoc, DeclBufID);
     Location.Length = NameLen;
-    std::tie(Location.Line, Location.Column) = SM.getLineAndColumnInBuffer(
-        Loc, DeclBufID);
+    std::tie(Location.Line, Location.Column) =
+        SM.getLineAndColumnInBuffer(DeclLoc, DeclBufID);
     if (auto GeneratedSourceInfo = SM.getGeneratedSourceInfo(DeclBufID)) {
       if (GeneratedSourceInfo->kind ==
           GeneratedSourceInfo::ReplacedFunctionBody) {
@@ -918,9 +919,8 @@ static void setLocationInfo(const ValueDecl *VD,
         auto GeneratedStartOffset = SM.getLocOffsetInBuffer(
             GeneratedSourceInfo->generatedSourceRange.getStart(), DeclBufID);
         Location.Offset += OriginalStartOffset - GeneratedStartOffset;
-        assert(SM.findBufferContainingLoc(Loc) == DeclBufID);
         std::tie(Location.Line, Location.Column) =
-            SM.getPresumedLineAndColumnForLoc(Loc, DeclBufID);
+            SM.getPresumedLineAndColumnForLoc(DeclLoc, DeclBufID);
       }
     }
   } else if (ClangNode) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -636,7 +636,8 @@ mapOffsetToNewerSnapshot(unsigned Offset,
 static void mapLocToLatestSnapshot(
     SwiftLangSupport &Lang, LocationInfo &Location,
     ArrayRef<ImmutableTextSnapshotRef> PreviousASTSnaps) {
-  auto EditorDoc = Lang.getEditorDocuments()->findByPath(Location.Filename);
+  auto EditorDoc = Lang.getEditorDocuments()->findByPath(Location.Filename,
+                                                         /*IsRealpath=*/true);
   if (!EditorDoc)
     return;
 
@@ -1435,9 +1436,9 @@ public:
   CursorRangeInfoConsumer(StringRef InputFile, unsigned Offset, unsigned Length,
                           SwiftLangSupport &Lang, SwiftInvocationRef ASTInvok,
                           bool TryExistingAST, bool CancelOnSubsequentRequest)
-    : Lang(Lang), ASTInvok(ASTInvok),InputFile(InputFile.str()), Offset(Offset),
-      Length(Length), TryExistingAST(TryExistingAST),
-      CancelOnSubsequentRequest(CancelOnSubsequentRequest) {}
+      : Lang(Lang), ASTInvok(ASTInvok), InputFile(InputFile.str()),
+        Offset(Offset), Length(Length), TryExistingAST(TryExistingAST),
+        CancelOnSubsequentRequest(CancelOnSubsequentRequest) {}
 
   bool canUseASTWithSnapshots(ArrayRef<ImmutableTextSnapshotRef> Snapshots) override {
     if (!TryExistingAST) {
@@ -1452,7 +1453,8 @@ public:
     // blocked waiting on the AST to be fully typechecked.
 
     ImmutableTextSnapshotRef InputSnap;
-    if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(InputFile))
+    if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(
+            InputFile, /*IsRealpath=*/true))
       InputSnap = EditorDoc->getLatestSnapshot();
     if (!InputSnap)
       return false;
@@ -1493,6 +1495,33 @@ public:
   }
 };
 
+static SourceFile *retrieveInputFile(StringRef inputBufferName,
+                                     const CompilerInstance &CI,
+                                     bool haveRealPath = false) {
+  // Don't bother looking up if we have the same file as the primary file or
+  // we weren't given a separate input file
+  if (inputBufferName.empty() ||
+      CI.getPrimarySourceFile()->getFilename() == inputBufferName)
+    return CI.getPrimarySourceFile();
+
+  // Otherwise, try to find the given buffer identifier
+  const SourceManager &SM = CI.getSourceMgr();
+  Optional<unsigned> inputBufferID =
+      SM.getIDForBufferIdentifier(inputBufferName);
+  if (!inputBufferID) {
+    // If that failed, try again with symlinks resolved (unless we've already
+    // done that)
+    if (haveRealPath)
+      return nullptr;
+    std::string realPath =
+        SwiftLangSupport::resolvePathSymlinks(inputBufferName);
+    return retrieveInputFile(realPath, CI, /*haveRealPath=*/true);
+  }
+
+  return CI.getMainModule()->getSourceFileContainingLocation(
+      SM.getRangeForBuffer(*inputBufferID).getStart());
+}
+
 static void resolveCursor(
     SwiftLangSupport &Lang, StringRef InputFile, unsigned Offset,
     unsigned Length, bool Actionables, bool SymbolGraph,
@@ -1524,13 +1553,21 @@ static void resolveCursor(
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       auto &CompIns = AstUnit->getCompilerInstance();
+
+      SourceFile *SF = retrieveInputFile(InputFile, CompIns);
+      if (!SF) {
+        Receiver(RequestResult<CursorInfoData>::fromError(
+            "Unable to find input file"));
+        return;
+      }
+
       SourceManager &SM = CompIns.getSourceMgr();
-      unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID().value();
+      unsigned BufferID = SF->getBufferID().value();
       SourceLoc Loc =
         Lexer::getLocForStartOfToken(SM, BufferID, Offset);
       if (Loc.isInvalid()) {
         Receiver(RequestResult<CursorInfoData>::fromError(
-          "Unable to resolve the start of the token."));
+            "Unable to find initial lookup location"));
         return;
       }
 
@@ -1556,8 +1593,8 @@ static void resolveCursor(
         Range.Column = Pair.second;
         Range.Length = Length;
         bool CollectRangeStartRefactorings = false;
-        collectAvailableRefactorings(&AstUnit->getPrimarySourceFile(), Range,
-                                     CollectRangeStartRefactorings, Kinds, {});
+        collectAvailableRefactorings(SF, Range, CollectRangeStartRefactorings,
+                                     Kinds, {});
         for (RefactoringKind Kind : Kinds) {
           Actions.emplace_back(SwiftLangSupport::getUIDForRefactoringKind(Kind),
                                getDescriptiveRefactoringKindName(Kind),
@@ -1575,10 +1612,9 @@ static void resolveCursor(
         // Fall through to collect cursor based refactorings
       }
 
-      auto *File = &AstUnit->getPrimarySourceFile();
       ResolvedCursorInfoPtr CursorInfo =
-          evaluateOrDefault(File->getASTContext().evaluator,
-                            CursorInfoRequest{CursorInfoOwner(File, Loc)},
+          evaluateOrDefault(CompIns.getASTContext().evaluator,
+                            CursorInfoRequest{CursorInfoOwner(SF, Loc)},
                             new ResolvedCursorInfo());
 
       CompilerInvocation CompInvok;
@@ -1671,7 +1707,7 @@ static void resolveCursor(
 }
 
 static void computeDiagnostics(
-    SwiftLangSupport &Lang, StringRef InputFile, SwiftInvocationRef Invok,
+    SwiftLangSupport &Lang, SwiftInvocationRef Invok,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<DiagnosticsResult> &)> Receiver) {
@@ -1685,8 +1721,7 @@ static void computeDiagnostics(
         : Receiver(Receiver) {}
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
-      unsigned BufferID =
-          AstUnit->getPrimarySourceFile().getBufferID().value();
+      unsigned BufferID = *AstUnit->getPrimarySourceFile().getBufferID();
       auto &DiagConsumer = AstUnit->getEditorDiagConsumer();
       auto Diagnostics = DiagConsumer.getDiagnosticsForBuffer(BufferID);
       Receiver(RequestResult<DiagnosticsResult>::fromResult(Diagnostics));
@@ -1732,19 +1767,24 @@ static void resolveName(
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       auto &CompIns = AstUnit->getCompilerInstance();
 
-      unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID().value();
-      SourceLoc Loc =
-        Lexer::getLocForStartOfToken(CompIns.getSourceMgr(), BufferID, Offset);
+      SourceFile *SF = retrieveInputFile(InputFile, CompIns);
+      if (!SF) {
+        Receiver(RequestResult<NameTranslatingInfo>::fromError(
+            "Unable to find input file"));
+        return;
+      }
+
+      SourceLoc Loc = Lexer::getLocForStartOfToken(CompIns.getSourceMgr(),
+                                                   *SF->getBufferID(), Offset);
       if (Loc.isInvalid()) {
         Receiver(RequestResult<NameTranslatingInfo>::fromError(
           "Unable to resolve the start of the token."));
         return;
       }
 
-      auto *File = &AstUnit->getPrimarySourceFile();
       ResolvedCursorInfoPtr CursorInfo =
-          evaluateOrDefault(File->getASTContext().evaluator,
-                            CursorInfoRequest{CursorInfoOwner(File, Loc)},
+          evaluateOrDefault(CompIns.getASTContext().evaluator,
+                            CursorInfoRequest{CursorInfoOwner(SF, Loc)},
                             new ResolvedCursorInfo());
       if (CursorInfo->isInvalid()) {
         NameTranslatingInfo Info;
@@ -1836,10 +1876,19 @@ resolveRange(SwiftLangSupport &Lang, StringRef InputFile, unsigned Offset,
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       // FIXME: Implement tracing
-      auto *File = &AstUnit->getPrimarySourceFile();
-      ResolvedRangeInfo Info = evaluateOrDefault(File->getASTContext().evaluator,
-        RangeInfoRequest(RangeInfoOwner({File, Offset, Length})),
-                                                 ResolvedRangeInfo());
+      auto &CompIns = AstUnit->getCompilerInstance();
+
+      SourceFile *SF = retrieveInputFile(InputFile, CompIns);
+      if (!SF) {
+        Receiver(
+            RequestResult<RangeInfo>::fromError("Unable to find input file"));
+        return;
+      }
+
+      ResolvedRangeInfo Info = evaluateOrDefault(
+          CompIns.getASTContext().evaluator,
+          RangeInfoRequest(RangeInfoOwner({SF, Offset, Length})),
+          ResolvedRangeInfo());
 
       CompilerInvocation CompInvok;
       ASTInvok->applyTo(CompInvok);
@@ -1939,17 +1988,18 @@ static void deliverCursorInfoResults(
 }
 
 void SwiftLangSupport::getCursorInfo(
-    StringRef InputFile, unsigned Offset, unsigned Length, bool Actionables,
-    bool SymbolGraph, bool CancelOnSubsequentRequest,
-    ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+    StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+    unsigned Length, bool Actionables, bool SymbolGraph,
+    bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+    Optional<VFSOptions> vfsOptions,
     SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
   std::string error;
-  auto fileSystem = getFileSystem(vfsOptions, InputFile, error);
+  auto fileSystem = getFileSystem(vfsOptions, PrimaryFilePath, error);
   if (!fileSystem)
     return Receiver(RequestResult<CursorInfoData>::fromError(error));
 
-  if (auto IFaceGenRef = IFaceGenContexts.get(InputFile)) {
+  if (auto IFaceGenRef = IFaceGenContexts.get(PrimaryFilePath)) {
     IFaceGenRef->accessASTAsync([this, IFaceGenRef, Offset, Actionables,
                                  SymbolGraph, Receiver] {
       SwiftInterfaceGenContext::ResolvedEntity Entity;
@@ -1991,7 +2041,7 @@ void SwiftLangSupport::getCursorInfo(
 
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, InputFile, fileSystem, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, fileSystem, Error);
   if (!Error.empty()) {
     LOG_WARN_FUNC("error creating ASTInvocation: " << Error);
   }
@@ -2001,14 +2051,18 @@ void SwiftLangSupport::getCursorInfo(
   }
 
   bool SolverBasedProducedResult = false;
-  std::string InputFileError;
-  llvm::SmallString<64> RealInputFilePath;
-  fileSystem->getRealPath(InputFile, RealInputFilePath);
-  std::unique_ptr<llvm::MemoryBuffer> UnresolvedInputFile =
-      getASTManager()->getMemoryBuffer(RealInputFilePath, fileSystem,
-                                       InputFileError);
-  // The solver-based implementation doesn't support range based cursor info.
-  if (UnresolvedInputFile && Length == 0) {
+  // Solver based cursor info cannot handle generated buffers or range based
+  // cursor info.
+  std::unique_ptr<llvm::MemoryBuffer> InputBuffer;
+  if (InputBufferName.empty() && Length == 0) {
+    std::string InputFileError;
+    llvm::SmallString<128> RealInputFilePath;
+    fileSystem->getRealPath(PrimaryFilePath, RealInputFilePath);
+    InputBuffer = getASTManager()->getMemoryBuffer(RealInputFilePath,
+                                                   fileSystem, InputFileError);
+  }
+
+  if (InputBuffer) {
     auto SolverBasedReceiver = [&](const RequestResult<CursorInfoData> &Res) {
       SolverBasedProducedResult = true;
       Receiver(Res);
@@ -2018,7 +2072,7 @@ void SwiftLangSupport::getCursorInfo(
     Invok->applyTo(CompInvok);
 
     performWithParamsToCompletionLikeOperation(
-        UnresolvedInputFile.get(), Offset,
+        InputBuffer.get(), Offset,
         /*InsertCodeCompletionToken=*/false, Args, fileSystem,
         CancellationToken,
         [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
@@ -2037,19 +2091,20 @@ void SwiftLangSupport::getCursorInfo(
   }
 
   if (!SolverBasedProducedResult) {
-    resolveCursor(*this, InputFile, Offset, Length, Actionables, SymbolGraph,
-                  Invok, /*TryExistingAST=*/true, CancelOnSubsequentRequest,
-                  fileSystem, CancellationToken, Receiver);
+    resolveCursor(*this, InputBufferName, Offset, Length, Actionables,
+                  SymbolGraph, Invok, /*TryExistingAST=*/true,
+                  CancelOnSubsequentRequest, fileSystem, CancellationToken,
+                  Receiver);
   }
 }
 
 void SwiftLangSupport::getDiagnostics(
-    StringRef InputFile, ArrayRef<const char *> Args,
+    StringRef PrimaryFilePath, ArrayRef<const char *> Args,
     Optional<VFSOptions> VfsOptions,
     SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<DiagnosticsResult> &)> Receiver) {
   std::string FileSystemError;
-  auto FileSystem = getFileSystem(VfsOptions, InputFile, FileSystemError);
+  auto FileSystem = getFileSystem(VfsOptions, PrimaryFilePath, FileSystemError);
   if (!FileSystem) {
     Receiver(RequestResult<DiagnosticsResult>::fromError(FileSystemError));
     return;
@@ -2057,7 +2112,7 @@ void SwiftLangSupport::getDiagnostics(
 
   std::string InvocationError;
   SwiftInvocationRef Invok = ASTMgr->getTypecheckInvocation(
-      Args, InputFile, FileSystem, InvocationError);
+      Args, PrimaryFilePath, FileSystem, InvocationError);
   if (!InvocationError.empty()) {
     LOG_WARN_FUNC("error creating ASTInvocation: " << InvocationError);
   }
@@ -2066,16 +2121,15 @@ void SwiftLangSupport::getDiagnostics(
     return;
   }
 
-  computeDiagnostics(*this, InputFile, Invok, FileSystem, CancellationToken,
-                     Receiver);
+  computeDiagnostics(*this, Invok, FileSystem, CancellationToken, Receiver);
 }
 
 void SwiftLangSupport::getRangeInfo(
-    StringRef InputFile, unsigned Offset, unsigned Length,
-    bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
-    SourceKitCancellationToken CancellationToken,
+    StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+    unsigned Length, bool CancelOnSubsequentRequest,
+    ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<RangeInfo> &)> Receiver) {
-  if (IFaceGenContexts.get(InputFile)) {
+  if (IFaceGenContexts.get(InputBufferName)) {
     // FIXME: return range info for generated interfaces.
     Receiver(RequestResult<RangeInfo>::fromError(
         "Range info for generated interfaces is not implemented."));
@@ -2083,7 +2137,7 @@ void SwiftLangSupport::getRangeInfo(
   }
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, InputFile, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<RangeInfo>::fromError(Error));
@@ -2093,8 +2147,9 @@ void SwiftLangSupport::getRangeInfo(
     Receiver(RequestResult<RangeInfo>::fromError("Invalid range length."));
     return;
   }
-  resolveRange(*this, InputFile, Offset, Length, Invok, /*TryExistingAST=*/true,
-               CancelOnSubsequentRequest, CancellationToken, Receiver);
+  resolveRange(*this, InputBufferName, Offset, Length, Invok,
+               /*TryExistingAST=*/true, CancelOnSubsequentRequest,
+               CancellationToken, Receiver);
 }
 
 void SwiftLangSupport::getNameInfo(
@@ -2283,17 +2338,18 @@ static void resolveCursorFromUSR(
 }
 
 void SwiftLangSupport::getCursorInfoFromUSR(
-    StringRef filename, StringRef USR, bool CancelOnSubsequentRequest,
-    ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
+    StringRef PrimaryFilePath, StringRef InputBufferName, StringRef USR,
+    bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+    Optional<VFSOptions> vfsOptions,
     SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
   std::string error;
 
-  auto fileSystem = getFileSystem(vfsOptions, filename, error);
+  auto fileSystem = getFileSystem(vfsOptions, PrimaryFilePath, error);
   if (!fileSystem)
     return Receiver(RequestResult<CursorInfoData>::fromError(error));
 
-  if (auto IFaceGenRef = IFaceGenContexts.get(filename)) {
+  if (auto IFaceGenRef = IFaceGenContexts.get(PrimaryFilePath)) {
     LOG_WARN_FUNC("Info from usr for generated interface not implemented yet.");
     CursorInfoData Info;
     Info.InternalDiagnostic = "Info for generated interfaces not implemented.";
@@ -2303,16 +2359,16 @@ void SwiftLangSupport::getCursorInfoFromUSR(
 
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, filename, fileSystem, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, fileSystem, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<CursorInfoData>::fromError(Error));
     return;
   }
 
-  resolveCursorFromUSR(*this, filename, USR, Invok, /*TryExistingAST=*/true,
-                       CancelOnSubsequentRequest, fileSystem, CancellationToken,
-                       Receiver);
+  resolveCursorFromUSR(*this, InputBufferName, USR, Invok,
+                       /*TryExistingAST=*/true, CancelOnSubsequentRequest,
+                       fileSystem, CancellationToken, Receiver);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2457,13 +2513,14 @@ private:
 } // end anonymous namespace
 
 void SwiftLangSupport::findRelatedIdentifiersInFile(
-    StringRef InputFile, unsigned Offset, bool CancelOnSubsequentRequest,
-    ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+    StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+    bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
+    SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver) {
 
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, InputFile, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<RelatedIdentsInfo>::fromError(Error));
@@ -2471,34 +2528,42 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
   }
 
   class RelatedIdConsumer : public SwiftASTConsumer {
+    std::string InputFile;
     unsigned Offset;
     std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver;
     SwiftInvocationRef Invok;
 
   public:
-    RelatedIdConsumer(unsigned Offset,
-                      std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver,
-                      SwiftInvocationRef Invok)
-      : Offset(Offset), Receiver(std::move(Receiver)), Invok(Invok) { }
+    RelatedIdConsumer(
+        StringRef InputFile, unsigned Offset,
+        std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver,
+        SwiftInvocationRef Invok)
+        : InputFile(InputFile.str()), Offset(Offset),
+          Receiver(std::move(Receiver)), Invok(Invok) {}
 
     // FIXME: Don't silently eat errors here.
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       auto &CompInst = AstUnit->getCompilerInstance();
-      auto &SrcFile = AstUnit->getPrimarySourceFile();
 
+      auto *SrcFile = retrieveInputFile(InputFile, CompInst);
+      if (!SrcFile) {
+        Receiver(RequestResult<RelatedIdentsInfo>::fromError(
+            "Unable to find input file"));
+        return;
+      }
 
       SmallVector<std::pair<unsigned, unsigned>, 8> Ranges;
 
       auto Action = [&]() {
-        unsigned BufferID = SrcFile.getBufferID().value();
+        unsigned BufferID = SrcFile->getBufferID().value();
         SourceLoc Loc =
           Lexer::getLocForStartOfToken(CompInst.getSourceMgr(), BufferID, Offset);
         if (Loc.isInvalid())
           return;
 
         ResolvedCursorInfoPtr CursorInfo =
-            evaluateOrDefault(SrcFile.getASTContext().evaluator,
-                              CursorInfoRequest{CursorInfoOwner(&SrcFile, Loc)},
+            evaluateOrDefault(CompInst.getASTContext().evaluator,
+                              CursorInfoRequest{CursorInfoOwner(SrcFile, Loc)},
                               new ResolvedCursorInfo());
         auto ValueRefCursorInfo =
             dyn_cast<ResolvedValueRefCursorInfo>(CursorInfo);
@@ -2539,7 +2604,8 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
             continue;
           }
 
-          RelatedIdScanner Scanner(SrcFile, BufferID, Dcl, RangesSet, Worklist);
+          RelatedIdScanner Scanner(*SrcFile, BufferID, Dcl, RangesSet,
+                                   Worklist);
 
           if (auto *Case = getCaseStmtOfCanonicalVar(Dcl)) {
             Scanner.walk(Case);
@@ -2550,7 +2616,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
                          Dcl->getDeclContext()->getLocalContext()) {
             Scanner.walk(LocalDC);
           } else {
-            Scanner.walk(SrcFile);
+            Scanner.walk(*SrcFile);
           }
         }
 
@@ -2592,7 +2658,8 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
     }
   };
 
-  auto Consumer = std::make_shared<RelatedIdConsumer>(Offset, Receiver, Invok);
+  auto Consumer = std::make_shared<RelatedIdConsumer>(InputBufferName, Offset,
+                                                      Receiver, Invok);
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
@@ -2607,16 +2674,14 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
 
 namespace {
 class IfConfigScanner : public SourceEntityWalker {
-  SmallVectorImpl<IfConfigInfo> &Infos;
-  SourceManager &SourceMgr;
   unsigned BufferID = -1;
+  SmallVectorImpl<IfConfigInfo> &Infos;
   bool Cancelled = false;
 
 public:
-  explicit IfConfigScanner(SourceFile &SrcFile, unsigned BufferID,
+  explicit IfConfigScanner(unsigned BufferID,
                            SmallVectorImpl<IfConfigInfo> &Infos)
-      : Infos(Infos), SourceMgr(SrcFile.getASTContext().SourceMgr),
-        BufferID(BufferID) {}
+      : BufferID(BufferID), Infos(Infos) {}
 
 private:
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
@@ -2625,7 +2690,8 @@ private:
 
     if (auto *IfDecl = dyn_cast<IfConfigDecl>(D)) {
       for (auto &Clause : IfDecl->getClauses()) {
-        unsigned Offset = SourceMgr.getLocOffsetInBuffer(Clause.Loc, BufferID);
+        unsigned Offset = D->getASTContext().SourceMgr.getLocOffsetInBuffer(
+            Clause.Loc, BufferID);
         Infos.emplace_back(Offset, Clause.isActive);
       }
     }
@@ -2637,13 +2703,13 @@ private:
 } // end anonymous namespace
 
 void SwiftLangSupport::findActiveRegionsInFile(
-    StringRef InputFile, ArrayRef<const char *> Args,
-    SourceKitCancellationToken CancellationToken,
+    StringRef PrimaryFilePath, StringRef InputBufferName,
+    ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<ActiveRegionsInfo> &)> Receiver) {
 
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, InputFile, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<ActiveRegionsInfo>::fromError(Error));
@@ -2651,23 +2717,29 @@ void SwiftLangSupport::findActiveRegionsInFile(
   }
 
   class IfConfigConsumer : public SwiftASTConsumer {
+    std::string InputFile;
     std::function<void(const RequestResult<ActiveRegionsInfo> &)> Receiver;
     SwiftInvocationRef Invok;
 
   public:
     IfConfigConsumer(
+        StringRef InputFile,
         std::function<void(const RequestResult<ActiveRegionsInfo> &)> Receiver,
         SwiftInvocationRef Invok)
-        : Receiver(std::move(Receiver)), Invok(Invok) {}
+        : InputFile(InputFile.str()), Receiver(std::move(Receiver)),
+          Invok(Invok) {}
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
-      auto &SrcFile = AstUnit->getPrimarySourceFile();
-      SmallVector<IfConfigInfo> Configs;
-      auto BufferID = SrcFile.getBufferID();
-      if (!BufferID)
+      auto *SF = retrieveInputFile(InputFile, AstUnit->getCompilerInstance());
+      if (!SF) {
+        Receiver(RequestResult<ActiveRegionsInfo>::fromError(
+            "Unable to find input file"));
         return;
-      IfConfigScanner Scanner(SrcFile, *BufferID, Configs);
-      Scanner.walk(SrcFile);
+      }
+
+      SmallVector<IfConfigInfo> Configs;
+      IfConfigScanner Scanner(*SF->getBufferID(), Configs);
+      Scanner.walk(SF);
 
       // Sort by offset so nested decls are reported
       // in source order (not tree order).
@@ -2690,7 +2762,8 @@ void SwiftLangSupport::findActiveRegionsInFile(
     }
   };
 
-  auto Consumer = std::make_shared<IfConfigConsumer>(Receiver, Invok);
+  auto Consumer =
+      std::make_shared<IfConfigConsumer>(InputBufferName, Receiver, Invok);
   ASTMgr->processASTAsync(Invok, std::move(Consumer),
                           /*OncePerASTToken=*/nullptr, CancellationToken,
                           llvm::vfs::getRealFileSystem());
@@ -2710,12 +2783,12 @@ static RefactoringKind getIDERefactoringKind(SemanticRefactoringInfo Info) {
 }
 
 void SwiftLangSupport::semanticRefactoring(
-    StringRef PrimaryFile, SemanticRefactoringInfo Info,
+    StringRef PrimaryFilePath, SemanticRefactoringInfo Info,
     ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
     CategorizedEditsReceiver Receiver) {
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, PrimaryFile, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromError(Error));
@@ -2736,20 +2809,17 @@ void SwiftLangSupport::semanticRefactoring(
       RequestRefactoringEditConsumer EditConsumer(Receiver);
 
       auto &CompIns = AstUnit->getCompilerInstance();
-      auto &SM = CompIns.getSourceMgr();
 
       RefactoringOptions Opts(getIDERefactoringKind(Info));
 
-      Optional<unsigned> BufferID;
-      if (Info.SourceFile.empty()) {
-        BufferID = AstUnit->getPrimarySourceFile().getBufferID();
-      } else {
-        BufferID = SM.getIDForBufferIdentifier(Info.SourceFile);
-      }
-      if (!BufferID)
+      SourceFile *SF = retrieveInputFile(Info.InputBufferName, CompIns);
+      if (!SF) {
+        Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromError(
+            "Unable to find input file"));
         return;
+      }
 
-      Opts.Range.BufferID = *BufferID;
+      Opts.Range.BufferID = *SF->getBufferID();
       Opts.Range.Line = Info.Line;
       Opts.Range.Column = Info.Column;
       Opts.Range.Length = Info.Length;
@@ -2778,14 +2848,15 @@ void SwiftLangSupport::semanticRefactoring(
 }
 
 void SwiftLangSupport::collectExpressionTypes(
-    StringRef FileName, ArrayRef<const char *> Args,
-    ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
-    bool CanonicalType, SourceKitCancellationToken CancellationToken,
+    StringRef PrimaryFilePath, StringRef InputBufferName,
+    ArrayRef<const char *> Args, ArrayRef<const char *> ExpectedProtocols,
+    bool FullyQualified, bool CanonicalType,
+    SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<ExpressionTypesInFile> &)>
         Receiver) {
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, FileName, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<ExpressionTypesInFile>::fromError(Error));
@@ -2794,6 +2865,7 @@ void SwiftLangSupport::collectExpressionTypes(
   assert(Invok);
   class ExpressionTypeCollector: public SwiftASTConsumer {
     std::function<void(const RequestResult<ExpressionTypesInFile> &)> Receiver;
+    std::string InputFile;
     std::vector<const char *> ExpectedProtocols;
     bool FullyQualified;
     bool CanonicalType;
@@ -2801,13 +2873,20 @@ void SwiftLangSupport::collectExpressionTypes(
     ExpressionTypeCollector(
         std::function<void(const RequestResult<ExpressionTypesInFile> &)>
             Receiver,
-        ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
-        bool CanonicalType)
-        : Receiver(std::move(Receiver)),
+        StringRef InputFile, ArrayRef<const char *> ExpectedProtocols,
+        bool FullyQualified, bool CanonicalType)
+        : Receiver(std::move(Receiver)), InputFile(InputFile.str()),
           ExpectedProtocols(ExpectedProtocols.vec()),
           FullyQualified(FullyQualified), CanonicalType(CanonicalType) {}
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
-      auto *SF = AstUnit->getCompilerInstance().getPrimarySourceFile();
+      SourceFile *SF =
+          retrieveInputFile(InputFile, AstUnit->getCompilerInstance());
+      if (!SF) {
+        Receiver(RequestResult<ExpressionTypesInFile>::fromError(
+            "Unable to find input file"));
+        return;
+      }
+
       std::vector<ExpressionTypeInfo> Scratch;
       llvm::SmallString<256> TypeBuffer;
       llvm::raw_svector_ostream OS(TypeBuffer);
@@ -2833,7 +2912,8 @@ void SwiftLangSupport::collectExpressionTypes(
     }
   };
   auto Collector = std::make_shared<ExpressionTypeCollector>(
-      Receiver, ExpectedProtocols, FullyQualified, CanonicalType);
+      Receiver, InputBufferName, ExpectedProtocols, FullyQualified,
+      CanonicalType);
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
@@ -2843,13 +2923,14 @@ void SwiftLangSupport::collectExpressionTypes(
 }
 
 void SwiftLangSupport::collectVariableTypes(
-    StringRef FileName, ArrayRef<const char *> Args, Optional<unsigned> Offset,
+    StringRef PrimaryFilePath, StringRef InputBufferName,
+    ArrayRef<const char *> Args, Optional<unsigned> Offset,
     Optional<unsigned> Length, bool FullyQualified,
     SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver) {
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getTypecheckInvocation(Args, FileName, Error);
+      ASTMgr->getTypecheckInvocation(Args, PrimaryFilePath, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<VariableTypesInFile>::fromError(Error));
@@ -2860,6 +2941,7 @@ void SwiftLangSupport::collectVariableTypes(
   class VariableTypeCollectorASTConsumer : public SwiftASTConsumer {
   private:
     std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver;
+    std::string InputFile;
     Optional<unsigned> Offset;
     Optional<unsigned> Length;
     bool FullyQualified;
@@ -2868,14 +2950,19 @@ void SwiftLangSupport::collectVariableTypes(
     VariableTypeCollectorASTConsumer(
         std::function<void(const RequestResult<VariableTypesInFile> &)>
             Receiver,
-        Optional<unsigned> Offset, Optional<unsigned> Length,
-        bool FullyQualified)
-        : Receiver(std::move(Receiver)), Offset(Offset), Length(Length),
-          FullyQualified(FullyQualified) {}
+        StringRef InputFile, Optional<unsigned> Offset,
+        Optional<unsigned> Length, bool FullyQualified)
+        : Receiver(std::move(Receiver)), InputFile(InputFile), Offset(Offset),
+          Length(Length), FullyQualified(FullyQualified) {}
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
       auto &CompInst = AstUnit->getCompilerInstance();
-      auto *SF = CompInst.getPrimarySourceFile();
+      SourceFile *SF = retrieveInputFile(InputFile, CompInst);
+      if (!SF) {
+        Receiver(RequestResult<VariableTypesInFile>::fromError(
+            "Unable to find input file"));
+        return;
+      }
 
       // Construct the range for which variable types are to be queried. If
       // offset/length are unset, the (default) range will be used, which
@@ -2914,7 +3001,7 @@ void SwiftLangSupport::collectVariableTypes(
   };
 
   auto Collector = std::make_shared<VariableTypeCollectorASTConsumer>(
-      Receiver, Offset, Length, FullyQualified);
+      Receiver, InputBufferName, Offset, Length, FullyQualified);
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -533,8 +533,6 @@ static void setRefactoringFields(sourcekitd_object_t &Req, TestOptions Opts,
   sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                         RequestSemanticRefactoring);
   sourcekitd_request_dictionary_set_uid(Req, KeyActionUID, RefactoringKind);
-  sourcekitd_request_dictionary_set_string(Req, KeyPrimaryFile,
-                                           Opts.PrimaryFile.c_str());
   sourcekitd_request_dictionary_set_string(Req, KeyName, Opts.Name.c_str());
   sourcekitd_request_dictionary_set_int64(Req, KeyLine, line);
   sourcekitd_request_dictionary_set_int64(Req, KeyColumn, col);
@@ -1119,6 +1117,11 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     }
     sourcekitd_request_dictionary_set_string(Req, KeySourceFile,
                                              Opts.SourceFile.c_str());
+  }
+
+  if (!Opts.PrimaryFile.empty()) {
+    sourcekitd_request_dictionary_set_string(Req, KeyPrimaryFile,
+                                             Opts.PrimaryFile.c_str());
   }
 
   if (Opts.SourceText) {

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -421,13 +421,14 @@ int main(int argc, char *argv[]) {
   RangeConfig Range = getRange(BufferID, SM, StartLoc, EndLoc);
 
   if (options::Action == RefactoringKind::None) {
-    llvm::SmallVector<RefactoringKind, 32> Kinds;
     bool CollectRangeStartRefactorings = false;
-    collectAvailableRefactorings(SF, Range, CollectRangeStartRefactorings,
-                                 Kinds, {&PrintDiags});
+    auto Refactorings = collectRefactorings(
+        SF, Range, CollectRangeStartRefactorings, {&PrintDiags});
     llvm::outs() << "Action begins\n";
-    for (auto Kind : Kinds) {
-      llvm::outs() << getDescriptiveRefactoringKindName(Kind) << "\n";
+    for (auto Info : Refactorings) {
+      if (Info.AvailableKind == RefactorAvailableKind::Available) {
+        llvm::outs() << getDescriptiveRefactoringKindName(Info.Kind) << "\n";
+      }
     }
     llvm::outs() << "Action ends\n";
     return 0;

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -163,7 +163,7 @@ public:
 
     TestCursorInfo TestInfo;
     getLang().getCursorInfo(
-        DocName, Offset, /*Length=*/0, /*Actionables=*/false,
+        DocName, DocName, Offset, /*Length=*/0, /*Actionables=*/false,
         /*SymbolGraph=*/false, CancelOnSubsequentRequest, Args,
         /*vfsOptions=*/None, CancellationToken,
         [&](const RequestResult<CursorInfoData> &Result) {
@@ -448,7 +448,7 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
   // cancelled as the next cursor info (which is faster) gets requested.
   Semaphore FirstCursorInfoSema(0);
   getLang().getCursorInfo(
-      SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
+      SlowDocName, SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
       /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/true, ArgsForSlow,
       /*vfsOptions=*/None, /*CancellationToken=*/nullptr,
       [&](const RequestResult<CursorInfoData> &Result) {
@@ -491,7 +491,7 @@ TEST_F(CursorInfoTest, CursorInfoCancellation) {
   // cancelled as the next cursor info (which is faster) gets requested.
   Semaphore CursorInfoSema(0);
   getLang().getCursorInfo(
-      SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
+      SlowDocName, SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
       /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/false, ArgsForSlow,
       /*vfsOptions=*/None, /*CancellationToken=*/CancellationToken,
       [&](const RequestResult<CursorInfoData> &Result) {


### PR DESCRIPTION
Update indexing and cursor info to return the original location for declarations/references inside generated (macro) code.
* Explanation: Bundle of fixes for indexing and cursor info to handle generated (macro) code. Updates swiftsourceinfo to use the original location for declarations (this is used in a number of places, including cursor info) and indexing to also use the original location for all declarations and references.
* Scope:  Anything using swiftsourceinfo + indexing
* Risk: Medium; macros is a new feature, this updates functionality to better handle such generated code
* Testing: Added various new tests to check locations across modules
* Original PRs: https://github.com/apple/swift/pull/64456, https://github.com/apple/swift/pull/64663, https://github.com/apple/swift/pull/64737