### PR TITLE
[⛔] Revert "[CSSimplify] Don't enable `OneWayBindParam` for result builder transformed closures"

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11053,7 +11053,8 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   // type as seen in the body of the closure and the external parameter
   // type.
   bool oneWayConstraints =
-      getASTContext().LangOpts.hasFeature(Feature::OneWayClosureParameters);
+    getASTContext().LangOpts.hasFeature(Feature::OneWayClosureParameters) ||
+    resultBuilderType;
 
   auto *paramList = closure->getParameters();
   SmallVector<AnyFunctionType::Param, 4> parameters;

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -623,7 +623,7 @@ func wrapperifyInfer<T, U>(_ cond: Bool, @WrapperBuilder body: (U) -> T) -> T {
 }
 
 let intValue = 17
-_ = wrapperifyInfer(true) { x in // Ok
+wrapperifyInfer(true) { x in // expected-error{{unable to infer type of a closure parameter 'x' in the current context}}
   intValue + x
 }
 
@@ -999,19 +999,5 @@ func test_requirement_failure_in_buildBlock() {
         B()
       }
     }
-  }
-}
-
-func test_partially_resolved_closure_params() {
-  struct S<T> {
-    var a: String = ""
-  }
-
-  func test<T>(@TupleBuilder _: (S<T>) -> T) { // expected-note {{in call to function 'test'}}
-  }
-
-  test { // expected-error {{generic parameter 'T' could not be inferred}}
-    $0.a
-    42
   }
 }


### PR DESCRIPTION
Reverts apple/swift#64443

Checking whether this caused a regression in experimental-string-processing.