### PR TITLE
[5.9] Downgrade placeholder error to warning for swiftparser

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -89,6 +89,7 @@ func emitDiagnostic(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
   sourceFileBuffer: UnsafeMutableBufferPointer<UInt8>,
   diagnostic: Diagnostic,
+  diagnosticSeverity: DiagnosticSeverity,
   messageSuffix: String? = nil
 ) {
   // Emit the main diagnostic
@@ -96,7 +97,7 @@ func emitDiagnostic(
     diagEnginePtr: diagEnginePtr,
     sourceFileBuffer: sourceFileBuffer,
     message: diagnostic.diagMessage.message + (messageSuffix ?? ""),
-    severity: diagnostic.diagMessage.severity,
+    severity: diagnosticSeverity,
     position: diagnostic.position,
     highlights: diagnostic.highlights
   )
@@ -107,7 +108,8 @@ func emitDiagnostic(
         diagEnginePtr: diagEnginePtr,
         sourceFileBuffer: sourceFileBuffer,
         message: fixIt.message.message,
-        severity: .note, position: diagnostic.position,
+        severity: .note,
+        position: diagnostic.position,
         fixItChanges: fixIt.changes.changes
     )
   }
@@ -118,7 +120,8 @@ func emitDiagnostic(
       diagEnginePtr: diagEnginePtr,
       sourceFileBuffer: sourceFileBuffer,
       message: note.message,
-      severity: .note, position: note.position
+      severity: .note,
+      position: note.position
     )
   }
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -186,9 +186,10 @@ extern "C" int swift_ASTGen_roundTripCheck(void *sourceFile);
 
 /// Emit parser diagnostics for given source file.. Returns non-zero if any
 /// diagnostics were emitted.
-extern "C" int swift_ASTGen_emitParserDiagnostics(void *diagEngine,
-                                                  void *sourceFile,
-                                                  int emitOnlyErrors);
+extern "C" int
+swift_ASTGen_emitParserDiagnostics(void *diagEngine, void *sourceFile,
+                                   int emitOnlyErrors,
+                                   int downgradePlaceholderErrorsToWarnings);
 
 // Build AST nodes for the top-level entities in the syntax.
 extern "C" void swift_ASTGen_buildTopLevelASTNodes(void *sourceFile,
@@ -274,9 +275,12 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
       diagnose(loc, diag::parser_round_trip_error);
     } else if (Context.LangOpts.hasFeature(Feature::ParserValidation) &&
                !Context.Diags.hadAnyError() &&
-               swift_ASTGen_emitParserDiagnostics(&Context.Diags,
-                                                  SF.exportedSourceFile,
-                                                  /*emitOnlyErrors=*/true)) {
+               swift_ASTGen_emitParserDiagnostics(
+                   &Context.Diags, SF.exportedSourceFile,
+                   /*emitOnlyErrors=*/true,
+                   /*downgradePlaceholderErrorsToWarnings=*/
+                       Context.LangOpts.Playground ||
+                       Context.LangOpts.WarnOnEditorPlaceholder)) {
       // We might have emitted warnings in the C++ parser but no errors, in
       // which case we still have `hadAnyError() == false`. To avoid emitting
       // the same warnings from SwiftParser, only emit errors from SwiftParser
@@ -316,7 +320,10 @@ Parser::parseSourceFileViaASTGen(SmallVectorImpl<ASTNode> &items,
          Context.LangOpts.hasFeature(Feature::ParserASTGen)) &&
         !suppressDiagnostics &&
         swift_ASTGen_emitParserDiagnostics(
-            &Context.Diags, SF.exportedSourceFile, /*emitOnlyErrors=*/false) &&
+            &Context.Diags, SF.exportedSourceFile, /*emitOnlyErrors=*/false,
+            /*downgradePlaceholderErrorsToWarnings=*/
+                Context.LangOpts.Playground ||
+                Context.LangOpts.WarnOnEditorPlaceholder) &&
         Context.Diags.hadAnyError() &&
         !Context.LangOpts.hasFeature(Feature::ParserASTGen)) {
       // Errors were emitted, and we're still using the C++ parser, so


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/64382 to `release/5.9`.

---

Companion of https://github.com/apple/swift-syntax/pull/1475#issuecomment-1491289675