### PR TITLE
[cxx-interop] Add `std::set` initializer that takes a Swift Sequence

### DIFF
--- a/stdlib/public/Cxx/CxxSet.swift
+++ b/stdlib/public/Cxx/CxxSet.swift
@@ -13,11 +13,31 @@
 public protocol CxxSet<Element> {
   associatedtype Element
   associatedtype Size: BinaryInteger
+  associatedtype InsertionResult // std::pair<iterator, bool>
+
+  init()
+
+  @discardableResult
+  mutating func __insertUnsafe(_ element: Element) -> InsertionResult
 
   func count(_ element: Element) -> Size
 }
 
 extension CxxSet {
+  /// Creates a C++ set containing the elements of a Swift Sequence.
+  ///
+  /// This initializes the set by copying every element of the sequence.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of elements in the Swift
+  ///   sequence
+  @inlinable
+  public init<S: Sequence>(_ sequence: S) where S.Element == Element {
+    self.init()
+    for item in sequence {
+      self.__insertUnsafe(item)
+    }
+  }
+
   @inlinable
   public func contains(_ element: Element) -> Bool {
     return count(element) > 0

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -47,4 +47,18 @@ StdSetTestSuite.test("MultisetOfCInt.contains") {
     expectFalse(s.contains(3))
 }
 
+StdSetTestSuite.test("SetOfCInt.init()") {
+    let s = SetOfCInt([1, 3, 5])
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+}
+
+StdSetTestSuite.test("UnorderedSetOfCInt.init()") {
+    let s = UnorderedSetOfCInt([1, 3, 5])
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+}
+
 runAllTests()


### PR DESCRIPTION
This got unblocked by https://github.com/apple/swift/pull/64897.

rdar://107909624