### PR TITLE
[Serialization] Only read the underlying type of an opaque type if inlinable

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3886,7 +3886,16 @@ public:
       opaqueDecl->setGenericSignature(genericSig);
     else
       opaqueDecl->setGenericSignature(GenericSignature());
-    if (underlyingTypeSubsID) {
+
+    auto *AFD = dyn_cast<AbstractFunctionDecl>(namingDecl);
+    if (MF.getResilienceStrategy() == ResilienceStrategy::Resilient &&
+        AFD && AFD->getResilienceExpansion() != ResilienceExpansion::Minimal) {
+      // Do not try to read the underlying type information if the function
+      // is not inlinable in clients. This reflects the swiftinterface behavior
+      // in where clients are only aware of the underlying type when the body
+      // of the function is public.
+
+    } else if (underlyingTypeSubsID) {
       auto subMapOrError = MF.getSubstitutionMapChecked(underlyingTypeSubsID);
       if (!subMapOrError) {
         // If the underlying type references internal details, ignore it.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3889,6 +3889,7 @@ public:
 
     auto *AFD = dyn_cast<AbstractFunctionDecl>(namingDecl);
     if (MF.getResilienceStrategy() == ResilienceStrategy::Resilient &&
+        !MF.FileContext->getParentModule()->isMainModule() &&
         AFD && AFD->getResilienceExpansion() != ResilienceExpansion::Minimal) {
       // Do not try to read the underlying type information if the function
       // is not inlinable in clients. This reflects the swiftinterface behavior

--- a/test/Serialization/Safety/skip-reading-internal-details.swift
+++ b/test/Serialization/Safety/skip-reading-internal-details.swift
@@ -86,6 +86,30 @@ public struct PublicStruct {
     }
 }
 
+// resultBuilder scenario
+public protocol V {}
+
+@resultBuilder
+public struct VB {
+    public static func buildExpression<Content>(_ content: Content) -> Content where Content : V { fatalError() }
+    public static func buildBlock() -> V { fatalError() }
+    public static func buildBlock<Content>(_ content: Content) -> Content where Content : V { fatalError() }
+}
+
+public struct EV : V {
+    public init () {}
+}
+
+@available(SwiftStdlib 5.1, *)
+public extension V {
+  @VB
+  func opaqueReferencingPrivate() -> some V {
+    referencedPrivateFunc(v: EV())
+  }
+
+  private func referencedPrivateFunc(v: some V) -> some V { return v }
+}
+
 //--- Client.swift
 
 import Lib
@@ -94,3 +118,8 @@ var x = PublicStruct()
 
 // Trigger a typo correction that reads all members.
 x.notAMember() // expected-error {{value of type 'PublicStruct' has no member 'notAMember'}}
+
+if #available(SwiftStdlib 5.1, *) {
+  let v = EV()
+  let _ = v.opaqueReferencingPrivate()
+}


### PR DESCRIPTION
The underlying type of an opaque type is defined by the function body, as such its knowledge needs to be spread in a similar manner. Clients of a resilient module using opaque types don't need access to the underlying type unless it's used for an inlinable function. Plus, the underlying type can reference internal details which can lead to crashes when deserialization safety is enabled, and in theory when they reference implementation-only dependencies. To realign this behavior, let's only read the underlying type when the opaque type is on an inlinable function.

rdar://105128784

---

This follows on my previous attempts to limit deserialization failures related to opaque types in #62980 and #63479. Hopefully this approach will prevent any issues even sooner.