### PR TITLE
[5.9] Fix covariant erasure for constrained existentials

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2112,7 +2112,7 @@ typeEraseExistentialSelfReferences(
       if (t->is<GenericTypeParamType>()) {
         erasedTy = baseTy;
       } else {
-        erasedTy = existentialSig->getNonDependentUpperBounds(t);
+        erasedTy = existentialSig->getDependentUpperBounds(t);
       }
 
       if (metatypeDepth) {

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -92,8 +92,14 @@ func protocolCompositionNotSupported1(_: SomeProto & Sequence<Int>) {}
 func protocolCompositionNotSupported2(_: any SomeProto & Sequence<Int>) {}
 // expected-error@-1 {{non-protocol, non-class type 'Sequence<Int>' cannot be used within a protocol-constrained type}}
 
-func increment(n : any Sequence<Float>) {
+func increment(_ n : any Collection<Float>) {
   for value in n {
       _ = value + 1
+  }
+}
+
+func genericIncrement<T: Numeric>(_ n : any Collection<T>) {
+  for value in n {
+    _ = value + 1
   }
 }

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -91,3 +91,9 @@ func protocolCompositionNotSupported1(_: SomeProto & Sequence<Int>) {}
 
 func protocolCompositionNotSupported2(_: any SomeProto & Sequence<Int>) {}
 // expected-error@-1 {{non-protocol, non-class type 'Sequence<Int>' cannot be used within a protocol-constrained type}}
+
+func increment(n : any Sequence<Float>) {
+  for value in n {
+      _ = value + 1
+  }
+}


### PR DESCRIPTION
Constrained existentials should be type erased to an upper bound that is dependent on other type parameters.

```
let t: (any Sequence<Int>) = [1, 2]

for value in t {
    let v = value + 1 // the existential is opened so that `value` is generic parameter Int instead of Any
}

```
Fixes rdar://101343646