### PR TITLE
Tests: Fix attr_availability_maccatalyst_implicit.swift

### DIFF
--- a/test/attr/attr_availability_maccatalyst_implicit.swift
+++ b/test/attr/attr_availability_maccatalyst_implicit.swift
@@ -16,8 +16,8 @@ extension NSBaseClass {
   // expected-warning@+3 {{_modify accessor cannot be more available than enclosing scope}}
   // expected-note@+2 {{_modify accessor implicitly declared here with availability of Mac Catalyst 13.1 or newer}}
   // expected-note@+1 {{enclosing scope requires availability of Mac Catalyst 15.0 or newer}}
-  var property: Int {
-    get { 1 }
+  var property: NSBaseClass {
+    get { self }
     set {}
   }
 }


### PR DESCRIPTION
Apparently, even though the test requires `maccatalyst_support` the standard library for the macCatalyst target triple seems to be inaccessible.

Resolves rdar://108044465
