### PR TITLE
[5.9][Completion] Only provide macro completions when they are valid

### DIFF
--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -116,9 +116,7 @@ public:
 struct RequestedCachedModule {
   CodeCompletionCache::Key Key;
   const ModuleDecl *TheModule;
-  bool OnlyTypes;
-  bool OnlyPrecedenceGroups;
-  bool OnlyMacros;
+  CodeCompletionFilter Filter;
 };
 
 } // end namespace ide

--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -28,8 +28,12 @@ enum class CustomAttributeKind : uint8_t {
   ResultBuilder = 1 << 1,
   /// A type that can be used as a global actor.
   GlobalActor = 1 << 2,
-  /// A macro can be used as a custom attribute.
-  Macro = 1 << 3,
+  /// A macro that can be used on variables or subscripts.
+  VarMacro = 1 << 3,
+  /// A macro that can be used on any type context.
+  ContextMacro = 1 << 4,
+  /// A macro that can be used on any declaration.
+  DeclMacro = 1 << 5,
 };
 
 /// The expected contextual type(s) for code-completion.

--- a/lib/IDE/AfterPoundExprCompletion.cpp
+++ b/lib/IDE/AfterPoundExprCompletion.cpp
@@ -52,7 +52,7 @@ void AfterPoundExprCompletion::deliverResults(
                             /*expectsNonVoid=*/true);
     Lookup.addPoundAvailable(ParentStmtKind);
     Lookup.addObjCPoundKeywordCompletions(/*needPound=*/false);
-    Lookup.getMacroCompletions(/*needPound=*/false);
+    Lookup.getMacroCompletions(CodeCompletionMacroRole::Expression);
   }
 
   deliverCompletionResults(CompletionCtx, Lookup, DC, Consumer);

--- a/lib/IDE/CodeCompletionConsumer.cpp
+++ b/lib/IDE/CodeCompletionConsumer.cpp
@@ -37,10 +37,19 @@ static MutableArrayRef<CodeCompletionResult *> copyCodeCompletionResults(
       return false;
 
     switch (R->getAssociatedDeclKind()) {
+    case CodeCompletionDeclKind::EnumElement:
+    case CodeCompletionDeclKind::Constructor:
+    case CodeCompletionDeclKind::Destructor:
+    case CodeCompletionDeclKind::Subscript:
+    case CodeCompletionDeclKind::StaticMethod:
+    case CodeCompletionDeclKind::InstanceMethod:
     case CodeCompletionDeclKind::PrefixOperatorFunction:
     case CodeCompletionDeclKind::PostfixOperatorFunction:
     case CodeCompletionDeclKind::InfixOperatorFunction:
     case CodeCompletionDeclKind::FreeFunction:
+    case CodeCompletionDeclKind::StaticVar:
+    case CodeCompletionDeclKind::InstanceVar:
+    case CodeCompletionDeclKind::LocalVar:
     case CodeCompletionDeclKind::GlobalVar:
       return filter.contains(CodeCompletionFilterFlag::Expr);
 
@@ -60,20 +69,9 @@ static MutableArrayRef<CodeCompletionResult *> copyCodeCompletionResults(
 
     case CodeCompletionDeclKind::Macro:
       return (bool)(R->getMacroRoles() & expectedMacroRoles);
-
-    case CodeCompletionDeclKind::EnumElement:
-    case CodeCompletionDeclKind::Constructor:
-    case CodeCompletionDeclKind::Destructor:
-    case CodeCompletionDeclKind::Subscript:
-    case CodeCompletionDeclKind::StaticMethod:
-    case CodeCompletionDeclKind::InstanceMethod:
-    case CodeCompletionDeclKind::StaticVar:
-    case CodeCompletionDeclKind::InstanceVar:
-    case CodeCompletionDeclKind::LocalVar:
-      break;
     }
 
-    return false;
+    llvm_unreachable("Unhandled associated decl kind");
   };
 
   USRBasedTypeContext USRTypeContext(TypeContext, source.USRTypeArena);

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -57,9 +57,6 @@ actor MyGenericGlobalActor<T> {
   static let shared = MyGenricGlobalActor<T>()
 }
 
-@attached(member)
-macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
-
 @available(#^AVAILABILITY1^#)
 
 // NOTE: Please do not include the ", N items" after "Begin completions". The
@@ -81,7 +78,6 @@ macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 // AVAILABILITY1-NEXT: Keyword/None:                       macCatalystApplicationExtension[#Platform#]; name=macCatalystApplicationExtension
 // AVAILABILITY1-NEXT: Keyword/None:                       OpenBSD[#Platform#]; name=OpenBSD{{$}}
 // AVAILABILITY1-NEXT: Keyword/None:                       Windows[#Platform#]; name=Windows{{$}}
-// AVAILABILITY1-NEXT: End completions
 
 @available(*, #^AVAILABILITY2^#)
 
@@ -91,7 +87,6 @@ macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 // AVAILABILITY2-NEXT:        Keyword/None:                       renamed: [#Specify replacing name#]; name=renamed{{$}}
 // AVAILABILITY2-NEXT:        Keyword/None:                       introduced: [#Specify version number#]; name=introduced{{$}}
 // AVAILABILITY2-NEXT:        Keyword/None:                       deprecated: [#Specify version number#]; name=deprecated{{$}}
-// AVAILABILITY2-NEXT:        End completions
 
 @#^KEYWORD2^# func method(){}
 
@@ -119,8 +114,6 @@ macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
 // KEYWORD2-DAG:              Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
-// KEYWORD2-DAG:              Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
-// KEYWORD2:                  End completions
 
 @#^KEYWORD3^# class C {}
 
@@ -141,8 +134,6 @@ macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
 // KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
 // KEYWORD3-NEXT:             Keyword/None:                       runtimeMetadata[#Class Attribute#]; name=runtimeMetadata
-// KEYWORD3-NEXT:             Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
-// KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD3_2^#IB class C2 {}
 // Same as KEYWORD3.
@@ -161,8 +152,6 @@ macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 // KEYWORD4-NEXT:             Keyword/None:                       globalActor[#Enum Attribute#]; name=globalActor
 // KEYWORD4-NEXT:             Keyword/None:                       preconcurrency[#Enum Attribute#]; name=preconcurrency
 // KEYWORD4-NEXT:             Keyword/None:                       runtimeMetadata[#Enum Attribute#]; name=runtimeMetadata
-// KEYWORD4-NEXT:             Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
-// KEYWORD4-NEXT:             End completions
 
 @#^KEYWORD5^# struct S{}
 // KEYWORD5:                  Begin completions
@@ -177,8 +166,6 @@ macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 // KEYWORD5-NEXT:             Keyword/None:                       globalActor[#Struct Attribute#]; name=globalActor
 // KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
 // KEYWORD5-NEXT:             Keyword/None:                       runtimeMetadata[#Struct Attribute#]; name=runtimeMetadata
-// KEYWORD5-NEXT:             Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
-// KEYWORD5-NEXT:             End completions
 
 @#^ON_GLOBALVAR^# var globalVar
 // ON_GLOBALVAR-DAG: Keyword/None:                       available[#Var Attribute#]; name=available

--- a/test/IDE/complete_macros.swift
+++ b/test/IDE/complete_macros.swift
@@ -1,0 +1,172 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mods)
+// RUN: %empty-directory(%t/co-same)
+// RUN: %empty-directory(%t/co-across)
+// RUN: split-file %s %t
+
+// Completion in the current file/module
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t/co-same
+
+// Completion across modules
+// RUN: %target-swift-frontend -emit-module %t/MacroDefinitions.swift -o %t/mods/ -experimental-allow-module-with-compiler-errors
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %t/MacroUses.swift -filecheck %raw-FileCheck -completion-output-dir %t/co-across -I %t/mods -D SEPARATED
+
+//--- MacroDefinitions.swift
+@freestanding(expression)
+public macro freestandingExprIntMacro() -> Int
+
+@freestanding(expression)
+public macro freestandingExprStringMacro() -> String
+
+@freestanding(expression)
+public macro freestandingExprTMacro<T>(_ value: T) -> T
+
+@freestanding(declaration)
+public macro freestandingDeclMacro()
+
+@freestanding(codeItem)
+public macro freestandingCodeItemMacro()
+
+@attached(accessor)
+public macro AttachedAccessorMacro()
+
+@attached(member)
+public macro AttachedMemberMacro()
+
+@attached(member)
+public macro AttachedMemberMacroWithArgs(arg1: Int)
+
+@attached(memberAttribute)
+public macro AttachedMemberAttributeMacro()
+
+@attached(peer)
+public macro AttachedPeerMacro()
+
+@attached(conformance)
+public macro AttachedConformanceMacro()
+
+@freestanding(expression)
+@freestanding(declaration)
+@attached(accessor)
+@attached(member)
+@attached(memberAttribute)
+@attached(peer)
+@attached(conformance)
+public macro EverythingMacro()
+
+//--- MacroUses.swift
+#if SEPARATED
+import MacroDefinitions
+#endif
+
+@#^CLASS_ATTR?check=NOMINAL_ATTR^# class C {}
+@#^EXTRA_FILTER?check=NOMINAL_ATTR^#IB class C2 {}
+@#^ENUM_ATTR?check=NOMINAL_ATTR^# enum E {}
+@#^STRUCT_ATTR?check=NOMINAL_ATTR^# struct S{}
+// NOMINAL_ATTR-NOT: freestanding
+// NOMINAL_ATTR-NOT: AttachedAccessorMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacro[#Void#]; name=AttachedMemberMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacroWithArgs({#arg1: Int#})[#Void#]; name=AttachedMemberMacroWithArgs
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberAttributeMacro[#Void#]; name=AttachedMemberAttributeMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedConformanceMacro[#Void#]; name=AttachedConformanceMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+@#^FUNC_ATTR?check=DECL_ATTR^# func method() {}
+struct MethodAttrs {
+  @#^INIT_ATTR?check=DECL_ATTR^# init() {}
+  @#^DEINIT_ATTR?check=DECL_ATTR^# deinit{}
+  @#^METHOD_ATTR?check=DECL_ATTR^# func method() {}
+}
+// DECL_ATTR-NOT: freestanding
+// DECL_ATTR-NOT: AttachedAccessorMacro
+// DECL_ATTR-NOT: AttachedMemberMacro
+// DECL_ATTR-NOT: AttachedMemberMacroWithArgs
+// DECL_ATTR-NOT: AttachedConformanceMacro
+// DECL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// DECL_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+@#^GLOBAL_ATTR?check=VAR_ATTR^# var globalVar
+struct PropAttr {
+  @#^PROP_ATTR?check=VAR_ATTR^# var propVar
+  func localAttr() {
+    @#^LOCAL_ATTR?check=VAR_ATTR^# var localVar
+  }
+}
+// VAR_ATTR-NOT: freestanding
+// VAR_ATTR-NOT: AttachedMemberMacro
+// VAR_ATTR-NOT: AttachedMemberMacroWithArgs
+// VAR_ATTR-NOT: AttachedMemberAttributeMacro
+// VAR_ATTR-NOT: AttachedConformanceMacro
+// VAR_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedAccessorMacro[#Void#]; name=AttachedAccessorMacro
+// VAR_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// VAR_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+func paramAttr(@#^PARAM_ATTR?check=PARAM_ATTR^#) {}
+func paramAttr2(@#^PARAM2_ATTR?check=PARAM_ATTR^# arg: Int) {}
+// TODO: These should both be PARAM_ATTR
+func takeNoArgClosure(_: (Int) -> Void) {
+  takeClosure { @#^NO_ARG_CLOSURE_ATTR?check=INDEPENDENT_ATTR^# in
+    print("x")
+  }
+}
+func takeNoArgClosure(_: () -> Void) {
+  takeClosure { @#^CLOSURE_ATTR?check=INDEPENDENT_ATTR^# in
+    print("x")
+  }
+}
+// PARAM_ATTR-NOT: freestanding
+// PARAM_ATTR-NOT: AttachedAccessorMacro
+// PARAM_ATTR-NOT: AttachedMemberMacro
+// PARAM_ATTR-NOT: AttachedMemberMacroWithArgs
+// PARAM_ATTR-NOT: AttachedMemberAttributeMacro
+// PARAM_ATTR-NOT: AttachedPeerMacro
+// PARAM_ATTR-NOT: AttachedConformanceMacro
+// PARAM_ATTR-NOT: EverythingMacro
+
+##^TOP_LEVEL_FREESTANDING?check=ALL_FREESTANDING^#
+func nestedFreestanding() {
+  ##^TOP_NESTED_FREESTANDING?check=ALL_FREESTANDING^#
+}
+// ALL_FREESTANDING-NOT: Attached
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclMacro[#Void#]; name=freestandingDeclMacro
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingCodeItemMacro[#Void#]; name=freestandingCodeItemMacro
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprIntMacro[#Int#]; name=freestandingExprIntMacro
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprStringMacro[#String#]; name=freestandingExprStringMacro
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprTMacro({#(value): T#})[#T#]; name=freestandingExprTMacro(:)
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+func exprFreestanding(arg: Int) {
+  _ = arg + ##^EXPR_FREESTANDING^#
+}
+// EXPR_FREESTANDING-NOT: freestandingDeclMacro
+// EXPR_FREESTANDING-NOT: freestandingCodeItemMacro
+// EXPR_FREESTANDING-NOT: Attached
+// EXPR_FREESTANDING-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: freestandingExprIntMacro[#Int#]; name=freestandingExprIntMacro
+// EXPR_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprStringMacro[#String#]; name=freestandingExprStringMacro
+// EXPR_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprTMacro({#(value): T#})[#T#]; name=freestandingExprTMacro(:)
+// TODO: This should be invalid in both same module and across modules
+// EXPR_FREESTANDING-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+struct NestedFreestanding {
+  ##^TYPE_NESTED_FREESTANDING?check=ITEM_FREESTANDING^#
+}
+// ITEM_FREESTANDING-NOT: Attached
+// ITEM_FREESTANDING-NOT: freestandingExpr
+// ITEM_FREESTANDING-NOT: freestandingCodeItemMacro
+// ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclMacro[#Void#]; name=freestandingDeclMacro
+// ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+struct LastMember {
+  @#^LAST_MEMBER_ATTR?check=INDEPENDENT_ATTR^#
+}
+@#^INDEPENDENT?check=INDEPENDENT_ATTR^#
+// INDEPENDENT_ATTR-NOT: freestandingExprMacro
+// INDEPENDENT_ATTR-NOT: freestandingDeclMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedAccessorMacro[#Void#]; name=AttachedAccessorMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacro[#Void#]; name=AttachedMemberMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacroWithArgs({#arg1: Int#})[#Void#]; name=AttachedMemberMacroWithArgs
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberAttributeMacro[#Void#]; name=AttachedMemberAttributeMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedConformanceMacro[#Void#]; name=AttachedConformanceMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro

--- a/test/IDE/complete_pound_directive.swift
+++ b/test/IDE/complete_pound_directive.swift
@@ -14,14 +14,15 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-sourcetext -code-completion-token=CONDITION_GLOBAL_2 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-sourcetext -code-completion-token=CONDITION_GLOBAL_2 -D FOO -D BAR | %FileCheck %s -check-prefix=CONDITION -check-prefix=WITHFLAG
 
-// POUND_DIRECTIVE: Begin completions, 7 items
 // POUND_DIRECTIVE-DAG: Keyword[#sourceLocation]/None:      sourceLocation(file: {#String#}, line: {#Int#}); name=sourceLocation(file:line:); sourcetext=sourceLocation(file: <#T##String#>, line: <#T##Int#>)
-// POUND_DIRECTIVE-DAG: Keyword[#warning]/None:             warning("{#(message)#}"); name=warning(""); sourcetext=warning(\"<#T##message#>\")
-// POUND_DIRECTIVE-DAG: Keyword[#error]/None:               error("{#(message)#}"); name=error(""); sourcetext=error(\"<#T##message#>\")
 // POUND_DIRECTIVE-DAG: Keyword[#if]/None:                  if {#(condition)#}; name=if ; sourcetext=if <#T##condition#>
 // POUND_DIRECTIVE-DAG: Keyword[#elseif]/None:              elseif {#(condition)#}; name=elseif ; sourcetext=elseif <#T##condition#>
 // POUND_DIRECTIVE-DAG: Keyword[#else]/None:                else; name=else; sourcetext=else
 // POUND_DIRECTIVE-DAG: Keyword[#endif]/None:               endif; name=endif; sourcetext=endif
+// TODO: These currently do not match between when macros are enabled and when
+// they aren't. Update to macros when
+// POUND_DIRECTIVE-DAG: name=warning
+// POUND_DIRECTIVE-DAG: name=error
 
 class C {
 ##^POUND_NOMINAL_TOP^#

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -15,10 +15,9 @@ func test1() {
   let _ = useSelector(##^POUND_EXPR_3^#)
 }
 
-// POUND_EXPR_INTCONTEXT: Begin completions, 10 items
+// POUND_EXPR_INTCONTEXT-NOT: warning
+// POUND_EXPR_INTCONTEXT-NOT: error
 // POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: function[#ExpressibleByStringLiteral#]; name=function
-// POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: warning({#(message): String#})[#Void#]; name=warning(:)
-// POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: error({#(message): String#})[#Void#]; name=error(:)
 // POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: fileID[#ExpressibleByStringLiteral#]; name=fileID
 // POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: file[#ExpressibleByStringLiteral#]; name=file
 // POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: dsohandle[#UnsafeRawPointer#]; name=dsohandle
@@ -27,10 +26,9 @@ func test1() {
 // POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: externalMacro({#module: String#}, {#type: String#})[#T#]; name=externalMacro(module:type:)
 // POUND_EXPR_INTCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: filePath[#ExpressibleByStringLiteral#]; name=filePath
 
-// POUND_EXPR_STRINGCONTEXT: Begin completions, 11 items
+// POUND_EXPR_STRINGCONTEXT-NOT: warning
+// POUND_EXPR_STRINGCONTEXT-NOT: error
 // POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: function[#ExpressibleByStringLiteral#]; name=function
-// POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: warning({#(message): String#})[#Void#]; name=warning(:)
-// POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: error({#(message): String#})[#Void#]; name=error(:)
 // POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: fileID[#ExpressibleByStringLiteral#]; name=fileID
 // POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: file[#ExpressibleByStringLiteral#]; name=file
 // POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: dsohandle[#UnsafeRawPointer#]; name=dsohandle
@@ -40,10 +38,9 @@ func test1() {
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword/None/TypeRelation[Convertible]: keyPath({#@objc property sequence#})[#String#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: externalMacro({#module: String#}, {#type: String#})[#T#]; name=externalMacro(module:type:)
 
-// POUND_EXPR_SELECTORCONTEXT: Begin completions, 11 items
+// POUND_EXPR_SELECTORCONTEXT-NOT: warning
+// POUND_EXPR_SELECTORCONTEXT-NOT: error
 // POUND_EXPR_SELECTORCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: function[#ExpressibleByStringLiteral#]; name=function
-// POUND_EXPR_SELECTORCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: warning({#(message): String#})[#Void#]; name=warning(:)
-// POUND_EXPR_SELECTORCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: error({#(message): String#})[#Void#]; name=error(:)
 // POUND_EXPR_SELECTORCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: fileID[#ExpressibleByStringLiteral#]; name=fileID
 // POUND_EXPR_SELECTORCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: file[#ExpressibleByStringLiteral#]; name=file
 // POUND_EXPR_SELECTORCONTEXT-DAG: Decl[Macro]/OtherModule[Swift]/IsSystem: dsohandle[#UnsafeRawPointer#]; name=dsohandle

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -13,7 +13,6 @@ func test() {
 // RUN: %FileCheck -check-prefix=NAME_UNSORTED %s < %t.orig.off
 // RUN: not %diff -u %t.orig %t.orig.off
 
-// NAME_SORTED: key.name: "column"
 // NAME_SORTED: key.name: "foo(a:)"
 // NAME_SORTED-NOT: key.name:
 // NAME_SORTED: key.name: "foo(a:)"
@@ -46,7 +45,6 @@ func test() {
 // CONTEXT: key.name: "foo(b:)"
 // CONTEXT-NOT: key.name:
 // CONTEXT: key.name: "test()"
-// CONTEXT: key.name: "column"
 // CONTEXT: key.name: "complete_sort_order"
 
 // RUN: %complete-test -tok=STMT_0 %s | %FileCheck %s -check-prefix=STMT
@@ -242,7 +240,3 @@ func test8() {
 // CALLARG: String
 // CALLARG: intVal
 }
-
-// REQUIRES: swift_swift_parser
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -1167,9 +1167,9 @@ Completion *CompletionBuilder::finish() {
         new (sink.allocator) ContextFreeCodeCompletionResult(
             contextFreeBase.getKind(),
             contextFreeBase.getOpaqueAssociatedKind(), opKind,
-            contextFreeBase.isSystem(), contextFreeBase.isAsync(),
-            contextFreeBase.hasAsyncAlternative(), newCompletionString,
-            contextFreeBase.getModuleName(),
+            contextFreeBase.getMacroRoles(), contextFreeBase.isSystem(),
+            contextFreeBase.isAsync(), contextFreeBase.hasAsyncAlternative(),
+            newCompletionString, contextFreeBase.getModuleName(),
             contextFreeBase.getBriefDocComment(),
             contextFreeBase.getAssociatedUSRs(),
             contextFreeBase.getResultType(),


### PR DESCRIPTION
* Explanation: Updates completion to only provide macros when they're valid. Also provides macros in a few positions they were missing previously.
* Scope:  Clients of completion.
* Risk: Low; macros is a new feature, this updates completion functionality to better support them
* Testing: New suite of macro tests for each role and the position they can be in.
* Original PRs: https://github.com/apple/swift/pull/64986 and https://github.com/apple/swift/pull/65036