### PR TITLE
[SymbolGraphGen] move "protocol implementations" check into isImplicitlyPrivate

### DIFF
--- a/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
+++ b/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
@@ -20,15 +20,20 @@
 // CHECK-LABEL: "symbols": [
 
 // SomeStruct.otherFunc() should be present because it has its own doc comment
-// CHECK: s:27SkipProtocolImplementations10SomeStructV9otherFuncyyF
+// CHECK-DAG: s:27SkipProtocolImplementations10SomeStructV9otherFuncyyF
+
+// Same for ExtraStruct.Inner
+// CHECK-DAG: s:27SkipProtocolImplementations11ExtraStructV5InnerV
 
 // CHECK-LABEL: "relationships": [
 
 // we want to make sure that the conformance relationship itself stays
 // CHECK-DAG: conformsTo
 
-// SomeStruct.otherFunc() should be the only one with sourceOrigin information
-// COUNT-COUNT-1: sourceOrigin
+// SomeStruct.otherFunc() and ExtraStruct.Inner should be the only ones with sourceOrigin information
+// (ExtraStruct.Inner will have two sourceOrigins because it has two relationships: a memberOf and a
+// conformsTo)
+// COUNT-COUNT-3: sourceOrigin
 // COUNT-NOT: sourceOrigin
 
 public protocol SomeProtocol {
@@ -61,3 +66,10 @@ public struct OtherStruct: OtherProtocol {
 }
 
 extension OtherStruct.Inner: Sendable {}
+
+public struct ExtraStruct: OtherProtocol {
+    /// This time with a doc comment!
+    public struct Inner {}
+}
+
+extension ExtraStruct.Inner: Sendable {}

--- a/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
+++ b/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
@@ -14,6 +14,9 @@
 // CHECK-NOT: s:27SkipProtocolImplementations04SomeB0PAAE9bonusFuncyyF::SYNTHESIZED::s:27SkipProtocolImplementations10SomeStructV
 // CHECK-NOT: s:27SkipProtocolImplementations10SomeStructV8someFuncyyF
 
+// ...as well as the inner type from `OtherProtocol` on `OtherStruct`
+// CHECK-NOT: "s:27SkipProtocolImplementations11OtherStructV5InnerV"
+
 // CHECK-LABEL: "symbols": [
 
 // SomeStruct.otherFunc() should be present because it has its own doc comment
@@ -26,6 +29,7 @@
 
 // SomeStruct.otherFunc() should be the only one with sourceOrigin information
 // COUNT-COUNT-1: sourceOrigin
+// COUNT-NOT: sourceOrigin
 
 public protocol SomeProtocol {
     /// Base docs
@@ -45,3 +49,15 @@ public struct SomeStruct: SomeProtocol {
     /// Local docs
     public func otherFunc() {}
 }
+
+// Make sure that protocol conformances added in extensions don't create bogus symbol relationships (rdar://107432084)
+
+public protocol OtherProtocol {
+    associatedtype Inner
+}
+
+public struct OtherStruct: OtherProtocol {
+    public struct Inner {}
+}
+
+extension OtherStruct.Inner: Sendable {}


### PR DESCRIPTION
Resolves rdar://107432084

The original implementation of `-skip-protocol-implementations` focused on dropping symbols that matched the description of "protocol implementation", but didn't extend the check to any extra relationships that can show up. This meant that if a "protocol implementation" symbol is a type that adds a protocol implementation via an extension, that protocol conformance still ends up in the symbol graph, creating a malformed graph where a relationship references a symbol that doesn't exist. This PR moves the "protocol implementation" check into `SymbolGraph::isImplictlyPrivate`, alongside the other checks for dropping a symbol, to catch these scenarios.