### PR TITLE
[TypeLowering] Fixed verifier variable shadowing.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2745,7 +2745,7 @@ bool TypeConverter::visitAggregateLeaves(
     Optional<unsigned> maybeIndex;
     if (index != UINT_MAX)
       maybeIndex = {index};
-    return {ty, origTy, field, index};
+    return {ty, origTy, field, maybeIndex};
   };
   auto isAggregate = [](CanType ty) {
     return isa<SILPackType>(ty) ||
@@ -2761,6 +2761,7 @@ bool TypeConverter::visitAggregateLeaves(
     ValueDecl *field;
     Optional<unsigned> index;
     std::tie(ty, origTy, field, index) = popFromWorklist();
+    assert(!field || !index && "both field and index!?");
     if (isAggregate(ty) && !isLeafAggregate(ty, origTy, field, index)) {
       if (auto packTy = dyn_cast<SILPackType>(ty)) {
         for (auto packIndex : indices(packTy->getElementTypes())) {

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -26,6 +26,10 @@ enum E {
 @_silgen_name("use_generic")
 func use_generic<T>(_ t: T) {}
 
+struct NonlexicalBox<X> {
+  @_eagerMove var x: X
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Declarations                                                               }}
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,6 +150,8 @@ extension C {
   __consuming
   func eagermove_method_attr() {}
 }
+
+func f<T>() -> (NonlexicalBox<T>) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Test                                                                       }}


### PR DESCRIPTION
To work around a build failure on MSVC, f53e88b25b0444757b53d602eb19f3baf9228959 changed what was vended from the verifier’s worklist from a `TaggedEnum<ValueDecl *, unsigned>` to two fields `ValueDecl *` and `Optional<unsigned>` with the idea that only one should ever be non-none.  That change failed, however, to return the _optional_ unsigned index represented by the value in the worklist, instead returning the actual value.  That’s a problem because the worklist can’t contain `Optional<unsigned>` but only unsigned with `UINT_MAX` indicating "none".

rdar://107709069
