### PR TITLE
Move exposed ownership pieces to `swift/ABI/`

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -20,11 +20,11 @@
 #define SWIFT_ABI_METADATAVALUES_H
 
 #include "swift/ABI/KeyPath.h"
+#include "swift/ABI/Ownership.h"
 #include "swift/ABI/ProtocolDispatchStrategy.h"
-#include "swift/AST/Ownership.h"
 #include "swift/Basic/Debug.h"
-#include "swift/Basic/LLVM.h"
 #include "swift/Basic/FlagSet.h"
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 
 #include <stdlib.h>

--- a/include/swift/ABI/Ownership.h
+++ b/include/swift/ABI/Ownership.h
@@ -1,0 +1,41 @@
+//===--- Ownership.h ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines ownership types exposed through the ABI.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_OWNERSHIP_H
+#define SWIFT_ABI_OWNERSHIP_H
+
+#include <stdint.h>
+
+namespace swift {
+
+/// Different kinds of value ownership supported by Swift.
+enum class ValueOwnership : uint8_t {
+  /// the context-dependent default ownership (sometimes shared,
+  /// sometimes owned)
+  Default,
+  /// an 'inout' exclusive, mutating borrow
+  InOut,
+  /// a 'borrowing' nonexclusive, usually nonmutating borrow
+  Shared,
+  /// a 'consuming' ownership transfer
+  Owned,
+
+  Last_Kind = Owned
+};
+
+} // namespace swift
+
+#endif // SWIFT_ABI_OWNERSHIP_H

--- a/include/swift/AST/Ownership.h
+++ b/include/swift/AST/Ownership.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_OWNERSHIP_H
 #define SWIFT_OWNERSHIP_H
 
+#include "swift/ABI/Ownership.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
@@ -117,20 +118,6 @@ optionalityOf(ReferenceOwnership ownership) {
   llvm_unreachable("impossible");
 }
 
-/// Different kinds of value ownership supported by Swift.
-enum class ValueOwnership : uint8_t {
-  /// the context-dependent default ownership (sometimes shared,
-  /// sometimes owned)
-  Default,
-  /// an 'inout' exclusive, mutating borrow
-  InOut,
-  /// a 'borrowing' nonexclusive, usually nonmutating borrow
-  Shared,
-  /// a 'consuming' ownership transfer
-  Owned,
-
-  Last_Kind = Owned
-};
 enum : unsigned { NumValueOwnershipBits =
   countBitsUsed(static_cast<unsigned>(ValueOwnership::Last_Kind)) };
 


### PR DESCRIPTION
We've been exposing all of `swift/AST/Ownership.h` to functions in `swift/ABI` since 2018. It looks like that was done only for the definition of the `ValueOwnership` enum. This commit pulls that enum out into the ABI directory to make it clearer that this is exposed to the Swift ABI (via MetadataValues.h) and removed the AST header from MetadataValues.h to prevent accidents.