### PR TITLE
Simple SILOptimizer peepholes for packs

### DIFF
--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -188,6 +188,8 @@ static CanType getSingletonPackExpansionParameter(CanPackType packType,
       return expansion.getPatternType();
     }
   }
+
+  return CanType();
 }
 
 bool FulfillmentMap::searchTypeMetadataPack(IRGenModule &IGM,

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -490,10 +490,8 @@ IRGenModule::emitWitnessTableRefString(CanType type,
             type = genericEnv->mapTypeIntoContext(type)->getCanonicalType();
           }
           if (origType->hasTypeParameter()) {
-            auto origSig = genericEnv->getGenericSignature();
             conformance = conformance.subst(origType,
-              QueryInterfaceTypeSubstitutions(genericEnv),
-              LookUpConformanceInSignature(origSig.getPointer()));
+                genericEnv->getForwardingSubstitutionMap());
           }
           auto ret = emitWitnessTableRef(IGF, type, conformance);
           IGF.Builder.CreateRet(ret);

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -881,6 +881,22 @@ namespace {
       return true;
     }
 
+    bool visitScalarPackIndexInst(const ScalarPackIndexInst *RHS) {
+      auto *X = cast<ScalarPackIndexInst>(LHS);
+      return (X->getIndexedPackType() == RHS->getIndexedPackType() &&
+              X->getComponentIndex() == RHS->getComponentIndex());
+    }
+
+    bool visitDynamicPackIndexInst(const DynamicPackIndexInst *RHS) {
+      auto *X = cast<DynamicPackIndexInst>(LHS);
+      return X->getIndexedPackType() == RHS->getIndexedPackType();
+    }
+
+    bool visitTuplePackElementAddrInst(const TuplePackElementAddrInst *RHS) {
+      auto *X = cast<TuplePackElementAddrInst>(LHS);
+      return X->getElementType() == RHS->getElementType();
+    }
+
   private:
     const SILInstruction *LHS;
   };

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -163,11 +163,21 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
 
   SILValue RecNext = Cmp->getArguments()[0];
   SILPhiArgument *RecArg;
+
+  // Match signed add with overflow, unsigned add with overflow and
+  // add without overflow.
   if (!match(RecNext, m_TupleExtractOperation(
                           m_ApplyInst(BuiltinValueKind::SAddOver,
                                       m_SILPhiArgument(RecArg), m_One()),
-                          0)))
+                          0)) &&
+      !match(RecNext, m_TupleExtractOperation(
+                          m_ApplyInst(BuiltinValueKind::UAddOver,
+                                      m_SILPhiArgument(RecArg), m_One()),
+                          0)) &&
+      !match(RecNext, m_ApplyInst(BuiltinValueKind::Add,
+                                      m_SILPhiArgument(RecArg), m_One()))) {
     return None;
+  }
 
   if (RecArg->getParent() != Header)
     return None;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -300,6 +300,11 @@ public:
   SILInstruction *
   visitDifferentiableFunctionExtractInst(DifferentiableFunctionExtractInst *DFEI);
   
+  SILInstruction *visitPackLengthInst(PackLengthInst *PLI);
+  SILInstruction *visitPackElementGetInst(PackElementGetInst *PEGI);
+  SILInstruction *visitTuplePackElementAddrInst(TuplePackElementAddrInst *TPEAI);
+  SILInstruction *visitCopyAddrInst(CopyAddrInst *CAI);
+
   SILInstruction *legacyVisitGlobalValueInst(GlobalValueInst *globalValue);
 
 #define PASS(ID, TAG, DESCRIPTION)

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -515,6 +515,24 @@ public:
         X->getKind(), tryLookThroughOwnershipInsts(&X->getOperandRef()),
         llvm::hash_combine_range(ConformsTo.begin(), ConformsTo.end()));
   }
+
+  hash_code visitScalarPackIndexInst(ScalarPackIndexInst *X) {
+    return llvm::hash_combine(
+        X->getKind(), X->getIndexedPackType(), X->getComponentIndex());
+  }
+
+  hash_code visitDynamicPackIndexInst(DynamicPackIndexInst *X) {
+    return llvm::hash_combine(
+        X->getKind(), X->getIndexedPackType(), &X->getOperandRef());
+  }
+
+  hash_code visitTuplePackElementAddrInst(TuplePackElementAddrInst *X) {
+    OperandValueArrayRef Operands(X->getAllOperands());
+    return llvm::hash_combine(
+        X->getKind(),
+        llvm::hash_combine_range(Operands.begin(), Operands.end()),
+        X->getElementType());
+  }
 };
 } // end anonymous namespace
 
@@ -1225,6 +1243,9 @@ bool CSE::canHandle(SILInstruction *Inst) {
   case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::InitExistentialMetatypeInst:
   case SILInstructionKind::WitnessMethodInst:
+  case SILInstructionKind::ScalarPackIndexInst:
+  case SILInstructionKind::DynamicPackIndexInst:
+  case SILInstructionKind::TuplePackElementAddrInst:
     // Intentionally we don't handle (prev_)dynamic_function_ref.
     // They change at runtime.
 #define LOADABLE_REF_STORAGE(Name, ...) \

--- a/test/IRGen/variadic_generic_opaque.swift
+++ b/test/IRGen/variadic_generic_opaque.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature VariadicGenerics -disable-availability-checking
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+
+// FIXME: Add more tests
+
+public protocol P {}
+
+public struct G<each T>: P {}
+
+public func returnsG<each T>(_ t: repeat each T) -> some P {
+  return G<repeat each T>()
+}

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -102,6 +102,25 @@ bb0:
 // CHECK-NEXT: return [[RES]] : $Builtin.Int64
 }
 
+// Compute an expression using a chain of arithmetic with non-overflowing instructions: 2 * (2 + 3) - 3
+sil @fold_arithmetic_without_overflow : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 2
+ %110 = integer_literal $Builtin.Int64, 3
+ %19 = builtin "add_Int64"(%0 : $Builtin.Int64, %110 : $Builtin.Int64) : $Builtin.Int64
+ %21 = builtin "mul_Int64"(%0 : $Builtin.Int64, %19 : $Builtin.Int64) : $Builtin.Int64
+ %23 = builtin "sub_Int64"(%21 : $Builtin.Int64, %110 : $Builtin.Int64) : $Builtin.Int64
+ return %23 : $Builtin.Int64
+
+// CHECK-LABEL: sil @fold_arithmetic_without_overflow
+// CHECK-NOT: integer_literal $Builtin.Int64, 2
+// CHECK-NOT: integer_literal $Builtin.Int64, 3
+// CHECK-NOT: integer_literal $Builtin.Int64, 0
+// CHECK-NOT: builtin
+// CHECK: [[RES:%.*]] = integer_literal $Builtin.Int64, 7
+// CHECK-NEXT: return [[RES]] : $Builtin.Int64
+}
+
 // Fold casts. (This test assumes that DCE does not run, otherwise the unreachable blocks will get removed.)
 sil @fold_trunc : $@convention(thin) () -> Builtin.Int64 {
 bb0:

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -297,6 +297,84 @@ bb6(%72 : $Builtin.Int64):
   return %401 : $()
 }
 
+// CHECK-LABEL: sil @loop_unroll_unsigned_overflow_1
+// CHECK: bb0
+// CHECK:  br bb1
+// CHECK: bb1
+// CHECK:  builtin "uadd_with_overflow_Word"
+// CHECK:  cond_br {{.*}}, bb2, bb3
+// CHECK: bb2
+// CHECK:  br bb7
+// CHECK: bb3
+// CHECK:  br bb4
+// CHECK: bb4
+// CHECK:  builtin "uadd_with_overflow_Word"
+// CHECK:  br bb5
+// CHECK: bb5
+// CHECK:  br bb7
+// CHECK: bb7:
+// CHECK:  return
+
+sil @loop_unroll_unsigned_overflow_1 : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Word, 0
+ %1 = integer_literal $Builtin.Word, 1
+ %2 = integer_literal $Builtin.Word, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ br bb1(%0 : $Builtin.Word)
+
+bb1(%4 : $Builtin.Word):
+  %5 = builtin "uadd_with_overflow_Word"(%4 : $Builtin.Word, %1 : $Builtin.Word, %3 : $Builtin.Int1) : $(Builtin.Word, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Word, Builtin.Int1), 0
+  %7 = builtin "cmp_eq_Word"(%6 : $Builtin.Word, %2 : $Builtin.Word) : $Builtin.Int1
+  cond_br %7, bb3, bb2
+
+bb2:
+  br bb1(%6 : $Builtin.Word)
+
+bb3:
+ %9 = tuple()
+ return %9 : $()
+}
+
+// CHECK-LABEL: sil @loop_unroll_no_overflow_1
+// CHECK: bb0
+// CHECK:  br bb1
+// CHECK: bb1
+// CHECK:  builtin "add_Int64"
+// CHECK:  cond_br {{.*}}, bb2, bb3
+// CHECK: bb2
+// CHECK:  br bb7
+// CHECK: bb3
+// CHECK:  br bb4
+// CHECK: bb4
+// CHECK:  builtin "add_Int64"
+// CHECK:  br bb5
+// CHECK: bb5
+// CHECK:  br bb7
+// CHECK: bb7:
+// CHECK:  return
+
+sil @loop_unroll_no_overflow_1 : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Int64, 0
+ %1 = integer_literal $Builtin.Int64, 1
+ %2 = integer_literal $Builtin.Int64, 2
+ br bb1(%0 : $Builtin.Int64)
+
+bb1(%4 : $Builtin.Int64):
+  %5 = builtin "add_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  %7 = builtin "cmp_eq_Int64"(%5 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %7, bb3, bb2
+
+bb2:
+  br bb1(%5 : $Builtin.Int64)
+
+bb3:
+ %9 = tuple()
+ return %9 : $()
+}
+
 // CHECK-LABEL: sil @unroll_with_exit_block_arg_2
 // CHECK: bb1({{.*}}):
 // CHECK:   cond_br {{.*}}, bb4, bb2

--- a/test/SILOptimizer/tuples_from_packs.swift
+++ b/test/SILOptimizer/tuples_from_packs.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-sil %s -enable-experimental-feature VariadicGenerics | %FileCheck %s
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+
+@_transparent func makeTuple<each T>(_ t: repeat each T) -> (repeat each T) {
+  return (repeat each t)
+}
+
+// FIXME: Useless alloc_pack/dealloc_pack
+
+// CHECK-LABEL: sil @$s17tuples_from_packs14makeEmptyTupleyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK-NEXT: %0 = alloc_pack $Pack{}
+// CHECK-NEXT: %1 = alloc_pack $Pack{}
+// CHECK-NEXT: dealloc_pack %1 : $*Pack{}
+// CHECK-NEXT: dealloc_pack %0 : $*Pack{}
+// CHECK-NEXT: [[RET:%.*]] = tuple ()
+// CHECK-NEXT: return [[RET]] : $()
+public func makeEmptyTuple() {
+  return makeTuple()
+}
+
+// FIXME: This crashes in SILGen
+/*public func makeOne<T>(_ t: T) -> T {
+  return makeTuple(t)
+}*/
+
+// FIXME: Useless pack_element_set/pack_element_get
+
+// CHECK-LABEL: sil @$s17tuples_from_packs8makePairyx_q_tx_q_tr0_lF : $@convention(thin) <T, U> (@in_guaranteed T, @in_guaranteed U) -> (@out T, @out U) {
+// CHECK: bb0(%0 : $*T, %1 : $*U, %2 : $*T, %3 : $*U):
+// CHECK:      [[PACK:%.*]] = alloc_pack $Pack{T, U}
+// CHECK-NEXT: [[IDX0:%.*]] = scalar_pack_index 0 of $Pack{T, U}
+// CHECK-NEXT: pack_element_set %0 : $*T into [[IDX0]] of [[PACK]] : $*Pack{T, U}
+// CHECK-NEXT: [[IDX1:%.*]] = scalar_pack_index 1 of $Pack{T, U}
+// CHECK-NEXT: pack_element_set %1 : $*U into [[IDX1]] of [[PACK]] : $*Pack{T, U}
+// CHECK-NEXT: [[PACK2:%.*]] = alloc_pack $Pack{T, U}
+// CHECK-NEXT: [[T:%.*]] = alloc_stack $T
+// CHECK-NEXT: copy_addr %2 to [init] [[T]] : $*T
+// CHECK-NEXT: pack_element_set [[T]] : $*T into [[IDX0]] of [[PACK2]] : $*Pack{T, U}
+// CHECK-NEXT: [[U:%.*]] = alloc_stack $U
+// CHECK-NEXT: copy_addr %3 to [init] [[U]] : $*U
+// CHECK-NEXT: pack_element_set [[U]] : $*U into [[IDX1]] of [[PACK2]] : $*Pack{T, U}
+// CHECK-NEXT: [[ELT0:%.*]] = pack_element_get [[IDX0]] of [[PACK]] : $*Pack{T, U} as $*T
+// CHECK-NEXT: [[ELT02:%.*]] = pack_element_get [[IDX0]] of [[PACK2]] : $*Pack{T, U} as $*T
+// CHECK-NEXT: copy_addr [[ELT02]] to [init] [[ELT0]] : $*T
+// CHECK-NEXT: [[ELT1:%.*]] = pack_element_get [[IDX1]] of [[PACK]] : $*Pack{T, U} as $*U
+// CHECK-NEXT: [[ELT12:%.*]] = pack_element_get [[IDX1]] of [[PACK2]] : $*Pack{T, U} as $*U
+// CHECK-NEXT: copy_addr [[ELT12]] to [init] [[ELT1]] : $*U
+// CHECK-NEXT: destroy_addr [[U]] : $*U
+// CHECK-NEXT: dealloc_stack [[U]] : $*U
+// CHECK-NEXT: destroy_addr [[T]] : $*T
+// CHECK-NEXT: dealloc_stack [[T]] : $*T
+// CHECK-NEXT: dealloc_pack [[PACK2]] : $*Pack{T, U}
+// CHECK-NEXT: dealloc_pack [[PACK]] : $*Pack{T, U}
+// CHECK-NEXT: %30 = tuple ()
+// CHECK-NEXT: return %30 : $()
+
+public func makePair<T, U>(_ t: T, _ u: U) -> (T, U) {
+  return makeTuple(t, u)
+}


### PR DESCRIPTION
The goal here is to inline away `(repeat each t)` for forming a tuple value from the elements of a value pack in the case where the pack becomes concrete. We're not quite there yet; there are still some unnecessary pack-related SIL instructions remaining.