### PR TITLE
[Dependency Scanning] Disable Swift Parser ASTGen during dependency scan

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -90,6 +90,10 @@ public:
     /// Whether to suppress warnings when parsing. This is set for secondary
     /// files, as they get parsed multiple times.
     SuppressWarnings = 1 << 4,
+
+    /// Whether to disable the Swift Parser ASTGen
+    /// e.g. in dependency scanning, where an AST is not needed.
+    DisableSwiftParserASTGen = 1 << 5,
   };
   using ParsingOptions = OptionSet<ParsingFlags>;
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1369,6 +1369,12 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
     opts |= SourceFile::ParsingFlags::SuppressWarnings;
   }
 
+  // Dependency scanning does not require an AST, so disable Swift Parser
+  // ASTGen parsing completely.
+  if (frontendOpts.RequestedAction ==
+      FrontendOptions::ActionType::ScanDependencies)
+    opts |= SourceFile::ParsingFlags::DisableSwiftParserASTGen;
+
   // Enable interface hash computation for primaries or emit-module-separately,
   // but not in WMO, as it's only currently needed for incremental mode.
   if (forPrimary ||

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/ModuleDependencies.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
@@ -157,8 +158,13 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
     // Create a source file.
     unsigned bufferID = Ctx.SourceMgr.addNewSourceBuffer(std::move(interfaceBuf.get()));
     auto moduleDecl = ModuleDecl::create(realModuleName, Ctx);
+
+    // Dependency scanning does not require an AST, so disable Swift Parser
+    // ASTGen parsing completely.
+    SourceFile::ParsingOptions parsingOpts;
+    parsingOpts |= SourceFile::ParsingFlags::DisableSwiftParserASTGen;
     auto sourceFile = new (Ctx) SourceFile(
-        *moduleDecl, SourceFileKind::Interface, bufferID);
+        *moduleDecl, SourceFileKind::Interface, bufferID, parsingOpts);
     moduleDecl->addAuxiliaryFile(*sourceFile);
 
     // Walk the source file to find the import declarations.


### PR DESCRIPTION
On both input moduel source-files and interface files. This currently yields dramatic scanning performance improvements at no cost - we do not require an AST during scan.
