### PR TITLE
TypeCheckType: Fix existential `any` migration diagnostics for extra-modular protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4889,8 +4889,14 @@ public:
   bool requiresSelfConformanceWitnessTable() const;
 
   /// Determine whether an existential type must be explicitly prefixed
-  /// with \c any. \c any is required if any of the members contain
-  /// an associated type, or if \c Self appears in non-covariant position.
+  /// with \c any. \c any is required if one of the following conditions is met
+  /// for this protocol or an inherited protocol:
+  /// - The protocol has an associated type requirement.
+  /// - `Self` appears in non-covariant position in the type signature of a
+  ///   value requirement.
+  ///
+  /// @Note This method does not take the state of language features into
+  /// account.
   bool existentialRequiresAny() const;
 
   /// Returns a list of protocol requirements that must be assessed to

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -714,10 +714,6 @@ ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
 bool
 ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
                                         ProtocolDecl *decl) const {
-  auto &ctx = decl->getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::ExistentialAny))
-    return true;
-
   // ObjC protocols do not require `any`.
   if (decl->isObjC())
     return false;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5166,6 +5166,10 @@ public:
     if (T->isInvalid())
       return;
 
+    if (Ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
+      return;
+    }
+
     // Compute the type repr to attach 'any' to.
     TypeRepr *replaceRepr = T;
     // Insert parens in expression context for '(any P).self'
@@ -5198,7 +5202,8 @@ public:
       OS << ")";
 
     if (auto *proto = dyn_cast_or_null<ProtocolDecl>(T->getBoundDecl())) {
-      if (proto->existentialRequiresAny() && !Ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
+      if (Ctx.LangOpts.hasFeature(Feature::ExistentialAny) ||
+          proto->existentialRequiresAny()) {
         Ctx.Diags.diagnose(T->getNameLoc(),
                            diag::existential_requires_any,
                            proto->getDeclaredInterfaceType(),
@@ -5216,7 +5221,8 @@ public:
       if (type->isConstraintType()) {
         auto layout = type->getExistentialLayout();
         for (auto *protoDecl : layout.getProtocols()) {
-          if (!protoDecl->existentialRequiresAny() || Ctx.LangOpts.hasFeature(Feature::ImplicitSome))
+          if (!Ctx.LangOpts.hasFeature(Feature::ExistentialAny) &&
+              !protoDecl->existentialRequiresAny())
             continue;
 
           Ctx.Diags.diagnose(T->getNameLoc(),

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -20,7 +20,7 @@ func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
 
 // When "fuzzy matching is disabled, this will fail.
 func forwardMatchFailure( // expected-note{{declared here}}
-  onError: ((Error) -> Void)? = nil,
+  onError: ((any Error) -> Void)? = nil,
   onCompletion: (Int) -> Void
 ) { }
 

--- a/test/type/explicit_existential_multimodule1.swift
+++ b/test/type/explicit_existential_multimodule1.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s         -swift-version 5 -emit-module -DM -module-name M -emit-module-path %t/M.swiftmodule -enable-upcoming-feature ExistentialAny
+// RUN: %target-swift-frontend %s -verify -swift-version 5 -typecheck -I %t
+
+// Test that the feature state used to compile a module is not reflected in
+// the module file. The feature must not be enforced on protocols originating in
+// a different module just because that module was compiled with the feature
+// enabled.
+
+#if M
+public protocol P {}
+#else
+import M
+func test(_: P) {}
+#endif

--- a/test/type/explicit_existential_multimodule2.swift
+++ b/test/type/explicit_existential_multimodule2.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s         -swift-version 5 -emit-module -DM -module-name M -emit-module-path %t/M.swiftmodule
+// RUN: %target-swift-frontend %s -verify -swift-version 5 -typecheck -I %t -enable-upcoming-feature ExistentialAny
+
+// Test that a protocol that requires 'any' *only* when the feature is enabled
+// is diagnosed as expected when said protocol originates in a different module.
+// In other words, test that deserialization does not affect 'any' migration
+// diagnostics.
+
+#if M
+public protocol P {}
+#else
+import M
+func test(_: P) {} // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
+#endif

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -229,17 +229,9 @@ extension MyError {
   }
 }
 
-struct Wrapper {
-  typealias E = Error
-}
-
-func typealiasMemberReferences(metatype: Wrapper.Type) {
-  let _: Wrapper.E.Protocol = metatype.E.self
-  let _: (any Wrapper.E).Type = metatype.E.self
-}
-
 func testAnyTypeExpr() {
   let _: (any P).Type = (any P).self
+  let _: (any P1 & P2).Type = (any P1 & P2).self
 
   func test(_: (any P).Type) {}
   test((any P).self)
@@ -311,6 +303,13 @@ enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not
   case hack
 }
 
+// Protocols from a serialized module (the standard library).
+do {
+  // expected-error@+1 {{use of protocol 'Decodable' as a type must be written 'any Decodable'}}
+  let _: Decodable
+  // expected-error@+1 2 {{use of 'Codable' (aka 'Decodable & Encodable') as a type must be written 'any Codable' (aka 'any Decodable & Encodable')}}
+  let _: Codable
+}
 
 func testAnyFixIt() {
   struct ConformingType : HasAssoc {
@@ -333,6 +332,19 @@ func testAnyFixIt() {
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
   let _: HasAssoc.Protocol = HasAssoc.self
+  do {
+    struct Wrapper {
+      typealias HasAssocAlias = HasAssoc
+    }
+    let wrapperMeta: Wrapper.Type
+    // FIXME: Both of these fix-its are wrong.
+    // 1. 'any' is attached to 'HasAssocAlias' instead of 'Wrapper.HasAssocAlias'
+    // 2. What is the correct fix-it for the initializer?
+    //
+    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{20-33=(any HasAssocAlias)}}
+    // expected-error@+1:57 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{57-70=(any HasAssocAlias)}}
+    let _: Wrapper.HasAssocAlias.Protocol = wrapperMeta.HasAssocAlias.self
+  }
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc).Protocol = (any HasAssoc).self
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}


### PR DESCRIPTION
There are two issues:
* The evaluation of `ExistentialRequiresAnyRequest` is dependent on whether the `ExistentialAny` feature is enabled in the current compiler invocation, but the evaluation is bypassed for deserialized protocols because the result of the request is part of the serialized record. This made `existentialRequiresAny()` independent of the feature state for deserialized protocols (#65034).
* The evaluation of `ExistentialRequiresAnyRequest` must not depend on the feature state, or else is will persist in module files and override the feature state for protocols originating in those modules. In other words, the feature must not be enforced on protocols originating in a different module just because that module was compiled with the feature enabled.

Resolves #65034
___
IMO there is no reason not to accept this into 5.9, but I would also vote to take it into 5.8 because the issue affects the new migration experience for a pretty impactful upcoming feature.