### PR TITLE
[5.9] Handle async vs. completion-handler mismatches in `@_objcImplementation`

### DIFF
--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -1,3 +1,5 @@
+@import Foundation;
+
 @interface ObjCBaseClass
 
 
@@ -81,6 +83,12 @@
 
 - (void)ambiguousMethod4WithCInt:(int)param  __attribute__((swift_name("ambiguousMethod4(with:)")));
 
+@end
+
+@interface ObjCClass (Effects)
+- (void)doSomethingAsynchronousWithCompletionHandler:(void (^ _Nonnull)(id _Nullable result, NSError * _Nullable error))completionHandler;
+- (void)doSomethingElseAsynchronousWithCompletionHandler:(void (^ _Nullable)(id _Nonnull result))completionHandler;
+- (void)doSomethingFunAndAsynchronousWithCompletionHandler:(void (^ _Nonnull)(id _Nullable result, NSError * _Nullable error))completionHandler;
 @end
 
 @interface ObjCSubclass : ObjCClass

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -276,6 +276,21 @@
   }
 }
 
+@_objcImplementation(Effects) extension ObjCClass {
+  @available(SwiftStdlib 5.1, *)
+  public func doSomethingAsynchronous() async throws -> Any {
+    return self
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  public func doSomethingElseAsynchronous() async -> Any {
+    return self
+  }
+
+  public func doSomethingFunAndAsynchronous(completionHandler: @escaping (Any?, Error?) -> Void) {
+  }
+}
+
 @_objcImplementation extension ObjCClass {}
 // expected-error@-1 {{duplicate implementation of Objective-C class 'ObjCClass'}}
 


### PR DESCRIPTION
* Explanation: When matching methods in an `@_objcImplementation` extension against an Objective-C method imported as `async`, we were not accounting for the fact that such methods can be imported both as both `async` and with a completion handler, and therefore complained that one of the two Objective-C method signatures was not satisfied. Allow both of those requirements to be satisfied by a single candidate, whether it's of the `async` or completion-handler form.
* Scope: Affects code using the experimental `@_objcImplementation` feature with Objective-C methods that are imported as `async`.
* Risk: Low, due to narrow scope and this loosening checking for certain methods.
* Issue: rdar://108160837
* Testing: Additional tests added.
* Original pull request: https://github.com/apple/swift/pull/65253
