### PR TITLE
Fix the REQUIRES line in a SIL test.

### DIFF
--- a/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
+++ b/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
@@ -1,6 +1,7 @@
 // RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -semantic-arc-opts -sil-semantic-arc-peepholes-lifetime-joining %s | %FileCheck %s
 //
-// REQUIRES: swift_stdlib_asserts
+// Enabling specific ARC opts requires an asserts build.
+// REQUIRES: asserts
 
 // NOTE: Some of our tests here depend on borrow elimination /not/ running!
 // Please do not add it to clean up the IR like we did in


### PR DESCRIPTION
SILOptimizer/semantic-arc-opts-lifetime-joining.sil had an incorrect REQUIRES line, so the test was disabled for normal compiler development.