### PR TITLE
[ASTGen] Remove usage of methods that shouldn’t be part of SwiftSynax’s public API

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -23,9 +23,20 @@ extension ASTGenVisitor {
     let nameLoc = self.base.advanced(by: node.name.position.utf8Offset).raw
     let eachLoc = node.each.map { self.base.advanced(by: $0.position.utf8Offset).raw }
 
+    var genericParameterIndex: Int?
+    for (index, sibling) in (node.parent?.as(GenericParameterListSyntax.self) ?? []).enumerated() {
+      if sibling == node {
+        genericParameterIndex = index
+        break
+      }
+    }
+    guard let genericParameterIndex = genericParameterIndex else {
+      preconditionFailure("Node not part of the parent?")
+    }
+
     return .decl(
       GenericTypeParamDecl_create(
-        self.ctx, self.declContext, name, nameLoc, eachLoc, node.indexInParent / 2,
+        self.ctx, self.declContext, name, nameLoc, eachLoc, genericParameterIndex,
         eachLoc != nil))
   }
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -136,7 +136,7 @@ public enum AddBlocker: ExpressionMacro {
               ExprSyntax(
                 binOp.with(
                   \.operatorToken,
-                  binOp.operatorToken.withKind(.binaryOperator("-"))
+                  binOp.operatorToken.with(\.tokenKind, .binaryOperator("-"))
                 )
               )
             )


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1482