### PR TITLE
[move-only] Change the destructure through deinit error to lookup the deinit at the AST level rather than the SIL level.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1333,7 +1333,7 @@ checkForDestructureThroughDeinit(MarkMustCheckInst *rootAddress, Operand *use,
     // cannot contain non-copyable types and that our parent root type must be
     // an enum, tuple, or struct.
     if (auto *nom = iterType.getNominalOrBoundGenericNominal()) {
-      if (mod.lookUpMoveOnlyDeinitFunction(nom)) {
+      if (nom->getValueTypeDestructor()) {
         // If we find one, emit an error since we are going to have to extract
         // through the deinit. Emit a nice error saying what it is. Since we
         // are emitting an error, we do a bit more work and construct the

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -774,4 +774,6 @@ void DiagnosticEmitter::emitCannotDestructureDeinitNominalError(
   }
   diagnose(astContext, consumingUser,
            diag::sil_moveonlychecker_consuming_use_here);
+  astContext.Diags.diagnose(deinitedNominal->getValueTypeDestructor(),
+                            diag::sil_moveonlychecker_deinit_here);
 }

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -59,6 +59,16 @@ struct DeinitStruct {
   var fifth: MoveOnlyKlass
 
   deinit {}
+  // expected-note @-1 {{deinit declared here}}
+  // expected-note @-2 {{deinit declared here}}
+  // expected-note @-3 {{deinit declared here}}
+  // expected-note @-4 {{deinit declared here}}
+  // expected-note @-5 {{deinit declared here}}
+  // expected-note @-6 {{deinit declared here}}
+  // expected-note @-7 {{deinit declared here}}
+  // expected-note @-8 {{deinit declared here}}
+  // expected-note @-9 {{deinit declared here}}
+  // expected-note @-10 {{deinit declared here}}
 }
 
 func testConsumeCopyable(_ x: consuming DeinitStruct) {


### PR DESCRIPTION
I also added a note telling the user where the deinit is.

rdar://101651138
