### PR TITLE
[5.9][CodeCompletion] Enable SwiftParser parsing for code completion 

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -269,7 +269,8 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
     // Perform round-trip and/or validation checking.
     if ((Context.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
          Context.LangOpts.hasFeature(Feature::ParserValidation)) &&
-        SF.exportedSourceFile) {
+        SF.exportedSourceFile &&
+        !SourceMgr.hasIDEInspectionTargetBuffer()) {
       if (Context.LangOpts.hasFeature(Feature::ParserRoundTrip) &&
           swift_ASTGen_roundTripCheck(SF.exportedSourceFile)) {
         SourceLoc loc;
@@ -305,8 +306,7 @@ Parser::parseSourceFileViaASTGen(SmallVectorImpl<ASTNode> &items,
                                  bool suppressDiagnostics) {
 #if SWIFT_SWIFT_PARSER
   Optional<DiagnosticTransaction> existingParsingTransaction;
-  if (!SourceMgr.hasIDEInspectionTargetBuffer() &&
-      SF.Kind != SourceFileKind::SIL) {
+  if (SF.Kind != SourceFileKind::SIL) {
     StringRef contents =
         SourceMgr.extractText(SourceMgr.getRangeForBuffer(L->getBufferID()));
 

--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -1,0 +1,29 @@
+// REQUIRES: swift_swift_parser
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -plugin-path %swift-host-lib-dir/plugins
+
+@OptionSet<UInt8>
+struct ShippingOptions {
+  private enum Options: Int {
+    case nextDay
+    case secondDay
+    case priority
+    case standard
+  }
+}
+
+func foo() {
+  ShippingOptions.#^MEMBER_STATIC^#
+}
+
+// MEMBER_STATIC: Keyword[self]/CurrNominal:          self[#ShippingOptions.Type#]; name=self
+// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        RawValue[#UInt8#]; name=RawValue
+// MEMBER_STATIC: Decl[Constructor]/CurrNominal:      init({#rawValue: ShippingOptions.RawValue#})[#ShippingOptions#]; name=init(rawValue:)
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        nextDay[#ShippingOptions#]; name=nextDay
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        secondDay[#ShippingOptions#]; name=secondDay
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        priority[#ShippingOptions#]; name=priority
+// MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        standard[#ShippingOptions#]; name=standard
+// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        Element[#ShippingOptions#]; name=Element
+// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        ArrayLiteralElement[#ShippingOptions#]; name=ArrayLiteralElement
+// MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init()[#ShippingOptions#]; name=init()
+// MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init({#(sequence): Sequence#})[#ShippingOptions#]; name=init(:)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -332,6 +332,22 @@ ImportObjCHeader("import-objc-header",
                  llvm::cl::desc("header to implicitly import"),
                  llvm::cl::cat(Category));
 
+static llvm::cl::list<std::string>
+PluginPath("plugin-path",
+               llvm::cl::desc("plugin-path"),
+               llvm::cl::cat(Category));
+
+static llvm::cl::list<std::string>
+LoadPluginLibrary("load-plugin-library",
+               llvm::cl::desc("load plugin library"),
+               llvm::cl::cat(Category));
+
+static llvm::cl::list<std::string>
+LoadPluginExecutable("load-plugin-executable",
+               llvm::cl::desc("load plugin executable"),
+               llvm::cl::cat(Category));
+
+
 static llvm::cl::opt<bool>
 EnableSourceImport("enable-source-import", llvm::cl::Hidden,
                    llvm::cl::cat(Category), llvm::cl::init(false));
@@ -4479,6 +4495,32 @@ int main(int argc, char *argv[]) {
       llvm::errs() << "invalid module alias arguments\n";
       return 1;
     }
+  }
+
+  for (auto path : options::PluginPath) {
+    InitInvok.getSearchPathOptions().PluginSearchPaths.push_back(path);
+  }
+  if (!options::LoadPluginLibrary.empty()) {
+    std::vector<std::string> paths;
+    for (auto path: options::LoadPluginLibrary) {
+      paths.push_back(path);
+    }
+    InitInvok.getSearchPathOptions().setCompilerPluginLibraryPaths(paths);
+  }
+  if (!options::LoadPluginExecutable.empty()) {
+    std::vector<PluginExecutablePathAndModuleNames> pairs;
+    for (auto arg: options::LoadPluginExecutable) {
+      StringRef path;
+      StringRef modulesStr;
+      std::tie(path, modulesStr) = StringRef(arg).rsplit('#');
+      std::vector<std::string> moduleNames;
+      for (auto name : llvm::split(modulesStr, ',')) {
+        moduleNames.emplace_back(name);
+      }
+      pairs.push_back({std::string(path), std::move(moduleNames)});
+    }
+
+    InitInvok.getSearchPathOptions().setCompilerPluginExecutablePaths(std::move(pairs));
   }
 
   // Process the clang arguments last and allow them to override previously


### PR DESCRIPTION
cherry-pick #65078 into release/5.9

**Explanation**: The new `SwiftSyntax` parsing is required for macro expansion, but it was disabled for a source manager mode that has code completion token in the buffer. Because of that, any macro generated declarations weren't suggested in code completion. Enable SwiftParser parsing for code completion, but without the roundtrip/validation testing. With this change, macros are correctly expanded, and those introduced decls are correctly suggested in code completion
**Scope**: Code completion with macros
**Risk**: Low-Mid. This introduces a new thing to code completion, but it is well tested in other modes including compilation and SourceKit cursor info
**Testing**: Added a regression test case
**Issues**: rdar://107900870
**Reviewers**: Ben Barham (@bnbarham) Alex Hoppen (@ahoppen)