### PR TITLE
[ConstraintSystem] Model pack expansion types via type variables

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5430,7 +5430,8 @@ ERROR(cannot_convert_tuple_into_pack_expansion_parameter,none,
 NOTE(cannot_convert_tuple_into_pack_expansion_parameter_note,none,
      "value pack expansion at parameter #%0 expects %1 separate arguments",
      (unsigned, unsigned))
-
+ERROR(value_expansion_not_variadic,none,
+      "value pack expansion must contain at least one pack reference", ())
 
 ERROR(expansion_not_same_shape,none,
       "pack expansion %0 requires that %1 and %2 have the same shape",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5423,6 +5423,14 @@ ERROR(tuple_duplicate_label,none,
       "cannot create a tuple with a duplicate element label", ())
 ERROR(multiple_ellipsis_in_tuple,none,
       "only a single element can be variadic", ())
+ERROR(cannot_convert_tuple_into_pack_expansion_parameter,none,
+      "value pack expansion at parameter #%0 expects %1 separate arguments"
+      "%select{|; remove extra parentheses to change tuple into separate arguments}2",
+      (unsigned, unsigned, bool))
+NOTE(cannot_convert_tuple_into_pack_expansion_parameter_note,none,
+     "value pack expansion at parameter #%0 expects %1 separate arguments",
+     (unsigned, unsigned))
+
 
 ERROR(expansion_not_same_shape,none,
       "pack expansion %0 requires that %1 and %2 have the same shape",

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -400,12 +400,12 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 6+32,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+31,
     /// Type variable options.
-    Options : 6,
+    Options : 7,
     : NumPadBits,
     /// The unique number assigned to this type variable.
-    ID : 32
+    ID : 31
   );
 
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+4+1+2+1+1,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -438,6 +438,9 @@ enum class FixKind : uint8_t {
   /// Allow a pack expansion parameter of N elements to be matched
   /// with a single tuple literal argument of the same arity.
   DestructureTupleToMatchPackExpansionParameter,
+
+  /// Allow value pack expansion without pack references.
+  AllowValueExpansionWithoutPackReferences,
 };
 
 class ConstraintFix {
@@ -3450,6 +3453,31 @@ public:
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() ==
            FixKind::DestructureTupleToMatchPackExpansionParameter;
+  }
+};
+
+class AllowValueExpansionWithoutPackReferences final : public ConstraintFix {
+  AllowValueExpansionWithoutPackReferences(ConstraintSystem &cs,
+                                           ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowValueExpansionWithoutPackReferences,
+                      locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow value pack expansion without pack references";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static AllowValueExpansionWithoutPackReferences *
+  create(ConstraintSystem &cs, ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowValueExpansionWithoutPackReferences;
   }
 };
 

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -233,6 +233,8 @@ enum class ConstraintKind : char {
   /// an overload. The second type is a PackType containing the explicit
   /// generic arguments.
   ExplicitGenericArguments,
+  /// Both (first and second) pack types should have the same reduced shape.
+  SameShape,
 };
 
 /// Classification of the different kinds of constraints.
@@ -701,6 +703,7 @@ public:
     case ConstraintKind::DefaultClosureType:
     case ConstraintKind::UnresolvedMemberChainBase:
     case ConstraintKind::PackElementOf:
+    case ConstraintKind::SameShape:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1177,6 +1177,22 @@ public:
   }
 };
 
+class LocatorPathElt::PackExpansionType final
+    : public StoredPointerElement<swift::PackExpansionType> {
+public:
+  PackExpansionType(swift::PackExpansionType *openedPackExpansionTy)
+      : StoredPointerElement(PathElementKind::PackExpansionType,
+                             openedPackExpansionTy) {
+    assert(openedPackExpansionTy);
+  }
+
+  swift::PackExpansionType *getOpenedType() const { return getStoredPointer(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == PathElementKind::PackExpansionType;
+  }
+};
+
 namespace details {
   template <typename CustomPathElement>
   class PathElement {

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -202,8 +202,8 @@ CUSTOM_LOCATOR_PATH_ELT(PackElement)
 /// The shape of a parameter pack.
 SIMPLE_LOCATOR_PATH_ELT(PackShape)
 
-/// The type of pack expansion
-SIMPLE_LOCATOR_PATH_ELT(PackExpansionType)
+/// The type of an "opened" pack expansion
+CUSTOM_LOCATOR_PATH_ELT(PackExpansionType)
 
 /// The pattern  of a pack expansion.
 SIMPLE_LOCATOR_PATH_ELT(PackExpansionPattern)

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -202,6 +202,9 @@ CUSTOM_LOCATOR_PATH_ELT(PackElement)
 /// The shape of a parameter pack.
 SIMPLE_LOCATOR_PATH_ELT(PackShape)
 
+/// The type of pack expansion
+SIMPLE_LOCATOR_PATH_ELT(PackExpansionType)
+
 /// The pattern  of a pack expansion.
 SIMPLE_LOCATOR_PATH_ELT(PackExpansionPattern)
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -335,6 +335,9 @@ enum TypeVariableOptions {
 
   /// Whether the type variable can be bound to a pack type or not.
   TVO_CanBindToPack = 0x20,
+
+  /// Whether the type variable can be bound only to a pack expansion type.
+  TVO_PackExpansion = 0x40,
 };
 
 /// The implementation object for a type variable used within the
@@ -406,6 +409,9 @@ public:
 
   /// Whether this type variable can bind to a PackType.
   bool canBindToPack() const { return getRawOptions() & TVO_CanBindToPack; }
+
+  /// Whether this type variable can bind only to PackExpansionType.
+  bool isPackExpansion() const { return getRawOptions() & TVO_PackExpansion; }
 
   /// Whether this type variable prefers a subtype binding over a supertype
   /// binding.
@@ -650,6 +656,7 @@ private:
     ENTRY(TVO_CanBindToHole, "hole");
     ENTRY(TVO_PrefersSubtypeBinding, "");
     ENTRY(TVO_CanBindToPack, "pack");
+    ENTRY(TVO_PackExpansion, "pack expansion");
     }
   #undef ENTRY
   }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4871,6 +4871,12 @@ private:
       Type type1, Type type2, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);
 
+  /// Simplify a same-shape constraint by comparing the reduced shape of the
+  /// left hand side to the right hand side.
+  SolutionKind simplifySameShapeConstraint(Type type1, Type type2,
+                                           TypeMatchOptions flags,
+                                           ConstraintLocatorBuilder locator);
+
 public: // FIXME: Public for use by static functions.
   /// Simplify a conversion constraint with a fix applied to it.
   SolutionKind simplifyFixConstraint(ConstraintFix *fix, Type type1, Type type2,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3985,7 +3985,8 @@ public:
   ///                     corresponding opened type variables.
   ///
   /// \returns The opened type, or \c type if there are no archetypes in it.
-  Type openType(Type type, OpenedTypeMap &replacements);
+  Type openType(Type type, OpenedTypeMap &replacements,
+                ConstraintLocatorBuilder locator);
 
 private:
   /// "Open" an opaque archetype type, similar to \c openType.
@@ -3996,7 +3997,8 @@ private:
   /// opening its pattern and shape types and connecting them to the
   /// aforementioned variable via special constraints.
   Type openPackExpansionType(PackExpansionType *expansion,
-                             OpenedTypeMap &replacements);
+                             OpenedTypeMap &replacements,
+                             ConstraintLocatorBuilder locator);
 
 public:
   /// Recurse over the given type and open any opaque archetype types.
@@ -4068,9 +4070,9 @@ public:
   /// Wrapper over swift::adjustFunctionTypeForConcurrency that passes along
   /// the appropriate closure-type and opening extraction functions.
   AnyFunctionType *adjustFunctionTypeForConcurrency(
-    AnyFunctionType *fnType, ValueDecl *decl, DeclContext *dc,
-    unsigned numApplies, bool isMainDispatchQueue,
-    OpenedTypeMap &replacements);
+      AnyFunctionType *fnType, ValueDecl *decl, DeclContext *dc,
+      unsigned numApplies, bool isMainDispatchQueue,
+      OpenedTypeMap &replacements, ConstraintLocatorBuilder locator);
 
   /// Retrieve the type of a reference to the given value declaration.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1467,6 +1467,9 @@ public:
   llvm::DenseMap<ConstraintLocator *, OpenedArchetypeType *>
     OpenedExistentialTypes;
 
+  llvm::DenseMap<PackExpansionType *, TypeVariableType *>
+      OpenedPackExpansionTypes;
+
   /// The pack expansion environment that can open pack elements for
   /// a given locator.
   llvm::DenseMap<ConstraintLocator *, std::pair<UUID, Type>>
@@ -2219,6 +2222,9 @@ private:
   llvm::SmallMapVector<ConstraintLocator *, OpenedArchetypeType *, 4>
       OpenedExistentialTypes;
 
+  llvm::SmallMapVector<PackExpansionType *, TypeVariableType *, 4>
+      OpenedPackExpansionTypes;
+
   llvm::SmallMapVector<ConstraintLocator *, std::pair<UUID, Type>, 4>
       PackExpansionEnvironments;
 
@@ -2701,6 +2707,9 @@ public:
 
     /// The length of \c OpenedExistentialTypes.
     unsigned numOpenedExistentialTypes;
+
+    /// The length of \c OpenedPackExpansionsTypes.
+    unsigned numOpenedPackExpansionTypes;
 
     /// The length of \c PackExpansionEnvironments.
     unsigned numPackExpansionEnvironments;
@@ -3972,6 +3981,12 @@ private:
   /// "Open" an opaque archetype type, similar to \c openType.
   Type openOpaqueType(OpaqueTypeArchetypeType *type,
                       ConstraintLocatorBuilder locator);
+
+  /// "Open" a pack expansion type by replacing it with a type variable,
+  /// opening its pattern and shape types and connecting them to the
+  /// aforementioned variable via special constraints.
+  Type openPackExpansionType(PackExpansionType *expansion,
+                             OpenedTypeMap &replacements);
 
 public:
   /// Recurse over the given type and open any opaque archetype types.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3888,6 +3888,16 @@ public:
   bool resolveClosure(TypeVariableType *typeVar, Type contextualType,
                       ConstraintLocatorBuilder locator);
 
+  /// Given the fact that contextual type is now available for the type
+  /// variable representing a pack expansion type, let's resolve the expansion.
+  ///
+  /// \param typeVar The type variable representing pack expansion type.
+  /// \param locator The locator associated with contextual type.
+  ///
+  /// \returns `true` if pack expansion has been resolved, `false` otherwise.
+  bool resolvePackExpansion(TypeVariableType *typeVar,
+                            ConstraintLocatorBuilder locator);
+
   /// Assign a fixed type to the given type variable.
   ///
   /// \param typeVar The type variable to bind.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3892,11 +3892,11 @@ public:
   /// variable representing a pack expansion type, let's resolve the expansion.
   ///
   /// \param typeVar The type variable representing pack expansion type.
-  /// \param locator The locator associated with contextual type.
+  /// \param contextualType The contextual type this pack expansion variable
+  /// would be bound/equated to.
   ///
   /// \returns `true` if pack expansion has been resolved, `false` otherwise.
-  bool resolvePackExpansion(TypeVariableType *typeVar,
-                            ConstraintLocatorBuilder locator);
+  bool resolvePackExpansion(TypeVariableType *typeVar, Type contextualType);
 
   /// Assign a fixed type to the given type variable.
   ///

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -117,8 +117,11 @@ unsigned TupleType::getNumScalarElements() const {
 }
 
 bool TupleType::containsPackExpansionType() const {
+  assert(!hasTypeVariable());
   for (auto elt : getElements()) {
-    if (elt.getType()->is<PackExpansionType>())
+    auto eltTy = elt.getType();
+    assert(!eltTy->hasTypeVariable());
+    if (eltTy->is<PackExpansionType>())
       return true;
   }
 
@@ -144,7 +147,9 @@ bool TupleType::isSingleUnlabeledPackExpansion() const {
 
 bool AnyFunctionType::containsPackExpansionType(ArrayRef<Param> params) {
   for (auto param : params) {
-    if (param.getPlainType()->is<PackExpansionType>())
+    auto paramTy = param.getPlainType();
+    assert(!paramTy->hasTypeVariable());
+    if (paramTy->is<PackExpansionType>())
       return true;
   }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -148,6 +148,11 @@ bool BindingSet::isDelayed() const {
 }
 
 bool BindingSet::involvesTypeVariables() const {
+  // This type variable always depends on a pack expansion variable
+  // which should be inferred first if possible.
+  if (TypeVar->getImpl().canBindToPack())
+    return true;
+
   // This is effectively O(1) right now since bindings are re-computed
   // on each step of the solver, but once bindings are computed
   // incrementally it becomes more important to double-check that

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1480,6 +1480,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::SameShape:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5232,9 +5232,6 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   if (!locator->isLastElement<LocatorPathElt::ApplyArgument>())
     return false;
 
-  if (SynthesizedArgs.size() < 2)
-    return false;
-
   auto *args = getArgumentListFor(locator);
   if (!args)
     return false;
@@ -5251,11 +5248,16 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   if (!decl)
     return false;
 
+  auto *funcType =
+      resolveType(selectedOverload->openedType)->getAs<FunctionType>();
+  if (!funcType)
+    return false;
+
   auto name = decl->getBaseName();
   auto diagnostic =
       emitDiagnostic(diag::cannot_convert_single_tuple_into_multiple_arguments,
                      decl->getDescriptiveKind(), name, name.isSpecial(),
-                     SynthesizedArgs.size(), isa<TupleExpr>(argExpr));
+                     funcType->getNumParams(), isa<TupleExpr>(argExpr));
 
   // If argument is a literal tuple, let's suggest removal of parentheses.
   if (auto *TE = dyn_cast<TupleExpr>(argExpr)) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8901,3 +8901,8 @@ bool DestructureTupleToUseWithPackExpansionParameter::diagnoseAsNote() {
       argLoc.getParamIdx(), ParamShape->getNumElements());
   return true;
 }
+
+bool ValuePackExpansionWithoutPackReferences::diagnoseAsError() {
+  emitDiagnostic(diag::value_expansion_not_variadic);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8859,3 +8859,45 @@ bool GlobalActorFunctionMismatchFailure::diagnoseAsError() {
   emitDiagnostic(message, getFromType(), getToType());
   return true;
 }
+
+bool DestructureTupleToUseWithPackExpansionParameter::diagnoseAsError() {
+  auto *locator = getLocator();
+  auto argLoc = locator->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
+
+  {
+    auto diagnostic =
+        emitDiagnostic(diag::cannot_convert_tuple_into_pack_expansion_parameter,
+                       argLoc.getParamIdx(), ParamShape->getNumElements(),
+                       isExpr<TupleExpr>(getAnchor()));
+
+    if (auto *tupleExpr = getAsExpr<TupleExpr>(getAnchor())) {
+      diagnostic.fixItRemove(tupleExpr->getLParenLoc());
+      diagnostic.fixItRemove(tupleExpr->getRParenLoc());
+    }
+  }
+
+  auto selectedOverload = getCalleeOverloadChoiceIfAvailable(getLocator());
+  if (!selectedOverload)
+    return true;
+
+  if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
+    emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+  }
+
+  return true;
+}
+
+bool DestructureTupleToUseWithPackExpansionParameter::diagnoseAsNote() {
+  auto selectedOverload = getCalleeOverloadChoiceIfAvailable(getLocator());
+  if (!selectedOverload || !selectedOverload->choice.isDecl())
+    return false;
+
+  auto *choice = selectedOverload->choice.getDecl();
+  auto argLoc =
+      getLocator()->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
+
+  emitDiagnosticAt(
+      choice, diag::cannot_convert_tuple_into_pack_expansion_parameter_note,
+      argLoc.getParamIdx(), ParamShape->getNumElements());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -99,37 +99,42 @@ public:
   /// Resolve type variables present in the raw type, if any.
   Type resolveType(Type rawType, bool reconstituteSugar = false,
                    bool wantRValue = true) const {
-    if (rawType->hasTypeVariable() || rawType->hasPlaceholder()) {
-      rawType = rawType.transform([&](Type type) -> Type {
-        if (auto *typeVar = type->getAs<TypeVariableType>()) {
-          auto resolvedType = S.simplifyType(typeVar);
+    rawType = rawType.transform([&](Type type) -> Type {
+      if (auto *typeVar = type->getAs<TypeVariableType>()) {
+        auto resolvedType = S.simplifyType(typeVar);
 
-          if (!resolvedType->hasUnresolvedType())
-            return resolvedType;
+        if (!resolvedType->hasUnresolvedType())
+          return resolvedType;
 
-          // If type variable was simplified to an unresolved pack expansion
-          // type, let's examine its original pattern type because it could
-          // contain type variables replaceable with their generic parameter
-          // types.
-          if (auto *expansion = resolvedType->getAs<PackExpansionType>()) {
-            auto *locator = typeVar->getImpl().getLocator();
-            auto *openedExpansionTy =
-                locator->castLastElementTo<LocatorPathElt::PackExpansionType>()
-                    .getOpenedType();
-            auto patternType = resolveType(openedExpansionTy->getPatternType());
-            return PackExpansionType::get(patternType,
-                                          expansion->getCountType());
-          }
-
-          Type GP = typeVar->getImpl().getGenericParameter();
-          return resolvedType->is<UnresolvedType>() && GP ? GP : resolvedType;
+        // If type variable was simplified to an unresolved pack expansion
+        // type, let's examine its original pattern type because it could
+        // contain type variables replaceable with their generic parameter
+        // types.
+        if (auto *expansion = resolvedType->getAs<PackExpansionType>()) {
+          auto *locator = typeVar->getImpl().getLocator();
+          auto *openedExpansionTy =
+              locator->castLastElementTo<LocatorPathElt::PackExpansionType>()
+                  .getOpenedType();
+          auto patternType = resolveType(openedExpansionTy->getPatternType());
+          return PackExpansionType::get(patternType, expansion->getCountType());
         }
 
-        return type->isPlaceholder()
-                   ? Type(type->getASTContext().TheUnresolvedType)
-                   : type;
-      });
-    }
+        Type GP = typeVar->getImpl().getGenericParameter();
+        return resolvedType->is<UnresolvedType>() && GP ? GP : resolvedType;
+      }
+
+      if (auto *packType = type->getAs<PackType>()) {
+        if (packType->getNumElements() == 1) {
+          auto eltType = resolveType(packType->getElementType(0));
+          if (auto expansion = eltType->getAs<PackExpansionType>())
+            return expansion->getPatternType();
+        }
+      }
+
+      return type->isPlaceholder()
+                 ? Type(type->getASTContext().TheUnresolvedType)
+                 : type;
+    });
 
     if (reconstituteSugar)
       rawType = rawType->reconstituteSugar(/*recursive*/ true);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2976,6 +2976,30 @@ private:
   bool diagnoseTupleElement();
 };
 
+/// Diagnose situation when a single argument to tuple type is passed to
+/// a value pack expansion parameter that expects distinct N elements:
+///
+/// ```swift
+/// struct S<each T> {
+///   func test(x: Int, _: repeat each T) {}
+/// }
+///
+/// S<Int, String>().test(x: 42, (2, "b"))
+/// ```
+class DestructureTupleToUseWithPackExpansionParameter final
+    : public FailureDiagnostic {
+  PackType *ParamShape;
+
+public:
+  DestructureTupleToUseWithPackExpansionParameter(const Solution &solution,
+                                                  PackType *paramShape,
+                                                  ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), ParamShape(paramShape) {}
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3000,6 +3000,23 @@ public:
   bool diagnoseAsNote() override;
 };
 
+/// Diagnose situations when value pack expansion doesn't have any pack
+/// references i.e.:
+///
+/// ```swift
+/// func test(x: Int) {
+///   repeat x
+/// }
+/// ```
+class ValuePackExpansionWithoutPackReferences final : public FailureDiagnostic {
+public:
+  ValuePackExpansionWithoutPackReferences(const Solution &solution,
+                                          ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2742,3 +2742,15 @@ AllowGlobalActorMismatch::create(ConstraintSystem &cs, Type fromType,
   return new (cs.getAllocator())
       AllowGlobalActorMismatch(cs, fromType, toType, locator);
 }
+
+bool DestructureTupleToMatchPackExpansionParameter::diagnose(
+    const Solution &solution, bool asNote) const {
+  return false;
+}
+
+DestructureTupleToMatchPackExpansionParameter *
+DestructureTupleToMatchPackExpansionParameter::create(
+    ConstraintSystem &cs, PackType *paramShapeTy, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      DestructureTupleToMatchPackExpansionParameter(cs, paramShapeTy, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2756,3 +2756,15 @@ DestructureTupleToMatchPackExpansionParameter::create(
   return new (cs.getAllocator())
       DestructureTupleToMatchPackExpansionParameter(cs, paramShapeTy, locator);
 }
+
+bool AllowValueExpansionWithoutPackReferences::diagnose(
+    const Solution &solution, bool asNote) const {
+  return false;
+}
+
+AllowValueExpansionWithoutPackReferences *
+AllowValueExpansionWithoutPackReferences::create(ConstraintSystem &cs,
+                                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowValueExpansionWithoutPackReferences(cs, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2759,7 +2759,8 @@ DestructureTupleToMatchPackExpansionParameter::create(
 
 bool AllowValueExpansionWithoutPackReferences::diagnose(
     const Solution &solution, bool asNote) const {
-  return false;
+  ValuePackExpansionWithoutPackReferences failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowValueExpansionWithoutPackReferences *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2745,7 +2745,9 @@ AllowGlobalActorMismatch::create(ConstraintSystem &cs, Type fromType,
 
 bool DestructureTupleToMatchPackExpansionParameter::diagnose(
     const Solution &solution, bool asNote) const {
-  return false;
+  DestructureTupleToUseWithPackExpansionParameter failure(solution, ParamShape,
+                                                          getLocator());
+  return failure.diagnose(asNote);
 }
 
 DestructureTupleToMatchPackExpansionParameter *

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3081,6 +3081,12 @@ namespace {
       // pack expansion expression through the shape type variable.
       SmallVector<ASTNode, 2> expandedPacks;
       expr->getExpandedPacks(expandedPacks);
+
+      if (expandedPacks.empty()) {
+        (void)CS.recordFix(AllowValueExpansionWithoutPackReferences::create(
+            CS, CS.getConstraintLocator(expr)));
+      }
+
       for (auto pack : expandedPacks) {
         Type packType;
         if (auto *elementExpr = getAsExpr<PackElementExpr>(pack)) {

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -473,7 +473,7 @@ bool CompareDeclSpecializationRequest::evaluate(
     cs.openGeneric(outerDC, innerDC->getGenericSignatureOfContext(), locator,
                    replacements);
 
-    return cs.openType(type, replacements);
+    return cs.openType(type, replacements, locator);
   };
 
   bool knownNonSubtype = false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14803,6 +14803,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowTupleLabelMismatch:
   case FixKind::AddExplicitExistentialCoercion:
   case FixKind::DestructureTupleToMatchPackExpansionParameter:
+  case FixKind::AllowValueExpansionWithoutPackReferences:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13269,6 +13269,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
       return formUnsolved();
   }
 
+  if (type1->hasPlaceholder()) {
+    if (!shouldAttemptFixes())
+      return SolutionKind::Error;
+
+    recordTypeVariablesAsHoles(type2);
+    return SolutionKind::Solved;
+  }
+
   auto shape = type1->getReducedShape();
   addConstraint(ConstraintKind::Bind, shape, type2, locator);
   return SolutionKind::Solved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5684,6 +5684,12 @@ bool ConstraintSystem::repairFailures(
     if (rhs->is<PackType>()) {
       ArrayRef tmpPath(path);
 
+      // Ignore argument/parameter type conversion mismatch if we already
+      // detected a tuple splat issue.
+      if (hasFixFor(loc,
+                    FixKind::DestructureTupleToMatchPackExpansionParameter))
+        return true;
+
       // Path would end with `ApplyArgument`.
       auto *argsLoc = getConstraintLocator(anchor, tmpPath.drop_back());
       if (hasFixFor(argsLoc, FixKind::RemoveExtraneousArguments) ||
@@ -13327,6 +13333,21 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
         auto *loc = getConstraintLocator(anchor, path);
         auto argLoc =
             loc->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
+
+        auto argPack = type1->castTo<PackType>();
+        auto paramPack = type2->castTo<PackType>();
+
+        // Tailed diagnostic to explode tuples.
+        if (argPack->getNumElements() == 1) {
+          if (auto *tuple = argPack->getElementType(0)->getAs<TupleType>()) {
+            if (tuple->getNumElements() == paramPack->getNumElements()) {
+              return recordShapeFix(
+                  DestructureTupleToMatchPackExpansionParameter::create(
+                      *this, paramPack, loc),
+                  /*impact=*/2 * paramPack->getNumElements());
+            }
+          }
+        }
 
         auto numArgs = shape1->castTo<PackType>()->getNumElements();
         auto numParams = shape2->castTo<PackType>()->getNumElements();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1793,7 +1793,13 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         auto *argPack = PackType::get(cs.getASTContext(), argTypes);
         auto *argPackExpansion = PackExpansionType::get(argPack, argPack);
 
-        cs.addConstraint(subKind, argPackExpansion, paramTy, loc);
+        auto firstArgIdx =
+            argTypes.empty() ? paramIdx : parameterBindings[paramIdx].front();
+
+        cs.addConstraint(
+            subKind, argPackExpansion, paramTy,
+            locator.withPathElement(LocatorPathElt::ApplyArgToParam(
+                firstArgIdx, paramIdx, param.getParameterFlags())));
         continue;
       }
     }
@@ -5673,6 +5679,18 @@ bool ConstraintSystem::repairFailures(
     if (hasFixFor(loc, FixKind::RemoveExtraneousArguments))
       return true;
 
+    // If parameter is a pack, let's see if we have already recorded
+    // either synthesized or extraneous argument fixes.
+    if (rhs->is<PackType>()) {
+      ArrayRef tmpPath(path);
+
+      // Path would end with `ApplyArgument`.
+      auto *argsLoc = getConstraintLocator(anchor, tmpPath.drop_back());
+      if (hasFixFor(argsLoc, FixKind::RemoveExtraneousArguments) ||
+          hasFixFor(argsLoc, FixKind::AddMissingArguments))
+        return true;
+    }
+
     // If the argument couldn't be found, this could be a default value
     // type mismatch.
     if (!simplifyLocatorToAnchor(loc)) {
@@ -7271,9 +7289,16 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case TypeKind::Pack: {
       auto tmpPackLoc = locator.withPathElement(LocatorPathElt::PackType(type1));
       auto packLoc = tmpPackLoc.withPathElement(LocatorPathElt::PackType(type2));
-      return matchPackTypes(cast<PackType>(desugar1),
-                            cast<PackType>(desugar2),
-                            kind, subflags, packLoc);
+
+      auto result =
+          matchPackTypes(cast<PackType>(desugar1), cast<PackType>(desugar2),
+                         kind, subflags, packLoc);
+
+      // Let `repairFailures` attempt to "fix" this.
+      if (shouldAttemptFixes() && result.isFailure())
+        break;
+
+      return result;
     }
     case TypeKind::PackExpansion: {
       auto expansion1 = cast<PackExpansionType>(desugar1);
@@ -13273,16 +13298,87 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
     return SolutionKind::Solved;
 
   if (shouldAttemptFixes()) {
+    // If there are placeholders involved shape mismatches are most
+    // likely just a symptom of some other issue i.e. type mismatch.
     if (type1->hasPlaceholder() || type2->hasPlaceholder())
       return SolutionKind::Solved;
+
+    auto recordShapeFix = [&](ConstraintFix *fix,
+                              unsigned impact) -> SolutionKind {
+      return recordFix(fix, impact) ? SolutionKind::Error
+                                    : SolutionKind::Solved;
+    };
+
+    // Let's check whether we can produce a tailored fix for argument/parameter
+    // mismatches.
+    if (locator.endsWith<LocatorPathElt::PackShape>()) {
+      SmallVector<LocatorPathElt> path;
+      auto anchor = locator.getLocatorParts(path);
+
+      // Drop `PackShape`
+      path.pop_back();
+
+      // Tailed diagnostics for argument/parameter mismatches - there
+      // are either missing or extra arguments.
+      if (path.size() > 0 &&
+          path[path.size() - 1].is<LocatorPathElt::ApplyArgToParam>()) {
+        auto &ctx = getASTContext();
+
+        auto *loc = getConstraintLocator(anchor, path);
+        auto argLoc =
+            loc->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
+
+        auto numArgs = shape1->castTo<PackType>()->getNumElements();
+        auto numParams = shape2->castTo<PackType>()->getNumElements();
+
+        // Drops `ApplyArgToParam` and left with `ApplyArgument`.
+        path.pop_back();
+
+        auto *argListLoc = getConstraintLocator(anchor, path);
+
+        // Missing arguments.
+        if (numParams > numArgs) {
+          SmallVector<SynthesizedArg> synthesizedArgs;
+          for (unsigned i = 0, n = numParams - numArgs; i != n; ++i) {
+            auto eltTy = shape2->castTo<PackType>()->getElementType(i);
+            synthesizedArgs.push_back(SynthesizedArg{
+                argLoc.getParamIdx(), AnyFunctionType::Param(eltTy)});
+          }
+
+          return recordShapeFix(
+              AddMissingArguments::create(*this, synthesizedArgs, argListLoc),
+              /*impact=*/2 * synthesizedArgs.size());
+        } else {
+          auto argIdx = argLoc.getArgIdx() + numParams;
+          SmallVector<std::pair<unsigned, AnyFunctionType::Param>, 4>
+              extraneousArgs;
+
+          for (unsigned i = 0, n = numArgs - numParams; i != n; ++i) {
+            extraneousArgs.push_back(
+                {argIdx + i, AnyFunctionType::Param(ctx.TheEmptyTupleType)});
+          }
+
+          auto overload = findSelectedOverloadFor(getCalleeLocator(argListLoc));
+          if (!overload)
+            return SolutionKind::Error;
+
+          return recordShapeFix(
+              RemoveExtraneousArguments::create(
+                  *this, overload->openedType->castTo<FunctionType>(),
+                  extraneousArgs, argListLoc),
+              /*impact=*/2 * extraneousArgs.size());
+        }
+      }
+    }
 
     unsigned impact = 1;
     if (locator.endsWith<LocatorPathElt::AnyRequirement>())
       impact = assessRequirementFailureImpact(*this, shape1, locator);
 
-    auto *fix = SkipSameShapeRequirement::create(*this, type1, type2,
-                                                 getConstraintLocator(locator));
-    return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
+    return recordShapeFix(
+        SkipSameShapeRequirement::create(*this, type1, type2,
+                                         getConstraintLocator(locator)),
+        impact);
   }
 
   return SolutionKind::Error;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11031,7 +11031,7 @@ static Type getOpenedResultBuilderTypeFor(ConstraintSystem &cs,
     auto substitutions = cs.getOpenedTypes(calleeLocator);
     if (!substitutions.empty()) {
       OpenedTypeMap replacements(substitutions.begin(), substitutions.end());
-      builderType = cs.openType(builderType, replacements);
+      builderType = cs.openType(builderType, replacements, locator);
     }
     assert(!builderType->hasTypeParameter());
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6891,6 +6891,13 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
               return true;
           }
 
+          // Delay matching if one of the elements is unresolved pack
+          // expansion represented by a type variable.
+          if (auto *typeVar = element.getType()->getAs<TypeVariableType>()) {
+            if (typeVar->getImpl().isPackExpansion())
+              return true;
+          }
+
           afterPack = element.getType()->is<PackExpansionType>();
         }
 
@@ -13103,11 +13110,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
     return formUnsolved();
 
   // We can't compute a reduced shape if the input type still
-  // contains type variables that might bind to pack archetypes.
+  // contains type variables that might bind to pack archetypes
+  // or pack expansions.
   SmallPtrSet<TypeVariableType *, 2> typeVars;
   type1->getTypeVariables(typeVars);
   for (auto *typeVar : typeVars) {
-    if (typeVar->getImpl().canBindToPack())
+    if (typeVar->getImpl().canBindToPack() ||
+        typeVar->getImpl().isPackExpansion())
       return formUnsolved();
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8998,67 +8998,78 @@ ConstraintSystem::simplifyBindTupleOfFunctionParamsConstraint(
   return SolutionKind::Solved;
 }
 
-static Type lookThroughSingletonPackExpansion(Type ty) {
-  if (auto pack = ty->getAs<PackType>()) {
-    if (pack->getNumElements() == 1) {
-      if (auto expansion = pack->getElementType(0)->getAs<PackExpansionType>()) {
-        auto countType = expansion->getCountType();
-        if (countType->isEqual(expansion->getPatternType()))
-          return countType;
-      }
-    }
-  }
-  return ty;
-}
-
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
                                                   TypeMatchOptions flags,
                                                   ConstraintLocatorBuilder locator) {
   auto elementType = simplifyType(first, flags);
-  auto packType = simplifyType(second, flags);
+  auto patternType = simplifyType(second, flags);
 
-  if (elementType->hasTypeVariable() || packType->hasTypeVariable()) {
+  auto formUnsolved = [&]() {
     if (!flags.contains(TMF_GenerateConstraints))
       return SolutionKind::Unsolved;
 
-    auto *loc = getConstraintLocator(locator);
     addUnsolvedConstraint(
-        Constraint::create(*this, ConstraintKind::PackElementOf,
-                           first, second, loc));
+        Constraint::create(*this, ConstraintKind::PackElementOf, first, second,
+                           getConstraintLocator(locator)));
 
     return SolutionKind::Solved;
-  }
+  };
 
-  // FIXME: I'm not sure this is actually necessary; I may only be seeing
-  // this because of something I've screwed up in element generic
-  // environments.
-  elementType = lookThroughSingletonPackExpansion(elementType);
-
-  // This constraint only exists to vend bindings.
-  auto *packEnv = DC->getGenericEnvironmentOfContext();
-
-  // Map element archetypes to the pack context to check for equality.
-  if (elementType->hasElementArchetype()) {
-    auto mappedPack = packEnv->mapElementTypeIntoPackContext(elementType);
-    return (packType->isEqual(mappedPack) ?
-            SolutionKind::Solved : SolutionKind::Error);
-  }
-
-  // Pack expansions can have concrete pattern types. In this case, the pack
-  // type and element type will be equal.
-  if (packType->isEqual(elementType)) {
-    return SolutionKind::Solved;
-  }
+  // If neither side is fully resolved yet, there is nothing we can do.
+  if (elementType->hasTypeVariable() && patternType->hasTypeVariable())
+    return formUnsolved();
 
   if (shouldAttemptFixes()) {
-    auto *loc = getConstraintLocator(locator);
-    if (elementType->isPlaceholder() ||
-        !recordFix(AllowInvalidPackElement::create(*this, packType, loc)))
+    if (elementType->isPlaceholder() || patternType->isPlaceholder())
       return SolutionKind::Solved;
   }
 
-  return SolutionKind::Error;
+  // Let's try to resolve element type based on the pattern type.
+  if (!patternType->hasTypeVariable()) {
+    auto *loc = getConstraintLocator(locator);
+    auto shapeClass = patternType->getReducedShape();
+    patternType = patternType->mapTypeOutOfContext();
+    auto *elementEnv = getPackElementEnvironment(loc, shapeClass);
+
+    // Without an opened element environment, we cannot derive the
+    // element binding.
+    if (!elementEnv) {
+      if (!shouldAttemptFixes())
+        return SolutionKind::Error;
+
+      // `each` was applied to a concrete type.
+      if (!shapeClass->is<PackArchetypeType>()) {
+        if (recordFix(AllowInvalidPackElement::create(*this, patternType, loc)))
+          return SolutionKind::Error;
+      }
+
+      // Only other posibility is that there is a shape mismatch between
+      // elements of the pack expansion pattern which is detected separately.
+
+      recordAnyTypeVarAsPotentialHole(elementType);
+      return SolutionKind::Solved;
+    }
+
+    auto expectedElementTy =
+        elementEnv->mapPackTypeIntoElementContext(patternType);
+    assert(!expectedElementTy->is<PackType>());
+
+    addConstraint(ConstraintKind::Equal, elementType, expectedElementTy,
+                  locator);
+    return SolutionKind::Solved;
+  }
+
+  // Otherwise we are inferred or checking pattern type.
+
+  auto *packEnv = DC->getGenericEnvironmentOfContext();
+
+  // Map element archetypes to the pack context to check for equality.
+  if (elementType->hasElementArchetype())
+    elementType = packEnv->mapElementTypeIntoPackContext(elementType);
+
+  addConstraint(ConstraintKind::Equal, elementType, patternType, locator);
+  return SolutionKind::Solved;
 }
 
 static bool isForKeyPathSubscript(ConstraintSystem &cs,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2412,13 +2412,16 @@ static PackType *replaceTypeVariablesWithFreshPacks(ConstraintSystem &cs,
       auto elementLoc = cs.getConstraintLocator(loc,
           LocatorPathElt::PackElement(freshTypeVars.size()));
       if (packExpansionElt != nullptr) {
-        auto *freshTypeVar =
-            cs.createTypeVariable(elementLoc, TVO_CanBindToPack);
+        auto *freshTypeVar = cs.createTypeVariable(
+            elementLoc,
+            TVO_CanBindToPack |
+                (typeVar->getImpl().canBindToHole() ? TVO_CanBindToHole : 0));
         freshTypeVars.push_back(PackExpansionType::get(
             freshTypeVar, packExpansionElt->getCountType()));
       } else {
-        freshTypeVars.push_back(
-            cs.createTypeVariable(elementLoc, /*options=*/0));
+        freshTypeVars.push_back(cs.createTypeVariable(
+            elementLoc,
+            typeVar->getImpl().canBindToHole() ? TVO_CanBindToHole : 0));
       }
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2086,9 +2086,7 @@ static bool isPackExpansionType(Type type) {
     return true;
 
   if (auto *typeVar = type->getAs<TypeVariableType>())
-    return typeVar->getImpl()
-        .getLocator()
-        ->isLastElement<LocatorPathElt::PackExpansionType>();
+    return typeVar->getImpl().isPackExpansion();
 
   return false;
 }
@@ -4311,6 +4309,11 @@ ConstraintSystem::matchTypesBindTypeVar(
     type = PlaceholderType::get(typeVar->getASTContext(), typeVar);
   }
 
+  // FIXME: Add a fix for this.
+  if (typeVar->getImpl().isPackExpansion() && !type->is<PackExpansionType>()) {
+    return getTypeMatchFailure(locator);
+  }
+
   // Binding to a pack expansion type is always an error in Swift 6 mode.
   // This indicates that a pack expansion expression was used in a context
   // that doesn't support it.
@@ -4322,7 +4325,7 @@ ConstraintSystem::matchTypesBindTypeVar(
   // generic parameter - `init(_ data: repeat each T)`.
   //
   // See BindTupleOfFunctionParams constraint for more details.
-  if (type->is<PackExpansionType>()) {
+  if (!typeVar->getImpl().isPackExpansion() && type->is<PackExpansionType>()) {
     bool representsParameterList =
         typeVar->getImpl()
             .getLocator()

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6577,6 +6577,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         auto rep1 = getRepresentative(typeVar1);
         auto rep2 = getRepresentative(typeVar2);
 
+        // Pack expansion variables cannot be merged because
+        // they involve other type variables.
+        if (rep1->getImpl().isPackExpansion() ||
+            rep2->getImpl().isPackExpansion())
+          return formUnsolvedResult();
+
         // If exactly one of the type variables can bind to an lvalue, we
         // can't merge these two type variables.
         if (kind == ConstraintKind::Equal &&
@@ -6633,6 +6639,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       } if (typeVar1 && typeVar2) {
         auto rep1 = getRepresentative(typeVar1);
         auto rep2 = getRepresentative(typeVar2);
+
+        // Pack expansion variables cannot be merged because
+        // they involve other type variables.
+        if (rep1->getImpl().isPackExpansion() ||
+            rep2->getImpl().isPackExpansion())
+          return formUnsolvedResult();
 
         if (!rep1->getImpl().canBindToInOut() ||
             !rep2->getImpl().canBindToLValue()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -117,6 +117,16 @@ static Optional<unsigned> scoreParamAndArgNameTypo(StringRef paramName,
   return dist;
 }
 
+static bool isPackExpansionType(Type type) {
+  if (type->is<PackExpansionType>())
+    return true;
+
+  if (auto *typeVar = type->getAs<TypeVariableType>())
+    return typeVar->getImpl().isPackExpansion();
+
+  return false;
+}
+
 bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
                                                 const ValueDecl *decl) {
   assert(decl->getDeclContext()->isTypeContext() &&
@@ -534,8 +544,7 @@ static bool matchCallArgumentsImpl(
     }
 
     // Handle variadic parameters.
-    if (param.isVariadic() ||
-        param.getPlainType()->is<PackExpansionType>()) {
+    if (param.isVariadic() || isPackExpansionType(param.getPlainType())) {
       // Claim the next argument with the name of this parameter.
       auto claimed =
           claimNextNamed(nextArgIdx, paramLabel, ignoreNameMismatch);
@@ -795,8 +804,7 @@ static bool matchCallArgumentsImpl(
       const auto &param = params[paramIdx];
 
       // Variadic parameters can be unfulfilled.
-      if (param.isVariadic() ||
-          param.getPlainType()->is<PackExpansionType>())
+      if (param.isVariadic() || isPackExpansionType(param.getPlainType()))
         continue;
 
       // Parameters with defaults can be unfulfilled.
@@ -886,7 +894,7 @@ static bool matchCallArgumentsImpl(
 
         // Does nothing for variadic tail.
         if ((params[paramIdx].isVariadic() ||
-             params[paramIdx].getPlainType()->is<PackExpansionType>()) &&
+             isPackExpansionType(params[paramIdx].getPlainType())) &&
             paramBindIdx > 0) {
           assert(args[fromArgIdx].getLabel().empty());
           continue;
@@ -1763,7 +1771,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       // is declared as `init(_: repeat each T)`. Although declaration
       // based information reports parameter at index 0 as variadic generic
       // the call site specializes it to `Int`.
-      if (auto *paramPackExpansion = paramTy->getAs<PackExpansionType>()) {
+      if (isPackExpansionType(paramTy)) {
         SmallVector<Type, 2> argTypes;
         for (auto argIdx : parameterBindings[paramIdx]) {
           auto argType = argsWithLabels[argIdx].getPlainType();
@@ -1773,9 +1781,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         auto *argPack = PackType::get(cs.getASTContext(), argTypes);
         auto *argPackExpansion = PackExpansionType::get(argPack, argPack);
 
-        cs.addConstraint(
-          subKind, argPackExpansion, paramPackExpansion,
-          loc, /*isFavored=*/false);
+        cs.addConstraint(subKind, argPackExpansion, paramTy, loc);
         continue;
       }
     }
@@ -2080,16 +2086,6 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
 }
 
 namespace {
-
-static bool isPackExpansionType(Type type) {
-  if (type->is<PackExpansionType>())
-    return true;
-
-  if (auto *typeVar = type->getAs<TypeVariableType>())
-    return typeVar->getImpl().isPackExpansion();
-
-  return false;
-}
 
 class TupleMatcher {
   TupleType *tuple1;
@@ -2421,8 +2417,9 @@ static PackType *replaceTypeVariablesWithFreshPacks(ConstraintSystem &cs,
   for (unsigned i = 0, e = pack->getNumElements(); i < e; ++i) {
     auto *packExpansionElt = pack->getElementType(i)->getAs<PackExpansionType>();
 
-    auto instantiatedPattern = pattern.transformRec([&](Type t) -> Optional<Type> {
-      if (t->is<PackExpansionType>())
+    auto instantiatedPattern = pattern.transformRec([&](Type t)
+                                                        -> Optional<Type> {
+      if (isPackExpansionType(t))
         return t;
 
       if (auto *typeVar = t->getAs<TypeVariableType>()) {
@@ -2658,8 +2655,7 @@ static bool isSingleTupleParam(ASTContext &ctx,
     return false;
 
   const auto &param = params.front();
-  if ((param.isVariadic() ||
-       param.getPlainType()->is<PackExpansionType>()) ||
+  if ((param.isVariadic() || isPackExpansionType(param.getPlainType())) ||
       param.isInOut() || param.hasLabel() || param.isIsolated())
     return false;
 
@@ -11033,7 +11029,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 
     // Cannot propagate pack expansion type from context,
     // it has to be handled by type matching logic.
-    if (contextualTy->is<PackExpansionType>())
+    if (isPackExpansionType(contextualTy))
       return false;
 
     // If contextual type has an error, let's wait for inference,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14773,6 +14773,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowSwiftToCPointerConversion:
   case FixKind::AllowTupleLabelMismatch:
   case FixKind::AddExplicitExistentialCoercion:
+  case FixKind::DestructureTupleToMatchPackExpansionParameter:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6529,6 +6529,9 @@ ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                              TypeMatchOptions flags,
                              ConstraintLocatorBuilder locator) {
+  auto origType1 = type1;
+  auto origType2 = type2;
+
   // If we have type variables that have been bound to fixed types, look through
   // to the fixed type.
   type1 = getFixedTypeRecursive(type1, flags, kind == ConstraintKind::Equal);
@@ -6792,11 +6795,32 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     return formUnsolvedResult();
   }
 
-  // If either side is a tuple that has unresolved pack expansions,
-  // delay matching until more is inferred about type structure.
-  if (isTupleWithUnresolvedPackExpansion(desugar1) ||
-      isTupleWithUnresolvedPackExpansion(desugar2))
-    return formUnsolvedResult();
+  // If the original type on one side consisted of a tuple type with
+  // unresolved pack expansion(s), let's make sure that both sides are
+  // tuples to enable proper pack matching for situations like:
+  //
+  // `Int <conversion> (_: $T3)`
+  // where `$T3` is pack expansion of pattern type `$T2`
+  //
+  // `Int` should be wrapped in a one-element tuple to make sure
+  // that tuple matcher can form a pack expansion type that would
+  // match `$T3` and propagate `Pack{Int}` to `$T2`.
+  //
+  // This is also important for situations like: `$T2 conv (Int, $T_exp)`
+  // becuase expansion could be defaulted to an empty pack which means
+  // that under substitution that element would disappear and the type
+  // would be just `(Int)`.
+  if (isTupleWithUnresolvedPackExpansion(origType1) ||
+      isTupleWithUnresolvedPackExpansion(origType2)) {
+    if (desugar1->is<TupleType>() != desugar2->is<TupleType>()) {
+      return matchTypes(
+          desugar1->is<TupleType>() ? type1
+                                    : TupleType::get({type1}, getASTContext()),
+          desugar2->is<TupleType>() ? type2
+                                    : TupleType::get({type2}, getASTContext()),
+          kind, flags, locator);
+    }
+  }
 
   llvm::SmallVector<RestrictionOrFix, 4> conversionsOrFixes;
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -169,6 +169,14 @@ Solution ConstraintSystem::finalize() {
     solution.OpenedExistentialTypes.insert(openedExistential);
   }
 
+  for (const auto &expansion : OpenedPackExpansionTypes) {
+    assert(solution.OpenedPackExpansionTypes.count(expansion.first) == 0 ||
+           solution.OpenedPackExpansionTypes[expansion.first] ==
+                   expansion.second &&
+               "Already recorded");
+    solution.OpenedPackExpansionTypes.insert(expansion);
+  }
+
   // Remember the defaulted type variables.
   solution.DefaultedConstraints.insert(DefaultedConstraints.begin(),
                                        DefaultedConstraints.end());
@@ -269,6 +277,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the solution's opened existential types.
   for (const auto &openedExistential : solution.OpenedExistentialTypes) {
     OpenedExistentialTypes.insert(openedExistential);
+  }
+
+  // Register the solution's opened pack expansion types.
+  for (const auto &expansion : solution.OpenedPackExpansionTypes) {
+    OpenedPackExpansionTypes.insert(expansion);
   }
 
   // Register the solutions's pack expansion environments.
@@ -594,6 +607,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numArgumentMatchingChoices = cs.argumentMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
+  numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
@@ -671,6 +685,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any opened existential types.
   truncate(cs.OpenedExistentialTypes, numOpenedExistentialTypes);
+
+  // Remove any opened pack expansion types.
+  truncate(cs.OpenedPackExpansionTypes, numOpenedPackExpansionTypes);
 
   // Remove any pack expansion environments.
   truncate(cs.PackExpansionEnvironments, numPackExpansionEnvironments);

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -82,6 +82,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -171,6 +172,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -319,6 +321,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -568,6 +571,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
     Out << " shape of ";
     break;
 
+  case ConstraintKind::SameShape:
+    Out << " same-shape ";
+    break;
+
   case ConstraintKind::ExplicitGenericArguments:
     Out << " explicit generic argument binding ";
     break;
@@ -740,6 +747,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -106,6 +106,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::AnyPatternDecl:
   case ConstraintLocator::GlobalActorType:
   case ConstraintLocator::CoercionOperand:
+  case ConstraintLocator::PackExpansionType:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -500,6 +501,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
 
   case ConstraintLocator::CoercionOperand: {
     out << "coercion operand";
+    break;
+
+  case ConstraintLocator::PackExpansionType:
+    out << "pack expansion type";
     break;
   }
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -504,7 +504,9 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     break;
 
   case ConstraintLocator::PackExpansionType:
-    out << "pack expansion type";
+    auto expansionElt = elt.castTo<LocatorPathElt::PackExpansionType>();
+    out << "pack expansion type ("
+        << expansionElt.getOpenedType()->getString(PO) << ")";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7207,6 +7207,21 @@ TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
     return;
   }
 
+  // Pack expansion type variable can only ever have one binding
+  // which is handled by \c resolvePackExpansion.
+  //
+  // There is no need to iterate over other bindings here because
+  // there is no use for contextual types (unlike closures that can
+  // propagate contextual information into the body).
+  if (TypeVar->getImpl().isPackExpansion()) {
+    for (const auto &entry : bindings.Defaults) {
+      auto *constraint = entry.second;
+      Bindings.push_back(getDefaultBinding(constraint));
+    }
+
+    return;
+  }
+
   // A binding to `Any` which should always be considered as a last resort.
   Optional<Binding> Any;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7235,21 +7235,6 @@ TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
     return;
   }
 
-  // Pack expansion type variable can only ever have one binding
-  // which is handled by \c resolvePackExpansion.
-  //
-  // There is no need to iterate over other bindings here because
-  // there is no use for contextual types (unlike closures that can
-  // propagate contextual information into the body).
-  if (TypeVar->getImpl().isPackExpansion()) {
-    for (const auto &entry : bindings.Defaults) {
-      auto *constraint = entry.second;
-      Bindings.push_back(getDefaultBinding(constraint));
-    }
-
-    return;
-  }
-
   // A binding to `Any` which should always be considered as a last resort.
   Optional<Binding> Any;
 
@@ -7265,6 +7250,40 @@ TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
       Bindings.push_back(binding);
     }
   };
+
+  if (TypeVar->getImpl().isPackExpansion()) {
+    SmallVector<Binding> viableBindings;
+
+    // Collect possible contextual types (keep in mind that pack
+    // expansion type variable gets bound to its "opened" type
+    // regardless). To be viable the binding has to come from `bind`
+    // or `equal` constraint (i.e. same-type constraint or explicit
+    // generic argument) and be fully resolved.
+    llvm::copy_if(bindings.Bindings, std::back_inserter(viableBindings),
+                  [&](const Binding &binding) {
+                    auto *source = binding.getSource();
+                    if (source->getKind() == ConstraintKind::Bind ||
+                        source->getKind() == ConstraintKind::Equal) {
+                      auto type = binding.BindingType;
+                      return type->is<PackExpansionType>() &&
+                             !type->hasTypeVariable();
+                    }
+                    return false;
+                  });
+
+    // If there is a single fully resolved contextual type, let's
+    // use it as a binding to help with performance and diagnostics.
+    if (viableBindings.size() == 1) {
+      addBinding(viableBindings.front());
+    } else {
+      for (const auto &entry : bindings.Defaults) {
+        auto *constraint = entry.second;
+        Bindings.push_back(getDefaultBinding(constraint));
+      }
+    }
+
+    return;
+  }
 
   for (const auto &binding : bindings.Bindings) {
     addBinding(binding);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5751,6 +5751,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
 
     case ConstraintLocator::PackElement:
     case ConstraintLocator::PackShape:
+    case ConstraintLocator::PackExpansionType:
       break;
 
     case ConstraintLocator::PackExpansionPattern: {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1018,7 +1018,8 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
     return known->second;
 
   auto *expansionVar = createTypeVariable(
-      getConstraintLocator({}, ConstraintLocator::PackExpansionType),
+      getConstraintLocator(
+          {}, LocatorPathElt::PackExpansionType(openedPackExpansion)),
       TVO_PackExpansion);
 
   // This constraint is important to make sure that pack expansion always
@@ -1026,7 +1027,8 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
   // that appear in pattern and shape types.
   addUnsolvedConstraint(Constraint::create(
       *this, ConstraintKind::Defaultable, expansionVar, openedPackExpansion,
-      getConstraintLocator({}, ConstraintLocator::PackExpansionType)));
+      getConstraintLocator(
+          {}, LocatorPathElt::PackExpansionType(openedPackExpansion))));
 
   OpenedPackExpansionTypes[openedPackExpansion] = expansionVar;
   return expansionVar;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3784,7 +3784,9 @@ struct TypeSimplifier {
         // Flatten single-element tuples containing type variables that cannot
         // bind to packs.
         auto typeVar = elementType->getAs<TypeVariableType>();
-        if (!element.hasName() && typeVar && !typeVar->getImpl().canBindToPack()) {
+        if (!element.hasName() && typeVar &&
+            !typeVar->getImpl().canBindToPack() &&
+            !typeVar->getImpl().isPackExpansion()) {
           return typeVar;
         }
       }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1590,6 +1590,16 @@ void ConstraintSystem::print(raw_ostream &out) const {
     }
   }
 
+  if (!OpenedPackExpansionTypes.empty()) {
+    out.indent(indent) << "Opened pack expansion types:\n";
+    for (const auto &expansion : OpenedPackExpansionTypes) {
+      out.indent(indent + 2);
+      out << expansion.first->getString(PO);
+      out << " opens to " << expansion.second->getString(PO);
+      out << "\n";
+    }
+  }
+
   if (!DefaultedConstraints.empty()) {
     out.indent(indent) << "Defaulted constraints:\n";
     interleave(DefaultedConstraints, [&](ConstraintLocator *locator) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -658,7 +658,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       cs.openGenericRequirement(DC->getParent(), index, requirement,
                                 /*skipSelfProtocolConstraint=*/false, locator,
                                 [&](Type type) -> Type {
-                                  return cs.openType(type, genericParameters);
+                                  return cs.openType(type, genericParameters,
+                                                     locator);
                                 });
     };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -69,6 +69,8 @@ void TypeVariableType::Implementation::print(llvm::raw_ostream &OS) {
     bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToHole);
   if (canBindToPack())
     bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToPack);
+  if (isPackExpansion())
+    bindingOptions.push_back(TypeVariableOptions::TVO_PackExpansion);
   if (!bindingOptions.empty()) {
     OS << " [allows bindings to: ";
     interleave(bindingOptions, OS,

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -133,7 +133,7 @@ func tupleExpansion<each T, each U>(
   _ = zip(repeat each tuple1.element, with: repeat each tuple1.element)
 
   _ = zip(repeat each tuple1.element, with: repeat each tuple2.element)
-  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each U' and 'each T' have the same shape}}
+  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each T' and 'each U' have the same shape}}
 }
 
 protocol Generatable {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -458,3 +458,26 @@ do {
     // expected-error@-1 {{pack reference 'each T' can only appear in pack expansion}}
   }
 }
+
+// rdar://107835215 - failed to produce a diagnostic for invalid pack expansion expression
+do {
+  func test1(x: Int) {
+    repeat x
+    // expected-error@-1:5 {{value pack expansion must contain at least one pack reference}}
+  }
+
+  func test2<T: Numeric>(_ x: T) {
+    repeat print(x * 2)
+    // expected-error@-1:5 {{value pack expansion must contain at least one pack reference}}
+  }
+
+  struct S<T> {
+    init(_: T) {}
+  }
+
+  func test<each T>(x: repeat each T, y: Int) {
+    func f<each A, each B>(_: repeat each A, y: repeat each B) {}
+    f(repeat each x, y: repeat [S(y)])
+    // expected-error@-1:25 {{value pack expansion must contain at least one pack reference}}
+  }
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -408,3 +408,16 @@ func test_no_unused_result_warning(arr: inout [Any]) {
     ((repeat arr.append(each value))) // no warning
   }
 }
+
+func test_partually_flattened_expansions() {
+  struct S<each T> {
+    init() {}
+
+    func fn<each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {
+      return (repeat (each t, each u))
+    }
+  }
+
+  _ = S().fn(t: 1, "hi", u: false, 1.0) // Ok
+  _ = S<Int, String>().fn(t: 1, "hi", u: false, 1.0) // Ok
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -50,7 +50,14 @@ protocol P {
   var value: A { get }
 
   func f(_ self: Self) -> Self
+
+  func makeA() -> A
 }
+
+extension P {
+  func makeA() -> [Self] { return [self] }
+}
+
 
 func outerArchetype<each T, U>(t: repeat each T, u: U) where repeat each T: P {
   let _: (repeat (each T.A, U)) = (repeat ((each t).value, u))
@@ -438,4 +445,16 @@ func test_partually_flattened_expansions() {
 
   _ = S().fn(t: 1, "hi", u: false, 1.0) // Ok
   _ = S<Int, String>().fn(t: 1, "hi", u: false, 1.0) // Ok
+}
+
+// rdar://107675464 - misplaced `each` results in `type of expression is ambiguous without more context`
+do {
+  func test_correct_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
+    return (repeat (each value).makeA()) // Ok
+  }
+
+  func test_misplaced_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
+    return (repeat each value.makeA())
+    // expected-error@-1 {{pack reference 'each T' can only appear in pack expansion}}
+  }
 }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -330,10 +330,11 @@ func test_pack_expansions_with_closures() {
 }
 
 // rdar://107151854 - crash on invalid due to specialized pack expansion
-func test_pack_expansion_specialization() {
+func test_pack_expansion_specialization(tuple: (Int, String, Float)) {
   struct Data<each T> {
-    init(_: repeat each T) {} // expected-note 3 {{'init(_:)' declared here}}
+    init(_: repeat each T) {} // expected-note 4 {{'init(_:)' declared here}}
     init(vals: repeat each T) {} // expected-note {{'init(vals:)' declared here}}
+    init<each U>(x: Int, _: repeat each T, y: repeat each U) {} // expected-note 3 {{'init(x:_:y:)' declared here}}
   }
 
   _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}
@@ -341,11 +342,28 @@ func test_pack_expansion_specialization() {
   _ = Data<Int, String>(42, "") // Ok
   _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
   _ = Data<Int, String>((42, ""))
-  // expected-error@-1 {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{32-33=}}
   _ = Data<Int, String, Float>(vals: (42, "", 0))
-  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{38-39=}} {{48-49=}}
   _ = Data<Int, String, Float>((vals: 42, "", 0))
-  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{32-33=}} {{48-49=}}
+  _ = Data<Int, String, Float>(tuple)
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+  _ = Data<Int, String, Float>(x: 42, tuple)
+  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}}
+  _ = Data<Int, String, Float>(x: 42, tuple, y: 1, 2, 3)
+  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}}
+  _ = Data<Int, String, Float>(x: 42, (42, "", 0), y: 1, 2, 3)
+  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}} {{39-40=}} {{49-50=}}
+
+  struct Ambiguity<each T> {
+    func test(_: repeat each T) -> Int { 42 }
+    // expected-note@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+    func test(_: repeat each T) -> String { "" }
+    // expected-note@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+  }
+
+  _ = Ambiguity<Int, String, Float>().test(tuple) // expected-error {{no exact matches in call to instance method 'test'}}
 }
 
 // rdar://107280056 - "Ambiguous without more context" with opaque return type + variadics

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -332,8 +332,8 @@ func test_pack_expansions_with_closures() {
 // rdar://107151854 - crash on invalid due to specialized pack expansion
 func test_pack_expansion_specialization() {
   struct Data<each T> {
-    init(_: repeat each T) {} // expected-note 2 {{'init(_:)' declared here}}
-    init(vals: repeat each T) {} // expected-note 2 {{'init(vals:)' declared here}}
+    init(_: repeat each T) {} // expected-note 3 {{'init(_:)' declared here}}
+    init(vals: repeat each T) {} // expected-note {{'init(vals:)' declared here}}
   }
 
   _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -210,7 +210,7 @@ func concreteReturnFunctionInvalid() {
 }
 
 func patternInstantiationTupleTest1<each T>() -> (repeat Array<each T>) {}
-// expected-note@-1 2 {{in call to function 'patternInstantiationTupleTest1()'}}
+// expected-note@-1 {{in call to function 'patternInstantiationTupleTest1()'}}
 func patternInstantiationTupleTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) {}
 
 func patternInstantiationFunctionTest1<each T>() -> (repeat Array<each T>) -> () {}
@@ -240,10 +240,9 @@ func patternInstantiationConcreteValid() {
 
 func patternInstantiationConcreteInvalid() {
   let _: Set<Int> = patternInstantiationTupleTest1()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(repeat Array<each T>)' to specified type 'Set<Int>'}}
+  // expected-error@-1 {{cannot convert value of type '(repeat Array<Pack{_}>)' to specified type 'Set<Int>'}}
 
-  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Pack{Int, _}>)' is not convertible to '(Array<Int>, Set<String>)', tuples have a different number of elements}}
 }
 
 func patternInstantiationGenericValid<each T, each U>(t: repeat each T, u: repeat each U)
@@ -273,7 +272,7 @@ func patternInstantiationGenericInvalid<each T: Hashable>(t: repeat each T) {
   let _: (repeat Set<each T>) = patternInstantiationTupleTest1() // expected-error {{cannot convert value of type '(repeat Array<each T>)' to specified type '(repeat Set<each T>)}}
   // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
 
-  let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+  let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Pack{repeat each T, _}>)' is not convertible to '(repeat Array<each T>, Set<String>)', tuples have a different number of elements}}
 }
 
 // rdar://107996926 - Vanishing metatype of tuple not supported

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -1,10 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
 func returnTuple1<each T>() -> (repeat each T) { fatalError() }
-// expected-note@-1 3 {{in call to function 'returnTuple1()'}}
+// expected-note@-1 {{in call to function 'returnTuple1()'}}
 
 func returnTuple2<each T>() -> (Int, repeat each T) { fatalError() }
-// expected-note@-1 3 {{in call to function 'returnTuple2()'}}
+// expected-note@-1 2 {{in call to function 'returnTuple2()'}}
 
 func returnTupleLabel1<each T>() -> (x: repeat each T) { fatalError() }
 // expected-error@-1 {{cannot use label with pack expansion tuple element}}
@@ -26,16 +26,10 @@ func returnTupleLabel6<each T, each U>() -> (Int, x: repeat each T, y: repeat ea
 
 func concreteReturnTupleValid() {
   let _: () = returnTuple1()
-  // FIXME: consider propagating 'Int' through the conversion constraint
-  // as a binding for the parameter pack expanded in the tuple return type.
   let _: Int = returnTuple1()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(repeat each T)' to specified type 'Int'}}
   let _: (Int, String) = returnTuple1()
 
   let _: Int = returnTuple2()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(Int, repeat each T)' to specified type 'Int'}}
   let _: (Int, String) = returnTuple2()
   let _: (Int, String, Float) = returnTuple2()
 
@@ -72,8 +66,6 @@ func concreteReturnTupleValid() {
 
 func concreteReturnTypeInvalid() {
   let _: Int = returnTuple1()
-  // expected-error@-1 {{cannot convert value of type '(repeat each T)' to specified type 'Int'}}
-  // expected-error@-2 {{generic parameter 'each T' could not be inferred}}
 
   let _: () = returnTuple2()
   // expected-error@-1 {{'(Int, repeat each T)' is not convertible to '()', tuples have a different number of elements}}
@@ -218,28 +210,20 @@ func concreteReturnFunctionInvalid() {
 }
 
 func patternInstantiationTupleTest1<each T>() -> (repeat Array<each T>) {}
-// expected-note@-1 3 {{in call to function 'patternInstantiationTupleTest1()'}}
+// expected-note@-1 2 {{in call to function 'patternInstantiationTupleTest1()'}}
 func patternInstantiationTupleTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) {}
-// expected-note@-1 {{in call to function 'patternInstantiationTupleTest2()'}}
 
 func patternInstantiationFunctionTest1<each T>() -> (repeat Array<each T>) -> () {}
 func patternInstantiationFunctionTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) -> () {}
 
 func patternInstantiationConcreteValid() {
   let _: () = patternInstantiationTupleTest1()
-  // FIXME
   let _: Array<Int> = patternInstantiationTupleTest1()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(repeat Array<each T>)' to specified type 'Array<Int>'}}
   let _: (Array<Int>, Array<String>) = patternInstantiationTupleTest1()
   let _: (Array<Int>, Array<String>, Array<Float>) = patternInstantiationTupleTest1()
 
   let _: () = patternInstantiationTupleTest2()
-  // FIXME
   let _: Dictionary<Int, String> = patternInstantiationTupleTest2()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{generic parameter 'each U' could not be inferred}}
-  // expected-error@-3 {{cannot convert value of type '(repeat Dictionary<each T, each U>)' to specified type 'Dictionary<Int, String>'}}
   let _: (Dictionary<Int, String>, Dictionary<Float, Bool>) = patternInstantiationTupleTest2()
   let _: (Dictionary<Int, String>, Dictionary<Float, Bool>, Dictionary<Double, Character>) = patternInstantiationTupleTest2()
 
@@ -290,4 +274,27 @@ func patternInstantiationGenericInvalid<each T: Hashable>(t: repeat each T) {
   // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
 
   let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+}
+
+// rdar://107996926 - Vanishing metatype of tuple not supported
+func test_one_element_tuple_vs_non_tuple_matching() {
+  struct S {
+    func test<each T>(_: (repeat each T).Type) -> (repeat each T) { fatalError() }
+    func testVanishing<each T>(_: (Int, repeat each T)) {}
+  }
+
+  let _ = S().test(Int.self) // Ok
+  let _: Int = S().test(Int.self) // Ok
+  let _ = S().test((Int, String).self) // Ok
+  let _ = S().testVanishing(42) // Ok
+
+  do {
+    struct V<T> {}
+
+    func test<each T>(_: V<(repeat each T)>?) {}
+    func test<each T>(_: V<(repeat each T)>.Type) {}
+
+    test(V<Int>()) // Ok
+    test(V<Int>.self) // Ok
+  }
 }

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -73,5 +73,5 @@ func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (re
 
 func badCallToZip<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = zip(t: repeat each t, u: repeat each u)
-  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each U' and 'each T' have the same shape}}
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each T' and 'each U' have the same shape}}
 }

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -58,14 +58,14 @@ takesParallelSequences(t: Array<String>(), Set<Int>(), u: Array<Int>(), Set<Stri
 // Same-shape requirements
 
 func zip<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {}
+// expected-note@-1 {{'zip(t:u:)' declared here}}
 
 let _ = zip()  // ok
 let _ = zip(t: 1, u: "hi")  // ok
 let _ = zip(t: 1, 2, u: "hi", "hello")  // ok
 let _ = zip(t: 1, 2, 3, u: "hi", "hello", "greetings")  // ok
-
-// FIXME: Bad diagnostic
-let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{type of expression is ambiguous without more context}}
+let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{extra arguments at positions #3, #4 in call}}
+// expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'Pack{Int}' and 'Pack{String, String, String}' have the same shape}}
 
 func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any {
   _ = zip(t: repeat each t, u: repeat each u)

--- a/test/Constraints/variadic_generic_functions.swift
+++ b/test/Constraints/variadic_generic_functions.swift
@@ -32,9 +32,15 @@ func call() {
 
   let x: String = multipleParameters(xs: "", ys: "")
   let (one, two) = multipleParameters(xs: "", 5.0, ys: "", 5.0)
-  multipleParameters(xs: "", 5.0, ys: 5.0, "") // expected-error {{type of expression is ambiguous without more context}}
+  multipleParameters(xs: "", 5.0, ys: 5.0, "") // expected-error {{conflicting arguments to generic parameter 'each T' ('Pack{Double, String}' vs. 'Pack{String, String}' vs. 'Pack{String, Double}' vs. 'Pack{Double, Double}')}}
 
   func multipleSequences<each T, each U>(xs: repeat each T, ys: repeat each U) -> (repeat each T) {
+    return (repeat each ys)
+    // expected-error@-1 {{pack expansion requires that 'each U' and 'each T' have the same shape}}
+    // expected-error@-2 {{cannot convert return expression of type '(repeat each U)' to return type '(repeat each T)'}}
+  }
+
+  func multipleSequencesWithSameShape<each T, each U>(xs: repeat each T, ys: repeat each U) -> (repeat each T) where (repeat (each T, each U)): Any {
     return (repeat each ys)
     // expected-error@-1 {{cannot convert return expression of type '(repeat each U)' to return type '(repeat each T)'}}
   }


### PR DESCRIPTION
- Adds `TVO_PackExpansion` to denote that a type variable can only be bound to a pack expansion type;
- Adjusts `openType` and `openUnboundGenericType` to "open" `PackExpansionType`s into type variables (and a constraint to connect it to pattern/shape type variables);
- Implements special inference/binding logic for pack expansion variables:
   - such variables are resolved via inference and bound to a opened pack expansion type they represent
- Prevents `matchTypes` and `TypeSimplifier` from eagerly matching/transforming types with unresolved pack expansion variables.

Resolves: rdar://107996926
Resolves: rdar://107835125
Resolves: rdar://107675464
Resolves: rdar://107429079
Resolves: rdar://107835215
Resolves: rdar://107835086

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
