### PR TITLE
[Runtime] Look for __swift5_types section in two segments

### DIFF
--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -42,6 +42,7 @@
 #define MachOAccessibleFunctionsSection "__swift5_acfuncs"
 
 #define MachOTextSegment "__TEXT"
+#define MachOSwiftROSegment "__SWIFT_RO"
 
 #else
 


### PR DESCRIPTION
Implement `addImageCallbackEitherOr()` which tries one section and then another one, and use that in `initializeTypeMetadataRecordLookup()` to search in both `__SWIFT_RO,__swift5_types` *and* `__TEXT,__swift5_types`.

rdar://107448417