### PR TITLE
[Macros] Don't visit auxiliary decls of class members twice.

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1821,9 +1821,13 @@ public:
 
   void visit(Decl *decl) {
     // Visit auxiliary decls first.
-    decl->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
-      this->visit(auxiliaryDecl);
-    });
+    // We don't do this for members of classes because it happens as part of
+    // visiting their ABI members.
+    if (!isa<ClassDecl>(decl->getDeclContext())) {
+      decl->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
+        this->visit(auxiliaryDecl);
+      });
+    }
 
     if (auto *Stats = getASTContext().Stats)
       ++Stats->getFrontendCounters().NumDeclsTypechecked;

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -67,6 +67,14 @@ func useCompletionHandlerG(s: S, _ body: @escaping (String) -> Void) {
   }
 }
 
+class C {
+  @addCompletionHandler
+  func f(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+}
+
+
 @addCompletionHandler
 func f(a: Int, for b: String, _ value: Double) async -> String {
   return b


### PR DESCRIPTION
To ensure that class vtables get laid out with the right ABI, visiting a class declaration visits all of its "ABI members", which includes visiting all of the auxiliary declarations. However, we also visit the auxiliary declarations of every declaration, which means some declarations get visited twice.

This led to another oddly-specific bug for macros, where we would visit declarations introduce by peer macros on class members twice. When combined with function-body-skipping (e.g., to emit a module file), this would result in spurious errors of the form:

    Expected '{' in body of function declaration

Stop visiting the auxiliary declarations of class members twice, eliminating this error. This one has been annoying me off and on for a while :).

Fixes rdar://107429169.
