### PR TITLE
Sema: Skip storage diagnostic for `@exclusivity` in swiftinterfaces

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2962,22 +2962,27 @@ void AttributeChecker::visitOptimizeAttr(OptimizeAttr *attr) {
 
 void AttributeChecker::visitExclusivityAttr(ExclusivityAttr *attr) {
   if (auto *varDecl = dyn_cast<VarDecl>(D)) {
-    if (!varDecl->hasStorage()) {
-      diagnose(attr->getLocation(), diag::exclusivity_on_computed_property);
-      attr->setInvalid();
-      return;
+    auto *DC = D->getDeclContext();
+    auto *parentSF = DC->getParentSourceFile();
+
+    if (parentSF && parentSF->Kind != SourceFileKind::Interface) {
+      if (!varDecl->hasStorage()) {
+        diagnose(attr->getLocation(), diag::exclusivity_on_computed_property);
+        attr->setInvalid();
+        return;
+      }
     }
-  
-    if (isa<ClassDecl>(varDecl->getDeclContext()))
+
+    if (isa<ClassDecl>(DC))
       return;
-    
-    if (varDecl->getDeclContext()->isTypeContext() && !varDecl->isInstanceMember())
+
+    if (DC->isTypeContext() && !varDecl->isInstanceMember())
       return;
-    
-    if (varDecl->getDeclContext()->isModuleScopeContext())
+
+    if (DC->isModuleScopeContext())
       return;
   }
-  diagnose(attr->getLocation(), diag::exclusivity_on_wrong_decl);
+  diagnoseAndRemoveAttr(attr, diag::exclusivity_on_wrong_decl);
   attr->setInvalid();
 }
 

--- a/test/ModuleInterface/exclusivity.swift
+++ b/test/ModuleInterface/exclusivity.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name exclusivity
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name exclusivity
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// CHECK: @exclusivity(checked) public var checkedGlobalVar: Swift.Int
+@exclusivity(checked)
+public var checkedGlobalVar = 1
+
+// CHECK: @exclusivity(unchecked) public var uncheckedGlobalVar: Swift.Int
+@exclusivity(unchecked)
+public var uncheckedGlobalVar = 1
+
+// CHECK-LABEL: public struct Struct
+public struct Struct {
+  // CHECK: @exclusivity(unchecked) public static var uncheckedStaticVar: Swift.Int
+  @exclusivity(unchecked)
+  public static var uncheckedStaticVar: Int = 27
+
+  // CHECK: @exclusivity(checked) public static var checkedStaticVar: Swift.Int
+  @exclusivity(checked)
+  public static var checkedStaticVar: Int = 27
+}
+
+// CHECK-LABEL: public class Class
+public class Class {
+  // CHECK: @exclusivity(unchecked) public var uncheckedInstanceVar: Swift.Int
+  @exclusivity(unchecked)
+  public var uncheckedInstanceVar: Int = 27
+
+  // CHECK: @exclusivity(checked) public var checkedInstanceVar: Swift.Int
+  @exclusivity(checked)
+  public var checkedInstanceVar: Int = 27
+
+  // CHECK:      @exclusivity(unchecked) public var uncheckedPrivateSetInstanceVar: Swift.Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+  @exclusivity(unchecked)
+  public private(set) var uncheckedPrivateSetInstanceVar: Int = 27
+
+  // CHECK: @exclusivity(unchecked) public static var uncheckedStaticVar: Swift.Int
+  @exclusivity(unchecked)
+  public static var uncheckedStaticVar: Int = 27
+}

--- a/test/SILGen/exclusivityattr.swift
+++ b/test/SILGen/exclusivityattr.swift
@@ -23,11 +23,11 @@ public func getUncheckedVar() -> Int {
   return globalUncheckedVar
 }
 
-public class ExclusivityAttrStruct {
+public struct ExclusivityAttrStruct {
 
-// CHECK-LABEL: sil {{.*}}@$s4test21ExclusivityAttrStructC9staticVarSivsZ
+// CHECK-LABEL: sil {{.*}}@$s4test21ExclusivityAttrStructV9staticVarSivsZ
 // CHECK-ON:      begin_access [modify] [unsafe]
-// CHECK:       } // end sil function '$s4test21ExclusivityAttrStructC9staticVarSivsZ'
+// CHECK:       } // end sil function '$s4test21ExclusivityAttrStructV9staticVarSivsZ'
   @exclusivity(unchecked)
   public static var staticVar: Int = 27
 }


### PR DESCRIPTION
Relax the diagnostics for the `@exclusivity` attribute in order to avoid type checking failures for `public private(set)` properties in resilient libraries. In a `swiftinterface` it's not possible to tell reliably whether a property has
storage.

Resolves rdar://107770440