### PR TITLE
Improved Cast Diagnostics when Literals are involved

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1184,9 +1184,9 @@ WARNING(conditional_downcast_coercion,none,
       (Type, Type))
 
 WARNING(literal_conditional_downcast_to_coercion,none,
-        "conditional downcast from literal to %0 always fails; "
+        "cast from literal of inferred type %0 to unrelated type %1 always fails; "
         "consider using 'as' coercion",
-        (Type))
+        (Type, Type))
 
 WARNING(forced_downcast_noop,none,
         "forced cast of %0 to same type has no effect", (Type))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8621,6 +8621,7 @@ bool UnsupportedRuntimeCheckedCastFailure::diagnoseAsError() {
 }
 
 bool CheckedCastToUnrelatedFailure::diagnoseAsError() {
+  const auto fromType = getFromType();
   const auto toType = getToType();
   auto *sub = CastExpr->getSubExpr()->getSemanticsProvidingExpr();
   // FIXME(https://github.com/apple/swift/issues/54529): This literal diagnostics needs to be revisited by a proposal to unify casting semantics for literals.
@@ -8632,7 +8633,8 @@ bool CheckedCastToUnrelatedFailure::diagnoseAsError() {
     // be statically coerced to the cast type.
     if (protocol && TypeChecker::conformsToProtocol(toType, protocol,
                                                     dc->getParentModule())) {
-      emitDiagnostic(diag::literal_conditional_downcast_to_coercion, toType);
+      emitDiagnostic(diag::literal_conditional_downcast_to_coercion, fromType,
+                     toType);
       return true;
     }
   }

--- a/test/expr/cast/literals_downcast.swift
+++ b/test/expr/cast/literals_downcast.swift
@@ -2,18 +2,26 @@
 
 let ok = "A" as Character // OK
 let succeed = "A" as? String // expected-warning {{always succeeds}}
-let bad = "A" as? Character // expected-warning {{conditional downcast from literal to 'Character' always fails; consider using 'as' coercion}} {{none}}
+let force = "A" as! String // expected-warning {{forced cast of 'String' to same type has no effect}}
+let bad = "A" as? Character // expected-warning {{cast from literal of inferred type 'String' to unrelated type 'Character' always fails; consider using 'as' coercion}} {{none}}
 let bad2 = "Aa" as? Character // expected-warning {{cast from 'String' to unrelated type 'Character' always fails}}
+let badForce = "Aa" as! Character // expected-warning {{cast from 'String' to unrelated type 'Character' always fails}}
 let bad1 = 1 as? Character // expected-warning {{cast from 'Int' to unrelated type 'Character' always fails}}
+let bad1Force = 1 as! Character // expected-warning {{cast from 'Int' to unrelated type 'Character' always fails}}
 
 let okInt = 1 as Int // OK
+let IntForce = 1 as! Int // expected-warning {{forced cast of 'Int' to same type has no effect}}
 let badInt = 1 as? Int // expected-warning {{always succeeds}}
 let badInt1 = 1.0 as? Int // expected-warning {{cast from 'Double' to unrelated type 'Int' always fails}}
-let badInt2 = 1 as? Double // expected-warning {{conditional downcast from literal to 'Double' always fails; consider using 'as' coercion}} {{none}}
+let badInt2 = 1 as? Double // expected-warning {{cast from literal of inferred type 'Int' to unrelated type 'Double' always fails; consider using 'as' coercion}} {{none}}
+let badInt3 = 1 as! Double // expected-warning {{cast from literal of inferred type 'Int' to unrelated type 'Double' always fails; consider using 'as' coercion}}
+let badInt4 = 1.0 as! Int // expected-warning {{cast from 'Double' to unrelated type 'Int' always fails}}
 
 let okUInt = 1 as UInt // OK
-let badUInt = 1 as? UInt // expected-warning {{conditional downcast from literal to 'UInt' always fails; consider using 'as' coercion}} {{none}}
+let badUInt = 1 as? UInt // expected-warning {{cast from literal of inferred type 'Int' to unrelated type 'UInt' always fails; consider using 'as' coercion}} {{none}}
 let badUInt1 = 1.0 as? UInt // expected-warning {{cast from 'Double' to unrelated type 'UInt' always fails}}
+let badUInt2 = 1.0 as! UInt // expected-warning {{cast from 'Double' to unrelated type 'UInt' always fails}}
+let badUInt3 = 1 as! UInt // expected-warning {{cast from literal of inferred type 'Int' to unrelated type 'UInt' always fails; consider using 'as' coercion}}
 
 // Custom protocol adoption
 struct S: ExpressibleByStringLiteral {
@@ -21,4 +29,5 @@ struct S: ExpressibleByStringLiteral {
   init(stringLiteral value: Self.StringLiteralType) {}
 }
 
-let a = "A" as? S // expected-warning {{conditional downcast from literal to 'S' always fails; consider using 'as' coercion}} {{none}}
+let a = "A" as? S // expected-warning {{cast from literal of inferred type 'String' to unrelated type 'S' always fails; consider using 'as' coercion}} {{none}}
+let a1 = "A" as! S // expected-warning {{cast from literal of inferred type 'String' to unrelated type 'S' always fails; consider using 'as' coercion}}


### PR DESCRIPTION
Fixes #53822

Emphasised the diagnostic involving conditional downcast to coercion making it more specific adding some contrast between casting (`as?`) and coercing (`as`).