### PR TITLE
5.9: [LexicalLifetimeEliminator] Removed flag from move_values.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8265,6 +8265,7 @@ public:
   void setAllowsDiagnostics(bool newValue) { allowDiagnostics = newValue; }
 
   bool isLexical() const { return lexical; };
+  void removeIsLexical() { lexical = false; }
 };
 
 /// Equivalent to a copy_addr to [init] except that it is used for diagnostics

--- a/lib/SILOptimizer/Mandatory/LexicalLifetimeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/LexicalLifetimeEliminator.cpp
@@ -46,7 +46,13 @@ class LexicalLifetimeEliminatorPass : public SILFunctionTransform {
           }
           continue;
         }
-
+        if (auto *mvi = dyn_cast<MoveValueInst>(&inst)) {
+          if (mvi->isLexical()) {
+            mvi->removeIsLexical();
+            madeChange = true;
+          }
+          continue;
+        }
         if (auto *asi = dyn_cast<AllocStackInst>(&inst)) {
           if (asi->isLexical()) {
             asi->removeIsLexical();

--- a/test/SILOptimizer/lexical_lifetime_elim.sil
+++ b/test/SILOptimizer/lexical_lifetime_elim.sil
@@ -6,6 +6,8 @@ import Builtin
 
 class Klass {}
 
+sil @getKlass : $() -> (@owned Klass)
+
 // CHECK-LABEL: sil [ossa] @lexical_lifetime_object : $@convention(thin) (@owned Klass) -> () {
 // CHECK: bb0(%0 : @owned $Klass):
 // CHECK-NEXT:   %1 = begin_borrow %0 : $Klass
@@ -21,6 +23,19 @@ bb0(%0 : @owned $Klass):
   destroy_value %0 : $Klass
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @lexical_lifetime_move : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK:     move_value
+// CHECK-LABEL: } // end sil function 'lexical_lifetime_move'
+sil [ossa] @lexical_lifetime_move : $@convention(thin) () -> () {
+  %getKlass = function_ref @getKlass : $@convention(thin) () -> (@owned Klass)
+  %instance = apply %getKlass() : $@convention(thin) () -> (@owned Klass) 
+  %lifetime = move_value [lexical] %instance : $Klass
+  destroy_value %lifetime : $Klass
+  %retval = tuple ()
+  return %retval : $()
 }
 
 // CHECK-LABEL: sil [ossa] @lexical_lifetime_address : $@convention(thin) (@in Klass) -> () {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64964

When eliminating lexical lifetimes, also eliminate the lifetimes introduced by `move_value`s in addition to those introduced by `begin_borrow`s and communicated via `alloc_stack`s.
