### PR TITLE
[SILSymbolVisitor] Skip internal nominal type decls

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -588,6 +588,10 @@ public:
   }
 
   void visitNominalTypeDecl(NominalTypeDecl *NTD) {
+    if (Ctx.getOpts().PublicSymbolsOnly &&
+        getDeclLinkage(NTD) != FormalLinkage::PublicUnique)
+      return;
+
     auto declaredType = NTD->getDeclaredType()->getCanonicalType();
 
     if (!NTD->getObjCImplementationDecl()) {

--- a/test/TBD/rdar107672461.swift
+++ b/test/TBD/rdar107672461.swift
@@ -1,0 +1,51 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/Modules
+// RUN: split-file %s %t
+
+// Build the public module
+// RUN: %target-swift-frontend %t/Public.swift \
+// RUN:   -emit-module -module-name Public \
+// RUN:   -o %t/Modules/Public.swiftmodule \
+// RUN:   -disable-experimental-string-processing
+
+// Build the project internal module
+// RUN: %target-swift-frontend %t/ProjectInternal.swift \
+// RUN:   -emit-module -module-name ProjectInternal \
+// RUN:   -o %t/Modules/ProjectInternal.swiftmodule \
+// RUN:   -I %t/Modules -disable-experimental-string-processing
+
+// Build MyModule with search path to the project internal module
+// RUN: %target-swift-frontend %t/MyModule.swift \
+// RUN:   -emit-module -module-name MyModule \
+// RUN:   -o %t/Modules/MyModule.swiftmodule \
+// RUN:   -I %t/Modules -disable-experimental-string-processing
+
+// Remove the project internal module as it's not available to clients of MyModule
+// RUN: rm %t/Modules/ProjectInternal.swiftmodule
+
+// Use swift-api-extract to load MyModule without ProjectInternal
+// RUN: %target-swift-api-extract -o - -pretty-print \
+// RUN:   -module-name MyModule -I %t/Modules
+
+//--- Public.swift
+public protocol PublicProtocol {}
+
+//--- ProjectInternal.swift
+import Public
+
+public struct InternalStruct: PublicProtocol {}
+
+public extension PublicProtocol {
+  func opaque() -> some PublicProtocol {
+    return InternalStruct()
+  }
+}
+
+//--- MyModule.swift
+import Public
+@_implementationOnly import ProjectInternal
+
+public func foo(bar: some PublicProtocol) -> some PublicProtocol {
+  return bar.opaque()
+}

--- a/test/TBD/rdar107672461.swift
+++ b/test/TBD/rdar107672461.swift
@@ -36,6 +36,7 @@ import Public
 
 public struct InternalStruct: PublicProtocol {}
 
+@available(SwiftStdlib 5.1, *)
 public extension PublicProtocol {
   func opaque() -> some PublicProtocol {
     return InternalStruct()
@@ -46,6 +47,7 @@ public extension PublicProtocol {
 import Public
 @_implementationOnly import ProjectInternal
 
+@available(SwiftStdlib 5.1, *)
 public func foo(bar: some PublicProtocol) -> some PublicProtocol {
   return bar.opaque()
 }


### PR DESCRIPTION
`SILSymbolVisitor` crashes with deserialization failures with opaque type in internal modules when adding conformances to public protocols.

Resolves rdar://107672461