### PR TITLE
Handle more copy-move-assignment cases

### DIFF
--- a/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
+++ b/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
@@ -20,7 +20,10 @@ public func copyAssign() {
 // CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignC2Ev|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE:.*]])
 // CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignC2Ev|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE2:.*]])
 // CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignD1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignD2Ev|"\?\?1NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE]])
-// CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1ERKS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@AEBU0@@Z"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE]], %struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE2]])
+// CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1ERKS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@AEBU0@@Z"}}(%struct.NonTrivialCopyAndCopyMoveAssign*
+// CHECK-SAME: %[[COPY_INSTANCE]],
+// CHECK-SAME: %struct.NonTrivialCopyAndCopyMoveAssign*
+// CHECK-SAME: %[[COPY_INSTANCE2]])
 // CHECK: call {{.*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignD1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignD2Ev|"\?\?1NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE2]])
 // CHECK: call {{.*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignD1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignD2Ev|"\?\?1NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE]])
 

--- a/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
+++ b/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
@@ -20,7 +20,7 @@ public func copyAssign() {
 // CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignC2Ev|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE:.*]])
 // CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignC2Ev|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE2:.*]])
 // CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignD1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignD2Ev|"\?\?1NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(%struct.NonTrivialCopyAndCopyMoveAssign* %[[COPY_INSTANCE]])
-// CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1ERKS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@AEBU0@@Z"}}(%struct.NonTrivialCopyAndCopyMoveAssign*
+// CHECK: call {{void|\%struct.NonTrivialCopyAndCopyMoveAssign\*}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1ERKS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_Tm|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@AEBU0@@Z"}}(%struct.NonTrivialCopyAndCopyMoveAssign*
 // CHECK-SAME: %[[COPY_INSTANCE]],
 // CHECK-SAME: %struct.NonTrivialCopyAndCopyMoveAssign*
 // CHECK-SAME: %[[COPY_INSTANCE2]])


### PR DESCRIPTION
The `copy-move-assignment-irgen` test case was failing on my Linux machine because the input pointers into the copy-move function call had additional attributes, and the function mangle was slightly different indicating that the function had been merged. I broke this PR into three commits to try making it clearer what each transform was.

- The first one splits the parameters going into the copy-assignment call to handle the possible presence of the additional attributes.
Here is what the call looks like when it fails: 
`call void @_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_Tm(%struct.NonTrivialCopyAndCopyMoveAssign* noundef nonnull align 4 dereferenceable(5) %2, %struct.NonTrivialCopyAndCopyMoveAssign* noundef nonnull align 4 dereferenceable(5) %4)`.
The test did not contain any attributes on the parameter pointers.

- The second commit adds `_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_Tm` to the accepted list of function mangles. My macBook is showing another call form still `@_ZN31NonTrivialCopyAndCopyMoveAssignC1EOS_`. I haven't fully made sense of what this demangles to, so I'm not prepared to suggest that it's correct at the moment though.

- The third commit reduces the cases down to alternation over only the parts of the function that are different instead of on the entire mangle.


