### PR TITLE
Revert "[Test] Disable failing async_task_locals tests on ARM64e."

### DIFF
--- a/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
+++ b/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
@@ -8,9 +8,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://105496007
-// UNSUPPORTED: CPU=arm64e
-
 @available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal

--- a/test/Concurrency/Runtime/async_task_locals_wrapper.swift
+++ b/test/Concurrency/Runtime/async_task_locals_wrapper.swift
@@ -8,9 +8,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://105496007
-// UNSUPPORTED: CPU=arm64e
-
 @available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal


### PR DESCRIPTION
This reverts commit cd1e0d7acbfb87ce7ebbe53530b04352e39a42a2 from https://github.com/apple/swift/pull/63681

These seemed to be failing on arm64e at some point but I was now trying to reproduce the failure and am unable to on a device. Let's reenable and double check.

rdar://105496007