### PR TITLE
[IDE] Inject Sendable conformance on public types only in `getTopLevelDeclsForDisplay`

### DIFF
--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -72,3 +72,8 @@
 // CHECK-GROUPS1-DAG: Collection/Type-erased
 // CHECK-GROUPS1-NOT: <NULL>
 // CHECK-GROUPS1: Module groups end.
+
+/// Check that we can still print the interface of the stdlib with
+/// deserialization safety enabled.
+// RUN: %target-swift-ide-test -print-module-groups -module-to-print=Swift -source-filename %s -print-interface -enable-deserialization-safety > %t-group.txt
+// RUN: %FileCheck -check-prefix=CHECK-GROUPS1 %s < %t-group.txt

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -397,6 +397,11 @@ DisableAccessControl("disable-access-control",
     llvm::cl::desc("Disables access control, like a debugger"),
     llvm::cl::cat(Category));
 
+static llvm::cl::opt<bool>
+EnableDeserializationSafety("enable-deserialization-safety",
+    llvm::cl::desc("Avoid reading potentially unsafe decls from swiftmodules"),
+    llvm::cl::cat(Category));
+
 static llvm::cl::opt<bool> CodeCompleteInitsInPostfixExpr(
     "code-complete-inits-in-postfix-expr",
     llvm::cl::desc(
@@ -4447,6 +4452,8 @@ int main(int argc, char *argv[]) {
     options::ImportObjCHeader;
   InitInvok.getLangOptions().EnableAccessControl =
     !options::DisableAccessControl;
+  InitInvok.getLangOptions().EnableDeserializationSafety =
+    options::EnableDeserializationSafety;
   InitInvok.getLangOptions().EnableSwift3ObjCInference =
     options::EnableSwift3ObjCInference;
   InitInvok.getClangImporterOptions().ImportForwardDeclarations |=


### PR DESCRIPTION
When `getTopLevelDeclsForDisplay` is called on an imported module, it may lists non-public decls. If we they try to inject the conformance on Sendable on internal types the compiler may crash on failing to deserialize internal details. Let's only inject the conformance on public or package types to avoid this.

In the future we may want to make `getTopLevelDeclsForDisplay` return only public and package types and no internal details at all.

rdar://95430471