### PR TITLE
build: Fixes for building Cxx module with/without stdlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1282,7 +1282,7 @@ else()
 
   # Some tools (e.g. swift-reflection-dump) rely on a host swiftRemoteInspection,
   # so ensure we build that when building tools.
-  if(SWIFT_INCLUDE_TOOLS)
+  if(SWIFT_INCLUDE_TOOLS OR SWIFT_BUILD_STDLIB_CXX_MODULE)
     add_subdirectory(stdlib/public/SwiftShims/swift/shims)
   endif()
 

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -1,6 +1,14 @@
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake/modules)
+include(StdlibOptions)
+
 set(SWIFT_CXX_LIBRARY_KIND STATIC)
 if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
   set(SWIFT_CXX_LIBRARY_KIND SHARED)
+endif()
+
+set(SWIFT_CXX_DEPS symlink_clang_headers)
+if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
+  list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
 add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
@@ -20,6 +28,7 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     -Xcc -nostdinc++
 
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+    DEPENDS ${SWIFT_CXX_DEPS}
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED)
 


### PR DESCRIPTION
With the changes introduced in #65055, the Cxx module will build even when not building the stdlib as long as
`SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT` was set. With the further changes in #65122 the previous flag is not necessary, and only `SWIFT_BUILD_STDLIB_CXX_MODULE` (which defaults to `TRUE`) is necessary.

However, `stdlib/public/Cxx` did rely on `StdlibOptions.cmake` to be include before it, or the functions that build the target libraries will find a half configured state. `StdlibOptions.cmake` are included in `stdlib/toolchain`, in `stdlib/` and `StandaloneOverlay.cmake`. Before
 #65122 it was working just because `stdlib/toolchain` was added just
before.

The second change is for the case of building the stdlib isolated. I don't think upstream builds this way at all. It adds a dependency on the legacy layouts, which is a dependency only added to the libraries of the stdlib core (IS_STDLIB_CORE flag). Since enabling that flag also enables a bunch other stuff, and I am not sure that Cxx should be classified as "core" anyway, I preferred to add the dependency. This is necessary for builds like the iPhoneOS and iPhoneSimulator, and does not seem to affect macOS.