### PR TITLE
[android][test] Disable new SwiftToCxxToSwift Interop class type bridging test

### DIFF
--- a/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/import-swift-class-back-to-swift.swift
@@ -10,6 +10,7 @@
 // RUN: %target-swift-frontend -typecheck %t/swiftMod.swift -typecheck -module-name SwiftMod -I %t -enable-experimental-cxx-interop -Xcc -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR -DSECOND_PASS -emit-sil -o - | %FileCheck --check-prefix=SIL %s
 
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 //--- header.h
 #ifndef FIRSTPASS


### PR DESCRIPTION
@hyp, this [broke the Android CI since you added it a couple weeks ago](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/3633/console), please disable this for Android.