### PR TITLE
5.9: [TypeLowering] NFC: Fix lexicality verification for packs and tuples.

### DIFF
--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -284,6 +284,14 @@ func callVariadicMemberwiseInit() -> MemberwiseTupleHolder<Int, String> {
   return MemberwiseTupleHolder(content: (0, "hello"))
 }
 
+@_eagerMove struct MyString {
+  var guts: AnyObject
+}
+
+func callVariadicMemberwiseInit(_ ms: MyString) -> MemberwiseTupleHolder<Int, MyString> {
+  return MemberwiseTupleHolder(content: (0, ms))
+}
+
 // rdar://107151145: when we tuple-destructure a black hole
 // initialization, the resulting element initializations need to
 // handle pack expansion initialization


### PR DESCRIPTION
Use the new mechanism for looking into tuples that properly handles packs.

Cherry-pick of one commit from https://github.com/apple/swift/pull/64553 and the test case from https://github.com/apple/swift/pull/64883 .
