### PR TITLE
🍒[cxx-interop] Add missing dependency to CxxStdlib

### DIFF
--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -144,4 +144,4 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB
     TARGET_SDKS ALL_APPLE_PLATFORMS LINUX
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED
-    DEPENDS libstdcxx-modulemap)
+    DEPENDS libstdcxx-modulemap libcxxshim_modulemap)


### PR DESCRIPTION
**Explanation**: The CxxStdlib module now relies on the libcxxshim modulemap, so we need to make sure that the modulemap is copied into the correct location before CxxStdlib is built.
**Scope**: Only affects the CMake build script for the CxxStdlib module.
**Risk**: Low: this does not affect the compiler's behavior in any way.

rdar://108007693
(cherry picked from commit 030313213cc1a23ae914d603d2316c2e86a3cc5f)