### PR TITLE
Fix dead end block collection while completing lexical lifetimes

### DIFF
--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -129,7 +129,7 @@ static bool endLifetimeAtUnreachableBlocks(SILValue value,
       changed = true;
     }
     for (auto *successor : block->getSuccessorBlocks()) {
-      deadEndBlocks.push(successor);
+      deadEndBlocks.pushIfNotVisited(successor);
     }
   }
   return changed;

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -102,3 +102,44 @@ bb3:
   return %r : $()
 }
 
+// Ensure no assert fires while inserting dead end blocks to the worklist
+sil [ossa] @testLexicalLifetimeCompletion : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  test_specification "ossa-lifetime-completion @argument"
+  debug_value %0 : $C, let, name "newElements", argno 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  cond_br undef, bb9, bb10
+
+bb3:
+  br bb8
+
+bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb7
+
+bb6:
+  br bb7
+
+bb7:
+  unreachable
+
+bb8:
+  %77 = apply undef(%0) : $@convention(method) (@guaranteed C) -> ()
+  destroy_value %0 : $C
+  %79 = tuple ()
+  return %79 : $()
+
+bb9:
+  br bb8
+
+bb10:
+  br bb8
+}
+


### PR DESCRIPTION
A dead end block can be visited multiple times on each of its predecessors path. Use BasicBlockWorklist::pushIfNotVisited api for insertion.

