### PR TITLE
Handle `#if` for if/switch expressions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1143,6 +1143,9 @@ ERROR(single_value_stmt_must_be_unlabeled,none,
 ERROR(if_expr_must_be_syntactically_exhaustive,none,
       "'if' must have an unconditional 'else' to be used as expression",
       ())
+ERROR(single_value_stmt_branch_empty,none,
+      "expected expression in branch of '%0' expression",
+      (StmtKind))
 ERROR(single_value_stmt_branch_must_end_in_throw,none,
       "non-expression branch of '%0' expression may only end with a 'throw'",
       (StmtKind))

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -212,6 +212,11 @@ public:
 
   ASTNode findAsyncNode();
 
+  /// If this brace contains a single ASTNode, or a \c #if that has a single active
+  /// element, returns it. This will always be the last element of the brace.
+  /// Otherwise returns \c nullptr.
+  ASTNode getSingleActiveElement() const;
+
   /// If this brace is wrapping a single expression, returns it. Otherwise
   /// returns \c nullptr.
   Expr *getSingleExpressionElement() const;

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -217,9 +217,15 @@ public:
   /// Otherwise returns \c nullptr.
   ASTNode getSingleActiveElement() const;
 
-  /// If this brace is wrapping a single expression, returns it. Otherwise
-  /// returns \c nullptr.
-  Expr *getSingleExpressionElement() const;
+  /// If this brace is wrapping a single active expression, returns it. This
+  /// includes both a single expression element, or a single expression in an
+  /// active \c #if. Otherwise returns \c nullptr.
+  Expr *getSingleActiveExpression() const;
+
+  /// If this brace is wrapping a single active statement, returns it. This
+  /// includes both a single statement element, or a single statement in an
+  /// active \c #if. Otherwise returns \c nullptr.
+  Stmt *getSingleActiveStatement() const;
 
   static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Brace; }
 };

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -691,11 +691,6 @@ public:
   /// \param DiagText name for the string literal in the diagnostic.
   Optional<StringRef>
   getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText);
-  
-  /// Returns true when body elements are eligible as single-expression implicit returns.
-  ///
-  /// \param Body elements to search for implicit single-expression returns.
-  bool shouldReturnSingleExpressionElement(ArrayRef<ASTNode> Body); 
 
   /// Returns true to indicate that experimental concurrency syntax should be
   /// parsed if the parser is generating only a syntax tree or if the user has

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2524,11 +2524,7 @@ SingleValueStmtExpr *SingleValueStmtExpr::createWithWrappedBranches(
     if (!BS)
       continue;
 
-    auto elts = BS->getElements();
-    if (elts.size() != 1)
-      continue;
-
-    auto *S = elts.front().dyn_cast<Stmt *>();
+    auto *S = BS->getSingleActiveStatement();
     if (!S)
       continue;
 
@@ -2615,7 +2611,7 @@ ArrayRef<Expr *> SingleValueStmtExpr::getSingleExprBranches(
     auto *BS = dyn_cast<BraceStmt>(branch);
     if (!BS)
       continue;
-    if (auto *E = BS->getSingleExpressionElement())
+    if (auto *E = BS->getSingleActiveExpression())
       scratch.push_back(E);
   }
   return scratch;

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -324,11 +324,12 @@ ASTNode BraceStmt::getSingleActiveElement() const {
   return hasSingleActiveElement(getElements()) ? getLastElement() : nullptr;
 }
 
-Expr *BraceStmt::getSingleExpressionElement() const {
-  if (getElements().size() != 1)
-    return nullptr;
+Expr *BraceStmt::getSingleActiveExpression() const {
+  return getSingleActiveElement().dyn_cast<Expr *>();
+}
 
-  return getElements()[0].dyn_cast<Expr *>();
+Stmt *BraceStmt::getSingleActiveStatement() const {
+  return getSingleActiveElement().dyn_cast<Stmt *>();
 }
 
 IsSingleValueStmtResult Stmt::mayProduceSingleValue(Evaluator &eval) const {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8032,8 +8032,7 @@ Parser::parseAbstractFunctionBodyImpl(AbstractFunctionDecl *AFD) {
   AFD->setHasSingleExpressionBody(false);
   AFD->setBodyParsed(BS, fp);
 
-  if (Parser::shouldReturnSingleExpressionElement(BS->getElements())) {
-    auto Element = BS->getLastElement();
+  if (auto Element = BS->getSingleActiveElement()) {
     if (auto *stmt = Element.dyn_cast<Stmt *>()) {
       if (isa<FuncDecl>(AFD)) {
         if (auto *returnStmt = dyn_cast<ReturnStmt>(stmt)) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2903,37 +2903,36 @@ ParserResult<Expr> Parser::parseExprClosure() {
     closure->setParameterList(params);
     closure->setHasAnonymousClosureVars();
   }
-  
+
+  auto *BS = BraceStmt::create(Context, leftBrace, bodyElements, rightBrace);
+
   // If the body consists of a single expression, turn it into a return
   // statement.
   bool hasSingleExpressionBody = false;
-  if (!missingRBrace &&
-      Parser::shouldReturnSingleExpressionElement(bodyElements)) {
-    auto Element = bodyElements.back();
-    
-    if (Element.is<Stmt *>()) {
-      if (auto returnStmt = dyn_cast<ReturnStmt>(Element.get<Stmt *>())) {
-        hasSingleExpressionBody = true;
-        if (!returnStmt->hasResult()) {
-          auto returnExpr = TupleExpr::createEmpty(Context,
-                                                   SourceLoc(),
-                                                   SourceLoc(),
-                                                   /*implicit*/true);
-          returnStmt->setResult(returnExpr);
+  if (!missingRBrace) {
+    if (auto Element = BS->getSingleActiveElement()) {
+      if (Element.is<Stmt *>()) {
+        if (auto returnStmt = dyn_cast<ReturnStmt>(Element.get<Stmt *>())) {
+          hasSingleExpressionBody = true;
+          if (!returnStmt->hasResult()) {
+            auto returnExpr = TupleExpr::createEmpty(Context,
+                                                     SourceLoc(),
+                                                     SourceLoc(),
+                                                     /*implicit*/true);
+            returnStmt->setResult(returnExpr);
+          }
         }
+      } else if (Element.is<Expr *>()) {
+        // Create the wrapping return.
+        hasSingleExpressionBody = true;
+        auto returnExpr = Element.get<Expr*>();
+        BS->setLastElement(new (Context) ReturnStmt(SourceLoc(), returnExpr));
       }
-    } else if (Element.is<Expr *>()) {
-      // Create the wrapping return.
-      hasSingleExpressionBody = true;
-      auto returnExpr = Element.get<Expr*>();
-      bodyElements.back() = new (Context) ReturnStmt(SourceLoc(), returnExpr);
     }
   }
 
   // Set the body of the closure.
-  closure->setBody(BraceStmt::create(Context, leftBrace, bodyElements,
-                                     rightBrace),
-                   hasSingleExpressionBody);
+  closure->setBody(BS, hasSingleExpressionBody);
 
   // If the closure includes a capture list, create an AST node for it as well.
   Expr *result = closure;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1096,31 +1096,6 @@ Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc,
                                                Segments.front().Length));
 }
 
-bool Parser::shouldReturnSingleExpressionElement(ArrayRef<ASTNode> Body) {
-  // If the body consists of an #if declaration with a single
-  // expression active clause, find a single expression.
-  if (Body.size() == 2) {
-    if (auto *D = Body.front().dyn_cast<Decl *>()) {
-      // Step into nested active clause.
-      while (auto *ICD = dyn_cast<IfConfigDecl>(D)) {
-        auto ACE = ICD->getActiveClauseElements();
-        if (ACE.size() == 1) {
-          assert(Body.back() == ACE.back() &&
-                 "active clause not found in body");
-          return true;
-        } else if (ACE.size() == 2) {
-          if (auto *ND = ACE.front().dyn_cast<Decl *>()) {
-            D = ND;
-            continue;
-          }
-        }
-        break;
-      }
-    }
-  }
-  return Body.size() == 1;
-}
-
 struct ParserUnit::Implementation {
   LangOptions LangOpts;
   TypeCheckerOptions TypeCheckerOpts;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3878,6 +3878,14 @@ private:
         break;
       case IsSingleValueStmtResult::Kind::UnterminatedBranches: {
         for (auto *branch : mayProduceSingleValue.getUnterminatedBranches()) {
+          if (auto *BS = dyn_cast<BraceStmt>(branch)) {
+            if (BS->empty()) {
+              Diags.diagnose(branch->getStartLoc(),
+                             diag::single_value_stmt_branch_empty,
+                             S->getKind());
+              continue;
+            }
+          }
           Diags.diagnose(branch->getEndLoc(),
                          diag::single_value_stmt_branch_must_end_in_throw,
                          S->getKind());

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1354,15 +1354,13 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   // LeaveClosureBodiesUnchecked, as the closure may become a single expression
   // closure.
   auto *body = closure->getBody();
-  if (body->getNumElements() == 1) {
-    if (auto *S = body->getLastElement().dyn_cast<Stmt *>()) {
-      if (S->mayProduceSingleValue(Ctx)) {
-        auto *SVE = SingleValueStmtExpr::createWithWrappedBranches(
-            Ctx, S, /*DC*/ closure, /*mustBeExpr*/ false);
-        auto *RS = new (Ctx) ReturnStmt(SourceLoc(), SVE);
-        body->setLastElement(RS);
-        closure->setBody(body, /*isSingleExpression*/ true);
-      }
+  if (auto *S = body->getSingleActiveStatement()) {
+    if (S->mayProduceSingleValue(Ctx)) {
+      auto *SVE = SingleValueStmtExpr::createWithWrappedBranches(
+          Ctx, S, /*DC*/ closure, /*mustBeExpr*/ false);
+      auto *RS = new (Ctx) ReturnStmt(SourceLoc(), SVE);
+      body->setLastElement(RS);
+      closure->setBody(body, /*isSingleExpression*/ true);
     }
   }
 

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -463,6 +463,100 @@ func testThrowInference() {
   }
 }
 
+// MARK: Pound if
+
+func testPoundIf1() -> Int {
+  if .random() {
+    #if true
+    0
+    #else
+    ""
+    #endif
+  } else {
+    0
+  }
+}
+
+func testPoundIf2() -> String {
+  if .random() {
+    #if true
+    0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+    #else
+    ""
+    #endif
+  } else {
+    ""
+  }
+}
+
+func testPoundIf3() -> String {
+  if .random() {
+    #if false
+    0
+    #else
+    ""
+    #endif
+  } else {
+    ""
+  }
+}
+
+func testPoundIf4() -> String {
+  let x = if .random() {
+    #if true
+    0 // expected-error {{branches have mismatching types 'Int' and 'String'}}
+    #else
+    ""
+    #endif
+  } else {
+    ""
+  }
+  return x
+}
+
+func testPoundIf5() -> String {
+  let x = if .random() {
+    #if false
+    0
+    #else
+    ""
+    #endif
+  } else {
+    ""
+  }
+  return x
+}
+
+func testPoundIfClosure1() -> Int {
+  let fn = {
+    if .random() {
+      #if true
+        0
+      #else
+        ""
+      #endif
+    } else {
+      0
+    }
+  }
+  return fn()
+}
+
+func testPoundIfClosure2() -> String {
+  let fn: () -> String = {
+    if .random() {
+      #if true
+        0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+      #else
+        ""
+      #endif
+    } else {
+      ""
+    }
+  }
+  return fn()
+}
+
 // MARK: Subtyping
 
 class A {}

--- a/test/Constraints/switch_expr.swift
+++ b/test/Constraints/switch_expr.swift
@@ -545,6 +545,107 @@ func testThrowInference() {
   }
 }
 
+// MARK: Pound if
+
+func testPoundIf1() -> Int {
+  switch Bool.random() {
+  case true:
+    #if true
+    0
+    #else
+    ""
+    #endif
+  case false:
+    0
+  }
+}
+
+func testPoundIf2() -> String {
+  switch Bool.random() {
+  case true:
+    #if true
+    0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+    #else
+    ""
+    #endif
+  case false:
+    ""
+  }
+}
+
+func testPoundIf3() -> String {
+  switch Bool.random() {
+  case true:
+    #if false
+    0
+    #else
+    ""
+    #endif
+  case false:
+    ""
+  }
+}
+
+func testPoundIf4() -> String {
+  let x = switch Bool.random() {
+  case true:
+    #if true
+    0 // expected-error {{branches have mismatching types 'Int' and 'String'}}
+    #else
+    ""
+    #endif
+  case false:
+    ""
+  }
+  return x
+}
+
+func testPoundIf5() -> String {
+  let x = switch Bool.random() {
+  case true:
+    #if false
+    0
+    #else
+    ""
+    #endif
+  case false:
+    ""
+  }
+  return x
+}
+
+func testPoundIfClosure1() -> Int {
+  let fn = {
+    switch Bool.random() {
+    case true:
+      #if true
+        0
+      #else
+        ""
+      #endif
+    case false:
+      0
+    }
+  }
+  return fn()
+}
+
+func testPoundIfClosure2() -> String {
+  let fn: () -> String = {
+    switch Bool.random() {
+    case true:
+      #if true
+        0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
+      #else
+        ""
+      #endif
+    case false:
+      ""
+    }
+  }
+  return fn()
+}
+
 // MARK: Subtyping
 
 class A {}

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -196,6 +196,39 @@ func testVar() -> Int {
   return x
 }
 
+func testPoundIf1() -> Int {
+  let x = if .random() {
+    #if true
+    1
+    #else
+    ""
+    #endif
+  } else {
+    #if false
+    ""
+    #else
+    2
+    #endif
+  }
+  return x
+}
+
+func testPoundIf2() -> Int {
+  if .random() {
+    #if false
+    0
+    #else
+    #if true
+    if .random() { 0 } else { 1 }
+    #endif
+    #endif
+  } else {
+    #if true
+    if .random() { 0 } else { 1 }
+    #endif
+  }
+}
+
 func testCatch() -> Int {
   do {
     let x = if .random() {

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -306,6 +306,41 @@ func testNested(_ e: E) throws -> Int {
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
+func testPoundIf1() -> Int {
+  let x = switch Bool.random() {
+  case true:
+    #if true
+    1
+    #else
+    ""
+    #endif
+  case false:
+    #if false
+    ""
+    #else
+    2
+    #endif
+  }
+  return x
+}
+
+func testPoundIf2() -> Int {
+  switch Bool.random() {
+  case true:
+    #if false
+    0
+    #else
+    #if true
+    switch Bool.random() { case true: 0 case false: 1 }
+    #endif
+    #endif
+  case false:
+    #if true
+    switch Bool.random() { case true: 0 case false: 1 }
+    #endif
+  }
+}
+
 func testAssignment() {
   var x = 0
   x = switch Bool.random() { case true: 0 case false: 1 }

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -646,6 +646,12 @@ func nestedType() -> Int {
   }
 }
 
+func testEmptyBranch() -> Int {
+  let x = if .random() {} else { 0 }
+  // expected-error@-1:24 {{expected expression in branch of 'if' expression}}
+  return x
+}
+
 // MARK: Jumping
 
 func break1() -> Int {

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -163,6 +163,117 @@ var inAComputedVar: String {
   if .random() { "a" } else { "b" }
 }
 
+// MARK: Outer pound if
+
+func withPoundIf() -> Int {
+  #if true
+  if .random() { 0 } else { 1 }
+  #endif
+}
+
+func withPoundIfClosure() -> Int {
+  let fn = {
+    #if true
+    if .random() { 0 } else { 1 }
+    #endif
+  }
+  return fn()
+}
+
+func withPoundIfElse1() -> Int {
+  #if true
+  if .random() { 0 } else { 1 }
+  #else
+  0
+  #endif
+}
+
+func withPoundIfElse2() -> Int {
+  #if true
+  0
+  #else
+  if .random() { 0 } else { 1 }
+  #endif
+}
+
+func withPoundIfElseIf1() -> Int {
+  #if true
+  if .random() { 0 } else { 1 }
+  #elseif true
+  0
+  #endif
+}
+
+
+func withPoundIfElseIf2() -> Int {
+  #if true
+  0
+  #elseif true
+  if .random() { 0 } else { 1 }
+  #endif
+}
+
+func withPoundIfElseIfElse1() -> Int {
+  #if true
+  if .random() { 0 } else { 1 }
+  #elseif true
+  0
+  #else
+  0
+  #endif
+}
+
+func withPoundIfElseIfElse2() -> Int {
+  #if true
+  0
+  #elseif true
+  if .random() { 0 } else { 1 }
+  #else
+  0
+  #endif
+}
+
+func withPoundIfElseIfElse3() -> Int {
+  #if true
+  0
+  #elseif true
+  0
+  #else
+  if .random() { 0 } else { 1 }
+  #endif
+}
+
+func withVeryNestedPoundIf() -> Int {
+  #if true
+    #if true
+      #if false
+      ""
+      #else
+      if .random() { 0 } else { 1 }
+      #endif
+    #elseif true
+    0
+    #endif
+  #endif
+}
+
+func withVeryNestedPoundIfClosure() -> Int {
+  let fn = {
+    #if true
+      #if true
+        #if false
+            ""
+        #else
+            if .random() { 0 } else { 1 }
+        #endif
+      #elseif true
+          0
+      #endif
+    #endif
+  }
+  return fn()
+}
+
 // MARK: Explicit returns
 
 func explicitReturn1() -> Int {
@@ -547,6 +658,32 @@ func returnBranches6() -> Int {
   return i
 }
 
+func returnBranches6PoundIf() -> Int {
+  // We don't allow multiple expressions.
+  let i = if .random() {
+    #if true
+    print("hello")
+    0 // expected-warning {{integer literal is unused}}
+    #endif
+  } else { // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
+    1
+  }
+  return i
+}
+
+func returnBranches6PoundIf2() -> Int {
+  // We don't allow multiple expressions.
+  let i = if .random() {
+    #if false
+    print("hello")
+    0
+    #endif
+  } else { // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
+    1
+  }
+  return i
+}
+
 func returnBranches7() -> Int {
   let i = if .random() {
     print("hello")
@@ -650,6 +787,110 @@ func testEmptyBranch() -> Int {
   let x = if .random() {} else { 0 }
   // expected-error@-1:24 {{expected expression in branch of 'if' expression}}
   return x
+}
+
+// MARK: Pound if branches
+
+func testPoundIfBranch1() -> Int {
+  if .random() {
+    #if true
+    0
+    #endif
+  } else {
+    0
+  }
+}
+
+func testPoundIfBranch2() -> Int {
+  if .random() {
+    #if false
+    0
+    #endif
+  } else {
+    0 // expected-warning {{integer literal is unused}}
+  }
+}
+
+func testPoundIfBranch3() -> Int {
+  let x = if .random() {
+    #if false
+    0
+    #endif
+  } else { // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
+    0
+  }
+  return x
+}
+
+func testPoundIfBranch4() -> Int {
+  if .random() {
+    #if true
+    0
+    #endif
+  } else {
+    #if true
+    0
+    #endif
+  }
+}
+
+func testPoundIfBranch5() -> Int {
+  // Not allowed (matches the behavior of implict expression returns)
+  if .random() {
+    #if false
+    0
+    #endif
+    0 // expected-warning {{integer literal is unused}}
+  } else {
+    1 // expected-warning {{integer literal is unused}}
+  }
+}
+
+func testPoundIfBranch6() -> Int {
+  // Not allowed (matches the behavior of implict expression returns)
+  let x = if .random() {
+    #if false
+    0
+    #endif
+    0 // expected-warning {{integer literal is unused}}
+  } else {  // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
+    1
+  }
+  return x
+}
+
+func testPoundIfBranch7() -> Int {
+  if .random() {
+    #if true
+      #if true
+        #if false
+            ""
+        #else
+            0
+        #endif
+      #elseif true
+          ""
+      #endif
+    #endif
+  } else {
+    0
+  }
+}
+
+func testPoundIfBranch8() -> Int {
+  if .random() {
+    #if false
+    0
+    #else
+    #if true
+    if .random() { 0 } else { 1 }
+    #endif
+    #endif
+  } else {
+    #if true
+    if .random() { 0 } else { 1 }
+    #endif
+  }
 }
 
 // MARK: Jumping

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -859,6 +859,21 @@ func nestedType() -> Int {
   }
 }
 
+func testEmptyBranch() -> Int {
+  // TODO: Ideally we wouldn't emit both diagnostics, the latter is the better
+  // one, but the former is currently emitted by the parser. Ideally the former
+  // one should become semantic, and we'd just avoid it for
+  // SingleValueStmtExprs.
+  let x = switch Bool.random() {
+    case true:
+    // expected-error@-1 {{'case' label in a 'switch' must have at least one executable statement}}
+    // expected-error@-2:14 {{expected expression in branch of 'switch' expression}}
+    case false:
+    0
+  }
+  return x
+}
+
 // MARK: Jumping
 
 func break1() -> Int {

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -226,6 +226,117 @@ func testNeverBranches2() {
   }
 }
 
+// MARK: Outer pound if
+
+func withPoundIf() -> Int {
+  #if true
+  switch Bool.random() { case true: 0 case false: 1 }
+  #endif
+}
+
+func withPoundIfClosure() -> Int {
+  let fn = {
+    #if true
+    switch Bool.random() { case true: 0 case false: 1 }
+    #endif
+  }
+  return fn()
+}
+
+func withPoundIfElse1() -> Int {
+  #if true
+  switch Bool.random() { case true: 0 case false: 1 }
+  #else
+  0
+  #endif
+}
+
+func withPoundIfElse2() -> Int {
+  #if true
+  0
+  #else
+  switch Bool.random() { case true: 0 case false: 1 }
+  #endif
+}
+
+func withPoundIfElseIf1() -> Int {
+  #if true
+  switch Bool.random() { case true: 0 case false: 1 }
+  #elseif true
+  0
+  #endif
+}
+
+
+func withPoundIfElseIf2() -> Int {
+  #if true
+  0
+  #elseif true
+  switch Bool.random() { case true: 0 case false: 1 }
+  #endif
+}
+
+func withPoundIfElseIfElse1() -> Int {
+  #if true
+  switch Bool.random() { case true: 0 case false: 1 }
+  #elseif true
+  0
+  #else
+  0
+  #endif
+}
+
+func withPoundIfElseIfElse2() -> Int {
+  #if true
+  0
+  #elseif true
+  switch Bool.random() { case true: 0 case false: 1 }
+  #else
+  0
+  #endif
+}
+
+func withPoundIfElseIfElse3() -> Int {
+  #if true
+  0
+  #elseif true
+  0
+  #else
+  switch Bool.random() { case true: 0 case false: 1 }
+  #endif
+}
+
+func withVeryNestedPoundIf() -> Int {
+  #if true
+    #if true
+      #if false
+      ""
+      #else
+      switch Bool.random() { case true: 0 case false: 1 }
+      #endif
+    #elseif true
+    0
+    #endif
+  #endif
+}
+
+func withVeryNestedPoundIfClosure() -> Int {
+  let fn = {
+    #if true
+      #if true
+        #if false
+            ""
+        #else
+            switch Bool.random() { case true: 0 case false: 1 }
+        #endif
+      #elseif true
+          0
+      #endif
+    #endif
+  }
+  return fn()
+}
+
 // MARK: Explicit returns
 
 func explicitReturn1() -> Int {
@@ -702,6 +813,36 @@ func returnBranches6() -> Int {
   return i
 }
 
+func returnBranches6PoundIf() -> Int {
+  // We don't allow multiple expressions.
+  let i = switch Bool.random() {
+  case true:
+    #if true
+    print("hello")
+    0 // expected-warning {{integer literal is unused}}
+    #endif
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+  case false:
+    1
+  }
+  return i
+}
+
+func returnBranches6PoundIf2() -> Int {
+  // We don't allow multiple expressions.
+  let i = switch Bool.random() {
+  case true:
+    #if false
+    print("hello")
+    0
+    #endif
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+  case false:
+    1
+  }
+  return i
+}
+
 func returnBranches7() -> Int {
   let i = switch Bool.random() {
   case true:
@@ -872,6 +1013,120 @@ func testEmptyBranch() -> Int {
     0
   }
   return x
+}
+
+// MARK: Pound if branches
+
+func testPoundIfBranch1() -> Int {
+  switch Bool.random() {
+  case true:
+    #if true
+    0
+    #endif
+  case false:
+    0
+  }
+}
+
+func testPoundIfBranch2() -> Int {
+  switch Bool.random() {
+  case true:
+    #if false
+    0
+    #endif
+  case false:
+    0 // expected-warning {{integer literal is unused}}
+  }
+}
+
+func testPoundIfBranch3() -> Int {
+  let x = switch Bool.random() {
+  case true:
+    #if false
+    0
+    #endif
+  // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+  case false:
+    0
+  }
+  return x
+}
+
+func testPoundIfBranch4() -> Int {
+  switch Bool.random() {
+  case true:
+    #if true
+    0
+    #endif
+  case false:
+    #if true
+    0
+    #endif
+  }
+}
+
+func testPoundIfBranch5() -> Int {
+  // Not allowed (matches the behavior of implict expression returns)
+  switch Bool.random() {
+  case true:
+    #if false
+    0
+    #endif
+    0 // expected-warning {{integer literal is unused}}
+  case false:
+    1 // expected-warning {{integer literal is unused}}
+  }
+}
+
+func testPoundIfBranch6() -> Int {
+  // Not allowed (matches the behavior of implict expression returns)
+  let x = switch Bool.random() {
+  case true:
+    #if false
+    0
+    #endif
+    0 // expected-warning {{integer literal is unused}}
+    // expected-error@-1 {{non-expression branch of 'switch' expression may only end with a 'throw'}}
+  case false:
+    1
+  }
+  return x
+}
+
+func testPoundIfBranch7() -> Int {
+  switch Bool.random() {
+  case true:
+    #if true
+      #if true
+        #if false
+        ""
+        #else
+        0
+        #endif
+      #elseif true
+      ""
+      #endif
+    #endif
+  case false:
+    0
+  }
+}
+
+func testPoundIfBranch8() -> Int {
+  switch Bool.random() {
+  case true:
+    #if false
+    0
+    #else
+    #if true
+    switch Bool.random() { case true: 0 case false: 1 }
+    #endif
+    #endif
+  case false:
+    #if true
+    switch Bool.random() { case true: 0 case false: 1 }
+    #endif
+  }
 }
 
 // MARK: Jumping


### PR DESCRIPTION
- Allow an if/switch expression to become an implicit return of a function that has a `#if` body with a single active element that is an `if` or `switch`.
- Allow `#if` branches of an if/switch expression, as long as there is a single active expression element.

rdar://107487977