### PR TITLE
[Test] Reenable a test.

### DIFF
--- a/test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil
+++ b/test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil
@@ -5,8 +5,6 @@
 
 // UNSUPPORTED: asserts
 
-// REQUIRES: rdar89986815
-
 class Klass {}
 
 sil [ossa] @leaky_code : $@convention(thin) () -> () {


### PR DESCRIPTION
The `SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil` passes locally with a noasserts build.  See how it does with CI.

rdar://89986815
