### PR TITLE
[cxx-interop] Enable CxxShim headers for armv7k watchOS

### DIFF
--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(libcxxshim_modulemap_target_list)
 foreach(sdk ${SWIFT_SDKS})
-  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES} ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
     set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
     set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
 


### PR DESCRIPTION
This fixes the `no such module 'CxxStdlibShim'` error when building CxxStdlib for armv7k.

For watchOS, armv7k is included in `${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES}` but not in `${SWIFT_SDK_${sdk}_ARCHITECTURES}`.

rdar://108206099