### PR TITLE
Sema: Ban unavailable deinits

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6122,6 +6122,13 @@ WARNING(availability_query_useless_enclosing_scope, none,
 NOTE(availability_query_useless_enclosing_scope_here, none,
      "enclosing scope here", ())
 
+ERROR(availability_deinit_no_potential, none,
+      "deinitializer cannot be marked potentially unavailable with "
+      "'@available'", ())
+
+ERROR(availability_deinit_no_unavailable, none,
+      "deinitializer cannot be marked unavailable with '@available'", ())
+
 ERROR(availability_global_script_no_potential,
       none, "global variable cannot be marked potentially "
       "unavailable with '@available' in script mode", ())

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1060,6 +1060,11 @@ TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
 Optional<Diag<>>
 diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 
+/// Returns a diagnostic indicating why the declaration cannot be annotated
+/// with an @available() attribute indicating it is unavailable or None if this
+/// is allowed.
+Optional<Diag<>> diagnosticIfDeclCannotBeUnavailable(const Decl *D);
+
 /// Same as \c checkDeclarationAvailability but doesn't give a reason for
 /// unavailability.
 bool isDeclarationUnavailable(

--- a/test/Sema/availability_deinit.swift
+++ b/test/Sema/availability_deinit.swift
@@ -1,0 +1,52 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+
+// REQUIRES: OS=macosx
+
+@available(*, unavailable)
+class Unavailable {
+  deinit {}
+}
+
+@available(*, unavailable)
+class UnavailableWithUnavailableDeinit {
+  @available(*, unavailable)
+  deinit {}
+}
+
+@available(*, unavailable)
+enum UnavailableEnum {
+  class NestedWithUnavailableDeinit {
+    @available(*, unavailable)
+    deinit {}
+  }
+}
+
+class DeinitUnavailable {
+  @available(*, unavailable) // expected-error {{deinitializer cannot be marked unavailable with '@available'}}
+  deinit {}
+}
+
+class DeinitUnavailableMacOS {
+  @available(macOS, unavailable) // expected-error {{deinitializer cannot be marked unavailable with '@available'}}
+  deinit {}
+}
+
+class AvailableAtDeploymentTargetDeinit {
+  @available(macOS 10.50, *)
+  deinit {}
+}
+
+class PotentiallyUnavailableDeinit {
+  @available(macOS 10.51, *) // expected-error {{deinitializer cannot be marked potentially unavailable with '@available'}}
+  deinit {}
+}
+
+@available(macOS 10.51, *)
+func funcAvailable10_51() {}
+
+class AlwaysAvailable { // expected-note {{add @available attribute to enclosing class}}
+  deinit {
+    funcAvailable10_51() // expected-error {{'funcAvailable10_51()' is only available in macOS 10.51 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  }
+}


### PR DESCRIPTION
Destructors are always called if declared, so allowing deinit to be declared as unavailable (or potentially unavailable) creates a type checking loophole that allows unavailable code to execute at runtime:

```swift
class C {
  @available(*, unavailable)
  deinit {
    print("Oops")
  }
}

_ = C() // prints "Oops"
```

Resolves rdar://106409012, resolves https://github.com/apple/swift/issues/63854.
