### PR TITLE
[cxx-interop] Fix CxxStdlib build error on CentOS

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -33,7 +33,7 @@ extension std.string {
       return
     }
 
-    let len = strlen(str)
+    let len = UTF8._nullCodeUnitOffset(in: str)
     for i in 0..<len {
       let char = UInt8(str[i])
       self.push_back(value_type(bitPattern: char))


### PR DESCRIPTION
This fixes a build failure that started occurring on CentOS after https://github.com/apple/swift/pull/65057:
```
error: cannot find 'strlen' in scope
```

rdar://107987115