### PR TITLE
Frontend: infer default blocklists to use when the explicit paths aren't given by swift-driver

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -235,6 +235,9 @@ public:
   ///       options have been parsed.
   void setDefaultPrebuiltCacheIfNecessary();
 
+  /// If we haven't explicitly passed -blocklist-paths, set it to the default value.
+  void setDefaultBlocklistsIfNecessary();
+
   /// Computes the runtime resource path relative to the given Swift
   /// executable.
   static void computeRuntimeResourcePathFromExecutablePath(


### PR DESCRIPTION
Although swift-driver always passes down these blocklist for the compiler to consume, some frontend tools, like ABI checker, are invoked by the build system directly. Therefore, we need to teach the compiler to infer these blocklist files like prebuilt module cache.

