### PR TITLE
Windows: add wincred.h to the modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -460,6 +460,13 @@ module WinSDK [system] {
     export *
   }
 
+  module WinCred {
+    header "wincred.h"
+    export *
+
+    link "AdvAPI32.lib"
+  }
+
   module WinDNS {
     header "WinDNS.h"
     export *


### PR DESCRIPTION
This adds the Windows credentials API to the modulemap for the Windows SDK module.