### PR TITLE
[Constant Evaluator] Enable SILConstants::setIndexedElement function to work with aggregates containing unknown values

### DIFF
--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -127,6 +127,10 @@ private:
   ConstExprStepEvaluator(const ConstExprStepEvaluator &) = delete;
   void operator=(const ConstExprStepEvaluator &) = delete;
 
+  /// Set all addresses that could be mutated by the instruction to an
+  /// unknown symbolic value if it is not already so.
+  void setMutableAddressesToUnknown(SILInstruction *inst);
+
 public:
   /// Constructs a step evaluator given an allocator and a non-null pointer to a
   /// SILFunction.

--- a/lib/SIL/IR/SILConstants.cpp
+++ b/lib/SIL/IR/SILConstants.cpp
@@ -1174,6 +1174,11 @@ static SymbolicValue setIndexedElement(SymbolicValue aggregate,
   if (accessPath.empty())
     return newElement;
 
+  // Callers are required to ensure unknowns are not passed. However,
+  // the recurisve call can pass an unknown as an aggregate.
+  if (aggregate.getKind() == SymbolicValue::Unknown)
+    return aggregate;
+
   // If we have an uninit memory, then scalarize it into an aggregate to
   // continue.  This happens when memory objects are initialized piecewise.
   if (aggregate.getKind() == SymbolicValue::UninitMemory) {

--- a/test/SILOptimizer/Inputs/OSLogConstantEvaluable.swift
+++ b/test/SILOptimizer/Inputs/OSLogConstantEvaluable.swift
@@ -50,3 +50,19 @@ func intValueWithPrecisionTest() -> OSLogMessage {
 func intValueWithPrivacyTest() -> OSLogMessage {
     return "An integer value \(10, privacy: .private(mask: .hash))"
 }
+
+// Test OSLogMessage with SIMD interpolations
+struct FloatVector {
+    let zero = SIMD4<Float>()
+    var pair: (SIMD4<Float>, SIMD4<Float>)
+
+    init() {
+        pair = (zero, zero)
+    }
+}
+
+@_semantics("test_driver")
+func testOSLogMessageSIMDInterpolation() -> OSLogMessage {
+    let vector = FloatVector()
+    return "\(vector.pair.0.x)"
+}

--- a/test/SILOptimizer/constant_evaluator_skip_test.sil
+++ b/test/SILOptimizer/constant_evaluator_skip_test.sil
@@ -330,3 +330,57 @@ bb0:
   dealloc_stack %0 : $*Outer
   return %32 : $Builtin.Int64
 } // CHECK: Returns int: 103
+
+// Test whether the constant evaluator can handle reading and writing into
+// structs containing unknown symbolic values created by skipping functions.
+
+struct UnknownStruct {
+  let value: Int64
+}
+
+struct StructWithSkippedElements {
+  let knownValue: Int64
+  let unknownValue: UnknownStruct
+}
+
+sil @skipUnknownStructCreate : $@convention(thin) () -> UnknownStruct
+
+// CHECK-LABEL: @interpretStructsWithSkippedElements
+sil @interpretStructsWithSkippedElements : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 301
+  %1 = struct $Int64 (%0 : $Builtin.Int64)
+  %2 = function_ref @skipUnknownStructCreate : $@convention(thin) () -> UnknownStruct
+  %3 = apply %2() : $@convention(thin) () -> UnknownStruct
+  %4 = struct $StructWithSkippedElements (%1 : $Int64, %3 : $UnknownStruct)
+  %5 = alloc_stack $StructWithSkippedElements, var, name "s"
+  store %4 to %5 : $*StructWithSkippedElements
+
+  %6 = struct_element_addr %5 : $*StructWithSkippedElements, #StructWithSkippedElements.unknownValue
+  %7 = struct_element_addr %6 : $*UnknownStruct, #UnknownStruct.value
+  %8 = load %7 : $*Int64
+  %9 = struct_extract %8 : $Int64, #Int64._value
+  dealloc_stack %5 : $*StructWithSkippedElements
+  return %9 : $Builtin.Int64
+} // CHECK: Returns unknown
+
+// CHECK-LABEL: @interpretStructsWithSkippedElementsRW
+sil @interpretStructsWithSkippedElementsRW : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 301
+  %1 = struct $Int64 (%0 : $Builtin.Int64)
+  %2 = function_ref @skipUnknownStructCreate : $@convention(thin) () -> UnknownStruct
+  %3 = apply %2() : $@convention(thin) () -> UnknownStruct
+  %4 = struct $StructWithSkippedElements (%1 : $Int64, %3 : $UnknownStruct)
+  %5 = alloc_stack $StructWithSkippedElements, var, name "s"
+  store %4 to %5 : $*StructWithSkippedElements
+
+  %6 = struct_element_addr %5 : $*StructWithSkippedElements, #StructWithSkippedElements.unknownValue
+  %7 = struct_element_addr %6 : $*UnknownStruct, #UnknownStruct.value
+  store %1 to %7 : $*Int64
+  %8 = struct_element_addr %5 : $*StructWithSkippedElements, #StructWithSkippedElements.knownValue
+  %9 = load %8 : $*Int64
+  %10 = struct_extract %9 : $Int64, #Int64._value
+  dealloc_stack %5 : $*StructWithSkippedElements
+  return %10 : $Builtin.Int64
+} // CHECK: Returns int: 301


### PR DESCRIPTION
Such aggregates can be generated when an instruction is skipped during constant evaluation and its results are used to create a struct.

rdar://107344820