### PR TITLE
[ConstraintSystem] NFC: Print attributes/capabilities only for unboun…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1784,7 +1784,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   PO.PrintTypesForDebugging = true;
 
   if (auto typeVar = getTypeVariable()) {
-    typeVar->print(out, PO);
+    typeVar->getImpl().print(out);
     out << " ";
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1442,14 +1442,14 @@ void ConstraintSystem::print(raw_ostream &out) const {
     auto rep = getRepresentative(tv);
     if (rep == tv) {
       if (auto fixed = getFixedType(tv)) {
-        tv->getImpl().print(out);
+        tv->print(out, PO);
         out << " as ";
         Type(fixed).print(out, PO);
       } else {
         const_cast<ConstraintSystem *>(this)->getBindingsFor(tv).dump(out, 1);
       }
     } else {
-      tv->getImpl().print(out);
+      tv->print(out, PO);
       out << " equivalent to ";
       Type(rep).print(out, PO);
     }

--- a/test/Constraints/init_literal_via_coercion.swift
+++ b/test/Constraints/init_literal_via_coercion.swift
@@ -7,7 +7,7 @@
 // CHECK: ---Constraint solving at [{{.*}}:12:1 - line:12:13]---
 // CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
 // CHECK: Type Variables:
-// CHECK: [[LITERAL_VAR]] [allows bindings to: {{.*}}] as UInt32 {{.*}}
+// CHECK: [[LITERAL_VAR]] as UInt32 {{.*}}
 // CHECK-NOT: disjunction (remembered) \[\[locator@{{.*}} [Coerce@{{.*}}\]\]]:
 _ = UInt32(0)
 
@@ -15,7 +15,7 @@ _ = UInt32(0)
 // CHECK: (coerce_expr implicit type='[[CAST_TYPE:\$T[0-9]+]]' {{.*}}
 // CHECK-NEXT: (nil_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
 // CHECK: Type Variables:
-// CHECK: [[LITERAL_VAR]] [allows bindings to: {{.*}}] as Int? {{.*}}
+// CHECK: [[LITERAL_VAR]] as Int? {{.*}}
 // CHECK: disjunction (remembered) {{.*}}
 // CHECK-NEXT: >  [favored]  [[CAST_TYPE]] bind Int?
 // CHECK-NEXT: >             [[CAST_TYPE]] bind Int


### PR DESCRIPTION
…d type variables

Print bound type variables as `$T<Num> as <Type> @ <locator>` 
and unbound ones as `$T<Num> [allows bindings to: ...] [attributes: ...] ... @ <locator>`


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
