### PR TITLE
[SIL] NFC: Removed visitBorrowIntroducingUserResults.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -461,8 +461,8 @@ struct BorrowingOperand {
     llvm_unreachable("Covered switch isn't covered?!");
   }
 
-  /// If this operand's user has a single borrowed value result return a
-  /// valid BorrowedValue instance.
+  /// If this operand's user has a borrowed value result return a valid
+  /// BorrowedValue instance.
   BorrowedValue getBorrowIntroducingUserResult() const;
 
   /// Compute the implicit uses that this borrowing operand "injects" into the

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -440,8 +440,8 @@ struct BorrowingOperand {
   /// values do not themselves introduce a borrow scope. In other words, they
   /// cannot be reborrowed.
   ///
-  /// If true, the visitBorrowIntroducingUserResults() can be called to acquire
-  /// each BorrowedValue that introduces a new borrow scopes.
+  /// If true, getBorrowIntroducingUserResult() can be called to acquire the
+  /// BorrowedValue that introduces a new borrow scope.
   bool hasBorrowIntroducingUser() const {
     // TODO: Can we derive this by running a borrow introducer check ourselves?
     switch (kind) {
@@ -460,16 +460,6 @@ struct BorrowingOperand {
     }
     llvm_unreachable("Covered switch isn't covered?!");
   }
-
-  /// Visit all of the "results" of the user of this operand that are borrow
-  /// scope introducers for the specific scope that this borrow scope operand
-  /// summarizes.
-  ///
-  /// Precondition: hasBorrowIntroducingUser() is true
-  ///
-  /// Returns false and early exits if \p visitor returns false.
-  bool visitBorrowIntroducingUserResults(
-      function_ref<bool(BorrowedValue)> visitor) const;
 
   /// If this operand's user has a single borrowed value result return a
   /// valid BorrowedValue instance.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -473,7 +473,7 @@ struct BorrowingOperand {
 
   /// If this operand's user has a single borrowed value result return a
   /// valid BorrowedValue instance.
-  BorrowedValue getBorrowIntroducingUserResult();
+  BorrowedValue getBorrowIntroducingUserResult() const;
 
   /// Compute the implicit uses that this borrowing operand "injects" into the
   /// set of its operands uses.

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -740,12 +740,17 @@ BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult() const {
   case BorrowingOperandKind::BeginAsyncLet:
     return BorrowedValue();
 
-  case BorrowingOperandKind::BeginBorrow:
-    return BorrowedValue(cast<BeginBorrowInst>(op->getUser()));
-
+  case BorrowingOperandKind::BeginBorrow: {
+    auto value = BorrowedValue(cast<BeginBorrowInst>(op->getUser()));
+    assert(value);
+    return value;
+  }
   case BorrowingOperandKind::Branch: {
     auto *bi = cast<BranchInst>(op->getUser());
-    return BorrowedValue(bi->getDestBB()->getArgument(op->getOperandNumber()));
+    auto value =
+        BorrowedValue(bi->getDestBB()->getArgument(op->getOperandNumber()));
+    assert(value && "guaranteed-to-unowned conversion not allowed on branches");
+    return value;
   }
   }
   llvm_unreachable("covered switch");

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -729,7 +729,7 @@ bool BorrowingOperand::visitBorrowIntroducingUserResults(
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult() {
+BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult() const {
   switch (kind) {
   case BorrowingOperandKind::Invalid:
   case BorrowingOperandKind::Apply:

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -118,10 +118,8 @@ SILCombiner::optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *bi) {
     if (auto operand = BorrowingOperand(use)) {
       if (operand.isReborrow())
         return nullptr;
-      operand.visitBorrowIntroducingUserResults([&](BorrowedValue bv) {
-        accumulatedBorrowedValues.push_back(bv);
-        return true;
-      });
+      auto bv = operand.getBorrowIntroducingUserResult();
+      accumulatedBorrowedValues.push_back(bv);
       continue;
     }
 


### PR DESCRIPTION
The function `visitBorrowIntroducingUserResults` is equivalent to `getBorrowIntroducingUserResult` except that it's less convenient to use and its name (and existence) implies that there could ever be more than one to visit. There's only ever one (or zero, depending on how you count `BorrowedValue()`) results, so there's no need for a visitor.  Updated all users to call `getBorrowIntroducingUserResult` instead.
