### PR TITLE
[Macros] Break reference cycles involving visible name lookup

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -372,10 +372,12 @@ OrigDeclAttributes Decl::getOriginalAttrs() const {
 }
 
 DeclAttributes Decl::getSemanticAttrs() const {
-  auto mutableThis = const_cast<Decl *>(this);
-  (void)evaluateOrDefault(getASTContext().evaluator,
-                          ExpandMemberAttributeMacros{mutableThis},
-                          { });
+  if (!getASTContext().evaluator.hasActiveResolveMacroRequest()) {
+    auto mutableThis = const_cast<Decl *>(this);
+    (void)evaluateOrDefault(getASTContext().evaluator,
+                            ExpandMemberAttributeMacros{mutableThis},
+                            { });
+  }
 
   return getAttrs();
 }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -255,17 +255,22 @@ static void doGlobalExtensionLookup(Type BaseType,
 
     // Expand member macros.
     ASTContext &ctx = nominal->getASTContext();
-    (void)evaluateOrDefault(
-        ctx.evaluator,
-        ExpandSynthesizedMemberMacroRequest{extension},
-        false);
+    if (!ctx.evaluator.hasActiveRequest(
+            ExpandSynthesizedMemberMacroRequest{extension})) {
+      (void)evaluateOrDefault(
+          ctx.evaluator,
+          ExpandSynthesizedMemberMacroRequest{extension},
+          false);
+    }
 
     // Expand peer macros.
     for (auto *member : extension->getMembers()) {
-      (void)evaluateOrDefault(
-          ctx.evaluator,
-          ExpandPeerMacroRequest{member},
-          {});
+      if (!ctx.evaluator.hasActiveRequest(ExpandPeerMacroRequest{member})) {
+        (void)evaluateOrDefault(
+            ctx.evaluator,
+            ExpandPeerMacroRequest{member},
+            {});
+      }
     }
 
     collectVisibleMemberDecls(CurrDC, LS, BaseType, extension, FoundDecls);
@@ -622,16 +627,21 @@ static void synthesizeMemberDeclsForLookup(NominalTypeDecl *NTD,
 
   // Expand synthesized member macros.
   auto &ctx = NTD->getASTContext();
-  (void)evaluateOrDefault(ctx.evaluator,
-                          ExpandSynthesizedMemberMacroRequest{NTD},
-                          false);
+  if (!ctx.evaluator.hasActiveRequest(
+          ExpandSynthesizedMemberMacroRequest{NTD})) {
+    (void)evaluateOrDefault(ctx.evaluator,
+                            ExpandSynthesizedMemberMacroRequest{NTD},
+                            false);
+  }
 
   // Expand peer macros.
   for (auto *member : NTD->getMembers()) {
-    (void)evaluateOrDefault(
-        ctx.evaluator,
-        ExpandPeerMacroRequest{member},
-        {});
+    if (!ctx.evaluator.hasActiveRequest(ExpandPeerMacroRequest{member})) {
+      (void)evaluateOrDefault(
+          ctx.evaluator,
+          ExpandPeerMacroRequest{member},
+          {});
+    }
   }
 
   synthesizePropertyWrapperVariables(NTD);

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -2,12 +2,12 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DTEST_DIAGNOSTICS
 
 // Check with the imported macro library vs. the local declaration of the macro.
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t -DTEST_DIAGNOSTICS
 
 
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
@@ -143,4 +143,12 @@ struct S2 {
   func g(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }
+
+  #if TEST_DIAGNOSTICS
+  // expected-error@+1{{cannot find 'nonexistent' in scope}}
+  @addCompletionHandlerArbitrarily(nonexistent)
+  func h(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+  #endif
 }


### PR DESCRIPTION
* **Explanation**: Lookup of all visible declarations, which occurs primarily in invalid code, could trigger request cycles due to macro expansion. Break those reference cycles.
* **Scope**: Impacts new, invalid code using macro expansion .
* **Risk**: Low.
* **Testing**: Extend existing tests.
* **Main branch PR**: https://github.com/apple/swift/pull/65219