### PR TITLE
[Test] Reenable custom_rr_abi.swift.

### DIFF
--- a/test/Runtime/Inputs/custom_rr_abi_utilities.h
+++ b/test/Runtime/Inputs/custom_rr_abi_utilities.h
@@ -30,8 +30,7 @@
   macro(25)                                                                    \
   macro(26)                                                                    \
   macro(27)                                                                    \
-  macro(28)                                                                    \
-  macro(29)
+  macro(28)
 
 // Apply `macro` with the given parameters to all registers that have
 // specialized entrypoints. That's the same as ALL_REGS, minus x0 (the standard

--- a/test/Runtime/custom_rr_abi.swift
+++ b/test/Runtime/custom_rr_abi.swift
@@ -6,8 +6,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// REQUIRES: rdar102912772
-
 import StdlibUnittest
 
 // A class that can provider a retainable pointer and determine whether it's


### PR DESCRIPTION
CI has updated macOS and we should no longer have the issue of dyld stubs using our nonstandard argument registers.

rdar://102912772