### PR TITLE
MultiDefPrunedLiveness: add support for arbitrary uses/defs.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -190,9 +190,6 @@ private:
   /// Optional vector of live blocks for clients that deterministically iterate.
   SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr;
 
-  /// Only a clean bitfield can be initialized.
-  bool cleanFlag = true;
-
   /// Once the first def has been initialized, uses can be added.
   bool initializedFlag = false;
 
@@ -207,7 +204,6 @@ public:
 
   void invalidate() {
     initializedFlag = false;
-    cleanFlag = false;
   }
 
   void initializeDiscoveredBlocks(

--- a/include/swift/SIL/ScopedAddressUtils.h
+++ b/include/swift/SIL/ScopedAddressUtils.h
@@ -119,7 +119,7 @@ struct ScopedAddressValue {
   ///
   /// Valid for any type of liveness, SSA or MultiDef, that may be used by a
   /// scoped address.
-  AddressUseKind updateTransitiveLiveness(PrunedLiveness &liveness) const;
+  AddressUseKind updateTransitiveLiveness(SSAPrunedLiveness &liveness) const;
 
   /// Create appropriate scope ending instruction at \p insertPt.
   void createScopeEnd(SILBasicBlock::iterator insertPt, SILLocation loc) const;

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -15,8 +15,8 @@
 ///
 /// Interior liveness handles the following cases naturally:
 ///
-/// When completing the lifetime if the initial value, %v1, transitively
-/// include all dominated reborrows. %phi1 in this example:
+/// When completing the lifetime of the initial value, %v1, transitively
+/// include all uses of dominated reborrows as, such as %phi1 in this example:
 ///
 ///     %v1 = ...
 ///     cond_br bb1, bb2
@@ -31,8 +31,8 @@
 ///     end_borrow %phi1
 ///     %k1 = destroy_value %v1 // must be below end_borrow %phi1
 ///
-/// When completing the lifetime for a (%phi2) transitively include all inner
-/// adjacent reborrows (%phi1):
+/// When completing the lifetime for a phi (%phi2) transitively include all
+/// uses of inner adjacent reborrows, such as %phi1 in this example:
 ///
 ///   bb1:
 ///     %v1 = ...

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -542,6 +542,8 @@ void MultiDefPrunedLiveness::findBoundariesInBlock(
   }
   // Handle a live-out or live-within block with potentially multiple defs
   unsigned prevCount = boundary.deadDefs.size() + boundary.lastUsers.size();
+  (void)prevCount;
+
   bool isLive = isLiveOut;
   for (auto &inst : llvm::reverse(*block)) {
     // Check if the instruction is a def before checking whether it is a

--- a/lib/SIL/Utils/ScopedAddressUtils.cpp
+++ b/lib/SIL/Utils/ScopedAddressUtils.cpp
@@ -105,8 +105,8 @@ AddressUseKind ScopedAddressValue::computeTransitiveLiveness(
   return updateTransitiveLiveness(liveness);
 }
 
-AddressUseKind
-ScopedAddressValue::updateTransitiveLiveness(PrunedLiveness &liveness) const {
+AddressUseKind ScopedAddressValue::updateTransitiveLiveness(
+    SSAPrunedLiveness &liveness) const {
   SmallVector<Operand *, 4> uses;
   // Collect all uses that need to be enclosed by the scope.
   auto addressKind = findTransitiveUsesForAddress(value, &uses);

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -507,22 +507,20 @@ bb0(%0 : @guaranteed $C):
 // CHECK-LABEL: begin running test 1 of 1 on testMultiDefUseAddressReinit
 // CHECK: MultiDef lifetime analysis:
 // CHECK:   def instruction:   store %{{.*}} to [init] [[ADR:%.*]] : $*C
-// CHECK:   def instruction:   destroy_addr [[ADR]] : $*C
-// CHECK: bb0: LiveWithin
+// CHECK:   def instruction:   store %0 to [init] [[ADR]] : $*C
+// CHECK: bb0: LiveOut
 // CHECK: bb1: LiveWithin
 // CHECK: regular user: %{{.*}} = load [copy] [[ADR]] : $*C
 // CHECK: last user:    %{{.*}} = load [copy] [[ADR]] : $*C
-//
-// FIXME: This store is not really a dead def!
-// CHECK: dead def:   store %2 to [init] %1 : $*C
-// CHECK: dead def:   destroy_addr %1 : $*C
+// CHECK: boundary edge: bb2
+// CHECK: dead def:   store %0 to [init] %1 : $*C
 // CHECK-LABEL: end running test 1 of 1 on testMultiDefUseAddressReinit
 sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
 bb0(%0: @owned $C):
   %1 = alloc_stack $C
   %2 = copy_value %0 : $C
   test_specification """
-                     multidefuse-liveness defs: @instruction @block[1].instruction[1]
+                     multidefuse-liveness defs: @instruction @block[1].instruction[2]
                      uses: @block[1].instruction[0]
                      """
   store %2 to [init] %1 : $*C


### PR DESCRIPTION
This now supports liveness holes within blocks where previously we
expected a phi def.

PrunedLiveness is streamlined for SSA liveness where we expect the
defs and uses to be related in the SSA def-use graph.
MultiDefPrunedLiveness was added on top of SSAPrunedLivenes to handle
extended SSA liveness that occurs with phis, but are still connected
in the def-use graph. Recently MultiDefPrunedLiveness was repurposed
for liveness of addressible storage. This means that we can now have
uses before defs in the same block without a corresponding phi.

Fortunately, handling this case is a straightforward extension of
MultiDefPrunedLiveness that does not complicate or penalize the
streamlined SSA case.

Restores PR: MultiDefPrunedLiveness: add support for arbitrary uses/defs. #64625
The CI failure in watchos RemoveWhere.o appears unrelated:
rdar://107341949 (Swift CI: [main, armv7k] benchmark/O-armv7k-apple-watchos2.0/RemoveWhere.o: assert in Control Flow Optimizer)