### PR TITLE
[Tests] Limit test/IRGen/moveonly_deinits.swift to 64bit targets

### DIFF
--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -9,6 +9,9 @@
 // REQUIRES: asserts
 // REQUIRES: CODEGENERATOR=X86
 
+// rdar://107495541 Test needs to be updated for 32bit.
+// REQUIRES: PTRSIZE=64
+
 //////////////////////
 // Misc Declaration //
 //////////////////////


### PR DESCRIPTION
rdar://107495541
