### PR TITLE
[cxx-interop] Fix dependency between CxxStdlib and CxxStdlibShim

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -32,5 +32,6 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED)
 
-add_subdirectory(std)
+# CxxStdlib relies on CxxStdlibShim, so it is important to include cxxshim first.
 add_subdirectory(cxxshim)
+add_subdirectory(std)


### PR DESCRIPTION
This is the second part of the fix for `error: no such module 'CxxStdlibShim' when building Swift`.

`add_subdirectory(std)` was executed before `subdirectory(cxxshim)`, which caused `DEPENDS  libcxxshim_modulemap` to have no effect.

rdar://108007693