### PR TITLE
[5.9][interop] do not import functions whose return type is not imported

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -257,6 +257,7 @@ NOTE(record_field_not_imported, none, "field %0 unavailable (cannot import)", (c
 NOTE(invoked_func_not_imported, none, "function %0 unavailable (cannot import)", (const clang::NamedDecl*))
 NOTE(record_method_not_imported, none, "method %0 unavailable (cannot import)", (const clang::NamedDecl*))
 NOTE(objc_property_not_imported, none, "property %0 unavailable (cannot import)", (const clang::NamedDecl*))
+NOTE(unsupported_return_type, none, "C++ function %0 is unavailable: return type is unavailable in Swift", (const clang::NamedDecl*))
 
 NOTE(placeholder_for_forward_declared_interface_member_access_failure, none,
      "class '%0' will be imported as an opaque placeholder class and may be "

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5622,13 +5622,7 @@ importName(const clang::NamedDecl *D,
 
 Type ClangImporter::importFunctionReturnType(
     const clang::FunctionDecl *clangDecl, DeclContext *dc) {
-  bool isInSystemModule =
-      cast<ClangModuleUnit>(dc->getModuleScopeContext())->isSystemModule();
-  bool allowNSUIntegerAsInt =
-      Impl.shouldAllowNSUIntegerAsInt(isInSystemModule, clangDecl);
-  if (auto imported =
-          Impl.importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt)
-              .getType())
+  if (auto imported = Impl.importFunctionReturnType(clangDecl, dc).getType())
     return imported;
   return dc->getASTContext().getNeverType();
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2075,6 +2075,15 @@ applyImportTypeAttrs(ImportTypeAttrs attrs, Type type,
 }
 
 ImportedType ClangImporter::Implementation::importFunctionReturnType(
+    const clang::FunctionDecl *clangDecl, DeclContext *dc) {
+  bool isInSystemModule =
+      cast<ClangModuleUnit>(dc->getModuleScopeContext())->isSystemModule();
+  bool allowNSUIntegerAsInt =
+      shouldAllowNSUIntegerAsInt(isInSystemModule, clangDecl);
+  return importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt);
+}
+
+ImportedType ClangImporter::Implementation::importFunctionReturnType(
     DeclContext *dc, const clang::FunctionDecl *clangDecl,
     bool allowNSUIntegerAsInt) {
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1340,6 +1340,9 @@ public:
                                         const clang::FunctionDecl *clangDecl,
                                         bool allowNSUIntegerAsInt);
 
+  ImportedType importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                                        DeclContext *dc);
+
   /// Import the parameter list for a function
   ///
   /// \param clangDecl The underlying declaration, if any; should only be

--- a/test/Interop/Cxx/class/returns-unavailable-class.swift
+++ b/test/Interop/Cxx/class/returns-unavailable-class.swift
@@ -1,0 +1,65 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift
+
+// RUN: not %target-swift-frontend -typecheck -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift 2>&1 | %FileCheck --check-prefix=NOTE %s
+
+
+//--- Inputs/module.modulemap
+module CxxTypes {
+    header "types.h"
+    requires cplusplus
+}
+
+module CxxModule {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/types.h
+
+template<class T>
+class TemplateInTypesModule {
+public:
+    T x, y;
+};
+
+//--- Inputs/header.h
+
+#pragma clang module import CxxTypes
+
+class Struct {
+public:
+    int x, y;
+
+    TemplateInTypesModule<int> returnsClassInTypesModules() const;
+
+    void takesClassInTypesModules(TemplateInTypesModule<int>) const;
+    void takesClassInTypesModulesRef(const TemplateInTypesModule<int> &) const;
+};
+
+// CHECK: struct Struct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT:   var y: Int32
+// CHECK-NEXT: }
+
+// CHECK-NOT: funcWithClass
+
+TemplateInTypesModule<int> funcWithClassInTypesModules();
+void funcWithClassInTypesModulesParam(TemplateInTypesModule<int>);
+void funcWithClassInTypesModulesParamRef(const TemplateInTypesModule<int> &);
+
+//--- test.swift
+
+import CxxModule
+
+func test() {
+    funcWithClassInTypesModules() // expected-error {{cannot find 'funcWithClassInTypesModules' in scope}}
+    Struct().returnsClassInTypesModules() // expected-error {{value of type 'Struct' has no member 'returnsClassInTypesModules'}}
+}
+
+// NOTE: note: C++ function 'funcWithClassInTypesModules' is unavailable: return type is unavailable in Swift


### PR DESCRIPTION
(cherry picked from commit 8e0c17b27470de49fecf19d5a222ab247984d677)

Explanation: Clang importer can sometimes import C++ functions with the `Never` return type because the original type can not be imported. That is wrong, as making such calls isn't going to cleanup the return value. Therefore, such functions should not be imported into Swift. The compiler diagnoses them as unavailable with a helpful message about the return type.
Scope: Swift's and C++ interoperability, Clang importer.
Issue: Resolves https://github.com/apple/swift/issues/64401
Risk: Medium.
Testing: Swift unit tests.
Reviewer: @egorzhdan