### PR TITLE
Remove a couple of over-eager assertions

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -524,9 +524,6 @@ class AbstractionPattern {
       assert(OrigType == signature.getReducedType(origType));
       GenericSig = signature;
     }
-    assert(!subs || !OrigType->hasTypeParameter() ||
-           subs.getGenericSignature()->isEqual(
-             getGenericSignatureForFunctionComponent()));
   }
 
   void initClangType(SubstitutionMap subs, CanGenericSignature signature,
@@ -1089,15 +1086,9 @@ public:
   AbstractionPattern withSubstitutions(SubstitutionMap subs) const {
     AbstractionPattern result = *this;
     if (subs) {
-#ifndef NDEBUG
       // If we have a generic signature, it should match the substitutions.
-      // But there are situations in which it's okay that we don't store
-      // a signature.
-      auto sig = getGenericSignatureForFunctionComponent();
-      assert((sig && sig->isEqual(subs.getGenericSignature())) ||
-             !OrigType ||
-             !OrigType->hasTypeParameter());
-#endif
+      // But in corner cases, "match" can mean that it applies to an inner
+      // local generic context, which is not something we can easily assert.
       result.GenericSubs = subs;
     }
     return result;

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -223,6 +223,20 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
   }
 }
 
+// Reduced from some code in Doggie.  rdar://107642925
+struct LocalGenericFunc<Element> {
+  var address: UnsafeMutablePointer<Element>
+  init(address: UnsafeMutablePointer<Element>) {
+    self.address = address
+  }
+
+  mutating func foo() {
+    func helper<S: Sequence>(_ newElements: S) where S.Element == Element {
+      let buffer = address
+    }
+  }
+}
+
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15nested_generics9OuterRingC05InnerD0Cyx_qd__GAA30ProtocolWithGenericRequirementA2aGP6method1t1u1v1TQz_1UQzqd__tAN_APqd__tlFTW : $@convention(witness_method: ProtocolWithGenericRequirement) <τ_0_0><τ_1_0><τ_2_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @in_guaranteed τ_2_0, @in_guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0) {
 // CHECK: bb0([[T:%[0-9]+]] : $*τ_0_0, [[U:%[0-9]+]] : $*τ_1_0, [[V:%[0-9]+]] : $*τ_2_0, [[TOut:%[0-9]+]] : $*τ_0_0, [[UOut:%[0-9]+]] : $*τ_1_0, [[VOut:%[0-9]+]] : $*τ_2_0, [[SELF:%[0-9]+]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>):
 // CHECK:   [[SELF_COPY_VAL:%[0-9]+]] = load_borrow [[SELF]] : $*OuterRing<τ_0_0>.InnerRing<τ_1_0>


### PR DESCRIPTION
The best substitutions we can easily find in nested functions for captured local variables are the forwarding substitutions of the current environment.  These should be fine for type-substitution purposes but do not necessarily match the generic signature of the original variable's environment, which can trip these assertions. Unfortunately, I can't think of an easy way to weaken these assertions sufficiently to cover this case.

This should fix the source-compat suite regression reported in rdar://107642925.

Resolves #65200, resolves #65083.