### PR TITLE
Update the scope of SILBuilder in ClosureCloner.

### DIFF
--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -687,6 +687,7 @@ void ClosureCloner::visitEndAccessInst(EndAccessInst *eai) {
 /// The two relevant cases are a direct load from a promoted address argument or
 /// a load of a struct_element_addr of a promoted address argument.
 void ClosureCloner::visitLoadBorrowInst(LoadBorrowInst *lbi) {
+  getBuilder().setCurrentDebugScope(getOpScope(lbi->getDebugScope()));
   assert(lbi->getFunction()->hasOwnership() &&
          "We should only see a load borrow in ownership qualified SIL");
   if (SILValue value = getProjectBoxMappedVal(lbi->getOperand())) {
@@ -729,6 +730,7 @@ void ClosureCloner::visitLoadBorrowInst(LoadBorrowInst *lbi) {
 /// The two relevant cases are a direct load from a promoted address argument or
 /// a load of a struct_element_addr of a promoted address argument.
 void ClosureCloner::visitLoadInst(LoadInst *li) {
+  getBuilder().setCurrentDebugScope(getOpScope(li->getDebugScope()));
   if (SILValue value = getProjectBoxMappedVal(li->getOperand())) {
     // Loads of the address argument get eliminated completely; the uses of
     // the loads get mapped to uses of the new object type argument.


### PR DESCRIPTION
This is something that every visit() function needs to do and these manual
overloads forgot to. I tried to come up with a more general solution, but due
the rather nested inheritance of SILCloner this turned out harde than expected.

rdar://107984038