### PR TITLE
[5.9] [Frontend] Add AvailabilityMacro feature

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -717,6 +717,19 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
       Opts.Features.insert(*feature);
     }
+
+    // Hack: In order to support using availability macros in SPM packages, we
+    // need to be able to use:
+    //    .enableExperimentalFeature("AvailabilityMacro='...'")
+    // within the package manifest and the feature recognizer can't recognize
+    // this form of feature, so specially handle it here until features can
+    // maybe have extra arguments in the future.
+    auto strRef = StringRef(A->getValue());
+    if (strRef.startswith("AvailabilityMacro=")) {
+      auto availability = strRef.split("=").second;
+
+      Opts.AvailabilityMacros.push_back(availability.str());
+    }
   }
 
   // Map historical flags over to future features.

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -5,6 +5,15 @@
 // RUN:   -define-availability "_macOS11_0:macOS 11.0" \
 // RUN:   -define-availability "_myProject 1.0:macOS 11.0" \
 // RUN:   -define-availability "_myProject 2.5:macOS 12.5"
+
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -enable-experimental-feature AvailabilityMacro='_iOS13Aligned:macOS 10.15, iOS 13.0' \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_iOS14Aligned:macOS 11.0, iOS 14.0" \
+// RUN:   -enable-experimental-feature AvailabilityMacro='_iOS14:iOS 14.0' \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_macOS11_0:macOS 11.0" \
+// RUN:   -enable-experimental-feature AvailabilityMacro='_myProject 1.0:macOS 11.0' \
+// RUN:   -enable-experimental-feature AvailabilityMacro="_myProject 2.5:macOS 12.5"
+
 // REQUIRES: OS=macosx
 
 @available(_iOS13Aligned, *)


### PR DESCRIPTION
This is a cherry pick of https://github.com/apple/swift/pull/65218

This is needed to support defining availabilities in SPM package manifests using `.enableExperimentalFeature("AvailabilityMacro=")`.