### PR TITLE
[Serialization] Compatibility fixes to deserialization safety and access-level

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -563,6 +563,17 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                                OPT_disable_deserialization_safety)) {
     Opts.EnableDeserializationSafety
       = A->getOption().matches(OPT_enable_deserialization_safety);
+  } else if (auto A = Args.getLastArg(OPT_enable_access_control,
+                                      OPT_disable_access_control)) {
+    // Disable deserialization safety along with access control.
+    Opts.EnableDeserializationSafety
+      = A->getOption().matches(OPT_enable_access_control);
+  }
+
+  if (auto A = Args.getLastArg(OPT_enable_access_control,
+                               OPT_disable_access_control)) {
+    Opts.EnableAccessControl
+      = A->getOption().matches(OPT_enable_access_control);
   }
 
   // Whether '/.../' regex literals are enabled. This implies experimental
@@ -615,12 +626,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.WarnOnPotentiallyUnavailableEnumCase |=
       Args.hasArg(OPT_warn_on_potentially_unavailable_enum_case);
   Opts.WarnOnEditorPlaceholder |= Args.hasArg(OPT_warn_on_editor_placeholder);
-
-  if (auto A = Args.getLastArg(OPT_enable_access_control,
-                               OPT_disable_access_control)) {
-    Opts.EnableAccessControl
-      = A->getOption().matches(OPT_enable_access_control);
-  }
 
   if (auto A = Args.getLastArg(OPT_disable_typo_correction,
                                OPT_typo_correction_limit)) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3146,7 +3146,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     // A decl is safe if formally accessible publicly.
     auto accessScope = value->getFormalAccessScope(/*useDC=*/nullptr,
                        /*treatUsableFromInlineAsPublic=*/true);
-    if (accessScope.isPublic())
+    if (accessScope.isPublic() || accessScope.isPackage())
       return true;
 
     if (auto accessor = dyn_cast<AccessorDecl>(value))

--- a/test/Sema/package-only-references.swift
+++ b/test/Sema/package-only-references.swift
@@ -17,6 +17,11 @@
 // RUN:   -package-name MyPackage -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name MyPackage -I %t \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
 /// A client outside of the package raises errors.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -package-name NotMyPackage -I %t \

--- a/test/Serialization/Safety/skip-reading-internal-details.swift
+++ b/test/Serialization/Safety/skip-reading-internal-details.swift
@@ -20,6 +20,11 @@
 
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-access-control 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=NEEDED,UNSAFE %s
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
 // RUN:   -enable-deserialization-safety 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=NEEDED,CLEAN,SAFE %s
 


### PR DESCRIPTION
* Consider decls with an access-level of `package` as deserialization safe. As with `public` decls, `package` decls are expected to be read by clients.
* When access-control is disabled, disable deserialization safety automatically by default. Tests that disable access-control expect to have access to unsafe decls.