### PR TITLE
[CSSyntaticElement] Desugar types before collecting "in scope" type v…

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -211,6 +211,14 @@ private:
         return;
     }
 
+    // Desugar type before collecting type variables, otherwise
+    // we can bring in scope unrelated type variables passed
+    // into the closure (via parameter/result) from contextual type.
+    // For example `Typealias<$T, $U>.Context` which desugars into
+    // `_Context<$U>` would bring in `$T` that could be inferrable
+    // only after the body of the closure is solved.
+    type = type->getDesugaredType();
+
     // Don't walk into the opaque archetypes because they are not
     // transparent in this context - `some P` could reference a
     // type variables as substitutions which are visible only to

--- a/validation-test/Sema/SwiftUI/rdar107835060.swift
+++ b/validation-test/Sema/SwiftUI/rdar107835060.swift
@@ -1,0 +1,51 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -disable-availability-checking
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+protocol Model<ReturnType> {
+  associatedtype ReturnType
+}
+
+struct AnyModel<ReturnType>: Model {
+}
+
+protocol ContentProtocol : View {
+  associatedtype _Context
+}
+
+struct CollectionContext<Data: RandomAccessCollection> {
+  let offset: Data.Index
+}
+
+struct ContinuousContent<Data: RandomAccessCollection, Content: View> : ContentProtocol
+  where Data.Element: Model, Data.Element.ReturnType: Sequence, Data.Index: Hashable {
+
+  typealias _Context = CollectionContext<Data>
+
+  var body: some View { EmptyView() }
+}
+
+struct TestView<Data, Content: View> : View {
+   typealias Context = Content._Context where Content: ContentProtocol
+
+   init<R, C>(_ data: Data,
+              @ViewBuilder shelfContent: @escaping (Context) -> C)
+       where Data.Element == any Model<R>,
+             Content == ContinuousContent<LazyMapCollection<Data, AnyModel<R>>, C> {
+   }
+
+   var body: some View { EmptyView() }
+}
+
+@ViewBuilder
+func test(values: [any Model<[Int]>]) -> some View {
+  TestView(values) { context in
+    VStack {
+      if context.offset == 0 {
+      }
+    }
+  }
+}


### PR DESCRIPTION
…ariables

Generic type aliases, unless desugared, could bring unrelated type variables into the scope i.e. 
`TypeAlias<$T, $U>.Context` is actually `_Context<$U>`. These variables could be inferrable 
only after the the body the closure is solved. To avoid that, let's adjust `TypeVariableRefFinder`
to desugar types before collecting referenced type variables.

Resolves: rdar://107835060

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
