### PR TITLE
[Executors] Ensure we treat DA older than 5.9 always as DefaultActor

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -891,6 +891,9 @@ public:
   /// Get the back-deployed availability for concurrency.
   AvailabilityContext getBackDeployedConcurrencyAvailability();
 
+  /// The the availability since when distributed actors are able to have custom executors.
+  AvailabilityContext getConcurrencyDistributedActorWithCustomExecutorAvailability();
+
   /// Get the runtime availability of support for differentiation.
   AvailabilityContext getDifferentiationAvailability();
 
@@ -933,6 +936,14 @@ public:
   /// Get the runtime availability of features introduced in the Swift 5.7
   /// compiler for the target platform.
   AvailabilityContext getSwift57Availability();
+
+  /// Get the runtime availability of features introduced in the Swift 5.8
+  /// compiler for the target platform.
+  AvailabilityContext getSwift58Availability();
+
+  /// Get the runtime availability of features introduced in the Swift 5.9
+  /// compiler for the target platform.
+  AvailabilityContext getSwift59Availability();
 
   // Note: Update this function if you add a new getSwiftXYAvailability above.
   /// Get the runtime availability for a particular version of Swift (5.0+).

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -329,6 +329,11 @@ public:
   bool isAvailableAsSPI() const {
     return SPI && *SPI;
   }
+
+  /// Returns a representation of this range as a string for debugging purposes.
+  std::string getAsString() const {
+    return "AvailabilityContext(" + OSVersion.getAsString() + (isAvailableAsSPI() ? ", spi" : "") + ")";
+  }
 };
 
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -489,6 +489,10 @@ AvailabilityContext ASTContext::getBackDeployedConcurrencyAvailability() {
   return getSwift51Availability();
 }
 
+AvailabilityContext ASTContext::getConcurrencyDistributedActorWithCustomExecutorAvailability() {
+  return getSwift59Availability();
+}
+
 AvailabilityContext ASTContext::getDifferentiationAvailability() {
   return getSwiftFutureAvailability();
 }
@@ -642,6 +646,28 @@ AvailabilityContext ASTContext::getSwift57Availability() {
   }
 }
 
+AvailabilityContext ASTContext::getSwift58Availability() {
+  auto target = LangOpts.Target;
+
+  if (target.isMacOSX()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(13, 3, 0)));
+  } else if (target.isiOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(16, 4, 0)));
+  } else if (target.isWatchOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(9, 4, 0)));
+  } else {
+    return AvailabilityContext::alwaysAvailable();
+  }
+}
+
+AvailabilityContext ASTContext::getSwift59Availability() {
+  // TODO: Update Availability impl when Swift 5.9 is released
+  return getSwiftFutureAvailability();
+}
+
 AvailabilityContext ASTContext::getSwiftFutureAvailability() {
   auto target = LangOpts.Target;
 
@@ -671,6 +697,8 @@ ASTContext::getSwift5PlusAvailability(llvm::VersionTuple swiftVersion) {
     case 5: return getSwift55Availability();
     case 6: return getSwift56Availability();
     case 7: return getSwift57Availability();
+    case 8: return getSwift58Availability();
+    case 9: return getSwift59Availability();
     default: break;
     }
   }

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -185,6 +185,9 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
   // If the actor type is a default actor, go ahead and devirtualize here.
   auto module = F->getModule().getSwiftModule();
   SILValue unmarkedExecutor;
+
+  // Determine if the actor is a "default actor" in which case we'll build a default
+  // actor executor ref inline, rather than calling out to the user-provided executor function.
   if (isDefaultActorType(actorType, module, F->getResilienceExpansion())) {
     auto builtinName = ctx.getIdentifier(
       getBuiltinName(BuiltinValueKind::BuildDefaultActorExecutorRef));

--- a/test/Distributed/Runtime/distributed_actor_assume_executor.swift
+++ b/test/Distributed/Runtime/distributed_actor_assume_executor.swift
@@ -39,6 +39,7 @@ func check(actor: MainDistributedFriend) {
   checkAssumeMainActor(actor: actor)
 }
 
+@available(SwiftStdlib 5.9, *)
 distributed actor MainDistributedFriend {
   nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
     print("get unowned executor")

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
@@ -1,0 +1,105 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.7, *)
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+@available(SwiftStdlib 5.7, *)
+distributed actor FiveSevenActor_NothingExecutor {
+//  @available(SwiftStdlib 5.9, *) // because of `localUnownedExecutor`
+  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    assumeOnMainActorExecutor {
+      // ignore
+    }
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+distributed actor FiveNineActor_NothingExecutor {
+//  @available(SwiftStdlib 5.9, *) // because of `localUnownedExecutor`
+  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    assumeOnMainActorExecutor {
+      // ignore
+    }
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+distributed actor FiveSevenActor_FiveNineExecutor {
+  @available(SwiftStdlib 5.9, *)
+  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    assumeOnMainActorExecutor {
+      // ignore
+    }
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    if #available(SwiftStdlib 5.9, *) {
+      let tests = TestSuite("DistributedActorExecutorAvailability")
+
+      let system = LocalTestingDistributedActorSystem()
+
+      tests.test("5.7 actor, no availability executor property => no custom executor") {
+        expectCrashLater(withMessage: "Fatal error: Incorrect actor executor assumption; Expected 'MainActor' executor.")
+        try! await FiveSevenActor_NothingExecutor(actorSystem: system).test(x: 42)
+      }
+
+      tests.test("5.9 actor, no availability executor property => custom executor") {
+        try! await FiveNineActor_NothingExecutor(actorSystem: system).test(x: 42)
+      }
+
+      tests.test("5.7 actor, 5.9 executor property => no custom executor") {
+        expectCrashLater(withMessage: "Fatal error: Incorrect actor executor assumption; Expected 'MainActor' executor.")
+        try! await FiveSevenActor_FiveNineExecutor(actorSystem: system).test(x: 42)
+      }
+
+      await runAllTestsAsync()
+    }
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
@@ -21,6 +21,7 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
+@available(SwiftStdlib 5.9, *) // because conforming to the protocol... that has this field in 5.9?
 distributed actor Worker {
   nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
     print("get unowned executor")

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
@@ -21,6 +21,7 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
+@available(SwiftStdlib 5.9, *)
 distributed actor Worker {
   nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
     print("get unowned 'local' executor via ID")

--- a/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
+++ b/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
@@ -20,7 +20,7 @@ distributed actor MyDistActor {
     }
 
 // // MyDistActor.init(actorSystem:)
-// CHECK: sil hidden @$s14default_deinit11MyDistActorC11actorSystemAC015FakeDistributedE7Systems0h9RoundtripeG0C_tcfc : $@convention(method) (@owned FakeRoundtripActorSystem, @owned MyDistActor) -> @owned MyDistActor
+// CHECK: sil hidden {{.*}} @$s14default_deinit11MyDistActorC11actorSystemAC015FakeDistributedE7Systems0h9RoundtripeG0C_tcfc : $@convention(method) (@owned FakeRoundtripActorSystem, @owned MyDistActor) -> @owned MyDistActor
 // CHECK-NOT: {{%[0-9]+}} = builtin "initializeDefaultActor"(%1 : $MyDistActor) : $()
 // CHECK: [[ACTOR_INSTANCE:%[0-9]+]] = builtin "initializeNonDefaultDistributedActor"(%1 : $MyDistActor) : $()
 }

--- a/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
+++ b/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -module-name default_deinit -primary-file %s -emit-sil -verify -disable-availability-checking -I %t | %FileCheck %s --enable-var-scope --dump-input=fail
+// RUN: %target-swift-frontend -module-name default_deinit -primary-file %s -emit-sil -verify -disable-availability-checking -I %t | %FileCheck %s --enable-var-scope
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -20,7 +20,7 @@ distributed actor MyDistActor {
     }
 
 // // MyDistActor.init(actorSystem:)
-// CHECK: sil hidden {{.*}} @$s14default_deinit11MyDistActorC11actorSystemAC015FakeDistributedE7Systems0h9RoundtripeG0C_tcfc : $@convention(method) (@owned FakeRoundtripActorSystem, @owned MyDistActor) -> @owned MyDistActor
+// CHECK: sil hidden{{.*}} @$s14default_deinit11MyDistActorC11actorSystemAC015FakeDistributedE7Systems0h9RoundtripeG0C_tcfc : $@convention(method) (@owned FakeRoundtripActorSystem, @owned MyDistActor) -> @owned MyDistActor
 // CHECK-NOT: {{%[0-9]+}} = builtin "initializeDefaultActor"(%1 : $MyDistActor) : $()
 // CHECK: [[ACTOR_INSTANCE:%[0-9]+]] = builtin "initializeNonDefaultDistributedActor"(%1 : $MyDistActor) : $()
 }

--- a/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
+++ b/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
@@ -13,6 +13,7 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 // ==== ----------------------------------------------------------------------------------------------------------------
 
+@available(SwiftStdlib 5.9, *)
 distributed actor MyDistActor {
     nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
         return MainActor.sharedUnownedExecutor

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -34,6 +34,7 @@ SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+# TODO: Also update ASTContext::getSwift59Availability when 5.9 is released
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
This is because cross module references to a RESILIENT actor would have short circuited and returned false for such actor, while an old compiler does not have code to handle the "NON default distributed actor" paths, so it would result in compile issues in HopToActor optimization