### PR TITLE
Sema: Only diagnose unavailable attr when it is active for the target

### DIFF
--- a/test/Sema/availability_stored_unavailable_maccatalyst.swift
+++ b/test/Sema/availability_stored_unavailable_maccatalyst.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-ios13.1-macabi -parse-as-library -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+
+// REQUIRES: OS=macosx
+
+struct BadStruct {
+  @available(macCatalyst 13.1, *)
+  @available(iOS, unavailable) // This attribute is inactive so we don't expect a diagnostic
+  var availableOnCatalyst: Int
+
+  @available(macCatalyst, unavailable) // expected-error {{stored properties cannot be marked unavailable with '@available'}}
+  @available(iOS 13, *)
+  var unavailableOnCatalyst: Int
+}


### PR DESCRIPTION
An attribute may be "active" but also not the most specific attribute for the current target and therefore ignored.

Resolves rdar://107678512
