### PR TITLE
[SE-0365] Allow implicit self in inner functions in [weak self] closures, like with [self] closures

### DIFF
--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -401,17 +401,66 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
   // and check that both its LHS and RHS are 'self'
   for (auto cond : conditionalStmt->getCond()) {
     if (auto pattern = cond.getPattern()) {
-      if (pattern->getBoundName() != Ctx.Id_self) {
+      bool isSelfRebinding = false;
+
+      if (pattern->getBoundName() == Ctx.Id_self) {
+        isSelfRebinding = true;
+      }
+
+      else if (auto OSP = dyn_cast<OptionalSomePattern>(pattern)) {
+        if (auto subPattern = OSP->getSubPattern()) {
+          if (subPattern->getBoundName() == Ctx.Id_self) {
+            isSelfRebinding = true;
+          }
+        }
+      }
+
+      if (!isSelfRebinding) {
         continue;
       }
     }
 
-    if (auto selfDRE = dyn_cast<DeclRefExpr>(cond.getInitializer())) {
-      return (selfDRE->getDecl()->getName().isSimpleName(Ctx.Id_self));
+    DeclRefExpr *condDRE = nullptr;
+    if (auto DRE = dyn_cast<DeclRefExpr>(cond.getInitializer())) {
+      condDRE = DRE;
     }
+
+    if (auto LE = dyn_cast<LoadExpr>(cond.getInitializer())) {
+      if (auto DRE = dyn_cast_or_null<DeclRefExpr>(LE->getSubExpr())) {
+        condDRE = DRE;
+      }
+    }
+
+    if (!condDRE) {
+      return false;
+    }
+
+    return condDRE->getDecl()->getName().isSimpleName(Ctx.Id_self);
   }
 
   return false;
+}
+
+// Finds the nearest parent closure, which would define the
+// permitted usage of implicit self. In closures this is most
+// often just `dc` itself, but in functions defined in the
+// closure body this would be some parent context.
+AbstractClosureExpr *closestParentClosure(DeclContext *dc) {
+  if (!dc) {
+    return nullptr;
+  }
+
+  if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
+    return closure;
+  }
+
+  // Stop searching if we find a type decl, since types always
+  // redefine what 'self' means, even when nested inside a closure.
+  if (dc->getContextKind() == DeclContextKind::GenericTypeDecl) {
+    return nullptr;
+  }
+
+  return closestParentClosure(dc->getParent());
 }
 
 ValueDecl *UnqualifiedLookupFactory::ResultFinderForTypeContext::lookupBaseDecl(
@@ -425,7 +474,8 @@ ValueDecl *UnqualifiedLookupFactory::ResultFinderForTypeContext::lookupBaseDecl(
   // self _always_ refers to the context's self `ParamDecl`, even if there
   // is another local decl with the name `self` that would be found by
   // `lookupSingleLocalDecl`.
-  auto closureExpr = dyn_cast<ClosureExpr>(factory->DC);
+  auto parentACE = closestParentClosure(factory->DC);
+  auto closureExpr = dyn_cast_or_null<ClosureExpr>(parentACE);
   if (!closureExpr) {
     return nullptr;
   }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -409,9 +409,7 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
 
       else if (auto OSP = dyn_cast<OptionalSomePattern>(pattern)) {
         if (auto subPattern = OSP->getSubPattern()) {
-          if (subPattern->getBoundName() == Ctx.Id_self) {
-            isSelfRebinding = true;
-          }
+          isSelfRebinding = subPattern->getBoundName() == Ctx.Id_self;
         }
       }
 
@@ -445,12 +443,12 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
 // permitted usage of implicit self. In closures this is most
 // often just `dc` itself, but in functions defined in the
 // closure body this would be some parent context.
-AbstractClosureExpr *closestParentClosure(DeclContext *dc) {
+ClosureExpr *closestParentClosure(DeclContext *dc) {
   if (!dc) {
     return nullptr;
   }
 
-  if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
+  if (auto closure = dyn_cast<ClosureExpr>(dc)) {
     return closure;
   }
 
@@ -474,8 +472,7 @@ ValueDecl *UnqualifiedLookupFactory::ResultFinderForTypeContext::lookupBaseDecl(
   // self _always_ refers to the context's self `ParamDecl`, even if there
   // is another local decl with the name `self` that would be found by
   // `lookupSingleLocalDecl`.
-  auto parentACE = closestParentClosure(factory->DC);
-  auto closureExpr = dyn_cast_or_null<ClosureExpr>(parentACE);
+  auto closureExpr = closestParentClosure(factory->DC);
   if (!closureExpr) {
     return nullptr;
   }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -418,18 +418,17 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
       }
     }
 
-    DeclRefExpr *condDRE = nullptr;
-    if (auto DRE = dyn_cast<DeclRefExpr>(cond.getInitializer())) {
-      condDRE = DRE;
-    }
-
-    if (auto LE = dyn_cast<LoadExpr>(cond.getInitializer())) {
-      if (auto DRE = dyn_cast_or_null<DeclRefExpr>(LE->getSubExpr())) {
-        condDRE = DRE;
+    Expr *exprToCheckForDRE = cond.getInitializer();
+    if (auto LE = dyn_cast<LoadExpr>(exprToCheckForDRE)) {
+      if (auto subexpr = LE->getSubExpr()) {
+        exprToCheckForDRE = subexpr;
       }
     }
 
-    if (!condDRE) {
+    exprToCheckForDRE = exprToCheckForDRE->getSemanticsProvidingExpr();
+
+    DeclRefExpr *condDRE = dyn_cast<DeclRefExpr>(exprToCheckForDRE);
+    if (!condDRE || !condDRE->getDecl()->hasName()) {
       return false;
     }
 


### PR DESCRIPTION


This PR fixes an issue in the implementation of [SE-0365](https://github.com/apple/swift-evolution/blob/main/proposals/0365-implicit-self-weak-capture.md), where implicit self was disallowed inside inner function declarations:

```swift
doWorkEscaping { [weak self] in
  guard let self else { return }
  func innerFunction() {
    // Before: Error: call to method 'test' in closure requires explicit use of 'self' to make capture semantics explicit
    // Now allowed without an error
    test()
  }
}
``` 

The intent of SE-0365 is to mirror the behavior of SE-0269 with `[self]` captures. This usage is allowed by SE-0269, so it should be allowed by SE-0365 as well:

```swift
doWorkEscaping { [self] in
  func innerFunction() {
    test() // ✅
  }
}
``` 

I [confirmed on the forums](https://forums.swift.org/t/why-does-se-0269-have-different-rules-for-inner-closures-vs-inner-functions/64334) that this was an intentional design choice of SE-0269.

Please review: @xedin 