### PR TITLE
Add new driver `-gcc-toolchain` argument

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1805,6 +1805,11 @@ def nostartfiles:
          HelpHidden, NewDriverOnlyOption]>,
   HelpText<"Do not link in the Swift language startup routines">;
 
+def gcc_toolchain: Separate<["-"], "gcc-toolchain">,
+  Flags<[HelpHidden, NewDriverOnlyOption, ArgumentIsPath]>,
+  MetaVarName<"<path>">,
+  HelpText<"Specify a directory where the clang importer and clang linker can find headers and libraries">;
+
 // END ONLY SUPPORTED IN NEW DRIVER
 
 def load_plugin_library:


### PR DESCRIPTION
The option is only available in the new driver and passes search paths to the clang importer and clang linker when working with a gcc toolchain.