### PR TITLE
IRGen: Try harder not to emit calls to swift_getExtendedExistentialTypeMetadata()

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -419,6 +419,12 @@ public:
   bool hasLocalArchetype() const {
     return getASTType()->hasLocalArchetype();
   }
+
+  /// Returns true if the referenced type is expressed in terms of one
+  /// or more parameterized protocol types.
+  bool hasParameterizedExistential() const {
+    return getASTType()->hasParameterizedExistential();
+  }
   
   /// Returns the representation used by an existential type. If the concrete
   /// type is provided, this may return a specialized representation kind that

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -279,62 +279,6 @@ EnumImplStrategy::emitResilientTagIndices(IRGenModule &IGM) const {
   }
 }
 
-void EnumImplStrategy::callOutlinedCopy(IRGenFunction &IGF,
-                                        Address dest, Address src, SILType T,
-                                        IsInitialization_t isInit,
-                                        IsTake_t isTake) const {
-  if (!IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
-    OutliningMetadataCollector collector(IGF);
-    if (T.hasArchetype()) {
-      collectMetadataForOutlining(collector, T);
-    }
-    collector.emitCallToOutlinedCopy(dest, src, T, *TI, isInit, isTake);
-    return;
-  }
-
-  if (!T.hasArchetype()) {
-    // Call the outlined copy function (the implementation will call vwt in this
-    // case).
-    OutliningMetadataCollector collector(IGF);
-    collector.emitCallToOutlinedCopy(dest, src, T, *TI, isInit, isTake);
-    return;
-  }
-
-  if (isInit == IsInitialization && isTake == IsTake) {
-    return emitInitializeWithTakeCall(IGF, T, dest, src);
-  } else if (isInit == IsInitialization && isTake == IsNotTake) {
-    return emitInitializeWithCopyCall(IGF, T, dest, src);
-  } else if (isInit == IsNotInitialization && isTake == IsTake) {
-    return emitAssignWithTakeCall(IGF, T, dest, src);
-  } else if (isInit == IsNotInitialization && isTake == IsNotTake) {
-    return emitAssignWithCopyCall(IGF, T, dest, src);
-  }
-  llvm_unreachable("unknown case");
-}
-
-void EnumImplStrategy::callOutlinedDestroy(IRGenFunction &IGF,
-                                           Address addr, SILType T) const {
-  if (!IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
-    OutliningMetadataCollector collector(IGF);
-    if (T.hasArchetype()) {
-      collectMetadataForOutlining(collector, T);
-    }
-    collector.emitCallToOutlinedDestroy(addr, T, *TI);
-    return;
-  }
-
-  if (!T.hasArchetype()) {
-    // Call the outlined copy function (the implementation will call vwt in this
-    // case).
-    OutliningMetadataCollector collector(IGF);
-    collector.emitCallToOutlinedDestroy(addr, T, *TI);
-    return;
-  }
-
-  emitDestroyCall(IGF, T, addr);
-  return;
-}
-
 namespace {
   /// Implementation strategy for singleton enums, with zero or one cases.
   class SingletonEnumImplStrategy final : public EnumImplStrategy {
@@ -2854,24 +2798,7 @@ namespace {
         }
         }
       } else {
-        if (!IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
-          OutliningMetadataCollector collector(IGF);
-          if (T.hasArchetype()) {
-            collectMetadataForOutlining(collector, T);
-          }
-          collector.emitCallToOutlinedDestroy(addr, T, *TI);
-          return;
-        }
-
-        if (!T.hasArchetype()) {
-          // Call the outlined copy function (the implementation will call vwt
-          // in this case).
-          OutliningMetadataCollector collector(IGF);
-          collector.emitCallToOutlinedDestroy(addr, T, *TI);
-          return;
-        }
-
-        emitDestroyCall(IGF, T, addr);
+        callOutlinedDestroy(IGF, addr, T);
         return;
       }
     }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -493,7 +493,7 @@ namespace {
       if (!getSingleton()) return;
       if (!ElementsAreABIAccessible) {
         emitAssignWithCopyCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->assignWithCopy(
@@ -508,7 +508,7 @@ namespace {
       if (!getSingleton()) return;
       if (!ElementsAreABIAccessible) {
         emitAssignWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->assignWithTake(
@@ -530,7 +530,7 @@ namespace {
       if (!getSingleton()) return;
       if (!ElementsAreABIAccessible) {
         emitInitializeWithCopyCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->initializeWithCopy(
@@ -545,7 +545,7 @@ namespace {
       if (!getSingleton()) return;
       if (!ElementsAreABIAccessible) {
         emitInitializeWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->initializeWithTake(
@@ -601,7 +601,7 @@ namespace {
           !getSingleton()->isTriviallyDestroyable(ResilienceExpansion::Maximal)) {
         if (!ElementsAreABIAccessible) {
           emitDestroyCall(IGF, T, addr);
-        } else if (isOutlined || T.hasLocalArchetype()) {
+        } else if (isOutlined || T.hasParameterizedExistential()) {
           getSingleton()->destroy(IGF, getSingletonAddress(IGF, addr),
                                   getSingletonType(IGF.IGM, T), isOutlined);
         } else {
@@ -2754,7 +2754,7 @@ namespace {
       }
       if (!ElementsAreABIAccessible) {
         return emitDestroyCall(IGF, T, addr);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         switch (CopyDestroyKind) {
         case TriviallyDestroyable:
           return;
@@ -3041,7 +3041,7 @@ namespace {
                         SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitAssignWithCopyCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsNotTake);
@@ -3052,7 +3052,7 @@ namespace {
                         SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitAssignWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsTake);
@@ -3063,7 +3063,7 @@ namespace {
                             SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitInitializeWithCopyCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsNotTake);
@@ -3074,7 +3074,7 @@ namespace {
                             SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitInitializeWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsTake);
@@ -4899,7 +4899,7 @@ namespace {
                         SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitAssignWithCopyCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsNotTake);
@@ -4910,7 +4910,7 @@ namespace {
                         SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitAssignWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsTake);
@@ -4921,7 +4921,7 @@ namespace {
                             SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitInitializeWithCopyCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsNotTake);
@@ -4932,7 +4932,7 @@ namespace {
                             SILType T, bool isOutlined) const override {
       if (!ElementsAreABIAccessible) {
         emitInitializeWithTakeCall(IGF, T, dest, src);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsTake);
@@ -4966,7 +4966,7 @@ namespace {
       }
       if (!ElementsAreABIAccessible) {
         emitDestroyCall(IGF, T, addr);
-      } else if (isOutlined || T.hasLocalArchetype()) {
+      } else if (isOutlined || T.hasParameterizedExistential()) {
         switch (CopyDestroyKind) {
         case TriviallyDestroyable:
           return;

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -449,9 +449,13 @@ public:
 
   void callOutlinedCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, IsInitialization_t isInit,
-                        IsTake_t isTake) const;
+                        IsTake_t isTake) const {
+    TI->callOutlinedCopy(IGF, dest, src, T, isInit, isTake);
+  }
 
-  void callOutlinedDestroy(IRGenFunction &IGF, Address addr, SILType T) const;
+  void callOutlinedDestroy(IRGenFunction &IGF, Address addr, SILType T) const {
+    TI->callOutlinedDestroy(IGF, addr, T);
+  }
 
   virtual void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                            SILType T) const = 0;

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -172,7 +172,7 @@ public:
       return emitAssignWithCopyCall(IGF, T, dest, src);
     }
 
-    if (isOutlined || T.hasLocalArchetype()) {
+    if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
         if (field.isEmpty())
@@ -195,7 +195,7 @@ public:
       return emitAssignWithTakeCall(IGF, T, dest, src);
     }
 
-    if (isOutlined || T.hasLocalArchetype()) {
+    if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
         if (field.isEmpty())
@@ -225,7 +225,7 @@ public:
       return emitInitializeWithCopyCall(IGF, T, dest, src);
     }
 
-    if (isOutlined || T.hasLocalArchetype()) {
+    if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
         if (field.isEmpty())
@@ -257,7 +257,7 @@ public:
       return emitInitializeWithTakeCall(IGF, T, dest, src);
     }
 
-    if (isOutlined || T.hasLocalArchetype()) {
+    if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
         if (field.isEmpty())
@@ -280,7 +280,7 @@ public:
       return emitDestroyCall(IGF, T, addr);
     }
 
-    if (isOutlined || T.hasLocalArchetype()) {
+    if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
         if (field.isTriviallyDestroyable())

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -138,7 +138,8 @@ irgen::getTypeAndGenericSignatureForManglingOutlineFunction(SILType type) {
 void TypeInfo::callOutlinedCopy(IRGenFunction &IGF, Address dest, Address src,
                                 SILType T, IsInitialization_t isInit,
                                 IsTake_t isTake) const {
-  if (!IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
+  if (!T.hasLocalArchetype() &&
+      !IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
     OutliningMetadataCollector collector(IGF);
     if (T.hasArchetype()) {
       collectMetadataForOutlining(collector, T);
@@ -340,7 +341,8 @@ void TypeInfo::callOutlinedDestroy(IRGenFunction &IGF,
   if (IGF.IGM.getTypeLowering(T).isTrivial())
     return;
 
-  if (!IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
+  if (!T.hasLocalArchetype() &&
+      !IGF.IGM.getOptions().UseTypeLayoutValueHandling) {
     OutliningMetadataCollector collector(IGF);
     if (T.hasArchetype()) {
       collectMetadataForOutlining(collector, T);

--- a/test/IRGen/extended_existential_metadata.swift
+++ b/test/IRGen/extended_existential_metadata.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s
+
+protocol Foo<T> {
+  associatedtype T
+  func acceptEvent<T>(event: T)
+}
+
+protocol FooFactory<T> {
+  associatedtype T
+  func makeFoo() -> any Foo<T>
+}
+
+class Bar<T> {
+  private var foo: (any Foo<T>)
+
+  init(fooFactory: any FooFactory<T>) {
+      self.foo = fooFactory.makeFoo()
+  }
+}
+
+// CHECK-NOT: swift_getExtendedExistentialTypeMetadata

--- a/test/IRGen/variadic_generic_outlining.sil
+++ b/test/IRGen/variadic_generic_outlining.sil
@@ -16,8 +16,10 @@ struct Wrapper<Value> {
 // CHECK-NEXT:  [[PACK:%.*]] = inttoptr [[INT]] [[PACK_ADDR2]] to %swift.type**
 // CHECK-NEXT:  [[T0:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[PACK]], [[INT]]
 // CHECK-NEXT:  [[ELT_TYPE:%.*]] = load %swift.type*, %swift.type** [[T0]], align
+// CHECK:       [[WRAPPER_RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s26variadic_generic_outlining7WrapperVMa"
+// CHECK-NEXT:  [[WRAPPER_TYPE:%.*]] = extractvalue %swift.metadata_response [[WRAPPER_RESPONSE]]
 //   Test that we do the copy through the VWT for the element type.
-// CHECK:       [[T0:%.*]] = bitcast %swift.type* [[ELT_TYPE]] to i8***
+// CHECK-NEXT:  [[T0:%.*]] = bitcast %swift.type* [[WRAPPER_TYPE]] to i8***
 // CHECK-NEXT:  [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], [[INT]] -1
 sil hidden @test_outlining : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat Wrapper<each T>}) -> @pack_out Pack{repeat Wrapper<each T>} {
 bb0(%0 : $*Pack{repeat Wrapper<each T>}, %1 : $*Pack{repeat Wrapper<each T>}):


### PR DESCRIPTION
This entry point doesn't exist on older runtimes, so if we can do a value operation without instantiating the entire metadata for a type, try to do that. Fixes https://github.com/apple/swift/issues/64657