### PR TITLE
[5.9] Don't insert a destroy on uninitialized move-only memory.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8318,8 +8318,8 @@ public:
     ConsumableAndAssignable,
 
     /// A signal to the move only checker to perform no consume or assign
-    /// checking. This forces the result of this instruction owned value to never
-    /// be consumed (for let/var semantics) or assigned over (for var
+    /// checking. This forces the result of this instruction owned value to
+    /// never be consumed (for let/var semantics) or assigned over (for var
     /// semantics). Of course, we still allow for non-consuming uses.
     NoConsumeOrAssign,
 
@@ -8330,6 +8330,11 @@ public:
     /// uninitialized state), but we are ok with the user assigning a new value,
     /// completely assigning over the value at once.
     AssignableButNotConsumable,
+
+    /// A signal to the move checker that the given value cannot be consumed or
+    /// assigned, but is allowed to be initialized. This is used for situations
+    /// like class initializers.
+    InitableButNotConsumable,
   };
 
 private:
@@ -8348,6 +8353,8 @@ private:
 public:
   CheckKind getCheckKind() const { return kind; }
 
+  void setCheckKind(CheckKind newKind) { kind = newKind; }
+
   bool hasMoveCheckerKind() const {
     switch (kind) {
     case CheckKind::Invalid:
@@ -8355,6 +8362,7 @@ public:
     case CheckKind::ConsumableAndAssignable:
     case CheckKind::NoConsumeOrAssign:
     case CheckKind::AssignableButNotConsumable:
+    case CheckKind::InitableButNotConsumable:
       return true;
     }
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2010,6 +2010,9 @@ public:
     case CheckKind::AssignableButNotConsumable:
       *this << "[assignable_but_not_consumable] ";
       break;
+    case CheckKind::InitableButNotConsumable:
+      *this << "[initable_but_not_consumable] ";
+      break;
     }
     *this << getIDAndType(I->getOperand());
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3710,7 +3710,10 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
             .Case("consumable_and_assignable",
                   CheckKind::ConsumableAndAssignable)
             .Case("no_consume_or_assign", CheckKind::NoConsumeOrAssign)
-            .Case("assignable_but_not_consumable", CheckKind::AssignableButNotConsumable)
+            .Case("assignable_but_not_consumable",
+                  CheckKind::AssignableButNotConsumable)
+            .Case("initable_but_not_consumable",
+                  CheckKind::InitableButNotConsumable)
             .Default(CheckKind::Invalid);
 
     if (CKind == CheckKind::Invalid) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2312,7 +2312,6 @@ void LifetimeChecker::updateInstructionForInitState(unsigned UseID) {
   // If this is an assign, rewrite it based on whether it is an initialization
   // or not.
   if (auto *AI = dyn_cast<AssignInst>(Inst)) {
-
     // Remove this instruction from our data structures, since we will be
     // removing it.
     Use.Inst = nullptr;
@@ -2326,6 +2325,24 @@ void LifetimeChecker::updateInstructionForInitState(unsigned UseID) {
       AI->setOwnershipQualifier((InitKind == IsInitialization
                                 ? AssignOwnershipQualifier::Init
                                 : AssignOwnershipQualifier::Reassign));
+    }
+
+    // Look and see if we are assigning a moveonly type into a mark_must_check
+    // [assignable_but_not_consumable]. If we are, then we need to transition
+    // its flag to initable_but_not_assignable.
+    //
+    // NOTE: We should only ever have to do this for a single level since SILGen
+    // always initializes values completely and we enforce that invariant.
+    if (InitKind == IsInitialization) {
+      if (auto *mmci =
+              dyn_cast<MarkMustCheckInst>(stripAccessMarkers(AI->getDest()))) {
+        if (mmci->getCheckKind() ==
+                MarkMustCheckInst::CheckKind::AssignableButNotConsumable &&
+            isa<RefElementAddrInst>(stripAccessMarkers(mmci->getOperand()))) {
+          mmci->setCheckKind(
+              MarkMustCheckInst::CheckKind::InitableButNotConsumable);
+        }
+      }
     }
 
     return;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -500,7 +500,11 @@ static bool isInOutDefThatNeedsEndOfFunctionLiveness(MarkMustCheckInst *markedAd
 
     if (isa<GlobalAddrInst>(stripAccessMarkers(operand)))
       return true;
+
+  if (auto *rei = dyn_cast<RefElementAddrInst>(stripAccessMarkers(operand)))
+    return true;
   }
+
 
   return false;
 }
@@ -2148,6 +2152,19 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
       insertUndefDebugValue(insertPt);
     } else {
       auto *inst = cast<SILInstruction>(defPair.first);
+
+      // If we have a dead def that is our mark must check and that mark must
+      // check was an init but not consumable, then do not destroy that
+      // def. This is b/c we are in some sort of class initialization and we are
+      // looking at the initial part of the live range before the initialization
+      // has occured. This is our way of makinmg this fit the model that the
+      // checker expects (which is that values are always initialized at the def
+      // point).
+      if (markedValue &&
+          markedValue->getCheckKind() ==
+              MarkMustCheckInst::CheckKind::InitableButNotConsumable)
+        continue;
+
       auto *insertPt = inst->getNextInstruction();
       assert(insertPt && "def instruction was a terminator");
       insertDestroyBeforeInstruction(addressUseState, insertPt,

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2200,17 +2200,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     break;
   }
 
-  case SILInstructionKind::MarkMustCheckInst: {
-    using CheckKind = MarkMustCheckInst::CheckKind;
-    auto Ty = MF->getType(TyID);
-    auto CKind = CheckKind(Attr);
-    ResultInst = Builder.createMarkMustCheckInst(
-        Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        CKind);
-    break;
-  }
-
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst: {
     using Kind = MarkUnresolvedReferenceBindingInst::Kind;
     auto ty = MF->getType(TyID);
@@ -2286,6 +2275,16 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Kind = (MarkUninitializedInst::Kind)Attr;
     auto Val = getLocalValue(ValID, Ty);
     ResultInst = Builder.createMarkUninitialized(Loc, Val, Kind);
+    break;
+  }
+  case SILInstructionKind::MarkMustCheckInst: {
+    using CheckKind = MarkMustCheckInst::CheckKind;
+    auto Ty = MF->getType(TyID);
+    auto CKind = CheckKind(Attr);
+    ResultInst = Builder.createMarkMustCheckInst(
+        Loc,
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        CKind);
     break;
   }
   case SILInstructionKind::StoreInst: {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1482,7 +1482,6 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::CopyValueInst:
   case SILInstructionKind::ExplicitCopyValueInst:
   case SILInstructionKind::MoveValueInst:
-  case SILInstructionKind::MarkMustCheckInst:
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
@@ -1559,6 +1558,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
                                                                      : false;
     }
     writeOneOperandLayout(SI.getKind(), Attr, SI.getOperand(0));
+    break;
+  }
+  case SILInstructionKind::MarkMustCheckInst: {
+    unsigned Attr = unsigned(cast<MarkMustCheckInst>(&SI)->getCheckKind());
+    writeOneOperandExtraAttributeLayout(SI.getKind(), Attr, SI.getOperand(0));
     break;
   }
   case SILInstructionKind::MarkUninitializedInst: {

--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -10,40 +10,82 @@ var Tests = TestSuite("MoveOnlyTests")
 
 @_moveOnly
 struct FD {
-    var a  = LifetimeTracked(0)
+  var a = LifetimeTracked(0)
 
-    deinit {
-    }
+  deinit {
+  }
 }
 
 Tests.test("simple deinit called once") {
-    do {
-        let s = FD()
-    }
-    expectEqual(0, LifetimeTracked.instances)
+  do {
+    let s = FD()
+  }
+  expectEqual(0, LifetimeTracked.instances)
 }
 
 Tests.test("ref element addr destroyed once") {
-    class CopyableKlass {
-        var fd = FD()
-    }
+  class CopyableKlass {
+    var fd = FD()
+  }
 
-    func assignCopyableKlass(_ x: CopyableKlass) {
-        x.fd = FD()
-    }
+  func assignCopyableKlass(_ x: CopyableKlass) {
+    x.fd = FD()
+  }
 
-    do {
-        let x = CopyableKlass()
-        assignCopyableKlass(x)
-    }
-    expectEqual(0, LifetimeTracked.instances)
+  do {
+    let x = CopyableKlass()
+    assignCopyableKlass(x)
+  }
+  expectEqual(0, LifetimeTracked.instances)
 }
 
 var global = FD()
 
 Tests.test("global destroyed once") {
-    do {
-        global = FD()
+  do {
+    global = FD()
+  }
+  expectEqual(0, LifetimeTracked.instances)    
+}
+
+// TODO (rdar://107494072): Move-only types with deinits declared inside
+// functions sometimes lose their deinit function.
+// When that's fixed, FD2 can be moved back inside the test closure below.
+@_moveOnly
+struct FD2 {
+  var field = 5
+  static var count = 0
+  init() { FD2.count += 1 }
+  deinit {
+    FD2.count -= 1
+    print("In deinit!")
+  }
+  func use() {}
+}
+
+Tests.test("deinit not called in init when assigned") {
+  class FDHaver {
+    var fd: FD2
+
+    init() {
+      self.fd = FD2()
     }
-    expectEqual(0, LifetimeTracked.instances)    
+  }
+
+  class FDHaver2 {
+    var fd: FD2
+
+    init() {
+      self.fd = FD2()
+      self.fd = FD2()
+      self.fd = FD2()
+      self.fd.use()
+    }
+  }
+
+  do {
+    let haver = FDHaver2()
+    let _ = haver
+  }
+  expectEqual(0, FD2.count)
 }

--- a/test/SILOptimizer/moveonly_class_inits_end_to_end.swift
+++ b/test/SILOptimizer/moveonly_class_inits_end_to_end.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -module-name moveonly_class_inits_end_to_end %s -emit-sil -o - | %FileCheck %s
+
+// A test that makes sure end to end in a copyable class containing a
+// non-copyable type, in the init, we only have a single destroy_addr.
+
+@_moveOnly
+public struct MO {
+  var x: Int8 = 0
+  deinit { print("destroyed MO") }
+}
+
+public class MOHaver {
+  var mo: MO
+
+  // CHECK-LABEL: sil hidden @$s028moveonly_class_inits_end_to_D07MOHaverCACycfc : $@convention(method) (@owned MOHaver) -> @owned MOHaver {
+  // CHECK: bb0([[ARG:%.*]] :
+  // CHECK-NEXT: debug_value [[ARG]]
+  // CHECK-NEXT: [[META:%.*]] = metatype
+  // CHECK-NEXT: function_ref MO.init()
+  // CHECK-NEXT: [[FUNC:%.*]] = function_ref @$s028moveonly_class_inits_end_to_D02MOVACycfC :
+  // CHECK-NEXT: [[RESULT:%.*]] = apply [[FUNC]]([[META]])
+  // CHECK-NEXT: [[REF:%.*]] = ref_element_addr [[ARG]]
+  // CHECK-NEXT: [[REF_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF]]
+  // CHECK-NEXT: store [[RESULT]] to [[REF_ACCESS]]
+  // CHECK-NEXT: end_access [[REF_ACCESS]]
+  // CHECK-NEXT: return [[ARG]]
+  // CHECK-NEXT: } // end sil function '$s028moveonly_class_inits_end_to_D07MOHaverCACycfc'
+  init() {
+    self.mo = MO()
+  }
+}


### PR DESCRIPTION
Teach the checker that the thing being checked is supposed to be uninitialized at the mark_must_check point so that we don't put a destroy_addr there.

The way this is implemented is that we always initially add assignable_but_not_consumable but in DI once we discover that the assign we are guarding is an init, we convert the assignable to its initable variant.

Main PR: #64690

rdar://106525988