### PR TITLE
[5.9][interop] mark C++ virtual functions as unavailable in Swift

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3443,6 +3443,11 @@ namespace {
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
       auto method = VisitFunctionDecl(decl);
+      if (decl->isVirtual() && isa_and_nonnull<ValueDecl>(method)) {
+        Impl.markUnavailable(
+            cast<ValueDecl>(method),
+            "virtual functions are not yet available in Swift");
+      }
 
       if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties) {
         CXXMethodBridging bridgingInfo(decl);

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -27,3 +27,7 @@ struct Unused : Base {
 };
 
 using UnusedInt = Unused<int>;
+
+struct VirtualNonAbstractBase {
+  virtual void nonAbstractMethod() const;
+};

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test -print-module -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK: struct Base {
+// CHECK-NEXT:  init()
+// CHECK-NEXT:   @available(*, unavailable, message: "virtual functions are not yet available in Swift")
+// CHECK-NEXT:   mutating func foo()
+
+// CHECK: struct Derived<Int32> {
+// CHECK: @available(*, unavailable, message: "virtual functions are not yet available in Swift")
+// CHECK:  mutating func foo()
+// CHECK: }
+
+// CHECK: struct VirtualNonAbstractBase {
+// CHECK:  @available(*, unavailable, message: "virtual functions are not yet available in Swift")
+// CHECK:  func nonAbstractMethod()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
+
+import VirtualMethods
+
+VirtualNonAbstractBase().nonAbstractMethod() // expected-error {{'nonAbstractMethod()' is unavailable: virtual functions are not yet available in Swift}}


### PR DESCRIPTION
They're not yet supported

(cherry picked from commit c2315060b666518dc77a9ac15260df7d046e24d1)

Explanation: Swift compiler does not IRGen virtual C++ calls. Thus their invocations are broken in Swift, as they do not perform virtual dispatch. We should mark them as 'unavailable' for now until they're supported.
Scope: Swift's and C++ interoperability. The virtual functions were always broken so haven't been adopted yet.
Risk: Little. The virtual functions calls from Swift are not yet adopted.
Testing: Swift unit tests.
Reviewer: @ravikandhadai 

Fixes https://github.com/apple/swift/issues/61471