### PR TITLE
🍒[cxx-interop] Include `Cxx` and `CxxStdlib` modules in no-stdlib builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1270,6 +1270,7 @@ else()
 
   if(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT)
     add_subdirectory(stdlib/toolchain)
+    add_subdirectory(stdlib/public/Cxx)
   endif()
 
   if (BUILD_SWIFT_CONCURRENCY_BACK_DEPLOYMENT_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,10 @@ option(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT
     "If not building stdlib, controls whether to build 'stdlib/toolchain' content"
     TRUE)
 
+option(SWIFT_BUILD_STDLIB_CXX_MODULE
+  "If not building stdlib, controls whether to build the Cxx module"
+  TRUE)
+
 # In many cases, the CMake build system needs to determine whether to include
 # a directory, or perform other actions, based on whether the stdlib or SDK is
 # being built at all -- statically or dynamically. Please note that these
@@ -1270,6 +1274,9 @@ else()
 
   if(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT)
     add_subdirectory(stdlib/toolchain)
+  endif()
+
+  if(SWIFT_BUILD_STDLIB_CXX_MODULE)
     add_subdirectory(stdlib/public/Cxx)
   endif()
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1678,6 +1678,7 @@ function(add_swift_target_library name)
         IS_SDK_OVERLAY
         IS_STDLIB
         IS_STDLIB_CORE
+        IS_SWIFT_ONLY
         NOSWIFTRT
         OBJECT_LIBRARY
         SHARED
@@ -1814,7 +1815,7 @@ function(add_swift_target_library name)
   endif()
 
   if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT BUILD_STANDALONE AND
-     NOT SWIFT_PREBUILT_CLANG)
+     NOT SWIFT_PREBUILT_CLANG AND NOT SWIFTLIB_IS_SWIFT_ONLY)
     list(APPEND SWIFTLIB_DEPENDS clang)
   endif()
 

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -3,7 +3,7 @@ if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
   set(SWIFT_CXX_LIBRARY_KIND SHARED)
 endif()
 
-add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB
+add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -127,7 +127,7 @@ add_dependencies(sdk-overlay libstdcxx-modulemap)
 #
 # C++ Standard Library Overlay.
 #
-add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB
+add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     std.swift
     String.swift
 


### PR DESCRIPTION
**Explanation**: This ensures that the `Cxx` and `CxxStdlib` binaries are compiled and installed correctly when building the stdlib separately from the compiler. These two modules are shipped with the toolchain, not with the SDK, so they need to be built along with the compiler. This also removes the unnecessary dependency on clang for these two modules.
**Scope**: Only affects clients which enable Swift/C++ interop.
**Risk**: Low: C++ interop is an opt-in feature that is enabled via a compiler flag. It is off by default.

rdar://107840627