### PR TITLE
[swift][AutoLinkExtract] Don't add autolink hint for frameworks. (#65…

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1575,8 +1575,7 @@ void AutolinkKind::collectEntriesFromLibraries(
   llvm::LLVMContext &ctx = IGM.getLLVMContext();
 
   switch (Value) {
-  case AutolinkKind::LLVMLinkerOptions:
-  case AutolinkKind::SwiftAutoLinkExtract: {
+  case AutolinkKind::LLVMLinkerOptions: {
     // On platforms that support autolinking, continue to use the metadata.
     for (LinkLibrary linkLib : AutolinkEntries) {
       switch (linkLib.getKind()) {
@@ -1592,6 +1591,24 @@ void AutolinkKind::collectEntriesFromLibraries(
         Entries.insert(llvm::MDNode::get(ctx, args));
         continue;
       }
+      }
+      llvm_unreachable("Unhandled LibraryKind in switch.");
+    }
+    return;
+  }
+  case AutolinkKind::SwiftAutoLinkExtract: {
+    // On platforms that support autolinking, continue to use the metadata.
+    for (LinkLibrary linkLib : AutolinkEntries) {
+      switch (linkLib.getKind()) {
+      case LibraryKind::Library: {
+        llvm::SmallString<32> opt =
+            getTargetDependentLibraryOption(IGM.Triple, linkLib.getName());
+        Entries.insert(llvm::MDNode::get(ctx, llvm::MDString::get(ctx, opt)));
+        continue;
+      }
+      case LibraryKind::Framework:
+        // Frameworks are not supported with Swift Autolink Extract.
+        continue;
       }
       llvm_unreachable("Unhandled LibraryKind in switch.");
     }

--- a/test/AutolinkExtract/Inputs/Frameworks/Link.framework/Headers/Link.h
+++ b/test/AutolinkExtract/Inputs/Frameworks/Link.framework/Headers/Link.h
@@ -1,0 +1,1 @@
+extern int APIFromLinkFramework;

--- a/test/AutolinkExtract/Inputs/Frameworks/Link.framework/Modules/module.modulemap
+++ b/test/AutolinkExtract/Inputs/Frameworks/Link.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module Link {
+    umbrella header "Link.h"
+    export *
+}

--- a/test/AutolinkExtract/import_framework.swift
+++ b/test/AutolinkExtract/import_framework.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -c %s -F %S/Inputs/Frameworks -o %t/import_framework.o
+// RUN: %target-swift-autolink-extract %t/import_framework.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
+
+// REQUIRES: autolink-extract
+
+// CHECK-elf-NOT: Link
+// CHECK-coff-NOT: Link
+
+import Link
+_ = Link.APIFromLinkFramework


### PR DESCRIPTION
…051)

Default system linkers on non-Darwin platforms do not support the `-framework` argument for framework linking. This change updates autolinking to not emit `-framework` into the .o _swift1_autolink_entries metadata when there is no native linker support.

This is related to rdar://106578342.

(cherry picked from commit 17c5010d0b977ce2d582c643c8092ccdfb852534)