### PR TITLE
[Test] For TypeLowering lexicality verify fix.

### DIFF
--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -284,6 +284,14 @@ func callVariadicMemberwiseInit() -> MemberwiseTupleHolder<Int, String> {
   return MemberwiseTupleHolder(content: (0, "hello"))
 }
 
+@_eagerMove struct MyString {
+  var guts: AnyObject
+}
+
+func callVariadicMemberwiseInit(_ ms: MyString) -> MemberwiseTupleHolder<Int, MyString> {
+  return MemberwiseTupleHolder(content: (0, ms))
+}
+
 // rdar://107151145: when we tuple-destructure a black hole
 // initialization, the resulting element initializations need to
 // handle pack expansion initialization


### PR DESCRIPTION
Added test case that exhibits failure without ff3ec198780f2ca5294b847dd3baa7c80b6f1996 even when collection types aren't eagermove.
