### PR TITLE
Fully enable ExperimentalStringProcessing

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -182,7 +182,7 @@ namespace swift {
     version::Version PackageDescriptionVersion;
 
     /// Enable experimental string processing
-    bool EnableExperimentalStringProcessing = false;
+    bool EnableExperimentalStringProcessing = true;
 
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -542,8 +542,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     // forward slash regex `/.../`.
     if (!Opts.EnableExperimentalStringProcessing)
       Opts.EnableBareSlashRegexLiterals = false;
-  } else {
-    Opts.EnableExperimentalStringProcessing = true;
   }
 
   Opts.DisableAvailabilityChecking |=

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -disable-implicit-concurrency-module-import -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %target-swift-ide-test -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 // NO_STDLIB_PRIVATE-NOT: Decl{{[^:]*}}/IsSystem: _
 

--- a/test/StringProcessing/Parse/forward-slash-regex-disabled.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-disabled.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 // REQUIRES: swift_in_compiler
 

--- a/test/StringProcessing/Sema/string_processing_import.swift
+++ b/test/StringProcessing/Sema/string_processing_import.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-implicit-string-processing-module-import -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-implicit-string-processing-module-import -disable-availability-checking
 // REQUIRES: swift_in_compiler
 
 // expected-error @+1 {{missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly}}

--- a/test/StringProcessing/Sema/string_processing_module_shadowing.swift
+++ b/test/StringProcessing/Sema/string_processing_module_shadowing.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/ShadowsStringProcessing.swiftmodule -module-name ShadowsStringProcessing %S/Inputs/ShadowsStringProcessing.swift -disable-availability-checking
-// RUN: %target-typecheck-verify-swift -I %t -enable-experimental-string-processing -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %t -disable-availability-checking
 
 import ShadowsStringProcessing
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -834,11 +834,6 @@ EnableExperimentalDistributed("enable-experimental-distributed",
                               llvm::cl::desc("Enable experimental distributed actors and functions"),
                               llvm::cl::init(false));
 
-static llvm::cl::opt<bool> EnableExperimentalStringProcessing(
-    "enable-experimental-string-processing",
-    llvm::cl::desc("Enable experimental string processing"),
-    llvm::cl::init(false));
-
 static llvm::cl::opt<bool> EnableBareSlashRegexLiterals(
     "enable-bare-slash-regex",
     llvm::cl::desc("Enable the ability to write '/.../' regex literals"),
@@ -4374,9 +4369,6 @@ int main(int argc, char *argv[]) {
 
   if (options::EnableExperimentalNamedOpaqueTypes) {
     InitInvok.getLangOptions().Features.insert(Feature::NamedOpaqueTypes);
-  }
-  if (options::EnableExperimentalStringProcessing) {
-    InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
   }
   if (options::EnableBareSlashRegexLiterals) {
     InitInvok.getLangOptions().Features.insert(Feature::BareSlashRegexLiterals);

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -129,10 +129,6 @@ static llvm::cl::opt<bool> EnableExperimentalConcurrency(
     "enable-experimental-concurrency",
     llvm::cl::desc("Whether to enable experimental concurrency or not"));
 
-static llvm::cl::opt<bool> EnableExperimentalStringProcessing(
-    "enable-experimental-string-processing",
-    llvm::cl::desc("Whether to enable experimental string processing or not"));
-
 static llvm::cl::opt<std::string>
     SDK("sdk", llvm::cl::desc("Path to the SDK to build against"));
 
@@ -315,9 +311,6 @@ int main(int argc, char *argv[]) {
 
   if (options::EnableExperimentalConcurrency)
     Invocation.getLangOptions().EnableExperimentalConcurrency = true;
-
-  if (options::EnableExperimentalStringProcessing)
-    Invocation.getLangOptions().EnableExperimentalStringProcessing = true;
 
   for (auto FileName : options::InputFilenames)
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -31,7 +31,6 @@ def parse_args():
          - swift-refactor
          - temp-dir
          - enable-experimental-concurrency (sent to both)
-         - enable-experimental-string-processing (sent to both)
          - I (sent to both)
          - sdk (sent to both)
          - target (sent to both)
@@ -74,14 +73,6 @@ def parse_args():
         '''
     )
     parser.add_argument(
-        '-enable-experimental-string-processing',
-        action='store_true',
-        help='''
-        Whether to enable experimental string processing in both swift-refactor
-        and swift-frontend
-        '''
-    )
-    parser.add_argument(
         '-I',
         action='append',
         help='Add a directory to the import search path'
@@ -110,8 +101,6 @@ def main():
     extra_both_args = []
     if args.enable_experimental_concurrency:
         extra_both_args.append('-enable-experimental-concurrency')
-    if args.enable_experimental_string_processing:
-        extra_both_args.append('-enable-experimental-string-processing')
     if args.I:
         for path in args.I:
             extra_both_args += ['-I', path]

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -104,8 +104,6 @@ def create_parser():
                         help='Enable experimental concurrency model.')
     parser.add_argument('--enable-experimental-distributed', action='store_true',
                         help='Enable experimental distributed actors.')
-    parser.add_argument('--enable-experimental-string-processing', action='store_true',
-                        help='Enable experimental string processing.')
     parser.add_argument('--enable-experimental-observation', action='store_true',
                         help='Enable experimental observation.')
     parser.add_argument('-swift-version', metavar='N',
@@ -335,8 +333,6 @@ def main():
     extra_args = ['-skip-imports']
     if args.enable_experimental_concurrency:
         extra_args = extra_args + ['-enable-experimental-concurrency']
-    if args.enable_experimental_string_processing:
-        extra_args = extra_args + ['-enable-experimental-string-processing']
     if args.swift_version:
         extra_args = extra_args + ['-swift-version', '%s' % args.swift_version]
 


### PR DESCRIPTION
Previously we would only enable by default when `parseArgs` was called. However this wouldn't enable it for clients such as LLDB, who provide their own invocation. Switch the default to `true` in the `LangOptions`, and remove some redundant uses of `-enable-experimental-string-processing`. The frontend flag remains, as it may be useful to disable.

rdar://107419385
rdar://101765556