### PR TITLE
[Macros] PluginRegistry vends 'LoadedLibraryPlugin' instead of 'void *' 

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -82,6 +82,7 @@ namespace swift {
   class ExtensionDecl;
   struct ExternalSourceLocs;
   class LoadedExecutablePlugin;
+  class LoadedLibraryPlugin;
   class ForeignRepresentationInfo;
   class FuncDecl;
   class GenericContext;
@@ -1496,7 +1497,7 @@ public:
   /// returns a nullptr.
   /// NOTE: This method is idempotent. If the plugin is already loaded, the same
   /// instance is simply returned.
-  void *loadLibraryPlugin(StringRef path);
+  LoadedLibraryPlugin *loadLibraryPlugin(StringRef path);
 
   /// Lookup an executable plugin that is declared to handle \p moduleName
   /// module by '-load-plugin-executable'.

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -22,6 +22,21 @@
 
 namespace swift {
 
+/// Represent a 'dlopen'ed plugin library.
+class LoadedLibraryPlugin {
+  // Opaque handle used to interface with OS-specific dynamic library.
+  void *handle;
+
+  /// Cache of loaded symbols.
+  llvm::StringMap<void *> resolvedSymbols;
+
+public:
+  LoadedLibraryPlugin(void *handle) : handle(handle) {}
+
+  /// Finds the address of the given symbol within the library.
+  void *getAddressOfSymbol(const char *symbolName);
+};
+
 /// Represent a "resolved" exectuable plugin.
 ///
 /// Plugin clients usually deal with this object to communicate with the actual
@@ -130,7 +145,7 @@ public:
 
 class PluginRegistry {
   /// Record of loaded plugin library modules.
-  llvm::StringMap<void *> LoadedPluginLibraries;
+  llvm::StringMap<std::unique_ptr<LoadedLibraryPlugin>> LoadedPluginLibraries;
 
   /// Record of loaded plugin executables.
   llvm::StringMap<std::unique_ptr<LoadedExecutablePlugin>>
@@ -146,7 +161,7 @@ public:
 
   /// Load a dynamic link library specified by \p path.
   /// If \p path plugin is already loaded, this returns the cached object.
-  llvm::Expected<void *> loadLibraryPlugin(llvm::StringRef path);
+  llvm::Expected<LoadedLibraryPlugin *> loadLibraryPlugin(llvm::StringRef path);
 
   /// Load an executable plugin specified by \p path .
   /// If \p path plugin is already loaded, this returns the cached object.

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -9,6 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+#ifndef SWIFT_PLUGIN_REGISTRY_H
+#define SWIFT_PLUGIN_REGISTRY_H
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
@@ -170,3 +172,5 @@ public:
 };
 
 } // namespace swift
+
+#endif // SWIFT_PLUGIN_REGISTRY_H

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -26,6 +26,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PluginRegistry.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/AST/SourceFile.h"
@@ -49,8 +50,6 @@ struct ExternalMacroDefinition;
 class ClosureExpr;
 class GenericParamList;
 class LabeledStmt;
-class LoadedExecutablePlugin;
-class LoadedLibraryPlugin;
 class MacroDefinition;
 class PrecedenceGroupDecl;
 class PropertyWrapperInitializerInfo;
@@ -3999,41 +3998,20 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Load a plugin module with the given name.
-///
-///
+/// Represent a loaded plugin either an in-process library or an executable.
 class LoadedCompilerPlugin {
-  enum class PluginKind : uint8_t {
-    None,
-    InProcess,
-    Executable,
-  };
-  PluginKind kind;
-  void *ptr;
-
-  LoadedCompilerPlugin(PluginKind kind, void *ptr) : kind(kind), ptr(ptr) {
-    assert(ptr != nullptr || kind == PluginKind::None);
-  }
+  llvm::PointerUnion<LoadedLibraryPlugin *, LoadedExecutablePlugin *> ptr;
 
 public:
-  LoadedCompilerPlugin(std::nullptr_t) : kind(PluginKind::None), ptr(nullptr) {}
+  LoadedCompilerPlugin(std::nullptr_t) : ptr(nullptr) {}
+  LoadedCompilerPlugin(LoadedLibraryPlugin *ptr) : ptr(ptr){};
+  LoadedCompilerPlugin(LoadedExecutablePlugin *ptr) : ptr(ptr){};
 
-  static LoadedCompilerPlugin inProcess(LoadedLibraryPlugin *ptr) {
-    return {PluginKind::InProcess, ptr};
-  }
-  static LoadedCompilerPlugin executable(LoadedExecutablePlugin *ptr) {
-    return {PluginKind::Executable, ptr};
-  }
-
-  LoadedLibraryPlugin *getAsInProcessPlugin() const {
-    return kind == PluginKind::InProcess
-               ? static_cast<LoadedLibraryPlugin *>(ptr)
-               : nullptr;
+  LoadedLibraryPlugin *getAsLibraryPlugin() const {
+    return ptr.dyn_cast<LoadedLibraryPlugin *>();
   }
   LoadedExecutablePlugin *getAsExecutablePlugin() const {
-    return kind == PluginKind::Executable
-               ? static_cast<LoadedExecutablePlugin *>(ptr)
-               : nullptr;
+    return ptr.dyn_cast<LoadedExecutablePlugin *>();
   }
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -50,6 +50,7 @@ class ClosureExpr;
 class GenericParamList;
 class LabeledStmt;
 class LoadedExecutablePlugin;
+class LoadedLibraryPlugin;
 class MacroDefinition;
 class PrecedenceGroupDecl;
 class PropertyWrapperInitializerInfo;
@@ -4017,15 +4018,17 @@ class LoadedCompilerPlugin {
 public:
   LoadedCompilerPlugin(std::nullptr_t) : kind(PluginKind::None), ptr(nullptr) {}
 
-  static LoadedCompilerPlugin inProcess(void *ptr) {
+  static LoadedCompilerPlugin inProcess(LoadedLibraryPlugin *ptr) {
     return {PluginKind::InProcess, ptr};
   }
   static LoadedCompilerPlugin executable(LoadedExecutablePlugin *ptr) {
     return {PluginKind::Executable, ptr};
   }
 
-  void *getAsInProcessPlugin() const {
-    return kind == PluginKind::InProcess ? ptr : nullptr;
+  LoadedLibraryPlugin *getAsInProcessPlugin() const {
+    return kind == PluginKind::InProcess
+               ? static_cast<LoadedLibraryPlugin *>(ptr)
+               : nullptr;
   }
   LoadedExecutablePlugin *getAsExecutablePlugin() const {
     return kind == PluginKind::Executable

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6412,7 +6412,7 @@ LoadedExecutablePlugin *ASTContext::loadExecutablePlugin(StringRef path) {
   return plugin.get();
 }
 
-void *ASTContext::loadLibraryPlugin(StringRef path) {
+LoadedLibraryPlugin *ASTContext::loadLibraryPlugin(StringRef path) {
   // Remember the path (even if it fails to load.)
   getImpl().LoadedPluginLibraryPaths.insert(path);
 

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -67,7 +67,7 @@ PluginRegistry::loadLibraryPlugin(StringRef path) {
   }
 #endif
 
-  storage = std::unique_ptr<LoadedLibraryPlugin>(new LoadedLibraryPlugin(lib));
+  storage = std::make_unique<LoadedLibraryPlugin>(lib);
   return storage.get();
 }
 
@@ -111,8 +111,8 @@ PluginRegistry::loadExecutablePlugin(StringRef path) {
                                    "not executable");
   }
 
-  auto plugin = std::unique_ptr<LoadedExecutablePlugin>(
-      new LoadedExecutablePlugin(path, stat.getLastModificationTime()));
+  auto plugin = std::make_unique<LoadedExecutablePlugin>(
+      path, stat.getLastModificationTime());
 
   plugin->setDumpMessaging(dumpMessaging);
 
@@ -153,9 +153,9 @@ llvm::Error LoadedExecutablePlugin::spawnIfNeeded() {
     return llvm::errorCodeToError(childInfo.getError());
   }
 
-  Process = std::unique_ptr<PluginProcess>(
-      new PluginProcess(childInfo->Pid, childInfo->ReadFileDescriptor,
-                        childInfo->WriteFileDescriptor));
+  Process = std::make_unique<PluginProcess>(childInfo->Pid,
+                                            childInfo->ReadFileDescriptor,
+                                            childInfo->WriteFileDescriptor);
 
   // Call "on reconnect" callbacks.
   for (auto *callback : onReconnect) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -358,13 +358,14 @@ CompilerPluginLoadRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
                                     Identifier moduleName) const {
   // Check dynamic link library plugins.
   // i.e. '-plugin-path', and '-load-plugin-library'.
-  if (auto found = loadLibraryPluginByName(*ctx, moduleName))
-    return LoadedCompilerPlugin::inProcess(found);
+  if (auto found = loadLibraryPluginByName(*ctx, moduleName)) {
+    return found;
+  }
 
   // Fall back to executable plugins.
   // i.e. '-external-plugin-path', and '-load-plugin-executable'.
   if (auto *found = loadExecutablePluginByName(*ctx, moduleName)) {
-    return LoadedCompilerPlugin::executable(found);
+    return found;
   }
 
   return nullptr;
@@ -421,7 +422,7 @@ ExternalMacroDefinitionRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
   LoadedCompilerPlugin loaded =
       evaluateOrDefault(evaluator, loadRequest, nullptr);
 
-  if (auto loadedLibrary = loaded.getAsInProcessPlugin()) {
+  if (auto loadedLibrary = loaded.getAsLibraryPlugin()) {
     if (auto inProcess = resolveInProcessMacro(
             *ctx, moduleName, typeName, loadedLibrary))
       return *inProcess;


### PR DESCRIPTION
`LoadedLibraryPlugin` is currently just a wrapper of `void` pointer from `dlopen`. This will be convenient for abstracting platform specific dynamic library handling.

Also update `LoadedCompierPlugin`  making it a `llvm::PointerUnion`