### PR TITLE
🍒[5.9] Fix test using assume APIs, which landed concurrently to API renames

### DIFF
--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -103,19 +103,19 @@ final class MainActorEcho {
     if #available(SwiftStdlib 5.9, *) {
       // === MainActor --------------------------------------------------------
 
-      tests.test("assumeOnMainActorExecutor: assume the main executor, from 'main() async'") {
+      tests.test("MainActor.assumeIsolated: assume the main executor, from 'main() async'") {
         await checkAssumeMainActor(echo: echo)
       }
 
-      tests.test("assumeOnMainActorExecutor: assume the main executor, from MainActor method") {
+      tests.test("MainActor.assumeIsolated: assume the main executor, from MainActor method") {
         await mainActorCallCheck(echo: echo)
       }
 
-      tests.test("assumeOnMainActorExecutor: assume the main executor, from actor on MainActor executor") {
+      tests.test("MainActor.assumeIsolated: assume the main executor, from actor on MainActor executor") {
         await MainFriend().callCheck(echo: echo)
       }
 
-      tests.test("assumeOnMainActorExecutor: wrongly assume the main executor, from actor on other executor") {
+      tests.test("MainActor.assumeIsolated: wrongly assume the main executor, from actor on other executor") {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor(echo: echo)
       }

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
@@ -33,7 +33,7 @@ distributed actor FiveSevenActor_NothingExecutor {
     defer {
       print("done executed: \(#function)")
     }
-    assumeOnMainActorExecutor {
+    MainActor.assumeIsolated {
       // ignore
     }
   }
@@ -52,7 +52,7 @@ distributed actor FiveNineActor_NothingExecutor {
     defer {
       print("done executed: \(#function)")
     }
-    assumeOnMainActorExecutor {
+    MainActor.assumeIsolated {
       // ignore
     }
   }
@@ -71,7 +71,7 @@ distributed actor FiveSevenActor_FiveNineExecutor {
     defer {
       print("done executed: \(#function)")
     }
-    assumeOnMainActorExecutor {
+    MainActor.assumeIsolated {
       // ignore
     }
   }


### PR DESCRIPTION
Cherry pick of: https://github.com/apple/swift/pull/64890

Resolves rdar://107541711

---

The PR https://github.com/apple/swift/pull/64800 had been using assume APIs in the tests which changed concurrently to merging this PR, resulting in a broken compile of the test.

This unbreaks the build and CI -- cc @rintaro