### PR TITLE
[Parser] Make parser aware of the unexpected attributes in operator declarations

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -461,7 +461,8 @@ ERROR(operator_decl_no_fixity,none,
       "operator must be declared as 'prefix', 'postfix', or 'infix'", ())
 ERROR(operator_decl_expected_precedencegroup, none,
       "expected precedence group name after ':' in operator declaration", ())
-
+ERROR(operator_decl_should_not_contain_other_attributes, none, 
+      "unexpected attribute %0 in operator declaration", (StringRef))
 WARNING(operator_decl_remove_designated_types,none,
         "designated types are no longer used by the compiler; please remove "
         "the designated type list from this operator declaration", ())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4606,6 +4606,17 @@ static void diagnoseOperatorFixityAttributes(Parser &P,
     if (fixityAttrs.empty()) {
       P.diagnose(OD->getOperatorLoc(), diag::operator_decl_no_fixity);
     }
+    for (auto it = Attrs.begin(); it != Attrs.end(); ++it) {
+      if (isFixityAttr(*it) || (*it)->getKind() == DAK_RawDocComment) {
+        continue;
+      }
+      auto *attr = *it;
+      P.diagnose(attr->getLocation(),
+                 diag::operator_decl_should_not_contain_other_attributes,
+                 attr->getAttrName())
+          .fixItRemove(attr->getRange());
+      attr->setInvalid();
+    }
   }
   // Infix operator is only allowed on operator declarations, not on func.
   else if (isa<FuncDecl>(D)) {

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -102,7 +102,7 @@ duplicateAttr(1) // expected-error{{argument passed to call that takes no argume
 
 // CHECK ALLOWED DECLS
 private import Swift // expected-error {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport}}
-private(set) infix operator ~~~ // expected-error {{'private' modifier cannot be applied to this declaration}} {{1-14=}}
+private(set) infix operator ~~~ // expected-error {{unexpected attribute private in operator declaration}} {{1-14=}}
 
 private typealias MyInt = Int
 

--- a/test/attr/attr_dynamic.swift
+++ b/test/attr/attr_dynamic.swift
@@ -7,7 +7,7 @@ struct NotObjCAble {
 
 @objc class ObjCClass {}
 
-dynamic prefix operator +!+  // expected-error{{'dynamic' modifier cannot be applied to this declaration}} {{1-9=}}
+dynamic prefix operator +!+  // expected-error{{unexpected attribute dynamic in operator declaration}} {{1-9=}}
 
 class Foo {
   @objc dynamic init() {}


### PR DESCRIPTION
To sync the changes in https://github.com/apple/swift-syntax/pull/1448#pullrequestreview-1383999927

