### PR TITLE
[CSSyntaticElement] Canonicalize type before collecting "in scope" va…

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -217,7 +217,7 @@ private:
     // For example `Typealias<$T, $U>.Context` which desugars into
     // `_Context<$U>` would bring in `$T` that could be inferrable
     // only after the body of the closure is solved.
-    type = type->getDesugaredType();
+    type = type->getCanonicalType();
 
     // Don't walk into the opaque archetypes because they are not
     // transparent in this context - `some P` could reference a

--- a/validation-test/Sema/SwiftUI/rdar107835060.swift
+++ b/validation-test/Sema/SwiftUI/rdar107835060.swift
@@ -32,7 +32,7 @@ struct TestView<Data, Content: View> : View {
    typealias Context = Content._Context where Content: ContentProtocol
 
    init<R, C>(_ data: Data,
-              @ViewBuilder shelfContent: @escaping (Context) -> C)
+              @ViewBuilder shelfContent: @escaping ([Context]) -> C)
        where Data.Element == any Model<R>,
              Content == ContinuousContent<LazyMapCollection<Data, AnyModel<R>>, C> {
    }
@@ -44,7 +44,7 @@ struct TestView<Data, Content: View> : View {
 func test(values: [any Model<[Int]>]) -> some View {
   TestView(values) { context in
     VStack {
-      if context.offset == 0 {
+      if context.first?.offset == 0 {
       }
     }
   }


### PR DESCRIPTION
…riables

Follow-up to https://github.com/apple/swift/pull/65048

`getDesugaredType` unwraps sugar types that appear in sequence,
 to remove sugar from nested positions we need to get a canonical type.

Thanks to @slavapestov for pointing it out.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
