### PR TITLE
🍒[cxx-interop] Treat un-instantiated templated types as unsafe

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6395,7 +6395,9 @@ static bool hasIteratorAPIAttr(const clang::Decl *decl) {
 static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
   // Probably a class template that has not yet been specialized:
   if (!decl->getDefinition())
-    return false;
+    // If the definition is unknown, there is no way to determine if the type
+    // stores pointers. Stay on the safe side and assume that it does.
+    return true;
 
   auto checkType = [](clang::QualType t) {
     if (t->isPointerType())
@@ -6689,9 +6691,10 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return false;
         }
 
-        // Mark this as safe to help our diganostics down the road.
         if (!cxxRecordReturnType->getDefinition()) {
-          return true;
+          // This is a templated type that has not been instantiated yet. We do
+          // not know if it is safe. Assume that it isn't.
+          return false;
         }
 
         if (!cxxRecordReturnType->hasUserDeclaredCopyConstructor() &&

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -213,4 +213,32 @@ struct HasMethodThatReturnsIteratorBox {
   IteratorBox getIteratorBox() const;
 };
 
+template <typename T>
+struct TemplatedPointerBox {
+  T *ptr;
+};
+
+struct HasMethodThatReturnsTemplatedPointerBox {
+  TemplatedPointerBox<int> getTemplatedPointerBox() const;
+};
+
+template <typename T>
+struct TemplatedBox {
+  T value;
+};
+
+struct HasMethodThatReturnsTemplatedBox {
+  TemplatedBox<int> getIntBox() const;
+  TemplatedBox<int *> getIntPtrBox() const;
+};
+
+template <typename T>
+struct __attribute__((swift_attr("import_iterator"))) TemplatedIterator {
+  T idx;
+};
+
+struct HasMethodThatReturnsTemplatedIterator {
+  TemplatedIterator<int *> getIterator() const;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_TYPE_CLASSIFICATION_H

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -35,3 +35,18 @@
 // CHECK:   func __getIteratorBoxUnsafe() -> IteratorBox
 // CHECK-SKIP-UNSAFE-NOT: func __getIteratorBoxUnsafe() -> IteratorBox
 // CHECK: }
+
+// CHECK: struct HasMethodThatReturnsTemplatedPointerBox {
+// CHECK:   func __getTemplatedPointerBoxUnsafe() -> TemplatedPointerBox<Int32>
+// CHECK-SKIP-UNSAFE-NOT: func __getTemplatedPointerBoxUnsafe() -> TemplatedPointerBox<Int32>
+// CHECK: }
+
+// CHECK: struct HasMethodThatReturnsTemplatedBox {
+// FIXME: This is unfortunate, we should be able to recognize that TemplatedBox<Int32> does not store any pointers as fields.
+// CHECK:   func __getIntBoxUnsafe() -> TemplatedBox<Int32>
+// CHECK:   func __getIntPtrBoxUnsafe()
+// CHECK: }
+
+// CHECK: struct HasMethodThatReturnsTemplatedIterator {
+// CHECK:   func __getIteratorUnsafe()
+// CHECK: }

--- a/test/Interop/Cxx/templates/Inputs/large-class-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/large-class-templates.h
@@ -28,17 +28,17 @@ struct ValExpr {
   using type = typename E::type;
   E expr;
   
-  ValExpr<SliceExpr<E, 1>> test1() { return {SliceExpr<E, 1>{expr}}; }
-  ValExpr<SliceExpr<E, 2>> test2() { return {SliceExpr<E, 2>{expr}}; }
-  ValExpr<SliceExpr<E, 3>> test3() { return {SliceExpr<E, 3>{expr}}; }
-  ValExpr<SliceExpr<E, 4>> test4() { return {SliceExpr<E, 4>{expr}}; }
-  ValExpr<SliceExpr<E, 5>> test5() { return {SliceExpr<E, 5>{expr}}; }
-  ValExpr<SliceExpr<E, 6>> test6() { return {SliceExpr<E, 6>{expr}}; }
-  ValExpr<SliceExpr<E, 7>> test7() { return {SliceExpr<E, 7>{expr}}; }
-  ValExpr<SliceExpr<E, 8>> test8() { return {SliceExpr<E, 8>{expr}}; }
-  ValExpr<SliceExpr<E, 9>> test9() { return {SliceExpr<E, 8>{expr}}; }
-  ValExpr<SliceExpr<E, 11>> test11() { return {SliceExpr<E, 11>{expr}}; }
-  ValExpr<SliceExpr<E, 12>> test12() { return {SliceExpr<E, 12>{expr}}; }
+  ValExpr<SliceExpr<E, 1>> test1() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 1>{expr}}; }
+  ValExpr<SliceExpr<E, 2>> test2() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 2>{expr}}; }
+  ValExpr<SliceExpr<E, 3>> test3() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 3>{expr}}; }
+  ValExpr<SliceExpr<E, 4>> test4() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 4>{expr}}; }
+  ValExpr<SliceExpr<E, 5>> test5() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 5>{expr}}; }
+  ValExpr<SliceExpr<E, 6>> test6() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 6>{expr}}; }
+  ValExpr<SliceExpr<E, 7>> test7() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 7>{expr}}; }
+  ValExpr<SliceExpr<E, 8>> test8() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 8>{expr}}; }
+  ValExpr<SliceExpr<E, 9>> test9() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 8>{expr}}; }
+  ValExpr<SliceExpr<E, 11>> test11() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 11>{expr}}; }
+  ValExpr<SliceExpr<E, 12>> test12() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 12>{expr}}; }
 };
 
 // This class template is exponentially slow to *fully* instantiate (and the


### PR DESCRIPTION
**Explanation**: This adjusts the C++ method importing logic to treat methods that return templated types as unsafe if the template was not instantiated. Previously such methods were treated as safe, even if the templated return type stores pointers in its fields.
**Scope**: This makes certain C++ methods unavailable that were previously available in Swift.
**Risk**: Low: C++ interop is an experimental feature that is not used in production.
**Testing**: Added LIT tests.

rdar://107609381
(cherry picked from commit c81325461afdc602b0901fa06f9d6f988381622b)