### PR TITLE
[Dependency Scanning] Consider optional dependencies of `@testable` textual dependencies with an adjacent binary module

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1033,6 +1033,7 @@ public:
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate,
       bool optionalDependencyLookup = false,
+      bool isTestableImport = false,
       llvm::Optional<std::pair<std::string, swift::ModuleDependencyKind>> dependencyOf = None);
 
   /// Retrieve the module dependencies for the Clang module with the given name.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1032,6 +1032,7 @@ public:
       StringRef moduleName,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate,
+      bool optionalDependencyLookup = false,
       llvm::Optional<std::pair<std::string, swift::ModuleDependencyKind>> dependencyOf = None);
 
   /// Retrieve the module dependencies for the Clang module with the given name.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1423,6 +1423,10 @@ public:
     return getAttrs().hasAttribute<ExportedAttr>();
   }
 
+  bool isTestable() const {
+    return getAttrs().hasAttribute<TestableAttr>();
+  }
+
   ModuleDecl *getModule() const { return Mod; }
   void setModule(ModuleDecl *M) { Mod = M; }
 

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -211,10 +211,14 @@ public:
   /// Details common to Swift textual (interface or source) modules
   CommonSwiftTextualModuleDependencyDetails textualModuleDetails;
 
+  /// Collection of module imports that were detected to be `@Testable`
+  llvm::StringSet<> testableImports;
+
   SwiftSourceModuleDependenciesStorage(
     ArrayRef<StringRef> extraPCMArgs
   ) : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftSource),
-      textualModuleDetails(extraPCMArgs) {}
+      textualModuleDetails(extraPCMArgs),
+      testableImports(llvm::StringSet<>()) {}
 
   ModuleDependencyInfoStorageBase *clone() const override {
     return new SwiftSourceModuleDependenciesStorage(*this);
@@ -222,6 +226,10 @@ public:
 
   static bool classof(const ModuleDependencyInfoStorageBase *base) {
     return base->dependencyKind == ModuleDependencyKind::SwiftSource;
+  }
+
+  void addTestableImport(ImportPath::Module module) {
+    testableImports.insert(module.front().Item.str());
   }
 };
 
@@ -459,6 +467,13 @@ public:
   void setIsResolved(bool isResolved) {
     storage->resolved = isResolved;
   }
+
+  /// For a Source dependency, register a `Testable` import
+  void addTestableImport(ImportPath::Module module);
+
+  /// Whether or not a queried module name is a `@Testable` import dependency
+  /// of this module. Can only return `true` for Swift source modules.
+  bool isTestableImport(StringRef moduleName) const;
 
   /// Whether the dependencies are for a Swift module: either Textual, Source, Binary, or Placeholder.
   bool isSwiftModule() const;

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -109,6 +109,11 @@ public:
   /// The set of modules on which this module depends.
   std::vector<std::string> moduleImports;
 
+  /// The set of modules which constitute optional module
+  /// dependencies for this module, such as `@_implementationOnly`
+  /// or `internal` imports.
+  std::vector<std::string> optionalModuleImports;
+
   /// The set of modules on which this module depends, resolved
   /// to Module IDs, qualified by module kind: Swift, Clang, etc.
   std::vector<ModuleDependencyID> resolvedModuleDependencies;
@@ -425,6 +430,11 @@ public:
     return storage->moduleImports;
   }
 
+  /// Retrieve the module-level optional imports.
+  ArrayRef<std::string> getOptionalModuleImports() const {
+    return storage->optionalModuleImports;
+  }
+
   /// Retreive the module-level dependencies.
   const ArrayRef<ModuleDependencyID> getModuleDependencies() const {
     assert(storage->resolved);
@@ -487,6 +497,11 @@ public:
   /// Retrieve the dependencies for a placeholder dependency module stub.
   const SwiftPlaceholderModuleDependencyStorage *
     getAsPlaceholderDependencyModule() const;
+
+  /// Add a dependency on the given module, if it was not already in the set.
+  void addOptionalModuleImport(StringRef module,
+                               llvm::StringSet<> *alreadyAddedModules = nullptr);
+
 
   /// Add a dependency on the given module, if it was not already in the set.
   void addModuleImport(StringRef module,

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -245,7 +245,8 @@ public:
   /// If a non-null \p versionInfo is provided, the module version will be
   /// parsed and populated.
   virtual bool canImportModule(ImportPath::Module named,
-                               ModuleVersionInfo *versionInfo) = 0;
+                               ModuleVersionInfo *versionInfo,
+                               bool isTestableImport = false) = 0;
 
   /// Import a module with the given module path.
   ///
@@ -328,7 +329,8 @@ public:
   virtual Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName,
       ModuleDependenciesCache &cache,
-      InterfaceSubContextDelegate &delegate) = 0;
+      InterfaceSubContextDelegate &delegate,
+      bool isTestableImport = false) = 0;
 };
 
 } // namespace swift

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -213,7 +213,8 @@ public:
   /// If a non-null \p versionInfo is provided, the module version will be
   /// parsed and populated.
   virtual bool canImportModule(ImportPath::Module named,
-                               ModuleVersionInfo *versionInfo) override;
+                               ModuleVersionInfo *versionInfo,
+                               bool isTestableImport = false) override;
 
   /// Import a module with the given module path.
   ///
@@ -427,7 +428,8 @@ public:
 
   Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
-      InterfaceSubContextDelegate &delegate) override;
+      InterfaceSubContextDelegate &delegate,
+      bool isTestableImport = false) override;
 
   /// Add dependency information for the bridging header.
   ///

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -142,8 +142,8 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-                  bool skipBuildingInterface, bool &isFramework,
-                  bool &isSystemModule) override;
+                  bool skipBuildingInterface, bool isTestableDependencyLookup,
+                  bool &isFramework, bool &isSystemModule) override;
 
   std::error_code findModuleFilesInDirectory(
       ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
@@ -152,10 +152,12 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool skipBuildingInterface, bool IsFramework) override;
+      bool SkipBuildingInterface, bool IsFramework,
+      bool IsTestableDependencyLookup = false) override;
 
   bool canImportModule(ImportPath::Module named,
-                       ModuleVersionInfo *versionInfo) override;
+                       ModuleVersionInfo *versionInfo,
+                       bool isTestableDependencyLookup = false) override;
 
   bool isCached(StringRef DepPath) override { return false; };
 
@@ -477,7 +479,8 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool skipBuildingInterface, bool IsFramework) override;
+      bool SkipBuildingInterface, bool IsFramework,
+      bool IsTestableDependencyLookup = false) override;
 
   bool isCached(StringRef DepPath) override;
 public:

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -60,7 +60,8 @@ public:
   /// If a non-null \p versionInfo is provided, the module version will be
   /// parsed and populated.
   virtual bool canImportModule(ImportPath::Module named,
-                               ModuleVersionInfo *versionInfo) override;
+                               ModuleVersionInfo *versionInfo,
+                               bool isTestableDependencyLookup = false) override;
 
   /// Import a module with the given module path.
   ///
@@ -98,7 +99,8 @@ public:
 
   Optional<const ModuleDependencyInfo*>
   getModuleDependencies(StringRef moduleName, ModuleDependenciesCache &cache,
-                        InterfaceSubContextDelegate &delegate) override;
+                        InterfaceSubContextDelegate &delegate,
+                        bool isTestableImport) override;
 };
 }
 

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -34,7 +34,8 @@ namespace swift {
 
       /// Scan the given interface file to determine dependencies.
       llvm::ErrorOr<ModuleDependencyInfo> scanInterfaceFile(
-          Twine moduleInterfacePath, bool isFramework);
+          Twine moduleInterfacePath, bool isFramework,
+          bool isTestableImport);
 
       InterfaceSubContextDelegate &astDelegate;
 
@@ -61,7 +62,8 @@ namespace swift {
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-          bool skipBuildingInterface, bool IsFramework) override;
+          bool SkipBuildingInterface, bool IsFramework,
+          bool IsTestableDependencyLookup) override;
 
       virtual void collectVisibleTopLevelModuleNames(
           SmallVectorImpl<Identifier> &names) const override {
@@ -125,8 +127,8 @@ namespace swift {
                  std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-                 bool skipBuildingInterface, bool &isFramework,
-                 bool &isSystemModule) override;
+                 bool skipBuildingInterface, bool isTestableDependencyLookup,
+                 bool &isFramework, bool &isSystemModule) override;
 
       static bool classof(const ModuleDependencyScanner *MDS) {
         return MDS->getKind() == MDS_placeholder;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -20,6 +20,8 @@
 
 namespace swift {
 class ModuleFile;
+class PathObfuscator;
+enum class ModuleLoadingBehavior;
 namespace file_types {
   enum ID : uint8_t;
 }
@@ -145,6 +147,16 @@ protected:
 
   /// Scan the given serialized module file to determine dependencies.
   llvm::ErrorOr<ModuleDependencyInfo> scanModuleFile(Twine modulePath, bool isFramework);
+
+  static llvm::ErrorOr<llvm::StringSet<>>
+  getModuleImportsOfModule(Twine modulePath,
+                           ModuleLoadingBehavior transitiveBehavior,
+                           bool isFramework,
+                           bool isRequiredOSSAModules,
+                           StringRef SDKName,
+                           StringRef packageName,
+                           llvm::vfs::FileSystem *fileSystem,
+                           PathObfuscator &recoverer);
 
   /// Load the module file into a buffer and also collect its module name.
   static std::unique_ptr<llvm::MemoryBuffer>

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -86,7 +86,8 @@ protected:
       std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-      bool skipBuildingInterface, bool &isFramework, bool &isSystemModule);
+      bool skipBuildingInterface, bool isTestableDependencyLookup,
+      bool &isFramework, bool &isSystemModule);
 
   /// Attempts to search the provided directory for a loadable serialized
   /// .swiftmodule with the provided `ModuleFilename`. Subclasses must
@@ -107,7 +108,8 @@ protected:
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool skipBuildingInterface, bool IsFramework) = 0;
+      bool SkipBuildingInterface, bool IsFramework,
+      bool isTestableDependencyLookup = false) = 0;
 
   std::error_code
   openModuleFile(
@@ -191,7 +193,8 @@ public:
   /// If a non-null \p versionInfo is provided, the module version will be
   /// parsed and populated.
   virtual bool canImportModule(ImportPath::Module named,
-                               ModuleVersionInfo *versionInfo) override;
+                               ModuleVersionInfo *versionInfo,
+                               bool isTestableDependencyLookup = false) override;
 
   /// Import a module with the given module path.
   ///
@@ -226,7 +229,8 @@ public:
 
   virtual Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
-      InterfaceSubContextDelegate &delegate) override;
+      InterfaceSubContextDelegate &delegate,
+      bool isTestableImport) override;
 };
 
 /// Imports serialized Swift modules into an ASTContext.
@@ -244,7 +248,8 @@ class ImplicitSerializedModuleLoader : public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool skipBuildingInterface, bool IsFramework) override;
+      bool SkipBuildingInterface, bool IsFramework,
+      bool isTestableDependencyLookup = false) override;
 
   bool maybeDiagnoseTargetMismatch(
       SourceLoc sourceLocation,
@@ -298,7 +303,8 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool skipBuildingInterface, bool IsFramework) override;
+      bool SkipBuildingInterface, bool IsFramework,
+      bool IsTestableDependencyLookup = false) override;
 
   bool maybeDiagnoseTargetMismatch(
       SourceLoc sourceLocation,
@@ -310,7 +316,8 @@ public:
   virtual ~MemoryBufferSerializedModuleLoader();
 
   bool canImportModule(ImportPath::Module named,
-                       ModuleVersionInfo *versionInfo) override;
+                       ModuleVersionInfo *versionInfo,
+                       bool isTestableDependencyLookup = false) override;
 
   ModuleDecl *
   loadModule(SourceLoc importLoc,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2024,6 +2024,7 @@ Optional<const ModuleDependencyInfo*> ASTContext::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate,
     bool optionalDependencyLookup,
+    bool isTestableImport,
     llvm::Optional<ModuleDependencyID> dependencyOf) {
   // Retrieve the dependencies for this module.
   // Check whether we've cached this result.
@@ -2045,7 +2046,8 @@ Optional<const ModuleDependencyInfo*> ASTContext::getModuleDependencies(
 
   for (auto &loader : getImpl().ModuleLoaders) {
     if (auto dependencies =
-        loader->getModuleDependencies(moduleName, cache, delegate))
+        loader->getModuleDependencies(moduleName, cache, delegate,
+                                      isTestableImport))
       return dependencies;
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2023,6 +2023,7 @@ static void diagnoseScannerFailure(StringRef moduleName,
 Optional<const ModuleDependencyInfo*> ASTContext::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate,
+    bool optionalDependencyLookup,
     llvm::Optional<ModuleDependencyID> dependencyOf) {
   // Retrieve the dependencies for this module.
   // Check whether we've cached this result.
@@ -2048,8 +2049,9 @@ Optional<const ModuleDependencyInfo*> ASTContext::getModuleDependencies(
       return dependencies;
   }
 
-  diagnoseScannerFailure(moduleName, Diags, cache,
-                         dependencyOf);
+  if (!optionalDependencyLookup)
+    diagnoseScannerFailure(moduleName, Diags, cache,
+                           dependencyOf);
   return None;
 }
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -89,6 +89,12 @@ void ModuleDependencyInfo::addModuleDependency(ModuleDependencyID dependencyID) 
   storage->resolvedModuleDependencies.push_back(dependencyID);
 }
 
+void ModuleDependencyInfo::addOptionalModuleImport(
+    StringRef module, llvm::StringSet<> *alreadyAddedModules) {
+  if (!alreadyAddedModules || alreadyAddedModules->insert(module).second)
+    storage->optionalModuleImports.push_back(module.str());
+}
+
 void ModuleDependencyInfo::addModuleImport(
     StringRef module, llvm::StringSet<> *alreadyAddedModules) {
   if (!alreadyAddedModules || alreadyAddedModules->insert(module).second)

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -127,6 +127,8 @@ void ModuleDependencyInfo::addModuleImport(
     auto realPath = importDecl->getRealModulePath(scratch);
     addModuleImport(realPath, &alreadyAddedModules);
 
+    // Additionally, keep track of which dependencies of a Source
+    // module are `@Testable`.
     if (getKind() == swift::ModuleDependencyKind::SwiftSource &&
         importDecl->isTestable())
       addTestableImport(realPath);
@@ -140,9 +142,8 @@ void ModuleDependencyInfo::addModuleImport(
   case swift::ModuleDependencyKind::SwiftInterface: {
     // If the storage is for an interface file, the only source file we
     // should see is that interface file.
-    auto swiftInterfaceStorage =
-        cast<SwiftInterfaceModuleDependenciesStorage>(storage.get());
-    assert(fileName == swiftInterfaceStorage->swiftInterfaceFile);
+    assert(fileName ==
+           cast<SwiftInterfaceModuleDependenciesStorage>(storage.get())->swiftInterfaceFile);
     break;
   }
   case swift::ModuleDependencyKind::SwiftSource: {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1855,7 +1855,8 @@ static std::string getScalaNodeText(llvm::yaml::Node *N) {
 }
 
 bool ClangImporter::canImportModule(ImportPath::Module modulePath,
-                                    ModuleVersionInfo *versionInfo) {
+                                    ModuleVersionInfo *versionInfo,
+                                    bool isTestableDependencyLookup) {
   // Look up the top-level module to see if it exists.
   auto &clangHeaderSearch = Impl.getClangPreprocessor().getHeaderSearchInfo();
   auto topModule = modulePath.front();

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -202,7 +202,7 @@ void ClangImporter::recordModuleDependencies(
 
 Optional<const ModuleDependencyInfo*> ClangImporter::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
-    InterfaceSubContextDelegate &delegate) {
+    InterfaceSubContextDelegate &delegate, bool isTestableImport) {
   auto &ctx = Impl.SwiftContext;
   // Determine the command-line arguments for dependency scanning.
   std::vector<std::string> commandLineArgs =

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -307,12 +307,12 @@ resolveExplicitModuleInputs(ModuleDependencyID moduleID,
 
 /// Resolve the direct dependencies of the given module.
 static ArrayRef<ModuleDependencyID>
-resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
+resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleID,
                           ModuleDependenciesCache &cache,
                           InterfaceSubContextDelegate &ASTDelegate) {
-  PrettyStackTraceStringAction trace("Resolving direct dependencies of: ", module.first);
+  PrettyStackTraceStringAction trace("Resolving direct dependencies of: ", moduleID.first);
   auto &ctx = instance.getASTContext();
-  auto optionalKnownDependencies = cache.findDependency(module.first, module.second);
+  auto optionalKnownDependencies = cache.findDependency(moduleID.first, moduleID.second);
   assert(optionalKnownDependencies.has_value());
   auto knownDependencies = optionalKnownDependencies.value();
 
@@ -329,16 +329,29 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
   ModuleDependencyIDSetVector result;
   for (auto dependsOn : knownDependencies->getModuleImports()) {
     // Figure out what kind of module we need.
-    bool onlyClangModule = !isSwift || module.first == dependsOn;
+    bool onlyClangModule = !isSwift || moduleID.first == dependsOn;
     if (onlyClangModule) {
       if (auto found =
               ctx.getClangModuleDependencies(dependsOn, cache, ASTDelegate))
         result.insert({dependsOn, ModuleDependencyKind::Clang});
     } else {
       if (auto found =
-              ctx.getModuleDependencies(dependsOn, cache, ASTDelegate, module))
+              ctx.getModuleDependencies(dependsOn, cache, ASTDelegate,
+                                        /* optionalDependencyLookup */ false,
+                                        moduleID))
         result.insert({dependsOn, found.value()->getKind()});
     }
+  }
+
+  // We may have a set of optional dependencies for this module, such as `@_implementationOnly`
+  // imports of a `@Testable` import. Attempt to locate those, but do not fail if they
+  // cannot be found.
+  for (auto optionallyDependsOn : knownDependencies->getOptionalModuleImports()) {
+    if (auto found =
+            ctx.getModuleDependencies(optionallyDependsOn, cache, ASTDelegate,
+                                      /* optionalDependencyLookup */ true,
+                                      moduleID))
+      result.insert({optionallyDependsOn, found.value()->getKind()});
   }
 
   if (isSwiftInterfaceOrSource) {
@@ -350,11 +363,11 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
     if (knownDependencies->getBridgingHeader()) {
       auto clangImporter =
           static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-      if (!clangImporter->addBridgingHeaderDependencies(module.first,
-                                                        module.second, cache)) {
+      if (!clangImporter->addBridgingHeaderDependencies(moduleID.first,
+                                                        moduleID.second, cache)) {
         // Grab the updated module dependencies.
         // FIXME: This is such a hack.
-        knownDependencies = *cache.findDependency(module.first, module.second);
+        knownDependencies = *cache.findDependency(moduleID.first, moduleID.second);
 
         // Add the Clang modules referenced from the bridging header to the
         // set of Clang modules we know about.
@@ -389,15 +402,15 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
     for (const auto &clangDep : allClangModules) {
       if (auto found =
               ctx.getSwiftModuleDependencies(clangDep, cache, ASTDelegate)) {
-        if (clangDep != module.first)
+        if (clangDep != moduleID.first)
           result.insert({clangDep, found.value()->getKind()});
       }
     }
   }
 
   // Resolve the dependnecy info
-  cache.resolveDependencyImports(module, result.takeVector());
-  return cache.findDependency(module.first, module.second).value()->getModuleDependencies();
+  cache.resolveDependencyImports(moduleID, result.takeVector());
+  return cache.findDependency(moduleID.first, moduleID.second).value()->getModuleDependencies();
 }
 
 static void discoverCrossImportOverlayDependencies(

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -330,6 +330,8 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleI
   for (auto dependsOn : knownDependencies->getModuleImports()) {
     // Figure out what kind of module we need.
     bool onlyClangModule = !isSwift || moduleID.first == dependsOn;
+    bool isTestable = knownDependencies->isTestableImport(dependsOn);
+
     if (onlyClangModule) {
       if (auto found =
               ctx.getClangModuleDependencies(dependsOn, cache, ASTDelegate))
@@ -338,6 +340,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleI
       if (auto found =
               ctx.getModuleDependencies(dependsOn, cache, ASTDelegate,
                                         /* optionalDependencyLookup */ false,
+                                        isTestable,
                                         moduleID))
         result.insert({dependsOn, found.value()->getKind()});
     }
@@ -350,6 +353,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleI
     if (auto found =
             ctx.getModuleDependencies(optionallyDependsOn, cache, ASTDelegate,
                                       /* optionalDependencyLookup */ true,
+                                      /* isTestableDependency */ false,
                                       moduleID))
       result.insert({optionallyDependsOn, found.value()->getKind()});
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1143,7 +1143,8 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool skipBuildingInterface, bool IsFramework) {
+    bool skipBuildingInterface, bool IsFramework,
+    bool isTestableImport) {
 
   // If running in OnlySerialized mode, ModuleInterfaceLoader
   // should not have been constructed at all.
@@ -1991,7 +1992,8 @@ bool ExplicitSwiftModuleLoader::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool skipBuildingInterface, bool &IsFramework, bool &IsSystemModule) {
+    bool skipBuildingInterface, bool isTestableDependencyLookup,
+    bool &IsFramework, bool &IsSystemModule) {
   // Find a module with an actual, physical name on disk, in case
   // -module-alias is used (otherwise same).
   //
@@ -2069,13 +2071,15 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool skipBuildingInterface, bool IsFramework) {
+    bool skipBuildingInterface, bool IsFramework,
+    bool IsTestableDependencyLookup) {
   llvm_unreachable("Not supported in the Explicit Swift Module Loader.");
   return std::make_error_code(std::errc::not_supported);
 }
 
 bool ExplicitSwiftModuleLoader::canImportModule(
-    ImportPath::Module path, ModuleVersionInfo *versionInfo) {
+    ImportPath::Module path, ModuleVersionInfo *versionInfo,
+    bool isTestableDependencyLookup) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -71,7 +71,8 @@ void SourceLoader::collectVisibleTopLevelModuleNames(
 }
 
 bool SourceLoader::canImportModule(ImportPath::Module path,
-                                   ModuleVersionInfo *versionInfo) {
+                                   ModuleVersionInfo *versionInfo,
+                                   bool isTestableDependencyLookup) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;
@@ -155,7 +156,8 @@ void SourceLoader::loadExtensions(NominalTypeDecl *nominal,
 Optional<const ModuleDependencyInfo*>
 SourceLoader::getModuleDependencies(StringRef moduleName,
                                     ModuleDependenciesCache &cache,
-                                    InterfaceSubContextDelegate &delegate) {
+                                    InterfaceSubContextDelegate &delegate,
+                                    bool isTestableImport) {
   // FIXME: Implement?
   return None;
 }

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -22,6 +22,9 @@
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/ModuleDependencyScanner.h"
 #include "swift/Subsystems.h"
+#include "ModuleFileSharedCore.h"
+
+#include <algorithm>
 using namespace swift;
 using llvm::ErrorOr;
 
@@ -32,7 +35,8 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool skipBuildingInterface, bool IsFramework) {
+    bool skipBuildingInterface, bool IsFramework,
+    bool isTestableDependencyLookup) {
   using namespace llvm::sys;
 
   auto &fs = *Ctx.SourceMgr.getFileSystem();
@@ -61,7 +65,8 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
   if (fs.exists(PrivateInPath)) {
     InPath = PrivateInPath;
   }
-  auto dependencies = scanInterfaceFile(InPath, IsFramework);
+  auto dependencies = scanInterfaceFile(InPath, IsFramework,
+                                        isTestableDependencyLookup);
   if (dependencies) {
     this->dependencies = std::move(dependencies.get());
     return std::error_code();
@@ -76,7 +81,8 @@ bool PlaceholderSwiftModuleScanner::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-    bool skipBuildingInterface, bool &isFramework, bool &isSystemModule) {
+    bool skipBuildingInterface, bool isTestableDependencyLookup,
+    bool &isFramework, bool &isSystemModule) {
   StringRef moduleName = Ctx.getRealModuleName(moduleID.Item).str();
   auto it = PlaceholderDependencyModuleMap.find(moduleName);
   if (it == PlaceholderDependencyModuleMap.end()) {
@@ -101,7 +107,7 @@ static std::vector<std::string> getCompiledCandidates(ASTContext &ctx,
 }
 
 ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
-    Twine moduleInterfacePath, bool isFramework) {
+    Twine moduleInterfacePath, bool isFramework, bool isTestableImport) {
   // Create a module filename.
   // FIXME: Query the module interface loader to determine an appropriate
   // name for the module, which includes an appropriate hash.
@@ -110,6 +116,8 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
   llvm::SmallString<32> modulePath = realModuleName.str();
   llvm::sys::path::replace_extension(modulePath, newExt);
   Optional<ModuleDependencyInfo> Result;
+
+  // FIXME: Consider not spawning a sub-instance for this
   std::error_code code =
     astDelegate.runInSubContext(realModuleName.str(),
                                               moduleInterfacePath.str(),
@@ -177,6 +185,29 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
     for (auto import: imInfo.AdditionalUnloadedImports) {
       Result->addModuleImport(import.module.getModulePath(), &alreadyAddedModules);
     }
+
+    // Check the adjacent binary module, if one is found,
+    // for additional "optional" dependencies.
+    if (isTestableImport) {
+      auto adjacentBinaryCandidate = std::find_if(
+          compiledCandidates.begin(), compiledCandidates.end(),
+          [moduleInterfacePath](const std::string &candidate) {
+            return llvm::sys::path::parent_path(candidate) ==
+                   llvm::sys::path::parent_path(moduleInterfacePath.str());
+          });
+      if (adjacentBinaryCandidate != compiledCandidates.end()) {
+        auto adjacentBinaryCandidateModules = getModuleImportsOfModule(
+            *adjacentBinaryCandidate, ModuleLoadingBehavior::Optional,
+            isFramework, isRequiredOSSAModules(), Ctx.LangOpts.SDKName,
+            Ctx.LangOpts.PackageName, Ctx.SourceMgr.getFileSystem().get(),
+            Ctx.SearchPathOpts.DeserializedPathRecoverer);
+        if (!adjacentBinaryCandidateModules)
+          return adjacentBinaryCandidateModules.getError();
+        for (const auto &t : *adjacentBinaryCandidateModules)
+          Result->addOptionalModuleImport(t.getKey(), &alreadyAddedModules);
+      }
+    }
+
     return std::error_code();
   });
 
@@ -188,7 +219,7 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
 
 Optional<const ModuleDependencyInfo*> SerializedModuleLoaderBase::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
-    InterfaceSubContextDelegate &delegate) {
+    InterfaceSubContextDelegate &delegate, bool isTestableDependencyLookup) {
   ImportPath::Module::Builder builder(Ctx, moduleName, /*separator=*/'.');
   auto modulePath = builder.get();
   auto moduleId = modulePath.front().Item;
@@ -209,7 +240,7 @@ Optional<const ModuleDependencyInfo*> SerializedModuleLoaderBase::getModuleDepen
   assert(isa<PlaceholderSwiftModuleScanner>(scanners[0].get()) &&
          "Expected PlaceholderSwiftModuleScanner as the first dependency scanner loader.");
   for (auto &scanner : scanners) {
-    if (scanner->canImportModule(modulePath, nullptr)) {
+    if (scanner->canImportModule(modulePath, nullptr, isTestableDependencyLookup)) {
       // Record the dependencies.
       cache.recordDependency(moduleName, *(scanner->dependencies));
       return cache.findDependency(moduleName, scanner->dependencies->getKind());

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -420,7 +420,7 @@ SerializedModuleLoaderBase::getModuleImportsOfModule(
             /*debuggerMode*/ false,
             /*isPartialModule*/ false, packageName,
             loadedModuleFile->isTestable());
-    if (dependencyTransitiveBehavior != transitiveBehavior)
+    if (dependencyTransitiveBehavior > transitiveBehavior)
       continue;
 
     // Find the top-level module name.

--- a/test/ScanDependencies/bin_mod_import.swift
+++ b/test/ScanDependencies/bin_mod_import.swift
@@ -17,12 +17,8 @@ import EWrapper
 // CHECK: "modulePath": "{{.*}}EWrapper.swiftmodule"
 // CHECK-NEXT: "directDependencies": [
 // CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "E"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "Swift"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
+// CHECK-DAG:     "swift": "E"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],

--- a/test/ScanDependencies/optional_deps_of_testable_imports.swift
+++ b/test/ScanDependencies/optional_deps_of_testable_imports.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: %empty-directory(%t/Foo.swiftmodule)
+// RUN: echo "@_implementationOnly import A; public func foo() {}" > %t/Foo.swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+@testable import Foo
+
+// Step 1: build swift interface and swift module side by side, make them testable
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing
+
+// Step 3: scan dependencies
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache -I %S/Inputs/CHeaders -I %S/Inputs/Swift
+
+// The dependency of `Foo` on `A` will not be visible if the scanner simply scans the textual interface
+// of `Foo`. So we verify that for a `@testable` import, the scanner also opens up the adjacent binary module and
+// attemtps to resolve optional dependencies contained within.
+//
+// CHECK: "swift": "A"

--- a/test/ScanDependencies/required_deps_of_testable_imports.swift
+++ b/test/ScanDependencies/required_deps_of_testable_imports.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: %empty-directory(%t/Foo.swiftmodule)
+// RUN: echo "internal import A; public func foo() {}" > %t/Foo.swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+@testable import Foo
+
+// Step 1: build swift interface and swift module side by side, make them testable
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing -enable-experimental-feature AccessLevelOnImport
+
+// Step 3: scan dependencies
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache -I %S/Inputs/CHeaders -I %S/Inputs/Swift
+
+// The dependency of `Foo` on `A` will not be visible if the scanner simply scans the textual interface
+// of `Foo`. So we verify that for a `@testable` import, the scanner also opens up the adjacent binary module and
+// resolves the required dependencies contained within.
+//
+// CHECK: "swift": "A"


### PR DESCRIPTION
For a `@testable` `import` in program source, if a Swift textual interface dependency is discovered, and has an adjacent binary `.swiftmodule`, only the binary module will reference the "optional" module dependencies that the built-for-testable module may need to be fully usable. 

This change, for `@testable` direct dependencies of module-under-scan, causes the scanner to open up the adjacent binary `.swiftmodule` module, and pull in its optional dependencies, and attempt to resolve them. If an optional dependency cannot be resolved on the filesystem, the scanner proceeds silently, without a diagnostic - this is a best-effort attempt to handle testable module dependencies as thoroughly as possible. 