### PR TITLE
[5.9][interop] make interop diagnostics more consistent with the rest of S…

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -83,7 +83,7 @@ NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
      (StringRef))
 
 WARNING(clang_swift_attr_unhandled,none,
-        "Ignoring unknown Swift attribute or modifier '%0'", (StringRef))
+        "ignoring unknown Swift attribute or modifier '%0'", (StringRef))
 
 WARNING(clang_error_code_must_be_sendable,none,
         "cannot make error code type '%0' non-sendable because Swift errors "
@@ -160,77 +160,75 @@ NOTE(incomplete_interface, none, "interface %0 is incomplete", (const clang::Nam
 NOTE(incomplete_protocol, none, "protocol %0 is incomplete", (const clang::NamedDecl*))
 NOTE(incomplete_record, none, "record '%0' is not defined (incomplete)", (StringRef))
 NOTE(record_over_aligned, none, "record '%0' is over aligned", (StringRef))
-NOTE(record_non_trivial_copy_destroy, none, "record '%0' is not trivial to copy/destroy", (StringRef))
+NOTE(record_non_trivial_copy_destroy, none, "record '%0' is not trivial to copy or destroy", (StringRef))
 NOTE(record_is_dependent, none, "record '%0' is dependent", (StringRef))
 NOTE(record_parent_unimportable, none, "record %0's parent is not importable", (StringRef))
 NOTE(reference_passed_by_value, none, "function uses foreign reference type "
                                       "'%0' as a value in %1 types which breaks "
-                                      "'swift_shared_reference' contract (outlined in "
-                                      "C++ Interop User Manual).",
+                                      "'swift_shared_reference' contract",
      (StringRef, StringRef))
 NOTE(record_not_automatically_importable, none, "record '%0' is not "
-                                                "automatically available: %1. "
-                                                "Does this type have reference "
+                                                "automatically available: %1; "
+                                                "does this type have reference "
                                                 "semantics?",
      (StringRef, StringRef))
 
 NOTE(projection_value_not_imported, none, "C++ method '%0' that returns a value "
-                                          "of type '%1' is unavailable. ",
+                                          "of type '%1' is unavailable",
      (StringRef, StringRef))
 NOTE(projection_ptr_not_imported, none, "C++ method '%0' that returns a pointer "
-                                          "of type '%1' is unavailable. ",
+                                          "of type '%1' is unavailable",
      (StringRef, StringRef))
 NOTE(projection_reference_not_imported, none, "C++ method '%0' that returns a reference "
-                                          "of type '%1' is unavailable. ",
+                                          "of type '%1' is unavailable",
      (StringRef, StringRef))
 NOTE(projection_may_return_interior_ptr, none, "C++ method '%0' may return an "
-                                    "interior pointer. ",
+                                    "interior pointer",
      (StringRef))
-NOTE(mark_self_contained, none, "Mark type '%0' as 'SWIFT_SELF_CONTAINED' in C++ to "
-                                 "make methods that use it available in Swift. ",
+NOTE(mark_self_contained, none, "annotate type '%0' with 'SWIFT_SELF_CONTAINED' in C++ to "
+                                 "make methods that return it available in Swift",
      (StringRef))
 NOTE(mark_safe_to_import, none, "annotate method '%0' with 'SWIFT_RETURNS_INDEPENDENT_VALUE' in C++ to "
                                 "make it available in Swift",
      (StringRef))
 
-NOTE(at_to_subscript, none, "Do you want to replace it with a call "
+NOTE(at_to_subscript, none, "do you want to replace it with a call "
                             "to the subscript operator?",
      ())
-NOTE(get_swift_iterator, none, "Do you want to make a Swift iterator instead?",
+NOTE(get_swift_iterator, none, "do you want to make a Swift iterator instead?",
      ())
-NOTE(replace_with_nil, none, "Do you want to compare against 'nil' instead?'",
+NOTE(replace_with_nil, none, "do you want to compare against 'nil' instead?",
      ())
-NOTE(get_first_element, none, "Do you want to get the first element instead?",
+NOTE(get_first_element, none, "do you want to get the first element instead?",
      ())
-NOTE(get_last_element, none, "Do you want to get the last element instead?",
+NOTE(get_last_element, none, "do you want to get the last element instead?",
      ())
 
 NOTE(iterator_method_unavailable, none, "C++ method '%0' that returns an "
                                   "iterator is unavailable",
      (StringRef))
 NOTE(iterator_potentially_unsafe, none, "C++ methods that return iterators "
-                                        "are potentially unsafe. Try re-writing "
-                                        "to use Swift iterator APIs.", ())
+                                        "are potentially unsafe; try using Swift collection APIs instead", ())
 
 ERROR(reference_type_must_have_retain_attr,none,
-      "reference type '%0' must have 'retain:' swift attribute.", (StringRef))
+      "reference type '%0' must have 'retain:' swift attribute", (StringRef))
 ERROR(reference_type_must_have_release_attr,none,
-      "reference type '%0' must have 'release:' swift attribute.", (StringRef))
+      "reference type '%0' must have 'release:' swift attribute", (StringRef))
 ERROR(foreign_reference_types_cannot_find_retain,none,
-      "cannot find retain function '%0' for reference type '%1'.", (StringRef, StringRef))
+      "cannot find retain function '%0' for reference type '%1'", (StringRef, StringRef))
 ERROR(foreign_reference_types_cannot_find_release,none,
-      "cannot find release function '%0' for reference type '%1'.", (StringRef, StringRef))
+      "cannot find release function '%0' for reference type '%1'", (StringRef, StringRef))
 ERROR(too_many_reference_type_retain_operations,none,
-      "too many functions with name '%0'. There must be exactly one retain "
-      "function for reference type '%1'.", (StringRef, StringRef))
+      "multiple functions '%0' found; there must be exactly one retain "
+      "function for reference type '%1'", (StringRef, StringRef))
 ERROR(too_many_reference_type_release_operations,none,
-      "too many functions with name '%0'. There must be exactly one release "
-      "function for reference type '%1'.", (StringRef, StringRef))
+      "multiple functions '%0' found; there must be exactly one release "
+      "function for reference type '%1'", (StringRef, StringRef))
 ERROR(foreign_reference_types_invalid_retain,none,
-      "specified retain function '%0' is invalid. Retain must have exactly one "
+      "specified retain function '%0' is invalid; retain function must have exactly one "
       "argument of type '%1'", (StringRef, StringRef))
 ERROR(foreign_reference_types_invalid_release,none,
-      "specified release function '%0' is invalid. Release must have exactly "
+      "specified release function '%0' is invalid; release function must have exactly "
       "one argument of type '%1'", (StringRef, StringRef))
 
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -515,18 +515,18 @@ WARNING(compiler_plugin_not_loaded,none,
         "compiler plugin not loaded: %0; loader error: %1", (StringRef, StringRef))
         
 ERROR(dont_enable_interop_and_compat,none,
-      "do not pass both -enable-experimental-cxx-interop and "
-      "-cxx-interoperability-mode. Remove -enable-experimental-cxx-interop.", ())
+      "do not pass both '-enable-experimental-cxx-interop' and "
+      "'-cxx-interoperability-mode'; remove '-enable-experimental-cxx-interop'", ())
 
 NOTE(valid_cxx_interop_modes,none,
       "valid arguments to '-cxx-interoperability-mode=' are %0", (StringRef))
 NOTE(swift_will_maintain_compat,none,
      "Swift will maintain source compatibility for imported APIs based on the "
      "selected compatibility mode, so updating the Swift compiler will not "
-     "change how APIs are imported.", ())
+     "change how APIs are imported", ())
 WARNING(enable_interop_flag_deprecated,none,
-        "the -enable-experimental-cxx-interop flag is deprecated. Please pass "
-        "'-cxx-interoperability-mode=' instead.", ())
+        "the '-enable-experimental-cxx-interop' flag is deprecated; please pass "
+        "'-cxx-interoperability-mode=' instead", ())
 
 ERROR(layout_string_instantiation_without_layout_strings,none,
       "-enable-layout-string-value-witnesses-instantiation can not be enabled "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2002,9 +2002,9 @@ ERROR(where_nongeneric_toplevel,none,
       "'where' clause cannot be applied to a non-generic top-level "
       "declaration", ())
 ERROR(unable_to_convert_generic_swift_types,none,
-      "could not generate C++ types from the generic Swift types provided. "
-      "The following Swift type(s) provided to '%0' could not be "
-      "converted: %1.",
+      "could not generate C++ types from the generic Swift types provided; "
+      "the following Swift type(s) provided to '%0' could not be "
+      "converted: %1",
       (StringRef, StringRef))
 
 // Type aliases

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_structs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_structs.h
@@ -8,10 +8,10 @@ struct StructOfBlocks {
   void (^__unsafe_unretained _Nonnull block)(void);
 };
 
-struct StrongsInAStruct { // expected-note {{record 'StrongsInAStruct' is not trivial to copy/destroy}}
+struct StrongsInAStruct { // expected-note {{record 'StrongsInAStruct' is not trivial to copy or destroy}}
   __strong NSString *nsstr;
 };
 
-struct WeaksInAStruct { // expected-note {{record 'WeaksInAStruct' is not trivial to copy/destroy}}
+struct WeaksInAStruct { // expected-note {{record 'WeaksInAStruct' is not trivial to copy or destroy}}
   __weak NSString *nsstr;
 };

--- a/test/Interop/Cxx/class/fixit-add-safe-to-import-self-contained.swift
+++ b/test/Interop/Cxx/class/fixit-add-safe-to-import-self-contained.swift
@@ -33,7 +33,7 @@ public func test(x: X) {
   // CHECK: ^
   // CHECK: SWIFT_RETURNS_INDEPENDENT_VALUE
   
-  // CHECK: note: Mark type 'Ptr' as 'SWIFT_SELF_CONTAINED' in C++ to make methods that use it available in Swift.
+  // CHECK: note: annotate type 'Ptr' with 'SWIFT_SELF_CONTAINED' in C++ to make methods that return it available in Swift
   // CHECK: struct Ptr {
   // CHECK: ^
   // CHECK: SWIFT_SELF_CONTAINED

--- a/test/Interop/Cxx/class/fixits-for-std-vector.swift
+++ b/test/Interop/Cxx/class/fixits-for-std-vector.swift
@@ -22,27 +22,27 @@ import CxxStdlib
 
 public func test(v: V) {
   // CHECK: note: C++ method 'begin' that returns an iterator is unavailable
-  // CHECK: note: Do you want to make a Swift iterator instead?
+  // CHECK: note: do you want to make a Swift iterator instead?
   // CHECK: ^~~~~
   // CHECK: makeIterator
   _ = v.begin()
   
   // CHECK: note: C++ method 'end' that returns an iterator is unavailable
-  // CHECK: note: Do you want to compare against 'nil' instead?'
+  // CHECK: note: do you want to compare against 'nil' instead?
   // CHECK: ^~~~
   // CHECK: nil
   _ = v.end()
 
-  // CHECK: note: C++ method 'front' that returns a reference of type 'UnsafePointer' is unavailable.
-  // CHECK: note: C++ method 'front' may return an interior pointer.
-  // CHECK: note: Do you want to get the first element instead?
+  // CHECK: note: C++ method 'front' that returns a reference of type 'UnsafePointer' is unavailable
+  // CHECK: note: C++ method 'front' may return an interior pointer
+  // CHECK: note: do you want to get the first element instead?
   // CHECK: ^~~~~~~
   // CHECK: first
   _ = v.front()
   
-  // CHECK: note: C++ method 'back' that returns a reference of type 'UnsafePointer' is unavailable.
-  // CHECK: note: C++ method 'back' may return an interior pointer.
-  // CHECK: note: Do you want to get the last element instead?
+  // CHECK: note: C++ method 'back' that returns a reference of type 'UnsafePointer' is unavailable
+  // CHECK: note: C++ method 'back' may return an interior pointer
+  // CHECK: note: do you want to get the last element instead?
   // CHECK: ^~~~~~
   // CHECK: last
   _ = v.back()

--- a/test/Interop/Cxx/class/invalid-class-errors.swift
+++ b/test/Interop/Cxx/class/invalid-class-errors.swift
@@ -27,17 +27,17 @@ struct Nested {
 
 import Test
 
-// CHECK: note: record 'A' is not automatically available: does not have a copy constructor or destructor. Does this type have reference semantics?
+// CHECK: note: record 'A' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?
 // CHECK: struct A {
 // CHECK: ^
 // CHECK: SWIFT_SHARED_REFERENCE(<#retain#>, <#release#>)
 public func test(x: A) { }
-// CHECK: note: record 'B' is not automatically available: does not have a copy constructor or destructor. Does this type have reference semantics?
+// CHECK: note: record 'B' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?
 // CHECK: struct {{.*}}B {
 // CHECK: ^
 // CHECK: SWIFT_SHARED_REFERENCE(<#retain#>, <#release#>)
 public func test(x: B) { }
-// CHECK: note: record 'Nested' is not automatically available: does not have a copy constructor or destructor. Does this type have reference semantics?
+// CHECK: note: record 'Nested' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?
 // CHECK: struct Nested {
 // CHECK: ^
 // CHECK: SWIFT_SHARED_REFERENCE(<#retain#>, <#release#>)

--- a/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
+++ b/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
@@ -27,21 +27,21 @@ struct M {
 import Test
 
 public func test(x: M) {
-  // CHECK: note: C++ method 'test1' that returns a pointer of type 'UnsafeMutablePointer' is unavailable.
-  // CHECK: note: C++ method 'test1' may return an interior pointer.
+  // CHECK: note: C++ method 'test1' that returns a pointer of type 'UnsafeMutablePointer' is unavailable
+  // CHECK: note: C++ method 'test1' may return an interior pointer
   // CHECK: note: annotate method 'test1' with 'SWIFT_RETURNS_INDEPENDENT_VALUE' in C++ to make it available in Swift
   x.test1()
-  // CHECK: note: C++ method 'test2' that returns a reference of type 'UnsafeMutablePointer' is unavailable.
-  // CHECK: note: C++ method 'test2' may return an interior pointer.
+  // CHECK: note: C++ method 'test2' that returns a reference of type 'UnsafeMutablePointer' is unavailable
+  // CHECK: note: C++ method 'test2' may return an interior pointer
   // CHECK: note: annotate method 'test2' with 'SWIFT_RETURNS_INDEPENDENT_VALUE' in C++ to make it available in Swift
   x.test2()
-  // CHECK: note: C++ method 'test3' that returns a value of type 'Ptr' is unavailable.
-  // CHECK: note: C++ method 'test3' may return an interior pointer.
+  // CHECK: note: C++ method 'test3' that returns a value of type 'Ptr' is unavailable
+  // CHECK: note: C++ method 'test3' may return an interior pointer
   // CHECK: note: annotate method 'test3' with 'SWIFT_RETURNS_INDEPENDENT_VALUE' in C++ to make it available in Swift
-  // CHECK: note: Mark type 'Ptr' as 'SWIFT_SELF_CONTAINED' in C++ to make methods that use it available in Swift.
+  // CHECK: note: annotate type 'Ptr' with 'SWIFT_SELF_CONTAINED' in C++ to make methods that return it available in Swift
   x.test3()
   // CHECK: note: C++ method 'begin' that returns an iterator is unavailable
-  // CHECK: note: C++ methods that return iterators are potentially unsafe. Try re-writing to use Swift iterator APIs.
+  // CHECK: note: C++ methods that return iterators are potentially unsafe; try using Swift collection APIs instead
   x.begin()
 
   // CHECK-NOT: error: value of type 'M' has no member 'stringLiteral'

--- a/test/Interop/Cxx/driver/dont-enable-interop-compat.swift
+++ b/test/Interop/Cxx/driver/dont-enable-interop-compat.swift
@@ -15,5 +15,5 @@ module Test {
 
 import Test
 
-// CHECK: warning: the -enable-experimental-cxx-interop flag is deprecated. Please pass '-cxx-interoperability-mode=' instead.
-// CHECK: note: Swift will maintain source compatibility for imported APIs based on the selected compatibility mode, so updating the Swift compiler will not change how APIs are imported.
+// CHECK: warning: the '-enable-experimental-cxx-interop' flag is deprecated; please pass '-cxx-interoperability-mode=' instead
+// CHECK: note: Swift will maintain source compatibility for imported APIs based on the selected compatibility mode, so updating the Swift compiler will not change how APIs are imported

--- a/test/Interop/Cxx/driver/enable-interop-flag-depr.swift
+++ b/test/Interop/Cxx/driver/enable-interop-flag-depr.swift
@@ -14,5 +14,5 @@ module Test {
 
 import Test
 
-// CHECK: error: do not pass both -enable-experimental-cxx-interop and -cxx-interoperability-mode. Remove -enable-experimental-cxx-interop.
-// CHECK: note: Swift will maintain source compatibility for imported APIs based on the selected compatibility mode, so updating the Swift compiler will not change how APIs are imported.
+// CHECK: error: do not pass both '-enable-experimental-cxx-interop' and '-cxx-interoperability-mode'; remove '-enable-experimental-cxx-interop'
+// CHECK: note: Swift will maintain source compatibility for imported APIs based on the selected compatibility mode, so updating the Swift compiler will not change how APIs are imported

--- a/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/invalid-retain-operation-errors.swift
@@ -32,14 +32,14 @@ void badRelease(BadRetainRelease *v, int i);
 
 import Test
 
-// CHECK: error: cannot find retain function 'nonexistant' for reference type 'NonExistant'.
-// CHECK: error: cannot find release function 'nonexistant' for reference type 'NonExistant'.
+// CHECK: error: cannot find retain function 'nonexistant' for reference type 'NonExistant'
+// CHECK: error: cannot find release function 'nonexistant' for reference type 'NonExistant'
 public func test(x: NonExistant) { }
 
-// CHECK: error: reference type 'NoRetainRelease' must have 'retain:' swift attribute.
-// CHECK: error: reference type 'NoRetainRelease' must have 'release:' swift attribute.
+// CHECK: error: reference type 'NoRetainRelease' must have 'retain:' swift attribute
+// CHECK: error: reference type 'NoRetainRelease' must have 'release:' swift attribute
 public func test(x: NoRetainRelease) { }
 
-// CHECK: error: specified retain function 'badRetain' is invalid. Retain must have exactly one argument of type 'BadRetainRelease'
-// CHECK: error: specified release function 'badRelease' is invalid. Release must have exactly one argument of type 'BadRetainRelease'
+// CHECK: error: specified retain function 'badRetain' is invalid; retain function must have exactly one argument of type 'BadRetainRelease'
+// CHECK: error: specified release function 'badRelease' is invalid; release function must have exactly one argument of type 'BadRetainRelease'
 public func test(x: BadRetainRelease) { }

--- a/test/Interop/Cxx/foreign-reference/value-type-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/value-type-errors.swift
@@ -19,8 +19,8 @@ void takesRef(Ref r);
 import Test
 
 public func test(x: Ref) {
-    // CHECK: note: function uses foreign reference type 'Ref' as a value in the return types which breaks 'swift_shared_reference' contract (outlined in C++ Interop User Manual).
+    // CHECK: note: function uses foreign reference type 'Ref' as a value in the return types which breaks 'swift_shared_reference' contract
     returnsRef()
-    // CHECK: note: function uses foreign reference type 'Ref' as a value in a parameter types which breaks 'swift_shared_reference' contract (outlined in C++ Interop User Manual).
+    // CHECK: note: function uses foreign reference type 'Ref' as a value in a parameter types which breaks 'swift_shared_reference' contract
     takesRef(x)
 }

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
@@ -2,12 +2,12 @@
 
 import ClassTemplateInstantiationErrors
 
-// CHECK: class-template-instantiation-typechecker.swift:7:11: error: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'MagicWrapper' could not be converted: Optional<_>.
+// CHECK: class-template-instantiation-typechecker.swift:7:11: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'MagicWrapper' could not be converted: Optional<_>
 func swiftTemplateArgNotSupported() {
   var _ = MagicWrapper<Optional>(t: "asdf")
 }
 
-// CHECK: class-template-instantiation-typechecker.swift:12:11: error: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'MagicWrapperWithExplicitCtor' could not be converted: String.
+// CHECK: class-template-instantiation-typechecker.swift:12:11: error: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'MagicWrapperWithExplicitCtor' could not be converted: String
 func swiftTemplateArgNotSupportedExplicitCtor() {
   var _ = MagicWrapperWithExplicitCtor<String>("asdf")
 }

--- a/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
@@ -20,12 +20,12 @@ public protocol A { }
 public protocol B { }
 public protocol C { }
 
-// CHECK: error: unexpected error produced: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'passThrough' could not be converted: A & B.
+// CHECK: error: unexpected error produced: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'passThrough' could not be converted: A & B
 public func caller1(x: A & B) -> A & B {
   return passThrough(x)
 }
 
-// CHECK: error: unexpected error produced: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'addMixedTypeParams' could not be converted: A & B, A & C.
+// CHECK: error: unexpected error produced: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'addMixedTypeParams' could not be converted: A & B, A & C
 public func caller2(x: A & B, y: A & C) -> A & B {
   return addMixedTypeParams(x, y)
 }


### PR DESCRIPTION
…wift diagnostics

(cherry picked from commit b60d635db7e695bdf5f9652a45f37a5cfc5c6668)

Explanation: Swift and C++ interoperability related diagnostics should match the Swift diagnostic style. Also, some wording for them has been cleaned up.
Scope: Swift's and C++ interoperability. 
Risk: Very low. It only changes the contents of the diagnostic.
Testing: Swift unit tests.
Reviewer: @zoecarver 