### PR TITLE
[AST] Ensure that type-checked Patterns always have types set

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -365,9 +365,11 @@ public:
   explicit NamedPattern(VarDecl *Var)
       : Pattern(PatternKind::Named), Var(Var) { }
 
-  static NamedPattern *createImplicit(ASTContext &Ctx, VarDecl *Var) {
+  static NamedPattern *createImplicit(ASTContext &Ctx, VarDecl *Var,
+                                      Type ty = Type()) {
     auto *NP = new (Ctx) NamedPattern(Var);
     NP->setImplicit();
+    NP->setType(ty);
     return NP;
   }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -486,7 +486,7 @@ public:
       return true;
     }
     bool shouldVerifyChecked(Stmt *S) { return true; }
-    bool shouldVerifyChecked(Pattern *S) { return S->hasType(); }
+    bool shouldVerifyChecked(Pattern *S) { return true; }
     bool shouldVerifyChecked(Decl *S) { return true; }
 
     // Only verify functions if they have bodies we can safely walk.
@@ -582,8 +582,14 @@ public:
         return;
       }
     }
+    void verifyChecked(Pattern *P) {
+      if (!P->hasType()) {
+        Out << "pattern has no type\n";
+        P->dump(Out);
+        abort();
+      }
+    }
     void verifyChecked(Stmt *S) {}
-    void verifyChecked(Pattern *P) { }
     void verifyChecked(Decl *D) {}
 
     void verifyChecked(Type type) {

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -99,9 +99,7 @@ static VarDecl *addImplicitDistributedActorIDProperty(
   propDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyType);
 
-  Pattern *propPat = NamedPattern::createImplicit(C, propDecl);
-  propPat->setType(propertyType);
-
+  Pattern *propPat = NamedPattern::createImplicit(C, propDecl, propertyType);
   propPat = TypedPattern::createImplicit(C, propPat, propertyType);
   propPat->setType(propertyType);
 
@@ -151,9 +149,7 @@ static VarDecl *addImplicitDistributedActorActorSystemProperty(
   propDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyType);
 
-  Pattern *propPat = NamedPattern::createImplicit(C, propDecl);
-  propPat->setType(propertyType);
-
+  Pattern *propPat = NamedPattern::createImplicit(C, propDecl, propertyType);
   propPat = TypedPattern::createImplicit(C, propPat, propertyType);
   propPat->setType(propertyType);
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -419,8 +419,8 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
     auto memberTanType =
         getTangentVectorInterfaceType(memberContextualType, parentDC);
     tangentProperty->setInterfaceType(memberTanType);
-    Pattern *memberPattern = NamedPattern::createImplicit(C, tangentProperty);
-    memberPattern->setType(memberTanType);
+    Pattern *memberPattern =
+        NamedPattern::createImplicit(C, tangentProperty, memberTanType);
     memberPattern =
         TypedPattern::createImplicit(C, memberPattern, memberTanType);
     memberPattern->setType(memberTanType);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -920,8 +920,8 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
       derived.Nominal->isActor())
     hashValueDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/ true));
 
-  Pattern *hashValuePat = NamedPattern::createImplicit(C, hashValueDecl);
-  hashValuePat->setType(intType);
+  Pattern *hashValuePat =
+      NamedPattern::createImplicit(C, hashValueDecl, intType);
   hashValuePat = TypedPattern::createImplicit(C, hashValuePat, intType);
   hashValuePat->setType(intType);
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -554,8 +554,8 @@ DerivedConformance::declareDerivedProperty(SynthesizedIntroducer intro,
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);
 
-  Pattern *propPat = NamedPattern::createImplicit(Context, propDecl);
-  propPat->setType(propertyContextType);
+  Pattern *propPat =
+      NamedPattern::createImplicit(Context, propDecl, propertyContextType);
 
   propPat = TypedPattern::createImplicit(Context, propPat, propertyContextType);
   propPat->setType(propertyContextType);
@@ -759,8 +759,7 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
   indexVar->setImplicit();
 
   // generate: var indexVar
-  Pattern *indexPat = NamedPattern::createImplicit(C, indexVar);
-  indexPat->setType(intType);
+  Pattern *indexPat = NamedPattern::createImplicit(C, indexVar, intType);
   indexPat = TypedPattern::createImplicit(C, indexPat, intType);
   indexPat->setType(intType);
   auto *indexBind = PatternBindingDecl::createImplicit(

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -518,7 +518,7 @@ public:
     VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
     VD->setImplicit();
 
-    NamedPattern *NP = NamedPattern::createImplicit(Context, VD);
+    NamedPattern *NP = NamedPattern::createImplicit(Context, VD, VD->getType());
     PatternBindingDecl *PBD = PatternBindingDecl::createImplicit(
         Context, StaticSpellingKind::None, NP, MaybeLoadInitExpr, TypeCheckDC);
 

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -760,7 +760,7 @@ public:
     VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
     VD->setImplicit();
 
-    NamedPattern *NP = NamedPattern::createImplicit(Context, VD);
+    NamedPattern *NP = NamedPattern::createImplicit(Context, VD, VD->getType());
     PatternBindingDecl *PBD = PatternBindingDecl::createImplicit(
         Context, StaticSpellingKind::None, NP, MaybeLoadInitExpr, TypeCheckDC);
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1485,8 +1485,7 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
   Tmp1VD->setInterfaceType(VD->getValueInterfaceType());
   Tmp1VD->setImplicit();
 
-  auto *Named = NamedPattern::createImplicit(Ctx, Tmp1VD);
-  Named->setType(Tmp1VD->getType());
+  auto *Named = NamedPattern::createImplicit(Ctx, Tmp1VD, Tmp1VD->getType());
   auto *Let =
       BindingPattern::createImplicit(Ctx, VarDecl::Introducer::Let, Named);
   Let->setType(Named->getType());
@@ -1551,7 +1550,8 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
   InitValue = new (Ctx) LazyInitializerExpr(InitValue);
   InitValue->setType(initType);
 
-  Pattern *Tmp2PBDPattern = NamedPattern::createImplicit(Ctx, Tmp2VD);
+  Pattern *Tmp2PBDPattern =
+      NamedPattern::createImplicit(Ctx, Tmp2VD, Tmp2VD->getType());
   Tmp2PBDPattern =
     TypedPattern::createImplicit(Ctx, Tmp2PBDPattern, Tmp2VD->getType());
 
@@ -1794,7 +1794,8 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
                                    SourceLoc(), Ctx.getIdentifier("tmp"), Set);
       OldValue->setImplicit();
       OldValue->setInterfaceType(VD->getValueInterfaceType());
-      auto *tmpPattern = NamedPattern::createImplicit(Ctx, OldValue);
+      auto *tmpPattern =
+          NamedPattern::createImplicit(Ctx, OldValue, OldValue->getType());
       auto *tmpPBD = PatternBindingDecl::createImplicit(
           Ctx, StaticSpellingKind::None, tmpPattern, OldValueExpr, Set);
       SetterBody.push_back(tmpPBD);
@@ -2619,8 +2620,8 @@ LazyStoragePropertyRequest::evaluate(Evaluator &evaluator,
 
   // Create the pattern binding decl for the storage decl.  This will get
   // default initialized to nil.
-  Pattern *PBDPattern = NamedPattern::createImplicit(Context, Storage);
-  PBDPattern->setType(StorageTy);
+  Pattern *PBDPattern =
+      NamedPattern::createImplicit(Context, Storage, StorageTy);
   PBDPattern = TypedPattern::createImplicit(Context, PBDPattern, StorageTy);
   auto *InitExpr = new (Context) NilLiteralExpr(SourceLoc(), /*Implicit=*/true);
   InitExpr->setType(Storage->getType());
@@ -3032,8 +3033,8 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   PropertyWrapperValuePlaceholderExpr *wrappedValue = nullptr;
 
   auto createPBD = [&](VarDecl *singleVar) -> PatternBindingDecl * {
-    Pattern *pattern = NamedPattern::createImplicit(ctx, singleVar);
-    pattern->setType(singleVar->getType());
+    Pattern *pattern =
+        NamedPattern::createImplicit(ctx, singleVar, singleVar->getType());
     pattern = TypedPattern::createImplicit(ctx, pattern, singleVar->getType());
     PatternBindingDecl *pbd = PatternBindingDecl::createImplicit(
         ctx, var->getCorrectStaticSpelling(), pattern, /*init*/nullptr,


### PR DESCRIPTION
Kind of amazed we don't already have this. Add an ASTVerifier assertion to ensure type-checked patterns always have types set.