### PR TITLE
Use "transparent_stepping" attribute in C++ compiler generated interop

### DIFF
--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -28,9 +28,9 @@
 # define SWIFT_CALL __attribute__((swiftcall))
 #endif
 
-#if __has_attribute(always_inline) && __has_attribute(nodebug)
+#if __has_attribute(transparent_stepping)
 #define SWIFT_INLINE_THUNK_ATTRIBUTES                                          \
-  __attribute__((always_inline)) __attribute__((nodebug))
+  __attribute__((transparent_stepping)) 
 #if defined(DEBUG) && __has_attribute(used)
 // Additional 'used' attribute is used in debug mode to make inline thunks
 // accessible to LLDB.


### PR DESCRIPTION
Use transparent_stepping instead of nodebug and alwaysinline in compiler generated C++ code from Swift. This attribute allow for annotated functions to be used in expression evaluation, which is an advantage over the former two.
