### PR TITLE
[ASTGen] Avoid including C standard libary headers in brigdging headers

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -16,10 +16,10 @@
 #include "swift/Basic/CBasicBridging.h"
 #include "swift/Basic/Compiler.h"
 
-#include <inttypes.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+// NOTE: DO NOT #include any stdlib headers here. e.g. <stdint.h>. Those are
+// part of "Darwin"/"Glibc" module, so when a Swift file imports this header,
+// it causes importing the "Darwin"/"Glibc" overlay module. That violates
+// layering. i.e. Darwin overlay is created by Swift compiler.
 
 #if __clang__
 // Provide macros to temporarily suppress warning about the use of
@@ -102,7 +102,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : long {
 
 typedef void* BridgedDiagnostic;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : ptrdiff_t {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : long {
   /// An expanded macro.
   BridgedExpandedMacro = 0,
   /// An external macro, spelled with either the old spelling (Module.Type)
@@ -126,28 +126,29 @@ extern "C" {
 ///
 /// \returns a diagnostic instance that can be extended with additional
 /// information and then must be finished via \c SwiftDiagnostic_finish.
-BridgedDiagnostic SwiftDiagnostic_create(
-    void *diagnosticEngine, BridgedDiagnosticSeverity severity,
-    const void *_Nullable sourceLoc,
-    const uint8_t *_Nullable text, long textLen);
+BridgedDiagnostic SwiftDiagnostic_create(void *diagnosticEngine,
+                                         BridgedDiagnosticSeverity severity,
+                                         const void *_Nullable sourceLoc,
+                                         const unsigned char *_Nullable text,
+                                         long textLen);
 
 /// Highlight a source range as part of the diagnostic.
 void SwiftDiagnostic_highlight(
     BridgedDiagnostic diag, const void *_Nullable startLoc, const void *_Nullable endLoc);
 
 /// Add a Fix-It to replace a source range as part of the diagnostic.
-void SwiftDiagnostic_fixItReplace(
-    BridgedDiagnostic diag,
-    const void *_Nullable replaceStartLoc,
-    const void *_Nullable replaceEndLoc,
-    const uint8_t *_Nullable newText, long newTextLen);
+void SwiftDiagnostic_fixItReplace(BridgedDiagnostic diag,
+                                  const void *_Nullable replaceStartLoc,
+                                  const void *_Nullable replaceEndLoc,
+                                  const unsigned char *_Nullable newText,
+                                  long newTextLen);
 
 /// Finish the given diagnostic and emit it.
 void SwiftDiagnostic_finish(BridgedDiagnostic diag);
 
-BridgedIdentifier SwiftASTContext_getIdentifier(void *ctx,
-                                                const uint8_t *_Nullable str,
-                                                long len);
+BridgedIdentifier
+SwiftASTContext_getIdentifier(void *ctx, const unsigned char *_Nullable str,
+                              long len);
 
 void *SwiftImportDecl_create(void *, void *, void *, char, void *,
                              BridgedArrayRef, BridgedArrayRef);
@@ -170,10 +171,12 @@ void *SwiftFunctionCallExpr_create(void *ctx, void *fn, void *args);
 
 void *SwiftIdentifierExpr_create(void *ctx, BridgedIdentifier base, void *loc);
 
-void *SwiftStringLiteralExpr_create(void *ctx, const uint8_t *_Nullable string,
+void *SwiftStringLiteralExpr_create(void *ctx,
+                                    const unsigned char *_Nullable string,
                                     long len, void *TokenLoc);
 
-void *SwiftIntegerLiteralExpr_create(void *ctx, const uint8_t *_Nullable string,
+void *SwiftIntegerLiteralExpr_create(void *ctx,
+                                     const unsigned char *_Nullable string,
                                      long len, void *TokenLoc);
 
 void *SwiftBooleanLiteralExpr_create(void *ctx, _Bool value, void *TokenLoc);

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -15,10 +15,10 @@
 
 #include "swift/Basic/Compiler.h"
 
-#include <inttypes.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+// NOTE: DO NOT #include any stdlib headers here. e.g. <stdint.h>. Those are
+// part of "Darwin"/"Glibc" module, so when a Swift file imports this header,
+// it causes importing the "Darwin"/"Glibc" overlay module. That violates
+// layering. i.e. Darwin overlay is created by Swift compiler.
 
 #if __clang__
 // Provide macros to temporarily suppress warning about the use of
@@ -41,11 +41,14 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 #ifdef __cplusplus
 extern "C" {
+
+#define _Bool bool
+
 #endif
 
 typedef struct BridgedData {
   const char *_Nullable baseAddress;
-  size_t size;
+  unsigned long size;
 } BridgedData;
 
 void BridgedData_free(BridgedData data);
@@ -70,44 +73,44 @@ void JSON_value_serialize(void *valuePtr, BridgedData *result);
 /// \c JSON_newValue() or \c JSON_deserializedValue() .
 void JSON_value_delete(void *valuePtr);
 
-bool JSON_value_getAsNull(void *valuePtr);
-bool JSON_value_getAsBoolean(void *valuePtr, bool *result);
-bool JSON_value_getAsString(void *valuePtr, BridgedData *result);
-bool JSON_value_getAsDouble(void *valuePtr, double *result);
-bool JSON_value_getAsInteger(void *valuePtr, int64_t *result);
-bool JSON_value_getAsObject(void *valuePtr, void *_Nullable *_Nonnull result);
-bool JSON_value_getAsArray(void *valuePtr, void *_Nullable *_Nonnull result);
+_Bool JSON_value_getAsNull(void *valuePtr);
+_Bool JSON_value_getAsBoolean(void *valuePtr, _Bool *result);
+_Bool JSON_value_getAsString(void *valuePtr, BridgedData *result);
+_Bool JSON_value_getAsDouble(void *valuePtr, double *result);
+_Bool JSON_value_getAsInteger(void *valuePtr, long long *result);
+_Bool JSON_value_getAsObject(void *valuePtr, void *_Nullable *_Nonnull result);
+_Bool JSON_value_getAsArray(void *valuePtr, void *_Nullable *_Nonnull result);
 
-size_t JSON_object_getSize(void *objectPtr);
-BridgedData JSON_object_getKey(void *objectPtr, size_t i);
-bool JSON_object_hasKey(void *objectPtr, const char *key);
+unsigned long JSON_object_getSize(void *objectPtr);
+BridgedData JSON_object_getKey(void *objectPtr, unsigned long i);
+_Bool JSON_object_hasKey(void *objectPtr, const char *key);
 void *JSON_object_getValue(void *objectPtr, const char *key);
 
-int64_t JSON_array_getSize(void *arrayPtr);
-void *JSON_array_getValue(void *arrayPtr, int64_t index);
+long long JSON_array_getSize(void *arrayPtr);
+void *JSON_array_getValue(void *arrayPtr, long long index);
 
 void JSON_value_emplaceNull(void *valuePtr);
-void JSON_value_emplaceBoolean(void *valuePtr, bool value);
+void JSON_value_emplaceBoolean(void *valuePtr, _Bool value);
 void JSON_value_emplaceString(void *valuePtr, const char *value);
 void JSON_value_emplaceDouble(void *valuePtr, double value);
-void JSON_value_emplaceInteger(void *valuePtr, int64_t value);
+void JSON_value_emplaceInteger(void *valuePtr, long long value);
 void *JSON_value_emplaceNewObject(void *valuePtr);
 void *JSON_value_emplaceNewArray(void *valuePtr);
 
 void JSON_object_setNull(void *objectPtr, const char *key);
-void JSON_object_setBoolean(void *objectPtr, const char *key, bool value);
+void JSON_object_setBoolean(void *objectPtr, const char *key, _Bool value);
 void JSON_object_setString(void *objectPtr, const char *key, const char *value);
 void JSON_object_setDouble(void *objectPtr, const char *key, double value);
-void JSON_object_setInteger(void *objectPtr, const char *key, int64_t value);
+void JSON_object_setInteger(void *objectPtr, const char *key, long long value);
 void *JSON_object_setNewObject(void *objectPtr, const char *key);
 void *JSON_object_setNewArray(void *objectPtr, const char *key);
 void *JSON_object_setNewValue(void *objectPtr, const char *key);
 
 void JSON_array_pushNull(void *arrayPtr);
-void JSON_array_pushBoolean(void *arrayPtr, bool value);
+void JSON_array_pushBoolean(void *arrayPtr, _Bool value);
 void JSON_array_pushString(void *arrayPtr, const char *value);
 void JSON_array_pushDouble(void *arrayPtr, double value);
-void JSON_array_pushInteger(void *arrayPtr, int64_t value);
+void JSON_array_pushInteger(void *arrayPtr, long long value);
 void *JSON_array_pushNewObject(void *arrayPtr);
 void *JSON_array_pushNewArray(void *arrayPtr);
 void *JSON_array_pushNewValue(void *arrayPtr);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -44,11 +44,11 @@ namespace {
   };
 }
 
-BridgedDiagnostic SwiftDiagnostic_create(
-    void *diagnosticEngine, BridgedDiagnosticSeverity severity,
-    const void *sourceLocPtr,
-    const uint8_t *textPtr, long textLen
-) {
+BridgedDiagnostic SwiftDiagnostic_create(void *diagnosticEngine,
+                                         BridgedDiagnosticSeverity severity,
+                                         const void *sourceLocPtr,
+                                         const unsigned char *textPtr,
+                                         long textLen) {
   StringRef origText{
     reinterpret_cast<const char *>(textPtr), size_t(textLen)};
   llvm::MallocAllocator mallocAlloc;
@@ -91,10 +91,11 @@ void SwiftDiagnostic_highlight(
 }
 
 /// Add a Fix-It to replace a source range as part of the diagnostic.
-void SwiftDiagnostic_fixItReplace(
-    BridgedDiagnostic diagPtr,
-    const void *replaceStartLocPtr, const void *replaceEndLocPtr,
-    const uint8_t *newTextPtr, long newTextLen) {
+void SwiftDiagnostic_fixItReplace(BridgedDiagnostic diagPtr,
+                                  const void *replaceStartLocPtr,
+                                  const void *replaceEndLocPtr,
+                                  const unsigned char *newTextPtr,
+                                  long newTextLen) {
 
   SourceLoc startLoc = getSourceLocFromPointer(replaceStartLocPtr);
   SourceLoc endLoc = getSourceLocFromPointer(replaceEndLocPtr);
@@ -115,9 +116,9 @@ void SwiftDiagnostic_finish(BridgedDiagnostic diagPtr) {
   delete impl;
 }
 
-BridgedIdentifier SwiftASTContext_getIdentifier(void *ctx,
-                                                const uint8_t *_Nullable str,
-                                                long len) {
+BridgedIdentifier
+SwiftASTContext_getIdentifier(void *ctx, const unsigned char *_Nullable str,
+                              long len) {
   return const_cast<void *>(
       static_cast<ASTContext *>(ctx)
           ->getIdentifier(
@@ -213,7 +214,8 @@ void *SwiftIdentifierExpr_create(void *ctx, BridgedIdentifier base, void *loc) {
   return E;
 }
 
-void *SwiftStringLiteralExpr_create(void *ctx, const uint8_t *_Nullable string,
+void *SwiftStringLiteralExpr_create(void *ctx,
+                                    const unsigned char *_Nullable string,
                                     long len, void *TokenLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   auto stringRef = Context.AllocateCopy(
@@ -222,7 +224,8 @@ void *SwiftStringLiteralExpr_create(void *ctx, const uint8_t *_Nullable string,
       StringLiteralExpr(stringRef, getSourceLocFromPointer(TokenLoc));
 }
 
-void *SwiftIntegerLiteralExpr_create(void *ctx, const uint8_t *_Nullable string,
+void *SwiftIntegerLiteralExpr_create(void *ctx,
+                                     const unsigned char *_Nullable string,
                                      long len, void *TokenLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   auto stringRef = Context.AllocateCopy(
@@ -687,6 +690,6 @@ bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {
   auto size = message.size();
   auto outPtr = malloc(size);
   memcpy(outPtr, message.data(), size);
-  *out = BridgedData{(const char *)outPtr, size};
+  *out = BridgedData{(const char *)outPtr, (unsigned long)size};
   return false;
 }

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -103,7 +103,7 @@ struct CompilerPlugin {
 
   private func sendMessage(_ message: HostToPluginMessage) throws {
     let hadError = try LLVMJSON.encoding(message) { (data) -> Bool in
-      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: data.count))
+      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: UInt(data.count)))
     }
     if hadError {
       throw PluginError.failedToSendMessage
@@ -117,7 +117,7 @@ struct CompilerPlugin {
     guard !hadError else {
       throw PluginError.failedToReceiveMessage
     }
-    let data = UnsafeBufferPointer(start: result.baseAddress, count: result.size)
+    let data = UnsafeBufferPointer(start: result.baseAddress, count: Int(result.size))
     return try LLVMJSON.decode(PluginToHostMessage.self, from: data)
   }
 

--- a/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
+++ b/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
@@ -14,7 +14,7 @@ import CBasicBridging
 
 extension String {
   init(_ data: BridgedData) {
-    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: data.size)
+    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: Int(data.size))
     self = buffer.withMemoryRebound(to: UInt8.self) { buffer in
       String(decoding: buffer, as: UTF8.self)
     }
@@ -35,13 +35,13 @@ public struct LLVMJSON {
     JSON_value_serialize(valuePtr, &data)
     assert(data.baseAddress != nil)
     defer { BridgedData_free(data) }
-    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: data.size)
+    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: Int(data.size))
     return try body(buffer)
   }
 
   /// Decode a JSON data to a Swift value.
   public static func decode<T: Decodable>(_ type: T.Type, from json: UnsafeBufferPointer<Int8>) throws -> T {
-    let data = BridgedData(baseAddress: json.baseAddress, size: json.count)
+    let data = BridgedData(baseAddress: json.baseAddress, size: UInt(json.count))
     let valuePtr = JSON_deserializedValue(data)
     defer { JSON_value_delete(valuePtr) }
 
@@ -209,7 +209,7 @@ extension LLVMJSONDecoding.KeyedContainer: KeyedDecodingContainerProtocol {
   var allKeys: [Key] {
     var keys: [Key] = []
     let size = JSON_object_getSize(objectPtr)
-    keys.reserveCapacity(size)
+    keys.reserveCapacity(Int(size))
     for i in 0 ..< size {
       let keyData = JSON_object_getKey(objectPtr, i)
       if let key = Key(stringValue: String(keyData)) {

--- a/lib/Basic/CBasicBridging.cpp
+++ b/lib/Basic/CBasicBridging.cpp
@@ -40,21 +40,21 @@ void JSON_value_serialize(void *value, BridgedData *out) {
 
   auto outPtr = malloc(result.size());
   memcpy(outPtr, result.data(), result.size());
-  *out = BridgedData{(const char *)outPtr, result.size()};
+  *out = BridgedData{(const char *)outPtr, (unsigned long)result.size()};
 }
 
 void JSON_value_delete(void *value) {
   delete static_cast<llvm::json::Value *>(value);
 }
 
-bool JSON_value_getAsNull(void *value) {
+_Bool JSON_value_getAsNull(void *value) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsNull()) {
     return true;
   }
   return false;
 }
 
-bool JSON_value_getAsBoolean(void *value, bool *result) {
+_Bool JSON_value_getAsBoolean(void *value, _Bool *result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsBoolean()) {
     *result = *val;
     return false;
@@ -62,7 +62,7 @@ bool JSON_value_getAsBoolean(void *value, bool *result) {
   return true;
 }
 
-bool JSON_value_getAsDouble(void *value, double *result) {
+_Bool JSON_value_getAsDouble(void *value, double *result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsNumber()) {
     *result = *val;
     return false;
@@ -70,7 +70,7 @@ bool JSON_value_getAsDouble(void *value, double *result) {
   return true;
 }
 
-bool JSON_value_getAsInteger(void *value, int64_t *result) {
+_Bool JSON_value_getAsInteger(void *value, long long *result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsInteger()) {
     *result = *val;
     return false;
@@ -78,22 +78,22 @@ bool JSON_value_getAsInteger(void *value, int64_t *result) {
   return true;
 }
 
-bool JSON_value_getAsString(void *value, BridgedData *result) {
+_Bool JSON_value_getAsString(void *value, BridgedData *result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsString()) {
-    *result = {val->data(), val->size()};
+    *result = {val->data(), (unsigned long)val->size()};
     return false;
   }
   return true;
 }
 
-bool JSON_value_getAsObject(void *value, void **result) {
+_Bool JSON_value_getAsObject(void *value, void **result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsObject()) {
     *result = val;
     return false;
   }
   return true;
 }
-bool JSON_value_getAsArray(void *value, void **result) {
+_Bool JSON_value_getAsArray(void *value, void **result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsArray()) {
     *result = val;
     return false;
@@ -101,21 +101,21 @@ bool JSON_value_getAsArray(void *value, void **result) {
   return true;
 }
 
-size_t JSON_object_getSize(void *objectPtr) {
+unsigned long JSON_object_getSize(void *objectPtr) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   return object->size();
 }
 
-BridgedData JSON_object_getKey(void *objectPtr, size_t i) {
+BridgedData JSON_object_getKey(void *objectPtr, unsigned long i) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   std::map<int, float> map;
   auto iter = object->begin();
   std::advance(iter, i);
   auto str = llvm::StringRef(iter->first);
-  return {str.data(), str.size()};
+  return {str.data(), (unsigned long)str.size()};
 }
 
-bool JSON_object_hasKey(void *objectPtr, const char *key) {
+_Bool JSON_object_hasKey(void *objectPtr, const char *key) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   return object->find(key) != object->end();
 }
@@ -124,11 +124,11 @@ void *JSON_object_getValue(void *objectPtr, const char *key) {
   return object->get(key);
 }
 
-int64_t JSON_array_getSize(void *objectPtr) {
+long long JSON_array_getSize(void *objectPtr) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(objectPtr);
   return array->size();
 }
-void *JSON_array_getValue(void *objectPtr, int64_t index) {
+void *JSON_array_getValue(void *objectPtr, long long index) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(objectPtr);
   return array->data() + index;
 }
@@ -137,7 +137,7 @@ void JSON_value_emplaceNull(void *valuePtr) {
   auto *value = static_cast<llvm::json::Value *>(valuePtr);
   *value = nullptr;
 }
-void JSON_value_emplaceBoolean(void *valuePtr, bool newValue) {
+void JSON_value_emplaceBoolean(void *valuePtr, _Bool newValue) {
   auto *value = static_cast<llvm::json::Value *>(valuePtr);
   *value = newValue;
 }
@@ -149,7 +149,7 @@ void JSON_value_emplaceDouble(void *valuePtr, double newValue) {
   auto *value = static_cast<llvm::json::Value *>(valuePtr);
   *value = newValue;
 }
-void JSON_value_emplaceInteger(void *valuePtr, int64_t newValue) {
+void JSON_value_emplaceInteger(void *valuePtr, long long newValue) {
   auto *value = static_cast<llvm::json::Value *>(valuePtr);
   *value = newValue;
 }
@@ -169,7 +169,7 @@ void JSON_object_setNull(void *objectPtr, const char *key) {
   auto keyStr = std::string(key);
   (*object)[keyStr] = nullptr;
 }
-void JSON_object_setBoolean(void *objectPtr, const char *key, bool value) {
+void JSON_object_setBoolean(void *objectPtr, const char *key, _Bool value) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   auto keyStr = std::string(key);
   (*object)[keyStr] = value;
@@ -185,7 +185,7 @@ void JSON_object_setDouble(void *objectPtr, const char *key, double value) {
   auto keyStr = std::string(key);
   (*object)[keyStr] = value;
 }
-void JSON_object_setInteger(void *objectPtr, const char *key, int64_t value) {
+void JSON_object_setInteger(void *objectPtr, const char *key, long long value) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   auto keyStr = std::string(key);
   (*object)[keyStr] = value;
@@ -213,7 +213,7 @@ void JSON_array_pushNull(void *arrayPtr) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(arrayPtr);
   array->emplace_back(nullptr);
 }
-void JSON_array_pushBoolean(void *arrayPtr, bool value) {
+void JSON_array_pushBoolean(void *arrayPtr, _Bool value) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(arrayPtr);
   array->emplace_back(value);
 }
@@ -225,7 +225,7 @@ void JSON_array_pushDouble(void *arrayPtr, double value) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(arrayPtr);
   array->emplace_back(value);
 }
-void JSON_array_pushInteger(void *arrayPtr, int64_t value) {
+void JSON_array_pushInteger(void *arrayPtr, long long value) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(arrayPtr);
   array->emplace_back(value);
 }

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/PluginServer.cpp
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/PluginServer.cpp
@@ -72,13 +72,14 @@ void PluginServer_destroyConnection(const void *connHandle) {
   delete conn;
 }
 
-ssize_t PluginServer_read(const void *connHandle, void *data, size_t nbyte) {
+long PluginServer_read(const void *connHandle, void *data,
+                       unsigned long nbyte) {
   const auto *conn = static_cast<const ConnectionHandle *>(connHandle);
   return ::read(conn->inputFD, data, nbyte);
 }
 
-ssize_t PluginServer_write(const void *connHandle, const void *data,
-                           size_t nbyte) {
+long PluginServer_write(const void *connHandle, const void *data,
+                        unsigned long nbyte) {
   const auto *conn = static_cast<const ConnectionHandle *>(connHandle);
   return ::write(conn->outputFD, data, nbyte);
 }

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/PluginServer.h
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/PluginServer.h
@@ -13,8 +13,6 @@
 #ifndef SWIFT_PLUGINSERVER_PLUGINSERVER_H
 #define SWIFT_PLUGINSERVER_PLUGINSERVER_H
 
-#include <sys/types.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,11 +29,11 @@ const void *PluginServer_createConnection(const char **errorMessage);
 void PluginServer_destroyConnection(const void *connHandle);
 
 /// Read bytes from the IPC communication handle.
-ssize_t PluginServer_read(const void *connHandle, void *data, size_t nbyte);
+long PluginServer_read(const void *connHandle, void *data, unsigned long nbyte);
 
 /// Write bytes to the IPC communication handle.
-ssize_t PluginServer_write(const void *connHandle, const void *data,
-                           size_t nbyte);
+long PluginServer_write(const void *connHandle, const void *data,
+                        unsigned long nbyte);
 
 //===----------------------------------------------------------------------===//
 // Dynamic link

--- a/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
+++ b/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
@@ -172,7 +172,7 @@ final class PluginHostConnection: MessageConnection {
     var ptr = buffer.baseAddress!
 
     while (bytesToWrite > 0) {
-      let writtenSize = PluginServer_write(handle, ptr, bytesToWrite)
+      let writtenSize = PluginServer_write(handle, ptr, UInt(bytesToWrite))
       if (writtenSize <= 0) {
         // error e.g. broken pipe.
         break
@@ -193,7 +193,7 @@ final class PluginHostConnection: MessageConnection {
     var ptr = buffer.baseAddress!
 
     while bytesToRead > 0 {
-      let readSize = PluginServer_read(handle, ptr, bytesToRead)
+      let readSize = PluginServer_read(handle, ptr, UInt(bytesToRead))
       if (readSize <= 0) {
         // 0: EOF (the host closed), -1: Broken pipe (the host crashed?)
         break;


### PR DESCRIPTION
Instead, use builtin types. e.g. `size_t` -> `unsigned long`

C stdlib headers are part of `Darwin`/`Glibc` clang module. If a Swift file imports a bridging headers and that has `#include` C stdlib headers, Swift compiler implicitly imports `Darwin`/`Glibc` overlay modules. That violates dependency layering. I.e. Compiler depends on Darwin overlay, Darwin overlay is created by the compiler.

rdar://107957117

