### PR TITLE
[cxx-interop] Include `Cxx` and `CxxStdlib` modules in no-stdlib builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1265,6 +1265,7 @@ else()
 
   if(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT)
     add_subdirectory(stdlib/toolchain)
+    add_subdirectory(stdlib/public/Cxx)
   endif()
 
   if (BUILD_SWIFT_CONCURRENCY_BACK_DEPLOYMENT_LIBRARIES)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1678,6 +1678,7 @@ function(add_swift_target_library name)
         IS_SDK_OVERLAY
         IS_STDLIB
         IS_STDLIB_CORE
+        IS_SWIFT_ONLY
         NOSWIFTRT
         OBJECT_LIBRARY
         SHARED
@@ -1814,7 +1815,7 @@ function(add_swift_target_library name)
   endif()
 
   if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT BUILD_STANDALONE AND
-     NOT SWIFT_PREBUILT_CLANG)
+     NOT SWIFT_PREBUILT_CLANG AND NOT SWIFTLIB_IS_SWIFT_ONLY)
     list(APPEND SWIFTLIB_DEPENDS clang)
   endif()
 

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -3,7 +3,7 @@ if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
   set(SWIFT_CXX_LIBRARY_KIND SHARED)
 endif()
 
-add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB
+add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -127,7 +127,7 @@ add_dependencies(sdk-overlay libstdcxx-modulemap)
 #
 # C++ Standard Library Overlay.
 #
-add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB
+add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     std.swift
     String.swift
 


### PR DESCRIPTION
These modules are shipped with the toolchain, while the stdlib might be built and shipped separately.

rdar://107840627