### PR TITLE
[5.9] Diagnose attempts to use tuples with noncopyable elements.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5367,6 +5367,8 @@ ERROR(tuple_single_element,none,
 ERROR(tuple_pack_element_label,none,
       "cannot use label with pack expansion tuple element",
       ())
+ERROR(tuple_move_only_not_supported,none,
+      "tuples with noncopyable elements are not supported", ())
 ERROR(vararg_not_allowed,none,
       "variadic parameter cannot appear outside of a function parameter list",
       ())

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -123,6 +123,7 @@ EXPERIMENTAL_FEATURE(MoveOnlyClasses, true)
 EXPERIMENTAL_FEATURE(NoImplicitCopy, true)
 EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
+EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3275,6 +3275,10 @@ static bool usesFeatureMoveOnlyClasses(Decl *decl) {
   return isa<ClassDecl>(decl) && usesFeatureMoveOnly(decl);
 }
 
+static bool usesFeatureMoveOnlyTuples(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureNoImplicitCopy(Decl *decl) {
   return decl->isNoImplicitCopy();
 }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -333,10 +333,16 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         }
       }
 
-      // Diagnose tuple expressions with duplicate element label.
       if (auto *tupleExpr = dyn_cast<TupleExpr>(E)) {
+        // Diagnose tuple expressions with duplicate element label.
         diagnoseDuplicateLabels(tupleExpr->getLoc(),
                                 tupleExpr->getElementNames());
+                                
+        // Diagnose attempts to form a tuple with any noncopyable elements.
+        if (E->getType()->isPureMoveOnly()
+            && !Ctx.LangOpts.hasFeature(Feature::MoveOnlyTuples)) {
+          Ctx.Diags.diagnose(E->getLoc(), diag::tuple_move_only_not_supported);
+        }
       }
 
       // Specially diagnose some checked casts that are illegal.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4660,12 +4660,22 @@ NeverNullType TypeResolver::resolveTupleType(TupleTypeRepr *repr,
 
   bool hadError = false;
   bool foundDupLabel = false;
+  Optional<unsigned> moveOnlyElementIndex = None;
   for (unsigned i = 0, end = repr->getNumElements(); i != end; ++i) {
     auto *tyR = repr->getElementType(i);
 
     auto ty = resolveType(tyR, elementOptions);
-    if (ty->hasError())
+    if (ty->hasError()) {
       hadError = true;
+    }
+    // Tuples with move-only elements aren't yet supported.
+    // Track the presence of a noncopyable field for diagnostic purposes.
+    // We don't need to re-diagnose if a tuple contains another tuple, though,
+    // since we should've diagnosed the inner tuple already.
+    if (ty->isPureMoveOnly() && !moveOnlyElementIndex.has_value()
+        && !isa<TupleTypeRepr>(tyR)) {
+      moveOnlyElementIndex = i;
+    }
 
     auto eltName = repr->getElementName(i);
 
@@ -4713,6 +4723,13 @@ NeverNullType TypeResolver::resolveTupleType(TupleTypeRepr *repr,
     if (elements.size() == 1 && !elements[0].hasName() &&
         !elements[0].getType()->is<PackExpansionType>())
       return ParenType::get(ctx, elements[0].getType());
+  }
+  
+  if (moveOnlyElementIndex.has_value()
+      && !options.contains(TypeResolutionFlags::SILType)
+      && !ctx.LangOpts.hasFeature(Feature::MoveOnlyTuples)) {
+    diagnose(repr->getElementType(*moveOnlyElementIndex)->getLoc(),
+             diag::tuple_move_only_not_supported);
   }
 
   return TupleType::get(elements, ctx);

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -226,7 +226,7 @@ func checkStdlibTypes(_ mo: __shared MO) {
   let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
       []
   let _: [String: MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-      ["hello" : MO()]
+      ["hello" : MO()]  // expected-error{{tuples with noncopyable elements are not supported}}
 
   // i think this one's only caught b/c of the 'Any' change
   _ = [MO()] // expected-error {{move-only type 'MO' cannot be used with generics yet}}

--- a/test/Constraints/moveonly_tuples.swift
+++ b/test/Constraints/moveonly_tuples.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// Tuples with noncopyable elements are not yet supported. Make sure we reject
+// them when code attempts to form such a type explicitly or by inference.
+
+@_moveOnly struct Butt {
+    var x: Int
+}
+
+@_moveOnly
+struct Foo {
+    var t: (Int, Butt) // expected-error{{tuples with noncopyable elements are not supported}}
+}
+@_moveOnly
+struct Bar<T> {
+    var t: (T, Butt) // expected-error{{tuples with noncopyable elements are not supported}}
+    var u: (Int, (T, Butt)) // expected-error{{tuples with noncopyable elements are not supported}}
+}
+
+func inferredTuples<T>(x: Int, y: borrowing Butt, z: T) {
+    let a = (x, y) // expected-error{{tuples with noncopyable elements are not supported}}
+    let b = (y, z) // expected-error{{tuples with noncopyable elements are not supported}}
+    let c = (x, y, z) // expected-error{{tuples with noncopyable elements are not supported}}
+    _ = a
+    _ = b
+    _ = c
+}

--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -48,9 +48,6 @@ Tests.test("global destroyed once") {
   expectEqual(0, LifetimeTracked.instances)    
 }
 
-// TODO (rdar://107494072): Move-only types with deinits declared inside
-// functions sometimes lose their deinit function.
-// When that's fixed, FD2 can be moved back inside the test closure below.
 @_moveOnly
 struct FD2 {
   var field = 5
@@ -83,6 +80,10 @@ Tests.test("deinit not called in init when assigned") {
     }
   }
 
+  do {
+    let haver = FDHaver()
+    let _ = haver
+  }
   do {
     let haver = FDHaver2()
     let _ = haver

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
 
 // This test validates that we properly emit errors if we partially invalidate
 // through a type with a deinit.


### PR DESCRIPTION
These aren't fully supported yet. rdar://108024586

Reviewed by @xedin in main PR: https://github.com/apple/swift/pull/65173