### PR TITLE
[MemAccessUtils] Handle debug_step in visitAccessedAddress.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2691,6 +2691,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::CopyBlockInst:
   case SILInstructionKind::CopyBlockWithoutEscapingInst:
   case SILInstructionKind::CopyValueInst:
+  case SILInstructionKind::DebugStepInst:
   case SILInstructionKind::DeinitExistentialAddrInst:
   case SILInstructionKind::DeinitExistentialValueInst:
   case SILInstructionKind::DestroyAddrInst:

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -103,3 +103,15 @@ sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on test_instructions_1: is-deinit-barrier
+// CHECK:  debug_step
+// CHECK:  false
+// CHECK-LABEL: end running test 1 of 1 on test_instructions_1: is-deinit-barrier
+sil [ossa] @test_instructions_1 : $@convention(thin) () -> () {
+entry:
+  test_specification "is-deinit-barrier @instruction"
+  debug_step
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
The `debug_step` instruction returns true for `mayReadOrWriteMemory` so it has to be handled there.

rdar://108043268
Resolves #65205

