### PR TITLE
Include extended typealias in index data

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1504,8 +1504,8 @@ bool IndexSwiftASTWalker::reportExtension(ExtensionDecl *D) {
   if (!startEntity(D, Info, /*IsRef=*/false))
     return false;
 
-  if (!reportRelatedRef(NTD, Loc, /*isImplicit=*/false,
-                        (SymbolRoleSet)SymbolRole::RelationExtendedBy, D))
+  TypeLoc TL(D->getExtendedTypeRepr(), D->getExtendedType());
+  if (!reportRelatedTypeRef(TL, (SymbolRoleSet)SymbolRole::RelationExtendedBy, D))
       return false;
   if (!reportInheritedTypeRefs(D->getInherited(), D))
       return false;

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -499,3 +499,13 @@ protocol WithPrimary<Assoc> {
 // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | Assoc | {{.*}} | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | protocol/Swift | WithPrimary | {{.*}}
 }
+
+struct Root {} // CHECK: [[@LINE]]:8 | struct/Swift | Root | [[Root_USR:.*]] | Def | rel: 0
+
+typealias Alias = Root // CHECK: [[@LINE]]:11 | type-alias/Swift | Alias | [[Alias_USR:.*]] | Def | rel: 0
+
+extension Alias {
+  // CHECK: [[@LINE-1]]:11 | type-alias/Swift | Alias | [[Alias_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:11 | struct/Swift | Root | [[Root_USR]] | Ref,Impl,RelExt | rel: 1
+  func empty() {}
+}


### PR DESCRIPTION
Previously only the type underlying the typealias was included in the index data. Now the extension of a typealias includes 2 entries, 1 for the underlying type and one for the typealias definition.

Fixes https://github.com/apple/swift/issues/64594