### PR TITLE
🍒 "Virtualize swift compiler outputs"

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -784,8 +784,8 @@ public:
   void deSerialize(StringRef Filename);
 
   // Serialize the content of all roots to a given file using JSON format.
-  void serialize(StringRef Filename);
-  static void serialize(StringRef Filename, SDKNode *Root, PayLoad otherInfo);
+  void serialize(llvm::raw_ostream &os);
+  static void serialize(llvm::raw_ostream &os, SDKNode *Root, PayLoad otherInfo);
 
   // After collecting decls, either from imported modules or from a previously
   // serialized JSON file, using this function to get the root of the SDK.
@@ -835,14 +835,15 @@ SDKNodeRoot *getSDKNodeRoot(SDKContext &SDKCtx,
 
 SDKNodeRoot *getEmptySDKNodeRoot(SDKContext &SDKCtx);
 
-void dumpSDKRoot(SDKNodeRoot *Root, PayLoad load, StringRef OutputFile);
-void dumpSDKRoot(SDKNodeRoot *Root, StringRef OutputFile);
+void dumpSDKRoot(SDKNodeRoot *Root, PayLoad load, llvm::raw_ostream &os);
+void dumpSDKRoot(SDKNodeRoot *Root, llvm::raw_ostream &os);
 
 int dumpSDKContent(const CompilerInvocation &InitInvoke,
                    const llvm::StringSet<> &ModuleNames,
-                   StringRef OutputFile, CheckerOptions Opts);
+                   llvm::raw_ostream &os, CheckerOptions Opts);
 
-void dumpModuleContent(ModuleDecl *MD, StringRef OutputFile, bool ABI, bool Empty);
+void dumpModuleContent(ModuleDecl *MD, llvm::raw_ostream &os, bool ABI,
+                       bool Empty);
 
 /// Mostly for testing purposes, this function de-serializes the SDK dump in
 /// dumpPath and re-serialize them to OutputPath. If the tool performs correctly,

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -44,6 +44,7 @@
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/DataTypes.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include <functional>
 #include <memory>
 #include <utility>
@@ -231,6 +232,7 @@ class ASTContext final {
       ClangImporterOptions &ClangImporterOpts,
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr,
       std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback = {});
 
 public:
@@ -248,6 +250,7 @@ public:
       ClangImporterOptions &ClangImporterOpts,
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr,
       std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback = {});
   ~ASTContext();
 
@@ -280,6 +283,9 @@ public:
 
   /// Diags - The diagnostics engine.
   DiagnosticEngine &Diags;
+
+  /// OutputBackend for writing outputs.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend;
 
   /// If the shared pointer is not a \c nullptr and the pointee is \c true,
   /// all operations working on this ASTContext should be aborted at the next
@@ -1515,6 +1521,18 @@ public:
   void setPluginRegistry(PluginRegistry *newValue);
 
   const llvm::StringSet<> &getLoadedPluginLibraryPaths() const;
+
+  /// Get the output backend. The output backend needs to be initialized via
+  /// constructor or `setOutputBackend`.
+  llvm::vfs::OutputBackend &getOutputBackend() const {
+    assert(OutputBackend && "OutputBackend is not setup");
+    return *OutputBackend;
+  }
+  /// Set output backend for virtualized outputs.
+  void setOutputBackend(
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend) {
+    OutputBackend = std::move(OutBackend);
+  }
 
 private:
   friend Decl;

--- a/include/swift/AST/AbstractSourceFileDepGraphFactory.h
+++ b/include/swift/AST/AbstractSourceFileDepGraphFactory.h
@@ -16,6 +16,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/FineGrainedDependencies.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 
 namespace swift {
 class DiagnosticEngine;
@@ -39,6 +40,9 @@ protected:
 
   DiagnosticEngine &diags;
 
+  /// OutputBackend.
+  llvm::vfs::OutputBackend &backend;
+
   /// Graph under construction
   SourceFileDepGraph g;
 
@@ -49,7 +53,8 @@ public:
                                     StringRef swiftDeps,
                                     Fingerprint fileFingerprint,
                                     bool emitDotFileAfterConstruction,
-                                    DiagnosticEngine &diags);
+                                    DiagnosticEngine &diags,
+                                    llvm::vfs::OutputBackend &outputBackend);
 
   virtual ~AbstractSourceFileDepGraphFactory() = default;
 

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -29,6 +29,9 @@ ERROR(not_implemented,none,
 ERROR(error_opening_output,none,
       "error opening '%0' for output: %1", (StringRef, StringRef))
 
+ERROR(error_closing_output,none,
+      "error closing '%0' for output: %1", (StringRef, StringRef))
+
 ERROR(cannot_find_group_info_file,none,
       "cannot find group info file at path: '%0'", (StringRef))
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -478,6 +478,16 @@ REMARK(interface_file_backup_used,none,
 
 WARNING(warn_flag_deprecated,none, "flag '%0' is deprecated", (StringRef))
 
+// Output deterministic check
+ERROR(error_nondeterministic_output,none,
+      "output file '%0' is not deterministic: hash value '%1' vs '%2' between two compilations",
+      (StringRef, StringRef, StringRef))
+ERROR(error_output_missing,none,
+      "output file '%0' is missing from %select{first|second}1 compilation for deterministic check",
+      (StringRef, /*SecondRun=*/bool))
+REMARK(matching_output_produced,none,
+      "produced matching output file '%0' for deterministic check: hash '%1'", (StringRef, StringRef))
+
 // Dependency Verifier Diagnostics
 ERROR(missing_member_dependency,none,
       "expected "

--- a/include/swift/AST/FileSystem.h
+++ b/include/swift/AST/FileSystem.h
@@ -16,29 +16,42 @@
 #include "swift/Basic/FileSystem.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsCommon.h"
+#include "llvm/Support/VirtualOutputBackend.h"
+#include "llvm/Support/VirtualOutputConfig.h"
 
 namespace swift {
-
-/// A wrapper around swift::atomicallyWritingToFile that handles diagnosing any
-/// filesystem errors and asserts the output path is nonempty.
+/// A wrapper around llvm::vfs::OutputBackend to handle diagnosing any file
+/// system errors during output creation.
 ///
 /// \returns true if there were any errors, either from the filesystem
 /// operations or from \p action returning true.
 inline bool
-withOutputFile(DiagnosticEngine &diags, StringRef outputPath,
+withOutputPath(DiagnosticEngine &diags, llvm::vfs::OutputBackend &Backend,
+               StringRef outputPath,
                llvm::function_ref<bool(llvm::raw_pwrite_stream &)> action) {
   assert(!outputPath.empty());
+  llvm::vfs::OutputConfig config;
+  config.setAtomicWrite().setOnlyIfDifferent();
 
-  bool actionFailed = false;
-  std::error_code EC = swift::atomicallyWritingToFile(
-      outputPath,
-      [&](llvm::raw_pwrite_stream &out) { actionFailed = action(out); });
-  if (EC) {
+  auto outputFile = Backend.createFile(outputPath, config);
+  if (!outputFile) {
     diags.diagnose(SourceLoc(), diag::error_opening_output, outputPath,
-                   EC.message());
+                   toString(outputFile.takeError()));
     return true;
   }
-  return actionFailed;
+
+  bool failed = action(*outputFile);
+  // If there is an error, discard output. Otherwise keep the output file.
+  if (auto error = failed ? outputFile->discard() : outputFile->keep()) {
+    // Don't diagnose discard error.
+    if (failed)
+      consumeError(std::move(error));
+    else
+      diags.diagnose(SourceLoc(), diag::error_closing_output, outputPath,
+                     toString(std::move(error)));
+    return true;
+  }
+  return failed;
 }
 } // end namespace swift
 

--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
@@ -357,8 +358,9 @@ private:
 /// \Note The returned graph should not be escaped from the callback.
 bool withReferenceDependencies(
     llvm::PointerUnion<const ModuleDecl *, const SourceFile *> MSF,
-    const DependencyTracker &depTracker, StringRef outputPath,
-    bool alsoEmitDotFile, llvm::function_ref<bool(SourceFileDepGraph &&)>);
+    const DependencyTracker &depTracker, llvm::vfs::OutputBackend &backend,
+    StringRef outputPath, bool alsoEmitDotFile,
+    llvm::function_ref<bool(SourceFileDepGraph &&)>);
 
 //==============================================================================
 // MARK: Enums
@@ -895,7 +897,8 @@ public:
 
   bool verifySequenceNumber() const;
 
-  void emitDotFile(StringRef outputPath, DiagnosticEngine &diags);
+  void emitDotFile(llvm::vfs::OutputBackend &outputBackend,
+                   StringRef outputPath, DiagnosticEngine &diags);
 
   void addNode(SourceFileDepGraphNode *n) {
     n->setSequenceNumber(allNodes.size());

--- a/include/swift/AST/FineGrainedDependencyFormat.h
+++ b/include/swift/AST/FineGrainedDependencyFormat.h
@@ -18,6 +18,9 @@
 
 namespace llvm {
 class MemoryBuffer;
+namespace vfs {
+class OutputBackend;
+}
 }
 
 namespace swift {
@@ -132,6 +135,7 @@ bool readFineGrainedDependencyGraph(llvm::StringRef path,
 /// Tries to write the dependency graph to the given path name.
 /// Returns true if there was an error.
 bool writeFineGrainedDependencyGraphToPath(DiagnosticEngine &diags,
+                                           llvm::vfs::OutputBackend &backend,
                                            llvm::StringRef path,
                                            const SourceFileDepGraph &g);
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -318,6 +318,9 @@ public:
   /// Print the LLVM inline tree at the end of the LLVM pass pipeline.
   unsigned PrintInlineTree : 1;
 
+  /// Always recompile the output even if the module hash might match.
+  unsigned AlwaysCompile : 1;
+
   /// Whether we should embed the bitcode file.
   IRGenEmbedMode EmbedMode : 2;
 
@@ -481,7 +484,7 @@ public:
         DisableLLVMOptzns(false), DisableSwiftSpecificLLVMOptzns(false),
         Playground(false),
         EmitStackPromotionChecks(false), UseSingleModuleLLVMEmission(false),
-        FunctionSections(false), PrintInlineTree(false),
+        FunctionSections(false), PrintInlineTree(false), AlwaysCompile(false),
         EmbedMode(IRGenEmbedMode::None), LLVMLTOKind(IRGenLLVMLTOKind::None),
         SwiftAsyncFramePointer(SwiftAsyncFramePointerKind::Auto),
         HasValueNamesSetting(false), ValueNames(false),

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -32,6 +32,9 @@
 
 namespace llvm {
 class FileCollectorBase;
+namespace vfs {
+class OutputBackend;
+}
 }
 
 namespace clang {
@@ -156,6 +159,7 @@ public:
   virtual bool tryEmitForwardingModule(StringRef moduleName,
                                StringRef interfacePath,
                                ArrayRef<std::string> candidates,
+                               llvm::vfs::OutputBackend &backend,
                                StringRef outPath) = 0;
   virtual ~ModuleInterfaceChecker() = default;
 };

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -28,6 +28,7 @@ namespace llvm {
   template<typename Fn> class function_ref;
   namespace vfs {
     class FileSystem;
+    class OutputBackend;
   }
 }
 
@@ -394,8 +395,7 @@ public:
   /// replica.
   ///
   /// \sa clang::GeneratePCHAction
-  bool emitBridgingPCH(StringRef headerPath,
-                       StringRef outputPCHPath);
+  bool emitBridgingPCH(StringRef headerPath, StringRef outputPCHPath);
 
   /// Returns true if a clang CompilerInstance can successfully read in a PCH,
   /// assuming it exists, with the current options. This can be used to find out

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -18,6 +18,9 @@
 
 namespace llvm {
 class MemoryBuffer;
+namespace vfs{
+class OutputBackend;
+}
 }
 
 namespace swift {
@@ -187,6 +190,7 @@ bool readInterModuleDependenciesCache(llvm::StringRef path,
 /// Tries to write the dependency graph to the given path name.
 /// Returns true if there was an error.
 bool writeInterModuleDependenciesCache(DiagnosticEngine &diags,
+                                       llvm::vfs::OutputBackend &backend,
                                        llvm::StringRef path,
                                        const SwiftDependencyScanningService &cache);
 

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -20,11 +20,14 @@
 #include "swift/Basic/OptionSet.h"
 #include "swift/Driver/Job.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
+#include "llvm/Support/VirtualOutputBackend.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -201,6 +204,9 @@ private:
                           std::vector<const ModuleDepGraphNode *>>
       dependencyPathsToJobs;
 
+  /// VirtualOutputBackend for emitting graphs.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> backend;
+
   /// For helping with performance tuning, may be null:
   UnifiedStatsReporter *stats;
 
@@ -306,6 +312,10 @@ public:
                 : None),
         stats(stats) {
     assert(verify() && "ModuleDepGraph should be fine when created");
+
+    // Create a OnDiskOutputBackend for emitting graphs. Currently, this is
+    // only used by driver so the backend is not shared with a CompilerInstance.
+    backend = llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>();
   }
 
   /// For unit tests.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -45,8 +45,11 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"
+#include "llvm/Support/BLAKE3.h"
+#include "llvm/Support/HashingOutputBackend.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 
 #include <memory>
 
@@ -457,6 +460,13 @@ class CompilerInstance {
   /// instance has completed its setup, this will be null.
   std::unique_ptr<UnifiedStatsReporter> Stats;
 
+  /// Virtual OutputBackend.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend = nullptr;
+
+  /// The verification output backend.
+  using HashBackendTy = llvm::vfs::HashingOutputBackend<llvm::BLAKE3>;
+  llvm::IntrusiveRefCntPtr<HashBackendTy> HashBackend;
+
   mutable ModuleDecl *MainModule = nullptr;
   SerializedModuleLoaderBase *DefaultSerializedLoader = nullptr;
   MemoryBufferSerializedModuleLoader *MemoryBufferLoader = nullptr;
@@ -506,6 +516,16 @@ public:
   void setFileSystem(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
     SourceMgr.setFileSystem(FS);
   }
+
+  llvm::vfs::OutputBackend &getOutputBackend() const {
+    return *OutputBackend;
+  }
+  void
+  setOutputBackend(llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> Backend) {
+    OutputBackend = std::move(Backend);
+  }
+  using HashingBackendPtrTy = llvm::IntrusiveRefCntPtr<HashBackendTy>;
+  HashingBackendPtrTy getHashingBackend() { return HashBackend; }
 
   ASTContext &getASTContext() { return *Context; }
   const ASTContext &getASTContext() const { return *Context; }
@@ -629,6 +649,7 @@ private:
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();
   void setupDependencyTrackerIfNeeded();
+  void setupOutputBackend();
 
   /// \return false if successful, true on error.
   bool setupDiagnosticVerifierIfNeeded();

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -498,6 +498,9 @@ public:
   /// to encode the actual paths into the .swiftmodule file.
   PathObfuscator serializedPathObfuscator;
 
+  /// Whether to run the job twice to check determinism.
+  bool DeterministicCheck = false;
+
   /// Avoid printing actual module content into the ABI descriptor file.
   /// This should only be used as a workaround when emitting ABI descriptor files
   /// crashes the compiler.

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -447,6 +447,7 @@ public:
   bool tryEmitForwardingModule(StringRef moduleName,
                                StringRef interfacePath,
                                ArrayRef<std::string> candidates,
+                               llvm::vfs::OutputBackend &backend,
                                StringRef outPath) override;
   bool isCached(StringRef DepPath);
 };

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1176,6 +1176,13 @@ def enable_emit_generic_class_ro_t_list :
   HelpText<"Enable emission of a section with references to class_ro_t of "
            "generic class patterns">;
 
+def enable_deterministic_check :
+  Flag<["-"], "enable-deterministic-check">,
+  HelpText<"Check compiler output determinisim by running it twice">;
+def always_compile_output_files :
+  Flag<["-"], "always-compile-output-files">,
+  HelpText<"Always compile output files even it might not change the results">;
+
 def experimental_spi_only_imports :
   Flag<["-"], "experimental-spi-only-imports">,
   HelpText<"Enable use of @_spiOnly imports">;

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -35,6 +35,9 @@ namespace llvm {
   class Module;
   class TargetOptions;
   class TargetMachine;
+  namespace vfs {
+    class OutputBackend;
+  }
 }
 
 namespace swift {
@@ -276,6 +279,7 @@ namespace swift {
   /// \param Module LLVM module to code gen, required.
   /// \param TargetMachine target of code gen, required.
   /// \param OutputFilename Filename for output.
+  /// \param Backend OutputBackend for writing output.
   bool performLLVM(const IRGenOptions &Opts,
                    DiagnosticEngine &Diags,
                    llvm::sys::Mutex *DiagMutex,
@@ -283,6 +287,7 @@ namespace swift {
                    llvm::Module *Module,
                    llvm::TargetMachine *TargetMachine,
                    StringRef OutputFilename,
+                   llvm::vfs::OutputBackend &Backend,
                    UnifiedStatsReporter *Stats);
 
   /// Dump YAML describing all fixed-size types imported from the given module.

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2470,11 +2470,10 @@ void SwiftDeclCollector::deSerialize(StringRef Filename) {
 }
 
 // Serialize the content of all roots to a given file using JSON format.
-void SwiftDeclCollector::serialize(StringRef Filename, SDKNode *Root,
+void SwiftDeclCollector::serialize(llvm::raw_ostream &os, SDKNode *Root,
                                    PayLoad OtherInfo) {
   std::error_code EC;
-  llvm::raw_fd_ostream fs(Filename, EC, llvm::sys::fs::OF_None);
-  json::Output yout(fs);
+  json::Output yout(os);
   assert(Root->getKind() == SDKNodeKind::Root);
   SDKNodeRoot &root = *static_cast<SDKNodeRoot*>(Root);
   yout.beginObject();
@@ -2486,8 +2485,8 @@ void SwiftDeclCollector::serialize(StringRef Filename, SDKNode *Root,
 }
 
 // Serialize the content of all roots to a given file using JSON format.
-void SwiftDeclCollector::serialize(StringRef Filename) {
-  SwiftDeclCollector::serialize(Filename, RootNode, PayLoad());
+void SwiftDeclCollector::serialize(llvm::raw_ostream &os) {
+  SwiftDeclCollector::serialize(os, RootNode, PayLoad());
 }
 
 SDKNodeRoot *
@@ -2550,28 +2549,26 @@ swift::ide::api::getSDKNodeRoot(SDKContext &SDKCtx,
 }
 
 void swift::ide::api::dumpSDKRoot(SDKNodeRoot *Root, PayLoad load,
-                                  StringRef OutputFile) {
+                                  llvm::raw_ostream &os) {
   assert(Root);
   auto Opts = Root->getSDKContext().getOpts();
   if (Opts.Verbose)
     llvm::errs() << "Dumping SDK...\n";
-  SwiftDeclCollector::serialize(OutputFile, Root, load);
-  if (Opts.Verbose)
-    llvm::errs() << "Dumped to "<< OutputFile << "\n";
+  SwiftDeclCollector::serialize(os, Root, load);
 }
 
-void swift::ide::api::dumpSDKRoot(SDKNodeRoot *Root, StringRef OutputFile) {
-  dumpSDKRoot(Root, PayLoad(), OutputFile);
+void swift::ide::api::dumpSDKRoot(SDKNodeRoot *Root, llvm::raw_ostream &os) {
+  dumpSDKRoot(Root, PayLoad(), os);
 }
 
 int swift::ide::api::dumpSDKContent(const CompilerInvocation &InitInvoke,
                                     const llvm::StringSet<> &ModuleNames,
-                                    StringRef OutputFile, CheckerOptions Opts) {
+                                    llvm::raw_ostream &os, CheckerOptions Opts) {
   SDKContext SDKCtx(Opts);
   SDKNodeRoot *Root = getSDKNodeRoot(SDKCtx, InitInvoke, ModuleNames);
   if (!Root)
     return 1;
-  dumpSDKRoot(Root, OutputFile);
+  dumpSDKRoot(Root, os);
   return 0;
 }
 
@@ -2589,11 +2586,11 @@ int swift::ide::api::deserializeSDKDump(StringRef dumpPath, StringRef OutputPath
 
   SwiftDeclCollector Collector(Ctx);
   Collector.deSerialize(dumpPath);
-  Collector.serialize(OutputPath);
+  Collector.serialize(FS);
   return 0;
 }
 
-void swift::ide::api::dumpModuleContent(ModuleDecl *MD, StringRef OutputFile,
+void swift::ide::api::dumpModuleContent(ModuleDecl *MD, llvm::raw_ostream &os,
                                         bool ABI, bool Empty) {
   CheckerOptions opts;
   opts.ABI = ABI;
@@ -2610,7 +2607,7 @@ void swift::ide::api::dumpModuleContent(ModuleDecl *MD, StringRef OutputFile,
   PayLoad payload;
   SWIFT_DEFER {
     payload.allContsValues = &extractor.getAllConstValues();
-    dumpSDKRoot(collector.getSDKRoot(), payload, OutputFile);
+    dumpSDKRoot(collector.getSDKRoot(), payload, os);
   };
   if (Empty) {
     return;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -72,6 +72,8 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/VirtualOutputBackend.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 #include <algorithm>
 #include <memory>
 #include <queue>
@@ -635,6 +637,7 @@ ASTContext *ASTContext::get(
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend,
     std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback) {
   // If more than two data structures are concatentated, then the aggregate
   // size math needs to become more complicated due to per-struct alignment
@@ -646,9 +649,10 @@ ASTContext *ASTContext::get(
   impl = reinterpret_cast<void *>(
       llvm::alignAddr(impl, llvm::Align(alignof(Implementation))));
   new (impl) Implementation();
-  return new (mem) ASTContext(langOpts, typecheckOpts, silOpts, SearchPathOpts,
-                              ClangImporterOpts, SymbolGraphOpts, SourceMgr,
-                              Diags, PreModuleImportCallback);
+  return new (mem)
+      ASTContext(langOpts, typecheckOpts, silOpts, SearchPathOpts,
+                 ClangImporterOpts, SymbolGraphOpts, SourceMgr, Diags,
+                 std::move(OutputBackend), PreModuleImportCallback);
 }
 
 ASTContext::ASTContext(
@@ -657,17 +661,19 @@ ASTContext::ASTContext(
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend,
     std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback)
     : LangOpts(langOpts), TypeCheckerOpts(typecheckOpts), SILOpts(silOpts),
       SearchPathOpts(SearchPathOpts), ClangImporterOpts(ClangImporterOpts),
       SymbolGraphOpts(SymbolGraphOpts), SourceMgr(SourceMgr), Diags(Diags),
-      evaluator(Diags, langOpts), TheBuiltinModule(createBuiltinModule(*this)),
+      OutputBackend(std::move(OutBackend)), evaluator(Diags, langOpts),
+      TheBuiltinModule(createBuiltinModule(*this)),
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
       PreModuleImportCallback(PreModuleImportCallback),
       TheErrorType(new (*this, AllocationArena::Permanent) ErrorType(
           *this, Type(), RecursiveTypeProperties::HasError)),
-      TheUnresolvedType(new (*this, AllocationArena::Permanent)
+      TheUnresolvedType(new(*this, AllocationArena::Permanent)
                             UnresolvedType(*this)),
       TheEmptyTupleType(TupleType::get(ArrayRef<TupleTypeElt>(), *this)),
       TheEmptyPackType(PackType::get(*this, {})),
@@ -707,6 +713,9 @@ ASTContext::ASTContext(
   registerNameLookupRequestFunctions(evaluator);
 
   createModuleToExecutablePluginMap();
+  // Provide a default OnDiskOutputBackend if user didn't supply one.
+  if (!OutputBackend)
+    OutputBackend = llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>();
 }
 
 ASTContext::~ASTContext() {

--- a/lib/AST/AbstractSourceFileDepGraphFactory.cpp
+++ b/lib/AST/AbstractSourceFileDepGraphFactory.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/YAMLParser.h"
 
 using namespace swift;
@@ -33,13 +34,13 @@ using namespace fine_grained_dependencies;
 //==============================================================================
 
 AbstractSourceFileDepGraphFactory::AbstractSourceFileDepGraphFactory(
-    bool hadCompilationError, StringRef swiftDeps,
-    Fingerprint fileFingerprint, bool emitDotFileAfterConstruction,
-    DiagnosticEngine &diags)
+    bool hadCompilationError, StringRef swiftDeps, Fingerprint fileFingerprint,
+    bool emitDotFileAfterConstruction, DiagnosticEngine &diags,
+    llvm::vfs::OutputBackend &backend)
     : hadCompilationError(hadCompilationError), swiftDeps(swiftDeps.str()),
       fileFingerprint(fileFingerprint),
-      emitDotFileAfterConstruction(emitDotFileAfterConstruction), diags(diags) {
-}
+      emitDotFileAfterConstruction(emitDotFileAfterConstruction), diags(diags),
+      backend(backend) {}
 
 SourceFileDepGraph AbstractSourceFileDepGraphFactory::construct() {
   addSourceFileNodesToGraph();
@@ -49,7 +50,7 @@ SourceFileDepGraph AbstractSourceFileDepGraphFactory::construct() {
   }
   assert(g.verify());
   if (emitDotFileAfterConstruction)
-    g.emitDotFile(swiftDeps, diags);
+    g.emitDotFile(backend, swiftDeps, diags);
   return std::move(g);
 }
 

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -373,11 +373,13 @@ void SourceFileDepGraph::verifySame(const SourceFileDepGraph &other) const {
 #endif
 }
 
-void SourceFileDepGraph::emitDotFile(StringRef outputPath,
+void SourceFileDepGraph::emitDotFile(llvm::vfs::OutputBackend &outputBackend,
+                                     StringRef outputPath,
                                      DiagnosticEngine &diags) {
   std::string dotFileName = outputPath.str() + ".dot";
-  withOutputFile(diags, dotFileName, [&](llvm::raw_pwrite_stream &out) {
-    DotFileEmitter<SourceFileDepGraph>(out, *this, false, false).emit();
-    return false;
-  });
+  withOutputPath(
+      diags, outputBackend, dotFileName, [&](llvm::raw_pwrite_stream &out) {
+        DotFileEmitter<SourceFileDepGraph>(out, *this, false, false).emit();
+        return false;
+      });
 }

--- a/lib/AST/FineGrainedDependencyFormat.cpp
+++ b/lib/AST/FineGrainedDependencyFormat.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Bitstream/BitstreamWriter.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 
 using namespace swift;
 using namespace fine_grained_dependencies;
@@ -498,10 +499,10 @@ void swift::fine_grained_dependencies::writeFineGrainedDependencyGraph(
 }
 
 bool swift::fine_grained_dependencies::writeFineGrainedDependencyGraphToPath(
-    DiagnosticEngine &diags, StringRef path,
+    DiagnosticEngine &diags, llvm::vfs::OutputBackend &backend, StringRef path,
     const SourceFileDepGraph &g) {
   PrettyStackTraceStringAction stackTrace("saving fine-grained dependency graph", path);
-  return withOutputFile(diags, path, [&](llvm::raw_ostream &out) {
+  return withOutputPath(diags, backend, path, [&](llvm::raw_ostream &out) {
     SmallVector<char, 0> Buffer;
     llvm::BitstreamWriter Writer{Buffer};
     writeFineGrainedDependencyGraph(Writer, g, Purpose::ForSwiftDeps);

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -43,6 +43,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/YAMLParser.h"
 
 using namespace swift;
@@ -232,18 +233,19 @@ StringRef DependencyKey::Builder::getTopLevelName(const Decl *decl) {
 
 bool fine_grained_dependencies::withReferenceDependencies(
     llvm::PointerUnion<const ModuleDecl *, const SourceFile *> MSF,
-    const DependencyTracker &depTracker, StringRef outputPath,
-    bool alsoEmitDotFile,
+    const DependencyTracker &depTracker, llvm::vfs::OutputBackend &backend,
+    StringRef outputPath, bool alsoEmitDotFile,
     llvm::function_ref<bool(SourceFileDepGraph &&)> cont) {
   if (auto *MD = MSF.dyn_cast<const ModuleDecl *>()) {
     SourceFileDepGraph g =
-        ModuleDepGraphFactory(MD, alsoEmitDotFile).construct();
+        ModuleDepGraphFactory(backend, MD, alsoEmitDotFile).construct();
     return cont(std::move(g));
   } else {
     auto *SF = MSF.get<const SourceFile *>();
-    SourceFileDepGraph g = FrontendSourceFileDepGraphFactory(
-                               SF, outputPath, depTracker, alsoEmitDotFile)
-                               .construct();
+    SourceFileDepGraph g =
+        FrontendSourceFileDepGraphFactory(SF, backend, outputPath, depTracker,
+                                          alsoEmitDotFile)
+            .construct();
     return cont(std::move(g));
   }
 }
@@ -253,11 +255,12 @@ bool fine_grained_dependencies::withReferenceDependencies(
 //==============================================================================
 
 FrontendSourceFileDepGraphFactory::FrontendSourceFileDepGraphFactory(
-    const SourceFile *SF, StringRef outputPath,
-    const DependencyTracker &depTracker, const bool alsoEmitDotFile)
+    const SourceFile *SF, llvm::vfs::OutputBackend &backend,
+    StringRef outputPath, const DependencyTracker &depTracker,
+    const bool alsoEmitDotFile)
     : AbstractSourceFileDepGraphFactory(
           SF->getASTContext().hadError(), outputPath, SF->getInterfaceHash(),
-          alsoEmitDotFile, SF->getASTContext().Diags),
+          alsoEmitDotFile, SF->getASTContext().Diags, backend),
       SF(SF), depTracker(depTracker) {}
 
 //==============================================================================
@@ -577,11 +580,12 @@ void FrontendSourceFileDepGraphFactory::addAllUsedDecls() {
 // MARK: ModuleDepGraphFactory
 //==============================================================================
 
-ModuleDepGraphFactory::ModuleDepGraphFactory(const ModuleDecl *Mod,
+ModuleDepGraphFactory::ModuleDepGraphFactory(llvm::vfs::OutputBackend &backend,
+                                             const ModuleDecl *Mod,
                                              bool emitDot)
     : AbstractSourceFileDepGraphFactory(
           Mod->getASTContext().hadError(), Mod->getNameStr(),
-          Mod->getFingerprint(), emitDot, Mod->getASTContext().Diags),
+          Mod->getFingerprint(), emitDot, Mod->getASTContext().Diags, backend),
       Mod(Mod) {}
 
 void ModuleDepGraphFactory::addAllDefinedDecls() {

--- a/lib/AST/FrontendSourceFileDepGraphFactory.h
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.h
@@ -14,6 +14,7 @@
 #define FrontendSourceFileDepGraphFactory_h
 
 #include "swift/AST/AbstractSourceFileDepGraphFactory.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 namespace swift {
 namespace fine_grained_dependencies {
 
@@ -27,7 +28,9 @@ class FrontendSourceFileDepGraphFactory
   const DependencyTracker &depTracker;
 
 public:
-  FrontendSourceFileDepGraphFactory(const SourceFile *SF, StringRef outputPath,
+  FrontendSourceFileDepGraphFactory(const SourceFile *SF,
+                                    llvm::vfs::OutputBackend &backend,
+                                    StringRef outputPath,
                                     const DependencyTracker &depTracker,
                                     bool alsoEmitDotFile);
 
@@ -42,7 +45,8 @@ class ModuleDepGraphFactory : public AbstractSourceFileDepGraphFactory {
   const ModuleDecl *Mod;
 
 public:
-  ModuleDepGraphFactory(const ModuleDecl *Mod, bool emitDot);
+  ModuleDepGraphFactory(llvm::vfs::OutputBackend &backend,
+                        const ModuleDecl *Mod, bool emitDot);
 
   ~ModuleDepGraphFactory() override = default;
 

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -20,6 +20,7 @@
 #include "swift/DependencyScan/DependencyScanImpl.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 
 #include <sstream>
 
@@ -187,8 +188,9 @@ void DependencyScanningTool::serializeCache(llvm::StringRef path) {
   SourceManager SM;
   DiagnosticEngine Diags(SM);
   Diags.addConsumer(CDC);
+  llvm::vfs::OnDiskOutputBackend Backend;
   module_dependency_cache_serialization::writeInterModuleDependenciesCache(
-      Diags, path, *ScanningService);
+      Diags, Backend, path, *ScanningService);
 }
 
 bool DependencyScanningTool::loadCache(llvm::StringRef path) {

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -16,6 +16,7 @@
 #include "swift/Basic/Version.h"
 #include "swift/DependencyScan/SerializedModuleDependencyCacheFormat.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include <unordered_map>
 
 using namespace swift;
@@ -1146,11 +1147,11 @@ void swift::dependencies::module_dependency_cache_serialization::
 
 bool swift::dependencies::module_dependency_cache_serialization::
     writeInterModuleDependenciesCache(
-        DiagnosticEngine &diags, StringRef path,
-        const SwiftDependencyScanningService &cache) {
+        DiagnosticEngine &diags, llvm::vfs::OutputBackend &backend,
+        StringRef path, const SwiftDependencyScanningService &cache) {
   PrettyStackTraceStringAction stackTrace(
       "saving inter-module dependency graph", path);
-  return withOutputFile(diags, path, [&](llvm::raw_ostream &out) {
+  return withOutputPath(diags, backend, path, [&](llvm::raw_ostream &out) {
     SmallVector<char, 0> Buffer;
     llvm::BitstreamWriter Writer{Buffer};
     writeInterModuleDependenciesCache(Writer, cache);

--- a/lib/Driver/FineGrainedDependencyDriverGraph.cpp
+++ b/lib/Driver/FineGrainedDependencyDriverGraph.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/raw_ostream.h"
 #include <unordered_set>
@@ -529,11 +530,12 @@ void ModuleDepGraph::emitDotFileForJob(DiagnosticEngine &diags,
   emitDotFile(diags, getSwiftDeps(job));
 }
 
-void ModuleDepGraph::emitDotFile(DiagnosticEngine &diags, StringRef baseName) {
+void ModuleDepGraph::emitDotFile(DiagnosticEngine &diags,
+                                 StringRef baseName) {
   unsigned seqNo = dotFileSequenceNumber[baseName.str()]++;
   std::string fullName =
       baseName.str() + "-post-integration." + std::to_string(seqNo) + ".dot";
-  withOutputFile(diags, fullName, [&](llvm::raw_ostream &out) {
+  withOutputPath(diags, *backend, fullName, [&](llvm::raw_ostream &out) {
     emitDotFile(out);
     return false;
   });

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -28,6 +28,7 @@
 #include "swift/Subsystems.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/Option.h"
@@ -35,6 +36,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 
 using namespace llvm::opt;
 using namespace swift;
@@ -183,7 +185,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   LangOpts.Target = Invocation.getTargetTriple();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
-      SymbolGraphOpts, SrcMgr, Instance.getDiags());
+      SymbolGraphOpts, SrcMgr, Instance.getDiags(),
+      llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
   

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -36,6 +36,9 @@
 #include "swift/IDE/APIDigesterData.h"
 #include "swift/Option/Options.h"
 #include "swift/Parse/ParseVersion.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/VirtualOutputBackends.h"
+#include "llvm/Support/raw_ostream.h"
 #include <functional>
 
 using namespace swift;
@@ -2536,13 +2539,18 @@ public:
     switch (Action) {
     case ActionType::DumpSDK: {
       llvm::StringSet<> Modules;
-      return (prepareForDump(InitInvoke, Modules))
-                 ? 1
-                 : dumpSDKContent(InitInvoke, Modules,
-                                  getJsonOutputFilePath(
-                                      InitInvoke.getLangOptions().Target,
-                                      CheckerOpts.ABI, OutputFile, OutputDir),
-                                  CheckerOpts);
+      if (prepareForDump(InitInvoke, Modules))
+        return 1;
+      auto JsonOut =
+          getJsonOutputFilePath(InitInvoke.getLangOptions().Target,
+                                CheckerOpts.ABI, OutputFile, OutputDir);
+      std::error_code EC;
+      llvm::raw_fd_ostream fs(JsonOut, EC);
+      if (EC) {
+        llvm::errs() << "Cannot open JSON output file: " << JsonOut << "\n";
+        return 1;
+      }
+      return dumpSDKContent(InitInvoke, Modules, fs, CheckerOpts);
     }
     case ActionType::MigratorGen:
     case ActionType::DiagnoseSDKs: {
@@ -2606,7 +2614,13 @@ public:
     }
     case ActionType::GenerateEmptyBaseline: {
       SDKContext Ctx(CheckerOpts);
-      dumpSDKRoot(getEmptySDKNodeRoot(Ctx), OutputFile);
+      std::error_code EC;
+      llvm::raw_fd_ostream fs(OutputFile, EC);
+      if (EC) {
+        llvm::errs() << "Cannot open output file: " << OutputFile << "\n";
+        return 1;
+      }
+      dumpSDKRoot(getEmptySDKNodeRoot(Ctx), fs);
       return 0;
     }
     case ActionType::FindUsr: {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -350,6 +350,7 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.serializedPathObfuscator.addMapping(SplitMap.first, SplitMap.second);
   }
   Opts.emptyABIDescriptor = Args.hasArg(OPT_empty_abi_descriptor);
+  Opts.DeterministicCheck = Args.hasArg(OPT_enable_deterministic_check);
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2377,6 +2377,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.UseProfile = ProfileUse ? ProfileUse->getValue() : "";
 
   Opts.PrintInlineTree |= Args.hasArg(OPT_print_llvm_inline_tree);
+  Opts.AlwaysCompile |= Args.hasArg(OPT_always_compile_output_files);
 
   Opts.EnableDynamicReplacementChaining |=
       Args.hasArg(OPT_enable_dynamic_replacement_chaining);

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -190,7 +190,8 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
   if (Instance.getASTContext()
           .getModuleInterfaceChecker()
           ->tryEmitForwardingModule(Invocation.getModuleName(), InterfacePath,
-                                    CompiledCandidates, OutputPath)) {
+                                    CompiledCandidates,
+                                    Instance.getOutputBackend(), OutputPath)) {
     return std::error_code();
   }
   FrontendOptions &FEOpts = Invocation.getFrontendOptions();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/xxhash.h"
@@ -901,8 +902,8 @@ class ModuleInterfaceLoaderImpl {
   /// this. If the write was successful, it also updates the
   /// list of dependencies to match what was written to the forwarding file.
   bool writeForwardingModuleAndUpdateDeps(
-      const DiscoveredModule &mod, StringRef outputPath,
-      SmallVectorImpl<FileDependency> &deps) {
+      const DiscoveredModule &mod, llvm::vfs::OutputBackend &backend,
+      StringRef outputPath, SmallVectorImpl<FileDependency> &deps) {
     assert(mod.isPrebuilt() &&
            "cannot write forwarding file for non-prebuilt module");
     ForwardingModule fwd(mod.path);
@@ -938,16 +939,12 @@ class ModuleInterfaceLoaderImpl {
       depsAdjustedToMTime.push_back(adjustedDep);
     }
 
-    // Create the module cache if we haven't created it yet.
-    StringRef parentDir = path::parent_path(outputPath);
-    (void)llvm::sys::fs::create_directories(parentDir);
-
-    auto hadError = withOutputFile(diags, outputPath,
-      [&](llvm::raw_pwrite_stream &out) {
-        llvm::yaml::Output yamlWriter(out);
-        yamlWriter << fwd;
-        return false;
-      });
+    auto hadError = withOutputPath(diags, backend, outputPath,
+                                      [&](llvm::raw_pwrite_stream &out) {
+                                        llvm::yaml::Output yamlWriter(out);
+                                        yamlWriter << fwd;
+                                        return false;
+                                      });
 
     if (hadError)
       return true;
@@ -1006,8 +1003,8 @@ class ModuleInterfaceLoaderImpl {
       // If it's prebuilt, use this time to generate a forwarding module and
       // update the dependencies to use modification times.
       if (module.isPrebuilt())
-        if (writeForwardingModuleAndUpdateDeps(module, cachedOutputPath,
-                                               allDeps))
+        if (writeForwardingModuleAndUpdateDeps(module, ctx.getOutputBackend(),
+                                               cachedOutputPath, allDeps))
           return std::make_error_code(std::errc::not_supported);
 
       // Report the module's dependencies to the dependencyTracker
@@ -1251,7 +1248,8 @@ ModuleInterfaceCheckerImpl::getCompiledModuleCandidatesForInterface(StringRef mo
 
 bool ModuleInterfaceCheckerImpl::tryEmitForwardingModule(
     StringRef moduleName, StringRef interfacePath,
-    ArrayRef<std::string> candidates, StringRef outputPath) {
+    ArrayRef<std::string> candidates, llvm::vfs::OutputBackend &backend,
+    StringRef outputPath) {
   // Derive .swiftmodule path from the .swiftinterface path.
   auto newExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
   llvm::SmallString<32> modulePath = interfacePath;
@@ -1269,12 +1267,12 @@ bool ModuleInterfaceCheckerImpl::tryEmitForwardingModule(
                                                    deps, moduleBuffer)) {
       // If so, emit a forwarding module to the candidate.
       ForwardingModule FM(mod);
-      auto hadError = withOutputFile(Ctx.Diags, outputPath,
-        [&](llvm::raw_pwrite_stream &out) {
-          llvm::yaml::Output yamlWriter(out);
-          yamlWriter << FM;
-          return false;
-        });
+      auto hadError = withOutputPath(Ctx.Diags, backend, outputPath,
+                                        [&](llvm::raw_pwrite_stream &out) {
+                                          llvm::yaml::Output yamlWriter(out);
+                                          yamlWriter << FM;
+                                          return false;
+                                        });
       if (!hadError)
         return true;
     }
@@ -1402,19 +1400,25 @@ bool ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
     ArrayRef<std::string> CompiledCandidates,
     DependencyTracker *tracker) {
   
-  // First, check if the expected output already exists and possibly up-to-date w.r.t.
-  // all of the dependencies it was built with. If so, early exit.
-  UpToDateModuleCheker checker(Instance.getASTContext(),
-                               RequireOSSAModules_t(Instance.getSILOptions()));
-  ModuleRebuildInfo rebuildInfo;
-  SmallVector<FileDependency, 3> allDeps;
-  std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
-  if (checker.swiftModuleIsUpToDate(outputPath, rebuildInfo, allDeps, moduleBuffer)) {
-    if (Instance.getASTContext().LangOpts.EnableSkipExplicitInterfaceModuleBuildRemarks) {
-      Instance.getDiags().diagnose(SourceLoc(),
-                                   diag::explicit_interface_build_skipped, outputPath);
+  if (!Instance.getInvocation().getIRGenOptions().AlwaysCompile) {
+    // First, check if the expected output already exists and possibly
+    // up-to-date w.r.t. all of the dependencies it was built with. If so, early
+    // exit.
+    UpToDateModuleCheker checker(
+        Instance.getASTContext(),
+        RequireOSSAModules_t(Instance.getSILOptions()));
+    ModuleRebuildInfo rebuildInfo;
+    SmallVector<FileDependency, 3> allDeps;
+    std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
+    if (checker.swiftModuleIsUpToDate(outputPath, rebuildInfo, allDeps,
+                                      moduleBuffer)) {
+      if (Instance.getASTContext()
+              .LangOpts.EnableSkipExplicitInterfaceModuleBuildRemarks) {
+        Instance.getDiags().diagnose(
+            SourceLoc(), diag::explicit_interface_build_skipped, outputPath);
+      }
+      return false;
     }
-    return false;
   }
   
   // Read out the compiler version.

--- a/lib/FrontendTool/Dependencies.h
+++ b/lib/FrontendTool/Dependencies.h
@@ -13,6 +13,12 @@
 #ifndef SWIFT_FRONTENDTOOL_DEPENDENCIES_H
 #define SWIFT_FRONTENDTOOL_DEPENDENCIES_H
 
+namespace llvm {
+namespace vfs {
+class OutputBackend;
+}
+} // namespace llvm
+
 namespace swift {
 
 class ASTContext;
@@ -23,11 +29,13 @@ class InputFile;
 class ModuleDecl;
 
 /// Emit the names of the modules imported by \c mainModule.
-bool emitImportedModules(ModuleDecl *mainModule, const FrontendOptions &opts);
+bool emitImportedModules(ModuleDecl *mainModule, const FrontendOptions &opts,
+                         llvm::vfs::OutputBackend &backend);
 bool emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
                                   DependencyTracker *depTracker,
                                   const FrontendOptions &opts,
-                                  const InputFile &input);
+                                  const InputFile &input,
+                                  llvm::vfs::OutputBackend &backend);
 bool emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
                                    DependencyTracker *depTracker,
                                    const FrontendOptions &opts,

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 
 using namespace swift;
 
@@ -43,16 +44,15 @@ static void findAllClangImports(const clang::Module *module,
 }
 
 bool swift::emitImportedModules(ModuleDecl *mainModule,
-                                const FrontendOptions &opts) {
+                                const FrontendOptions &opts,
+                                llvm::vfs::OutputBackend &backend) {
   auto &Context = mainModule->getASTContext();
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
-  std::error_code EC;
-  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::OF_None);
-
-  if (out.has_error() || EC) {
-    Context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,
-                           EC.message());
-    out.clear_error();
+  auto &diags = Context.Diags;
+  auto out = backend.createFile(path);
+  if (!out) {
+    diags.diagnose(SourceLoc(), diag::error_opening_output,
+                   path, toString(out.takeError()));
     return true;
   }
 
@@ -110,7 +110,13 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
   }
 
   for (auto name : Modules) {
-    out << name << "\n";
+    *out << name << "\n";
+  }
+
+  if (auto error = out->keep()) {
+    diags.diagnose(SourceLoc(), diag::error_closing_output,
+                   path, toString(std::move(error)));
+    return true;
   }
 
   return false;

--- a/lib/FrontendTool/MakeStyleDependencies.cpp
+++ b/lib/FrontendTool/MakeStyleDependencies.cpp
@@ -20,6 +20,7 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 
 using namespace swift;
 
@@ -91,18 +92,16 @@ reversePathSortedFilenames(const Container &elts) {
 bool swift::emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
                                          DependencyTracker *depTracker,
                                          const FrontendOptions &opts,
-                                         const InputFile &input) {
+                                         const InputFile &input,
+                                         llvm::vfs::OutputBackend &backend) {
   auto dependenciesFilePath = input.getDependenciesFilePath();
   if (dependenciesFilePath.empty())
     return false;
 
-  std::error_code EC;
-  llvm::raw_fd_ostream out(dependenciesFilePath, EC, llvm::sys::fs::OF_None);
-
-  if (out.has_error() || EC) {
+  auto out = backend.createFile(dependenciesFilePath);
+  if (!out) {
     diags.diagnose(SourceLoc(), diag::error_opening_output,
-                   dependenciesFilePath, EC.message());
-    out.clear_error();
+                   dependenciesFilePath, toString(out.takeError()));
     return true;
   }
 
@@ -138,8 +137,14 @@ bool swift::emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
   // dependency line.
   opts.forAllOutputPaths(input, [&](const StringRef targetName) {
     auto targetNameEscaped = frontend::utils::escapeForMake(targetName, buffer);
-    out << targetNameEscaped << " :" << dependencyString << '\n';
+    *out << targetNameEscaped << " :" << dependencyString << '\n';
   });
+
+  if (auto error = out->keep()) {
+    diags.diagnose(SourceLoc(), diag::error_closing_output,
+                   dependenciesFilePath, toString(std::move(error)));
+    return true;
+  }
 
   return false;
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -46,6 +46,7 @@
 #include "swift/Subsystems.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
@@ -74,6 +75,8 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualOutputBackend.h"
+#include "llvm/Support/VirtualOutputConfig.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
@@ -534,6 +537,7 @@ bool swift::performLLVM(const IRGenOptions &Opts,
                         llvm::Module *Module,
                         llvm::TargetMachine *TargetMachine,
                         StringRef OutputFilename,
+                        llvm::vfs::OutputBackend &Backend,
                         UnifiedStatsReporter *Stats) {
 
   if (Opts.UseIncrementalLLVMCodeGen && HashGlobal) {
@@ -552,7 +556,7 @@ bool swift::performLLVM(const IRGenOptions &Opts,
     ArrayRef<uint8_t> HashData(reinterpret_cast<uint8_t *>(&hash),
                                sizeof(hash));
     if (Opts.OutputKind == IRGenOutputKind::ObjectFile &&
-        !Opts.PrintInlineTree &&
+        !Opts.PrintInlineTree && !Opts.AlwaysCompile &&
         !needsRecompile(OutputFilename, HashData, HashGlobal, DiagMutex)) {
       // The llvm IR did not change. We don't need to re-create the object file.
       return false;
@@ -564,23 +568,28 @@ bool swift::performLLVM(const IRGenOptions &Opts,
     HashGlobal->setInitializer(HashConstant);
   }
 
-  Optional<raw_fd_ostream> RawOS;
+  llvm::Optional<llvm::vfs::OutputFile> OutputFile;
+  SWIFT_DEFER {
+    if (!OutputFile)
+      return;
+    if (auto E = OutputFile->keep()) {
+      diagnoseSync(Diags, DiagMutex, SourceLoc(), diag::error_closing_output,
+                   OutputFilename, toString(std::move(E)));
+    }
+  };
   if (!OutputFilename.empty()) {
     // Try to open the output file.  Clobbering an existing file is fine.
     // Open in binary mode if we're doing binary output.
-    llvm::sys::fs::OpenFlags OSFlags = llvm::sys::fs::OF_None;
-    std::error_code EC;
-    RawOS.emplace(OutputFilename, EC, OSFlags);
-
-    if (RawOS->has_error() || EC) {
-      diagnoseSync(Diags, DiagMutex,
-                   SourceLoc(), diag::error_opening_output,
-                   OutputFilename, EC.message());
-      RawOS->clear_error();
+    llvm::vfs::OutputConfig Config;
+    if (auto E =
+            Backend.createFile(OutputFilename, Config).moveInto(OutputFile)) {
+      diagnoseSync(Diags, DiagMutex, SourceLoc(), diag::error_opening_output,
+                   OutputFilename, toString(std::move(E)));
       return true;
     }
+
     if (Opts.OutputKind == IRGenOutputKind::LLVMAssemblyBeforeOptimization) {
-      Module->print(RawOS.value(), nullptr);
+      Module->print(*OutputFile, nullptr);
       return false;
     }
   } else {
@@ -588,7 +597,7 @@ bool swift::performLLVM(const IRGenOptions &Opts,
   }
 
   performLLVMOptimizations(Opts, Module, TargetMachine,
-                           RawOS ? &*RawOS : nullptr);
+                           OutputFile ? &OutputFile->getOS() : nullptr);
 
   if (Stats) {
     if (DiagMutex)
@@ -598,11 +607,11 @@ bool swift::performLLVM(const IRGenOptions &Opts,
       DiagMutex->unlock();
   }
 
-  if (!RawOS)
+  if (OutputFilename.empty())
     return false;
 
-  return compileAndWriteLLVM(Module, TargetMachine, Opts, Stats, Diags, *RawOS,
-                             DiagMutex);
+  return compileAndWriteLLVM(Module, TargetMachine, Opts, Stats, Diags,
+                                    *OutputFile, DiagMutex);
 }
 
 bool swift::compileAndWriteLLVM(llvm::Module *module,
@@ -1241,7 +1250,8 @@ struct LLVMCodeGenThreads {
         embedBitcode(IGM->getModule(), parent.irgen->Opts);
         performLLVM(parent.irgen->Opts, IGM->Context.Diags, diagMutex,
                     IGM->ModuleHash, IGM->getModule(), IGM->TargetMachine.get(),
-                    IGM->OutputFilename, IGM->Context.Stats);
+                    IGM->OutputFilename, IGM->Context.getOutputBackend(),
+                    IGM->Context.Stats);
         if (IGM->Context.Diags.hadAnyError())
           return;
       }
@@ -1359,10 +1369,9 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
     if (!targetMachine) continue;
 
     // Create the IR emitter.
-    IRGenModule *IGM =
-        new IRGenModule(irgen, std::move(targetMachine), nextSF,
-                        desc.ModuleName, *OutputIter++, nextSF->getFilename(),
-                        nextSF->getPrivateDiscriminator().str());
+    IRGenModule *IGM = new IRGenModule(
+        irgen, std::move(targetMachine), nextSF, desc.ModuleName, *OutputIter++,
+        nextSF->getFilename(), nextSF->getPrivateDiscriminator().str());
     IGMcreated = true;
 
     initLLVMModule(*IGM, *SILMod);
@@ -1535,9 +1544,9 @@ GeneratedModule swift::performIRGeneration(
   const auto *SILModPtr = SILMod.get();
   const auto &SILOpts = SILModPtr->getOptions();
   auto desc = IRGenDescriptor::forWholeModule(
-      M, Opts, TBDOpts, SILOpts, SILModPtr->Types, std::move(SILMod),
-      ModuleName, PSPs, /*symsToEmit*/ None, parallelOutputFilenames,
-      outModuleHash);
+      M, Opts, TBDOpts, SILOpts, SILModPtr->Types,
+      std::move(SILMod), ModuleName, PSPs, /*symsToEmit*/ None,
+      parallelOutputFilenames, outModuleHash);
 
   if (Opts.shouldPerformIRGenerationInParallel() &&
       !parallelOutputFilenames.empty() &&
@@ -1561,15 +1570,14 @@ performIRGeneration(FileUnit *file, const IRGenOptions &Opts,
   const auto *SILModPtr = SILMod.get();
   const auto &SILOpts = SILModPtr->getOptions();
   auto desc = IRGenDescriptor::forFile(
-      file, Opts, TBDOpts, SILOpts, SILModPtr->Types, std::move(SILMod),
-      ModuleName, PSPs, PrivateDiscriminator, /*symsToEmit*/ None,
-      outModuleHash);
+      file, Opts, TBDOpts, SILOpts, SILModPtr->Types,
+      std::move(SILMod), ModuleName, PSPs, PrivateDiscriminator,
+      /*symsToEmit*/ None, outModuleHash);
   return llvm::cantFail(file->getASTContext().evaluator(IRGenRequest{desc}));
 }
 
-void
-swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
-                                   StringRef OutputPath) {
+void swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
+                                        StringRef OutputPath) {
   auto &Ctx = SILMod.getASTContext();
   assert(!Ctx.hadError());
 
@@ -1620,7 +1628,7 @@ swift::createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,
   ASTSym->setAlignment(llvm::MaybeAlign(serialization::SWIFTMODULE_ALIGNMENT));
   ::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, IGM.getModule(),
                 IGM.TargetMachine.get(),
-                OutputPath, Ctx.Stats);
+                OutputPath, Ctx.getOutputBackend(), Ctx.Stats);
 }
 
 bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
@@ -1636,8 +1644,8 @@ bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
 
   embedBitcode(Module, Opts);
   if (::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, Module,
-                    TargetMachine.get(),
-                    OutputFilename, Ctx.Stats))
+                    TargetMachine.get(), OutputFilename, Ctx.getOutputBackend(),
+                    Ctx.Stats))
     return true;
   return false;
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2034,7 +2034,6 @@ bool swift::writeEmptyOutputFilesFor(
   const ASTContext &Context,
   std::vector<std::string>& ParallelOutputFilenames,
   const IRGenOptions &IRGenOpts) {
-
   for (auto fileName : ParallelOutputFilenames) {
     // The first output file, was use for genuine output.
     if (fileName == ParallelOutputFilenames[0])

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -248,7 +248,8 @@ int swift::RunImmediately(CompilerInstance &CI,
 
   performLLVM(IRGenOpts, Context.Diags, /*diagMutex*/ nullptr, /*hash*/ nullptr,
               GenModule.getModule(), GenModule.getTargetMachine(),
-              PSPs.OutputFilename, Context.Stats);
+              PSPs.OutputFilename, CI.getOutputBackend(),
+              Context.Stats);
 
   if (Context.hadError())
     return -1;

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -40,11 +40,13 @@ int serializeSymbolGraph(SymbolGraph &SG,
   SmallString<1024> OutputPath(Options.OutputDir);
   llvm::sys::path::append(OutputPath, FileName);
 
-  return withOutputFile(SG.M.getASTContext().Diags, OutputPath, [&](raw_ostream &OS) {
-    llvm::json::OStream J(OS, Options.PrettyPrint ? 2 : 0);
-    SG.serialize(J);
-    return false;
-  });
+  return withOutputPath(
+      SG.M.getASTContext().Diags, SG.M.getASTContext().getOutputBackend(),
+      OutputPath, [&](raw_ostream &OS) {
+        llvm::json::OStream J(OS, Options.PrettyPrint ? 2 : 0);
+        SG.serialize(J);
+        return false;
+      });
 }
 
 } // end anonymous namespace

--- a/test/Frontend/output_determinism_check.swift
+++ b/test/Frontend/output_determinism_check.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name test -emit-module -o %t/test.swiftmodule -primary-file %s  -emit-module-doc-path %t/test.docc -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=MODULE_OUTPUT --check-prefix=DOCC_OUTPUT
+// RUN: %target-swift-frontend -module-name test -emit-sib -o %t/test.sib -primary-file %s -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=SIB_OUTPUT
+
+/// object files are "not" deterministic because the second run going to match the mod hash and skip code generation.
+// RUN: not %target-swift-frontend -module-name test -c -o %t/test.o -primary-file %s -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=OBJECT_MISMATCH
+/// object files should match when forcing object generation.
+// RUN: %target-swift-frontend -module-name test -emit-dependencies -c -o %t/test.o -primary-file %s -enable-deterministic-check -always-compile-output-files 2>&1 | %FileCheck %s --check-prefix=OBJECT_OUTPUT --check-prefix=DEPS_OUTPUT
+
+/// FIXME: Fine-grain dependencies graph is not deterministics.
+/// FAIL:  %target-swift-frontend -module-name test -emit-reference-dependencies-path %t/test.swiftdeps -c -o %t/test.o -primary-file %s -enable-deterministic-check -always-compile-output-files
+
+/// Explicit module build. Check building swiftmodule from interface file.
+// RUN: %target-swift-frontend -scan-dependencies -module-name test -o %t/test.json %s -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=DEPSCAN_OUTPUT
+/// TODO: Implicit module build use a different compiler instance so it doesn't support checking yet.
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/test.swiftinterface %s -O -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=INTERFACE_OUTPUT
+/// Hit cache and not emit the second time.
+// RUN: rm %t/test.swiftmodule
+// RUN: not %target-swift-frontend -compile-module-from-interface %t/test.swiftinterface -explicit-interface-module-build -o %t/test.swiftmodule -enable-deterministic-check 2>&1 | %FileCheck --check-prefix=MODULE_MISMATCH %s
+/// Force swiftmodule generation.
+// RUN: %target-swift-frontend -compile-module-from-interface %t/test.swiftinterface -explicit-interface-module-build -o %t/test.swiftmodule -enable-deterministic-check -always-compile-output-files 2>&1 | %FileCheck --check-prefix=MODULE_OUTPUT %s
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name test %s -o %t/test.deps.json -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=DEPS_JSON_OUTPUT
+
+// RUN: %target-swift-frontend -emit-pcm -module-name UserClangModule -o %t/test.pcm %S/Inputs/dependencies/module.modulemap -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=PCM_OUTPUT
+
+// DOCC_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.docc'
+// MODULE_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.swiftmodule'
+// SIB_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.sib'
+// DEPS_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.d'
+// OBJECT_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.o'
+// OBJECT_MISMATCH: error: output file '{{.*}}{{/|\\}}test.o' is missing from second compilation for deterministic check
+// DEPSCAN_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.json'
+// INTERFACE_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.swiftinterface'
+// MODULE_MISMATCH: error: output file '{{.*}}{{/|\\}}test.swiftmodule' is missing from second compilation for deterministic check
+// DEPS_JSON_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.deps.json'
+// PCM_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.pcm'
+
+public var x = 1
+public func test() {}

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -34,6 +34,7 @@
 #include "swift/Serialization/SerializedSILLoader.h"
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
@@ -43,6 +44,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 #include <cstdio>
 using namespace swift;
 
@@ -181,14 +183,19 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  std::error_code EC;
-  llvm::raw_fd_ostream outStream(OutputFilename, EC, llvm::sys::fs::OF_None);
-  if (outStream.has_error() || EC) {
+  llvm::vfs::OnDiskOutputBackend Backend;
+  auto outFile = Backend.createFile(OutputFilename);
+  if (!outFile) {
     CI.getDiags().diagnose(SourceLoc(), diag::error_opening_output,
-                           OutputFilename, EC.message());
-    outStream.clear_error();
+                           OutputFilename, toString(outFile.takeError()));
     return 1;
   }
+  auto closeFile = llvm::make_scope_exit([&]() {
+    if (auto E = outFile->keep()) {
+      CI.getDiags().diagnose(SourceLoc(), diag::error_closing_output,
+                             OutputFilename, toString(std::move(E)));
+    }
+  });
 
   auto *mod = CI.getMainModule();
   assert(mod->getFiles().size() == 1);
@@ -205,20 +212,20 @@ int main(int argc, char **argv) {
           mod, Opts, TBDOpts, SILOpts, SILTypes,
           /*SILMod*/ nullptr, moduleName, PSPs);
     } else {
-      return IRGenDescriptor::forFile(mod->getFiles()[0], Opts, TBDOpts,
-                                      SILOpts, SILTypes, /*SILMod*/ nullptr,
-                                      moduleName, PSPs, /*discriminator*/ "");
+      return IRGenDescriptor::forFile(
+          mod->getFiles()[0], Opts, TBDOpts, SILOpts, SILTypes,
+          /*SILMod*/ nullptr, moduleName, PSPs, /*discriminator*/ "");
     }
   };
 
   auto &eval = CI.getASTContext().evaluator;
   auto desc = getDescriptor();
-  desc.out = &outStream;
+  desc.out = &outFile->getOS();
   auto generatedMod = llvm::cantFail(eval(OptimizedIRRequest{desc}));
   if (!generatedMod)
     return 1;
 
   return compileAndWriteLLVM(generatedMod.getModule(),
                              generatedMod.getTargetMachine(), Opts,
-                             CI.getStatsReporter(), CI.getDiags(), outStream);
+                             CI.getStatsReporter(), CI.getDiags(), *outFile);
 }

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -18,6 +18,7 @@
 #include "swift/Basic/LLVMInitialize.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 
@@ -208,6 +209,7 @@ int main(int argc, char *argv[]) {
 
   SourceManager sourceMgr;
   DiagnosticEngine diags(sourceMgr);
+  llvm::vfs::OnDiskOutputBackend outputBackend;
 
   switch (options::Action) {
   case ActionType::None: {
@@ -224,7 +226,7 @@ int main(int argc, char *argv[]) {
     }
 
     bool hadError =
-      withOutputFile(diags, options::OutputFilename,
+      withOutputPath(diags, outputBackend, options::OutputFilename,
         [&](llvm::raw_pwrite_stream &out) {
           out << "# Fine-grained v0\n";
           llvm::yaml::Output yamlWriter(out);
@@ -256,7 +258,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (writeFineGrainedDependencyGraphToPath(
-            diags, options::OutputFilename, fg)) {
+            diags, outputBackend, options::OutputFilename, fg)) {
       llvm::errs() << "Failed to write binary swiftdeps\n";
       return 1;
     }

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -7,8 +7,10 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/ReferenceDependencyKeys.h"
 #include "swift/Basic/SourceManager.h"
+#include "llvm/Support/VirtualOutputBackends.h"
 
 #include <array>
 #include <unordered_map>
@@ -48,12 +49,13 @@ mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
 
   SourceManager sm;
   DiagnosticEngine diags(sm);
+  llvm::vfs::OnDiskOutputBackend backend;
 
   auto sfdg =
       UnitTestSourceFileDepGraphFactory(
           hadCompilationError, swiftDeps, interfaceHash,
           g.emitFineGrainedDependencyDotFileAfterEveryImport,
-          dependencyDescriptions, diags)
+          dependencyDescriptions, diags, backend)
           .construct();
 
   return g.loadFromSourceFileDepGraph(cmd, sfdg, diags);

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.h
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.h
@@ -13,6 +13,7 @@
 #define UnitTestSourceFileDepGraphFactory_h
 
 #include "swift/AST/AbstractSourceFileDepGraphFactory.h"
+#include "llvm/Support/VirtualOutputBackend.h"
 
 namespace swift {
 namespace fine_grained_dependencies {
@@ -30,10 +31,10 @@ public:
       bool hadCompilationError, StringRef swiftDeps,
       Fingerprint fileFingerprint, bool emitDotFileAfterConstruction,
       const DependencyDescriptions &dependencyDescriptions,
-      DiagnosticEngine &diags)
+      DiagnosticEngine &diags, llvm::vfs::OutputBackend &backend)
       : AbstractSourceFileDepGraphFactory(
             hadCompilationError, swiftDeps, fileFingerprint,
-            emitDotFileAfterConstruction, diags),
+            emitDotFileAfterConstruction, diags, backend),
         dependencyDescriptions(dependencyDescriptions) {}
 
   ~UnitTestSourceFileDepGraphFactory() override = default;


### PR DESCRIPTION
This PR https://github.com/apple/swift/pull/63206 had a companion PR https://github.com/apple/llvm-project/pull/6112 that was required because it changed a Swift API (`ASTContext::get`). But that same LLVM containing the change is also used by `release/5.9` and the Swift API change was not cherry-picked to the `release/5.9` branch. This broke the build and made it difficult to catch-up `swift/release/5.9` in https://github.com/apple/llvm-project/pull/6619