### PR TITLE
tests: disable IRGen/run_variadic_generics.sil to unblock CI

### DIFF
--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -11,6 +11,8 @@
 // Because of -enable-experimental-feature VariadicGenerics
 // REQUIRES: asserts
 
+// REQUIRES: rdar108045677
+
 import Builtin
 import Swift
 import PrintShims


### PR DESCRIPTION
It crashes the compiler on linux
rdar://108045677
