### PR TITLE
[5.9] Make sure we visit auxiliary declarations for symbol visitation.

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -390,7 +390,7 @@ public:
   void visit(FileUnit *file) {
     auto visitFile = [this](FileUnit *file) {
       SmallVector<Decl *, 16> decls;
-      file->getTopLevelDecls(decls);
+      file->getTopLevelDeclsWithAuxiliaryDecls(decls);
 
       addMainIfNecessary(file);
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1259,6 +1259,20 @@ public struct DefineStructWithUnqualifiedLookupMacro: DeclarationMacro {
   }
 }
 
+extension TupleExprElementListSyntax {
+  /// Retrieve the first element with the given label.
+  func first(labeled name: String) -> Element? {
+    return first { element in
+      if let label = element.label, label.text == name {
+        return true
+      }
+
+      return false
+    }
+  }
+}
+
+
 public struct DefineAnonymousTypesMacro: DeclarationMacro {
   public static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
@@ -1267,13 +1281,22 @@ public struct DefineAnonymousTypesMacro: DeclarationMacro {
     guard let body = node.trailingClosure else {
       throw CustomError.message("#anonymousTypes macro requires a trailing closure")
     }
+
+    let accessSpecifier: String
+    if let _ = node.argumentList.first(labeled: "public") {
+      accessSpecifier = "public "
+    } else {
+      accessSpecifier = ""
+    }
     return [
       """
 
-      class \(context.makeUniqueName("name")) {
-        func hello() -> String {
+      \(raw:accessSpecifier)class \(context.makeUniqueName("name")) {
+        \(raw:accessSpecifier)func hello() -> String {
           \(body.statements)
         }
+
+        \(raw:accessSpecifier)func getSelf() -> Any.Type { return Self.self }
       }
       """,
       """

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -25,11 +25,11 @@ func lookupGlobalFreestandingExpansion() {
 }
 
 @freestanding(declaration)
-macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+macro anonymousTypes(public: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
 
-#anonymousTypes { "hello" }
+#anonymousTypes(public: true) { "hello" }
 
-// CHECK-SIL: sil hidden @$s9MacroUser03$s9A71User33_082AE7CFEFA6960C804A9FE7366EB5A0Ll14anonymousTypesfMf0_4namefMu_C5helloSSyF
+// CHECK-SIL: sil @$s9MacroUser03$s9A71User33_082AE7CFEFA6960C804A9FE7366EB5A0Ll14anonymousTypesfMf0_4namefMu_C5helloSSyF
 
 @main
 struct Main {

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -131,6 +131,8 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:   func hello() -> String {
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
+// EXPAND_MACRO_DECL-NEXT:
+// EXPAND_MACRO_DECL-NEXT:   func getSelf() -> Any.Type { return Self.self }
 // EXPAND_MACRO_DECL-NEXT: }
 // EXPAND_MACRO_DECL-NEXT: enum $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu0_ {
 // EXPAND_MACRO_DECL-NEXT:   case apple

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -131,8 +131,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:   func hello() -> String {
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
-// EXPAND_MACRO_DECL-NEXT:
-// EXPAND_MACRO_DECL-NEXT:   func getSelf() -> Any.Type { return Self.self }
+// EXPAND_MACRO_DECL:        func getSelf() -> Any.Type { return Self.self }
 // EXPAND_MACRO_DECL-NEXT: }
 // EXPAND_MACRO_DECL-NEXT: enum $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu0_ {
 // EXPAND_MACRO_DECL-NEXT:   case apple


### PR DESCRIPTION
* Explanation: Ensure that we visit top-level auxiliary declarations as part of SIL symbol visitation, which fixes TBD generation (e.g., `<symbol> is in generated IR file, but not in TBD file` errors) that occur when using top-level freestanding or peer macros that introduce new public declarations.
* Scope: Affects code using peer or freestanding macro expansions at the top level.
* Risk: Low; only affects macro expansions at the top level.
* Issue: rdar://107426276
* Testing: Additional tests added.
* Original pull request: https://github.com/apple/swift/pull/64942


SIL symbol visitation wasn't visiting top-level auxiliary declarations, which meant that it skipped peer and freestanding macros at module scope. This would manifest in errors of the form

    <symbol> is in the generated IR file, but not in TBD file

Fixes rdar://107426276.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
