### PR TITLE
[CMake] Workaround sanitizer flag bug in swift driver

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -86,7 +86,7 @@ endfunction()
 function(_add_host_variant_swift_sanitizer_flags target)
   if(LLVM_USE_SANITIZER)
     if(LLVM_USE_SANITIZER STREQUAL "Address")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=address")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=address" "-Xclang-linker" "-fsanitize=address")
     elseif(LLVM_USE_SANITIZER STREQUAL "HWAddress")
       # Not supported?
     elseif(LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
@@ -95,14 +95,14 @@ function(_add_host_variant_swift_sanitizer_flags target)
         # Not supported
       endif()
     elseif(LLVM_USE_SANITIZER STREQUAL "Undefined")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=undefined")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=undefined" "-Xclang-linker" "-fsanitize=undefined")
     elseif(LLVM_USE_SANITIZER STREQUAL "Thread")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=thread")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=thread" "-Xclang-linker" "-fsanitize=thread")
     elseif(LLVM_USE_SANITIZER STREQUAL "DataFlow")
       # Not supported
     elseif(LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
            LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
-      set(_Swift_SANITIZER_FLAGS "-sanitize=address" "-sanitize=undefined")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=address" "-sanitize=undefined" "-Xclang-linker" "-fsanitize=address" "-Xclang-linker" "-fsanitize=undefined")
     elseif(LLVM_USE_SANITIZER STREQUAL "Leaks")
       # Not supported
     else()


### PR DESCRIPTION
Some versions of the swift driver have a bug where passing `-sanitize=` does not emit the correct `-fsanitize=` flag for the clang link step. Although this is being fixed, we must be able to correctly build with older versions of the swift driver for some period of time. We workaround that issue by explicitly passing the correct `-fsanitize=` argument ourselves.

This works around rdar://107733898

