### PR TITLE
5.9: [SemanticARCOpts] Don't shorten owned lexical values lifetimes through deinit barriers.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2690,6 +2690,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::CopyBlockInst:
   case SILInstructionKind::CopyBlockWithoutEscapingInst:
   case SILInstructionKind::CopyValueInst:
+  case SILInstructionKind::DebugStepInst:
   case SILInstructionKind::DeinitExistentialAddrInst:
   case SILInstructionKind::DeinitExistentialValueInst:
   case SILInstructionKind::DestroyAddrInst:

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -103,3 +103,15 @@ sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on test_instructions_1: is-deinit-barrier
+// CHECK:  debug_step
+// CHECK:  false
+// CHECK-LABEL: end running test 1 of 1 on test_instructions_1: is-deinit-barrier
+sil [ossa] @test_instructions_1 : $@convention(thin) () -> () {
+entry:
+  test_specification "is-deinit-barrier @instruction"
+  debug_step
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
+++ b/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
@@ -116,6 +116,13 @@ struct NativeObjectWrapper {
 
 sil @owned_user_object_pair : $@convention(thin) (@owned NativeObjectPair) -> ()
 
+class X {}
+struct S {}
+
+sil @getX : $@convention(thin) () -> @owned X
+sil @getS : $@convention(thin) (@owned X) -> @out S
+sil @loadWeakX_from : $@convention(thin) (@in_guaranteed S) -> @owned FakeOptional<X>
+
 ///////////
 // Tests //
 ///////////
@@ -923,3 +930,51 @@ bb0:
   destroy_value %0 : ${ var Bool }
   return %11 : $Bool
 }
+
+// Don't do this optimization:
+//   Eliminate copy of lexical value which ends after lifetime of copy IF there
+//   may be deinit barriers between the final consume and the copy.
+//
+// CHECK-LABEL: sil [ossa] @testDestroyedLexicalValue : {{.*}} {
+// CHECK:         [[GET:%[^,]+]] = function_ref @getX
+// CHECK:         [[X:%[^,]+]] = apply [[GET]]()
+// CHECK:         [[MX:%[^,]+]] = move_value [lexical] [[X]]
+// CHECK:         destroy_value [[MX]] : $X
+// CHECK-LABEL: } // end sil function 'testDestroyedLexicalValue'
+sil [ossa] @testDestroyedLexicalValue : $@convention(thin) () -> @owned FakeOptional<X> {
+bb0:
+  %getX = function_ref @getX : $@convention(thin) () -> @owned X
+  %x = apply %getX() : $@convention(thin) () -> @owned X
+  %mx = move_value [lexical] %x : $X
+  %a = alloc_stack [lexical] $S, let, name "s"
+  %c = copy_value %mx : $X
+  %getS = function_ref @getS : $@convention(thin) (@owned X) -> @out S
+  %s = apply %getS(%a, %c) : $@convention(thin) (@owned X) -> @out S
+  %loadWeakX_from = function_ref @loadWeakX_from : $@convention(thin) (@in_guaranteed S) -> @owned FakeOptional<X>
+  %o = apply %loadWeakX_from(%a) : $@convention(thin) (@in_guaranteed S) -> @owned FakeOptional<X>
+  // ^^^^^ Deinit barrier
+  destroy_addr %a : $*S
+  dealloc_stack %a : $*S
+  destroy_value %mx : $X
+  return %o : $FakeOptional<X>
+}
+
+// CHECK-LABEL: sil [ossa] @testDestroyedLexicalValueNoBarriers : {{.*}} {
+// CHECK-NOT:     destroy_value
+// CHECK-LABEL: } // end sil function 'testDestroyedLexicalValueNoBarriers'
+sil [ossa] @testDestroyedLexicalValueNoBarriers : $@convention(thin) () -> () {
+bb0:
+  %getX = function_ref @getX : $@convention(thin) () -> @owned X
+  %x = apply %getX() : $@convention(thin) () -> @owned X
+  %mx = move_value [lexical] %x : $X
+  %a = alloc_stack [lexical] $S, let, name "s"
+  %c = copy_value %mx : $X
+  %getS = function_ref @getS : $@convention(thin) (@owned X) -> @out S
+  %s = apply %getS(%a, %c) : $@convention(thin) (@owned X) -> @out S
+  destroy_addr %a : $*S
+  dealloc_stack %a : $*S
+  destroy_value %mx : $X
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65164 .

Prevent joining lifetimes of copies with destroyed owned lexical values if there may be deinit barriers between the final consume of the copy and the destroy of the lexical value.

rdar://108014714
