### PR TITLE
[5.9][interop] add availability for foreign reference types

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -53,10 +53,16 @@ public struct DiagnosticFixIt {
 }
 
 public struct DiagnosticEngine {
-  private let bridged: swift.DiagnosticEngine
+  private let bridged: BridgedDiagnosticEngine
 
-  public init(bridged: swift.DiagnosticEngine) {
+  public init(bridged: BridgedDiagnosticEngine) {
     self.bridged = bridged
+  }
+  public init?(bridged: BridgedOptionalDiagnosticEngine) {
+    guard let object = bridged.object else {
+      return nil
+    }
+    self.bridged = BridgedDiagnosticEngine(object: object)
   }
 
   public func diagnose(_ position: SourceLoc?,

--- a/SwiftCompilerSources/Sources/Parse/Regex.swift
+++ b/SwiftCompilerSources/Sources/Parse/Regex.swift
@@ -46,7 +46,7 @@ private func _RegexLiteralLexingFn(
   _ curPtrPtr: UnsafeMutablePointer<UnsafePointer<CChar>>,
   _ bufferEndPtr: UnsafePointer<CChar>,
   _ mustBeRegex: CBool,
-  _ bridgedDiagnosticEngine: swift.DiagnosticEngine?
+  _ bridgedDiagnosticEngine: BridgedOptionalDiagnosticEngine
 ) -> /*CompletelyErroneous*/ CBool {
   let inputPtr = curPtrPtr.pointee
 
@@ -62,8 +62,7 @@ private func _RegexLiteralLexingFn(
 
   if let error = error {
     // Emit diagnostic if diagnostics are enabled.
-    if let bridged = bridgedDiagnosticEngine {
-      let diagEngine = DiagnosticEngine(bridged: bridged)
+    if let diagEngine = DiagnosticEngine(bridged: bridgedDiagnosticEngine) {
       let startLoc = SourceLoc(
         locationInFile: error.location.assumingMemoryBound(to: UInt8.self))!
       diagEngine.diagnose(startLoc, .foreign_diagnostic, error.message)
@@ -94,7 +93,7 @@ public func _RegexLiteralParsingFn(
   _ captureStructureOut: UnsafeMutableRawPointer,
   _ captureStructureSize: CUnsignedInt,
   _ bridgedDiagnosticBaseLoc: swift.SourceLoc,
-  _ bridgedDiagnosticEngine: swift.DiagnosticEngine
+  _ bridgedDiagnosticEngine: BridgedDiagnosticEngine
 ) -> Bool {
   let str = String(cString: inputPtr)
   let captureBuffer = UnsafeMutableRawBufferPointer(

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -32,11 +32,21 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {
 #include "swift/AST/DiagnosticsAll.def"
 } BridgedDiagID;
 
+typedef struct {
+  void * _Nonnull object;
+} BridgedDiagnosticEngine;
+
+typedef struct {
+  void *_Nullable object;
+} BridgedOptionalDiagnosticEngine;
+
 // FIXME: Can we bridge InFlightDiagnostic?
-void DiagnosticEngine_diagnose(swift::DiagnosticEngine &, swift::SourceLoc loc,
+void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, swift::SourceLoc loc,
                                BridgedDiagID diagID, BridgedArrayRef arguments,
                                swift::CharSourceRange highlight,
                                BridgedArrayRef fixIts);
+
+bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine);
 
 using ArrayRefOfDiagnosticArgument = llvm::ArrayRef<swift::DiagnosticArgument>;
 

--- a/include/swift/AST/BridgingUtils.h
+++ b/include/swift/AST/BridgingUtils.h
@@ -1,0 +1,32 @@
+//===--- BridgingUtils.h - utilities for swift bridging -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_BRIDGINGUTILS_H
+#define SWIFT_AST_BRIDGINGUTILS_H
+
+#include "swift/AST/ASTBridging.h"
+#include "swift/AST/DiagnosticEngine.h"
+
+namespace swift {
+
+inline BridgedDiagnosticEngine getBridgedDiagnosticEngine(DiagnosticEngine *D) {
+  return {(void *)D};
+}
+inline BridgedOptionalDiagnosticEngine
+getBridgedOptionalDiagnosticEngine(DiagnosticEngine *D) {
+  return {(void *)D};
+}
+
+} // namespace swift
+
+#endif
+

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -804,7 +804,7 @@ namespace swift {
 
   /// Class responsible for formatting diagnostics and presenting them
   /// to the user.
-  class SWIFT_IMPORT_REFERENCE DiagnosticEngine {
+  class DiagnosticEngine {
   public:
     /// The source manager used to interpret source locations and
     /// display diagnostics.

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -184,15 +184,6 @@
 #define SWIFT_VFORMAT(fmt)
 #endif
 
-// Tells Swift's ClangImporter to import a C++ type as a foreign reference type.
-#if __has_attribute(swift_attr)
-#define SWIFT_IMPORT_REFERENCE __attribute__((swift_attr("import_reference"))) \
-  __attribute__((swift_attr("retain:immortal")))                               \
-  __attribute__((swift_attr("release:immortal")))
-#else
-#define SWIFT_IMPORT_REFERENCE
-#endif
-
 #if __has_attribute(enum_extensibility)
 #define ENUM_EXTENSIBILITY_ATTR(arg) __attribute__((enum_extensibility(arg)))
 #else

--- a/include/swift/Parse/RegexParserBridging.h
+++ b/include/swift/Parse/RegexParserBridging.h
@@ -27,8 +27,8 @@
 ///              past.
 /// - MustBeRegex: whether an error during lexing should be considered a regex
 ///                literal, or some thing else.
-/// - OptionalDiagnosticEngine: RegexLiteralLexingFn should diagnose the
-///                             token using this engine.
+/// - BridgedOptionalDiagnosticEngine: RegexLiteralLexingFn should diagnose the
+///                                    token using this engine.
 ///
 /// Returns: A bool indicating whether lexing was completely erroneous, and
 ///          cannot be recovered from, or false if there either was no error,
@@ -36,7 +36,7 @@
 typedef bool (*RegexLiteralLexingFn)(
     /*CurPtrPtr*/ const char *_Nonnull *_Nonnull,
     /*BufferEnd*/ const char *_Nonnull,
-    /*MustBeRegex*/ bool, swift::DiagnosticEngine *_Nullable);
+    /*MustBeRegex*/ bool, BridgedOptionalDiagnosticEngine);
 void Parser_registerRegexLiteralLexingFn(RegexLiteralLexingFn _Nullable fn);
 
 /// Parse a regex literal string. Takes the following arguments:
@@ -48,8 +48,8 @@ void Parser_registerRegexLiteralLexingFn(RegexLiteralLexingFn _Nullable fn);
 /// - CaptureStructureSize: The size of the capture structure buffer. Must be
 ///                         greater than or equal to `strlen(InputPtr) + 3`.
 /// - DiagnosticBaseLoc: Start location of the regex literal.
-/// - DiagnosticEngine: RegexLiteralParsingFn should diagnose the
-///                     parsing errors using this engine.
+/// - BridgedDiagnosticEngine: RegexLiteralParsingFn should diagnose the
+///                            parsing errors using this engine.
 ///
 /// Returns: A bool value indicating if there was an error while parsing.
 typedef bool (*RegexLiteralParsingFn)(/*InputPtr*/ const char *_Nonnull,
@@ -57,7 +57,7 @@ typedef bool (*RegexLiteralParsingFn)(/*InputPtr*/ const char *_Nonnull,
                                       /*CaptureStructureOut*/ void *_Nonnull,
                                       /*CaptureStructureSize*/ unsigned,
                                       /*DiagnosticBaseLoc*/ swift::SourceLoc,
-                                      swift::DiagnosticEngine &);
+                                      BridgedDiagnosticEngine);
 void Parser_registerRegexLiteralParsingFn(RegexLiteralParsingFn _Nullable fn);
 
 #endif // REGEX_PARSER_BRIDGING

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -17,18 +17,28 @@
 
 using namespace swift;
 
+namespace {
+/// BridgedDiagnosticEngine -> DiagnosticEngine *.
+DiagnosticEngine *getDiagnosticEngine(const BridgedDiagnosticEngine &bridged) {
+  return static_cast<DiagnosticEngine *>(bridged.object);
+}
+
+} // namespace
+
 void DiagnosticEngine_diagnose(
-    DiagnosticEngine &engine, SourceLoc loc, BridgedDiagID bridgedDiagID,
+    BridgedDiagnosticEngine bridgedEngine, SourceLoc loc,
+    BridgedDiagID bridgedDiagID,
     BridgedArrayRef /*DiagnosticArgument*/ bridgedArguments,
     CharSourceRange highlight,
     BridgedArrayRef /*DiagnosticInfo::FixIt*/ bridgedFixIts) {
+  auto *D = getDiagnosticEngine(bridgedEngine);
 
   auto diagID = static_cast<DiagID>(bridgedDiagID);
   SmallVector<DiagnosticArgument, 2> arguments;
   for (auto arg : getArrayRef<DiagnosticArgument>(bridgedArguments)) {
     arguments.push_back(arg);
   }
-  auto inflight = engine.diagnose(loc, diagID, arguments);
+  auto inflight = D->diagnose(loc, diagID, arguments);
 
   // Add highlight.
   if (highlight.isValid()) {
@@ -41,4 +51,9 @@ void DiagnosticEngine_diagnose(
     auto text = fixIt.getText();
     inflight.fixItReplaceChars(range.getStart(), range.getEnd(), text);
   }
+}
+
+bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine bridgedEngine) {
+  auto *D = getDiagnosticEngine(bridgedEngine);
+  return D->hadAnyError();
 }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Parse/Lexer.h"
+#include "swift/AST/BridgingUtils.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/LangOptions.h"
@@ -2084,7 +2085,7 @@ const char *Lexer::tryScanRegexLiteral(const char *TokStart, bool MustBeRegex,
   //   recovered from.
   auto *Ptr = TokStart;
   CompletelyErroneous = regexLiteralLexingFn(
-      &Ptr, BufferEnd, MustBeRegex, Diags);
+      &Ptr, BufferEnd, MustBeRegex, getBridgedOptionalDiagnosticEngine(Diags));
 
   // If we didn't make any lexing progress, this isn't a regex literal and we
   // should fallback to lexing as something else.

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -14,6 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/BridgingUtils.h"
+#include "swift/AST/DiagnosticsParse.h"
 #include "swift/Basic/BridgingUtils.h"
 #include "swift/Parse/Parser.h"
 
@@ -42,7 +44,8 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
       regexLiteralParsingFn(regexText.str().c_str(), &version,
                             /*captureStructureOut*/ capturesBuf.data(),
                             /*captureStructureSize*/ capturesBuf.size(),
-                            /*diagBaseLoc*/ Tok.getLoc(), Diags);
+                            /*diagBaseLoc*/ Tok.getLoc(),
+                            getBridgedDiagnosticEngine(&Diags));
   auto loc = consumeToken();
   SourceMgr.recordRegexLiteralStartLoc(loc);
 

--- a/test/Interop/Cxx/foreign-reference/base-class-layout-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/base-class-layout-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test  | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test -disable-availability-checking  | %FileCheck %s
 
 import MemberLayout
 

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 
@@ -30,6 +30,6 @@ public func test() {
   _ = x.test()
 }
 
-// CHECK-LABEL: sil [clang MoveOnly.create] @{{_ZN8MoveOnly6createEv|\?create\@MoveOnly\@\@SAPEAU1\@XZ}} : $@convention(c) () -> MoveOnly
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang MoveOnly.create] @{{_ZN8MoveOnly6createEv|\?create\@MoveOnly\@\@SAPEAU1\@XZ}} : $@convention(c) () -> MoveOnly
 
-// CHECK-LABEL: sil [clang MoveOnly.test] @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed MoveOnly) -> Int32
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang MoveOnly.test] @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed MoveOnly) -> Int32

--- a/test/Interop/Cxx/foreign-reference/move-only.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/nullable.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface-macos.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface-macos.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=POD -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -target %target-arch-apple-macos11 | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+// CHECK: @available(macOS 13.3.0, *)
+// CHECK-NEXT: class Empty {
+
+// CHECK: @available(macOS 13.3.0, *)
+// CHECK-NEXT: class MultipleAttrs {

--- a/test/Interop/Cxx/foreign-reference/pod-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 
@@ -36,6 +36,6 @@ public func test() {
   _ = x.test()
 }
 
-// CHECK-LABEL: sil [clang IntPair.create] @{{_ZN7IntPair6createEv|\?create\@IntPair\@\@SAPEAU1\@XZ}} : $@convention(c) () -> IntPair
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang IntPair.create] @{{_ZN7IntPair6createEv|\?create\@IntPair\@\@SAPEAU1\@XZ}} : $@convention(c) () -> IntPair
 
-// CHECK-LABEL: sil [clang IntPair.test] @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed IntPair) -> Int32
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang IntPair.test] @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed IntPair) -> Int32

--- a/test/Interop/Cxx/foreign-reference/pod.swift
+++ b/test/Interop/Cxx/foreign-reference/pod.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 // XFAIL: OS=windows-msvc

--- a/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 
@@ -36,8 +36,8 @@ public func test() {
   mutateIt(x)
 }
 
-// CHECK-LABEL: sil [clang DeletedSpecialMembers.create] @{{_ZN21DeletedSpecialMembers6createEv|\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ}} : $@convention(c) () -> DeletedSpecialMembers
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang DeletedSpecialMembers.create] @{{_ZN21DeletedSpecialMembers6createEv|\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ}} : $@convention(c) () -> DeletedSpecialMembers
 
-// CHECK-LABEL: sil [clang DeletedSpecialMembers.test] @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed DeletedSpecialMembers) -> Int32
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang DeletedSpecialMembers.test] @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed DeletedSpecialMembers) -> Int32
 
-// CHECK-LABEL: sil [serialized] [clang mutateIt] @{{_Z8mutateItR21DeletedSpecialMembers|\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z}} : $@convention(c) (DeletedSpecialMembers) -> ()
+// CHECK-LABEL: sil{{ \[available .*\] | }}[serialized] [clang mutateIt] @{{_Z8mutateItR21DeletedSpecialMembers|\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z}} : $@convention(c) (DeletedSpecialMembers) -> ()

--- a/test/Interop/Cxx/foreign-reference/singleton.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/unimportable-member-layout-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/unimportable-member-layout-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test -disable-availability-checking | %FileCheck %s
 
 import MemberLayout
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
 
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -disable-availability-checking
 
 // RUN: %FileCheck %s < %t/UseCxxTyExposeOnly.h
 


### PR DESCRIPTION
Such types have runtime support only SwiftStdlib 5.8 and above
Also,  Revert "[cxx-interop][SwiftCompilerSources] Use `swift::DiagnosticEngine` instead of `BridgedDiagnosticEngine`".
The revert is required as foreign reference types are available for SwiftStdlib 5.8 and above, but the Swift compiler sources back deploy to older stdlibs as well.

Explanation: C++ types that are bridged as Foreign reference types in Swift are only supported with runtimes included in SwiftStdlib 5.8 and above. Therefore, such types should be given appropriate availability annotations. The change in Swift compiler sources is needed to avoid using FRTs in Swift itself, as Swift back deploys to platforms whose runtime is older than 5.8.
Scope: Swift's and C++ interoperability, Clang importer.
Risk: Low. The adoption of FRTs in Swift compiler sources has been removed, and other adopters do not backdeploy to an older runtime.
Testing: Swift unit tests.
Reviewer: @zoecarver