### PR TITLE
[5.9] add AST printer support for _documentation attribute

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1394,6 +1394,32 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_Documentation: {
+    auto *attr = cast<DocumentationAttr>(this);
+
+    Printer.printAttrName("@_documentation");
+    Printer << "(";
+
+    bool needs_comma = !attr->Metadata.empty() && attr->Visibility;
+
+    if (attr->Visibility) {
+      Printer << "visibility: ";
+      Printer << getAccessLevelSpelling(*attr->Visibility);
+    }
+
+    if (needs_comma) {
+      Printer << ", ";
+    }
+
+    if (!attr->Metadata.empty()) {
+      Printer << "metadata: ";
+      Printer << attr->Metadata;
+    }
+
+    Printer << ")";
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 

--- a/test/SourceKit/CursorInfo/doc_attr.swift
+++ b/test/SourceKit/CursorInfo/doc_attr.swift
@@ -1,0 +1,9 @@
+@_documentation(visibility: public)
+enum E
+{
+}
+
+// The @_documentation attribute caused sourcekit-lsp to crash
+// cf. https://github.com/apple/swift/issues/64309
+
+// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64326

- **Explanation**: Use of the `@_documentation` attribute crashes symbolkit-lsp, because it lacks an AST printer implementation. This PR adds support for printing `@_documentation` attributes via the AST printer to prevent sourcekit-lsp from crashing.
- **Scope**: Allows SourceKit to be used with projects that have adopted the `@_documentation` attribute.
- **Issue**: Resolves #64309, rdar://106657906
- **Risk**: Low. Ordinary compilation should not be affected.
- **Testing**: An automated test has been added to ensure that SourceKit doesn't crash. Existing automated tests still pass.
- **Reviewer**: @ahoppen, @xedin, @bnbarham 