### PR TITLE
[5.9] Sema: Downgrade over availability diagnostics to warnings for implicit decls

### DIFF
--- a/test/attr/attr_availability_maccatalyst_implicit.swift
+++ b/test/attr/attr_availability_maccatalyst_implicit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %t -I %S/Inputs/custom-modules -parse-stdlib -parse-as-library -typecheck -verify -target x86_64-apple-ios15.4-macabi %s
+// RUN: %target-swift-frontend -I %t -I %S/Inputs/custom-modules -parse-stdlib -parse-as-library -typecheck -verify -target %target-cpu-apple-ios15.4-macabi %s
 
 // REQUIRES: objc_interop
 // REQUIRES: maccatalyst_support
@@ -7,7 +7,17 @@ import Available_NSObject
 
 @available(iOS 15.0, *)
 open class OverAvailableClass: NSBaseClass {}
-// expected-error@-1 {{initializer cannot be more available than enclosing scope}}
+// expected-warning@-1 {{initializer cannot be more available than enclosing scope}}
 // expected-note@-2 {{initializer implicitly declared here with availability of Mac Catalyst 13.1 or newer}}
 // expected-note@-3 {{enclosing scope requires availability of Mac Catalyst 15.0 or newer}}
 
+extension NSBaseClass {
+  @available(iOS 15.0, *)
+  // expected-warning@+3 {{_modify accessor cannot be more available than enclosing scope}}
+  // expected-note@+2 {{_modify accessor implicitly declared here with availability of Mac Catalyst 13.1 or newer}}
+  // expected-note@+1 {{enclosing scope requires availability of Mac Catalyst 15.0 or newer}}
+  var property: Int {
+    get { 1 }
+    set {}
+  }
+}


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/65014.

It's likely that incorrect availability annotations on implicit decls represent compiler bugs, so downgrade the diagnostic to a warning to avoid blocking the developer.

Resolves rdar://107764128