### PR TITLE
[ASTScope] Adjust parent location for peer macro to after its attached decl.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -30,6 +30,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeRepr.h"
+#include "swift/Parse/Lexer.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/STLExtras.h"
 #include "llvm/Support/Compiler.h"
@@ -262,10 +263,19 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     case MacroRole::Declaration:
     case MacroRole::Accessor:
     case MacroRole::MemberAttribute:
-    case MacroRole::Peer:
     case MacroRole::Conformance:
       parentLoc = expansion.getStartLoc();
       break;
+    case MacroRole::Peer: {
+      ASTContext &ctx = SF->getASTContext();
+      SourceManager &sourceMgr = ctx.SourceMgr;
+      const auto &generatedSourceInfo =
+          *sourceMgr.getGeneratedSourceInfo(*SF->getBufferID());
+
+      ASTNode node = ASTNode::getFromOpaqueValue(generatedSourceInfo.astNode);
+      parentLoc = Lexer::getLocForEndOfToken(sourceMgr, node.getEndLoc());
+      break;
+    }
     case MacroRole::Member: {
       // For synthesized member macros, take the end loc of the
       // enclosing declaration (before the closing brace), because

--- a/test/Macros/Inputs/macro_library.swift
+++ b/test/Macros/Inputs/macro_library.swift
@@ -35,3 +35,6 @@ public macro ObservableProperty() = #externalMacro(module: "MacroDefinition", ty
 
 @attached(peer, names: overloaded)
 public macro addCompletionHandler() = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
+
+@attached(peer, names: suffixed(Builder))
+public macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition", type: "AddClassReferencingSelfMacro")

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1296,3 +1296,26 @@ public struct DefineAnonymousTypesMacro: DeclarationMacro {
     ]
   }
 }
+
+public struct AddClassReferencingSelfMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
+      throw CustomError.message("Macro can only be applied to a protocol declarations.")
+    }
+
+    let className = "\(protocolDecl.identifier.text)Builder"
+    return [
+      """
+      struct \(raw: className) {
+       init(_ build: (_ builder: Self) -> Self) {
+         _ = build(self)
+       }
+      }
+      """
+    ]
+  }
+}

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -25,6 +25,8 @@ import macro_library
 #else
 @attached(peer, names: overloaded)
 macro addCompletionHandler() = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
+@attached(peer, names: suffixed(Builder))
+macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition", type: "AddClassReferencingSelfMacro")
 #endif
 
 struct S {
@@ -113,3 +115,6 @@ struct Main {
     // CHECK-EXEC: hahaha global
   }
 }
+
+@AddClassReferencingSelf
+protocol MyProto { }


### PR DESCRIPTION
Peer macro produce declarations that are semantically alongside the declaration to which the macro is attached. However, the source location used for constructing the scope tree was based on the attribute itself, which meant it was inside the scope of the declaration to which the macro was attached. This lead to incorrect unqualified name lookup; in the example that's now a test case, this meant that the `Self` of the protocol to which the macro was attached was visible from within the peer declaration. Hilarity (in the form of a type checker crash) ensued.

Fix the location used for constructing the scope tree of peer macros to be right after the attached declaration. Fixes rdar://107228586.
