### PR TITLE
[5.9][SourceKit] Pass 'swiftc' path to Driver when creating frontend args

### DIFF
--- a/include/swift/Driver/FrontendUtil.h
+++ b/include/swift/Driver/FrontendUtil.h
@@ -33,6 +33,7 @@ void ExpandResponseFilesWithRetry(llvm::StringSaver &Saver,
 /// Generates the list of arguments that would be passed to the compiler
 /// frontend from the given driver arguments.
 ///
+/// \param DriverPath The path to 'swiftc'.
 /// \param ArgList The driver arguments (i.e. normal arguments for \c swiftc).
 /// \param Diags The DiagnosticEngine used to report any errors parsing the
 /// arguments.
@@ -48,7 +49,8 @@ void ExpandResponseFilesWithRetry(llvm::StringSaver &Saver,
 /// \note This function is not intended to create invocations which are
 /// suitable for use in REPL or immediate modes.
 bool getSingleFrontendInvocationFromDriverArguments(
-    ArrayRef<const char *> ArgList, DiagnosticEngine &Diags,
+    StringRef DriverPath, ArrayRef<const char *> ArgList,
+    DiagnosticEngine &Diags,
     llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action,
     bool ForceNoOutputs = false);
 

--- a/include/swift/IDETool/CompileInstance.h
+++ b/include/swift/IDETool/CompileInstance.h
@@ -31,6 +31,7 @@ namespace ide {
 
 /// Manages \c CompilerInstance for completion like operations.
 class CompileInstance {
+  const std::string &SwiftExecutablePath;
   const std::string &RuntimeResourcePath;
   const std::string &DiagnosticDocumentationPath;
   const std::shared_ptr<swift::PluginRegistry> Plugins;
@@ -67,10 +68,12 @@ class CompileInstance {
                    std::shared_ptr<std::atomic<bool>> CancellationFlag);
 
 public:
-  CompileInstance(const std::string &RuntimeResourcePath,
+  CompileInstance(const std::string &SwiftExecutablePath,
+                  const std::string &RuntimeResourcePath,
                   const std::string &DiagnosticDocumentationPath,
                   std::shared_ptr<swift::PluginRegistry> Plugins = nullptr)
-      : RuntimeResourcePath(RuntimeResourcePath),
+      : SwiftExecutablePath(SwiftExecutablePath),
+        RuntimeResourcePath(RuntimeResourcePath),
         DiagnosticDocumentationPath(DiagnosticDocumentationPath),
         Plugins(Plugins), CachedCIInvalidated(false), CachedReuseCount(0) {}
 

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -59,7 +59,7 @@ static void removeSupplementaryOutputs(llvm::opt::ArgList &ArgList) {
 }
 
 bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
-    ArrayRef<const char *> Argv, DiagnosticEngine &Diags,
+    StringRef DriverPath, ArrayRef<const char *> Argv, DiagnosticEngine &Diags,
     llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action,
     bool ForceNoOutputs) {
   SmallVector<const char *, 16> Args;
@@ -87,7 +87,7 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   ExpandResponseFilesWithRetry(Saver, Args);
 
   // Force the driver into batch mode by specifying "swiftc" as the name.
-  Driver TheDriver("swiftc", "swiftc", Args, Diags);
+  Driver TheDriver(DriverPath, "swiftc", Args, Diags);
 
   // Don't check for the existence of input files, since the user of the
   // CompilerInvocation may wish to remap inputs to source buffers.

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -261,10 +261,14 @@ bool CompileInstance::setupCI(
                DiagnosticDocumentationPath.c_str()});
   args.append(origArgs.begin(), origArgs.end());
 
+  SmallString<256> driverPath(SwiftExecutablePath);
+  llvm::sys::path::remove_filename(driverPath);
+  llvm::sys::path::append(driverPath, "swiftc");
+
   CompilerInvocation invocation;
   bool invocationCreationFailed =
       driver::getSingleFrontendInvocationFromDriverArguments(
-          args, Diags,
+          driverPath, args, Diags,
           [&](ArrayRef<const char *> FrontendArgs) {
             return invocation.parseArgs(FrontendArgs, Diags);
           },

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -173,9 +173,14 @@ bool ide::initCompilerInvocation(
   StreamDiagConsumer DiagConsumer(ErrOS);
   Diags.addConsumer(DiagConsumer);
 
+  // Derive 'swiftc' path from 'swift-frontend' path (swiftExecutablePath).
+  SmallString<256> driverPath(swiftExecutablePath);
+  llvm::sys::path::remove_filename(driverPath);
+  llvm::sys::path::append(driverPath, "swiftc");
+
   bool InvocationCreationFailed =
       driver::getSingleFrontendInvocationFromDriverArguments(
-          Args, Diags,
+          driverPath, Args, Diags,
           [&](ArrayRef<const char *> FrontendArgs) {
             return Invocation.parseArgs(
                 FrontendArgs, Diags, /*ConfigurationFileBuffers=*/nullptr,

--- a/test/SourceKit/Macros/macro_option_set.swift
+++ b/test/SourceKit/Macros/macro_option_set.swift
@@ -1,0 +1,47 @@
+
+@OptionSet<UInt8>
+struct ShippingOptions {
+  private enum Options: Int {
+    case nextDay
+    case secondDay
+    case priority
+    case standard
+  }
+
+  static let express: ShippingOptions = [.nextDay, .secondDay]
+  static let all: ShippingOptions = [.express, .priority, .standard]
+}
+
+func test(opts: ShippingOptions) {
+  let _ = ShippingOptions.nextDay
+}
+
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## DIAGS ##' == \
+// RUN:   -req=diags %s -- %s ==\
+// RUN:   -shell -- echo '## CURSOR ##' == \
+// RUN:   -req=cursor -pos=16:27 %s -- %s == \
+// RUN:   -shell -- echo '## COMPLETE ##' == \
+// RUN:   -req=complete -pos=16:27 %s -- %s == \
+// RUN:   -shell -- echo '## COMPILE ##' == \
+// RUN:   -req=compile -name test -- -c %s -module-name TestModule -o %t/out.o \
+// RUN: | %FileCheck %s
+
+// CHECK-LABEL: ## DIAGS ##
+// CHECK: key.diagnostics: [
+// CHECK-NEXT: ]
+
+// CHECK-LABEL: ## CURSOR ##
+// CHECK: source.lang.swift.ref.var.static
+
+// CHECK-LABEL: ## COMPLETE ##
+// CHECK: key.results: [
+// CHECK:   key.description: "secondDay"
+
+// CHECK-LABEL: ## COMPILE ##
+// CHECK:      key.diagnostics: [
+// CHECK-NEXT: ],
+// CHECK:      key.value: 0

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompile.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompile.cpp
@@ -31,9 +31,10 @@ compile::SessionManager::getSession(StringRef name) {
   }
 
   bool inserted = false;
-  std::tie(i, inserted) = sessions.try_emplace(
-      name, std::make_shared<compile::Session>(
-                RuntimeResourcePath, DiagnosticDocumentationPath, Plugins));
+  std::tie(i, inserted) =
+      sessions.try_emplace(name, std::make_shared<compile::Session>(
+                                     SwiftExecutablePath, RuntimeResourcePath,
+                                     DiagnosticDocumentationPath, Plugins));
   assert(inserted);
   return i->second;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -297,7 +297,8 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
                                  SKCtx.getGlobalConfiguration());
 
   CompileManager = std::make_shared<compile::SessionManager>(
-      RuntimeResourcePath, DiagnosticDocumentationPath, Plugins);
+      SwiftExecutablePath, RuntimeResourcePath, DiagnosticDocumentationPath,
+      Plugins);
 
   // By default, just use the in-memory cache.
   CCCache->inMemory = std::make_unique<ide::CodeCompletionCache>();

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -292,10 +292,12 @@ class Session {
   swift::ide::CompileInstance Compiler;
 
 public:
-  Session(const std::string &RuntimeResourcePath,
+  Session(const std::string &SwiftExecutablePath,
+          const std::string &RuntimeResourcePath,
           const std::string &DiagnosticDocumentationPath,
           std::shared_ptr<swift::PluginRegistry> Plugins)
-      : Compiler(RuntimeResourcePath, DiagnosticDocumentationPath, Plugins) {}
+      : Compiler(SwiftExecutablePath, RuntimeResourcePath,
+                 DiagnosticDocumentationPath, Plugins) {}
 
   bool
   performCompile(llvm::ArrayRef<const char *> Args,
@@ -307,6 +309,7 @@ public:
 };
 
 class SessionManager {
+  const std::string &SwiftExecutablePath;
   const std::string &RuntimeResourcePath;
   const std::string &DiagnosticDocumentationPath;
   const std::shared_ptr<swift::PluginRegistry> Plugins;
@@ -317,10 +320,12 @@ class SessionManager {
   mutable llvm::sys::Mutex mtx;
 
 public:
-  SessionManager(std::string &RuntimeResourcePath,
-                 std::string &DiagnosticDocumentationPath,
-                 std::shared_ptr<swift::PluginRegistry> Plugins)
-      : RuntimeResourcePath(RuntimeResourcePath),
+  SessionManager(const std::string &SwiftExecutablePath,
+                 const std::string &RuntimeResourcePath,
+                 const std::string &DiagnosticDocumentationPath,
+                 const std::shared_ptr<swift::PluginRegistry> Plugins)
+      : SwiftExecutablePath(SwiftExecutablePath),
+        RuntimeResourcePath(RuntimeResourcePath),
         DiagnosticDocumentationPath(DiagnosticDocumentationPath),
         Plugins(Plugins) {}
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -896,7 +896,8 @@ std::shared_ptr<sma::Module> createSMAModel(ModuleDecl *M) {
 
 } // unnamed namespace
 
-int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
+int swift::doGenerateModuleAPIDescription(StringRef DriverPath,
+                                          StringRef MainExecutablePath,
                                           ArrayRef<std::string> Args) {
   std::vector<const char *> CStringArgs;
   for (auto &S : Args) {
@@ -910,9 +911,10 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
 
   CompilerInvocation Invocation;
   bool HadError = driver::getSingleFrontendInvocationFromDriverArguments(
-      CStringArgs, Diags, [&](ArrayRef<const char *> FrontendArgs) {
-    return Invocation.parseArgs(FrontendArgs, Diags);
-  });
+      MainExecutablePath, CStringArgs, Diags,
+      [&](ArrayRef<const char *> FrontendArgs) {
+        return Invocation.parseArgs(FrontendArgs, Diags);
+      });
 
   if (HadError) {
     llvm::errs() << "error: unable to create a CompilerInvocation\n";
@@ -941,4 +943,3 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
 
   return 0;
 }
-

--- a/tools/swift-ide-test/ModuleAPIDiff.h
+++ b/tools/swift-ide-test/ModuleAPIDiff.h
@@ -6,7 +6,8 @@
 
 namespace swift {
 
-int doGenerateModuleAPIDescription(StringRef MainExecutablePath,
+int doGenerateModuleAPIDescription(StringRef DriverPath,
+                                   StringRef MainExecutablePath,
                                    ArrayRef<std::string> Args);
 
 } // end namespace swift


### PR DESCRIPTION
Cherry-pick #65068 into `release/5.9`

**Explanation**: `libDriver` uses its path to derive the plugin paths (i.e. `lib/swift/host/plugins`) Previously it was a constant string `swiftc` not an actual path, that caused SourceKit failed to find dylib plugins in the toolchain. Since `SwiftLangSupport` knows the swift-frontend path, use it, but replacing the filename with `swiftc`, to derive the plugin paths.
**Scope**: Legacy `libDriver` clients using `getSingleFrontendInvocationFromDriverArguments` currently only SourceKit
**Risk**: Low
**Testing**: Added regression test cases
**Issue**: rdar://107849796
**Reviewer**: Alex Hoppen (@ahoppen)