### PR TITLE
[NFC] CS: Misc minor debug output tweaks

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -164,6 +164,7 @@ constraints and present the final type checked solution, e.g.:
 
 ```
 ---Constraint solving at [test.swift:3:1 - line:3:1]---
+
 ---Initial constraints for the given expression---
 (integer_literal_expr type='$T0' location=test.swift:3:1 range=[test.swift:3:1 - line:3:1] value=0 builtin_initializer=**NULL** initializer=**NULL**)
 
@@ -172,14 +173,14 @@ Type Variables:
    ($T0 [attributes: [literal: integer]] [with possible bindings: (default type of literal) Int]) @ locator@0x13e009800 [IntegerLiteral@test.swift:3:1]
 
 Inactive Constraints:
-  $T0 literal conforms to ExpressibleByIntegerLiteral [[locator@0x13e009800 [IntegerLiteral@test.swift:3:1]]];
+  $T0 literal conforms to ExpressibleByIntegerLiteral @ locator@0x13e009800 [IntegerLiteral@test.swift:3:1]
 
   (Potential Binding(s): 
     ($T0 [attributes: [literal: integer]] [with possible bindings: (default type of literal) Int])
   (attempting type variable $T0 := Int
-    (considering -> $T0 literal conforms to ExpressibleByIntegerLiteral [[locator@0x13e009800 [IntegerLiteral@test.swift:3:1]]];
+    (considering: $T0 literal conforms to ExpressibleByIntegerLiteral @ locator@0x13e009800 [IntegerLiteral@test.swift:3:1]
       (simplification result:
-        (removed constraint: $T0 literal conforms to ExpressibleByIntegerLiteral [[locator@0x13e009800 [IntegerLiteral@test.swift:3:1]]];)
+        (removed constraint: $T0 literal conforms to ExpressibleByIntegerLiteral @ locator@0x13e009800 [IntegerLiteral@test.swift:3:1])
       )
       (outcome: simplified)
     )
@@ -188,7 +189,7 @@ Inactive Constraints:
         > $T0 := Int
       )
       (Removed Constraint: 
-        > $T0 literal conforms to ExpressibleByIntegerLiteral [[locator@0x13e009800 [IntegerLiteral@test.swift:3:1]]];
+        > $T0 literal conforms to ExpressibleByIntegerLiteral @ locator@0x13e009800 [IntegerLiteral@test.swift:3:1]
       )
     )
     (found solution: <default 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5765,7 +5765,7 @@ public:
   void print(llvm::raw_ostream &Out, SourceManager *, unsigned indent) const {
     PrintOptions PO;
     PO.PrintTypesForDebugging = true;
-    Out << "type variable " << TypeVar->getString(PO)
+    Out << "type variable binding " << TypeVar->getString(PO)
         << " := " << Binding.BindingType->getString(PO);
   }
 };

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4604,7 +4604,7 @@ bool ConstraintSystem::generateConstraints(
 
     if (isDebugMode()) {
       auto &log = llvm::errs();
-      log << "---Initial constraints for the given expression---\n";
+      log << "\n---Initial constraints for the given expression---\n";
       print(log, expr);
       log << "\n";
       print(log);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -369,7 +369,7 @@ bool ConstraintSystem::simplify() {
     if (isDebugMode()) {
       auto &log = llvm::errs();
       log.indent(solverState->getCurrentIndent());
-      log << "(considering -> ";
+      log << "(considering: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent());
       log << "\n";
@@ -1485,7 +1485,7 @@ ConstraintSystem::solveImpl(SyntacticElementTarget &target,
                             FreeTypeVariableBinding allowFreeTypeVariables) {
   if (isDebugMode()) {
     auto &log = llvm::errs();
-    log << "---Constraint solving at ";
+    log << "\n---Constraint solving at ";
     auto R = target.getSourceRange();
     if (R.isValid()) {
       R.print(log, getASTContext().SourceMgr, /*PrintText=*/ false);

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -380,9 +380,8 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
       Out << " (isolated)";
 
     if (Locator) {
-      Out << " [[";
+      Out << " @ ";
       Locator->dump(sm, Out);
-      Out << "]]";
     }
     Out << ":\n";
     
@@ -479,7 +478,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
   case ConstraintKind::KeyPath:
       Out << " key path from ";
       Out << getSecondType()->getString(PO);
-      Out << " -> ";
+      Out << " → ";
       Out << getThirdType()->getString(PO);
       skipSecond = true;
       break;
@@ -487,7 +486,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
   case ConstraintKind::KeyPathApplication:
       Out << " key path projecting ";
       Out << getSecondType()->getString(PO);
-      Out << " -> ";
+      Out << " → ";
       Out << getThirdType()->getString(PO);
       skipSecond = true;
       break;
@@ -608,9 +607,8 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
   }
 
   if (Locator && !skipLocator) {
-    Out << " [[";
+    Out << " @ ";
     Locator->dump(sm, Out);
-    Out << "]];";
   }
 }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -707,7 +707,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
   constraints::dumpAnchor(anchor, sm, out);
 
   for (auto elt : getPath()) {
-    out << " -> ";
+    out << " → ";
     elt.dump(out);
   }
   out << ']';

--- a/test/Concurrency/async_overload_filtering.swift
+++ b/test/Concurrency/async_overload_filtering.swift
@@ -19,7 +19,7 @@ var a: String? = nil
 // CHECK: attempting disjunction choice $T0 bound to decl async_overload_filtering.(file).filter_async(fn2:)
 // CHECK-NEXT: added constraint: {{.*}} conforms to _Copyable
 // CHECK-NEXT: overload set choice binding $T0 := {{.*}}
-// CHECK-NEXT: (considering -> ({{.*}}) -> {{.*}} applicable fn {{.*}}
+// CHECK-NEXT: (considering: ({{.*}}) -> {{.*}} applicable fn {{.*}}
 // CHECK: increasing 'sync-in-asynchronous' score by 1
 // CHECK: solution is worse than the best solution
 filter_async {

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -28,10 +28,10 @@ func f(_: Double) -> Y { return Y() }
 
 func testCallCommonType() {
   // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
-  // CHECK: (considering -> $T{{[0-9]+}}[.g: value] == [[G:\$T[0-9]+]]
+  // CHECK: (considering: $T{{[0-9]+}}[.g: value] == [[G:\$T[0-9]+]]
   // CHECK: (common result type for [[G]] is Int)
   // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
-  // CHECK: (considering -> $T{{[0-9]+}}[.g: value] == [[F:\$T[0-9]+]]
+  // CHECK: (considering: $T{{[0-9]+}}[.g: value] == [[F:\$T[0-9]+]]
   // CHECK: (common result type for [[F]] is Double)
   _ = f(0).g(0)
 }

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -28,19 +28,19 @@ func testTernaryOneWayOverload(b: Bool) {
   // CHECK: 0: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}}
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: (attempting type variable binding [[C]] := Int8
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: (attempting type variable binding [[C]] := Int8
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: (attempting type variable binding [[C]] := Int8
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
-  // CHECK: (considering -> $T{{[0-9]+}} conv [[C]]
-  // CHECK: (considering -> $T{{[0-9]+}} conv [[C]]
-  // CHECK: (considering -> [[C]] conv Int8
+  // CHECK: (attempting type variable binding [[C]] := Int8
+  // CHECK: (considering: $T{{[0-9]+}} conv [[C]]
+  // CHECK: (considering: $T{{[0-9]+}} conv [[C]]
+  // CHECK: (considering: [[C]] conv Int8
   // CHECK: (found solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
 
   // CHECK: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])

--- a/test/Constraints/result_builder_conjunction_selection.swift
+++ b/test/Constraints/result_builder_conjunction_selection.swift
@@ -33,11 +33,11 @@ do {
 
   // CHECK: ---Initial constraints for the given expression---
   // CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
-  // CHECK: (attempting type variable [[CLOSURE:\$T[0-9]+]] := () -> {{.*}}
-  // CHECK-NOT: (attempting type variable [[LITERAL_VAR]] := {{.*}}
+  // CHECK: (attempting type variable binding [[CLOSURE:\$T[0-9]+]] := () -> {{.*}}
+  // CHECK-NOT: (attempting type variable binding [[LITERAL_VAR]] := {{.*}}
   // CHECK: (attempting conjunction element pattern binding element @ 0
   // CHECK: (applying conjunction result to outer context
-  // CHECK: (attempting type variable [[LITERAL_VAR]] := Int
+  // CHECK: (attempting type variable binding [[LITERAL_VAR]] := Int
   test(42) {
     1
     ""
@@ -49,7 +49,7 @@ do {
 
   // CHECK: ---Initial constraints for the given expression---
   // CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
-  // CHECK: (attempting type variable [[LITERAL_VAR]] := Int
+  // CHECK: (attempting type variable binding [[LITERAL_VAR]] := Int
   // CHECK: (attempting conjunction element pattern binding element @ 0
   test(42) { v in
     v


### PR DESCRIPTION
* Use fancy arrows (`→`) because they are distinct from and shorter than `->`, and fancier.
* We have two ways of demarcating locators: `@ <locator>` and `[[<locator>]];`. Stick to the first, which is shorter and clearer.
* 'attempting type variable' → 'attempting binding'. *Bindings* are attempted, not type variables.
* `considering ->` → `considering:`. I think a colon is semantically more fit and makes things easier to read if the considered constraint has arrows in its description or types. Also, it’s shorter this way.