### PR TITLE
[Macros] Properly compute the innermost declaration context of a macro.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -574,6 +574,8 @@ DeclContext *Decl::getInnermostDeclContext() const {
     return const_cast<ExtensionDecl*>(ext);
   if (auto topLevel = dyn_cast<TopLevelCodeDecl>(this))
     return const_cast<TopLevelCodeDecl*>(topLevel);
+  if (auto macro = dyn_cast<MacroDecl>(this))
+    return const_cast<MacroDecl*>(macro);
 
   return getDeclContext();
 }

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -169,3 +169,13 @@ func test() {
   let _: [MacroOrType.Nested] = []
   _ = [MacroOrType.Nested]()
 }
+
+// Make sure we have the right declaration context for type-checking the result
+// types of macros. At one point, we would reject the following macro.
+protocol MyProto {
+}
+struct MyStruct<T: MyProto> {
+}
+
+@freestanding(expression) macro myMacro<T : MyProto>(_ value: MyStruct<T>) -> MyStruct<T> = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}


### PR DESCRIPTION
How did we go this long without having the right context? Who knows. The fix is trivial and obvious.

The failure mode here is that we wouldn't get an appropriate generic context in the result type of a macro, so we would complain about generic parameters not meeting their own generic requirements.
