### PR TITLE
[Distributed] AST test was too picky about asserting the shape;

### DIFF
--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -27,7 +27,7 @@ distributed actor DefaultWorker {
 // CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non-resilient actor
 // The unowned executor property:
 // CHECK:    (var_decl implicit "localUnownedExecutor" type='Optional<UnownedSerialExecutor>' interface type='Optional<UnownedSerialExecutor>' access=internal final readImpl=getter immutable
-// CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal final get_for=localUnownedExecutor
+// CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal {{.*}} get_for=localUnownedExecutor
 // CHECK:       (parameter "self" type='DefaultWorker' interface type='DefaultWorker')
 // CHECK:       (parameter_list)
 // CHECK:       (brace_stmt implicit


### PR DESCRIPTION
depending on configuration some attributes may not be present in the AST here it seems, causing the test to fail in some configurations

Resolves rdar://107385732