### PR TITLE
build: add control of the build of `Cxx` module in -stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,10 @@ option(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT
     "If not building stdlib, controls whether to build 'stdlib/toolchain' content"
     TRUE)
 
+option(SWIFT_BUILD_STDLIB_CXX_MODULE
+  "If not building stdlib, controls whether to build the Cxx module"
+  TRUE)
+
 # In many cases, the CMake build system needs to determine whether to include
 # a directory, or perform other actions, based on whether the stdlib or SDK is
 # being built at all -- statically or dynamically. Please note that these
@@ -1265,6 +1269,9 @@ else()
 
   if(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT)
     add_subdirectory(stdlib/toolchain)
+  endif()
+
+  if(SWIFT_BUILD_STDLIB_CXX_MODULE)
     add_subdirectory(stdlib/public/Cxx)
   endif()
 


### PR DESCRIPTION
This adds the ability to control the C++ interop module in the -stdlib build separately from "extra toolchain content".  This is helpful for Windows where we bootstrap the entire toolchain and do not have a stdlib built when building tools.