### PR TITLE
build: Further fixes for Cxx w/o stdlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1269,10 +1269,10 @@ else()
 
   if(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT)
     add_subdirectory(stdlib/toolchain)
-  endif()
 
-  if(SWIFT_BUILD_STDLIB_CXX_MODULE)
-    add_subdirectory(stdlib/public/Cxx)
+    if(SWIFT_BUILD_STDLIB_CXX_MODULE)
+      add_subdirectory(stdlib/public/Cxx)
+    endif()
   endif()
 
   if (BUILD_SWIFT_CONCURRENCY_BACK_DEPLOYMENT_LIBRARIES)


### PR DESCRIPTION
In #65172 I tried to fix a problem when the Cxx module is enabled, but we are not building the stdlib. The fix work for `swiftCxx`, but I failed to to realize that `swiftCxxStdlib` overlay is also built, which needs parts of the stdlib.

The original #65055 only built the Cxx module when `EXTRA_TOOLCHAIN_CONTENT` was set, but #65122 changed so it was two independent checks. A more faithful fix will had been to nest the `if` as I am trying to do with this PR. Parts of #65172 are still necessary to build in every case, though: the `swiftCxx` target is dependent on the Clang headers and the legacy layouts. Those two pieces are normally in place because of other targets in upstream builds, but fail to materialize when the stdlib is trying to be built with the host compiler in isolation.

This one and #65172 will need to be cherry-picked to 5.9 because #65055 and #65122 where cherry-picked, so 5.9 is having the same problems as `main`.