### PR TITLE
[5.9][Macros] Fix visiting nested conformance macro declarations in SIL and IRGen.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5493,6 +5493,11 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
       continue;
 
     member->visitAuxiliaryDecls([&](Decl *decl) {
+      // FIXME: Conformance macros can generate extension decls. These
+      // are visited as top-level decls; skip them here.
+      if (isa<ExtensionDecl>(decl))
+        return;
+
       emitNestedTypeDecls({decl, nullptr});
     });
     switch (member->getKind()) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1086,6 +1086,11 @@ public:
     SGM.emitLazyConformancesForType(theType);
 
     forEachMemberToLower(theType, [&](Decl *member) {
+      // FIXME: Conformance macros can generate extension decls. These
+      // are visited as top-level decls; skip them here.
+      if (isa<ExtensionDecl>(member))
+        return;
+
       visit(member);
     });
 

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -29,6 +29,10 @@ struct S {}
 @Hashable
 struct S2 {}
 
+enum E {
+  @Equatable struct Nested {}
+}
+
 // CHECK-DUMP: @__swiftmacro_25macro_expand_conformances1S9EquatablefMc_.swift
 // CHECK-DUMP: extension S : Equatable  {}
 
@@ -37,6 +41,8 @@ requireEquatable(S())
 
 requireEquatable(S2())
 requireHashable(S2())
+
+requireEquatable(E.Nested())
 
 @attached(conformance)
 @attached(member, names: named(requirement))


### PR DESCRIPTION
* **Explanation**: When expanding a conformance macro, the generated extension decls are added to the `TopLevelDecls` vector of the synthesized file unit to expose them to `sf->getSynthesizedFile()->getTopLevelDecls()`. There are two problems with this:

1. These decls are also visited via `visitAuxiliaryDecls()` for the purpose of type checking. This causes problems in code generation because the extensions are visited separately, and because SIL and IRGen assume nested auxiliary decls are members.
2. SILGen only emits top-level decls directly from the source file rather than its synthesized file. Auxiliary decls are visited here, but this doesn't work for nested conformance macros because the attached-to decl is not at the top-level, so macro-generated conformances for nested types never emit their descriptor.

    To fix this in the short term, visit top-level decls in the synthesized file that are generated by conformance macros, and skip auxiliary extension decls when emitting type members. This fix is narrowly scoped to only impact macros, but in the future this warrants a more structural fix to better handle top-level decls in the synthesized file.

* **Scope**: Only impacts macros.
* **Issue**: rdar://107962528
* **Risk**: Low.
* **Testing**: Added a nested type with an attached conformance macro to `test/Macros/macro_expand_conformance.swift`.
* **Reviewer**: @DougGregor 
* **Main branch PR**: https://github.com/apple/swift/pull/65231