### PR TITLE
[5.9] SILGen and SIL type lowering for vanishing tuples

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1283,8 +1283,9 @@ public:
   }
 
   /// Is the given tuple type a valid substitution of this abstraction
-  /// pattern?
-  bool matchesTuple(CanTupleType substType) const;
+  /// pattern?  Note that the type doesn't have to be a tuple type in the
+  /// case of a vanishing tuple.
+  bool matchesTuple(CanType substType) const;
 
   bool isTuple() const {
     switch (getKind()) {
@@ -1344,6 +1345,14 @@ public:
 
   bool doesTupleContainPackExpansionType() const;
 
+  /// If this type is a tuple type that vanishes (is flattened to its
+  /// singleton non-expansion element) under the stored substitutions,
+  /// return the abstraction pattern of the surviving element.
+  ///
+  /// If the surviving element came from an expansion element, the
+  /// returned element is the pattern type of the expansion.
+  Optional<AbstractionPattern> getVanishingTupleElementPatternType() const;
+
   static AbstractionPattern
   projectTupleElementType(const AbstractionPattern *base, size_t index) {
     return base->getTupleElementType(index);
@@ -1360,8 +1369,9 @@ public:
   /// original type and how many elements of the substituted type they
   /// expand to.
   ///
-  /// This pattern must be a tuple pattern.
-  void forEachTupleElement(CanTupleType substType,
+  /// This pattern must be a tuple pattern.  The substituted type may be
+  /// a non-tuple only if this is a vanshing tuple pattern.
+  void forEachTupleElement(CanType substType,
          llvm::function_ref<void(TupleElementGenerator &element)> fn) const;
 
   /// Perform a parallel visitation of the elements of a tuple type,
@@ -1372,7 +1382,7 @@ public:
   ///
   /// This pattern must match the substituted type, but it may be an
   /// opaque pattern.
-  void forEachExpandedTupleElement(CanTupleType substType,
+  void forEachExpandedTupleElement(CanType substType,
       llvm::function_ref<void(AbstractionPattern origEltType,
                               CanType substEltType,
                               const TupleTypeElt &elt)> handleElement) const;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1270,8 +1270,7 @@ public:
   void destructure(AbstractionPattern origType, CanType substType) {
     // Recur into tuples.
     if (origType.isTuple()) {
-      auto substTupleType = cast<TupleType>(substType);
-      origType.forEachTupleElement(substTupleType,
+      origType.forEachTupleElement(substType,
                                    [&](TupleElementGenerator &elt) {
         // If the original element type is not a pack expansion, just
         // pull off the next substituted element type.
@@ -1646,7 +1645,7 @@ private:
 
     // Tuples get expanded unless they're inout.
     if (origType.isTuple() && ownership != ValueOwnership::InOut) {
-      expandTuple(ownership, forSelf, origType, cast<TupleType>(substType),
+      expandTuple(ownership, forSelf, origType, substType,
                   isNonDifferentiable);
       return;
     }
@@ -1683,7 +1682,7 @@ private:
 
   /// Recursively expand a tuple type into separate parameters.
   void expandTuple(ValueOwnership ownership, bool forSelf,
-                   AbstractionPattern origType, CanTupleType substType,
+                   AbstractionPattern origType, CanType substType,
                    bool isNonDifferentiable) {
     assert(ownership != ValueOwnership::InOut);
     assert(origType.isTuple());

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -584,16 +584,15 @@ public:
 /// A result plan which produces a larger RValue from a bunch of
 /// components.
 class TupleRValueResultPlan final : public ResultPlan {
-  CanTupleType substType;
-
+  CanType substType;
   SmallVector<ResultPlanPtr, 4> origEltPlans;
 
 public:
   TupleRValueResultPlan(ResultPlanBuilder &builder, AbstractionPattern origType,
-                        CanTupleType substType)
+                        CanType substType)
       : substType(substType) {
     // Create plans for all the elements.
-    origEltPlans.reserve(substType->getNumElements());
+    origEltPlans.reserve(origType.getNumTupleElements());
     origType.forEachTupleElement(substType,
                                  [&](TupleElementGenerator &origElt) {
       AbstractionPattern origEltType = origElt.getOrigType();
@@ -643,7 +642,7 @@ public:
   TupleInitializationResultPlan(ResultPlanBuilder &builder,
                                 Initialization *tupleInit,
                                 AbstractionPattern origType,
-                                CanTupleType substType)
+                                CanType substType)
       : tupleInit(tupleInit) {
     // Get the sub-initializations.
     eltInits = tupleInit->splitIntoTupleElements(builder.SGF, builder.loc,
@@ -1115,7 +1114,7 @@ ResultPlanPtr ResultPlanBuilder::build(Initialization *init,
                                        CanType substType) {
   // Destructure original tuples.
   if (origType.isTuple()) {
-    return buildForTuple(init, origType, cast<TupleType>(substType));
+    return buildForTuple(init, origType, substType);
   }
 
   assert(!origType.isPackExpansion() &&
@@ -1299,12 +1298,16 @@ ResultPlanBuilder::buildScalarIntoPack(SILValue packAddr,
 
 ResultPlanPtr ResultPlanBuilder::buildForTuple(Initialization *init,
                                                AbstractionPattern origType,
-                                               CanTupleType substType) {
+                                               CanType substType) {
   // If we have an initialization, and we can split it, do so.
   if (init && init->canSplitIntoTupleElements()) {
     return ResultPlanPtr(
         new TupleInitializationResultPlan(*this, init, origType, substType));
   }
+
+  auto substTupleType = dyn_cast<TupleType>(substType);
+  bool substHasPackExpansion =
+    (substTupleType && substTupleType.containsPackExpansionType());
 
   // Otherwise, if the tuple contains a pack expansion, we'll need to
   // initialize a single buffer one way or another: either we're giving
@@ -1319,9 +1322,9 @@ ResultPlanPtr ResultPlanBuilder::buildForTuple(Initialization *init,
   // do that if we're not using lowered addresses because we prefer to
   // build tuples with scalar operations.
   auto &substTL = SGF.getTypeLowering(substType);
-  assert(substTL.isAddressOnly() || !substType.containsPackExpansionType());
+  assert(substTL.isAddressOnly() || !substHasPackExpansion);
   if (substTL.isAddressOnly() &&
-      (substType.containsPackExpansionType() ||
+      (substHasPackExpansion ||
        (init != nullptr && SGF.F.getConventions().useLoweredAddresses()))) {
     // Create a temporary.
     auto temporary = SGF.emitTemporary(loc, substTL);

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -97,7 +97,7 @@ struct ResultPlanBuilder {
                                SILResultInfo result);
   ResultPlanPtr buildForTuple(Initialization *emitInto,
                               AbstractionPattern origType,
-                              CanTupleType substType);
+                              CanType substType);
   ResultPlanPtr buildForPackExpansion(Optional<MutableArrayRef<InitializationPtr>> inits,
                                       AbstractionPattern origExpansionType,
                                       CanTupleEltTypeArrayRef substTypes);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -377,7 +377,8 @@ public:
       } else {
         assert(init);
         expandPack(origEltType, substEltTypes, elt.getSubstIndex(),
-                   eltInits, elements);
+                   eltInits.slice(elt.getSubstIndex(), substEltTypes.size()),
+                   elements);
       }
     });
 

--- a/test/SILGen/variadic-generic-vanishing-tuples.swift
+++ b/test/SILGen/variadic-generic-vanishing-tuples.swift
@@ -1,0 +1,77 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature VariadicGenerics %s | %FileCheck %s
+
+// rdar://107459964
+// rdar://107478603
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+
+public struct G<Value> {
+  public let id: Int
+}
+
+public struct Holder<each T> {
+  public let values: (repeat G<each T>)
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4main21testInstanceVarAccessyAA1GVyxGAA6HolderVyx_QPGlF :
+// CHECK:       [[T0:%.*]] = struct_extract %0 : $Holder<X>, #Holder.values
+// CHECK-NEXT:  return [[T0]] : $G<X>
+public func testInstanceVarAccess<X>(_ holder: Holder<X>) -> G<X> {
+  return holder.values
+}
+
+extension Holder {
+  public static var allValues: (repeat G<each T>) {
+    return (repeat G<each T>(id: 0))
+  }
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4main19testStaticVarAccessAA1GVyxGylF :
+// CHECK:       [[METATYPE:%.*]] = metatype $@thin Holder<X>.Type
+// CHECK-NEXT:  [[PACK:%.*]] = alloc_pack $Pack{G<X>}
+// CHECK-NEXT:  [[TEMP:%.*]] = alloc_stack $G<X>
+// CHECK-NEXT:  [[INDEX:%.*]] = scalar_pack_index 0 of $Pack{G<X>}
+// CHECK-NEXT:  pack_element_set [[TEMP]] : $*G<X> into [[INDEX]] of [[PACK]] :
+// CHECK-NEXT:  // function_ref
+// CHECK-NEXT:  [[FN:%.*]] = function_ref @$s4main6HolderV9allValuesAA1GVyxGxQp_tvgZ : $@convention(method) <each τ_0_0> (@thin Holder<repeat each τ_0_0>.Type) -> @pack_out Pack{repeat G<each τ_0_0>}
+// CHECK-NEXT:  apply [[FN]]<Pack{X}>([[PACK]], [[METATYPE]])
+// CHECK-NEXT:  [[T0:%.*]] = load [trivial] [[TEMP]] : $*G<X>
+// CHECK-NEXT:  dealloc_stack [[TEMP]]
+// CHECK-NEXT:  dealloc_pack [[PACK]]
+// CHECK-NEXT:  return [[T0]] : $G<X>
+public func testStaticVarAccess<X>() -> G<X> {
+  return Holder<X>.allValues
+}
+
+extension Holder {
+  static func takeExpansion(arg: (repeat G<each T>)) {}
+  static func takePartial(arg: (Int, repeat G<each T>)) {}
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4main23testArgPassingExpansion3argyAA1GVyxG_tlF :
+// CHECK:       [[METATYPE:%.*]] = metatype $@thin Holder<X>.Type
+// CHECK-NEXT:  [[PACK:%.*]] = alloc_pack $Pack{G<X>}
+// CHECK-NEXT:  [[TEMP:%.*]] = alloc_stack $G<X>
+// CHECK-NEXT:  store %0 to [trivial] [[TEMP]] : $*G<X>
+// CHECK-NEXT:  [[INDEX:%.*]] = scalar_pack_index 0 of $Pack{G<X>}
+// CHECK-NEXT:  pack_element_set [[TEMP]] : $*G<X> into [[INDEX]] of [[PACK]] :
+// CHECK-NEXT:  // function_ref
+// CHECK-NEXT:  [[FN:%.*]] = function_ref @$s4main6HolderV13takeExpansion3argyAA1GVyxGxQp_t_tFZ : $@convention(method) <each τ_0_0> (@pack_guaranteed Pack{repeat G<each τ_0_0>}, @thin Holder<repeat each τ_0_0>.Type) -> ()
+// CHECK-NEXT:  apply [[FN]]<Pack{X}>([[PACK]], [[METATYPE]])
+// CHECK-NEXT:  dealloc_stack [[TEMP]]
+// CHECK-NEXT:  dealloc_pack [[PACK]]
+public func testArgPassingExpansion<X>(arg: G<X>) {
+  Holder<X>.takeExpansion(arg: arg)
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4main21testArgPassingPartialyyF :
+// CHECK:       [[METATYPE:%.*]] = metatype $@thin Holder<>.Type
+// CHECK:       [[PACK:%.*]] = alloc_pack $Pack{}
+// CHECK-NEXT:  // function_ref
+// CHECK-NEXT:  [[FN:%.*]] = function_ref @$s4main6HolderV11takePartial3argySi_AA1GVyxGxQpt_tFZ : $@convention(method) <each τ_0_0> (Int, @pack_guaranteed Pack{repeat G<each τ_0_0>}, @thin Holder<repeat each τ_0_0>.Type) -> ()
+// CHECK-NEXT:  apply [[FN]]<Pack{}>({{.*}}, [[PACK]], [[METATYPE]])
+// CHECK-NEXT:  dealloc_pack [[PACK]]
+public func testArgPassingPartial() {
+  Holder< >.takePartial(arg: 0)
+}


### PR DESCRIPTION
The language says that `( type-tuple-body )` is a tuple type only if `type-tuple-body` is not a single non-expansion component; otherwise it is merely parentheses.  We follow this same idea in substitution: substitution of type parameter packs can change the number of components in a tuple, and the result is no longer a tuple if there is a single non-expansion component.  These "vanishing" tuples pose an annoyance for the lowering of types and expressions: lowering must often consider the unsubstituted type of declarations (the "abstraction pattern"), and it has historically been true that the substituted type will be a tuple if the unsubstituted type is.  There is therefore quite a bit of code in lowering that assumes that e.g. it can check whether the substituted type is a tuple before it checks the unsubstituted type.  This code must be fixed to be primarily driven by the unsubstituted type.  (The original tuple structure is usually very significant!  For example, if we take a formal parameter of type `(Int, repeat each T)`, we will actually have two lowered parameters, one of which completely disappears from the substituted type if `T` is substituted with an empty pack.)

5.9 version of https://github.com/apple/swift/pull/64887

Explanation: as above
Scope: widespread crashes in SILGen when substitution turns a tuple containing pack expansions into an underlying element
Issue: rdar://107459964 and rdar://107478603
Risk: Low; the patch touches many common code paths, but the changes are modest and should only affect code using pack expansions
Testing: Regression tests added