### PR TITLE
Revert "Enable mem2reg of enum types "

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -25,7 +25,6 @@
 #include "swift/Basic/TaggedUnion.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/Dominance.h"
-#include "swift/SIL/OSSALifetimeCompletion.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
@@ -373,189 +372,6 @@ static void collectLoads(SILInstruction *i,
   for (auto *use : cast<SingleValueInstruction>(i)->getUses()) {
     collectLoads(use->getUser(), foundLoads);
   }
-}
-
-/// Returns true if \p I is an address of a LoadInst, skipping struct and
-/// tuple address projections. Sets \p singleBlock to null if the load (or
-/// it's address is not in \p singleBlock.
-/// This function looks for these patterns:
-/// 1. (load %ASI)
-/// 2. (load (struct_element_addr/tuple_element_addr/unchecked_addr_cast %ASI))
-static bool isAddressForLoad(SILInstruction *load, SILBasicBlock *&singleBlock,
-                             bool &involvesUntakableProjection) {
-  if (auto *li = dyn_cast<LoadInst>(load)) {
-    // SILMem2Reg is disabled when we find a load [take] of an untakable
-    // projection.  See below for further discussion.
-    if (involvesUntakableProjection &&
-        li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
-      return false;
-    }
-    return true;
-  }
-
-  if (isa<LoadBorrowInst>(load)) {
-    if (involvesUntakableProjection) {
-      return false;
-    }
-    return true;
-  }
-
-  if (!isa<UncheckedAddrCastInst>(load) && !isa<StructElementAddrInst>(load) &&
-      !isa<TupleElementAddrInst>(load))
-    return false;
-
-  // None of the projections are lowered to owned values:
-  //
-  // struct_element_addr and tuple_element_addr instructions are lowered to
-  // struct_extract and tuple_extract instructions respectively.  These both
-  // have guaranteed ownership (since they forward ownership and can only be
-  // used on a guaranteed value).
-  //
-  // unchecked_addr_cast instructions are lowered to unchecked_bitwise_cast
-  // instructions.  These have unowned ownership.
-  //
-  // So in no case can a load [take] be lowered into the new projected value
-  // (some sequence of struct_extract, tuple_extract, and
-  // unchecked_bitwise_cast instructions) taking over ownership of the original
-  // value.  Without additional changes.
-  //
-  // For example, for a sequence of element_addr projections could be
-  // transformed into a sequence of destructure instructions, followed by a
-  // sequence of structure instructions where all the original values are
-  // kept in place but the taken value is "knocked out" and replaced with
-  // undef.  The running value would then be set to the newly structed
-  // "knockout" value.
-  //
-  // Alternatively, a new copy of the running value could be created and a new
-  // set of destroys placed after its last uses.
-  involvesUntakableProjection = true;
-
-  // Recursively search for other (non-)loads in the instruction's uses.
-  auto *svi = cast<SingleValueInstruction>(load);
-  for (auto *use : svi->getUses()) {
-    SILInstruction *user = use->getUser();
-    if (user->getParent() != singleBlock)
-      singleBlock = nullptr;
-
-    if (!isAddressForLoad(user, singleBlock, involvesUntakableProjection))
-      return false;
-  }
-  return true;
-}
-
-/// Returns true if \p I is a dead struct_element_addr or tuple_element_addr.
-static bool isDeadAddrProjection(SILInstruction *inst) {
-  if (!isa<UncheckedAddrCastInst>(inst) && !isa<StructElementAddrInst>(inst) &&
-      !isa<TupleElementAddrInst>(inst))
-    return false;
-
-  // Recursively search for uses which are dead themselves.
-  for (auto UI : cast<SingleValueInstruction>(inst)->getUses()) {
-    SILInstruction *II = UI->getUser();
-    if (!isDeadAddrProjection(II))
-      return false;
-  }
-  return true;
-}
-
-/// Returns true if this \p def is captured.
-/// Sets \p inSingleBlock to true if all uses of \p def are in a single block.
-static bool isCaptured(SILValue def, bool *inSingleBlock) {
-  SILBasicBlock *singleBlock = def->getParentBlock();
-
-  // For all users of the def
-  for (auto *use : def->getUses()) {
-    SILInstruction *user = use->getUser();
-
-    if (user->getParent() != singleBlock)
-      singleBlock = nullptr;
-
-    // Loads are okay.
-    bool involvesUntakableProjection = false;
-    if (isAddressForLoad(user, singleBlock, involvesUntakableProjection))
-      continue;
-
-    // We can store into an AllocStack (but not the pointer).
-    if (auto *si = dyn_cast<StoreInst>(user))
-      if (si->getDest() == def)
-        continue;
-
-    if (auto *sbi = dyn_cast<StoreBorrowInst>(user)) {
-      if (sbi->getDest() == def) {
-        if (isCaptured(sbi, inSingleBlock)) {
-          return true;
-        }
-        continue;
-      }
-    }
-
-    // Deallocation is also okay, as are DebugValue w/ address value. We will
-    // promote the latter into normal DebugValue.
-    if (isa<DeallocStackInst>(user) || DebugValueInst::hasAddrVal(user))
-      continue;
-
-    if (isa<EndBorrowInst>(user))
-      continue;
-
-    // Destroys of loadable types can be rewritten as releases, so
-    // they are fine.
-    if (auto *dai = dyn_cast<DestroyAddrInst>(user))
-      if (dai->getOperand()->getType().isLoadable(*dai->getFunction()))
-        continue;
-
-    // Other instructions are assumed to capture the AllocStack.
-    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack is captured by: " << *user);
-    return true;
-  }
-
-  // None of the users capture the AllocStack.
-  *inSingleBlock = (singleBlock != nullptr);
-  return false;
-}
-
-/// Returns true if the \p def is only stored into.
-static bool isWriteOnlyAllocation(SILValue def) {
-  assert(isa<AllocStackInst>(def) || isa<StoreBorrowInst>(def));
-
-  // For all users of the def:
-  for (auto *use : def->getUses()) {
-    SILInstruction *user = use->getUser();
-
-    // It is okay to store into the AllocStack.
-    if (auto *si = dyn_cast<StoreInst>(user))
-      if (!isa<AllocStackInst>(si->getSrc()))
-        continue;
-
-    if (auto *sbi = dyn_cast<StoreBorrowInst>(user)) {
-      // Since all uses of the alloc_stack will be via store_borrow, check if
-      // there are any non-writes from the store_borrow location.
-      if (!isWriteOnlyAllocation(sbi)) {
-        return false;
-      }
-      continue;
-    }
-
-    // Deallocation is also okay.
-    if (isa<DeallocStackInst>(user))
-      continue;
-
-    if (isa<EndBorrowInst>(user))
-      continue;
-
-    // If we haven't already promoted the AllocStack, we may see
-    // DebugValue uses.
-    if (DebugValueInst::hasAddrVal(user))
-      continue;
-
-    if (isDeadAddrProjection(user))
-      continue;
-
-    // Can't do anything else with it.
-    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack has non-write use: " << *user);
-    return false;
-  }
-
-  return true;
 }
 
 static void
@@ -1785,8 +1601,6 @@ void StackAllocationPromoter::promoteAllocationToPhi() {
 }
 
 void StackAllocationPromoter::run() {
-  auto *function = asi->getFunction();
-
   // Reduce the number of load/stores in the function to minimum.
   // After this phase we are left with up to one load and store
   // per block and the last store is recorded.
@@ -1794,33 +1608,6 @@ void StackAllocationPromoter::run() {
 
   // Replace AllocStacks with Phi-nodes.
   promoteAllocationToPhi();
-
-  // Make sure that all of the allocations were promoted into registers.
-  assert(isWriteOnlyAllocation(asi) && "Non-write uses left behind");
-
-  SmallVector<SILValue> valuesToComplete;
-
-  // Enum types may have incomplete lifetimes in address form, when promoted to
-  // value form after mem2reg, they will end up with incomplete ossa lifetimes.
-  // Use the lifetime completion utility to complete such lifetimes.
-  // First, collect the stored values to complete.
-  if (asi->getType().isOrHasEnum()) {
-    for (auto it : initializationPoints) {
-      auto *si = it.second;
-      auto src = si->getOperand(0);
-      valuesToComplete.push_back(src);
-    }
-  }
-
-  // ... and erase the allocation.
-  deleter.forceDeleteWithUsers(asi);
-
-  // Now, complete lifetimes!
-  OSSALifetimeCompletion completion(function, domInfo);
-
-  for (auto it : valuesToComplete) {
-    completion.completeOSSALifetime(it);
-  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -1877,6 +1664,9 @@ class MemoryToRegisters {
     return *domTreeLevels;
   }
 
+  /// Check if \p def is a write-only allocation.
+  bool isWriteOnlyAllocation(SILValue def);
+
   /// Promote all of the AllocStacks in a single basic block in one
   /// linear scan. Note: This function deletes all of the users of the
   /// AllocStackInst, including the DeallocStackInst but it does not remove the
@@ -1898,6 +1688,189 @@ public:
 };
 
 } // end anonymous namespace
+
+/// Returns true if \p I is an address of a LoadInst, skipping struct and
+/// tuple address projections. Sets \p singleBlock to null if the load (or
+/// it's address is not in \p singleBlock.
+/// This function looks for these patterns:
+/// 1. (load %ASI)
+/// 2. (load (struct_element_addr/tuple_element_addr/unchecked_addr_cast %ASI))
+static bool isAddressForLoad(SILInstruction *load, SILBasicBlock *&singleBlock,
+                             bool &involvesUntakableProjection) {
+  if (auto *li = dyn_cast<LoadInst>(load)) {
+    // SILMem2Reg is disabled when we find a load [take] of an untakable
+    // projection.  See below for further discussion.
+    if (involvesUntakableProjection &&
+        li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
+      return false;
+    }
+    return true;
+  }
+
+  if (isa<LoadBorrowInst>(load)) {
+    if (involvesUntakableProjection) {
+      return false;
+    }
+    return true;
+  }
+
+  if (!isa<UncheckedAddrCastInst>(load) && !isa<StructElementAddrInst>(load) &&
+      !isa<TupleElementAddrInst>(load))
+    return false;
+
+  // None of the projections are lowered to owned values:
+  //
+  // struct_element_addr and tuple_element_addr instructions are lowered to
+  // struct_extract and tuple_extract instructions respectively.  These both
+  // have guaranteed ownership (since they forward ownership and can only be
+  // used on a guaranteed value).
+  //
+  // unchecked_addr_cast instructions are lowered to unchecked_bitwise_cast
+  // instructions.  These have unowned ownership.
+  //
+  // So in no case can a load [take] be lowered into the new projected value
+  // (some sequence of struct_extract, tuple_extract, and
+  // unchecked_bitwise_cast instructions) taking over ownership of the original
+  // value.  Without additional changes.
+  //
+  // For example, for a sequence of element_addr projections could be
+  // transformed into a sequence of destructure instructions, followed by a
+  // sequence of structure instructions where all the original values are
+  // kept in place but the taken value is "knocked out" and replaced with
+  // undef.  The running value would then be set to the newly structed
+  // "knockout" value.
+  //
+  // Alternatively, a new copy of the running value could be created and a new
+  // set of destroys placed after its last uses.
+  involvesUntakableProjection = true;
+
+  // Recursively search for other (non-)loads in the instruction's uses.
+  auto *svi = cast<SingleValueInstruction>(load);
+  for (auto *use : svi->getUses()) {
+    SILInstruction *user = use->getUser();
+    if (user->getParent() != singleBlock)
+      singleBlock = nullptr;
+
+    if (!isAddressForLoad(user, singleBlock, involvesUntakableProjection))
+      return false;
+  }
+  return true;
+}
+
+/// Returns true if \p I is a dead struct_element_addr or tuple_element_addr.
+static bool isDeadAddrProjection(SILInstruction *inst) {
+  if (!isa<UncheckedAddrCastInst>(inst) && !isa<StructElementAddrInst>(inst) &&
+      !isa<TupleElementAddrInst>(inst))
+    return false;
+
+  // Recursively search for uses which are dead themselves.
+  for (auto UI : cast<SingleValueInstruction>(inst)->getUses()) {
+    SILInstruction *II = UI->getUser();
+    if (!isDeadAddrProjection(II))
+      return false;
+  }
+  return true;
+}
+
+/// Returns true if this \p def is captured.
+/// Sets \p inSingleBlock to true if all uses of \p def are in a single block.
+static bool isCaptured(SILValue def, bool *inSingleBlock) {
+  SILBasicBlock *singleBlock = def->getParentBlock();
+
+  // For all users of the def
+  for (auto *use : def->getUses()) {
+    SILInstruction *user = use->getUser();
+
+    if (user->getParent() != singleBlock)
+      singleBlock = nullptr;
+
+    // Loads are okay.
+    bool involvesUntakableProjection = false;
+    if (isAddressForLoad(user, singleBlock, involvesUntakableProjection))
+      continue;
+
+    // We can store into an AllocStack (but not the pointer).
+    if (auto *si = dyn_cast<StoreInst>(user))
+      if (si->getDest() == def)
+        continue;
+
+    if (auto *sbi = dyn_cast<StoreBorrowInst>(user)) {
+      if (sbi->getDest() == def) {
+        if (isCaptured(sbi, inSingleBlock)) {
+          return true;
+        }
+        continue;
+      }
+    }
+
+    // Deallocation is also okay, as are DebugValue w/ address value. We will
+    // promote the latter into normal DebugValue.
+    if (isa<DeallocStackInst>(user) || DebugValueInst::hasAddrVal(user))
+      continue;
+
+    if (isa<EndBorrowInst>(user))
+      continue;
+
+    // Destroys of loadable types can be rewritten as releases, so
+    // they are fine.
+    if (auto *dai = dyn_cast<DestroyAddrInst>(user))
+      if (dai->getOperand()->getType().isLoadable(*dai->getFunction()))
+        continue;
+
+    // Other instructions are assumed to capture the AllocStack.
+    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack is captured by: " << *user);
+    return true;
+  }
+
+  // None of the users capture the AllocStack.
+  *inSingleBlock = (singleBlock != nullptr);
+  return false;
+}
+
+/// Returns true if the \p def is only stored into.
+bool MemoryToRegisters::isWriteOnlyAllocation(SILValue def) {
+  assert(isa<AllocStackInst>(def) || isa<StoreBorrowInst>(def));
+
+  // For all users of the def:
+  for (auto *use : def->getUses()) {
+    SILInstruction *user = use->getUser();
+
+    // It is okay to store into the AllocStack.
+    if (auto *si = dyn_cast<StoreInst>(user))
+      if (!isa<AllocStackInst>(si->getSrc()))
+        continue;
+
+    if (auto *sbi = dyn_cast<StoreBorrowInst>(user)) {
+      // Since all uses of the alloc_stack will be via store_borrow, check if
+      // there are any non-writes from the store_borrow location.
+      if (!isWriteOnlyAllocation(sbi)) {
+        return false;
+      }
+      continue;
+    }
+
+    // Deallocation is also okay.
+    if (isa<DeallocStackInst>(user))
+      continue;
+
+    if (isa<EndBorrowInst>(user))
+      continue;
+
+    // If we haven't already promoted the AllocStack, we may see
+    // DebugValue uses.
+    if (DebugValueInst::hasAddrVal(user))
+      continue;
+
+    if (isDeadAddrProjection(user))
+      continue;
+
+    // Can't do anything else with it.
+    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack has non-write use: " << *user);
+    return false;
+  }
+
+  return true;
+}
 
 void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
   LLVM_DEBUG(llvm::dbgs() << "*** Promoting in-block: " << *asi);
@@ -2121,31 +2094,12 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc) {
     deleter.forceDeleteWithUsers(alloc);
     return true;
   } else {
-    auto enableOptimizationForEnum = [](AllocStackInst *asi) {
-      if (asi->isLexical()) {
-        return false;
-      }
-      for (auto *use : asi->getUses()) {
-        auto *user = use->getUser();
-        if (!isa<StoreInst>(user) && !isa<StoreBorrowInst>(user)) {
-          continue;
-        }
-        auto stored = user->getOperand(CopyLikeInstruction::Src);
-        if (stored->isLexical()) {
-          return false;
-        }
-      }
-      return true;
-    };
-    // For stack locs of enum type that are lexical or with lexical stored
-    // values, we require that all uses are in the same block. This is because
-    // we can have incomplete lifetime of enum typed addresses, and on
-    // converting to value form this causes verification error. For all other
-    // stack locs of enum type, we use the lifetime completion utility to fix
-    // the lifetime. But when we have a lexical value, the utility can complete
-    // lifetimes on dead end blocks only.
-    if (f.hasOwnership() && alloc->getType().isOrHasEnum() &&
-        !enableOptimizationForEnum(alloc))
+    // For enums we require that all uses are in the same block.
+    // Otherwise there could be a switch_enum of an optional where the none-case
+    // does not have a destroy of the enum value.
+    // After transforming such an alloc_stack, the value would leak in the none-
+    // case block.
+    if (f.hasOwnership() && alloc->getType().isOrHasEnum())
       return false;
   }
 
@@ -2157,6 +2111,11 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc) {
   StackAllocationPromoter(alloc, domInfo, domTreeLevels, ctx, deleter,
                           instructionsToDelete)
       .run();
+
+  // Make sure that all of the allocations were promoted into registers.
+  assert(isWriteOnlyAllocation(alloc) && "Non-write uses left behind");
+  // ... and erase the allocation.
+  deleter.forceDeleteWithUsers(alloc);
   return true;
 }
 

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
@@ -1061,6 +1061,7 @@ enum KlassOptional {
 sil @return_optional_or_error : $@convention(thin) () -> (@owned KlassOptional, @error Error)
 
 // CHECK-LABEL: sil [ossa] @test_deadphi4 :
+// mem2reg cannot optimize an enum location which spans over multiple blocks.
 // CHECK:         alloc_stack
 // CHECK-LABEL: } // end sil function 'test_deadphi4'
 sil [ossa] @test_deadphi4 : $@convention(thin) (@owned KlassOptional) -> () {

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -489,10 +489,10 @@ bb0:
   return %16 : $((), ())
 }
 
-// CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks :
-// CHECK-NOT:         alloc_stack
-// CHECK:       } // end sil function 'test_optional_in_multiple_blocks'
-sil [ossa] @test_optional_in_multiple_blocks : $@convention(method) (@guaranteed Optional<Klass>) -> () {
+// CHECK-LABEL: sil [ossa] @dont_optimize_optional_in_multiple_blocks :
+// CHECK:         alloc_stack
+// CHECK:       } // end sil function 'dont_optimize_optional_in_multiple_blocks'
+sil [ossa] @dont_optimize_optional_in_multiple_blocks : $@convention(method) (@guaranteed Optional<Klass>) -> () {
 bb0(%0 : @guaranteed $Optional<Klass>):
   %1 = copy_value %0 : $Optional<Klass>
   %32 = alloc_stack $Optional<Klass>
@@ -504,62 +504,8 @@ bb5:
   br bb7
 
 bb6(%50 : @guaranteed $Klass):
-  %53 = load [copy] %32 : $*Optional<Klass>
+  %53 = load [take] %32 : $*Optional<Klass>
   destroy_value %53 : $Optional<Klass>
-  destroy_addr %32 : $*Optional<Klass>
-  dealloc_stack %32 : $*Optional<Klass>
-  br bb7
-
-bb7:
-  %r = tuple ()
-  return %r : $()
-}
-
-// CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks_lexical :
-// CHECK:         alloc_stack
-// CHECK:       } // end sil function 'test_optional_in_multiple_blocks_lexical'
-sil [ossa] @test_optional_in_multiple_blocks_lexical : $@convention(method) (@guaranteed Optional<Klass>) -> () {
-bb0(%0 : @guaranteed $Optional<Klass>):
-  %1 = copy_value %0 : $Optional<Klass>
-  %32 = alloc_stack [lexical] $Optional<Klass>
-  store %1 to [init] %32 : $*Optional<Klass>
-  switch_enum %0 : $Optional<Klass>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb5
-
-bb5:
-  dealloc_stack %32 : $*Optional<Klass>
-  br bb7
-
-bb6(%50 : @guaranteed $Klass):
-  %53 = load [copy] %32 : $*Optional<Klass>
-  destroy_value %53 : $Optional<Klass>
-  destroy_addr %32 : $*Optional<Klass>
-  dealloc_stack %32 : $*Optional<Klass>
-  br bb7
-
-bb7:
-  %r = tuple ()
-  return %r : $()
-}
-
-// CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue :
-// CHECK:         alloc_stack
-// CHECK:       } // end sil function 'test_optional_in_multiple_blocks_lexical_storedvalue'
-sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue : $@convention(method) (@owned Optional<Klass>) -> () {
-bb0(%0 : @owned $Optional<Klass>):
-  %1 = copy_value %0 : $Optional<Klass>
-  %32 = alloc_stack $Optional<Klass>
-  store %0 to [init] %32 : $*Optional<Klass>
-  switch_enum %1 : $Optional<Klass>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb5
-
-bb5:
-  dealloc_stack %32 : $*Optional<Klass>
-  br bb7
-
-bb6(%50 : @owned $Klass):
-  %53 = load [copy] %32 : $*Optional<Klass>
-  destroy_value %53 : $Optional<Klass>
-  destroy_value %50 : $Klass
-  destroy_addr %32 : $*Optional<Klass>
   dealloc_stack %32 : $*Optional<Klass>
   br bb7
 

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -53,11 +53,6 @@ struct UInt8 {
   var _value : Builtin.Int8
 }
 
-enum KlassOptional {
-  case some(Klass)
-  case none
-}
-
 sil [ossa] @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
 sil [ossa] @get_nontrivialenum : $@convention(thin) () -> @owned NonTrivialEnum
 sil [ossa] @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
@@ -1031,10 +1026,16 @@ bb12:
   return %39 : $()
 }
 
+enum KlassOptional {
+  case some(Klass)
+  case none
+}
+
 sil @return_optional_or_error : $@convention(thin) () -> (@owned KlassOptional, @error Error)
 
 // CHECK-LABEL: sil [ossa] @test_deadphi4 :
-// CHECK-NOT:         alloc_stack
+// mem2reg cannot optimize an enum location which spans over multiple blocks.
+// CHECK:         alloc_stack
 // CHECK-LABEL: } // end sil function 'test_deadphi4'
 sil [ossa] @test_deadphi4 : $@convention(thin) (@owned KlassOptional) -> () {
 bb0(%0 : @owned $KlassOptional):


### PR DESCRIPTION
Reverts #65085

This may have introduced a regression on Windows

```
cmd.exe /C "cd . && D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe -target x86_64-unknown-windows-msvc -j 2 -num-threads 2 -emit-library -o bin\Workspace.dll -module-name Workspace -module-link-name Workspace -emit-module -emit-module-path swift\Workspace.swiftmodule -emit-dependencies -DWorkspace_EXPORTS -sdk D:\a\swift-build\swift-build/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk -O -swift-version 5 -libc MD -Xcc -D_CRT_SECURE_NO_WARNINGS -output-file-map Sources\Workspace\CMakeFiles\Workspace.dir\Release\output-file-map.json -I D:\a\swift-build\swift-build\BinaryCache\swift-package-manager\swift -I D:\a\swift-build\swift-build\BinaryCache\swift-tools-support-core\swift -I D:\a\swift-build\swift-build\BinaryCache\swift-system\swift -I D:\a\swift-build\swift-build\SourceCache\swift-system\Sources\CSystem\include -I D:\a\swift-build\swift-build\BinaryCache\swift-collections\swift -I D:\a\swift-build\swift-build\BinaryCache\swift-crypto\swift -I D:\a\swift-build\swift-build\SourceCache\swift-crypto\Sources\CCryptoBoringSSL\include -I D:\a\swift-build\swift-build\BinaryCache\swift-certificates\swift -I D:\a\swift-build\swift-build\BinaryCache\swift-asn1\swift @CMakeFiles\Workspace.rsp    -Xlinker -implib:lib\Workspace.lib  && cd ."
Assertion failed: pai && pai->isOnStack(), file C:\a\swift-build\swift-build\SourceCache\swift\include\swift/SIL/OwnershipUseVisitor.h, line 295
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: D:\\a\\swift-build\\swift-build\\BuildRoot\\Library\\Developer\\Toolchains\\unknown-Asserts-development.xctoolchain\\usr\\bin\\swiftc.exe -frontend -c D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\CheckoutState.swift -primary-file D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\DefaultPluginScriptRunner.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\Diagnostics.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\FileSystemPackageContainer.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\InitPackage.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\ManagedArtifact.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\ManagedDependency.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\RegistryPackageContainer.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\ResolvedFileWatcher.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\ResolverPrecomputationProvider.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\SourceControlPackageContainer.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\ToolsVersionSpecificationRewriter.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\Workspace.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\Workspace+BinaryArtifacts.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\Workspace+Configuration.swift D:\\a\\swift-build\\swift-build\\SourceCache\\swift-package-manager\\Sources\\Workspace\\Workspace+State.swift -emit-module-path Sources\\Workspace\\CMakeFiles\\Workspace.dir\\DefaultPluginScriptRunner.swift.swiftmodule -emit-module-doc-path Sources\\Workspace\\CMakeFiles\\Workspace.dir\\DefaultPluginScriptRunner.swift.swiftdoc -emit-module-source-info-path Sources\\Workspace\\CMakeFiles\\Workspace.dir\\DefaultPluginScriptRunner.swift.swiftsourceinfo -emit-dependencies-path Sources\\Workspace\\CMakeFiles\\Workspace.dir\\DefaultPluginScriptRunner.swift.obj.d -target x86_64-unknown-windows-msvc -disable-objc-interop -sdk D:\\a\\swift-build\\swift-build/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-package-manager\\swift -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-tools-support-core\\swift -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-system\\swift -I D:\\a\\swift-build\\swift-build\\SourceCache\\swift-system\\Sources\\CSystem\\include -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-collections\\swift -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-crypto\\swift -I D:\\a\\swift-build\\swift-build\\SourceCache\\swift-crypto\\Sources\\CCryptoBoringSSL\\include -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-certificates\\swift -I D:\\a\\swift-build\\swift-build\\BinaryCache\\swift-asn1\\swift -module-link-name Workspace -swift-version 5 -O -D Workspace_EXPORTS -plugin-path D:\\a\\swift-build\\swift-build\\BuildRoot\\Library\\Developer\\Toolchains\\unknown-Asserts-development.xctoolchain\\usr\\lib\\swift\\host\\plugins -plugin-path D:\\a\\swift-build\\swift-build\\BuildRoot\\Library\\Developer\\Toolchains\\unknown-Asserts-development.xctoolchain\\usr\\local\\lib\\swift\\host\\plugins -Xcc -D_CRT_SECURE_NO_WARNINGS -autolink-library oldnames -autolink-library msvcrt -Xcc -D_MT -Xcc -D_DLL -parse-as-library -module-name Workspace -num-threads 2 -o Sources\\Workspace\\CMakeFiles\\Workspace.dir\\DefaultPluginScriptRunner.swift.obj
1.	compnerd.org Swift version 5.9-dev (LLVM 0b945a41db5d9af, Swift 4e71efce1f56373)
2.	Compiling with the current language version
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { PrepareOptimizationPasses, EarlyModulePasses, HighLevel,Function+EarlyLoopOpt, HighLevel,Module+StackPromote, MidLevel,Function, ClosureSpecialize, LowLevel,Function, LateLoopOpt, SIL Debug Info Generator } on SIL for Workspace)
4.	While running pass #67608 SILFunctionTransform "Mem2Reg" on SILFunction "@$s9Workspace25DefaultPluginScriptRunnerV07compilecD011sourceFiles10pluginName12toolsVersion18observabilityScope13callbackQueue8delegate10completionySay8TSCBasic12AbsolutePathVG_SS12PackageModel05ToolsL0V6Basics013ObservabilityN0C8Dispatch08DispatchP0C12SPMBuildCore0cD16CompilerDelegate_pys6ResultOyAY0C17CompilationResultVs5Error_pGctFyA0_yAL13ProcessResultVsA3__pGcfU3_".
 for expression at [D:\a\swift-build\swift-build\SourceCache\swift-package-manager\Sources\Workspace\DefaultPluginScriptRunner.swift:347:104 - line:387:9] RangeText="{
            // We are now on our caller's requested callback queue, so we just call the completion handler directly.
            dispatchPrecondition(condition: .onQueue(callbackQueue))
            completion($0.tryMap { process in
                // Emit the compiler output as observable info.
                let compilerOutput = ((try? process.utf8Output()) ?? "") + ((try? process.utf8stderrOutput()) ?? "")
                if !compilerOutput.isEmpty {
                    observabilityScope.emit(info: compilerOutput)
                }

                // Save the persisted compilation state for possible reuse next time.
                let compilationState = PersistedCompilationState(
                    commandLine: commandLine,
                    environment: toolchain.swiftCompilerEnvironment,
                    inputHash: compilerInputHash,
                    output: compilerOutput,
                    result: .init(process.exitStatus))
                do {
                    try JSONEncoder.makeWithDefaults().encode(path: stateFilePath, fileSystem: self.fileSystem, compilationState)
                }
                catch {
                    // We couldn't write out the `.state` file. We warn about it but proceed.
                    observabilityScope.emit(debug: "Couldn't save plugin compilation state (\(error))")
                }

                // Construct a PluginCompilationResult for both the successful and unsuccessful cases (to convey diagnostics, etc).
                let result = PluginCompilationResult(
                    succeeded: compilationState.succeeded,
                    commandLine: commandLine,
                    executableFile: execFilePath,
                    diagnosticsFile: diagFilePath,
                    compilerOutput: compilerOutput,
                    cached: false)

                // Tell the delegate that we're done compiling the plugin, passing it the result.
                delegate.didCompilePlugin(result: result)

                // Also return the result to the caller.
                return result
            })
        "
Exception Code: 0x80000003
 #0 0x00007ff65fa52675 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x55c2675)
 #1 0x00007ffa17d9bab4 (C:\Windows\System32\ucrtbase.dll+0x7bab4)
 #2 0x00007ffa17d9ca81 (C:\Windows\System32\ucrtbase.dll+0x7ca81)
 #3 0x00007ffa17d9e451 (C:\Windows\System32\ucrtbase.dll+0x7e451)
 #4 0x00007ffa17d9e691 (C:\Windows\System32\ucrtbase.dll+0x7e691)
 #5 0x00007ff65b57d04e (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x10ed04e)
 #6 0x00007ff65b4b0c73 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x1020c73)
 #7 0x00007ff65b4b0d1a (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x1020d1a)
 #8 0x00007ff65b4b0d1a (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x1020d1a)
 #9 0x00007ff65b4af512 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x101f512)
#10 0x00007ff65b5584b7 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x10c84b7)
#11 0x00007ff65b57ce6c (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x10ece6c)
#12 0x00007ff65b57d40e (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x10ed40e)
#13 0x00007ff65b57c643 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x10ec643)
#14 0x00007ff65b57a859 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x10ea859)
#15 0x00007ff65af4386d (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xab386d)
#16 0x00007ff65af3fdbb (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xaafdbb)
#17 0x00007ff65af42f77 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xab2f77)
#18 0x00007ff65af43397 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xab3397)
#19 0x00007ff65acb6053 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x826053)
#20 0x00007ff65acb5331 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x825331)
#21 0x00007ff65acb38fc (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x8238fc)
#22 0x00007ff65acb3bb4 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x823bb4)
#23 0x00007ff65acb3607 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x807)
#24 0x00007ff65ac813ad (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x7f13ad)
#25 0x00007ff65acb01fb (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x8201fb)
#26 0x00007ff65acb3c54 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x823c54)
#27 0x00007ff65ac811c5 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x7f11c5)
#28 0x00007ff65a745c45 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x2b5c45)
#29 0x00007ff65a55a78d (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xca78d)
#30 0x00007ff65a55b6a2 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xcb6a2)
#31 0x00007ff65a559ff5 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xc9ff5)
#32 0x00007ff65a55a45b (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xca45b)
#33 0x00007ff65a55ca44 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0xcca44)
#34 0x00007ff65a518bf6 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x88bf6)
#35 0x00007ff65a518729 (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x88729)
#36 0x00007ff65fade16c (D:\a\swift-build\swift-build\BuildRoot\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swiftc.exe+0x564e16c)
#37 0x00007ffa19e24de0 (C:\Windows\System32\KERNEL32.DLL+0x14de0)
#38 0x00007ffa1a7de3db (C:\Windows\SYSTEM32\ntdll.dll+0x7e3db)

<unknown>:0: error: compile command failed due to signal -2147483645 (use -v to see invocation)
```