### PR TITLE
[AST] Convert ASTContext::getSwiftName to a free function

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -160,7 +160,7 @@ namespace ide {
 /// While the names of Foundation types aren't likely to change in
 /// Objective-C, their mapping into Swift can. Therefore, when
 /// referring to names of Foundation entities in Swift, use this enum
-/// and \c ASTContext::getSwiftName or \c ASTContext::getSwiftId.
+/// and \c swift::getSwiftName or \c ASTContext::getSwiftId.
 enum class KnownFoundationEntity {
 #define FOUNDATION_ENTITY(Name) Name,
 #include "swift/AST/KnownFoundationEntities.def"
@@ -169,6 +169,10 @@ enum class KnownFoundationEntity {
 /// Retrieve the Foundation entity kind for the given Objective-C
 /// entity name.
 Optional<KnownFoundationEntity> getKnownFoundationEntity(StringRef name);
+
+/// Retrieve the Swift name for the given Foundation entity, where
+/// "NS" prefix stripping will apply under omit-needless-words.
+StringRef getSwiftName(KnownFoundationEntity kind);
 
 /// Introduces a new constraint checker arena, whose lifetime is
 /// tied to the lifetime of this RAII object.
@@ -1344,14 +1348,10 @@ public:
   /// Returns memory used exclusively by constraint solver.
   size_t getSolverMemory() const;
 
-  /// Retrieve the Swift name for the given Foundation entity, where
-  /// "NS" prefix stripping will apply under omit-needless-words.
-  StringRef getSwiftName(KnownFoundationEntity kind);
-
   /// Retrieve the Swift identifier for the given Foundation entity, where
   /// "NS" prefix stripping will apply under omit-needless-words.
   Identifier getSwiftId(KnownFoundationEntity kind) {
-    return getIdentifier(getSwiftName(kind));
+    return getIdentifier(swift::getSwiftName(kind));
   }
 
   /// Populate \p names with visible top level module names.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3046,7 +3046,7 @@ Optional<KnownFoundationEntity> swift::getKnownFoundationEntity(StringRef name){
     .Default(None);
 }
 
-StringRef ASTContext::getSwiftName(KnownFoundationEntity kind) {
+StringRef swift::getSwiftName(KnownFoundationEntity kind) {
   StringRef objcName;
   switch (kind) {
 #define FOUNDATION_ENTITY(Name) case KnownFoundationEntity::Name:  \

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -248,7 +248,7 @@ clang::QualType ClangTypeConverter::visitStructType(StructType *type) {
   CHECK_NAMED_TYPE("OpaquePointer", ctx.VoidPtrTy);
   CHECK_NAMED_TYPE("CVaListPointer", getClangDecayedVaListType(ctx));
   CHECK_NAMED_TYPE("DarwinBoolean", ctx.UnsignedCharTy);
-  CHECK_NAMED_TYPE(swiftDecl->getASTContext().getSwiftName(
+  CHECK_NAMED_TYPE(swift::getSwiftName(
                      KnownFoundationEntity::NSZone),
                    ctx.VoidPtrTy);
   CHECK_NAMED_TYPE("WindowsBool", ctx.IntTy);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -454,7 +454,7 @@ namespace {
           ModuleDecl *objCModule = Impl.SwiftContext.getLoadedModule(Id_ObjectiveC);
           Type wrapperTy = Impl.getNamedSwiftType(
                              objCModule,
-                             Impl.SwiftContext.getSwiftName(
+                             swift::getSwiftName(
                                KnownFoundationEntity::NSZone));
           if (wrapperTy)
             return {wrapperTy, ImportHint::OtherPointer};
@@ -1358,7 +1358,7 @@ static Type maybeImportNSErrorOutParameter(ClangImporter::Implementation &impl,
 
   // FIXME: Avoid string comparison by caching this identifier.
   if (elementClass->getName().str() !=
-        impl.SwiftContext.getSwiftName(KnownFoundationEntity::NSError))
+        swift::getSwiftName(KnownFoundationEntity::NSError))
     return Type();
 
   if (!impl.canImportFoundationModule() ||
@@ -1369,7 +1369,7 @@ static Type maybeImportNSErrorOutParameter(ClangImporter::Implementation &impl,
   if (resugarNSErrorPointer)
     return impl.getNamedSwiftType(
       foundationModule,
-        impl.SwiftContext.getSwiftName(
+        swift::getSwiftName(
           KnownFoundationEntity::NSErrorPointer));
 
   // The imported type is AUMP<NSError?>, but the typealias is AUMP<NSError?>?

--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -146,13 +146,13 @@ MAP_TYPE("__swift_shims_dispatch_data_t", ObjCId, 0, "Dispatch", "dispatch_data_
 MAP_TYPE("SEL",  ObjCSel, 0, "ObjectiveC", "Selector", false, DoNothing)
 MAP_STDLIB_TYPE("Class", ObjCClass, 0, "AnyClass", false, DoNothing)
 MAP_STDLIB_TYPE(
-  Impl.SwiftContext.getSwiftName(KnownFoundationEntity::NSInteger),
+  swift::getSwiftName(KnownFoundationEntity::NSInteger),
   SignedWord, 0, "Int", false, DefineOnly)
 
 // Treat NSUInteger specially: exposing it as a typealias for "Int" would be
 // confusing.
 MAP_STDLIB_TYPE(
-  Impl.SwiftContext.getSwiftName(KnownFoundationEntity::NSUInteger),
+  swift::getSwiftName(KnownFoundationEntity::NSUInteger),
   UnsignedWord, 0, "Int", false, DoNothing)
 
 // CGFloat.

--- a/lib/PrintAsClang/PrimitiveTypeMapping.cpp
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.cpp
@@ -88,7 +88,7 @@ void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
       "BOOL", None, None, false};
   mappedTypeNames[{ID_ObjectiveC, ctx.getIdentifier("Selector")}] = {
       "SEL", None, None, true};
-  mappedTypeNames[{ID_ObjectiveC, ctx.getIdentifier(ctx.getSwiftName(
+  mappedTypeNames[{ID_ObjectiveC, ctx.getIdentifier(swift::getSwiftName(
                                       KnownFoundationEntity::NSZone))}] = {
       "struct _NSZone *", None, None, true};
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1374,7 +1374,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       repr->overwriteNameRef(DeclNameRef(ctx.getIdentifier(RemappedTy)));
 
       // HACK: 'NSUInteger' suggests both 'UInt' and 'Int'.
-      if (TypeName == ctx.getSwiftName(KnownFoundationEntity::NSUInteger)) {
+      if (TypeName == swift::getSwiftName(KnownFoundationEntity::NSUInteger)) {
         diags.diagnose(L, diag::note_remapped_type, "UInt")
           .fixItReplace(R, "UInt");
       }


### PR DESCRIPTION
The only state `getSwiftName` uses is its argument, and can be made a free function. Of note the inverse operation, `getKnownFoundationEntity`, is also a free function. This removes the requirement that callers have an `ASTContext` instance.

(cherry-picked from commit fb524c0b865659cd81af31241667abf808677006)