### PR TITLE
[5.9] [move-only] Temporarily ban deinits on non-copyable enums.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -424,6 +424,8 @@ ERROR(initializer_result_type,PointsToFirstBadToken,
 // Destructor
 ERROR(destructor_decl_outside_class_or_noncopyable,none,
       "deinitializers may only be declared within a class, actor, or noncopyable type", ())
+ERROR(destructor_decl_on_noncopyable_enum,none,
+      "deinitializers are not yet supported on noncopyable enums", ())
 ERROR(destructor_decl_on_objc_enum,none,
       "deinitializers cannot be declared on an @objc enum type", ())
 ERROR(expected_lbrace_destructor,PointsToFirstBadToken,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -117,6 +117,9 @@ EXPERIMENTAL_FEATURE(FreestandingMacros, true)
 // but our tests currently rely on it, and we want to run those
 // tests in non-asserts builds too.
 EXPERIMENTAL_FEATURE(MoveOnlyClasses, true)
+EXPERIMENTAL_FEATURE(NoImplicitCopy, true)
+EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
+EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3256,6 +3256,21 @@ static bool usesFeatureMoveOnlyClasses(Decl *decl) {
   return isa<ClassDecl>(decl) && usesFeatureMoveOnly(decl);
 }
 
+static bool usesFeatureNoImplicitCopy(Decl *decl) {
+  return decl->isNoImplicitCopy();
+}
+
+static bool usesFeatureOldOwnershipOperatorSpellings(Decl *decl) {
+  return false;
+}
+
+static bool usesFeatureMoveOnlyEnumDeinits(Decl *decl) {
+  if (auto *ei = dyn_cast<EnumDecl>(decl)) {
+    return usesFeatureMoveOnly(ei) && ei->getValueTypeDestructor();
+  }
+  return false;
+}
+
 static bool usesFeatureOneWayClosureParameters(Decl *decl) {
   return false;
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3610,6 +3610,14 @@ public:
         DD->diagnose(diag::destructor_decl_outside_class_or_noncopyable);
       }
 
+      // Temporarily ban deinit on noncopyable enums, unless the experimental
+      // feature flag is set.
+      if (!DD->getASTContext().LangOpts.hasFeature(
+              Feature::MoveOnlyEnumDeinits) &&
+          nom->isMoveOnly() && isa<EnumDecl>(nom)) {
+        DD->diagnose(diag::destructor_decl_on_noncopyable_enum);
+      }
+
       // If we have a noncopyable type, check if we have an @objc enum with a
       // deinit and emit a specialized error. We will have technically already
       // emitted an error since @objc enum cannot be marked noncopyable, but

--- a/test/IRGen/moveonly_deinit.sil
+++ b/test/IRGen/moveonly_deinit.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/moveonly_deinit.sil
-// RUN: %target-swift-frontend -emit-ir %t/moveonly_deinit.sil | %FileCheck %t/moveonly_deinit.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyEnumDeinits -emit-ir %t/moveonly_deinit.sil | %FileCheck %t/moveonly_deinit.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // UNSUPPORTED: CPU=arm64e
 

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -1,5 +1,5 @@
 // TODO: re-enable the simplification passes once rdar://104875010 is fixed
-// RUN: %target-swift-emit-ir -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=IR %s
+// RUN: %target-swift-emit-ir -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=IR %s
 
 // Test that makes sure that at IRGen time we properly handle conditional
 // releases for trivial and non-trivial move only types. The SIL/SILGen part of
@@ -7,7 +7,7 @@
 // we can test on other platforms the other behavior.
 
 // REQUIRES: asserts
-// REQUIRES: CPU=x86_64
+// REQUIRES: CODEGENERATOR=X86
 
 //////////////////////
 // Misc Declaration //

--- a/test/Interpreter/moveonly_forget.swift
+++ b/test/Interpreter/moveonly_forget.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
 
 // REQUIRES: executable_test
 

--- a/test/SILGen/forget.swift
+++ b/test/SILGen/forget.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name test %s | %FileCheck %s --enable-var-scope
-// RUN: %target-swift-emit-sil -module-name test -sil-verify-all %s | %FileCheck %s --check-prefix CHECK-SIL --enable-var-scope
+// RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyEnumDeinits -module-name test %s | %FileCheck %s --enable-var-scope
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyEnumDeinits -module-name test -sil-verify-all %s | %FileCheck %s --check-prefix CHECK-SIL --enable-var-scope
 
 func invokedDeinit() {}
 

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -1,6 +1,6 @@
 // TODO: re-enable the simplification passes once rdar://104875010 is fixed
-// RUN: %target-swift-emit-silgen -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=SILGEN %s
-// RUN: %target-swift-emit-sil -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=SILGEN %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=SIL %s
 
 // Test that makes sure that throughout the pipeline we properly handle
 // conditional releases for trivial and non-trivial move only types.

--- a/test/SILOptimizer/moveonly_deinit_insertion.sil
+++ b/test/SILOptimizer/moveonly_deinit_insertion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name main -enable-sil-verify-all -sil-move-only-deinit-insertion -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name main -enable-sil-verify-all -sil-move-only-deinit-insertion -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil %s
+// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s
 
 class Klass {}
 

--- a/test/Sema/forget.swift
+++ b/test/Sema/forget.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature MoveOnlyEnumDeinits
 
 // Typechecking for the forget statement.
 

--- a/test/Sema/moveonly_enum.swift
+++ b/test/Sema/moveonly_enum.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+@_moveOnly
+enum Foo {
+    deinit {} // expected-error {{deinitializers are not yet supported on noncopyable enums}}
+}
+
+@_moveOnly
+enum Foo2 {
+}

--- a/test/Sema/moveonly_objc_enum.swift
+++ b/test/Sema/moveonly_objc_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature MoveOnlyEnumDeinits
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/moveonly_deinit.swift
+++ b/test/Serialization/moveonly_deinit.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // TODO: re-enable the simplification passes once rdar://104875010 is fixed
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -g -emit-module  -module-name OtherModule %S/Inputs/moveonly_deinit.swift -emit-module-path %t/OtherModule.swiftmodule
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -g -I %t %s -emit-silgen
+// RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification -g -emit-module  -module-name OtherModule %S/Inputs/moveonly_deinit.swift -emit-module-path %t/OtherModule.swiftmodule
+// RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification -g -I %t %s -emit-silgen
 
 // Make sure we can deserialize deinits of both enums and structs.
 

--- a/test/Serialization/moveonly_error_on_import_into_module_without_flag.swift
+++ b/test/Serialization/moveonly_error_on_import_into_module_without_flag.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 // TODO: re-enable the simplification passes once rdar://104875010 is fixed
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -emit-module -o %t/Library.swiftmodule -module-name Library %S/Inputs/moveonly_deinit.swift
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -emit-module -o %t/Library.swiftmodule -module-name Library %S/Inputs/moveonly_deinit.swift -enable-experimental-feature MoveOnlyEnumDeinits
 
 // >>> make sure borrow scopes are required when using a move-only type from another module
-// RUN: not %target-swift-frontend -DUSE_MOVEONLY_TYPE -typecheck -enable-lexical-borrow-scopes=false -I %t %s 2>&1 | %FileCheck %s --check-prefix CHECK-ERROR
+// RUN: not %target-swift-frontend -DUSE_MOVEONLY_TYPE -typecheck -enable-experimental-feature MoveOnlyEnumDeinits -enable-lexical-borrow-scopes=false -I %t %s 2>&1 | %FileCheck %s --check-prefix CHECK-ERROR
 // RUN: %target-swift-frontend -DUSE_MOVEONLY_TYPE -typecheck -I %t %s 2>&1 | %FileCheck %s --allow-empty
 
 // >>> try turning off lexical borrow scopes with no move-only types; shouldn't be an error.
 //     we have to pipe into FileCheck because -verify ignores errors from other files.
-// RUN: %target-swift-frontend -enable-lexical-borrow-scopes=false -typecheck -I %t %s 2>&1 | %FileCheck %s --allow-empty
+// RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyEnumDeinits -enable-lexical-borrow-scopes=false -typecheck -I %t %s 2>&1 | %FileCheck %s --allow-empty
 
 // This test makes sure that if we import a move only type
 // and do not have lexical borrow scopes enabled, we emit an error.


### PR DESCRIPTION
The reason why we are doing this is that:

1. For non-copyable types, switches are always at +1 for now.
2. non-copyable enums with deinits cannot be switched upon since that would invalidate the deinit.

So deinits on non-copyable enums are just not useful at this point since you cannot open the enum.

Once we make it so that you can bind a non-copyable enum at +0, we will remove this check.

I added an experimental feature MoveOnlyEnumDeinits so tests that validate the codegen/etc will still work.

rdar://101651138