### PR TITLE
[5.9 🍒] TypeCheckType: Fix existential `any` migration diagnostics for extra-modular protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4887,8 +4887,14 @@ public:
   bool requiresSelfConformanceWitnessTable() const;
 
   /// Determine whether an existential type must be explicitly prefixed
-  /// with \c any. \c any is required if any of the members contain
-  /// an associated type, or if \c Self appears in non-covariant position.
+  /// with \c any. \c any is required if one of the following conditions is met
+  /// for this protocol or an inherited protocol:
+  /// - The protocol has an associated type requirement.
+  /// - `Self` appears in non-covariant position in the type signature of a
+  ///   value requirement.
+  ///
+  /// @Note This method does not take the state of language features into
+  /// account.
   bool existentialRequiresAny() const;
 
   /// Returns a list of protocol requirements that must be assessed to

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -553,11 +553,12 @@ protected:
     /// Whether the existential of this protocol conforms to itself.
     ExistentialConformsToSelf : 1,
 
-    /// Whether the \c ExistentialRequiresAny bit is valid.
-    ExistentialRequiresAnyValid : 1,
+    /// Whether the \c HasSelfOrAssociatedTypeRequirements bit is valid.
+    HasSelfOrAssociatedTypeRequirementsValid : 1,
 
-    /// Whether the existential of this protocol must be spelled with \c any.
-    ExistentialRequiresAny : 1,
+    /// Whether this protocol has \c Self or associated type requirements.
+    /// See \c hasSelfOrAssociatedTypeRequirements() for clarification.
+    HasSelfOrAssociatedTypeRequirements : 1,
 
     /// True if the protocol has requirements that cannot be satisfied (e.g.
     /// because they could not be imported from Objective-C).
@@ -4754,19 +4755,19 @@ class ProtocolDecl final : public NominalTypeDecl {
     Bits.ProtocolDecl.ExistentialConformsToSelf = result;
   }
 
-  /// Returns the cached result of \c existentialRequiresAny or \c None if it
-  /// hasn't yet been computed.
-  Optional<bool> getCachedExistentialRequiresAny() {
-    if (Bits.ProtocolDecl.ExistentialRequiresAnyValid)
-      return Bits.ProtocolDecl.ExistentialRequiresAny;
+  /// Returns the cached result of \c hasSelfOrAssociatedTypeRequirements or
+  /// \c None if it hasn't yet been computed.
+  Optional<bool> getCachedHasSelfOrAssociatedTypeRequirements() {
+    if (Bits.ProtocolDecl.HasSelfOrAssociatedTypeRequirementsValid)
+      return Bits.ProtocolDecl.HasSelfOrAssociatedTypeRequirements;
 
     return None;
   }
 
-  /// Caches the result of \c existentialRequiresAny
-  void setCachedExistentialRequiresAny(bool requiresAny) {
-    Bits.ProtocolDecl.ExistentialRequiresAnyValid = true;
-    Bits.ProtocolDecl.ExistentialRequiresAny = requiresAny;
+  /// Caches the result of \c hasSelfOrAssociatedTypeRequirements
+  void setCachedHasSelfOrAssociatedTypeRequirements(bool value) {
+    Bits.ProtocolDecl.HasSelfOrAssociatedTypeRequirementsValid = true;
+    Bits.ProtocolDecl.HasSelfOrAssociatedTypeRequirements = value;
   }
 
   bool hasLazyRequirementSignature() const {
@@ -4787,7 +4788,7 @@ class ProtocolDecl final : public NominalTypeDecl {
   friend class RequirementSignatureRequestGSB;
   friend class ProtocolRequiresClassRequest;
   friend class ExistentialConformsToSelfRequest;
-  friend class ExistentialRequiresAnyRequest;
+  friend class HasSelfOrAssociatedTypeRequirementsRequest;
   friend class InheritedProtocolsRequest;
   friend class PrimaryAssociatedTypesRequest;
   friend class ProtocolRequirementsRequest;
@@ -4886,15 +4887,20 @@ public:
   /// Does this protocol require a self-conformance witness table?
   bool requiresSelfConformanceWitnessTable() const;
 
-  /// Determine whether an existential type must be explicitly prefixed
-  /// with \c any. \c any is required if one of the following conditions is met
-  /// for this protocol or an inherited protocol:
+  /// Determine whether this protocol has `Self` or associated type
+  /// requirements.
+  ///
+  /// This is true if one of the following conditions is met for this protocol
+  /// or an inherited protocol:
   /// - The protocol has an associated type requirement.
   /// - `Self` appears in non-covariant position in the type signature of a
   ///   value requirement.
+  bool hasSelfOrAssociatedTypeRequirements() const;
+
+  /// Determine whether an existential type constrained by this protocol must
+  /// be written using `any` syntax.
   ///
-  /// @Note This method does not take the state of language features into
-  /// account.
+  /// \Note This method takes language feature state into account.
   bool existentialRequiresAny() const;
 
   /// Returns a list of protocol requirements that must be assessed to

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -300,8 +300,8 @@ public:
 
 /// Determine whether an existential type conforming to this protocol
 /// requires the \c any syntax.
-class ExistentialRequiresAnyRequest :
-    public SimpleRequest<ExistentialRequiresAnyRequest,
+class HasSelfOrAssociatedTypeRequirementsRequest :
+    public SimpleRequest<HasSelfOrAssociatedTypeRequirementsRequest,
                          bool(ProtocolDecl *),
                          RequestFlags::SeparatelyCached> {
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -95,7 +95,7 @@ SWIFT_REQUEST(TypeChecker, EnumRawTypeRequest,
               Type(EnumDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExistentialConformsToSelfRequest,
               bool(ProtocolDecl *), SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, ExistentialRequiresAnyRequest,
+SWIFT_REQUEST(TypeChecker, HasSelfOrAssociatedTypeRequirementsRequest,
               bool(ProtocolDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExtendedTypeRequest, Type(ExtensionDecl *), Cached,
               NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6019,9 +6019,18 @@ bool ProtocolDecl::existentialConformsToSelf() const {
     ExistentialConformsToSelfRequest{const_cast<ProtocolDecl *>(this)}, true);
 }
 
-bool ProtocolDecl::existentialRequiresAny() const {
+bool ProtocolDecl::hasSelfOrAssociatedTypeRequirements() const {
   return evaluateOrDefault(getASTContext().evaluator,
-    ExistentialRequiresAnyRequest{const_cast<ProtocolDecl *>(this)}, true);
+                           HasSelfOrAssociatedTypeRequirementsRequest{
+                               const_cast<ProtocolDecl *>(this)},
+                           true);
+}
+
+bool ProtocolDecl::existentialRequiresAny() const {
+  if (getASTContext().LangOpts.hasFeature(Feature::ExistentialAny))
+    return true;
+
+  return hasSelfOrAssociatedTypeRequirements();
 }
 
 ArrayRef<AssociatedTypeDecl *>

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -263,28 +263,31 @@ void ExistentialConformsToSelfRequest::cacheResult(bool value) const {
 }
 
 //----------------------------------------------------------------------------//
-// existentialRequiresAny computation.
+// hasSelfOrAssociatedTypeRequirementsRequest computation.
 //----------------------------------------------------------------------------//
 
-void ExistentialRequiresAnyRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+void HasSelfOrAssociatedTypeRequirementsRequest::diagnoseCycle(
+    DiagnosticEngine &diags) const {
   auto decl = std::get<0>(getStorage());
   diags.diagnose(decl, diag::circular_protocol_def, decl->getName());
 }
 
-void ExistentialRequiresAnyRequest::noteCycleStep(DiagnosticEngine &diags) const {
+void HasSelfOrAssociatedTypeRequirementsRequest::noteCycleStep(
+    DiagnosticEngine &diags) const {
   auto requirement = std::get<0>(getStorage());
   diags.diagnose(requirement, diag::kind_declname_declared_here,
                  DescriptiveDeclKind::Protocol, requirement->getName());
 }
 
-Optional<bool> ExistentialRequiresAnyRequest::getCachedResult() const {
+Optional<bool>
+HasSelfOrAssociatedTypeRequirementsRequest::getCachedResult() const {
   auto decl = std::get<0>(getStorage());
-  return decl->getCachedExistentialRequiresAny();
+  return decl->getCachedHasSelfOrAssociatedTypeRequirements();
 }
 
-void ExistentialRequiresAnyRequest::cacheResult(bool value) const {
+void HasSelfOrAssociatedTypeRequirementsRequest::cacheResult(bool value) const {
   auto decl = std::get<0>(getStorage());
-  decl->setCachedExistentialRequiresAny(value);
+  decl->setCachedHasSelfOrAssociatedTypeRequirements(value);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -711,9 +711,8 @@ ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
   return true;
 }
 
-bool
-ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
-                                        ProtocolDecl *decl) const {
+bool HasSelfOrAssociatedTypeRequirementsRequest::evaluate(
+    Evaluator &evaluator, ProtocolDecl *decl) const {
   // ObjC protocols do not require `any`.
   if (decl->isObjC())
     return false;
@@ -736,7 +735,7 @@ ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
 
   // Check whether any of the inherited protocols require `any`.
   for (auto proto : decl->getInheritedProtocols()) {
-    if (proto->existentialRequiresAny())
+    if (proto->hasSelfOrAssociatedTypeRequirements())
       return true;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -714,10 +714,6 @@ ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
 bool
 ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
                                         ProtocolDecl *decl) const {
-  auto &ctx = decl->getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::ExistentialAny))
-    return true;
-
   // ObjC protocols do not require `any`.
   if (decl->isObjC())
     return false;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5194,8 +5194,7 @@ public:
       OS << ")";
 
     if (auto *proto = dyn_cast_or_null<ProtocolDecl>(T->getBoundDecl())) {
-      if (Ctx.LangOpts.hasFeature(Feature::ExistentialAny) ||
-          proto->existentialRequiresAny()) {
+      if (proto->existentialRequiresAny()) {
         Ctx.Diags.diagnose(T->getNameLoc(),
                            diag::existential_requires_any,
                            proto->getDeclaredInterfaceType(),
@@ -5213,8 +5212,7 @@ public:
       if (type->isConstraintType()) {
         auto layout = type->getExistentialLayout();
         for (auto *protoDecl : layout.getProtocols()) {
-          if (!Ctx.LangOpts.hasFeature(Feature::ExistentialAny) &&
-              !protoDecl->existentialRequiresAny())
+          if (!protoDecl->existentialRequiresAny())
             continue;
 
           Ctx.Diags.diagnose(T->getNameLoc(),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3985,14 +3985,14 @@ public:
                                        StringRef blobData) {
     IdentifierID nameID;
     DeclContextID contextID;
-    bool isImplicit, isClassBounded, isObjC, existentialRequiresAny;
+    bool isImplicit, isClassBounded, isObjC, hasSelfOrAssocTypeRequirements;
     uint8_t rawAccessLevel;
     unsigned numInheritedTypes;
     ArrayRef<uint64_t> rawInheritedAndDependencyIDs;
 
     decls_block::ProtocolLayout::readRecord(scratch, nameID, contextID,
                                             isImplicit, isClassBounded, isObjC,
-                                            existentialRequiresAny,
+                                            hasSelfOrAssocTypeRequirements,
                                             rawAccessLevel, numInheritedTypes,
                                             rawInheritedAndDependencyIDs);
 
@@ -4020,8 +4020,8 @@ public:
 
     ctx.evaluator.cacheOutput(ProtocolRequiresClassRequest{proto},
                               std::move(isClassBounded));
-    ctx.evaluator.cacheOutput(ExistentialRequiresAnyRequest{proto},
-                              std::move(existentialRequiresAny));
+    ctx.evaluator.cacheOutput(HasSelfOrAssociatedTypeRequirementsRequest{proto},
+                              std::move(hasSelfOrAssocTypeRequirements));
 
     if (auto accessLevel = getActualAccessLevel(rawAccessLevel))
       proto->setAccess(*accessLevel);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4090,7 +4090,7 @@ public:
                                const_cast<ProtocolDecl *>(proto)
                                  ->requiresClass(),
                                proto->isObjC(),
-                               proto->existentialRequiresAny(),
+                               proto->hasSelfOrAssociatedTypeRequirements(),
                                rawAccessLevel, numInherited,
                                inheritedAndDependencyTypes);
 

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -20,7 +20,7 @@ func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
 
 // When "fuzzy matching is disabled, this will fail.
 func forwardMatchFailure( // expected-note{{declared here}}
-  onError: ((Error) -> Void)? = nil,
+  onError: ((any Error) -> Void)? = nil,
   onCompletion: (Int) -> Void
 ) { }
 

--- a/test/type/explicit_existential_multimodule1.swift
+++ b/test/type/explicit_existential_multimodule1.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s         -swift-version 5 -emit-module -DM -module-name M -emit-module-path %t/M.swiftmodule -enable-upcoming-feature ExistentialAny
+// RUN: %target-swift-frontend %s -verify -swift-version 5 -typecheck -I %t
+
+// Test that the feature state used to compile a module is not reflected in
+// the module file. The feature must not be enforced on protocols originating in
+// a different module just because that module was compiled with the feature
+// enabled.
+
+#if M
+public protocol P {}
+#else
+import M
+func test(_: P) {}
+#endif

--- a/test/type/explicit_existential_multimodule2.swift
+++ b/test/type/explicit_existential_multimodule2.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s         -swift-version 5 -emit-module -DM -module-name M -emit-module-path %t/M.swiftmodule
+// RUN: %target-swift-frontend %s -verify -swift-version 5 -typecheck -I %t -enable-upcoming-feature ExistentialAny
+
+// Test that a protocol that requires 'any' *only* when the feature is enabled
+// is diagnosed as expected when said protocol originates in a different module.
+// In other words, test that deserialization does not affect 'any' migration
+// diagnostics.
+
+#if M
+public protocol P {}
+#else
+import M
+func test(_: P) {} // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
+#endif

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -229,17 +229,9 @@ extension MyError {
   }
 }
 
-struct Wrapper {
-  typealias E = Error
-}
-
-func typealiasMemberReferences(metatype: Wrapper.Type) {
-  let _: Wrapper.E.Protocol = metatype.E.self
-  let _: (any Wrapper.E).Type = metatype.E.self
-}
-
 func testAnyTypeExpr() {
   let _: (any P).Type = (any P).self
+  let _: (any P1 & P2).Type = (any P1 & P2).self
 
   func test(_: (any P).Type) {}
   test((any P).self)
@@ -311,6 +303,13 @@ enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not
   case hack
 }
 
+// Protocols from a serialized module (the standard library).
+do {
+  // expected-error@+1 {{use of protocol 'Decodable' as a type must be written 'any Decodable'}}
+  let _: Decodable
+  // expected-error@+1 2 {{use of 'Codable' (aka 'Decodable & Encodable') as a type must be written 'any Codable' (aka 'any Decodable & Encodable')}}
+  let _: Codable
+}
 
 func testAnyFixIt() {
   struct ConformingType : HasAssoc {
@@ -333,6 +332,19 @@ func testAnyFixIt() {
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
   let _: HasAssoc.Protocol = HasAssoc.self
+  do {
+    struct Wrapper {
+      typealias HasAssocAlias = HasAssoc
+    }
+    let wrapperMeta: Wrapper.Type
+    // FIXME: Both of these fix-its are wrong.
+    // 1. 'any' is attached to 'HasAssocAlias' instead of 'Wrapper.HasAssocAlias'
+    // 2. What is the correct fix-it for the initializer?
+    //
+    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{20-33=(any HasAssocAlias)}}
+    // expected-error@+1:57 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{57-70=(any HasAssocAlias)}}
+    let _: Wrapper.HasAssocAlias.Protocol = wrapperMeta.HasAssocAlias.self
+  }
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc).Protocol = (any HasAssoc).self
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}


### PR DESCRIPTION
* **Explanation**: See #65112.
* **Scope**: Missing diagnostics for adoption of explicit existential `any` in Swift 6 mode.
* **Issue**: Resolves #65034.
* **Risk**: Very low. A simple and predictable functional change.
* **Testing**: No additional testing warranted. This change does not impact code generation whatsoever, and is source-compatible unless the `ExistentialAny` feature is enabled (enabling the feature is supposed to be source-breaking).
* **Reviewer**: @hborla
* **Main branch PRs**: 
  * #65112 
  * #65132