### PR TITLE
[5.9] Always specify `-gmodules` on built-in Clang invocations

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -75,12 +75,8 @@ static void addSearchPathInvocationArguments(
 static std::vector<std::string> getClangDepScanningInvocationArguments(
     ASTContext &ctx,
     Optional<StringRef> sourceFileName = None) {
-  std::vector<std::string> commandLineArgs;
-
-  // Form the basic command line.
-  commandLineArgs.push_back("clang");
-  importer::getNormalInvocationArguments(commandLineArgs, ctx);
-  importer::addCommonInvocationArguments(commandLineArgs, ctx);
+  std::vector<std::string> commandLineArgs =
+      ClangImporter::getClangArguments(ctx);
   addSearchPathInvocationArguments(commandLineArgs, ctx);
 
   auto sourceFilePos = std::find(
@@ -113,6 +109,10 @@ static std::vector<std::string> getClangDepScanningInvocationArguments(
     assert(syntaxOnlyPos != commandLineArgs.end());
     *syntaxOnlyPos = "-c";
   }
+
+  // The Clang modules produced by ClangImporter are always embedded in an
+  // ObjectFilePCHContainer and contain -gmodules debug info.
+  commandLineArgs.push_back("-gmodules");
 
   return commandLineArgs;
 }

--- a/test/ScanDependencies/test_clang_gmodules.swift
+++ b/test/ScanDependencies/test_clang_gmodules.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target %target-cpu-apple-macosx10.14
+// RUN: %FileCheck %s < %t/deps.json
+
+import X
+
+// CHECK: "clang": "X"
+// CHECK: "clang": "X"
+// CHECK: "commandLine": [
+// CHECK-DAG: "-fmodule-format=obj"
+// CHECK-DAG: "-dwarf-ext-refs"


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64912
-----------------------------------
This is currently always done when instantiating `ClangImporter` by manually setting the option on the Clang invocation with:
```
Invocation->getCodeGenOpts().DebugTypeExtRefs = true
```
Now also add it to `importer::addCommonInvocationArguments` so that the dependency scanner always generates command-lines with the required for Swift Clang flags.

Resolves rdar://107570568
