### PR TITLE
[Macros] Properly compute the innermost declaration context of a macro.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -574,6 +574,8 @@ DeclContext *Decl::getInnermostDeclContext() const {
     return const_cast<ExtensionDecl*>(ext);
   if (auto topLevel = dyn_cast<TopLevelCodeDecl>(this))
     return const_cast<TopLevelCodeDecl*>(topLevel);
+  if (auto macro = dyn_cast<MacroDecl>(this))
+    return const_cast<MacroDecl*>(macro);
 
   return getDeclContext();
 }

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -167,3 +167,13 @@ func test() {
   let _: [MacroOrType.Nested] = []
   _ = [MacroOrType.Nested]()
 }
+
+// Make sure we have the right declaration context for type-checking the result
+// types of macros. At one point, we would reject the following macro.
+protocol MyProto {
+}
+struct MyStruct<T: MyProto> {
+}
+
+@freestanding(expression) macro myMacro<T : MyProto>(_ value: MyStruct<T>) -> MyStruct<T> = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}


### PR DESCRIPTION
* Explanation: A core operation to find the "innermost" declaration context for a macro declaration was incorrect, leading to the type checker rejecting obviously-correct generic macro declarations.
* Scope: Affects generic macro declarations.
* Risk: Low; only affects generic macro declarations that were incorrectly rejected before.
* Issue: rdar://107479809
* Testing: Additional tests added.
* Original pull request: https://github.com/apple/swift/pull/64806
