### PR TITLE
[Module-scope lookup] Only add macro-expanded names that match.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -444,10 +444,12 @@ void SourceLookupCache::lookupValue(DeclName Name, NLKind LookupKind,
     return;
 
   for (auto *unexpandedDecl : auxDecls->second) {
-    // Add expanded peers to the result.
+    // Add expanded peers and freestanding declarations to the result.
     unexpandedDecl->forEachMacroExpandedDecl(
         [&](ValueDecl *decl) {
-          Result.push_back(decl);
+          if (decl->getName().matchesRef(Name)) {
+            Result.push_back(decl);
+          }
         });
   }
 }

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -13,7 +13,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser -g
 // RUN: %target-run %t/main | %FileCheck %s -check-prefix=CHECK-EXEC
 
 // Emit module while skipping function bodies


### PR DESCRIPTION
When we look into expanded macros to find declarations for module-scope name lookup, make sure that we only return declarations whose name matches the requested name.

We were effectively spamming the results with unrelated names, and most clients trust the results of this lookup (vs. filtering them further), so they would get confused. The particular failure for this test is that type reconstruction would fail because we were looking for one unique name, but we found many non-matching names, and type reconstruction bails out rather than try to filter further.
