### PR TITLE
[Macros] Break reference cycles involving visible name lookup

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -372,10 +372,12 @@ OrigDeclAttributes Decl::getOriginalAttrs() const {
 }
 
 DeclAttributes Decl::getSemanticAttrs() const {
-  auto mutableThis = const_cast<Decl *>(this);
-  (void)evaluateOrDefault(getASTContext().evaluator,
-                          ExpandMemberAttributeMacros{mutableThis},
-                          { });
+  if (!getASTContext().evaluator.hasActiveResolveMacroRequest()) {
+    auto mutableThis = const_cast<Decl *>(this);
+    (void)evaluateOrDefault(getASTContext().evaluator,
+                            ExpandMemberAttributeMacros{mutableThis},
+                            { });
+  }
 
   return getAttrs();
 }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -255,17 +255,22 @@ static void doGlobalExtensionLookup(Type BaseType,
 
     // Expand member macros.
     ASTContext &ctx = nominal->getASTContext();
-    (void)evaluateOrDefault(
-        ctx.evaluator,
-        ExpandSynthesizedMemberMacroRequest{extension},
-        false);
+    if (!ctx.evaluator.hasActiveRequest(
+            ExpandSynthesizedMemberMacroRequest{extension})) {
+      (void)evaluateOrDefault(
+          ctx.evaluator,
+          ExpandSynthesizedMemberMacroRequest{extension},
+          false);
+    }
 
     // Expand peer macros.
     for (auto *member : extension->getMembers()) {
-      (void)evaluateOrDefault(
-          ctx.evaluator,
-          ExpandPeerMacroRequest{member},
-          {});
+      if (!ctx.evaluator.hasActiveRequest(ExpandPeerMacroRequest{member})) {
+        (void)evaluateOrDefault(
+            ctx.evaluator,
+            ExpandPeerMacroRequest{member},
+            {});
+      }
     }
 
     collectVisibleMemberDecls(CurrDC, LS, BaseType, extension, FoundDecls);
@@ -622,16 +627,21 @@ static void synthesizeMemberDeclsForLookup(NominalTypeDecl *NTD,
 
   // Expand synthesized member macros.
   auto &ctx = NTD->getASTContext();
-  (void)evaluateOrDefault(ctx.evaluator,
-                          ExpandSynthesizedMemberMacroRequest{NTD},
-                          false);
+  if (!ctx.evaluator.hasActiveRequest(
+          ExpandSynthesizedMemberMacroRequest{NTD})) {
+    (void)evaluateOrDefault(ctx.evaluator,
+                            ExpandSynthesizedMemberMacroRequest{NTD},
+                            false);
+  }
 
   // Expand peer macros.
   for (auto *member : NTD->getMembers()) {
-    (void)evaluateOrDefault(
-        ctx.evaluator,
-        ExpandPeerMacroRequest{member},
-        {});
+    if (!ctx.evaluator.hasActiveRequest(ExpandPeerMacroRequest{member})) {
+      (void)evaluateOrDefault(
+          ctx.evaluator,
+          ExpandPeerMacroRequest{member},
+          {});
+    }
   }
 
   synthesizePropertyWrapperVariables(NTD);

--- a/test/Macros/macro_expand_other.swift
+++ b/test/Macros/macro_expand_other.swift
@@ -1,0 +1,38 @@
+// Expanding macros that are defined in terms of other macros.
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Diagnostics testing
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
+
+// Execution testing
+// RUN: %target-build-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-codesign %t/main
+// REQUIRES: swift_swift_parser, executable_test
+
+@freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+@freestanding(expression) macro stringifySeven() -> (Int, String) = #stringify(7)
+
+@freestanding(expression) macro recurse(_: Bool) = #externalMacro(module: "MacroDefinition", type: "RecursiveMacro")
+
+@freestanding(expression) macro recurseThrough(_ value: Bool) = #recurse(value)
+
+func testFreestandingExpansionOfOther() {
+  // CHECK: ---testFreestandingExpansionOfOther
+  print("---testFreestandingExpansionOfOther")
+
+  // CHECK-NEXT: (7, "7")
+  print(#stringifySeven)
+
+  #recurseThrough(false)
+
+  #if TEST_DIAGNOSTICS
+#recurseThrough(true)
+  // expected-note@-1 2{{in expansion of macro 'recurseThrough' here}}
+  #endif
+}
+
+testFreestandingExpansionOfOther()

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -6,12 +6,12 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DTEST_DIAGNOSTICS
 
 // Check with the imported macro library vs. the local declaration of the macro.
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t -DTEST_DIAGNOSTICS
 
 
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
@@ -147,4 +147,12 @@ struct S2 {
   func g(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }
+
+  #if TEST_DIAGNOSTICS
+  // expected-error@+1{{cannot find 'nonexistent' in scope}}
+  @addCompletionHandlerArbitrarily(nonexistent)
+  func h(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+  #endif
 }


### PR DESCRIPTION
Break some reference cycles involving macro resolution that were uncovered through visible name in invalid code.