### PR TITLE
[5.9] Fix the type-lowering verifier to handle pack expansions

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1260,14 +1260,16 @@ private:
   /// Check the result of
   /// getTypeLowering(AbstractionPattern,Type,TypeExpansionContext).
   void verifyLowering(const TypeLowering &, AbstractionPattern origType,
-                      Type origSubstType, TypeExpansionContext forExpansion);
+                      CanType origSubstType,
+                      TypeExpansionContext forExpansion);
   bool
-  visitAggregateLeaves(Lowering::AbstractionPattern origType, Type substType,
+  visitAggregateLeaves(Lowering::AbstractionPattern origType,
+                       CanType substType,
                        TypeExpansionContext context,
-                       std::function<bool(Type, Lowering::AbstractionPattern,
+                       std::function<bool(CanType, Lowering::AbstractionPattern,
                                           ValueDecl *, Optional<unsigned>)>
                            isLeafAggregate,
-                       std::function<bool(Type, Lowering::AbstractionPattern,
+                       std::function<bool(CanType, Lowering::AbstractionPattern,
                                           ValueDecl *, Optional<unsigned>)>
                            visit);
 #endif

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2750,6 +2750,7 @@ bool TypeConverter::visitAggregateLeaves(
   auto isAggregate = [](CanType ty) {
     return isa<SILPackType>(ty) ||
            isa<TupleType>(ty) ||
+           isa<PackExpansionType>(ty) ||
            ty.getEnumOrBoundGenericEnum() ||
            ty.getStructOrBoundGenericStruct();
   };
@@ -2781,6 +2782,10 @@ bool TypeConverter::visitAggregateLeaves(
                                  tupleIndex);
               ++tupleIndex;
             });
+      } else if (auto expansion = dyn_cast<PackExpansionType>(ty)) {
+        insertIntoWorklist(expansion.getPatternType(),
+                           origTy.getPackExpansionPatternType(),
+                           field, index);
       } else if (auto *decl = ty.getStructOrBoundGenericStruct()) {
         for (auto *structField : decl->getStoredProperties()) {
           auto subMap = ty->getContextSubstitutionMap(&M, decl);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2712,31 +2712,32 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
 
 #ifndef NDEBUG
 bool TypeConverter::visitAggregateLeaves(
-    Lowering::AbstractionPattern origType, Type substType,
+    Lowering::AbstractionPattern origType, CanType substType,
     TypeExpansionContext context,
-    std::function<bool(Type, Lowering::AbstractionPattern, ValueDecl *,
+    std::function<bool(CanType, Lowering::AbstractionPattern, ValueDecl *,
                        Optional<unsigned>)>
         isLeafAggregate,
-    std::function<bool(Type, Lowering::AbstractionPattern, ValueDecl *,
+    std::function<bool(CanType, Lowering::AbstractionPattern, ValueDecl *,
                        Optional<unsigned>)>
         visit) {
-  llvm::SmallSet<std::tuple<TypeBase *, ValueDecl *, unsigned>, 16> visited;
+  llvm::SmallSet<std::tuple<CanType, ValueDecl *, unsigned>, 16> visited;
   llvm::SmallVector<
-      std::tuple<TypeBase *, AbstractionPattern, ValueDecl *, unsigned>, 16>
+      std::tuple<CanType, AbstractionPattern, ValueDecl *, unsigned>, 16>
       worklist;
   auto insertIntoWorklist = [&visited,
-                             &worklist](Type substTy, AbstractionPattern origTy,
+                             &worklist](CanType substTy,
+                                        AbstractionPattern origTy,
                                         ValueDecl *field,
                                         Optional<unsigned> maybeIndex) -> bool {
     unsigned index = maybeIndex.value_or(UINT_MAX);
-    if (!visited.insert({substTy.getPointer(), field, index}).second)
+    if (!visited.insert({substTy, field, index}).second)
       return false;
-    worklist.push_back({substTy.getPointer(), origTy, field, index});
+    worklist.push_back({substTy, origTy, field, index});
     return true;
   };
   auto popFromWorklist = [&worklist]()
-      -> std::tuple<Type, AbstractionPattern, ValueDecl *, Optional<unsigned>> {
-    TypeBase *ty;
+      -> std::tuple<CanType, AbstractionPattern, ValueDecl *, Optional<unsigned>> {
+    CanType ty;
     AbstractionPattern origTy = AbstractionPattern::getOpaque();
     ValueDecl *field;
     unsigned index;
@@ -2744,34 +2745,35 @@ bool TypeConverter::visitAggregateLeaves(
     Optional<unsigned> maybeIndex;
     if (index != UINT_MAX)
       maybeIndex = {index};
-    return {ty->getCanonicalType(), origTy, field, index};
+    return {ty, origTy, field, index};
   };
-  auto isAggregate = [](Type ty) {
-    return ty->is<SILPackType>() || ty->is<TupleType>() || ty->getEnumOrBoundGenericEnum() ||
-           ty->getStructOrBoundGenericStruct();
+  auto isAggregate = [](CanType ty) {
+    return isa<SILPackType>(ty) ||
+           isa<TupleType>(ty) ||
+           ty.getEnumOrBoundGenericEnum() ||
+           ty.getStructOrBoundGenericStruct();
   };
   insertIntoWorklist(substType, origType, nullptr, llvm::None);
   while (!worklist.empty()) {
-    Type ty;
+    CanType ty;
     AbstractionPattern origTy = AbstractionPattern::getOpaque();
     ValueDecl *field;
     Optional<unsigned> index;
     std::tie(ty, origTy, field, index) = popFromWorklist();
     if (isAggregate(ty) && !isLeafAggregate(ty, origTy, field, index)) {
-      if (auto packTy = ty->getAs<SILPackType>()) {
+      if (auto packTy = dyn_cast<SILPackType>(ty)) {
         for (auto packIndex : indices(packTy->getElementTypes())) {
           auto origElementTy = origTy.getPackElementType(packIndex);
-          auto substElementTy =
-              packTy->getElementType(packIndex)->getCanonicalType();
+          auto substElementTy = packTy.getElementType(packIndex);
           substElementTy =
               computeLoweredRValueType(context, origElementTy, substElementTy);
           insertIntoWorklist(substElementTy, origElementTy, nullptr,
                              packIndex);
         }
-      } else if (auto tupleTy = ty->getAs<TupleType>()) {
+      } else if (auto tupleTy = dyn_cast<TupleType>(ty)) {
         unsigned tupleIndex = 0;
         origTy.forEachExpandedTupleElement(
-            CanTupleType(tupleTy),
+            tupleTy,
             [&](auto origElementTy, auto substElementTy, auto element) {
               substElementTy =
                   substOpaqueTypesWithUnderlyingTypes(substElementTy, context);
@@ -2779,7 +2781,7 @@ bool TypeConverter::visitAggregateLeaves(
                                  tupleIndex);
               ++tupleIndex;
             });
-      } else if (auto *decl = ty->getStructOrBoundGenericStruct()) {
+      } else if (auto *decl = ty.getStructOrBoundGenericStruct()) {
         for (auto *structField : decl->getStoredProperties()) {
           auto subMap = ty->getContextSubstitutionMap(&M, decl);
           auto substFieldTy =
@@ -2794,7 +2796,7 @@ bool TypeConverter::visitAggregateLeaves(
           insertIntoWorklist(substFieldTy, origFieldType, structField,
                              llvm::None);
         }
-      } else if (auto *decl = ty->getEnumOrBoundGenericEnum()) {
+      } else if (auto *decl = ty.getEnumOrBoundGenericEnum()) {
         auto subMap = ty->getContextSubstitutionMap(&M, decl);
         for (auto *element : decl->getAllElements()) {
           if (!element->hasAssociatedValues())
@@ -2827,16 +2829,17 @@ bool TypeConverter::visitAggregateLeaves(
 }
 
 void TypeConverter::verifyLowering(const TypeLowering &lowering,
-                                   AbstractionPattern origType, Type substType,
+                                   AbstractionPattern origType,
+                                   CanType substType,
                                    TypeExpansionContext forExpansion) {
   // Non-trivial lowerings should always be lexical unless all non-trivial
   // fields are eager move.
   if (!lowering.isTrivial() && !lowering.isLexical()) {
     if (lowering.getRecursiveProperties().isInfinite())
       return;
-    auto getLifetimeAnnotation = [](Type ty) -> LifetimeAnnotation {
+    auto getLifetimeAnnotation = [](CanType ty) -> LifetimeAnnotation {
       NominalTypeDecl *nominal;
-      if (!(nominal = ty->getAnyNominal()))
+      if (!(nominal = ty.getAnyNominal()))
         return LifetimeAnnotation::None;
       return nominal->getLifetimeAnnotation();
     };
@@ -2865,7 +2868,7 @@ void TypeConverter::verifyLowering(const TypeLowering &lowering,
 
           // If the leaf is the whole type, verify that it is annotated
           // @_eagerMove.
-          if (ty->getCanonicalType() == substType->getCanonicalType())
+          if (ty == substType)
             return getLifetimeAnnotation(ty) == LifetimeAnnotation::EagerMove;
 
           auto &tyLowering = getTypeLowering(origTy, ty, forExpansion);

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -331,3 +331,6 @@ func testFancyTuple_concrete() {
 func testFancyTuple_pack<each T>(values: repeat each T) {
   FancyTuple<Int, String, repeat each T, Bool>(x: (1, "hi", repeat each values, false)).makeTuple()
 }
+
+// rdar://107664237
+func f<each T>() -> (repeat Array<each T>) {}


### PR DESCRIPTION
5.9 version of #64951.

Explanation: There's a check we do when producing a TypeLowering object that checks that certain type properties are consistent with the directly-stored values in the type.  I'm not sure it's a very useful piece of code, but unless we remove it, it needs to do the right thing with pack expansions, which it currently isn't.
Scope: Crashes in SILGen when assertions are enabled and when a tuple contains a pack expansion element where the a pattern type that has interesting type properties that the verifier checks; generally this means something like `repeat Array<each T>`
Issue: rdar://107664237
Risk: Low; straightforward change to handle a type that's specific to variadic generics
Testing: Regression tests added
Reviewer: Slava Pestov