### PR TITLE
🍒[5.9][Concurrency] Unlock executor tests on iOS again, moveonly issue was …

### DIFF
--- a/test/Concurrency/Runtime/custom_executors_complex_equality.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality.swift
@@ -7,9 +7,6 @@
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
-// FIXME: rdar://107112715 test failing on iOS simulator, investigating
-// UNSUPPORTED: OS=ios
-
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 

--- a/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
@@ -7,9 +7,6 @@
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
-// FIXME: rdar://107112715 test failing on iOS simulator
-// UNSUPPORTED: OS=ios
-
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 

--- a/test/Concurrency/Runtime/custom_executors_complex_equality_subclass.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality_subclass.swift
@@ -7,9 +7,6 @@
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
-// FIXME: rdar://107112715 test failing on iOS simulator, investigating
-// UNSUPPORTED: OS=ios
-
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 

--- a/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
+++ b/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
@@ -6,9 +6,6 @@
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
-// FIXME: rdar://107112715 test failing on iOS simulator, investigating
-// UNSUPPORTED: OS=ios
-
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 

--- a/test/Concurrency/Runtime/custom_executors_priority.swift
+++ b/test/Concurrency/Runtime/custom_executors_priority.swift
@@ -6,9 +6,6 @@
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
-// FIXME: rdar://107112715 test failing on iOS simulator, investigating
-// UNSUPPORTED: OS=ios
-
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 

--- a/test/Concurrency/Runtime/custom_executors_protocol.swift
+++ b/test/Concurrency/Runtime/custom_executors_protocol.swift
@@ -7,9 +7,6 @@
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
-// FIXME: rdar://107112715 test failing on iOS simulator, investigating
-// UNSUPPORTED: OS=ios
-
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 


### PR DESCRIPTION
**Description:** Unblock tests which we had disabled because of the moveonly types not working in all configs previously: rdar://107050387. The fixes were done https://github.com/apple/swift/commit/a6d2299051e29f7c6ca35d31420d218493cbae8e & https://github.com/apple/swift/commit/df35da45cc6a7cfad51872e4530fd113ea16c8ca and therefore we should enable the tests again. 
**Risk:** Low, enables tests
**Review by:** @DougGregor, @kavon who fixed the underlying moveonly issue
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/65039
**Radar:** rdar://107112715 