### PR TITLE
🍒[5.9][Executors] Move assert/assume APIs onto actors; assumeIsolated()

### DIFF
--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -14,237 +14,243 @@ import Swift
 import SwiftShims
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+
 // ==== -----------------------------------------------------------------------
 // MARK: Precondition executors
 
-/// Unconditionally if the current task is executing on the expected serial executor,
-/// and if not crash the program offering information about the executor mismatch.
-///
-/// This function's effect varies depending on the build flag used:
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration), stops program execution in a debuggable state after
-///   printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration), stops
-///   program execution.
-///
-/// * In `-Ounchecked` builds, the optimizer may assume that this function is
-///   never called. Failure to satisfy that assumption is a serious
-///   programming error.
-///
-/// - Parameter executor: the expected current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func preconditionTaskOnExecutor(
-    _ executor: some SerialExecutor,
-    message: @autoclosure () -> String = String(),
-    file: StaticString = #fileID, line: UInt = #line
-) {
-  guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
-    return
+@available(SwiftStdlib 5.9, *)
+extension SerialExecutor {
+  /// Unconditionally if the current task is executing on the expected serial executor,
+  /// and if not crash the program offering information about the executor mismatch.
+  ///
+  /// This function's effect varies depending on the build flag used:
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration), stops program execution in a debuggable state after
+  ///   printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration), stops
+  ///   program execution.
+  ///
+  /// * In `-Ounchecked` builds, the optimizer may assume that this function is
+  ///   never called. Failure to satisfy that assumption is a serious
+  ///   programming error.
+  @available(SwiftStdlib 5.9, *)
+  public func preconditionIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+      return
+    }
+
+    let expectationCheck = _taskIsCurrentExecutor(self.asUnownedSerialExecutor().executor)
+
+    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+    precondition(expectationCheck,
+        // TODO: offer information which executor we actually got
+        "Incorrect actor executor assumption; Expected '\(self)' executor. \(message())",
+        file: file, line: line) // short-cut so we get the exact same failure reporting semantics
   }
-
-  let expectationCheck = _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor)
-
-  /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
-  precondition(expectationCheck,
-      // TODO: offer information which executor we actually got
-      "Incorrect actor executor assumption; Expected '\(executor)' executor. \(message())",
-      file: file, line: line) // short-cut so we get the exact same failure reporting semantics
 }
 
-/// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
-/// and if not crash the program offering information about the executor mismatch.
-///
-/// This function's effect varies depending on the build flag used:
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration), stops program execution in a debuggable state after
-///   printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration), stops
-///   program execution.
-///
-/// * In `-Ounchecked` builds, the optimizer may assume that this function is
-///   never called. Failure to satisfy that assumption is a serious
-///   programming error.
-///
-/// - Parameter actor: the actor whose serial executor we expect to be the current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func preconditionTaskOnActorExecutor(
-    _ actor: some Actor,
-    message: @autoclosure () -> String = String(),
-    file: StaticString = #fileID, line: UInt = #line
-) {
-  guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
-    return
+@available(SwiftStdlib 5.9, *)
+extension Actor {
+  /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
+  /// and if not crash the program offering information about the executor mismatch.
+  ///
+  /// This function's effect varies depending on the build flag used:
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration), stops program execution in a debuggable state after
+  ///   printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration), stops
+  ///   program execution.
+  ///
+  /// * In `-Ounchecked` builds, the optimizer may assume that this function is
+  ///   never called. Failure to satisfy that assumption is a serious
+  ///   programming error.
+  @available(SwiftStdlib 5.9, *)
+  public nonisolated func preconditionIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+      return
+    }
+
+    let expectationCheck = _taskIsCurrentExecutor(self.unownedExecutor.executor)
+
+    // TODO: offer information which executor we actually got
+    precondition(expectationCheck,
+        // TODO: figure out a way to get the typed repr out of the unowned executor
+        "Incorrect actor executor assumption; Expected '\(self.unownedExecutor)' executor. \(message())",
+        file: file, line: line)
   }
+}
 
-  let expectationCheck = _taskIsCurrentExecutor(actor.unownedExecutor.executor)
-
-  // TODO: offer information which executor we actually got
-  precondition(expectationCheck,
-      // TODO: figure out a way to get the typed repr out of the unowned executor
-      "Incorrect actor executor assumption; Expected '\(actor.unownedExecutor)' executor. \(message())",
-      file: file, line: line)
+@available(SwiftStdlib 5.9, *)
+extension GlobalActor {
+  /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
+  /// and if not crash the program offering information about the executor mismatch.
+  ///
+  /// This function's effect varies depending on the build flag used:
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration), stops program execution in a debuggable state after
+  ///   printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration), stops
+  ///   program execution.
+  ///
+  /// * In `-Ounchecked` builds, the optimizer may assume that this function is
+  ///   never called. Failure to satisfy that assumption is a serious
+  ///   programming error.
+  @available(SwiftStdlib 5.9, *)
+  public static func preconditionIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    try Self.shared.preconditionIsolated(message(), file: file, line: line)
+  }
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: Assert executors
 
-/// Performs an executor check in debug builds.
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration): If `condition` evaluates to `false`, stop program
-///   execution in a debuggable state after printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration),
-///   `condition` is not evaluated, and there are no effects.
-///
-/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
-///   may assume that it *always* evaluates to `true`. Failure to satisfy that
-///   assumption is a serious programming error.
-///
-/// - Parameter executor: the expected current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func assertTaskOnExecutor(
-    _ executor: some SerialExecutor,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #fileID, line: UInt = #line
-) {
-  guard _isDebugAssertConfiguration() else {
-    return
-  }
+@available(SwiftStdlib 5.9, *)
+extension SerialExecutor {
+  /// Performs an executor check in debug builds.
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration): If `condition` evaluates to `false`, stop program
+  ///   execution in a debuggable state after printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration),
+  ///   `condition` is not evaluated, and there are no effects.
+  ///
+  /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+  ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+  ///   assumption is a serious programming error.
+  @available(SwiftStdlib 5.9, *)
+  public func assertIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    guard _isDebugAssertConfiguration() else {
+      return
+    }
 
-  guard _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor) else {
-    // TODO: offer information which executor we actually got
-    let msg = "Incorrect actor executor assumption; Expected '\(executor)' executor. \(message())"
-    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
-    assertionFailure(msg, file: file, line: line)
-    return
+    guard _taskIsCurrentExecutor(self.asUnownedSerialExecutor().executor) else {
+      // TODO: offer information which executor we actually got
+      let msg = "Incorrect actor executor assumption; Expected '\(self)' executor. \(message())"
+      /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+      assertionFailure(msg, file: file, line: line)
+      return
+    }
   }
 }
 
-/// Performs an executor check in debug builds.
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration): If `condition` evaluates to `false`, stop program
-///   execution in a debuggable state after printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration),
-///   `condition` is not evaluated, and there are no effects.
-///
-/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
-///   may assume that it *always* evaluates to `true`. Failure to satisfy that
-///   assumption is a serious programming error.
-///
-///
-/// - Parameter actor: the actor whose serial executor we expect to be the current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func assertTaskOnActorExecutor(
-    _ actor: some Actor,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #fileID, line: UInt = #line
-) {
-  guard _isDebugAssertConfiguration() else {
-    return
-  }
+@available(SwiftStdlib 5.9, *)
+extension Actor {
+  /// Performs an executor check in debug builds.
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration): If `condition` evaluates to `false`, stop program
+  ///   execution in a debuggable state after printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration),
+  ///   `condition` is not evaluated, and there are no effects.
+  ///
+  /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+  ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+  ///   assumption is a serious programming error.
+  @available(SwiftStdlib 5.9, *)
+  public nonisolated func assertIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    guard _isDebugAssertConfiguration() else {
+      return
+    }
 
-  guard _taskIsCurrentExecutor(actor.unownedExecutor.executor) else {
-    // TODO: offer information which executor we actually got
-    // TODO: figure out a way to get the typed repr out of the unowned executor
-    let msg = "Incorrect actor executor assumption; Expected '\(actor.unownedExecutor)' executor. \(message())"
-    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
-    assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
-    return
+    guard _taskIsCurrentExecutor(self.unownedExecutor.executor) else {
+      // TODO: offer information which executor we actually got
+      // TODO: figure out a way to get the typed repr out of the unowned executor
+      let msg = "Incorrect actor executor assumption; Expected '\(self.unownedExecutor)' executor. \(message())"
+      /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+      assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
+      return
+    }
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+extension GlobalActor {
+  /// Performs an executor check in debug builds.
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration): If `condition` evaluates to `false`, stop program
+  ///   execution in a debuggable state after printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration),
+  ///   `condition` is not evaluated, and there are no effects.
+  ///
+  /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+  ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+  ///   assumption is a serious programming error.
+  @available(SwiftStdlib 5.9, *)
+  public static func assertIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    try Self.shared.assertIsolated(message(), file: file, line: line)
   }
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: Assume Executor
 
-/// A safe way to synchronously assume that the current execution context belongs to the MainActor.
-///
-/// This API should only be used as last resort, when it is not possible to express the current
-/// execution context definitely belongs to the main actor in other ways. E.g. one may need to use
-/// this in a delegate style API, where a synchronous method is guaranteed to be called by the
-/// main actor, however it is not possible to annotate this legacy API with `@MainActor`.
-///
-/// - Warning: If the current executor is *not* the MainActor's serial executor, this function will crash.
-///
-/// Note that this check is performed against the MainActor's serial executor, meaning that
-/// if another actor uses the same serial executor--by using ``MainActor/sharedUnownedExecutor``
-/// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
-/// perspective, the serial executor guarantees mutual exclusion of those two actors.
-@available(SwiftStdlib 5.9, *) 
-@_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
-public
-func assumeOnMainActorExecutor<T>(
-    _ operation: @MainActor () throws -> T,
-    file: StaticString = #fileID, line: UInt = #line
-) rethrows -> T {
-  typealias YesMainActor = @MainActor () throws -> T
-  typealias NoMainActor = () throws -> T
-
-  /// This is guaranteed to be fatal if the check fails,
-  /// as this is our "safe" version of this API.
-  guard _taskIsCurrentExecutor(Builtin.buildMainActorExecutorRef()) else {
-    // TODO: offer information which executor we actually got
-    fatalError("Incorrect actor executor assumption; Expected 'MainActor' executor.", file: file, line: line)
-  }
-
-  // To do the unsafe cast, we have to pretend it's @escaping.
-  return try withoutActuallyEscaping(operation) {
-    (_ fn: @escaping YesMainActor) throws -> T in
-    let rawFn = unsafeBitCast(fn, to: NoMainActor.self)
-    return try rawFn()
-  }
-}
-
-/// A safe way to synchronously assume that the current execution context belongs to the passed in actor.
-///
-/// This API should only be used as last resort, when it is not possible to express the current
-/// execution context definitely belongs to the specified actor in other ways. E.g. one may need to use
-/// this in a delegate style API, where a synchronous method is guaranteed to be called by the
-/// specified actor, however it is not possible to move this method as being declared on the specified actor.
-///
-/// - Warning: If the current executor is *not* the expected serial executor, this function will crash.
-///
-/// Note that this check is performed against the passed in actor's serial executor, meaning that
-/// if another actor uses the same serial executor--by using that actor's ``Actor/unownedExecutor``
-/// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
-/// perspective, the serial executor guarantees mutual exclusion of those two actors.
 @available(SwiftStdlib 5.9, *)
-@_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
-public
-func assumeOnActorExecutor<Act: Actor, T>(
-    _ actor: Act,
-    _ operation: (isolated Act) throws -> T,
-    file: StaticString = #fileID, line: UInt = #line
-) rethrows -> T {
-  typealias YesActor = (isolated Act) throws -> T
-  typealias NoActor = (Act) throws -> T
+extension Actor {
+  /// A safe way to synchronously assume that the current execution context belongs to the passed in actor.
+  ///
+  /// This API should only be used as last resort, when it is not possible to express the current
+  /// execution context definitely belongs to the specified actor in other ways. E.g. one may need to use
+  /// this in a delegate style API, where a synchronous method is guaranteed to be called by the
+  /// specified actor, however it is not possible to move this method as being declared on the specified actor.
+  ///
+  /// - Warning: If the current executor is *not* the expected serial executor, this function will crash.
+  ///
+  /// Note that this check is performed against the passed in actor's serial executor, meaning that
+  /// if another actor uses the same serial executor--by using that actor's ``Actor/unownedExecutor``
+  /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
+  /// perspective, the serial executor guarantees mutual exclusion of those two actors.
+  @available(SwiftStdlib 5.9, *)
+  @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
+  public nonisolated func assumeIsolated<T>(
+      _ operation: (isolated Self) throws -> T,
+      file: StaticString = #fileID, line: UInt = #line
+  ) rethrows -> T {
+    typealias YesActor = (isolated Self) throws -> T
+    typealias NoActor = (Self) throws -> T
 
-  /// This is guaranteed to be fatal if the check fails,
-  /// as this is our "safe" version of this API.
-  let executor: Builtin.Executor = actor.unownedExecutor.executor
-  guard _taskIsCurrentExecutor(executor) else {
-    // TODO: offer information which executor we actually got
-    fatalError("Incorrect actor executor assumption; Expected same executor as \(actor).", file: file, line: line)
-  }
+    /// This is guaranteed to be fatal if the check fails,
+    /// as this is our "safe" version of this API.
+    let executor: Builtin.Executor = self.unownedExecutor.executor
+    guard _taskIsCurrentExecutor(executor) else {
+      // TODO: offer information which executor we actually got
+      fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
+    }
 
-  // To do the unsafe cast, we have to pretend it's @escaping.
-  return try withoutActuallyEscaping(operation) {
-    (_ fn: @escaping YesActor) throws -> T in
-    let rawFn = unsafeBitCast(fn, to: NoActor.self)
-    return try rawFn(actor)
+    // To do the unsafe cast, we have to pretend it's @escaping.
+    return try withoutActuallyEscaping(operation) {
+      (_ fn: @escaping YesActor) throws -> T in
+      let rawFn = unsafeBitCast(fn, to: NoActor.self)
+      return try rawFn(self)
+    }
   }
 }
-
-// TODO(ktoso): implement assume for distributed actors as well
 
 #endif // not SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -98,4 +98,46 @@ extension MainActor {
     return try await body()
   }
 }
+
+@available(SwiftStdlib 5.9, *)
+extension MainActor {
+  /// A safe way to synchronously assume that the current execution context belongs to the MainActor.
+  ///
+  /// This API should only be used as last resort, when it is not possible to express the current
+  /// execution context definitely belongs to the main actor in other ways. E.g. one may need to use
+  /// this in a delegate style API, where a synchronous method is guaranteed to be called by the
+  /// main actor, however it is not possible to annotate this legacy API with `@MainActor`.
+  ///
+  /// - Warning: If the current executor is *not* the MainActor's serial executor, this function will crash.
+  ///
+  /// Note that this check is performed against the MainActor's serial executor, meaning that
+  /// if another actor uses the same serial executor--by using ``MainActor/sharedUnownedExecutor``
+  /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
+  /// perspective, the serial executor guarantees mutual exclusion of those two actors.
+  @available(SwiftStdlib 5.9, *)
+  @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
+  public static func assumeIsolated<T>(
+      _ operation: @MainActor () throws -> T,
+      file: StaticString = #fileID, line: UInt = #line
+  ) rethrows -> T {
+
+    typealias YesActor = @MainActor () throws -> T
+    typealias NoActor = () throws -> T
+
+    /// This is guaranteed to be fatal if the check fails,
+    /// as this is our "safe" version of this API.
+    let executor: Builtin.Executor = Self.shared.unownedExecutor.executor
+    guard _taskIsCurrentExecutor(executor) else {
+      // TODO: offer information which executor we actually got
+      fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
+    }
+
+    // To do the unsafe cast, we have to pretend it's @escaping.
+    return try withoutActuallyEscaping(operation) {
+      (_ fn: @escaping YesActor) throws -> T in
+      let rawFn = unsafeBitCast(fn, to: NoActor.self)
+      return try rawFn()
+    }
+  }
+}
 #endif

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -16,98 +16,97 @@ import _Concurrency
 // ==== -----------------------------------------------------------------------
 // MARK: Precondition APIs
 
-/// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
-/// and if not crash the program offering information about the executor mismatch.
-///
-/// This function's effect varies depending on the build flag used:
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration), stops program execution in a debuggable state after
-///   printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration), stops
-///   program execution.
-///
-/// * In `-Ounchecked` builds, the optimizer may assume that this function is
-///   never called. Failure to satisfy that assumption is a serious
-///   programming error.
-///
-/// - Parameter actor: the actor whose serial executor we expect to be the current executor
 @available(SwiftStdlib 5.9, *)
-public func preconditionOnExecutor(
-    of actor: some DistributedActor,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #fileID, line: UInt = #line
-) {
-  guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
-    return
-  }
+extension DistributedActor {
+  /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
+  /// and if not crash the program offering information about the executor mismatch.
+  ///
+  /// This function's effect varies depending on the build flag used:
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration), stops program execution in a debuggable state after
+  ///   printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration), stops
+  ///   program execution.
+  ///
+  /// * In `-Ounchecked` builds, the optimizer may assume that this function is
+  ///   never called. Failure to satisfy that assumption is a serious
+  ///   programming error.
+  @available(SwiftStdlib 5.9, *)
+  public nonisolated func preconditionIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+      return
+    }
 
-  guard __isLocalActor(actor) else {
-    return
-  }
+    guard __isLocalActor(self) else {
+      return
+    }
 
-  guard let unownedExecutor = actor.localUnownedExecutor else {
-    preconditionFailure(
-        "Incorrect actor executor assumption; Distributed actor \(actor) is 'local' but has no executor!",
+    guard let unownedExecutor = self.localUnownedExecutor else {
+      preconditionFailure(
+          "Incorrect actor executor assumption; Distributed actor \(self) is 'local' but has no executor!",
+          file: file, line: line)
+    }
+
+    let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor)
+
+    // TODO: offer information which executor we actually got
+    precondition(expectationCheck,
+        // TODO: figure out a way to get the typed repr out of the unowned executor
+        "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())",
         file: file, line: line)
   }
-
-  let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor)
-
-  // TODO: offer information which executor we actually got
-  precondition(expectationCheck,
-      // TODO: figure out a way to get the typed repr out of the unowned executor
-      "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())",
-      file: file, line: line)
 }
 
 // ==== -----------------------------------------------------------------------
 // MARK: Assert APIs
 
-/// Performs an executor check in debug builds.
-///
-/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
-///   configuration): If `condition` evaluates to `false`, stop program
-///   execution in a debuggable state after printing `message`.
-///
-/// * In `-O` builds (the default for Xcode's Release configuration),
-///   `condition` is not evaluated, and there are no effects.
-///
-/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
-///   may assume that it *always* evaluates to `true`. Failure to satisfy that
-///   assumption is a serious programming error.
-///
-///
-/// - Parameter actor: the actor whose serial executor we expect to be the current executor
 @available(SwiftStdlib 5.9, *)
-@_transparent
-public func assertOnExecutor(
-    of actor: some DistributedActor,
-    _ message: @autoclosure () -> String = String(),
-    file: StaticString = #fileID, line: UInt = #line
-) {
-  guard _isDebugAssertConfiguration() else {
-    return
-  }
+extension DistributedActor {
+  /// Performs an executor check in debug builds.
+  ///
+  /// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+  ///   configuration): If `condition` evaluates to `false`, stop program
+  ///   execution in a debuggable state after printing `message`.
+  ///
+  /// * In `-O` builds (the default for Xcode's Release configuration),
+  ///   `condition` is not evaluated, and there are no effects.
+  ///
+  /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+  ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+  ///   assumption is a serious programming error.
+  @available(SwiftStdlib 5.9, *)
+  @_transparent
+  public nonisolated func assertIsolated(
+      _ message: @autoclosure () -> String = String(),
+      file: StaticString = #fileID, line: UInt = #line
+  ) {
+    guard _isDebugAssertConfiguration() else {
+      return
+    }
 
-  guard __isLocalActor(actor) else {
-    return
-  }
+    guard __isLocalActor(self) else {
+      return
+    }
 
-  guard let unownedExecutor = actor.localUnownedExecutor else {
-    preconditionFailure(
-        "Incorrect actor executor assumption; Distributed actor \(actor) is 'local' but has no executor!",
-        file: file, line: line)
-  }
+    guard let unownedExecutor = self.localUnownedExecutor else {
+      preconditionFailure(
+          "Incorrect actor executor assumption; Distributed actor \(self) is 'local' but has no executor!",
+          file: file, line: line)
+    }
 
-  guard _taskIsCurrentExecutor(unownedExecutor._executor) else {
-    // TODO: offer information which executor we actually got
-    // TODO: figure out a way to get the typed repr out of the unowned executor
-    let msg = "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())"
-    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
-    assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
-    return
+    guard _taskIsCurrentExecutor(unownedExecutor._executor) else {
+      // TODO: offer information which executor we actually got
+      // TODO: figure out a way to get the typed repr out of the unowned executor
+      let msg = "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())"
+      /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+      assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
+      return
+    }
   }
 }
 
@@ -116,34 +115,58 @@ public func assertOnExecutor(
 // MARK: Assume APIs
 
 @available(SwiftStdlib 5.9, *)
-@_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
-public func assumeOnLocalDistributedActorExecutor<Act: DistributedActor, T>(
-    of actor: Act,
-    _ operation: (isolated Act) throws -> T,
-    file: StaticString = #fileID, line: UInt = #line
-) rethrows -> T {
-  typealias YesActor = (isolated Act) throws -> T
-  typealias NoActor = (Act) throws -> T
+extension DistributedActor {
 
-  guard __isLocalActor(actor) else {
-    fatalError("Cannot assume to be 'isolated \(Act.self)' since distributed actor '\(actor)' is remote.")
-  }
+  /// Assume that the current actor is a local distributed actor and that the currently executing context is the same as that actors
+  /// serial executor, or crash.
+  ///
+  /// This method allows developers to *assume and verify* that the currently executing synchronous function
+  /// is actually executing on the serial executor that this distributed (local) actor is using.
+  ///
+  /// If that is the case, the operation is invoked with an `isolated` version of the actoe,
+  /// allowing synchronous access to actor local state without hopping through asynchronous boundaries.
+  ///
+  /// If the current context is not running on the actor's serial executor, or if the actor is a reference to a remote actor,
+  /// this method will crash with a fatalError (similar to ``preconditionIsolated()``).
+  ///
+  /// This method can only be used from synchronous functions, as asynchronous ones should instead
+  /// perform normal method call to the actor.
+  ///
+  /// - Parameters:
+  ///   - operation: the operation that will be executed if the current context is executing on the actors serial executor, and the actor is a local reference
+  ///   - file: source location where the assume call is made
+  ///   - file: source location where the assume call is made
+  /// - Returns: the return value of the `operation`
+  /// - Throws: rethrows the `Error` thrown by the operation if it threw
+  @available(SwiftStdlib 5.9, *)
+  @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
+  public nonisolated func assumeIsolated<T>(
+      _ operation: (isolated Self) throws -> T,
+      file: StaticString = #fileID, line: UInt = #line
+  ) rethrows -> T {
+    typealias YesActor = (isolated Self) throws -> T
+    typealias NoActor = (Self) throws -> T
 
-  /// This is guaranteed to be fatal if the check fails,
-  /// as this is our "safe" version of this API.
-  guard let executor = actor.localUnownedExecutor else {
-    fatalError("Distributed local actor MUST have executor, but was nil")
-  }
-  guard _taskIsCurrentExecutor(executor._executor) else {
-    // TODO: offer information which executor we actually got when
-    fatalError("Incorrect actor executor assumption; Expected same executor as \(actor).", file: file, line: line)
-  }
+      guard __isLocalActor(self) else {
+        fatalError("Cannot assume to be 'isolated \(Self.self)' since distributed actor '\(self)' is a remote actor reference.")
+      }
 
-  // To do the unsafe cast, we have to pretend it's @escaping.
-  return try withoutActuallyEscaping(operation) {
-    (_ fn: @escaping YesActor) throws -> T in
-    let rawFn = unsafeBitCast(fn, to: NoActor.self)
-    return try rawFn(actor)
+    /// This is guaranteed to be fatal if the check fails,
+    /// as this is our "safe" version of this API.
+    guard let executor = self.localUnownedExecutor else {
+      fatalError("Distributed local actor MUST have executor, but was nil")
+    }
+    guard _taskIsCurrentExecutor(executor._executor) else {
+      // TODO: offer information which executor we actually got when
+      fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
+    }
+
+    // To do the unsafe cast, we have to pretend it's @escaping.
+    return try withoutActuallyEscaping(operation) {
+      (_ fn: @escaping YesActor) throws -> T in
+      let rawFn = unsafeBitCast(fn, to: NoActor.self)
+      return try rawFn(self)
+    }
   }
 }
 

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -15,11 +15,17 @@
 import StdlibUnittest
 
 func checkPreconditionMainActor() /* synchronous! */ {
-  preconditionTaskOnActorExecutor(MainActor.shared)
+  MainActor.shared.preconditionIsolated()
+  MainActor.preconditionIsolated()
+
+  // check for the existence of the assert version of APIs
+  MainActor.shared.assertIsolated()
+  MainActor.assertIsolated()
 }
 
 func checkPreconditionFamousActor() /* synchronous! */ {
-  preconditionTaskOnActorExecutor(FamousActor.shared)
+  FamousActor.shared.preconditionIsolated() // instance version for global actor
+  FamousActor.preconditionIsolated() // static version for global actor
 }
 
 @MainActor
@@ -62,7 +68,7 @@ actor Someone {
     if #available(SwiftStdlib 5.9, *) {
       // === MainActor --------------------------------------------------------
 
-      tests.test("preconditionTaskOnActorExecutor(main): from 'main() async', with await") {
+      tests.test("precondition on actor (main): from 'main() async', with await") {
         await checkPreconditionMainActor()
       }
 
@@ -72,14 +78,14 @@ actor Someone {
         await MainFriend().callCheckMainActor()
       }
 
-      tests.test("preconditionTaskOnActorExecutor(main): wrongly assume the main executor, from actor on other executor") {
+      tests.test("precondition on actor (main): wrongly assume the main executor, from actor on other executor") {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor()
       }
 
       // === Global actor -----------------------------------------------------
 
-      tests.test("preconditionTaskOnActorExecutor(main): assume FamousActor, from FamousActor") {
+      tests.test("precondition on actor (main): assume FamousActor, from FamousActor") {
         await FamousActor.shared.callCheckFamousActor()
       }
 

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -16,7 +16,7 @@ import StdlibUnittest
 
 func checkAssumeMainActor(echo: MainActorEcho) /* synchronous! */ {
   // Echo.get("any") // error: main actor isolated, cannot perform async call here
-  assumeOnMainActorExecutor {
+  MainActor.assumeIsolated {
     let input = "example"
     let got = echo.get(input)
     precondition(got == "example", "Expected echo to match \(input)")
@@ -40,7 +40,7 @@ actor MainFriend {
 
 func checkAssumeSomeone(someone: Someone) /* synchronous */ {
   // someone.something // can't access, would need a hop but we can't
-  assumeOnActorExecutor(someone) { someone in
+  someone.assumeIsolated { someone in
     let something = someone.something
     let expected = "isolated something"
     precondition(something == expected, "expected '\(expected)', got: \(something)")

--- a/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
@@ -65,7 +65,7 @@ actor MyActor {
   }
 
   func test(expectedExecutor: NaiveQueueExecutor) {
-    preconditionTaskOnExecutor(expectedExecutor, message: "Expected deep equality to trigger for \(expectedExecutor) and our \(self.executor)")
+    expectedExecutor.preconditionIsolated("Expected deep equality to trigger for \(expectedExecutor) and our \(self.executor)")
     print("\(Self.self): [\(self.executor.name)] on same context as [\(expectedExecutor.name)]")
   }
 }

--- a/test/Concurrency/Runtime/custom_executors_protocol.swift
+++ b/test/Concurrency/Runtime/custom_executors_protocol.swift
@@ -64,7 +64,7 @@ actor MyActor: WithSpecifiedExecutor {
   }
 
   func test(expectedExecutor: some SerialExecutor, expectedQueue: DispatchQueue) {
-    // FIXME(waiting on preconditions to merge): preconditionTaskOnExecutor(expectedExecutor, "Expected to be on: \(expectedExecutor)")
+    // FIXME(waiting on preconditions to merge): expectedExecutor.preconditionIsolated("Expected to be on: \(expectedExecutor)")
     dispatchPrecondition(condition: .onQueue(expectedQueue))
     print("\(Self.self): on executor \(expectedExecutor)")
   }

--- a/test/Distributed/Runtime/distributed_actor_assume_executor.swift
+++ b/test/Distributed/Runtime/distributed_actor_assume_executor.swift
@@ -21,14 +21,14 @@ import FakeDistributedActorSystems
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 func checkAssumeLocalDistributedActor(actor: MainDistributedFriend) /* synchronous! */ -> String {
-  assumeOnLocalDistributedActorExecutor(of: actor) { dist in
+  actor.assumeIsolated { dist in
     print("gained access to: \(dist.isolatedProperty)")
     return dist.isolatedProperty
   }
 }
 
 func checkAssumeMainActor(actor: MainDistributedFriend) /* synchronous! */ {
-  assumeOnMainActorExecutor {
+  MainActor.assumeIsolated {
     print("yay")
   }
 }
@@ -63,7 +63,7 @@ actor OtherMain {
   }
 
   func checkAssumeLocalDistributedActor(actor: MainDistributedFriend) /* synchronous! */ {
-    _ = assumeOnLocalDistributedActorExecutor(of: actor) { dist in
+    _ = actor.assumeIsolated { dist in
       print("gained access to: \(dist.isolatedProperty)")
       return dist.isolatedProperty
     }
@@ -94,7 +94,7 @@ actor OtherMain {
       }
 
       tests.test("assumeOnLocalDistributedActorExecutor: on remote actor reference") {
-        expectCrashLater(withMessage: "Cannot assume to be 'isolated MainDistributedFriend' since distributed actor 'a.MainDistributedFriend' is remote.")
+        expectCrashLater(withMessage: "Cannot assume to be 'isolated MainDistributedFriend' since distributed actor 'a.MainDistributedFriend' is a remote actor reference.")
         let remoteRef = try! MainDistributedFriend.resolve(id: distLocal.id, using: system)
         await OtherMain().checkAssumeLocalDistributedActor(actor: remoteRef)
       }

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
@@ -29,7 +29,7 @@ distributed actor Worker {
 
   distributed func test(x: Int) async throws {
     print("executed: \(#function)")
-    assumeOnMainActorExecutor {
+    MainActor.assumeIsolated {
       print("assume: this distributed actor shares executor with MainActor")
     }
     print("done executed: \(#function)")

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
@@ -27,10 +27,14 @@ distributed actor Worker {
     return self.id.executorPreference
   }
 
-  distributed func test(x: Int) async throws {
+  distributed func test(x: Int) {
     print("executed: \(#function)")
-    assumeOnMainActorExecutor {
+    MainActor.assumeIsolated {
       print("assume: this distributed actor shares executor with MainActor")
+    }
+    self.assumeIsolated { isolatedSelf in
+      // it of course is isolated by "itself"
+      print("assume: this distributed actor is isolated by itself")
     }
     print("done executed: \(#function)")
   }
@@ -54,6 +58,7 @@ extension DefaultDistributedActorSystem.ActorID {
     // CHECK: get unowned 'local' executor
     // CHECK: executed: test(x:)
     // CHECK: assume: this distributed actor shares executor with MainActor
+    // CHECK: assume: this distributed actor is isolated by itself
     // CHECK: done executed: test(x:)
 
     print("OK") // CHECK: OK

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -38,7 +38,7 @@ protocol Worker: DistributedActor {
 
 extension Worker {
   distributed func preconditionSameExecutor(as other: some Worker) {
-    preconditionOnExecutor(of: other, "Expected for [\(self)] share executor with [\(other)]")
+    other.preconditionIsolated("Expected for [\(self)] share executor with [\(other)]")
   }
 }
 

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -32,20 +32,30 @@ func testAsync() async -> Int {
 }
 func testSyncMember(obj: MyActor) -> Int {
     obj.#^MEMBER_IN_SYNC^#
-// MEMBER_IN_SYNC: Begin completions, 4 items
+// MEMBER_IN_SYNC: Begin completions, 9 items
 // MEMBER_IN_SYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated({#(message): String#})[#Void#]; name=assertIsolated(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> T##(isolated MyActor) throws -> T#})[' rethrows'][#T#]; name=assumeIsolated(:)
 }
 
 func testSyncMember(obj: MyActor) async -> Int {
     obj.#^MEMBER_IN_ASYNC^#
-// MEMBER_IN_ASYNC: Begin completions, 4 items
+// MEMBER_IN_ASYNC: Begin completions, 9 items
 // MEMBER_IN_ASYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated({#(message): String#})[#Void#]; name=assertIsolated(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> T##(isolated MyActor) throws -> T#})[' rethrows'][#T#]; name=assumeIsolated(:)
 }
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
**Description:** Address SE feedback around naming of the assume/precondition/assert APIs for actor isolation.
**Risk:** Low, the APIs should not have been adopted in user-code yet. We opted to not provide deprecated shims, but could so if necessary.
**Review by:** @DougGregor @jckarter @rjmccall 
**Testing:** CI testing
**Original PR:**  https://github.com/apple/swift/pull/64812
**Radar:** rdar://107541711 