### PR TITLE
[5.9][Test] Fix swift_swift_parser feature and use in tests

### DIFF
--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -1,20 +1,18 @@
+// REQUIRES: swift_swift_parser, executable_test
+
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // First check for no errors.
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition)
 
 // Check that the expansion buffer are as expected.
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5  -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
 
 @attached(accessor)
 macro myPropertyWrapper() =

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest
 // REQUIRES: swift_swift_parser
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest
 
 @attached(accessor) macro m1() = #externalMacro(module: "MyMacros", type: "Macro1")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'}}

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -1,13 +1,10 @@
-// RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUNx: %target-swift-frontend -dump-ast -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
-// RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
+// REQUIRES: swift_swift_parser, executable_test
 
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-run %t/main | %FileCheck %s
 
 @attached(memberAttribute)
 @attached(member, names: named(_storage))

--- a/test/Macros/external-macro-without-decl.swift
+++ b/test/Macros/external-macro-without-decl.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name Swift -parse-stdlib
 // REQUIRES: swift_swift_parser
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name Swift -parse-stdlib
 
 // expected-warning@+2{{@expression has been removed in favor of @freestanding(expression)}}
 // expected-warning@+1{{external macro implementation type 'A.B' could not be found for macro 'myMacro()'; the type must be public and provided via '-load-plugin-library'}}

--- a/test/Macros/macro_availability_macosx.swift
+++ b/test/Macros/macro_availability_macosx.swift
@@ -1,5 +1,6 @@
+// REQUIRES: swift_swift_parser, OS=macosx
+
 // RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest -target %target-cpu-apple-macosx11
-// REQUIRES: OS=macosx
 
 @available(macOS 12.0, *)
 struct X { }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -1,34 +1,31 @@
+// REQUIRES: swift_swift_parser, executable_test
+
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
-// RUNx: %target-swift-frontend -dump-ast -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Diagnostics testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
 
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics > %t/macro-printing.txt
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics > %t/macro-printing.txt
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS %s
 
 // RUN: %FileCheck %s  --check-prefix CHECK-MACRO-PRINTED < %t/macro-printing.txt
 
 // Debug info SIL testing
-// RUN: %target-swift-frontend -swift-version 5 -emit-sil -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-SIL %s
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-SIL %s
 
 // Debug info IR testing
-// RUN: %target-swift-frontend -swift-version 5 -emit-ir -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-IR %s
+// RUN: %target-swift-frontend -swift-version 5 -emit-ir -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-IR %s
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
 
 // Plugin search path and loaded module trace testing
-// RUN: %target-swift-frontend -swift-version 5 -emit-sil -enable-experimental-feature FreestandingMacros -plugin-path %t -I %swift-host-lib-dir %s -module-name MacroUser -emit-loaded-module-trace -o %t/loaded_module_trace
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -enable-experimental-feature FreestandingMacros -plugin-path %t %s -module-name MacroUser -emit-loaded-module-trace -o %t/loaded_module_trace
 // RUN: %FileCheck -check-prefix=CHECK-MODULE-TRACE %s < %t/loaded_module_trace.trace.json
 
 // CHECK-MODULE-TRACE: {{libMacroDefinition.dylib|libMacroDefinition.so|MacroDefinition.dll}}
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
 
 #if TEST_DIAGNOSTICS
 @freestanding(declaration)

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -1,13 +1,10 @@
-// RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUNx: %target-swift-frontend -dump-ast -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
-// RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
+// REQUIRES: swift_swift_parser, executable_test
 
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-run %t/main | %FileCheck %s
 
 @attached(memberAttribute) macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
 

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -1,14 +1,12 @@
-// RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
-// RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
-// RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
+// REQUIRES: swift_swift_parser, executable_test
 
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-run %t/main | %FileCheck %s
 
 @attached(conformance)
 macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")

--- a/test/Macros/macro_expand_conformances_multi.swift
+++ b/test/Macros/macro_expand_conformances_multi.swift
@@ -1,14 +1,10 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // Make sure we see the conformances from another file.
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -swift-version 5 -primary-file %S/Inputs/macro_expand_conformances_other.swift -DDISABLE_TOP_LEVEL_CODE
-
-
-// REQUIRES: executable_test
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -swift-version 5 -primary-file %S/Inputs/macro_expand_conformances_other.swift -DDISABLE_TOP_LEVEL_CODE
 
 @attached(conformance)
 macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -1,24 +1,23 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir -disable-availability-checking
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking
 
 // Check with the imported macro library vs. the local declaration of the macro.
-// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t
 
 
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s -check-prefix=CHECK-EXEC
 
 // Emit module while skipping function bodies
-// RUN: %target-swift-frontend -swift-version 5 -emit-module -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir %s -disable-availability-checking -o %t/macro_expand_peers.swiftmodule -experimental-skip-non-inlinable-function-bodies-without-types
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -o %t/macro_expand_peers.swiftmodule -experimental-skip-non-inlinable-function-bodies-without-types
 
 #if IMPORT_MACRO_LIBRARY
 import macro_library

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser
+// REQUIRES: swift_swift_parser, executable_test
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath

--- a/test/Macros/macro_expand_primary.swift
+++ b/test/Macros/macro_expand_primary.swift
@@ -1,12 +1,11 @@
+// REQUIRES: swift_swift_parser, asserts
+//
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -I%t -verify -primary-file %s %S/Inputs/macro_expand_other.swift -verify-ignore-unknown  -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -I%t -verify -primary-file %s %S/Inputs/macro_expand_other.swift -verify-ignore-unknown  -load-plugin-library %t/%target-library-name(MacroDefinition) -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
-
-// REQUIRES: asserts
-// REQUIRES: OS=macosx
 
 import macro_library
 

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -1,13 +1,10 @@
+// REQUIRES: swift_swift_parser, executable_test
+//
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUNx: %target-swift-frontend -dump-ast -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -g -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -g -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
 // RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
 
 @attached(
   member,

--- a/test/Macros/macro_expand_throwing.swift
+++ b/test/Macros/macro_expand_throwing.swift
@@ -1,14 +1,13 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Make sure the diagnostic comes through...
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
 
 // Make sure the diagnostic doesn't crash in SILGen
-// RUN: not %target-swift-frontend -swift-version 5 -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: not %target-swift-frontend -swift-version 5 -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -o - -g
 
 @freestanding(expression) macro myWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "WarningMacro")
 

--- a/test/Macros/macro_expand_variadic.swift
+++ b/test/Macros/macro_expand_variadic.swift
@@ -1,13 +1,10 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/variadic_macros.swift -g -no-toolchain-stdlib-rpath
-// RUNx: %target-swift-frontend -dump-ast -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -swift-version 5 -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
-// RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
+// REQUIRES: swift_swift_parser, executable_test
 
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/variadic_macros.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -swift-version 5 -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-run %t/main | %FileCheck %s
 
 @freestanding(expression) macro print<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
 

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -1,4 +1,4 @@
-// REQUIRES: OS=macosx
+// REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -1,4 +1,4 @@
-// REQUIRES: OS=macosx
+// REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -7,8 +7,6 @@
 //== Build the plugin library
 // RUN: %host-build-swift \
 // RUN:   -swift-version 5 \
-// RUN:   -I %swift-host-lib-dir \
-// RUN:   -L %swift-host-lib-dir \
 // RUN:   -emit-library \
 // RUN:   -o %t/plugins/%target-library-name(MacroDefinition) \
 // RUN:   -module-name=MacroDefinition \
@@ -17,8 +15,6 @@
 
 // RUN: %host-build-swift \
 // RUN:   -swift-version 5 \
-// RUN:   -I %swift-host-lib-dir \
-// RUN:   -L %swift-host-lib-dir \
 // RUN:   -emit-library \
 // RUN:   -o %t/plugins/%target-library-name(EvilMacros) \
 // RUN:   -module-name=EvilMacros \

--- a/test/Macros/macro_vfs.swift
+++ b/test/Macros/macro_vfs.swift
@@ -1,16 +1,15 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/hidden)
 // RUN: split-file %s %t
 // RUN: sed -e "s@VFS_DIR@%{/t:regex_replacement}/vfs@g" -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/hidden@g" %t/base.yaml > %t/overlay.yaml
 
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/hidden/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/hidden/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Check that loading plugins respects VFS overlays
-// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -load-plugin-library %t/vfs/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
-// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -plugin-path %t/vfs -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -load-plugin-library %t/vfs/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -plugin-path %t/vfs -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
 
 //--- macro.swift
 // expected-no-diagnostics

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -1,5 +1,6 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -module-name MacrosTest
-// REQUIRES: OS=macosx
 
 @expression macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 // expected-note@-1 2{{'stringify' declared here}}

--- a/test/Macros/option_set.swift
+++ b/test/Macros/option_set.swift
@@ -1,6 +1,6 @@
+// REQUIRES: swift_swift_parser, executable_test
+
 // RUN: %target-run-simple-swift(-Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins -emit-tbd -emit-tbd-path %t.tbd)
-// REQUIRES: executable_test
-// REQUIRES: OS=macosx
 
 import Swift
 

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -1,5 +1,6 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros
-// REQUIRES: OS=macosx
 
 protocol P { }
 protocol Q { associatedtype Assoc }

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -1,17 +1,15 @@
+// REQUIRES: swift_swift_parser, executable_test
+//
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -parse-as-library -enable-experimental-feature FreestandingMacros -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -enable-experimental-feature FreestandingMacros -parse-as-library -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-SIL %s
+// RUN: %host-build-swift -swift-version 5 -parse-as-library -enable-experimental-feature FreestandingMacros -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -enable-experimental-feature FreestandingMacros -parse-as-library -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-SIL %s
 
 // Type check testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5  %S/Inputs/top_level_freestanding_other.swift
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5  %S/Inputs/top_level_freestanding_other.swift
 
 // Execution testing
-// RUN: %target-build-swift -g -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s %S/Inputs/top_level_freestanding_other.swift -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-build-swift -g -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) %s %S/Inputs/top_level_freestanding_other.swift -o %t/main -module-name MacroUser -swift-version 5
 // RUN: %target-run %t/main | %FileCheck %s
-// REQUIRES: executable_test
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
 
 // Test unqualified lookup from within a macro expansion
 @freestanding(declaration, names: named(StructWithUnqualifiedLookup))

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -1,13 +1,12 @@
-// REQUIRES: asserts
+// REQUIRES: swift_swift_parser, asserts
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
-// RUN: %host-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/def_macro_plugin.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -emit-module -o %t/def_macros.swiftmodule %S/Inputs/def_macros.swift -module-name def_macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
-// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
+// RUN: %host-build-swift -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/def_macro_plugin.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -emit-module -o %t/def_macros.swiftmodule %S/Inputs/def_macros.swift -module-name def_macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: llvm-bcanalyzer %t/def_macros.swiftmodule | %FileCheck %s
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -module-to-print=def_macros -I %t -source-filename=%s | %FileCheck -check-prefix=CHECK-PRINT %s
-// REQUIRES: OS=macosx
 
 import def_macros
 

--- a/test/SourceKit/Macros/macro_across_modules.swift
+++ b/test/SourceKit/Macros/macro_across_modules.swift
@@ -1,6 +1,4 @@
 // REQUIRES: swift_swift_parser
-// TODO: This shouldn't be required
-// REQUIRES: OS=macosx
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/mods)
@@ -10,10 +8,10 @@
 // than generated macro buffer.
 
 // Create a plugin that adds a new function as a member
-// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
 
 // Prepare a test module that uses the macro in a struct
-// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name TestModule -o %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -I %swift-host-lib-dir %t/TestModule.swift -index-store-path %t/idx
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name TestModule -o %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) %t/TestModule.swift -index-store-path %t/idx
 
 // Check we correctly output the added `newFunc` on the line of the attached
 // macro.
@@ -70,9 +68,9 @@ public struct LocalStruct {
 
 // Check the location in cursor info is the attached macro.
 func test(l: LocalStruct, m: ModStruct) {
-  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -I %swift-host-lib-dir %t/test.swift | %FileCheck %s --check-prefix=LOCAL_CURSOR
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods -load-plugin-library %t/%target-library-name(MacroPlugin) -target %target-triple %t/test.swift | %FileCheck %s --check-prefix=LOCAL_CURSOR
   l.newFunc()
 
-  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods %t/test.swift | %FileCheck %s --check-prefix=MOD_CURSOR
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %t/test.swift -- -I %t/mods -target %target-triple %t/test.swift | %FileCheck %s --check-prefix=MOD_CURSOR
   m.newFunc()
 }

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -56,22 +56,16 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 
 #anonymousTypes { "hello" }
 
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
-
-// REQUIRES: executable_test
-
-// REQUIRES=shell
+// REQUIRES: swift_swift_parser, executable_test, shell
 
 // RUN: %empty-directory(%t)
 
 //##-- Prepare the macro plugin.
-// RUN: %host-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // RUN: COMPILER_ARGS_WITHOUT_SOURCE=( \
 // RUN:   -swift-version 5 \
 // RUN:   -load-plugin-library %t/%target-library-name(MacroDefinition) \
-// RUN:   -I %swift-host-lib-dir \
 // RUN:   -module-name MacroUser \
 // RUN: )
 

--- a/test/SymbolGraph/Symbols/Macro.swift
+++ b/test/SymbolGraph/Symbols/Macro.swift
@@ -1,14 +1,11 @@
-// FIXME: Swift parser is not enabled on non-MacOS yet
-// REQUIRES: OS=macosx
-
-// REQUIRES: executable_test
+// REQUIRES: swift_swift_parser, executable_test
 
 // RUN: %empty-directory(%t)
 
 // Build the plugin
-// RUN: %host-build-swift %S/../../Macros/Inputs/syntax_macro_definitions.swift -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -g -no-toolchain-stdlib-rpath
+// RUN: %host-build-swift %S/../../Macros/Inputs/syntax_macro_definitions.swift -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition -swift-version 5 -g -no-toolchain-stdlib-rpath
 
-// RUN: %target-build-swift %s -module-name Macro -emit-module -emit-module-path %t -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
+// RUN: %target-build-swift %s -module-name Macro -emit-module -emit-module-path %t -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: %target-swift-symbolgraph-extract -module-name Macro -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/Macro.symbols.json
 // RUN: %FileCheck %s --input-file %t/Macro.symbols.json --check-prefix MISSING

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
@@ -1,6 +1,9 @@
+// '-enable-experimental-feature Macros' requires an asserts build.
+// REQUIRES: swift_swift_parser, asserts
+
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/stringify_macro.swift -g -no-toolchain-stdlib-rpath -swift-version 5
-// RUN: %target-swift-frontend -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name Macros -emit-module -emit-module-path %t/Macros.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/stringify_macro.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %target-swift-frontend -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name Macros -emit-module -emit-module-path %t/Macros.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %{python} -m json.tool %t/Macros.symbols.json %t/Macros.formatted.symbols.json
 
 // Make sure that the `= #externalMacro(...)` doesn't show up in declaration fragments and in names fragments.
@@ -8,11 +11,6 @@
 // RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json --check-prefix NAMES
 
-// '-enable-experimental-feature Macros' requires an asserts build.
-// REQUIRES: asserts
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
 
 @freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -520,6 +520,7 @@ shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 
+config.swift_host_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
 
 if kIsWindows:
     config.swift_driver = (
@@ -537,13 +538,12 @@ else:
         % (shell_quote(config.host_sdkroot), config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
     config.swiftc_driver = (
         "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s"
-        % (shell_quote(config.host_sdkroot), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) 
- 
+        % (shell_quote(config.host_sdkroot), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
+
 config.host_build_swift = (
-    "%s -sdk %s -target %s" % (config.swiftc_driver, config.host_sdkroot, config.host_triple)
+    "%s -sdk %s -target %s -I %s -L %s" % (config.swiftc_driver, config.host_sdkroot, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir)
 )
 
-config.swift_host_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
 config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%swift-lib-dir', config.swift_lib_dir) )
 config.substitutions.append( ('%swift-host-lib-dir', config.swift_host_lib_dir))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -158,15 +158,15 @@ config.freestanding_sdk_name = "@SWIFT_SDK_FREESTANDING_LIB_SUBDIR@"
 if "@BOOTSTRAPPING_MODE@" != "OFF":
   config.available_features.add('swift_in_compiler')
 
-if "@SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR@" != "":
-  config.available_features.add('swift_swift_parser')
-
 if "@BOOTSTRAPPING_MODE@" == 'HOSTTOOLS':
   config.available_features.add('hosttools_mode')
 elif "@BOOTSTRAPPING_MODE@" == 'BOOTSTRAPPING':
   config.available_features.add('bootstrapping_mode')
 elif "@BOOTSTRAPPING_MODE@" == 'BOOTSTRAPPING-WITH-HOSTLIBS':
   config.available_features.add('bootstrapping_with_hostlibs_mode')
+
+if '@SWIFT_SWIFT_PARSER@' == 'TRUE':
+  config.available_features.add('swift_swift_parser')
 
 # Let the main config do the real work.
 if config.test_exec_root is None:

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -1,10 +1,10 @@
+// REQUIRES: swift_swift_parser, executable_test
+
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
 
-// REQUIRES: executable_test
 // REQUIRES: observation
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
-// REQUIRES: executable_test
 
 import StdlibUnittest
 import _Observation


### PR DESCRIPTION
* Explanation: Various test updates to properly use `swift_swift_parser` rather than `OS=macosx`. This is required so that these tests run on other platforms once they also have host compilers.
* Scope: Tests
* Risk: Extremely low, this only updates tests
* Original PR: https://github.com/apple/swift/pull/64089