### PR TITLE
[Diagnostics] Forgo all restrictions if one side of conversion has in…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5156,6 +5156,14 @@ bool ConstraintSystem::repairFailures(
       if (auto *inoutExpr = dyn_cast<InOutExpr>(AE->getSrc())) {
         auto *loc = getConstraintLocator(inoutExpr);
 
+        // Remove all of the restrictions because none of them
+        // are going to succeed.
+        conversionsOrFixes.erase(
+            llvm::remove_if(
+                conversionsOrFixes,
+                [](const auto &entry) { return bool(entry.getRestriction()); }),
+            conversionsOrFixes.end());
+
         if (hasFixFor(loc, FixKind::RemoveAddressOf))
           return true;
 

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -302,3 +302,11 @@ func test_incorrect_inout_at_assignment_source() {
     s.prop = &val // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   }
 }
+
+// rdar://100369066 - type of expression is ambiguous when `&` is used incorrectly
+func test_invalid_inout_with_restrictions(lhs: inout any BinaryInteger, rhs: any BinaryInteger) {
+  lhs = &rhs // expected-error {{'&' may only be used to pass an argument to inout parameter}}
+
+  var other: (any BinaryInteger)? = nil
+  other = &rhs // expected-error {{'&' may only be used to pass an argument to inout parameter}}
+}


### PR DESCRIPTION
…valid use of `&`

None of the restrictions like existential conversion or optional promotion
would actually match, so there is no point in trying them just to add more unrelated fixes.

Resolves: rdar://100369066

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
