### PR TITLE
[RemoteInspection] Specify precise return type of RecordTypeInfo (NFC)

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -121,7 +121,8 @@ class ReflectionContext
   using super::readMetadata;
   using super::readObjCClassName;
   using super::readResolvedPointerValue;
-  std::unordered_map<typename super::StoredPointer, const TypeInfo *> Cache;
+  std::unordered_map<typename super::StoredPointer, const RecordTypeInfo *>
+      Cache;
 
   /// All buffers we need to keep around long term. This will automatically free them
   /// when this object is destroyed.
@@ -873,7 +874,7 @@ public:
 
   /// Return a description of the layout of a class instance with the given
   /// metadata as its isa pointer.
-  const TypeInfo *
+  const RecordTypeInfo *
   getMetadataTypeInfo(StoredPointer MetadataAddress,
                       remote::TypeInfoProvider *ExternalTypeInfo) {
     // See if we cached the layout already
@@ -883,7 +884,7 @@ public:
 
     auto &TC = getBuilder().getTypeConverter();
 
-    const TypeInfo *TI = nullptr;
+    const RecordTypeInfo *TI = nullptr;
 
     auto TR = readTypeFromMetadata(MetadataAddress);
     auto kind = this->readKindFromMetadata(MetadataAddress);

--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -377,7 +377,7 @@ public:
   /// class.
   ///
   /// Not cached.
-  const TypeInfo *
+  const RecordTypeInfo *
   getClassInstanceTypeInfo(const TypeRef *TR, unsigned start,
                            remote::TypeInfoProvider *ExternalTypeInfo);
 

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2602,7 +2602,7 @@ TypeConverter::getTypeInfo(const TypeRef *TR,
   return TI;
 }
 
-const TypeInfo *TypeConverter::getClassInstanceTypeInfo(
+const RecordTypeInfo *TypeConverter::getClassInstanceTypeInfo(
     const TypeRef *TR, unsigned start,
     remote::TypeInfoProvider *ExternalTypeInfo) {
   auto FD = getBuilder().getFieldTypeInfo(TR);


### PR DESCRIPTION
Update the return type of `ReflectionContext::getMetadataTypeInfo` and `TypeConverter::getClassInstanceTypeInfo` to be more precise: `RecordTypeInfo` instead of `TypeInfo`. This means callers don't have to unnecessarily dynamically check types and down cast.