### PR TITLE
[interop] mark C++ virtual functions as unavailable in Swift

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3451,6 +3451,11 @@ namespace {
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
       auto method = VisitFunctionDecl(decl);
+      if (decl->isVirtual() && isa_and_nonnull<ValueDecl>(method)) {
+        Impl.markUnavailable(
+            cast<ValueDecl>(method),
+            "virtual functions are not yet available in Swift");
+      }
 
       if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties ||
           hasComputedPropertyAttr(decl)) {

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -27,3 +27,7 @@ struct Unused : Base {
 };
 
 using UnusedInt = Unused<int>;
+
+struct VirtualNonAbstractBase {
+  virtual void nonAbstractMethod() const;
+};

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test -print-module -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK: struct Base {
+// CHECK-NEXT:  init()
+// CHECK-NEXT:   @available(*, unavailable, message: "virtual functions are not yet available in Swift")
+// CHECK-NEXT:   mutating func foo()
+
+// CHECK: struct Derived<Int32> {
+// CHECK: @available(*, unavailable, message: "virtual functions are not yet available in Swift")
+// CHECK:  mutating func foo()
+// CHECK: }
+
+// CHECK: struct VirtualNonAbstractBase {
+// CHECK:  @available(*, unavailable, message: "virtual functions are not yet available in Swift")
+// CHECK:  func nonAbstractMethod()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
+
+import VirtualMethods
+
+VirtualNonAbstractBase().nonAbstractMethod() // expected-error {{'nonAbstractMethod()' is unavailable: virtual functions are not yet available in Swift}}


### PR DESCRIPTION
They're not yet supported
