### PR TITLE
[CSBindings] NFC: Log binding attempt failures

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2302,8 +2302,17 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   auto result =
       cs.matchTypes(TypeVar, type, ConstraintKind::Bind, options, srcLocator);
 
-  if (result.isFailure())
+  if (result.isFailure()) {
+    if (cs.isDebugMode()) {
+      PrintOptions PO;
+      PO.PrintTypesForDebugging = true;
+
+      llvm::errs().indent(cs.solverState->getCurrentIndent())
+          << "(failed to establish binding " << TypeVar->getString(PO)
+          << " := " << type->getString(PO) << ")\n";
+    }
     return false;
+  }
 
   auto reportHole = [&]() {
     if (cs.isForCodeCompletion()) {


### PR DESCRIPTION
Currently we end up with an empty scope with no indication about what actually happened i.e.:

```
(attempting type variable $T0 := Int
)
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
