### PR TITLE
[5.9][IRGen] Pass component generic sig when emitting key path component for external property

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -904,7 +904,8 @@ emitKeyPathComponent(IRGenModule &IGM,
                     reqt.getProtocol());
                 externalSubArgs.push_back(IGM.emitWitnessTableRefString(
                     substType, conformance,
-                    genericEnv ? genericEnv->getGenericSignature() : nullptr,
+                    genericEnv ? genericEnv->getGenericSignature() :
+                                 componentCanSig,
                     /*shouldSetLowBit*/ true));
               }
             });

--- a/validation-test/IRGen/rdar101179225.swift
+++ b/validation-test/IRGen/rdar101179225.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -c %s -o %t/main.o
+
+struct Section: Identifiable {
+    let id: Int
+    let items: [any Item]
+}
+
+protocol Item: AnyObject, Identifiable {
+}
+
+protocol P {
+}
+
+struct Iter<D, I, C>: P where D : RandomAccessCollection, I : Hashable {
+    init(_ xs: D, id: KeyPath<D.Element, I>, f: (D.Element) -> C) {}
+}
+
+struct V {
+  var s: Section
+  var p: some P {
+    Iter(s.items, id: \.id) { x in
+      ""
+    }
+  }
+}

--- a/validation-test/IRGen/rdar101179225.swift
+++ b/validation-test/IRGen/rdar101179225.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -c %s -o %t/main.o
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-ir > /dev/null
 
 struct Section: Identifiable {
     let id: Int


### PR DESCRIPTION
Cherry-picked from: https://github.com/apple/swift/pull/64871

rdar://101179225

When no generic environment was present, we passed nullptr, which is not correct when the property uses an external associated type, causing crashes in IRGen. In those cases, we have to pass the component generic sig instead.
