### PR TITLE
Stop binding a constant reference to a temporary that goes away.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -269,7 +269,7 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     case MacroRole::Peer: {
       ASTContext &ctx = SF->getASTContext();
       SourceManager &sourceMgr = ctx.SourceMgr;
-      const auto &generatedSourceInfo =
+      auto generatedSourceInfo =
           *sourceMgr.getGeneratedSourceInfo(*SF->getBufferID());
 
       ASTNode node = ASTNode::getFromOpaqueValue(generatedSourceInfo.astNode);


### PR DESCRIPTION
Thank you, ASan.

Fixes rdar://107621137, ASan reporting a use-after-end-of-scope for this `const &`.