### PR TITLE
🍒[cxx-interop] Conform `std::string` to Hashable

### DIFF
--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(sdk ${SWIFT_SDKS})
     endif()
 
     set(outputs)
-    foreach(source libcxxshim.modulemap libcxxshim.h)
+    foreach(source libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h)
       add_custom_command(OUTPUT ${module_dir}/${source}
                          DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source}
                          COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${module_dir}/${source}"
@@ -41,11 +41,11 @@ foreach(sdk ${SWIFT_SDKS})
     list(APPEND libcxxshim_modulemap_target_list cxxshim-${sdk}-${arch})
 
 
-    swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h
+    swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
                                DESTINATION "lib/swift/${arch_subdir}"
                                COMPONENT compiler)
     if(SWIFT_BUILD_STATIC_STDLIB)
-      swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h
+      swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
                                  DESTINATION "lib/swift_static/${arch_subdir}"
                                  COMPONENT compiler)
     endif()

--- a/stdlib/public/Cxx/cxxshim/libcxxshim.modulemap
+++ b/stdlib/public/Cxx/cxxshim/libcxxshim.modulemap
@@ -2,3 +2,8 @@ module CxxShim {
   header "libcxxshim.h"
   requires cplusplus
 }
+
+module CxxStdlibShim {
+  header "libcxxstdlibshim.h"
+  requires cplusplus
+}

--- a/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
@@ -1,0 +1,8 @@
+#include <functional>
+#include <string>
+
+/// Used for std::string conformance to Swift.Hashable
+typedef std::hash<std::string> __swift_interopHashOfString;
+
+/// Used for std::u16string conformance to Swift.Hashable
+typedef std::hash<std::u16string> __swift_interopHashOfU16String;

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CxxStdlibShim
+
 // MARK: Initializing C++ string from a Swift String
 
 extension std.string {
@@ -84,6 +86,24 @@ extension std.u16string: Equatable {
     var copy = lhs
     copy += rhs
     return copy
+  }
+}
+
+// MARK: Hashing C++ strings
+
+extension std.string: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    // Call std::hash<std::string>::operator()
+    let cxxHash = __swift_interopHashOfString().callAsFunction(self)
+    hasher.combine(cxxHash)
+  }
+}
+
+extension std.u16string: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    // Call std::hash<std::u16string>::operator()
+    let cxxHash = __swift_interopHashOfU16String().callAsFunction(self)
+    hasher.combine(cxxHash)
   }
 }
 

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -85,6 +85,48 @@ StdStringOverlayTestSuite.test("std::u16string operators") {
   expectTrue(s1 == "something123literal")
 }
 
+StdStringOverlayTestSuite.test("std::string as Hashable") {
+  let s0 = std.string()
+  let h0 = s0.hashValue
+
+  let s1 = std.string("something")
+  let h1 = s1.hashValue
+
+  let s2 = std.string("something123")
+  let h2 = s2.hashValue
+
+  let s3 = std.string("something")
+  let h3 = s3.hashValue
+
+  expectEqual(h1, h3)
+  expectNotEqual(h0, h1)
+  expectNotEqual(h0, h2)
+  expectNotEqual(h0, h3)
+  expectNotEqual(h1, h2)
+  expectNotEqual(h2, h3)
+}
+
+StdStringOverlayTestSuite.test("std::u16string as Hashable") {
+  let s0 = std.u16string()
+  let h0 = s0.hashValue
+
+  let s1 = std.u16string("something")
+  let h1 = s1.hashValue
+
+  let s2 = std.u16string("something123")
+  let h2 = s2.hashValue
+
+  let s3 = std.u16string("something")
+  let h3 = s3.hashValue
+
+  expectEqual(h1, h3)
+  expectNotEqual(h0, h1)
+  expectNotEqual(h0, h2)
+  expectNotEqual(h0, h3)
+  expectNotEqual(h1, h2)
+  expectNotEqual(h2, h3)
+}
+
 StdStringOverlayTestSuite.test("std::u16string <=> Swift.String") {
   let cxx1 = std.u16string()
   let swift1 = String(cxx1)


### PR DESCRIPTION
**Explanation**: This adds a conformance to `Swift.Hashable` protocol for `std::string` and `std::u16string` types.
**Scope**: Only has an effect when experimental C++ interop is enabled.
**Risk**: Low, C++ interop is an experimental feature, and this change is covered by tests.
**Testing**: Added execution tests.

rdar://107709149