### PR TITLE
[5.9][SE-0393] Require the `repeat` keyword for generic requirement expansions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5382,9 +5382,8 @@ ERROR(invalid_expansion_argument,none,
 ERROR(expansion_not_variadic,none,
       "pack expansion %0 must contain at least one pack reference", (Type))
 ERROR(pack_reference_outside_expansion,none,
-      "pack reference %0 can only appear in pack expansion "
-      "%select{or generic requirement|}1",
-      (Type, /*inExpression*/ bool))
+      "pack reference %0 can only appear in pack expansion ",
+      (Type))
 ERROR(each_non_pack,none,
       "'each' cannot be applied to non-pack type %0",
       (Type))

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1842,16 +1842,23 @@ void PrintAST::printRequirement(const Requirement &req) {
     Printer << ")) : Any";
     return;
   case RequirementKind::Layout:
+    if (req.getFirstType()->hasParameterPack())
+      Printer << "repeat ";
     printTransformedType(req.getFirstType());
     Printer << " : ";
     req.getLayoutConstraint()->print(Printer, Options);
     return;
   case RequirementKind::Conformance:
   case RequirementKind::Superclass:
+    if (req.getFirstType()->hasParameterPack())
+      Printer << "repeat ";
     printTransformedType(req.getFirstType());
     Printer << " : ";
     break;
   case RequirementKind::SameType:
+    if (req.getFirstType()->hasParameterPack() ||
+        req.getSecondType()->hasParameterPack())
+      Printer << "repeat ";
     printTransformedType(req.getFirstType());
     Printer << " == ";
     break;

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -559,12 +559,12 @@ void *GenericParamList_create(void *ctx, void *lAngleLoc,
     case BridgedRequirementReprKindTypeConstraint:
       requirements.push_back(RequirementRepr::getTypeConstraint(
           (TypeRepr *)req.FirstType, getSourceLocFromPointer(req.SeparatorLoc),
-          (TypeRepr *)req.SecondType));
+          (TypeRepr *)req.SecondType, /*isExpansionPattern*/false));
       break;
     case BridgedRequirementReprKindSameType:
       requirements.push_back(RequirementRepr::getSameType(
           (TypeRepr *)req.FirstType, getSourceLocFromPointer(req.SeparatorLoc),
-          (TypeRepr *)req.SecondType));
+          (TypeRepr *)req.SecondType, /*isExpansionPattern*/false));
       break;
     case BridgedRequirementReprKindLayoutConstraint:
       llvm_unreachable("cannot handle layout constraints!");

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6043,7 +6043,7 @@ bool InvalidPackElement::diagnoseAsError() {
 
 bool InvalidPackReference::diagnoseAsError() {
   emitDiagnostic(diag::pack_reference_outside_expansion,
-                 packType, /*inExpression*/true);
+                 packType);
   return true;
 }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1028,7 +1028,8 @@ RequirementRequest::evaluate(Evaluator &evaluator,
     context = TypeResolverContext::GenericRequirement;
   }
   auto options = TypeResolutionOptions(context);
-  options |= TypeResolutionFlags::AllowPackReferences;
+  if (reqRepr.isExpansionPattern())
+    options |= TypeResolutionFlags::AllowPackReferences;
   if (owner.dc->isInSpecializeExtensionContext())
     options |= TypeResolutionFlags::AllowUsableFromInline;
   Optional<TypeResolution> resolution;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4629,7 +4629,7 @@ NeverNullType TypeResolver::resolvePackElement(PackElementTypeRepr *repr,
   if (!options.contains(TypeResolutionFlags::AllowPackReferences)) {
     ctx.Diags.diagnose(repr->getLoc(),
                        diag::pack_reference_outside_expansion,
-                       packReference, /*inExpression*/false);
+                       packReference);
     return ErrorType::get(ctx);
   }
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -52,11 +52,11 @@ protocol P {
   func f(_ self: Self) -> Self
 }
 
-func outerArchetype<each T, U>(t: repeat each T, u: U) where each T: P {
+func outerArchetype<each T, U>(t: repeat each T, u: U) where repeat each T: P {
   let _: (repeat (each T.A, U)) = (repeat ((each t).value, u))
 }
 
-func sameElement<each T, U>(t: repeat each T, u: U) where each T: P, each T == U {
+func sameElement<each T, U>(t: repeat each T, u: U) where repeat each T: P, repeat each T == U {
 // expected-error@-1{{same-element requirements are not yet supported}}
 
   // FIXME: Opened element archetypes in diagnostics
@@ -65,7 +65,7 @@ func sameElement<each T, U>(t: repeat each T, u: U) where each T: P, each T == U
 }
 
 func forEachEach<each C, U>(c: repeat each C, function: (U) -> Void)
-    where each C: Collection, each C.Element == U {
+    where repeat each C: Collection, repeat (each C).Element == U {
     // expected-error@-1{{same-element requirements are not yet supported}}
 
   // FIXME: Opened element archetypes in diagnostics
@@ -73,7 +73,7 @@ func forEachEach<each C, U>(c: repeat each C, function: (U) -> Void)
   // expected-error@-1 {{cannot convert value of type '(U) -> Void' to expected argument type '(τ_1_0.Element) throws -> Void'}}
 }
 
-func typeReprPacks<each T>(_ t: repeat each T) where each T: ExpressibleByIntegerLiteral {
+func typeReprPacks<each T: ExpressibleByIntegerLiteral>(_ t: repeat each T) {
   _ = (repeat Array<each T>())
   _ = (repeat 1 as each T)
 

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -264,7 +264,8 @@ func patternInstantiationConcreteInvalid() {
   let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
 }
 
-func patternInstantiationGenericValid<each T, each U>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any, each T: Hashable {
+func patternInstantiationGenericValid<each T, each U>(t: repeat each T, u: repeat each U)
+    where (repeat (each T, each U)): Any, repeat each T: Hashable {
   let _: (repeat Array<each T>) = patternInstantiationTupleTest1()
   let _: (repeat Array<each T>, Array<String>) = patternInstantiationTupleTest1()
   let _: (Array<String>, repeat Array<each T>) = patternInstantiationTupleTest1()
@@ -286,7 +287,7 @@ func patternInstantiationGenericValid<each T, each U>(t: repeat each T, u: repea
   let _: (Dictionary<Int, String>, repeat Dictionary<each T, each U>, Dictionary<Double, Character>) -> () = patternInstantiationFunctionTest2()
 }
 
-func patternInstantiationGenericInvalid<each T>(t: repeat each T) where each T: Hashable {
+func patternInstantiationGenericInvalid<each T: Hashable>(t: repeat each T) {
   let _: (repeat Set<each T>) = patternInstantiationTupleTest1() // expected-error {{cannot convert value of type '(repeat Array<each T>)' to specified type '(repeat Set<each T>)}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
 

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -47,9 +47,11 @@ takesAnyObject(C(), S(), C())  // expected-error {{type of expression is ambiguo
 
 // Same-type requirements
 
-func takesParallelSequences<each T, each U>(t: repeat each T, u: repeat each U) where each T: Sequence, each U: Sequence, each T.Element == each U.Element {}
-// expected-note@-1 {{where 'T.Element' = 'String', 'U.Element' = 'Int'}}
-
+// expected-note@+1 {{where 'T.Element' = 'String', 'U.Element' = 'Int'}}
+func takesParallelSequences<each T, each U>(t: repeat each T, u: repeat each U)
+    where repeat each T: Sequence,
+          repeat each U: Sequence,
+          repeat (each T).Element == (each U).Element {}
 takesParallelSequences()  // ok
 takesParallelSequences(t: Array<Int>(), u: Set<Int>())  // ok
 takesParallelSequences(t: Array<String>(), Set<Int>(), u: Set<String>(), Array<Int>())  // ok

--- a/test/Constraints/variadic_generic_functions.swift
+++ b/test/Constraints/variadic_generic_functions.swift
@@ -3,7 +3,7 @@
 // REQUIRES: asserts
 
 func debugPrint<each T>(_ items: repeat each T)
-  where each T: CustomDebugStringConvertible
+  where repeat each T: CustomDebugStringConvertible
 {
   /*for (item: T) in items {
     stdout.write(item.debugDescription)
@@ -11,7 +11,7 @@ func debugPrint<each T>(_ items: repeat each T)
 }
 
 func max<each T>(_ values: repeat each T) -> (repeat each T)?
-  where each T: Comparable
+  where repeat each T: Comparable
 {
   return nil
 }

--- a/test/Frontend/experimental_feature.swift
+++ b/test/Frontend/experimental_feature.swift
@@ -11,6 +11,6 @@ let x = BOOM
 
 // Use variadic generics
 func debugPrint<each T>(_ items: repeat each T)
-  where each T: CustomDebugStringConvertible
+  where repeat each T: CustomDebugStringConvertible
 {
 }

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -12,9 +12,9 @@ func inferSameShape<each T, each U>(ts t: repeat each T, us u: repeat each U) wh
 }
 
 // CHECK-LABEL: desugarSameShape(ts:us:)
-// CHECK-NEXT: Generic signature: <each T, each U where T : P, (repeat (each T, each U)) : Any, U : P>
-func desugarSameShape<each T, each U>(ts t: repeat each T, us u: repeat each U) where each T: P, each U: P, (repeat (each T.A, each U.A)): Any {
-}
+// CHECK-NEXT: Generic signature: <each T, each U where repeat T : P, (repeat (each T, each U)) : Any, repeat U : P>
+func desugarSameShape<each T, each U>(ts t: repeat each T, us u: repeat each U)
+  where repeat each T: P, repeat each U: P, (repeat (each T.A, each U.A)): Any {}
 
 // CHECK-LABEL: multipleSameShape1(ts:us:vs:)
 // CHECK-NEXT: Generic signature: <each T, each U, each V where (repeat (each T, each U)) : Any, (repeat (each U, each V)) : Any>
@@ -49,14 +49,14 @@ func multipleSameShape6<each T, each U, each V>(ts t: repeat each T, us u: repea
 struct Ts<each T> {
   struct Us<each U> {
     // CHECK-LABEL: Ts.Us.packEquality()
-    // CHECK-NEXT: Generic signature: <each T, each U where T == U>
-    func packEquality() where each T == each U, (repeat (each T, each U)): Any {
+    // CHECK-NEXT: Generic signature: <each T, each U where repeat T == U>
+    func packEquality() where repeat each T == each U, (repeat (each T, each U)): Any {
     }
 
     struct Vs<each V> {
       // CHECK-LABEL: Ts.Us.Vs.packEquality()
-      // CHECK-NEXT: Generic signature: <each T, each U, each V where T == U, (repeat (each T, each V)) : Any>
-      func packEquality() where each T == each U, (repeat (each U, each V)): Any {
+      // CHECK-NEXT: Generic signature: <each T, each U, each V where repeat T == U, (repeat (each T, each V)) : Any>
+      func packEquality() where repeat each T == each U, (repeat (each U, each V)): Any {
       }
     }
   }

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -11,7 +11,7 @@ protocol P {
   func f()
 }
 
-extension Builtin.TheTupleType: P where each Elements: P {
+extension Builtin.TheTupleType: P where repeat each Elements: P {
   typealias A = (repeat each Elements.A)
   typealias B = Float
   func f() {}

--- a/test/Generics/variadic_generic_requirements.swift
+++ b/test/Generics/variadic_generic_requirements.swift
@@ -22,7 +22,7 @@ _ = Layout<Class, Subclass>.self  // ok
 _ = Layout<Int, String>.self  // expected-error {{'Layout' requires that 'Int' be a class type}}
 
 struct Outer<each T: Sequence> {
-  struct Inner<each U: Sequence> where each T.Element == each U.Element {}
+  struct Inner<each U: Sequence> where repeat each T.Element == each U.Element {}
   // expected-note@-1 {{requirement specified as 'T.Element' == 'U.Element' [with each T = Array<Int>, Array<String>; each U = Set<String>, Set<Int>]}}
   // expected-note@-2 {{requirement specified as 'T.Element' == 'U.Element' [with each T = Array<Int>; each U = Set<Int>, Set<String>]}}
 

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -626,7 +626,7 @@ entry(%intIndex : $Builtin.Word):
   return %t : $()
 }
 
-sil @unwrap_from_PA : $<each T_1 : PA where each T_1.A : P> (Builtin.Word) -> () {
+sil @unwrap_from_PA : $<each T_1 : PA where repeat each T_1.A : P> (Builtin.Word) -> () {
 entry(%intIndex : $Builtin.Word):
   %direct_access_from_parameter_with_conformance = function_ref @direct_access_from_parameter_with_conformance : $@convention(thin) <each T_1: P> (Builtin.Word) -> ()
   apply %direct_access_from_parameter_with_conformance<Pack{repeat GenFwdP<each T_1.A>}>(%intIndex) : $@convention(thin) <each T_1: P> (Builtin.Word) -> ()
@@ -637,7 +637,7 @@ entry(%intIndex : $Builtin.Word):
 sil @extract_associatedtype_with_conformance : $<each T_1 : P> (Builtin.Word) -> () {
 entry(%intIndex : $Builtin.Word):
   %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat each T_1}
-  %token = open_pack_element %innerIndex of <each U_1 : PA where each U_1.A : P> at <Pack{repeat GenAssocPA<GenFwdP<each T_1>>}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000005"
+  %token = open_pack_element %innerIndex of <each U_1 : PA where repeat each U_1.A : P> at <Pack{repeat GenAssocPA<GenFwdP<each T_1>>}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000005"
   %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000005") U_1).Type
   %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
   apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000005") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
@@ -653,7 +653,7 @@ sil @extract_associatedtype_with_conformance2 : $<each T_1 : P, Tee : P, each T_
 entry(%intIndex : $Builtin.Word):
   %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>, repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>}
   %token = open_pack_element %innerIndex 
-    of <each U_1 : PA, Ewe : PA, each U_2 : PA where each U_1.A : PA, each U_1.A.A : PA, each U_1.A.A.A : P, Ewe.A : PA, Ewe.A.A : PA, Ewe.A.A.A : P, each U_2.A : PA, each U_2.A.A : PA, each U_2.A.A.A : P, (repeat (each U_1, each U_2)): Any> 
+    of <each U_1 : PA, Ewe : PA, each U_2 : PA where repeat each U_1.A : PA, repeat each U_1.A.A : PA, repeat each U_1.A.A.A : P, Ewe.A : PA, Ewe.A.A : PA, Ewe.A.A.A : P, repeat each U_2.A : PA, repeat each U_2.A.A : PA, repeat each U_2.A.A.A : P, (repeat (each U_1, each U_2)): Any> 
     at <
         Pack{repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>, repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>}, 
         GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<Tee>>>>, 

--- a/test/IRGen/variadic_generic_captures.swift
+++ b/test/IRGen/variadic_generic_captures.swift
@@ -83,6 +83,6 @@ public func has_witness_table_pack<each T: Sequence>(t: repeat each T) -> () -> 
 }
 
 public func has_witness_table_pack2<each T: Sequence>(t: repeat each T) -> () -> ()
-    where each T.Element: Sequence {
+    where repeat each T.Element: Sequence {
   return { _ = (repeat (each T).Element.Element).self }
 }

--- a/test/IRGen/variadic_generic_functions.sil
+++ b/test/IRGen/variadic_generic_functions.sil
@@ -76,14 +76,14 @@ sil @fc : $<each T : P> () -> () {}
 // CHECK-SAME:        i8*** %T.PA,
 // CHECK-SAME:        i8*** %T.A.P)
 // CHECK:         call swiftcc void @f1c([[INT]] %0, %swift.type** %T, i8*** %T.PA, i8*** %T.A.P)
-sil @f1 : $<each T : PA where each T.A : P> () -> () {
-    %f1c = function_ref @f1c : $@convention(thin) <each T : PA where each T.A : P> () -> ()
-    apply %f1c<Pack{repeat each T}>() : $@convention(thin) <each T : PA where each T.A : P> () -> ()
+sil @f1 : $<each T : PA where repeat each T.A : P> () -> () {
+    %f1c = function_ref @f1c : $@convention(thin) <each T : PA where repeat each T.A : P> () -> ()
+    apply %f1c<Pack{repeat each T}>() : $@convention(thin) <each T : PA where repeat each T.A : P> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
 
-sil @f1c : $<each T : PA where each T.A : P> () -> () {}
+sil @f1c : $<each T : PA where repeat each T.A : P> () -> () {}
 
 // Construct associatedtype metadata pack, forward root wtable pack.
 // CHECK-LABEL: define {{.*}}@associatedtype_with_added_conformance(
@@ -96,7 +96,7 @@ sil @f1c : $<each T : PA where each T.A : P> () -> () {}
 // CHECK-SAME:        [[INT]] [[SHAPE]],
 // CHECK-SAME:        %swift.type** [[ASSOCIATEDTYPES]],
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q]])
-sil @associatedtype_with_added_conformance : $<each T : PA where each T.A : Q> () -> () {
+sil @associatedtype_with_added_conformance : $<each T : PA where repeat each T.A : Q> () -> () {
     %callee = function_ref @associatedtype_with_added_conformance_callee : $@convention(thin) <each T : Q> () -> ()
     apply %callee<Pack{repeat each T.A}>() : $@convention(thin) <each T : Q> () -> ()
     %ret = tuple ()
@@ -116,7 +116,7 @@ sil @associatedtype_with_added_conformance_callee : $<each T : Q> () -> () {}
 // CHECK-SAME:        [[INT]] [[SHAPE]],
 // CHECK-SAME:        %swift.type** [[ASSOCIATEDTYPES]],
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q]])
-sil @associatedtype_with_added_conformance_2 : $<each T : PA where each T.A : QA, each T.A.A : R> () -> () {
+sil @associatedtype_with_added_conformance_2 : $<each T : PA where repeat each T.A : QA, repeat each T.A.A : R> () -> () {
     %j = function_ref @associatedtype_with_added_conformance_2_callee : $@convention(thin) <each T : R> () -> ()
     apply %j<Pack{repeat each T.A.A}>() : $@convention(thin) <each T : R> () -> ()
     %ret = tuple ()
@@ -157,13 +157,13 @@ sil @associatedtype_with_forwarded_conformance_1_callee : $<each T : Q> () -> ()
 // CHECK-SAME:        %swift.type** [[GEN1_TYPES]],
 // CHECK-SAME:        i8*** [[GEN1_CONFORMANCES_TO_PA]],
 // CHECK-SAME:        i8*** %T.A.Q)
-sil @generictype_with_forwarded_conformance_2 : $<each T : PA where each T.A : Q>() -> () {
-    %callee = function_ref @generictype_with_forwarded_conformance_2_callee : $@convention(thin) <each T : PA where each T.A : Q> () -> ()
-    apply %callee<Pack{repeat Gen1<each T>}>() : $@convention(thin) <each T : PA where each T.A : Q> () -> ()
+sil @generictype_with_forwarded_conformance_2 : $<each T : PA where repeat each T.A : Q>() -> () {
+    %callee = function_ref @generictype_with_forwarded_conformance_2_callee : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
+    apply %callee<Pack{repeat Gen1<each T>}>() : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
-sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where each T.A : Q> () -> () {}
+sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where repeat each T.A : Q> () -> () {}
 
 // Construct a pack of generic types of generic types which "forward" conformance to a protocol with an associatedtype which itself conforms to a protocol.
 // CHECK-LABEL: define {{.*}}@generic_with_forwarded_conformance_3(
@@ -178,12 +178,12 @@ sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where each 
 // CHECK-SAME:        %swift.type** [[GEN1_GEN1_TYPES]],
 // CHECK-SAME:        i8*** [[GEN1_GEN1_CONFORMANCES_TO_PA]],
 // CHECK-SAME:        i8*** %T.A.Q)
-sil @generic_with_forwarded_conformance_3 : $<each T : PA where each T.A : Q> () -> () {
-    %callee = function_ref @generic_with_forwarded_conformance_3_callee : $@convention(thin) <each T : PA where each T.A : Q> () -> ()
-    apply %callee<Pack{repeat Gen1<Gen1<each T>>}>() : $@convention(thin) <each T : PA where each T.A : Q> () -> ()
+sil @generic_with_forwarded_conformance_3 : $<each T : PA where repeat each T.A : Q> () -> () {
+    %callee = function_ref @generic_with_forwarded_conformance_3_callee : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
+    apply %callee<Pack{repeat Gen1<Gen1<each T>>}>() : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
-sil @generic_with_forwarded_conformance_3_callee : $<each T : PA where each T.A : Q> () -> () {
+sil @generic_with_forwarded_conformance_3_callee : $<each T : PA where repeat each T.A : Q> () -> () {
 }
 

--- a/test/Interpreter/variadic_generic_captures.swift
+++ b/test/Interpreter/variadic_generic_captures.swift
@@ -31,7 +31,7 @@ types.test("WitnessTable") {
   expectEqual((Int, String, Bool).self, hasWitnessTablePack([1], ["hi"], [false])())
 }
 
-func hasWitnessTablePack2<each T: Sequence>(_: repeat each T) -> () -> Any.Type where (each T).Element: Sequence {
+func hasWitnessTablePack2<each T: Sequence>(_: repeat each T) -> () -> Any.Type where repeat (each T).Element: Sequence {
   return { return (repeat (each T).Element.Element).self }
 }
 

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -104,7 +104,7 @@ types.test("LayoutReq") {
 }
 
 public struct OuterSeq<each T: Sequence> {
-  public struct InnerSeq<each U: Sequence> where each T.Element == each U.Element {}
+  public struct InnerSeq<each U: Sequence> where repeat each T.Element == each U.Element {}
 }
 
 types.test("SameTypeReq") {

--- a/test/SILGen/variadic_generic_types.swift
+++ b/test/SILGen/variadic_generic_types.swift
@@ -3,6 +3,6 @@
 // Because of -enable-experimental-feature VariadicGenerics
 // REQUIRES: asserts
 
-struct Variadic<each T> where each T: Equatable {}
+struct Variadic<each T> where repeat each T: Equatable {}
 
 _ = Variadic<Int, String>()

--- a/test/TypeDecoder/variadic_nominal_types.swift
+++ b/test/TypeDecoder/variadic_nominal_types.swift
@@ -12,7 +12,7 @@ struct Variadic<each T, U> {
   struct Inner<each V, W> {}
 }
 
-extension Variadic where each T: Equatable {
+extension Variadic where repeat each T: Equatable {
   struct Constrained {}
 }
 

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -49,7 +49,6 @@ enum E<each T> {
 }
 
 func withWhereClause<each T>(_ x: repeat each T) where repeat each T: P {}
-// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
 
 struct Outer<each T> {
   struct Bad<each U> {
@@ -65,9 +64,9 @@ struct Outer<each T> {
   }
 }
 
-func packRef<each T>(_: repeat each T) where each T: P {}
+func packRef<each T>(_: repeat each T) where repeat each T: P {}
 
-func packMemberRef<each T>(_: repeat each T.T) where each T: P {}
+func packMemberRef<each T>(_: repeat each T.T) where repeat each T: P {}
 
 // expected-error@+1 {{'each' cannot be applied to non-pack type 'Int'}}
 func invalidPackRefEachInt(_: each Int) {}
@@ -89,6 +88,12 @@ func packRefOutsideExpansion<each T>(_: (each T)) {}
 
 // expected-error@+1 {{pack reference 'T' requires expansion using keyword 'repeat'}}
 func packRefOutsideExpansion<each T>(_: each T.Type) {}
+
+// expected-error@+1 {{pack reference 'T' requires expansion using keyword 'repeat'}}
+func packRefOutsideExpansionRequirement1<each T>(_: repeat each T) where each T: P {}
+
+// expected-error@+1 {{pack reference 'T' requires expansion using keyword 'repeat'}}
+func packRefOutsideExpansionRequirement2<each T>(_: repeat each T) where G<each T>: P {}
 
 // coverage to ensure a 'repeat each' type is considered Copyable
 func golden<Z>(_ z: Z) {}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65134

* **Explanation**: The review of SE-0393 surfaced a potential ambiguity between parameter pack requirement expansions and requirements on a single pack element on a local function inside of a pack expansion expression. The proposal is revised in https://github.com/apple/swift-evolution/pull/2004 to require the `repeat` keyword for generic requirement expansions to resolve the ambiguity.

* **Scope**: Only affects parameter packs.

* **Risk**: Low.

* **Testing**: Updated existing parameter pack tests and added new test for error messages for `each T` in requirements outside of an expansion.


