### PR TITLE
[5.9][IRGen] Use ConditionalDominanceScope in AbstractMetadataAccessor::em…

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2400,6 +2400,7 @@ namespace {
 
             {
               IGF.Builder.emitBlock(returnTypeBB);
+              ConditionalDominanceScope domScope(IGF);
               IGF.Builder.CreateRet(getResultValue(
                   IGF, genericEnv, underlyingTy->getSubstitutions()));
             }

--- a/test/IRGen/Inputs/opaque_result_with_conditional_availability_types.swift
+++ b/test/IRGen/Inputs/opaque_result_with_conditional_availability_types.swift
@@ -1,0 +1,31 @@
+public protocol SomeProtocol {
+    associatedtype T: SomeProtocol
+
+    func foo() -> T
+}
+
+@available(macOS 100.0, *)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public extension SomeProtocol {
+    func modify() -> some SomeProtocol {
+        return NestedStruct(x: self, y: 32)
+    }
+}
+
+public struct PublicStruct: SomeProtocol {
+    public init<T: SomeProtocol>(_ x: T) {}
+
+    public func foo() -> some SomeProtocol {
+        return self
+    }
+}
+
+struct NestedStruct<A: SomeProtocol, B>: SomeProtocol {
+    init(x: A, y: B) {}
+
+    func foo() -> some SomeProtocol {
+        return self
+    }
+}

--- a/test/IRGen/opaque_result_with_conditional_availability.swift
+++ b/test/IRGen/opaque_result_with_conditional_availability.swift
@@ -1,5 +1,10 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-ir %s -swift-version 5 | %IRGenFileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-module -emit-module-path=%t/opaque_result_with_conditional_availability_types.swiftmodule %S/Inputs/opaque_result_with_conditional_availability_types.swift
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -c -parse-as-library -o %t/opaque_result_with_conditional_availability_types.o %S/Inputs/opaque_result_with_conditional_availability_types.swift
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -I%t -emit-ir %s -swift-version 5 | %IRGenFileCheck %s
 // REQUIRES: OS=macosx
+
+import opaque_result_with_conditional_availability_types
 
 protocol P {
   func hello()
@@ -173,3 +178,37 @@ func test_multiple_generic<T: P>(_ t: T) -> some P {
 // CHECK: universal:                                        ; preds = %cond-0-0
 // CHECK-NEXT:  ret i8** {{.*}} @"$s43opaque_result_with_conditional_availability1CVAA1PAAWP"
 // CHECK-NEXT: }
+
+
+// rdar://103179745
+struct LocalStruct: SomeProtocol {
+  func foo() -> some SomeProtocol {
+    return self
+  }
+}
+
+func test_cross_module() -> some SomeProtocol {
+  if #available(macOS 100, *) {
+    return PublicStruct(LocalStruct()).modify()
+  } else {
+    return PublicStruct(LocalStruct())
+  }
+}
+
+// CHECK: define private i8** @"get_underlying_witness 43opaque_result_with_conditional_availabilityAA17test_cross_moduleQryFQOx0a1_b1_c1_d1_E6_types12SomeProtocolHC"(i8* %0)
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %1 = alloca { %swift.type*, i8** }, align 8
+// CHECK-NEXT:   br label %conditional-0
+// CHECK: conditional-0:                                    ; preds = %entry
+// CHECK-NEXT:   br label %cond-0-0
+// CHECK: cond-0-0:                                         ; preds = %conditional-0
+// CHECK:   %{{.*}} = call i32 @__isPlatformVersionAtLeast(i32 1, i32 100, i32 0, i32 0)
+// CHECK:   %{{.*}} = icmp ne i32 %{{.*}}, 0
+// CHECK:   br i1 %{{.*}}, label %result-0, label %universal
+// CHECK: result-0:                                         ; preds = %cond-0-0
+// CHECK-NEXT:   %{{.*}} = call i8** @"$s49opaque_result_with_conditional_availability_types12PublicStructVAcA12SomeProtocolAAWl"()
+// CHECK:   ret i8** %{{.*}}
+// CHECK: universal:                                        ; preds = %cond-0-0
+// CHECK-NEXT:   [[R0:%.*]] = call i8** @"$s49opaque_result_with_conditional_availability_types12PublicStructVAcA12SomeProtocolAAWl"()
+// CHECK-NEXT:   ret i8** [[R0]]
+// CHECK: }


### PR DESCRIPTION
…it (#64585)

Cherry-picked from: https://github.com/apple/swift/pull/64585

* [IRGen] Use ConditionalDominanceScope in AbstractMetadataAccessor::emit

rdar://103179745

Under certain conditions the missing dominance scope caused a cached witness table ref to be used in a block that it was not available in.

* Fix target in test
