### PR TITLE
[5.9][interop][sourcekit] report a module error for any unconditional modu…

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_clang_mixed_lang_fmwk_cxx_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_mixed_lang_fmwk_cxx_module.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/TestFmSwift.swift -module-name TestFm -enable-experimental-cxx-interop -F %t -o %t/TestFm.swiftmodule -import-underlying-module
+
+// RUN: %sourcekitd-test -req=interface-gen -module TestFm -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck %s
+
+//--- TestFm.framework/Headers/TestFm.h
+#pragma once
+
+namespace ns {
+    void testFunction();
+}
+
+//--- TestFm.framework/Modules/module.modulemap
+framework module TestFm {
+    umbrella header "TestFm.h"
+
+    export *
+    module * { export * }
+}
+
+//--- TestFmSwift.swift
+
+public func testSwiftFunc() {
+}
+
+// CHECK: public enum ns {
+// CHECK:  public static func testFunction()
+// CHECK: }
+
+// CHECK: public func testSwiftFunc()

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -287,9 +287,12 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx,
     ErrMsg += ModuleName;
     return true;
   }
-  if (Mod->failedToLoad() && ModuleName == "CxxStdlib") {
+  if (Mod->failedToLoad()) {
     // We might fail to load the underlying Clang module
-    // for a Swift overlay module like 'CxxStdlib'. Make sure an error is reported in this case, so that we can either retry to load with C++ interoperability enabled, and if that fails, we can report this to the user.
+    // for a Swift overlay module like 'CxxStdlib', or a mixed-language
+    // framework. Make sure an error is reported in this case, so that we can
+    // either retry to load with C++ interoperability enabled, and if that
+    // fails, we can report this to the user.
     ErrMsg = "Could not load underlying module for: ";
     ErrMsg += ModuleName;
     return true;


### PR DESCRIPTION
…le loading failure

This ensures that interface gen reports an error when importing a framework Swift module that also imports the underlying C++ module into Swift, when interop is disabled, so that we can retry the interface gen with interop enabled.

(cherry picked from commit 3b143d7d4ecdf0a32c1e98e1e37d2473c1a8730d)
