### PR TITLE
[cxx-interop] Adding std.string initializer for UnsafePointer<CChar>?

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -25,6 +25,20 @@ extension std.string {
       self.push_back(value_type(bitPattern: char))
     }
   }
+
+  public init(_ string: UnsafePointer<CChar>?) {
+    self.init()
+
+    guard let str = string else {
+      return
+    }
+
+    let len = strlen(str)
+    for i in 0..<len {
+      let char = UInt8(str[i])
+      self.push_back(value_type(bitPattern: char))
+    }
+  }
 }
 
 extension std.u16string {

--- a/test/Interop/Cxx/objc-correctness/init-String-with-NSString-utf8String.swift
+++ b/test/Interop/Cxx/objc-correctness/init-String-with-NSString-utf8String.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -I %S/Inputs -cxx-interoperability-mode=swift-5.9 -emit-ir %s -Xcc -fignore-exceptions | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import CxxStdlib
+
+// CHECK: @"\01L_selector(UTF8String)"
+// CHECK: @objc_msgSend
+// CHECK: call swiftcc void @"$sSo3stdO3__1O0067basic_stringInt8char_traitsInt8allocatorInt8_FABErpaBGcqaGHerapGgqaV9CxxStdlibEyAFSPys4Int8VGSgcfC"
+
+let ObjCStr: NSString = "hello"
+let CxxStr = std.string(ObjCStr.utf8String) // Should not crash here

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -236,4 +236,11 @@ StdStringOverlayTestSuite.test("std::u16string as Swift.CustomStringConvertible"
   expectEqual(cxx3.description, "a�c")
 }
 
+StdStringOverlayTestSuite.test("std::string from C string") {
+  let str = "abc".withCString { ptr in
+    std.string(ptr)
+  }
+  expectEqual(str, std.string("abc"))
+}
+
 runAllTests()


### PR DESCRIPTION
Currently without an initializer for the unsafe char pointer type swiftc hits an assert around not being able to handle conversions of unsafe pointers with Any type. This patch adds the ability to convert to a std::string.

This is to address issue https://github.com/apple/swift/issues/61218
