### PR TITLE
[Basic] Ensure empty NullTerminatedStringRef have valid pointer

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -490,7 +490,7 @@ public:
 
   /// Create a null-terminated string, copying \p Str into \p A .
   template <typename Allocator>
-  NullTerminatedStringRef(StringRef Str, Allocator &A) : Ref() {
+  NullTerminatedStringRef(StringRef Str, Allocator &A) : Ref("") {
     if (Str.empty())
       return;
 


### PR DESCRIPTION
`NullterminatedStringRef` is meant to be safe for reading `data()` as a valid C-string.

rdar://108215490
