### PR TITLE
[5.9][Tests] Disable a test case

### DIFF
--- a/test/Interpreter/objc_protocols.swift
+++ b/test/Interpreter/objc_protocols.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar107343134
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
cherry-pick https://github.com/apple/swift/pull/64739
Disable test/Interpreter/objc_protocols.swift while investigating

rdar://107343134