### PR TITLE
[docs][Concurrency] Fix typo in method signature in code snippets of groups

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -35,7 +35,7 @@ import Swift
 /// before returning from this function:
 ///
 /// ```
-/// await withDiscardingTaskGroup { group in
+/// await withDiscardingTaskGroup(...) { group in
 ///   group.addTask { /* slow-task */ }
 ///   // slow-task executes...
 /// }
@@ -357,7 +357,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// before returning from this function:
 ///
 /// ```
-/// try await withThrowingDiscardingTaskGroup { group in
+/// try await withThrowingDiscardingTaskGroup(of: Void.self) { group in
 ///   group.addTask { /* slow-task */ }
 ///   // slow-task executes...
 /// }
@@ -390,7 +390,7 @@ extension DiscardingTaskGroup: Sendable { }
 ///
 /// ```
 /// // ThrowingTaskGroup, pattern not applicable to ThrowingDiscardingTaskGroup
-/// try await withThrowingTaskGroup { group in
+/// try await withThrowingTaskGroup(of: Void.self) { group in
 ///   group.addTask { try boom() }
 ///   try await group.next() // re-throws "boom"
 /// }

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -89,7 +89,7 @@ using FutureFragment = AsyncTask::FutureFragment;
 
 /// During evolution discussions we opted to implement the following semantic of
 /// a discarding task-group throw:
-/// - the error thrown out of withThrowingDiscardingTaskGroup { ... } always "wins",
+/// - the error thrown out of withThrowingDiscardingTaskGroup(...) { ... } always "wins",
 ///   even if the group already had an error stored within.
 ///
 /// This is harder to implement, since we have to always store the "first error from children",


### PR DESCRIPTION
A few snippets wrongly spelled snippets as `try await withThrowingTaskGroup { group in`, but we require being explicit about the group type like this: `try await withThrowingTaskGroup(of: Void.self) { group in`

Reported in https://twitter.com/kuba_suder/status/1643368916914253826

rdar://111547369