### PR TITLE
[5.9][interop] emit symbolic interfaces with method signatures with matchi…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3249,7 +3249,26 @@ namespace {
       } else {
         if (importFuncWithoutSignature) {
           importedType = ImportedType{Impl.SwiftContext.getVoidType(), false};
-          bodyParams = ParameterList::createEmpty(Impl.SwiftContext);
+          if (decl->param_empty())
+            bodyParams = ParameterList::createEmpty(Impl.SwiftContext);
+          else {
+            llvm::SmallVector<ParamDecl *, 4> params;
+            for (const auto &param : decl->parameters()) {
+
+              Identifier bodyName =
+                  Impl.importFullName(param, Impl.CurrentVersion)
+                      .getDeclName()
+                      .getBaseIdentifier();
+              auto paramInfo = Impl.createDeclWithClangNode<ParamDecl>(
+                  param, AccessLevel::Private, SourceLoc(), SourceLoc(),
+                  Identifier(), Impl.importSourceLoc(param->getLocation()),
+                  bodyName, Impl.ImportedHeaderUnit);
+              paramInfo->setSpecifier(ParamSpecifier::Default);
+              paramInfo->setInterfaceType(Impl.SwiftContext.TheAnyType);
+              params.push_back(paramInfo);
+            }
+            bodyParams = ParameterList::create(Impl.SwiftContext, params);
+          }
         } else {
           // Import the function type. If we have parameters, make sure their
           // names get into the resulting function type.

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
@@ -9,7 +9,9 @@
 // Verify that symbolic interface is not emitted without interop.
 //
 // RUN: rm -r %t/store/interfaces
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NONE %s
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -Rindexing-system-module 2>&1 > %t/out
+// RUN: echo "non-empty-file-check" >> %t/out
+// RUN: cat %t/out | %FileCheck --check-prefix=REMARK_NONE %s
 // RUN: not ls %t/store/interfaces
 
 // REQUIRES: objc_interop

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
@@ -35,7 +35,7 @@ public func useConcreteTemplate() {
 // CHECK-EMPTY:
 // CHECK-NEXT: public struct TemplateRecord {
 // CHECK-EMPTY:
-// CHECK-NEXT:    public func methodFunc()
+// CHECK-NEXT:    public func methodFunc(_ x: Any)
 // CHECK-NEXT:}
 // CHECK-NEXT:}
 // CHECK-NEXT: public typealias TemplateRecordInt = ns.TemplateRecord

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -123,11 +123,11 @@ import CxxModule
 // CHECK-EMPTY:
 // CHECK-NEXT:  struct TemplateRecord {
 // CHECK-EMPTY:
-// CHECK-NEXT:    mutating func methodFunc()
+// CHECK-NEXT:    mutating func methodFunc(_ x: Any)
 // CHECK-EMPTY:
 // CHECK-NEXT:    struct InnerRecord {
 // CHECK-EMPTY:
-// CHECK-NEXT:      mutating func innerMethod()
+// CHECK-NEXT:      mutating func innerMethod(_ y: Any)
 // CHECK-NEXT:    }
 // CHECK-EMPTY:
 // CHECK-NEXT:    struct InnerTemplate {

--- a/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
@@ -15,7 +15,7 @@
 // STRING: typealias string = std.__1.basic_string
 
 // VECTOR: struct vector {
-// VECTOR: mutating func push_back()
+// VECTOR: mutating func push_back(_ __x: Any)
 // VECTOR: }
 
 // MAP: struct map {

--- a/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
@@ -52,9 +52,9 @@ using MyType = ns::TemplateRecord<int>;
 // CHECK-NEXT:    var y: Int32
 // CHECK-NEXT:  }
 // CHECK-NEXT:  struct TemplateRecord {
-// CHECK-NEXT:    mutating func methodFunc()
+// CHECK-NEXT:    mutating func methodFunc(_ x: Any)
 // CHECK-NEXT:    struct InnerRecord {
-// CHECK-NEXT:      mutating func innerMethod()
+// CHECK-NEXT:      mutating func innerMethod(_ y: Any)
 // CHECK-NEXT:    }
 // CHECK-NEXT:    struct InnerTemplate {
 // CHECK-NEXT:      mutating func innerTemplateMethod()


### PR DESCRIPTION
…ng parameter count

We do not care about parameter's type in the symbolic method declaration, but we do care about the arity of the method.

(cherry picked from commit 991d0a720de39c215e99b5d8cf6cc121292f9dd5)

rdar://105179395