### PR TITLE
[🍒 5.9] Replace mismatched `delete` with `swift_cxx_deleteObject`

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1061,7 +1061,7 @@ namespace {
 
         // Otherwise, use the new entry and destroy the one we allocated.
         assert(existingEntry && "spurious failure of strong compare-exchange?");
-        delete allocatedEntry;
+        swift_cxx_deleteObject(allocatedEntry);
       }
 
       return { static_cast<SingletonMetadataCacheEntry*>(existingEntry), false };


### PR DESCRIPTION
The `allocatedEntry` is allocated with `swift_cxx_newObject` so it should be deallocated with the `swift_cxx_deleteObject`.

Cherry-picking: https://github.com/apple/swift/pull/65076