### PR TITLE
Adjustment for SwiftSyntax rename `members` -> `memberBlock`

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -39,7 +39,7 @@ extension ASTGenVisitor {
     declContext = out.declContext
     defer { declContext = oldDeclContext }
 
-    node.members.members
+    node.memberBlock.members
       .map { self.visit($0).rawValue }
       .withBridgedArrayRef { ref in
         NominalTypeDecl_setMembers(out.nominalDecl, ref)
@@ -60,7 +60,7 @@ extension ASTGenVisitor {
     declContext = out.declContext
     defer { declContext = oldDeclContext }
 
-    node.members.members
+    node.memberBlock.members
       .map { self.visit($0).rawValue }
       .withBridgedArrayRef { ref in
         NominalTypeDecl_setMembers(out.nominalDecl, ref)

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -71,7 +71,7 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro, ConformanceMac
       """
 
     let memberList = MemberDeclListSyntax(
-      declaration.members.members.filter {
+      declaration.memberBlock.members.filter {
         $0.decl.isObservableStoredProperty
       }
     )

--- a/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
@@ -97,7 +97,7 @@ public struct OptionSetMacro {
     }
 
     // Find the option enum within the struct.
-    let optionsEnums: [EnumDeclSyntax] = decl.members.members.compactMap({ member in
+    let optionsEnums: [EnumDeclSyntax] = decl.memberBlock.members.compactMap({ member in
       if let enumDecl = member.decl.as(EnumDeclSyntax.self),
          enumDecl.identifier.text == optionsEnumName {
         return enumDecl
@@ -163,7 +163,7 @@ extension OptionSetMacro: MemberMacro {
 
     // Find all of the case elements.
     var caseElements: [EnumCaseElementSyntax] = []
-    for member in optionsEnum.members.members {
+    for member in optionsEnum.memberBlock.members {
       if let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) {
         caseElements.append(contentsOf: caseDecl.elements)
       }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -681,7 +681,7 @@ extension DeclGroupSyntax {
   /// Enumerate the stored properties that syntactically occur in this
   /// declaration.
   func storedProperties() -> [VariableDeclSyntax] {
-    return members.members.compactMap { member in
+    return memberBlock.members.compactMap { member in
       guard let variable = member.decl.as(VariableDeclSyntax.self),
             variable.isStoredProperty else {
         return nil
@@ -1020,7 +1020,7 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
       """
 
     let memberList = MemberDeclListSyntax(
-      declaration.members.members.filter {
+      declaration.memberBlock.members.filter {
         $0.decl.isObservableStoredProperty
       }
     )


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1524
