### PR TITLE
🍒[5.9][Executors] Remote distributed actors get "crash on enqueue" default executor

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4533,7 +4533,6 @@ public:
 
   /// Fetch this class's unownedExecutor property, if it has one.
   const VarDecl *getUnownedExecutorProperty() const;
-  const VarDecl *getLocalUnownedExecutorProperty() const;
 
   /// Is this the NSObject class type?
   bool isNSObject() const;

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -231,8 +231,6 @@ IDENTIFIER(className)
 IDENTIFIER(_defaultActorInitialize)
 IDENTIFIER(_defaultActorDestroy)
 IDENTIFIER(unownedExecutor)
-IDENTIFIER(localUnownedExecutor)
-IDENTIFIER(_unwrapLocalUnownedExecutor)
 
 IDENTIFIER_(ErrorType)
 IDENTIFIER(Code)

--- a/include/swift/AST/KnownSDKDecls.def
+++ b/include/swift/AST/KnownSDKDecls.def
@@ -21,7 +21,7 @@
 
 KNOWN_SDK_FUNC_DECL(Distributed, IsRemoteDistributedActor, "__isRemoteActor")
 KNOWN_SDK_FUNC_DECL(Distributed, IsLocalDistributedActor, "__isLocalActor")
-KNOWN_SDK_FUNC_DECL(Distributed, GetUnwrapLocalDistributedActorUnownedExecutor, "_getUnwrapLocalDistributedActorUnownedExecutor")
+KNOWN_SDK_FUNC_DECL(Distributed, BuildDefaultDistributedRemoteActorUnownedExecutor, "buildDefaultDistributedRemoteActorExecutor")
 
 #undef KNOWN_SDK_FUNC_DECL
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9649,29 +9649,6 @@ const VarDecl *ClassDecl::getUnownedExecutorProperty() const {
   return nullptr;
 }
 
-const VarDecl *ClassDecl::getLocalUnownedExecutorProperty() const {
-  auto &C = getASTContext();
-
-  if (!isDistributedActor())
-    return nullptr;
-
-  llvm::SmallVector<ValueDecl *, 2> results;
-  this->lookupQualified(getSelfNominalTypeDecl(),
-                        DeclNameRef(C.Id_localUnownedExecutor),
-                        NL_ProtocolMembers,
-                        results);
-
-  for (auto candidate: results) {
-    if (isa<ProtocolDecl>(candidate->getDeclContext()))
-      continue;
-
-    if (VarDecl *var = dyn_cast<VarDecl>(candidate))
-      return var;
-  }
-
-  return nullptr;
-}
-
 bool ClassDecl::isRootDefaultActor() const {
   return isRootDefaultActor(getModuleContext(), ResilienceExpansion::Maximal);
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -335,7 +335,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
     // Actor.unownedExecutor
     if (name.isSimpleName(ctx.Id_unownedExecutor)) {
-      return getRequirement(KnownProtocolKind::Actor);
+      if (nominal->isDistributedActor()) {
+        return getRequirement(KnownProtocolKind::DistributedActor);
+      } else {
+        return getRequirement(KnownProtocolKind::Actor);
+      }
     }
 
     // DistributedActor.id
@@ -345,11 +349,6 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     // DistributedActor.actorSystem
     if (name.isSimpleName(ctx.Id_actorSystem))
       return getRequirement(KnownProtocolKind::DistributedActor);
-
-    // DistributedActor.localUnownedExecutor
-    if (name.isSimpleName(ctx.Id_localUnownedExecutor)) {
-      return getRequirement(KnownProtocolKind::DistributedActor);
-    }
 
     return nullptr;
   }
@@ -693,11 +692,6 @@ GuardStmt *DerivedConformance::returnNilIfFalseGuardTypeChecked(ASTContext &C,
   statements.push_back(returnStmt);
 
   // Next, generate the condition being checked.
-//  auto cmpFuncExpr = new (C) UnresolvedDeclRefExpr(
-//      DeclNameRef(C.Id_EqualsOperator), DeclRefKind::BinaryOperator,
-//      DeclNameLoc());
-//  auto *cmpExpr = BinaryExpr::create(C, lhsExpr, cmpFuncExpr, rhsExpr,
-//      /*implicit*/ true);
   conditions.emplace_back(testExpr);
 
   // Build and return the complete guard statement.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -221,16 +221,6 @@ bool IsDefaultActorRequest::evaluate(
         executorProperty->getAttrs().hasSemanticsAttr(SEMANTICS_DEFAULT_ACTOR);
   }
 
-  // Maybe it was a distributed actor, let's double-check it's localUnownedExecutor property.
-  // If we synthesized that one with appropriate semantics we may still be a default actor.
-  if (!isDefaultActor && classDecl->isDistributedActor()) {
-    if (auto localExecutorProperty = classDecl->getLocalUnownedExecutorProperty()) {
-      foundExecutorPropertyImpl = true;
-      isDefaultActor = isDefaultActor ||
-          localExecutorProperty->getAttrs().hasSemanticsAttr(SEMANTICS_DEFAULT_ACTOR);
-    }
-  }
-
   // Only if we found one of the executor properties, do we return the status of default or not,
   // based on the findings of the semantics attribute of that located property.
   if (foundExecutorPropertyImpl) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2039,7 +2039,6 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
               cast<ClassDecl>(prop->getDeclContext())->isActor() &&
               !prop->isStatic() &&
               prop->getName() == ctx.Id_unownedExecutor &&
-              prop->getName() == ctx.Id_localUnownedExecutor &&
               prop->getInterfaceType()->getAnyNominal() == ctx.getUnownedSerialExecutorDecl());
     };
 

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -407,7 +407,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// out of the `withThrowingDiscardingTaskGroup` method when it returns.
 ///
 /// ```
-/// try await withThrowingDiscardingTaskGroup() { group in
+/// try await withThrowingDiscardingTaskGroup { group in
 ///   group.addTask { try boom(1) }
 ///   group.addTask { try boom(2, after: .seconds(5)) }
 ///   group.addTask { try boom(3, after: .seconds(5)) }
@@ -490,7 +490,7 @@ public func withThrowingDiscardingTaskGroup<GroupResult>(
 /// A throwing discarding task group becomes cancelled in one of the following ways:
 ///
 /// - when ``cancelAll()`` is invoked on it,
-/// - when an error is thrown out of the `withThrowingDiscardingTaskGroup(...) { }` closure,
+/// - when an error is thrown out of the `withThrowingDiscardingTaskGroup { ... }` closure,
 /// - when the ``Task`` running this task group is cancelled.
 ///
 /// But also, and uniquely in *discarding* task groups:
@@ -598,7 +598,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
 
   /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
-  /// At the start of the body of a `withThrowingDiscardingTaskGroup(of:returning:body:)` call,
+  /// At the start of the body of a `withThrowingDiscardingTaskGroup(returning:body:)` call,
   /// the task group is always empty.
   ///
   /// It's guaranteed to be empty when returning from that body

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_target_library(swiftDistributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   DistributedActor.swift
   DistributedActorSystem.swift
   DistributedAssertions.swift
+  DistributedDefaultExecutor.swift
   DistributedMetadata.swift
   LocalTestingDistributedActorSystem.swift
 

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -260,7 +260,7 @@ public protocol DistributedActor: AnyActor, Identifiable, Hashable
   /// be introduced when not strictly required.  Visible side effects
   /// are therefore strongly discouraged within this property.
   @available(SwiftStdlib 5.9, *)
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? { get }
+  nonisolated var unownedExecutor: UnownedSerialExecutor{ get }
 
   /// Resolves the passed in `id` against the `system`, returning
   /// either a local or remote actor reference.
@@ -278,15 +278,6 @@ public protocol DistributedActor: AnyActor, Identifiable, Hashable
   /// - Parameter system: `system` which should be used to resolve the `identity`, and be associated with the returned actor
   static func resolve(id: ID, using system: ActorSystem) throws -> Self
 
-}
-
-@available(SwiftStdlib 5.9, *)
-public func _getUnwrapLocalDistributedActorUnownedExecutor(_ actor: some DistributedActor) -> UnownedSerialExecutor {
-  guard let executor = actor.localUnownedExecutor else {
-    fatalError("Expected distributed actor executor to be not nil!")
-  }
-
-  return executor
 }
 
 // ==== Hashable conformance ---------------------------------------------------

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -42,22 +42,13 @@ extension DistributedActor {
       return
     }
 
-    guard __isLocalActor(self) else {
-      return
-    }
-
-    guard let unownedExecutor = self.localUnownedExecutor else {
-      preconditionFailure(
-          "Incorrect actor executor assumption; Distributed actor \(self) is 'local' but has no executor!",
-          file: file, line: line)
-    }
-
+    let unownedExecutor = self.unownedExecutor
     let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor)
 
     // TODO: offer information which executor we actually got
     precondition(expectationCheck,
         // TODO: figure out a way to get the typed repr out of the unowned executor
-        "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())",
+        "Incorrect actor executor assumption; Expected '\(self.unownedExecutor)' executor. \(message())",
         file: file, line: line)
   }
 }
@@ -89,16 +80,7 @@ extension DistributedActor {
       return
     }
 
-    guard __isLocalActor(self) else {
-      return
-    }
-
-    guard let unownedExecutor = self.localUnownedExecutor else {
-      preconditionFailure(
-          "Incorrect actor executor assumption; Distributed actor \(self) is 'local' but has no executor!",
-          file: file, line: line)
-    }
-
+    let unownedExecutor = self.unownedExecutor
     guard _taskIsCurrentExecutor(unownedExecutor._executor) else {
       // TODO: offer information which executor we actually got
       // TODO: figure out a way to get the typed repr out of the unowned executor
@@ -147,16 +129,12 @@ extension DistributedActor {
     typealias YesActor = (isolated Self) throws -> T
     typealias NoActor = (Self) throws -> T
 
-      guard __isLocalActor(self) else {
-        fatalError("Cannot assume to be 'isolated \(Self.self)' since distributed actor '\(self)' is a remote actor reference.")
-      }
-
-    /// This is guaranteed to be fatal if the check fails,
-    /// as this is our "safe" version of this API.
-    guard let executor = self.localUnownedExecutor else {
-      fatalError("Distributed local actor MUST have executor, but was nil")
+    guard __isLocalActor(self) else {
+      fatalError("Cannot assume to be 'isolated \(Self.self)' since distributed actor '\(self)' is a remote actor reference.")
     }
-    guard _taskIsCurrentExecutor(executor._executor) else {
+
+    let unownedExecutor = self.unownedExecutor
+    guard _taskIsCurrentExecutor(unownedExecutor._executor) else {
       // TODO: offer information which executor we actually got when
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }

--- a/stdlib/public/Distributed/DistributedDefaultExecutor.swift
+++ b/stdlib/public/Distributed/DistributedDefaultExecutor.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+import _Concurrency
+
+@available(SwiftStdlib 5.9, *)
+@usableFromInline
+internal final class DistributedRemoteActorReferenceExecutor: SerialExecutor {
+  static let _shared: DistributedRemoteActorReferenceExecutor = DistributedRemoteActorReferenceExecutor()
+  static var sharedUnownedExecutor: UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: _shared)
+  }
+
+  internal init() {}
+
+  @inlinable
+  public func enqueue(_ job: __owned Job) {
+    let jobDescription = job.description
+    fatalError("Attempted to enqueue \(Job.self) (\(jobDescription)) on executor of remote distributed actor reference!")
+  }
+
+  public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// Obtain the unowned `SerialExecutor` that is used by by remote distributed actor references.
+/// The executor is shared between all remote default executor remote distributed actors,
+/// and it will crash if any job is enqueued on it.
+///
+/// It is possible to obtain the executor e.g. for logging or general debugging,
+/// however attempting to enqueue work on what might potentially be a remote actor
+/// is a programming error and therefore will crash if the actor is potentially.
+///
+/// If one intends to use a distributed actor's executor to schedule work on it,
+/// one should programmatically ensure that that actor is local, e.g. using the `whenLocal`
+/// functionality of distributed actors, or by other means (e.g. "knowing that it definitely must be local")
+@available(SwiftStdlib 5.9, *)
+public func buildDefaultDistributedRemoteActorExecutor<Act>(
+    _ actor: Act
+) -> UnownedSerialExecutor where Act: DistributedActor {
+  return DistributedRemoteActorReferenceExecutor.sharedUnownedExecutor
+}

--- a/test/Distributed/Runtime/distributed_actor_assume_executor.swift
+++ b/test/Distributed/Runtime/distributed_actor_assume_executor.swift
@@ -41,7 +41,7 @@ func check(actor: MainDistributedFriend) {
 
 @available(SwiftStdlib 5.9, *)
 distributed actor MainDistributedFriend {
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
@@ -23,7 +23,7 @@ typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
 
 @available(SwiftStdlib 5.7, *)
 distributed actor FiveSevenActor_NothingExecutor {
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }
@@ -41,8 +41,7 @@ distributed actor FiveSevenActor_NothingExecutor {
 
 @available(SwiftStdlib 5.9, *)
 distributed actor FiveNineActor_NothingExecutor {
-//  @available(SwiftStdlib 5.9, *) // because of `localUnownedExecutor`
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }
@@ -61,7 +60,7 @@ distributed actor FiveNineActor_NothingExecutor {
 @available(SwiftStdlib 5.7, *)
 distributed actor FiveSevenActor_FiveNineExecutor {
   @available(SwiftStdlib 5.9, *)
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
@@ -23,7 +23,7 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 @available(SwiftStdlib 5.9, *) // because conforming to the protocol... that has this field in 5.9?
 distributed actor Worker {
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
@@ -23,9 +23,9 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 @available(SwiftStdlib 5.9, *)
 distributed actor Worker {
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned 'local' executor via ID")
-    return self.id.executorPreference
+    return self.id.executorPreference ?? buildDefaultDistributedRemoteActorExecutor(self)
   }
 
   distributed func test(x: Int) {

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -46,12 +46,15 @@ extension Worker {
 
 actor EnqueueTest {
   let unownedExecutor: UnownedSerialExecutor
+  var field: Int = 0
 
   init(unownedExecutor: UnownedSerialExecutor) {
     self.unownedExecutor = unownedExecutor
   }
 
   func test() {
+    // do something, so the test call does not get optimized away (if it was just an empty method)
+    self.field += 1
   }
 }
 

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -22,13 +22,15 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
+@available(SwiftStdlib 5.9, *)
 distributed actor MainWorker: Worker {
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }
 }
 
+@available(SwiftStdlib 5.9, *)
 distributed actor NormalWorker: Worker {
   // empty on purpose, default executor
 }
@@ -39,6 +41,17 @@ protocol Worker: DistributedActor {
 extension Worker {
   distributed func preconditionSameExecutor(as other: some Worker) {
     other.preconditionIsolated("Expected for [\(self)] share executor with [\(other)]")
+  }
+}
+
+actor EnqueueTest {
+  let unownedExecutor: UnownedSerialExecutor
+
+  init(unownedExecutor: UnownedSerialExecutor) {
+    self.unownedExecutor = unownedExecutor
+  }
+
+  func test() {
   }
 }
 
@@ -54,24 +67,24 @@ extension Worker {
 
       let normalRemoteWorker = try! NormalWorker.resolve(id: normalLocalWorker.id, using: system)
       precondition(__isRemoteActor(normalRemoteWorker), "must be remote")
+      precondition(normalLocalWorker.id == normalRemoteWorker.id, "IDs must be equal")
 
-      if #available(SwiftStdlib 5.9, *) {
-        precondition(normalLocalWorker.id == normalRemoteWorker.id, "IDs must be equal")
+      tests.test("exactly the same actor") {
+        try! await normalLocalWorker.preconditionSameExecutor(as: normalLocalWorker)
+      }
 
-        tests.test("exactly the same actor") {
-          try! await normalLocalWorker.preconditionSameExecutor(as: normalLocalWorker)
-        }
+      tests.test("different normal local worker, not same executor") {
+        expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'UnownedSerialExecutor(executor: (Opaque Value))' executor. Expected for [main.NormalWorker] share executor with main.NormalWorker")
+        let other = NormalWorker(actorSystem: system)
+        try! await normalLocalWorker.preconditionSameExecutor(as: other)
+      }
 
-        tests.test("different normal local worker, not same executor") {
-          expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'UnownedSerialExecutor(executor: (Opaque Value))' executor. Expected for [main.NormalWorker] share executor with main.NormalWorker")
-          let other = NormalWorker(actorSystem: system)
-          try! await normalLocalWorker.preconditionSameExecutor(as: other)
-        }
-
-        tests.test("remote actor reference should have nil executor") {
-          precondition(normalRemoteWorker.localUnownedExecutor == nil,
-              "Expected nil executor but was: \(String(describing: normalRemoteWorker.localUnownedExecutor!))")
-        }
+      tests.test("remote actor reference should have crash-on-enqueue executor") {
+        expectCrashLater(withMessage: "Attempted to enqueue Job (Job(id: 1)) on executor of remote distributed actor reference!")
+        // we do the bad idea of taking an executor from a remote worker
+        // and then force another actor to run on it; this will cause an enqueue on the "crash on enqueue" executor.
+        let wrongUse = EnqueueTest(unownedExecutor: normalRemoteWorker.unownedExecutor)
+        await wrongUse.test()
       }
     }
 

--- a/test/Distributed/Runtime/distributed_actor_executor_default.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_default.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+@available(SwiftStdlib 5.9, *)
+distributed actor DefaultDistributedActor {
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let tests = TestSuite("DistributedActorDefaultExecutorTests")
+
+    let system = FakeRoundtripActorSystem()
+    let distLocal = DefaultDistributedActor(actorSystem: system)
+
+    if #available(SwiftStdlib 5.9, *) {
+
+      tests.test("distributed actor, local: default executor, just works") {
+        try! await distLocal.test(x: 42)
+      }
+
+      tests.test("distributed actor, remote: obtaining executor works") {
+        let remoteRef = try! DefaultDistributedActor.resolve(id: distLocal.id, using: system)
+        print("Executor was: \(remoteRef.unownedExecutor)") // accessing it is okey, it will be the "explode on use" executor
+      }
+    }
+
+    await runAllTestsAsync()
+  }
+}

--- a/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
+++ b/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
@@ -15,7 +15,7 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 @available(SwiftStdlib 5.9, *)
 distributed actor MyDistActor {
-    nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
         return MainActor.sharedUnownedExecutor
     }
 

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -73,7 +73,7 @@ final class DA2: DistributedActor {
   nonisolated var actorSystem: ActorSystem {
     fatalError()
   }
-  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }
 

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -26,39 +26,19 @@ distributed actor DefaultWorker {
 // Check DefaultWorker, the DefaultActor version of the synthesis:
 // CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non-resilient actor
 // The unowned executor property:
-// CHECK:    (var_decl implicit "localUnownedExecutor" type='Optional<UnownedSerialExecutor>' interface type='Optional<UnownedSerialExecutor>' access=internal final readImpl=getter immutable
-// CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal {{.*}}get_for=localUnownedExecutor
-// CHECK:       (parameter "self" type='DefaultWorker' interface type='DefaultWorker')
-// CHECK:       (parameter_list)
-// CHECK:       (brace_stmt implicit
+// CHECK:    (var_decl implicit "unownedExecutor" type='UnownedSerialExecutor' interface type='UnownedSerialExecutor' access=internal final readImpl=getter immutable
+
 // We guard the rest of the body; we only return a default executor if the actor is local:
 // CHECK:       (guard_stmt implicit
 // CHECK:         (call_expr implicit type='Bool' nothrow
 // CHECK:           (declref_expr implicit type='@_NO_EXTINFO (AnyObject) -> Bool' decl=Distributed.(file).__isLocalActor function_ref=unapplied)
-// CHECK:           (argument_list implicit
-// CHECK:             (argument
-// CHECK:               (erasure_expr implicit type='AnyObject'
-// CHECK:                 (declref_expr implicit type='DefaultWorker' decl=main.(file).DefaultWorker.<anonymous>.self function_ref=unapplied)))))
-// CHECK:           (brace_stmt implicit
-// CHECK:             (return_stmt implicit
-// CHECK:               (nil_literal_expr implicit type='Optional<UnownedSerialExecutor>' initializer=**NULL**))))
-// If the actor is not local, we return a default executor for it, same as normal actors:
-// CHECK:         (return_stmt implicit
-// CHECK:           (inject_into_optional implicit type='Optional<UnownedSerialExecutor>'
-// CHECK:             (call_expr implicit type='UnownedSerialExecutor' nothrow
-// CHECK:               (constructor_ref_call_expr implicit type='(Builtin.Executor) -> UnownedSerialExecutor' nothrow
-// CHECK:                 (declref_expr implicit type='(UnownedSerialExecutor.Type) -> (Builtin.Executor) -> UnownedSerialExecutor' decl=_Concurrency.(file).UnownedSerialExecutor.init(_:) function_ref=unapplied)
-// CHECK:                 (argument_list implicit
-// CHECK:                   (argument
-// CHECK:                     (type_expr implicit type='UnownedSerialExecutor.Type' typerepr='<<NULL>>'))))
-// CHECK:               (argument_list implicit
-// CHECK:                 (argument
-// CHECK:                   (call_expr implicit type='Builtin.Executor' nothrow
-// CHECK:                     (declref_expr implicit type='(DefaultWorker) -> Builtin.Executor' decl=Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature=<T where T : AnyObject> (substitution T -> DefaultWorker))] function_ref=unapplied)
-// CHECK:                     (argument_list implicit
-// CHECK:                       (argument
-// CHECK:                         (declref_expr implicit type='DefaultWorker' decl=main.(file).DefaultWorker.<anonymous>.self function_ref=unapplied))))))))))))
-// CHECK:   (pattern_binding_decl implicit
-// CHECK:     (pattern_typed implicit type='Optional<UnownedSerialExecutor>'
-// CHECK:       (pattern_named implicit type='Optional<UnownedSerialExecutor>' 'localUnownedExecutor')))
 
+// Check that we create the "remote reference" executor:
+// CHECK: (return_stmt implicit
+// CHECK:   (call_expr implicit type='UnownedSerialExecutor' nothrow
+// CHECK:     (declref_expr implicit type='(DefaultWorker) -> UnownedSerialExecutor' decl=Distributed.(file).buildDefaultDistributedRemoteActorExecutor [with (substitution_map generic_signature=<Act where Act : DistributedActor> (substitution Act -> DefaultWorker))]
+
+// Check the default executor synthesis for local actor otherwise:
+// CHECK: (return_stmt implicit
+// CHECK:   (call_expr implicit type='Builtin.Executor' nothrow
+// CHECK:     (declref_expr implicit type='(DefaultWorker) -> Builtin.Executor' decl=Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature=<T where T : AnyObject> (substitution T -> DefaultWorker))] function_ref=unapplied)


### PR DESCRIPTION
**Description:** According to SE review, we do actually want to keep the non-optional distributed actor executor, however at the same time make the default one for remote actors one that "crashes on enqueue". This makes a lot of sense since just touching an executor in order to e.g. compare it should still be okey.
**Risk:** Low, no adopters of this feature yet; Implementation is simplified from previous style
**Review by:** @DougGregor @jckarter 
**Testing:** PR testing
**Original PR:**  https://github.com/apple/swift/pull/64969


Associated SE update: https://github.com/apple/swift-evolution/pull/2000

> There was good discussion of what should happen when code asks a distributed actor instance what its executor is. The question doesn't really make sense to ask of a remote actor instance, since the only code that locally executes on its behalf is the nonisolated remote call stub, and it doesn't make sense to try to enqueue additional local work on a remote actor's executor. One possibility would be to have the unownedExecutor property of an actor be Optional, and have distributed actor instances return nil, but the Language Workgroup agrees with the proposal's choice not to take this route, since doing so would add friction to code that only works with local actors. Instead of returning a "default" executor, though, the language workgroup would like to see if it's possible to use an executor implementation that raises a fatalError if any code tries to enqueue additional jobs on it. Although it may make sense to ask an arbitrary actor for its executor to log the value as a debugging aid, it is likely a programming mistake to attempt to use that executor reference to enqueue work, so it may be preferable to trap at the attempt rather than to fall back to some default executor, to avoid expectations that the work will actually occur exclusively with work being done on the remote actor instance.

