### PR TITLE
[CodeCompletion] Enable SwiftParser parsing for code completion 

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -269,7 +269,8 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
     // Perform round-trip and/or validation checking.
     if ((Context.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
          Context.LangOpts.hasFeature(Feature::ParserValidation)) &&
-        SF.exportedSourceFile) {
+        SF.exportedSourceFile &&
+        !SourceMgr.hasIDEInspectionTargetBuffer()) {
       if (Context.LangOpts.hasFeature(Feature::ParserRoundTrip) &&
           swift_ASTGen_roundTripCheck(SF.exportedSourceFile)) {
         SourceLoc loc;
@@ -305,8 +306,7 @@ Parser::parseSourceFileViaASTGen(SmallVectorImpl<ASTNode> &items,
                                  bool suppressDiagnostics) {
 #if SWIFT_SWIFT_PARSER
   Optional<DiagnosticTransaction> existingParsingTransaction;
-  if (!SourceMgr.hasIDEInspectionTargetBuffer() &&
-      SF.Kind != SourceFileKind::SIL) {
+  if (SF.Kind != SourceFileKind::SIL) {
     StringRef contents =
         SourceMgr.extractText(SourceMgr.getRangeForBuffer(L->getBufferID()));
 

--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -1,0 +1,29 @@
+// REQUIRES: swift_swift_parser
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -plugin-path %swift-host-lib-dir/plugins
+
+@OptionSet<UInt8>
+struct ShippingOptions {
+  private enum Options: Int {
+    case nextDay
+    case secondDay
+    case priority
+    case standard
+  }
+}
+
+func foo() {
+  ShippingOptions.#^MEMBER_STATIC^#
+}
+
+// MEMBER_STATIC: Keyword[self]/CurrNominal:          self[#ShippingOptions.Type#]; name=self
+// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        RawValue[#UInt8#]; name=RawValue
+// MEMBER_STATIC: Decl[Constructor]/CurrNominal:      init({#rawValue: ShippingOptions.RawValue#})[#ShippingOptions#]; name=init(rawValue:)
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        nextDay[#ShippingOptions#]; name=nextDay
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        secondDay[#ShippingOptions#]; name=secondDay
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        priority[#ShippingOptions#]; name=priority
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        standard[#ShippingOptions#]; name=standard
+// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        Element[#ShippingOptions#]; name=Element
+// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        ArrayLiteralElement[#ShippingOptions#]; name=ArrayLiteralElement
+// MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init()[#ShippingOptions#]; name=init()
+// MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init({#(sequence): Sequence#})[#ShippingOptions#]; name=init(:)


### PR DESCRIPTION
Enable SwiftParser parsing for code completion, but disable the roundtrip/validation testing. So that macro expansions are correctly performed in code completion, while avoiding an assertion failure
caused by existence of null character in the source buffer.

rdar://107900870
