### PR TITLE
[🍒][cxx-interop] Allow specific getters/setters to be imported as computed properties.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3441,10 +3441,19 @@ namespace {
              });
     }
 
+    static bool hasComputedPropertyAttr(const clang::Decl *decl) {
+      return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
+               if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
+                 return swiftAttr->getAttribute() == "import_computed_property";
+               return false;
+             });
+    }
+
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
       auto method = VisitFunctionDecl(decl);
 
-      if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties) {
+      if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties ||
+          hasComputedPropertyAttr(decl)) {
         CXXMethodBridging bridgingInfo(decl);
         if (bridgingInfo.classify() == CXXMethodBridging::Kind::getter) {
           auto name = bridgingInfo.getClangName().drop_front(3);

--- a/lib/ClangImporter/bridging
+++ b/lib/ClangImporter/bridging
@@ -111,4 +111,17 @@
 #define SWIFT_CONFORMS_TO_PROTOCOL(_moduleName_protocolName) \
   __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(conforms_to:_moduleName_protocolName))))
 
+/// Specifies that a specific C++ method should be imported as a computed
+/// property. If this macro is specified on a getter, a getter will be
+/// synthesized. If this macro is specified on a setter, both a getter and
+/// setter will be synthesized.
+///
+/// For example:
+///  ```
+///    int getX() SWIFT_COMPUTED_PROPERTY;
+///  ```
+/// Will be imported as `var x: CInt {...}`.
+#define SWIFT_COMPUTED_PROPERTY \
+  __attribute__((swift_attr("import_computed_property")))
+
 #endif // SWIFT_CLANGIMPORTER_SWIFT_INTEROP_SUPPORT_H

--- a/test/Interop/Cxx/ergonomics/explicit-computed-properties.swift
+++ b/test/Interop/Cxx/ergonomics/explicit-computed-properties.swift
@@ -1,0 +1,26 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+
+#define SWIFT_COMPUTED_PROPERTY \
+  __attribute__((swift_attr("import_computed_property")))
+
+struct Record {
+  int getX() SWIFT_COMPUTED_PROPERTY { return 42; }
+};
+
+//--- test.swift
+
+// CHECK: struct Record {
+// CHECK:   init()
+// CHECK:   var x: Int32 { mutating get }
+// CHECK:   mutating func getX() -> Int32
+// CHECK: }


### PR DESCRIPTION
Picking https://github.com/apple/swift/pull/65010

…

Adds `SWIFT_COMPUTED_PROPERTY`. Refs `-cxx-interop-getters-setters-as-properties`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
