### PR TITLE
build: Fixes for building Cxx w/, w/o stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1287,7 +1287,7 @@ else()
 
   # Some tools (e.g. swift-reflection-dump) rely on a host swiftRemoteInspection,
   # so ensure we build that when building tools.
-  if(SWIFT_INCLUDE_TOOLS)
+  if(SWIFT_INCLUDE_TOOLS OR SWIFT_BUILD_STDLIB_CXX_MODULE)
     add_subdirectory(stdlib/public/SwiftShims/swift/shims)
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1274,10 +1274,10 @@ else()
 
   if(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT)
     add_subdirectory(stdlib/toolchain)
-  endif()
 
-  if(SWIFT_BUILD_STDLIB_CXX_MODULE)
-    add_subdirectory(stdlib/public/Cxx)
+    if(SWIFT_BUILD_STDLIB_CXX_MODULE)
+      add_subdirectory(stdlib/public/Cxx)
+    endif()
   endif()
 
   if (BUILD_SWIFT_CONCURRENCY_BACK_DEPLOYMENT_LIBRARIES)

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -1,6 +1,14 @@
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake/modules)
+include(StdlibOptions)
+
 set(SWIFT_CXX_LIBRARY_KIND STATIC)
 if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
   set(SWIFT_CXX_LIBRARY_KIND SHARED)
+endif()
+
+set(SWIFT_CXX_DEPS symlink_clang_headers)
+if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
+  list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
 add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
@@ -20,6 +28,7 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     -Xcc -nostdinc++
 
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+    DEPENDS ${SWIFT_CXX_DEPS}
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED)
 


### PR DESCRIPTION
Two cherry-picks: from #65172 and a follow up #65217. The changes in `main` that those two pull request are trying to fix (#65055 and #65122), were cherry-picked into `release/5.9` with #65065, so the same problems that occur in `main` now occur in `release/5.9`.

This only affects people building only the compiler with no stdlib (a no stdlib extra toolchain content either), and later using that compiler as host compiler to build the stdlib in isolation.

/cc @egorzhdan 