### PR TITLE
[5.9] Arbitrary peer and freestanding macros

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -396,13 +396,13 @@ Entities
 
   macro-discriminator-list ::= macro-discriminator-list? file-discriminator? macro-expansion-operator INDEX
 
-  macro-expansion-operator ::= identifier 'fMa' // attached accessor macro
-  macro-expansion-operator ::= identifier 'fMA' // attached member-attribute macro
+  macro-expansion-operator ::= decl-name identifier 'fMa' // attached accessor macro
+  macro-expansion-operator ::= decl-name identifier 'fMA' // attached member-attribute macro
   macro-expansion-operator ::= identifier 'fMf' // freestanding macro
-  macro-expansion-operator ::= identifier 'fMm' // attached member macro
-  macro-expansion-operator ::= identifier 'fMp' // attached peer macro
-  macro-expansion-operator ::= identifier 'fMc' // attached conformance macro
-  macro-expansion-operator ::= identifier 'fMu' // uniquely-named entity
+  macro-expansion-operator ::= decl-name identifier 'fMm' // attached member macro
+  macro-expansion-operator ::= decl-name identifier 'fMp' // attached peer macro
+  macro-expansion-operator ::= decl-name identifier 'fMc' // attached conformance macro
+  macro-expansion-operator ::= decl-name identifier 'fMu' // uniquely-named entity
 
   file-discriminator ::= identifier 'Ll'     // anonymous file-discriminated declaration
 

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -401,7 +401,8 @@ protected:
   void appendType(Type type, GenericSignature sig,
                   const ValueDecl *forDecl = nullptr);
   
-  void appendDeclName(const ValueDecl *decl);
+  void appendDeclName(
+      const ValueDecl *decl, DeclBaseName name = DeclBaseName());
 
   GenericTypeParamType *appendAssocType(DependentMemberType *DepTy,
                                         GenericSignature sig,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3835,6 +3835,8 @@ public:
     /// Whether to include @_implements members.
     /// Used by conformance-checking to find special @_implements members.
     IncludeAttrImplements = 1 << 0,
+    /// Whether to exclude members of macro expansions.
+    ExcludeMacroExpansions = 1 << 1,
   };
 
   /// Find all of the declarations with the given name within this nominal type

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -430,7 +430,7 @@ class UnqualifiedLookupRequest
                            RequestFlags::Uncached |
                                RequestFlags::DependencySink> {
 public:
-  using SimpleRequest::SimpleRequest;
+  UnqualifiedLookupRequest(UnqualifiedLookupDescriptor);
 
 private:
   friend SimpleRequest;
@@ -456,7 +456,10 @@ class LookupInModuleRequest
                                 NLOptions),
           RequestFlags::Uncached | RequestFlags::DependencySink> {
 public:
-  using SimpleRequest::SimpleRequest;
+  LookupInModuleRequest(
+      const DeclContext *, DeclName, NLKind,
+      namelookup::ResolutionKind, const DeclContext *,
+      NLOptions);
 
 private:
   friend SimpleRequest;
@@ -504,7 +507,9 @@ class ModuleQualifiedLookupRequest
                            RequestFlags::Uncached |
                               RequestFlags::DependencySink> {
 public:
-  using SimpleRequest::SimpleRequest;
+  ModuleQualifiedLookupRequest(const DeclContext *,
+                               ModuleDecl *, DeclNameRef,
+                               NLOptions);
 
 private:
   friend SimpleRequest;
@@ -528,7 +533,9 @@ class QualifiedLookupRequest
                                                  DeclNameRef, NLOptions),
                            RequestFlags::Uncached> {
 public:
-  using SimpleRequest::SimpleRequest;
+  QualifiedLookupRequest(const DeclContext *,
+                         SmallVector<NominalTypeDecl *, 4>,
+                         DeclNameRef, NLOptions);
 
 private:
   friend SimpleRequest;
@@ -579,7 +586,7 @@ class DirectLookupRequest
                            TinyPtrVector<ValueDecl *>(DirectLookupDescriptor),
                            RequestFlags::Uncached|RequestFlags::DependencySink> {
 public:
-  using SimpleRequest::SimpleRequest;
+  DirectLookupRequest(DirectLookupDescriptor);
 
 private:
   friend SimpleRequest;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -444,10 +444,12 @@ void SourceLookupCache::lookupValue(DeclName Name, NLKind LookupKind,
     return;
 
   for (auto *unexpandedDecl : auxDecls->second) {
-    // Add expanded peers to the result.
+    // Add expanded peers and freestanding declarations to the result.
     unexpandedDecl->forEachMacroExpandedDecl(
         [&](ValueDecl *decl) {
-          Result.push_back(decl);
+          if (decl->getName().matchesRef(Name)) {
+            Result.push_back(decl);
+          }
         });
   }
 }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -555,8 +555,17 @@ static UnqualifiedLookupDescriptor excludeMacrosIfNeeded(
 /// Exclude macros in the direct lookup descriptor if we need to.
 static DirectLookupDescriptor excludeMacrosIfNeeded(
     DirectLookupDescriptor descriptor) {
-  // FIXME: Direct lookups don't currently have an "exclude macro expansions"
-  // flag.
+  if (descriptor.Options.contains(
+          NominalTypeDecl::LookupDirectFlags::ExcludeMacroExpansions))
+    return descriptor;
+
+  auto &evaluator = descriptor.DC->getASTContext().evaluator;
+  if (!evaluator.hasActiveResolveMacroRequest())
+    return descriptor;
+
+  descriptor.Options |=
+      NominalTypeDecl::LookupDirectFlags::ExcludeMacroExpansions;
+
   return descriptor;
 }
 

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -508,6 +508,99 @@ swift::extractNearestSourceLoc(CustomRefCountingOperationDescriptor desc) {
   return SourceLoc();
 }
 
+//----------------------------------------------------------------------------//
+// Macro-related adjustments to name lookup requests.
+//----------------------------------------------------------------------------//
+//
+// Macros introduced a significant wrinkle into Swift's name lookup mechanism.
+// Specifically, when resolving names (and, really, anything else) within the
+// arguments to a macro expansion, name lookup must not try to expand any
+// macros, because doing so trivially creates a cyclic dependency amongst the
+// macro expansions that will be detected by the request-evaluator.
+//
+// Our lookup requests don't always have enough information to answer the
+// question "is this part of an argument to a macro?", so we do a much simpler,
+// more efficient, and not-entirely-sound hack based on the request-evaluator.
+// Specifically, if we are in the process of resolving a macro (which is
+// determined by checking for the presence of a `ResolveMacroRequest` in the
+// request-evaluator stack), then we adjust the options used for the name
+// lookup request we are forming to exclude macro expansions. The evaluation
+// of that request will then avoid expanding any macros, and not produce any
+// results that involve entries in already-expanded macros. By adjusting the
+// request itself, we still distinguish between requests that can and cannot
+// look into macro expansions, so it doesn't break caching for those immediate
+// requests.
+//
+// Over time, we should seek to replace this heuristic with a location-based
+// check, where we use ASTScope to determine whether we are inside a macro
+// argument. This existing check might still be useful because it's going to
+// be faster than a location-based query, but the location-based query can be
+// fully correct.
+
+/// Exclude macros in the unqualified lookup descriptor if we need to.
+static UnqualifiedLookupDescriptor excludeMacrosIfNeeded(
+    UnqualifiedLookupDescriptor descriptor) {
+  if (descriptor.Options.contains(
+          UnqualifiedLookupFlags::ExcludeMacroExpansions))
+    return descriptor;
+
+  auto &evaluator = descriptor.DC->getASTContext().evaluator;
+  if (!evaluator.hasActiveResolveMacroRequest())
+    return descriptor;
+
+  descriptor.Options |= UnqualifiedLookupFlags::ExcludeMacroExpansions;
+  return descriptor;
+}
+
+/// Exclude macros in the direct lookup descriptor if we need to.
+static DirectLookupDescriptor excludeMacrosIfNeeded(
+    DirectLookupDescriptor descriptor) {
+  // FIXME: Direct lookups don't currently have an "exclude macro expansions"
+  // flag.
+  return descriptor;
+}
+
+/// Exclude macros in the name lookup options if we need to.
+static NLOptions
+excludeMacrosIfNeeded(const DeclContext *dc, NLOptions options) {
+  if (options & NL_ExcludeMacroExpansions)
+    return options;
+
+  auto &evaluator = dc->getASTContext().evaluator;
+  if (!evaluator.hasActiveResolveMacroRequest())
+    return options;
+
+  return options | NL_ExcludeMacroExpansions;
+}
+
+UnqualifiedLookupRequest::UnqualifiedLookupRequest(
+    UnqualifiedLookupDescriptor descriptor
+) : SimpleRequest(excludeMacrosIfNeeded(descriptor)) { }
+
+LookupInModuleRequest::LookupInModuleRequest(
+      const DeclContext *moduleOrFile, DeclName name, NLKind lookupKind,
+      namelookup::ResolutionKind resolutionKind,
+      const DeclContext *moduleScopeContext,
+      NLOptions options
+ ) : SimpleRequest(moduleOrFile, name, lookupKind, resolutionKind,
+                   moduleScopeContext,
+                   excludeMacrosIfNeeded(moduleOrFile, options)) { }
+
+ModuleQualifiedLookupRequest::ModuleQualifiedLookupRequest(
+    const DeclContext *dc, ModuleDecl *module, DeclNameRef name,
+    NLOptions options
+ ) : SimpleRequest(dc, module, name, excludeMacrosIfNeeded(dc, options)) { }
+
+QualifiedLookupRequest::QualifiedLookupRequest(
+                       const DeclContext *dc,
+                       SmallVector<NominalTypeDecl *, 4> decls,
+                       DeclNameRef name, NLOptions options
+) : SimpleRequest(dc, std::move(decls), name,
+                  excludeMacrosIfNeeded(dc, options)) { }
+
+DirectLookupRequest::DirectLookupRequest(DirectLookupDescriptor descriptor)
+    : SimpleRequest(excludeMacrosIfNeeded(descriptor)) { }
+
 // Implement the clang importer type zone.
 #define SWIFT_TYPEID_ZONE ClangImporter
 #define SWIFT_TYPEID_HEADER "swift/ClangImporter/ClangImporterTypeIDZone.def"

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1434,28 +1434,38 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
                        /*hasName*/ true);
   case Node::Kind::AccessorAttachedMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true, "accessor macro expansion #",
-                       (int)Node->getChild(2)->getIndex() + 1);
+                       /*hasName*/true,
+                       ("accessor macro @" +
+                        nodeToString(Node->getChild(2)) + " expansion #"),
+                       (int)Node->getChild(3)->getIndex() + 1);
   case Node::Kind::FreestandingMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
                        /*hasName*/true, "freestanding macro expansion #",
                        (int)Node->getChild(2)->getIndex() + 1);
   case Node::Kind::MemberAttributeAttachedMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true, "member attribute macro expansion #",
-                       (int)Node->getChild(2)->getIndex() + 1);
+                       /*hasName*/true,
+                       ("member attribute macro @" +
+                        nodeToString(Node->getChild(2)) + " expansion #"),
+                       (int)Node->getChild(3)->getIndex() + 1);
   case Node::Kind::MemberAttachedMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true, "member macro expansion #",
-                       (int)Node->getChild(2)->getIndex() + 1);
+                       /*hasName*/true,
+                       ("member macro @" + nodeToString(Node->getChild(2)) +
+                        " expansion #"),
+                       (int)Node->getChild(3)->getIndex() + 1);
   case Node::Kind::PeerAttachedMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true, "peer macro expansion #",
-                       (int)Node->getChild(2)->getIndex() + 1);
+                       /*hasName*/true,
+                       ("peer macro @" + nodeToString(Node->getChild(2)) +
+                        " expansion #"),
+                       (int)Node->getChild(3)->getIndex() + 1);
   case Node::Kind::ConformanceAttachedMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true, "conformance macro expansion #",
-                       (int)Node->getChild(2)->getIndex() + 1);
+                       /*hasName*/true,
+                       ("conformance macro @" + nodeToString(Node->getChild(2)) +
+                        " expansion #"),
+                       (int)Node->getChild(3)->getIndex() + 1);
   case Node::Kind::MacroExpansionUniqueName:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
                        /*hasName*/true, "unique name #",

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2908,51 +2908,46 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
 ManglingError Remangler::mangleAccessorAttachedMacroExpansion(
     Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  if (auto privateDiscriminator = node->getChild(3))
-    RETURN_IF_ERROR(mangle(privateDiscriminator, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
   Buffer << "fMa";
-  return mangleChildNode(node, 2, depth + 1);
+  return mangleChildNode(node, 3, depth + 1);
 }
 
 ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
     Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  if (auto privateDiscriminator = node->getChild(3))
-    RETURN_IF_ERROR(mangle(privateDiscriminator, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
   Buffer << "fMA";
-  return mangleChildNode(node, 2, depth + 1);
+  return mangleChildNode(node, 3, depth + 1);
 }
 
 ManglingError Remangler::mangleMemberAttachedMacroExpansion(
     Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  if (auto privateDiscriminator = node->getChild(3))
-    RETURN_IF_ERROR(mangle(privateDiscriminator, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
   Buffer << "fMm";
-  return mangleChildNode(node, 2, depth + 1);
+  return mangleChildNode(node, 3, depth + 1);
 }
 
 ManglingError Remangler::manglePeerAttachedMacroExpansion(
     Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  if (auto privateDiscriminator = node->getChild(3))
-    RETURN_IF_ERROR(mangle(privateDiscriminator, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
   Buffer << "fMp";
-  return mangleChildNode(node, 2, depth + 1);
+  return mangleChildNode(node, 3, depth + 1);
 }
 
 ManglingError Remangler::mangleConformanceAttachedMacroExpansion(
     Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  if (auto privateDiscriminator = node->getChild(3))
-    RETURN_IF_ERROR(mangle(privateDiscriminator, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
   Buffer << "fMc";
-  return mangleChildNode(node, 2, depth + 1);
+  return mangleChildNode(node, 3, depth + 1);
 }
 
 ManglingError Remangler::mangleMacroExpansionUniqueName(

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -615,9 +615,11 @@ static Type lookupDefaultLiteralType(const DeclContext *dc,
                                      StringRef name) {
   auto &ctx = dc->getASTContext();
   DeclNameRef nameRef(ctx.getIdentifier(name));
-  auto lookup = TypeChecker::lookupUnqualified(dc->getModuleScopeContext(),
-                                               nameRef, SourceLoc(),
-                                               defaultUnqualifiedLookupOptions);
+  auto lookup = TypeChecker::lookupUnqualified(
+      dc->getModuleScopeContext(),
+      nameRef, SourceLoc(),
+      defaultUnqualifiedLookupOptions | NameLookupFlags::ExcludeMacroExpansions
+  );
   TypeDecl *TD = lookup.getSingleTypeResult();
   if (!TD)
     return Type();

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1330,6 +1330,7 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
 Optional<unsigned> swift::expandAccessors(
     AbstractStorageDecl *storage, CustomAttr *attr, MacroDecl *macro
 ) {
+  (void)storage->getInterfaceType();
   // Evaluate the macro.
   auto macroSourceFile = evaluateAttachedMacro(macro, storage, attr,
                                                /*passParentContext*/false,

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -217,6 +217,8 @@ convertToUnqualifiedLookupOptions(NameLookupOptions options) {
     newOptions |= UnqualifiedLookupFlags::IncludeOuterResults;
   if (options.contains(NameLookupFlags::IncludeUsableFromInline))
     newOptions |= UnqualifiedLookupFlags::IncludeUsableFromInline;
+  if (options.contains(NameLookupFlags::ExcludeMacroExpansions))
+    newOptions |= UnqualifiedLookupFlags::ExcludeMacroExpansions;
 
   return newOptions;
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -160,6 +160,8 @@ enum class NameLookupFlags {
   IncludeOuterResults = 1 << 1,
   // Whether to include results that are marked @inlinable or @usableFromInline.
   IncludeUsableFromInline = 1 << 2,
+  /// This lookup should exclude any names introduced by macro expansions.
+  ExcludeMacroExpansions = 1 << 3,
 };
 
 /// A set of options that control name lookup.

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -454,7 +454,5 @@ $s4main4TestVAA3ABCV4hereyySiFfa ---> runtime attribute generator of main.ABC.he
 $s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
 @__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_  ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
-@__swiftmacro_15accessor_macros8MyStructV4nameSSvp17myPropertyWrapperfMa_ ---> accessor macro expansion #1 of myPropertyWrapper in accessor_macros.MyStruct.name : Swift.String
-@__swiftmacro_18macro_expand_peers1SV1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_ ---> peer macro expansion #1 of addCompletionHandler in macro_expand_peers.S.f(a: Swift.Int, for: Swift.String, _: Swift.Double) async -> Swift.String
-@__swiftmacro_25macro_expand_conformances7GenericV20DelegatedConformancefMc_ ---> conformance macro expansion #1 of DelegatedConformance in macro_expand_conformances.Generic
+@__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_ ---> peer macro @addCompletionHandler expansion #1 of f in macro_expand_peers.S
 @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_ ---> freestanding macro expansion #2 of NotCovered(in _4361AD9339943F52AE6186DD51E04E91) in MacroUser.MemberNotCovered

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -43,7 +43,7 @@ struct MyStruct {
 
   @myPropertyWrapper
   var name: String
-  // CHECK-DUMP: @__swiftmacro_15accessor_macros8MyStructV4nameSSvp17myPropertyWrapperfMa_.swift
+  // CHECK-DUMP: @__swiftmacro_15accessor_macros8MyStructV4name17myPropertyWrapperfMa_.swift
   // CHECK-DUMP: get {
   // CHECK-DUMP:   _name.wrappedValue
   // CHECK-DUMP: }
@@ -53,7 +53,7 @@ struct MyStruct {
 
   @myPropertyWrapper
   var birthDate: Date?
-  // CHECK-DUMP: @__swiftmacro_15accessor_macros8MyStructV9birthDateAA0F0VSgvp17myPropertyWrapperfMa_.swift 
+  // CHECK-DUMP: @__swiftmacro_15accessor_macros8MyStructV9birthDate17myPropertyWrapperfMa_.swift
   // CHECK-DUMP: get {
   // CHECK-DUMP:   _birthDate.wrappedValue
   // CHECK-DUMP: }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -67,7 +67,7 @@ struct Bad {}
 // CHECK-DIAGS: error: macro expansion cannot introduce default literal type '_ImageLiteralType'
 // CHECK-DIAGS: error: macro expansion cannot introduce default literal type '_FileReferenceLiteralType'
 
-// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3Bad7InvalidfMp_.swift
 // CHECK-DIAGS: import Swift
 // CHECK-DIAGS: precedencegroup MyPrecedence {}
 // CHECK-DIAGS: @attached(member) macro myMacro()

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -274,6 +274,10 @@ _ = StructWithUnqualifiedLookup().foo()
 func testFreestandingMacroExpansion() {
   // Explicit structs to force macros to be parsed as decl.
   struct Foo {
+    static let singleton = Foo()
+
+    static let s2 = Foo.singleton
+
     #bitwidthNumberedStructs("MyIntOne")
   }
 
@@ -333,9 +337,10 @@ func testFreestandingMacroExpansion() {
 testFreestandingMacroExpansion()
 
 // Explicit structs to force macros to be parsed as decl.
+var globalBool = true
 struct ContainerOfNumberedStructs {
   #bitwidthNumberedStructs("MyIntOne")
-  #bitwidthNumberedStructs("MyIntTwo")
+  #bitwidthNumberedStructs("MyIntTwo", blah: globalBool)
 }
 
 // Avoid re-type-checking declaration macro arguments.

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -29,7 +29,7 @@ struct S {}
 @Hashable
 struct S2 {}
 
-// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances1SV9EquatablefMc_.swift
+// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances1S9EquatablefMc_.swift
 // CHECK-DUMP: extension S : Equatable  {}
 
 // CHECK: true
@@ -55,7 +55,7 @@ struct Wrapped: P {
 @DelegatedConformance
 struct Generic<Element> {}
 
-// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances7GenericV20DelegatedConformancefMc_.swift
+// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances7Generic20DelegatedConformancefMc_.swift
 // CHECK-DUMP: extension Generic : P where Element: P {}
 
 func requiresP(_ value: (some P).Type) {

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -13,7 +13,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
-// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser -g
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s -check-prefix=CHECK-EXEC
 

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -29,13 +29,16 @@ macro addCompletionHandler() = #externalMacro(module: "MacroDefinition", type: "
 macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition", type: "AddClassReferencingSelfMacro")
 #endif
 
+@attached(peer, names: arbitrary)
+macro addCompletionHandlerArbitrarily(_: Int) = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
+
 struct S {
   @addCompletionHandler
   func f(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }
 
-  // CHECK-DUMP: @__swiftmacro_18macro_expand_peers1SV1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift
+  // CHECK-DUMP: @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_.swift
   // CHECK-DUMP: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
   // CHECK-DUMP:   Task {
   // CHECK-DUMP:     completionHandler(await f(a: a, for: b, value))
@@ -55,10 +58,10 @@ extension S {
     return b
   }
 
-  // CHECK-DUMP: @__swiftmacro_18macro_expand_peers1SV1g1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift
-  // CHECK-DUMP: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
+  // CHECK-DUMP: @__swiftmacro_18macro_expand_peers1SV1g20addCompletionHandlerfMp_.swift
+  // CHECK-DUMP: func g(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
   // CHECK-DUMP:   Task {
-  // CHECK-DUMP:     completionHandler(await f(a: a, for: b, value))
+  // CHECK-DUMP:     completionHandler(await g(a: a, for: b, value))
   // CHECK-DUMP:   }
   // CHECK-DUMP: }
 
@@ -97,9 +100,9 @@ func global(a: Int, b: String) {
   print(a, b)
 }
 
-// CHECK-DUMP: @__swiftmacro_18macro_expand_peers6global1a1bySi_SStF10wrapInTypefMp_.swift
-// CHECK-DUMP: struct $s18macro_expand_peers6global1a1bySi_SStF10wrapInTypefMp_6globalfMu0_ {
-// CHECK-DUMP:   func $s18macro_expand_peers6global1a1bySi_SStF10wrapInTypefMp_6globalfMu_(a: Int, b: String)  {
+// CHECK-DUMP: @__swiftmacro_18macro_expand_peers6global10wrapInTypefMp_.swift
+// CHECK-DUMP: struct $s18macro_expand_peers6global10wrapInTypefMp_6globalfMu0_ {
+// CHECK-DUMP:   func $s18macro_expand_peers6global10wrapInTypefMp_6globalfMu_(a: Int, b: String)  {
 // CHECK-DUMP:     global(a: a, b: b)
 // CHECK-DUMP:   }
 // CHECK-DUMP: }
@@ -126,3 +129,18 @@ struct Main {
 
 @AddClassReferencingSelf
 protocol MyProto { }
+
+// Reference cycles amongst arbitrary peer macros and macro arguments.
+let x = 10
+let y = 10
+struct S2 {
+  @addCompletionHandlerArbitrarily(x)
+  func f(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+
+  @addCompletionHandlerArbitrarily(y)
+  func g(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+}

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -54,3 +54,13 @@ struct HasInnerClosure {
   #freestandingWithClosure(0) { x in x }
   #freestandingWithClosure(1) { x in x }
 }
+
+// Arbitrary names at global scope
+
+@freestanding(declaration, names: arbitrary) macro bitwidthNumberedStructs(_ baseName: String) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
+
+#bitwidthNumberedStructs("MyIntGlobal")
+
+func testArbitraryAtGlobal() {
+  _ = MyIntGlobal16()
+}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -165,11 +165,11 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:1 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift) "@accessViaStorage "
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA0_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV1y13myTypeWrapperfMA0_.swift) "@accessViaStorage "
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 25:1-25:1 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMm_.swift) "
+// ATTACHED_EXPAND-NEXT: 25:1-25:1 (@__swiftmacro_9MacroUser1S13myTypeWrapperfMm_.swift) "
 // ATTACHED_EXPAND-EMPTY:
 // ATTACHED_EXPAND-NEXT: private var _storage = _Storage()
 // ATTACHED_EXPAND-NEXT: "
@@ -177,7 +177,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // ATTACHED_EXPAND-NEXT: 21:1-21:15 ""
 
 //##-- Cursor info on the attribute expanded by @myTypeWrapper
-// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=2 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
 // NESTED_ATTACHED_CURSOR: source.lang.swift.ref.macro
 // NESTED_ATTACHED_CURSOR-SAME: macro_basic.swift:10:27-10:43
 // NESTED_ATTACHED_CURSOR-LABEL: SYMBOL GRAPH BEGIN
@@ -196,9 +196,9 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_CURSOR-NEXT: ACTIONS END
 
 //##-- Expansion on the attribute expanded by @myTypeWrapper
-// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
 // NESTED_ATTACHED_EXPAND: source.edit.kind.active:
-// NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1xSivp16accessViaStoragefMa_.swift) "{
+// NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1x16accessViaStoragefMa_.swift) "{
 // NESTED_ATTACHED_EXPAND-NEXT:  get { _storage.x }
 // NESTED_ATTACHED_EXPAND-EMPTY:
 // NESTED_ATTACHED_EXPAND-NEXT:  set { _storage.x = newValue }
@@ -209,7 +209,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on the first accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s
 // ACCESSOR1_EXPAND: source.edit.kind.active:
-// ACCESSOR1_EXPAND-NEXT: 31:13-31:13 (@__swiftmacro_9MacroUser2S2V1xSivp16accessViaStoragefMa_.swift) "{
+// ACCESSOR1_EXPAND-NEXT: 31:13-31:13 (@__swiftmacro_9MacroUser2S2V1x16accessViaStoragefMa_.swift) "{
 // ACCESSOR1_EXPAND-NEXT:  get { _storage.x }
 // ACCESSOR1_EXPAND-EMPTY:
 // ACCESSOR1_EXPAND-NEXT:  set { _storage.x = newValue }
@@ -220,7 +220,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on the second accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=33:13 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR2_EXPAND %s
 // ACCESSOR2_EXPAND: source.edit.kind.active:
-// ACCESSOR2_EXPAND-NEXT: 34:14-34:18 (@__swiftmacro_9MacroUser2S2V1ySivp16accessViaStoragefMa_.swift) "{
+// ACCESSOR2_EXPAND-NEXT: 34:14-34:18 (@__swiftmacro_9MacroUser2S2V1y16accessViaStoragefMa_.swift) "{
 // ACCESSOR2_EXPAND-NEXT:  get { _storage.y }
 // ACCESSOR2_EXPAND-EMPTY:
 // ACCESSOR2_EXPAND-NEXT:  set { _storage.y = newValue }
@@ -231,7 +231,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on the addCompletionHandler macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=42:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=PEER_EXPAND %s
 // PEER_EXPAND: source.edit.kind.active:
-// PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift) "
+// PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f20addCompletionHandlerfMp_.swift) "
 // PEER_EXPAND-EMPTY:
 // PEER_EXPAND-NEXT: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
 // PEER_EXPAND-NEXT:  Task {
@@ -245,7 +245,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on a conformance macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=51:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CONFORMANCE_EXPAND %s
 // CONFORMANCE_EXPAND: source.edit.kind.active:
-// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S4V8HashablefMc_.swift) "
+// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S48HashablefMc_.swift) "
 // CONFORMANCE_EXPAND-EMPTY:
 // CONFORMANCE_EXPAND-NEXT: extension S4 : Hashable {}
 // CONFORMANCE_EXPAND-NEXT: "

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -286,6 +286,8 @@
 // RUN:             -e _ZSteqIcSt11char_traitsIcESaIcEEbRKNSt7__cxx1112basic_stringIT_T0_T1_EEPKS5_ \
 // RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EEPKS5_RKS8_ \
 // RUN:             -e _ZN9__gnu_cxx32__throw_concurrence_unlock_errorEv \
+// RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EEOS8_PKS5_ \
+// RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EEPKS5_OS8_ \
 // RUN:             -e _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_disjunctEPKc \
 // RUN:             -e _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE11_M_is_localEv \
 // RUN:             -e _ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12find_last_ofEPKcm \

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -27,6 +27,8 @@
 // RUN:             -e _ZNSt3_V28__rotateIPcEET_S2_S2_S2_St26random_access_iterator_tag \
 // RUN:             -e _ZN9__gnu_cxx12__to_xstringINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEcEET_PFiPT0_mPKS8_P13__va_list_tagEmSB_z \
 // RUN:             -e _ZN9__gnu_cxx12__to_xstringINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEcEET_PFiPT0_mPKS8_St9__va_listEmSB_z \
+// RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EEOS8_PKS5_ \
+// RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EEPKS5_OS8_ \
 // RUN:             -e _ZZNSt19_Sp_make_shared_tag5_S_tiEvE5__tag \
 // RUN:             -e _ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEDnEEEvv \
 // RUN:             -e '_ZSt16__once_call_implISt12_Bind_simpleIFPFvPvEPA[0-9]\+_cEEEvv' \


### PR DESCRIPTION
* Explanation: Rework the point at which macros are expanded for name-lookup purposes in two key ways. First, ensure that we expand peer and freestanding macros that introduce "arbitrary" names whenever we are performing lookup into the corresponding scope, but with one critical heuristic: the arguments of macros expansions themselves do not see the results of macro expansions. Second, rework the mangling scheme used for attached macros to use context + declaration name + macro name + discriminator, eliminating the dependency on the interface type. In both cases, the complexity is in avoiding reference cycles detected by the request-evaluator, by ensuring that the process of expanding a macro (and deciding which macro to expand) does not depend on the expansion of other macros.
* Scope: Affects code using macros, especially in the areas of name mangling and name lookup.
* Risk: Low; only affects macros, although it is a significant change to macro mangling and expands "arbitrary" macros much more freely.
* Issue: rdar://107596329, rdar://107442606
* Testing: Additional tests added.
* Original pull request: https://github.com/apple/swift/pull/64967, https://github.com/apple/swift/pull/64968, https://github.com/apple/swift/pull/65032
