### PR TITLE
[5.9][ASTGen/Macros] Adjustments to split `FunctionParameterSyntax` into multiple nodes for function parameters, closure parameters and enum parameters

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -89,11 +89,10 @@ extension ASTGenVisitor {
 
     let firstName: UnsafeMutableRawPointer?
     let secondName: UnsafeMutableRawPointer?
-    let type: UnsafeMutableRawPointer?
-
-    if let nodeFirstName = node.firstName,
-       // Swift AST represnts "_" as nil.
-       nodeFirstName.text != "_" {
+    
+    let nodeFirstName = node.firstName
+    if nodeFirstName.text != "_" {
+      // Swift AST represents "_" as nil.
       var text = nodeFirstName.text
       firstName = text.withUTF8 { buf in
         SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
@@ -111,11 +110,7 @@ extension ASTGenVisitor {
       secondName = nil
     }
 
-    if let typeSyntax = node.type {
-      type = visit(typeSyntax).rawValue
-    } else {
-      type = nil
-    }
+    let type = visit(node.type).rawValue
 
     return .decl(ParamDecl_create(ctx, loc, loc, firstName, loc, secondName, type, declContext))
   }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -774,15 +774,11 @@ public struct AddCompletionHandler: PeerMacro {
       newParameterList = parameterList.appending(completionHandlerParam)
     }
 
-    let callArguments: [String] = try parameterList.map { param in
-      guard let argName = param.secondName ?? param.firstName else {
-        throw CustomError.message(
-          "@addCompletionHandler argument must have a name"
-        )
-      }
+    let callArguments: [String] = parameterList.map { param in
+      let argName = param.secondName ?? param.firstName
 
-      if let paramName = param.firstName, paramName.text != "_" {
-        return "\(paramName.text): \(argName.text)"
+      if param.firstName.text != "_" {
+        return "\(param.firstName.text): \(argName.text)"
       }
 
       return "\(argName.text)"
@@ -903,13 +899,11 @@ public struct WrapInType: PeerMacro {
     // Build a new function with the same signature that forwards arguments
     // to the the original function.
     let parameterList = funcDecl.signature.input.parameterList
-    let callArguments: [String] = try parameterList.map { param in
-      guard let argName = param.secondName ?? param.firstName else {
-        throw CustomError.message("@wrapInType argument must have a name")
-      }
+    let callArguments: [String] = parameterList.map { param in
+      let argName = param.secondName ?? param.firstName
 
-      if let paramName = param.firstName, paramName.text != "_" {
-        return "\(paramName.text): \(argName.text)"
+      if param.firstName.text != "_" {
+        return "\(param.firstName.text): \(argName.text)"
       }
 
       return "\(argName.text)"


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64697 to release/5.9

---

Companion of https://github.com/apple/swift-syntax/pull/1495
