### PR TITLE
[CSSimplify] Fix external property wrapper check to use parameter index

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1912,11 +1912,14 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       }
 
       auto argLabel = argument.getLabel();
-      if (paramInfo.hasExternalPropertyWrapper(argIdx) || argLabel.hasDollarPrefix()) {
-        auto *param = getParameterAt(callee, argIdx);
+      if (paramInfo.hasExternalPropertyWrapper(paramIdx) ||
+          argLabel.hasDollarPrefix()) {
+        auto *param = getParameterAt(callee, paramIdx);
         assert(param);
-        if (cs.applyPropertyWrapperToParameter(paramTy, argTy, const_cast<ParamDecl *>(param),
-                                               argLabel, subKind, loc).isFailure()) {
+        if (cs.applyPropertyWrapperToParameter(paramTy, argTy,
+                                               const_cast<ParamDecl *>(param),
+                                               argLabel, subKind, loc)
+                .isFailure()) {
           return cs.getTypeMatchFailure(loc);
         }
         continue;

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -36,11 +36,23 @@ struct NoProjection<T> {
 // expected-note@+1 {{property wrapper type 'NoProjection<String>' does not support initialization from a projected value}}
 func takesNoProjectionWrapper(@NoProjection value: String) {}
 
+// expected-note@+1 {{property wrapper type 'NoProjection<String>' does not support initialization from a projected value}}
+func takesNoProjectionWrapperWithDefault(_: Int? = nil, @NoProjection value: String) {}
+
+// expected-note@+1 {{property wrapper type 'NoProjection<String>' does not support initialization from a projected value}}
+func takesNoProjectionWrapperWithVariadic(_: Int..., @NoProjection value: String) {}
+
 func testNoProjection(message: String) {
   takesNoProjectionWrapper(value: message) // okay
 
   // expected-error@+1 {{cannot use property wrapper projection argument}}
   takesNoProjectionWrapper($value: message)
+
+  // expected-error@+1 {{cannot use property wrapper projection argument}}
+  takesNoProjectionWrapperWithDefault($value: message)
+
+  // expected-error@+1 {{cannot use property wrapper projection argument}}
+  takesNoProjectionWrapperWithVariadic(1, 2, 3, $value: message)
 
   // expected-error@+2 {{cannot use property wrapper projection parameter}}
   // expected-note@+1 {{property wrapper type 'NoProjection<Int>' does not support initialization from a projected value}}


### PR DESCRIPTION
Both `ParameterListInfo` and `getParameterAt` expect parameter index because they 
operate on a declaration referenced by a call.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
