### PR TITLE
[5.9][Tests/Macros] Add %target-codesign before %target-run

### DIFF
--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -12,6 +12,7 @@
 
 // Execution testing
 // RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @attached(accessor)

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -4,6 +4,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
 // RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @attached(memberAttribute)

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -19,6 +19,7 @@
 
 // Execution testing
 // RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 // Plugin search path and loaded module trace testing

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -4,6 +4,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
 // RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @attached(memberAttribute) macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")

--- a/test/Macros/macro_expand_codeitems.swift
+++ b/test/Macros/macro_expand_codeitems.swift
@@ -9,6 +9,7 @@
 
 // Execution testing
 // RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature FreestandingMacros -enable-experimental-feature CodeItemMacros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @freestanding(codeItem)

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -6,6 +6,7 @@
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
 // RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @attached(conformance)

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -14,6 +14,7 @@
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
 // RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s -check-prefix=CHECK-EXEC
 
 // Emit module while skipping function bodies

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -4,6 +4,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
 // RUN: %target-build-swift -g -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @attached(

--- a/test/Macros/macro_expand_variadic.swift
+++ b/test/Macros/macro_expand_variadic.swift
@@ -4,6 +4,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/variadic_macros.swift -g -no-toolchain-stdlib-rpath
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
 // RUN: %target-build-swift -swift-version 5 -enable-experimental-feature VariadicGenerics -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 @freestanding(expression) macro print<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -9,6 +9,7 @@
 
 // Execution testing
 // RUN: %target-build-swift -g -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) %s %S/Inputs/top_level_freestanding_other.swift -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 // Test unqualified lookup from within a macro expansion


### PR DESCRIPTION
Cherry-pick #64946 into release/5.9 (cherry picked from commit 02a604e7e782aadb8bff68f164cf729da315f92a)

**Explanation**: `%target-codesign ${executable}` is required before `%target-run ${executable}`.
**Scope**: Macro related test cases
**Risk**: Low
**Issues**: rdar://107658689
**Reviewer**: Ben Barham (@bnbarham)