### PR TITLE
Serialize `package` and SPI doc comments in swiftsourceinfo 

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1545,12 +1545,6 @@ private:
   Optional<ExternalSourceLocs *> getExternalSourceLocs(const Decl *D);
   void setExternalSourceLocs(const Decl *D, ExternalSourceLocs *Locs);
 
-  Optional<std::pair<RawComment, bool>> getRawComment(const Decl *D);
-  void setRawComment(const Decl *D, RawComment RC, bool FromSerialized);
-
-  Optional<StringRef> getBriefComment(const Decl *D);
-  void setBriefComment(const Decl *D, StringRef Comment);
-
   friend TypeBase;
   friend ArchetypeType;
   friend OpaqueTypeDecl;

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -111,6 +111,25 @@ extractCommentParts(swift::markup::MarkupContext &MC,
 
 /// Extract brief comment from \p RC, and print it to \p OS .
 void printBriefComment(RawComment RC, llvm::raw_ostream &OS);
+
+/// Describes the intended serialization target for a doc comment.
+enum class DocCommentSerializationTarget : uint8_t {
+  /// The doc comment should not be serialized.
+  None = 0,
+
+  /// The doc comment should only be serialized in the 'swiftsourceinfo'.
+  SourceInfoOnly,
+
+  /// The doc comment should be serialized in both the 'swiftdoc' and
+  /// 'swiftsourceinfo'.
+  SwiftDocAndSourceInfo,
+};
+
+/// Retrieve the expected serialization target for a documentation comment
+/// attached to the given decl.
+DocCommentSerializationTarget
+getDocCommentSerializationTargetFor(const Decl *D);
+
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_COMMENT_H

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -93,27 +93,16 @@ public:
 };
 
 /// Get a parsed documentation comment for the declaration, if there is one.
-///
-/// \param AllowSerialized Allow loading serialized doc comment data, including
-/// comment ranges.
 DocComment *getSingleDocComment(swift::markup::MarkupContext &Context,
-                                const Decl *D, bool AllowSerialized = false);
+                                const Decl *D);
 
 /// Get the declaration that actually provides a doc comment for another.
-///
-/// \param AllowSerialized Allow loading serialized doc comment data, including
-/// comment ranges.
-const Decl *getDocCommentProvidingDecl(const Decl *D,
-                                       bool AllowSerialized = false);
+const Decl *getDocCommentProvidingDecl(const Decl *D);
 
 /// Attempt to get a doc comment from the declaration, or other inherited
 /// sources, like from base classes or protocols.
-///
-/// \param AllowSerialized Allow loading serialized doc comment data, including
-/// comment ranges.
 DocComment *getCascadingDocComment(swift::markup::MarkupContext &MC,
-                                   const Decl *D,
-                                   bool AllowSerialized = false);
+                                   const Decl *D);
 
 /// Extract comments parts from the given Markup node.
 swift::markup::CommentParts

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -747,6 +747,7 @@ protected:
   friend class IterableDeclContext;
   friend class MemberLookupTable;
   friend class DeclDeserializer;
+  friend class RawCommentRequest;
 
 private:
   llvm::PointerUnion<DeclContext *, ASTContext *> Context;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1024,8 +1024,9 @@ public:
 
   Optional<unsigned> getSourceOrder() const;
 
-  /// \returns the brief comment attached to this declaration.
-  StringRef getBriefComment() const;
+  /// \returns The brief comment attached to this declaration, or the brief
+  /// comment attached to the comment providing decl.
+  StringRef getSemanticBriefComment() const;
 
   /// Returns true if there is a Clang AST node associated
   /// with self.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1015,7 +1015,7 @@ public:
   }
 
   /// \returns the unparsed comment attached to this declaration.
-  RawComment getRawComment(bool SerializedOK = false) const;
+  RawComment getRawComment() const;
 
   Optional<StringRef> getGroupName() const;
 

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -167,6 +167,10 @@ public:
     return None;
   }
 
+  /// For a serialized AST file, returns \c true if an adjacent swiftdoc has been
+  /// loaded. Otherwise, returns \c false.
+  virtual bool hasLoadedSwiftDoc() const { return false; }
+
   virtual Optional<StringRef>
   getGroupNameForDecl(const Decl *D) const {
     return None;

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -161,7 +161,7 @@ public:
   ///
   /// This function is an implementation detail for comment serialization.
   /// If you just want to get a comment attached to a decl, use
-  /// \c Decl::getRawComment() or \c Decl::getBriefComment().
+  /// \c Decl::getRawComment() or \c Decl::getSemanticBriefComment().
   virtual Optional<CommentInfo>
   getCommentForDecl(const Decl *D) const {
     return None;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4187,9 +4187,10 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Retrieve the brief portion of a declaration's document comment.
-class BriefCommentRequest
-    : public SimpleRequest<BriefCommentRequest,
+/// Retrieve the brief portion of a declaration's document comment, potentially
+/// walking to find the comment providing decl if needed.
+class SemanticBriefCommentRequest
+    : public SimpleRequest<SemanticBriefCommentRequest,
                            StringRef(const Decl *),
                            RequestFlags::Cached> {
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4168,6 +4168,44 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Retrieve the raw documentation comment of a declaration.
+class RawCommentRequest
+    : public SimpleRequest<RawCommentRequest,
+                           RawComment(const Decl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  RawComment evaluate(Evaluator &evaluator, const Decl *D) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+};
+
+/// Retrieve the brief portion of a declaration's document comment.
+class BriefCommentRequest
+    : public SimpleRequest<BriefCommentRequest,
+                           StringRef(const Decl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  StringRef evaluate(Evaluator &evaluator, const Decl *D) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+};
+
 /// Checks that all of a class's \c \@objcImplementation extensions provide
 /// complete and correct implementations for their corresponding interfaces.
 /// This is done on all of a class's implementations at once to improve diagnostics.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -466,6 +466,12 @@ SWIFT_REQUEST(TypeChecker, GetRuntimeDiscoverableAttributes,
 SWIFT_REQUEST(TypeChecker, LocalDiscriminatorsRequest,
               unsigned(DeclContext *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, RawCommentRequest,
+              RawComment(const Decl *),
+              Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, BriefCommentRequest,
+              StringRef(const Decl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsNonUserModuleRequest,
               bool(ModuleDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -469,7 +469,7 @@ SWIFT_REQUEST(TypeChecker, LocalDiscriminatorsRequest,
 SWIFT_REQUEST(TypeChecker, RawCommentRequest,
               RawComment(const Decl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, BriefCommentRequest,
+SWIFT_REQUEST(TypeChecker, SemanticBriefCommentRequest,
               StringRef(const Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsNonUserModuleRequest,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -430,6 +430,8 @@ public:
 
   Optional<CommentInfo> getCommentForDecl(const Decl *D) const override;
 
+  bool hasLoadedSwiftDoc() const override;
+
   Optional<StringRef> getGroupNameForDecl(const Decl *D) const override;
 
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -316,12 +316,6 @@ struct ASTContext::Implementation {
   /// actual \c SourceLocs that require opening their external buffer.
   llvm::DenseMap<const Decl *, ExternalSourceLocs *> ExternalSourceLocs;
 
-  /// Map from Swift declarations to raw comments.
-  llvm::DenseMap<const Decl *, std::pair<RawComment, bool>> RawComments;
-
-  /// Map from Swift declarations to brief comments.
-  llvm::DenseMap<const Decl *, StringRef> BriefComments;
-
   /// Map from declarations to foreign error conventions.
   /// This applies to both actual imported functions and to @objc functions.
   llvm::DenseMap<const AbstractFunctionDecl *,
@@ -2610,30 +2604,6 @@ void ASTContext::setExternalSourceLocs(const Decl *D,
   getImpl().ExternalSourceLocs[D] = Locs;
 }
 
-Optional<std::pair<RawComment, bool>> ASTContext::getRawComment(const Decl *D) {
-  auto Known = getImpl().RawComments.find(D);
-  if (Known == getImpl().RawComments.end())
-    return None;
-
-  return Known->second;
-}
-
-void ASTContext::setRawComment(const Decl *D, RawComment RC, bool FromSerialized) {
-  getImpl().RawComments[D] = std::make_pair(RC, FromSerialized);
-}
-
-Optional<StringRef> ASTContext::getBriefComment(const Decl *D) {
-  auto Known = getImpl().BriefComments.find(D);
-  if (Known == getImpl().BriefComments.end())
-    return None;
-
-  return Known->second;
-}
-
-void ASTContext::setBriefComment(const Decl *D, StringRef Comment) {
-  getImpl().BriefComments[D] = Comment;
-}
-
 NormalProtocolConformance *
 ASTContext::getConformance(Type conformingType,
                            ProtocolDecl *protocol,
@@ -2936,8 +2906,6 @@ size_t ASTContext::getTotalMemory() const {
     getImpl().Allocator.getTotalMemory() +
     getImpl().Cleanups.capacity() +
     llvm::capacity_in_bytes(getImpl().ModuleLoaders) +
-    llvm::capacity_in_bytes(getImpl().RawComments) +
-    llvm::capacity_in_bytes(getImpl().BriefComments) +
     llvm::capacity_in_bytes(getImpl().ModuleTypes) +
     llvm::capacity_in_bytes(getImpl().GenericParamTypes) +
     // getImpl().GenericFunctionTypes ?

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -573,8 +573,8 @@ static Optional<StringRef> getDirectBriefComment(const Decl *D) {
   return Ctx.AllocateCopy(BriefStr.str());
 }
 
-StringRef BriefCommentRequest::evaluate(Evaluator &evaluator,
-                                        const Decl *D) const {
+StringRef SemanticBriefCommentRequest::evaluate(Evaluator &evaluator,
+                                                const Decl *D) const {
   // Perform a walk over the potential providers of the brief comment,
   // retrieving the first one we come across.
   CommentProviderFinder finder(getDirectBriefComment);
@@ -582,10 +582,11 @@ StringRef BriefCommentRequest::evaluate(Evaluator &evaluator,
   return result ? result->first : StringRef();
 }
 
-StringRef Decl::getBriefComment() const {
+StringRef Decl::getSemanticBriefComment() const {
   if (!this->canHaveComment())
     return StringRef();
 
   auto &eval = getASTContext().evaluator;
-  return evaluateOrDefault(eval, BriefCommentRequest{this}, StringRef());
+  return evaluateOrDefault(eval, SemanticBriefCommentRequest{this},
+                           StringRef());
 }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -392,85 +392,122 @@ DocComment *swift::getSingleDocComment(swift::markup::MarkupContext &MC,
 }
 
 namespace {
-const ValueDecl *findOverriddenDeclWithDocComment(const ValueDecl *VD) {
-  // Only applies to class member.
-  if (!VD->getDeclContext()->getSelfClassDecl())
-    return nullptr;
+/// Helper class for finding the comment providing decl for either a brief or
+/// raw comment.
+template <typename Result>
+class CommentProviderFinder final {
+  using ResultWithDecl = std::pair<Result, const Decl *>;
+  using VisitFnTy = Optional<Result>(*)(const Decl *);
 
-  while (auto *baseDecl = VD->getOverriddenDecl()) {
-    if (!baseDecl->getRawComment().isEmpty())
-      return baseDecl;
-    VD = baseDecl;
+  VisitFnTy VisitFn;
+
+public:
+  CommentProviderFinder(VisitFnTy visitFn) : VisitFn(visitFn) {}
+
+private:
+  Optional<ResultWithDecl> visit(const Decl *D) {
+    // Adapt the provided visitor function to also return the decl.
+    if (auto result = VisitFn(D))
+      return {{*result, D}};
+    return None;
   }
 
-  return nullptr;
-}
+  Optional<ResultWithDecl> findOverriddenDecl(const ValueDecl *VD) {
+    // Only applies to class member.
+    if (!VD->getDeclContext()->getSelfClassDecl())
+      return None;
 
-const ValueDecl *findDefaultProvidedDeclWithDocComment(const ValueDecl *VD) {
-  auto protocol = VD->getDeclContext()->getExtendedProtocolDecl();
-  // Only applies to protocol extension member.
-  if (!protocol)
-    return nullptr;
+    while (auto *baseDecl = VD->getOverriddenDecl()) {
+      if (auto result = visit(baseDecl))
+        return result;
 
-  ValueDecl *requirement = nullptr;
-
-  SmallVector<ValueDecl *, 2> members;
-  protocol->lookupQualified(const_cast<ProtocolDecl *>(protocol),
-                            DeclNameRef(VD->getName()),
-                            NLOptions::NL_ProtocolMembers,
-                            members);
-
-  for (auto *member : members) {
-    if (!isa<ProtocolDecl>(member->getDeclContext()) ||
-        !member->isProtocolRequirement() || member->getRawComment().isEmpty())
-      continue;
-    if (requirement)
-      // Found two or more decls with doc-comment.
-      return nullptr;
-
-    requirement = member;
-  }
-  return requirement;
-}
-
-const ValueDecl *findRequirementDeclWithDocComment(const ValueDecl *VD) {
-  std::queue<const ValueDecl *> requirements;
-  while (true) {
-    for (auto *req : VD->getSatisfiedProtocolRequirements()) {
-      if (!req->getRawComment().isEmpty())
-        return req;
-      else
-        requirements.push(req);
+      VD = baseDecl;
     }
-    if (requirements.empty())
-      return nullptr;
-    VD = requirements.front();
-    requirements.pop();
+    return None;
   }
-}
-} // namespace
+
+  Optional<ResultWithDecl> findDefaultProvidedDecl(const ValueDecl *VD) {
+    // Only applies to protocol extension member.
+    auto *protocol = VD->getDeclContext()->getExtendedProtocolDecl();
+    if (!protocol)
+      return None;
+
+    SmallVector<ValueDecl *, 2> members;
+    protocol->lookupQualified(const_cast<ProtocolDecl *>(protocol),
+                              DeclNameRef(VD->getName()),
+                              NLOptions::NL_ProtocolMembers, members);
+
+    Optional<ResultWithDecl> result;
+    for (auto *member : members) {
+      if (!isa<ProtocolDecl>(member->getDeclContext()) ||
+          !member->isProtocolRequirement())
+        continue;
+
+      auto newResult = visit(member);
+      if (!newResult)
+        continue;
+
+      if (result) {
+        // Found two or more decls with doc-comment.
+        return None;
+      }
+      result = newResult;
+    }
+    return result;
+  }
+
+  Optional<ResultWithDecl> findRequirementDecl(const ValueDecl *VD) {
+    std::queue<const ValueDecl *> requirements;
+    while (true) {
+      for (auto *req : VD->getSatisfiedProtocolRequirements()) {
+        if (auto result = visit(req))
+          return result;
+
+        requirements.push(req);
+      }
+      if (requirements.empty())
+        return None;
+
+      VD = requirements.front();
+      requirements.pop();
+    }
+  }
+
+public:
+  Optional<ResultWithDecl> findCommentProvider(const Decl *D) {
+    if (auto result = visit(D))
+      return result;
+
+    auto *VD = dyn_cast<ValueDecl>(D);
+    if (!VD)
+      return None;
+
+    if (auto result = findOverriddenDecl(VD))
+      return result;
+
+    if (auto result = findDefaultProvidedDecl(VD))
+      return result;
+
+    if (auto result = findRequirementDecl(VD))
+      return result;
+
+    return None;
+  }
+};
+} // end anonymous namespace
 
 const Decl *swift::getDocCommentProvidingDecl(const Decl *D) {
-  if (!D->canHaveComment())
-    return nullptr;
+  // Search for the first decl we see with a non-empty raw comment.
+  auto finder = CommentProviderFinder<RawComment>(
+      [](const Decl *D) -> Optional<RawComment> {
+        auto comment = D->getRawComment();
+        if (comment.isEmpty())
+          return None;
+        return comment;
+      });
 
-  if (!D->getRawComment().isEmpty())
-    return D;
-
-  auto *VD = dyn_cast<ValueDecl>(D);
-  if (!VD)
-    return nullptr;
-
-  if (auto *overridden = findOverriddenDeclWithDocComment(VD))
-    return overridden;
-
-  if (auto *requirement = findDefaultProvidedDeclWithDocComment(VD))
-    return requirement;
-
-  if (auto *requirement = findRequirementDeclWithDocComment(VD))
-    return requirement;
-
-  return nullptr;
+  auto result = finder.findCommentProvider(D);
+  return result ? result->second : nullptr;
 }
 
 DocComment *swift::getCascadingDocComment(swift::markup::MarkupContext &MC,
@@ -499,31 +536,50 @@ DocComment *swift::getCascadingDocComment(swift::markup::MarkupContext &MC,
   return doc;
 }
 
-StringRef
-BriefCommentRequest::evaluate(Evaluator &evaluator, const Decl *D) const {
-  auto *DC = D->getDeclContext();
-  auto &ctx = DC->getASTContext();
+/// Retrieve the brief comment for a given decl \p D, without attempting to
+/// walk any requirements or overrides.
+static Optional<StringRef> getDirectBriefComment(const Decl *D) {
+  if (!D->canHaveComment())
+    return None;
 
-  // Check if the brief comment is available in the swiftdoc.
-  if (auto *Unit = dyn_cast<FileUnit>(DC->getModuleScopeContext())) {
-    if (auto C = Unit->getCommentForDecl(D))
-      return C->Brief;
+  auto *ModuleDC = D->getDeclContext()->getModuleScopeContext();
+  auto &Ctx = ModuleDC->getASTContext();
+
+  // If we expect the comment to be in the swiftdoc, check for it if we loaded a
+  // swiftdoc. If missing from the swiftdoc, we know it will not be in the
+  // swiftsourceinfo either, so we can bail early.
+  if (auto *Unit = dyn_cast<FileUnit>(ModuleDC)) {
+    if (Unit->hasLoadedSwiftDoc()) {
+      auto target = getDocCommentSerializationTargetFor(D);
+      if (target == DocCommentSerializationTarget::SwiftDocAndSourceInfo) {
+        auto C = Unit->getCommentForDecl(D);
+        if (!C)
+          return None;
+
+        return C->Brief;
+      }
+    }
   }
 
-  // Otherwise, parse the brief from the raw comment itself. This will look into the
-  // swiftsourceinfo if needed.
+  // Otherwise, parse the brief from the raw comment itself. This will look into
+  // the swiftsourceinfo if needed.
   auto RC = D->getRawComment();
-  if (RC.isEmpty()) {
-    if (auto *docD = getDocCommentProvidingDecl(D))
-      RC = docD->getRawComment();
-  }
   if (RC.isEmpty())
-    return StringRef();
+    return None;
 
   SmallString<256> BriefStr;
   llvm::raw_svector_ostream OS(BriefStr);
   printBriefComment(RC, OS);
-  return ctx.AllocateCopy(BriefStr.str());
+  return Ctx.AllocateCopy(BriefStr.str());
+}
+
+StringRef BriefCommentRequest::evaluate(Evaluator &evaluator,
+                                        const Decl *D) const {
+  // Perform a walk over the potential providers of the brief comment,
+  // retrieving the first one we come across.
+  CommentProviderFinder finder(getDirectBriefComment);
+  auto result = finder.findCommentProvider(D);
+  return result ? result->first : StringRef();
 }
 
 StringRef Decl::getBriefComment() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1440,7 +1440,7 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
   Result.SourceFilePath = SM.getIdentifierForBuffer(BufferID);
   setLoc(Result.Loc, MainLoc);
   if (!InGeneratedBuffer) {
-    for (const auto &SRC : D->getRawComment(/*SerializedOK=*/false).Comments) {
+    for (const auto &SRC : D->getRawComment().Comments) {
       Result.DocRanges.emplace_back(ExternalSourceLocs::RawLoc(),
                                     SRC.Range.getByteLength());
       setLoc(Result.DocRanges.back().first, SRC.Range.getStart());

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -222,7 +222,7 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
       }
     }
   } else {
-    setBriefDocComment(AssociatedDecl->getBriefComment());
+    setBriefDocComment(AssociatedDecl->getSemanticBriefComment());
   }
 }
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -294,8 +294,9 @@ struct SynthesizedExtensionAnalyzer::Implementation {
                ExtensionDecl *EnablingExt, NormalProtocolConformance *Conf) {
     SynthesizedExtensionInfo Result(IsSynthesized, EnablingExt);
     ExtensionMergeInfo MergeInfo;
-    MergeInfo.Unmergable = !Ext->getRawComment(/*SerializedOK=*/false).isEmpty() || // With comments
-                           Ext->getAttrs().hasAttribute<AvailableAttr>(); // With @available
+    MergeInfo.Unmergable =
+        !Ext->getRawComment().isEmpty() ||             // With comments
+        Ext->getAttrs().hasAttribute<AvailableAttr>(); // With @available
     MergeInfo.InheritsCount = countInherits(Ext);
 
     // There's (up to) two extensions here: the extension with the items that we

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -829,7 +829,7 @@ static SourceLoc getDeclStartPosition(SourceFile &File) {
   for (auto D : File.getTopLevelDecls()) {
     if (tryUpdateStart(D->getStartLoc())) {
       tryUpdateStart(D->getAttrs().getStartLoc());
-      auto RawComment = D->getRawComment(/*SerializedOK=*/false);
+      auto RawComment = D->getRawComment();
       if (!RawComment.isEmpty())
         tryUpdateStart(RawComment.Comments.front().Range.getStart());
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -198,7 +198,7 @@ bool NameMatcher::handleCustomAttrs(Decl *D) {
 
 ASTWalker::PreWalkAction NameMatcher::walkToDeclPre(Decl *D) {
   // Handle occurrences in any preceding doc comments
-  RawComment R = D->getRawComment(/*SerializedOK=*/false);
+  RawComment R = D->getRawComment();
   if (!R.isEmpty()) {
     for(SingleRawComment C: R.Comments) {
       while(!shouldSkip(C.Range))

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -514,7 +514,7 @@ CharSourceRange innerCharSourceRangeFromSourceRange(const SourceManager &SM,
 static void setDecl(SyntaxStructureNode &N, Decl *D) {
   N.Dcl = D;
   N.Attrs = D->getOriginalAttrs();
-  N.DocRange = D->getRawComment(/*SerializedOK=*/false).getCharSourceRange();
+  N.DocRange = D->getRawComment().getCharSourceRange();
 }
 
 } // anonymous namespace

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1065,6 +1065,10 @@ Optional<CommentInfo> ModuleFile::getCommentForDecl(const Decl *D) const {
   return getCommentForDeclByUSR(USRBuffer.str());
 }
 
+bool ModuleFile::hasLoadedSwiftDoc() const {
+  return Core->DeclCommentTable != nullptr;
+}
+
 void ModuleFile::collectSerializedSearchPath(
     llvm::function_ref<void(StringRef)> callback) const {
   for (auto path: Core->SearchPaths) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -883,6 +883,7 @@ public:
   Optional<unsigned> getSourceOrderForDecl(const Decl *D) const;
   void collectAllGroups(SmallVectorImpl<StringRef> &Names) const;
   Optional<CommentInfo> getCommentForDecl(const Decl *D) const;
+  bool hasLoadedSwiftDoc() const;
   Optional<CommentInfo> getCommentForDeclByUSR(StringRef USR) const;
   Optional<StringRef> getGroupNameByUSR(StringRef USR) const;
   Optional<ExternalSourceLocs::RawLocs>

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -357,7 +357,9 @@ static void writeDeclCommentTable(
       if (!D->canHaveComment())
         return false;
 
-      // Skip the decl if it does not have a comment.
+      // Skip the decl if it does not have a comment. Note this means
+      // we'll only serialize "direct" brief comments, but that's okay
+      // because clients can compute the semantic brief comment themselves.
       if (D->getRawComment().Comments.empty())
         return false;
       return true;
@@ -372,9 +374,8 @@ static void writeDeclCommentTable(
           return;
       }
       generator.insert(copyString(USRBuffer.str()),
-                       { ED->getBriefComment(), ED->getRawComment(),
-                         GroupContext.getGroupSequence(ED),
-                         SourceOrder++ });
+                       {ED->getSemanticBriefComment(), ED->getRawComment(),
+                        GroupContext.getGroupSequence(ED), SourceOrder++});
     }
 
     MacroWalking getMacroWalkingBehavior() const override {
@@ -407,9 +408,8 @@ static void writeDeclCommentTable(
       }
 
       generator.insert(copyString(USRBuffer.str()),
-                       { VD->getBriefComment(), D->getRawComment(),
-                         GroupContext.getGroupSequence(VD),
-                         SourceOrder++ });
+                       {VD->getSemanticBriefComment(), D->getRawComment(),
+                        GroupContext.getGroupSequence(VD), SourceOrder++});
       return Action::Continue();
     }
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1617,6 +1617,10 @@ SerializedASTFile::getCommentForDecl(const Decl *D) const {
   return File.getCommentForDecl(D);
 }
 
+bool SerializedASTFile::hasLoadedSwiftDoc() const {
+  return File.hasLoadedSwiftDoc();
+}
+
 Optional<ExternalSourceLocs::RawLocs>
 SerializedASTFile::getExternalRawLocsForDecl(const Decl *D) const {
   return File.getExternalRawLocsForDecl(D);

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -210,8 +210,8 @@ void Symbol::serializeRange(size_t InitialIndentation,
 
 const ValueDecl *Symbol::getDeclInheritingDocs() const {
   // get the decl that would provide docs for this symbol
-  const auto *DocCommentProvidingDecl = dyn_cast_or_null<ValueDecl>(
-      getDocCommentProvidingDecl(D, /*AllowSerialized=*/true));
+  const auto *DocCommentProvidingDecl =
+      dyn_cast_or_null<ValueDecl>(getDocCommentProvidingDecl(D));
 
   // if the decl is the same as the one for this symbol, we're not
   // inheriting docs, so return null. however, if this symbol is
@@ -356,13 +356,13 @@ void Symbol::serializeDocComment(llvm::json::OStream &OS) const {
 
   const auto *DocCommentProvidingDecl = D;
   if (!Graph->Walker.Options.SkipInheritedDocs) {
-    DocCommentProvidingDecl = dyn_cast_or_null<ValueDecl>(
-        getDocCommentProvidingDecl(D, /*AllowSerialized=*/true));
+    DocCommentProvidingDecl =
+        dyn_cast_or_null<ValueDecl>(getDocCommentProvidingDecl(D));
     if (!DocCommentProvidingDecl) {
       DocCommentProvidingDecl = D;
     }
   }
-  auto RC = DocCommentProvidingDecl->getRawComment(/*SerializedOK=*/true);
+  auto RC = DocCommentProvidingDecl->getRawComment();
   if (RC.isEmpty()) {
     return;
   }

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -705,8 +705,7 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
     // If we've been asked to skip protocol implementations, filter them out here.
     if (Walker.Options.SkipProtocolImplementations && getProtocolRequirement(VD)) {
       // Allow them to stay if they have their own doc comment
-      const auto *DocCommentProvidingDecl =
-        getDocCommentProvidingDecl(VD, /*AllowSerialized=*/true);
+      const auto *DocCommentProvidingDecl = getDocCommentProvidingDecl(VD);
       if (DocCommentProvidingDecl != VD)
         return true;
     }

--- a/test/Serialization/Inputs/def_comments.swift
+++ b/test/Serialization/Inputs/def_comments.swift
@@ -27,5 +27,11 @@ public protocol second_decl_protocol_1 {
 
 public var (decl_var_2, decl_var_3): (Int, Float) = (1, 1.0)
 
+/// Comment on package function
+package func second_package_function() {}
+
+/// Comment on SPI function
+@_spi(DocSPI) public func second_spi_function() {}
+
 #sourceLocation(file:"NonExistingSource.swift", line:100000)
 public func functionAfterPoundSourceLoc() {}

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -1,7 +1,7 @@
 // Test the case when we have a single file in a module.
 //
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s
+// RUN: %target-swift-frontend -module-name comments -package-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s
 // RUN: llvm-bcanalyzer %t/comments.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
@@ -10,9 +10,9 @@
 // Test the case when we have a multiple files in a module.
 //
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/first.swiftmodule -emit-module-doc -emit-module-doc-path %t/first.swiftdoc -primary-file %s %S/Inputs/def_comments.swift -emit-module-source-info-path %t/first.swiftsourceinfo
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/second.swiftmodule -emit-module-doc -emit-module-doc-path %t/second.swiftdoc %s -primary-file %S/Inputs/def_comments.swift -emit-module-source-info-path %t/second.swiftsourceinfo
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %t/first.swiftmodule %t/second.swiftmodule -emit-module-source-info-path %t/comments.swiftsourceinfo
+// RUN: %target-swift-frontend -module-name comments -package-name comments -emit-module -emit-module-path %t/first.swiftmodule -emit-module-doc -emit-module-doc-path %t/first.swiftdoc -primary-file %s %S/Inputs/def_comments.swift -emit-module-source-info-path %t/first.swiftsourceinfo
+// RUN: %target-swift-frontend -module-name comments -package-name comments -emit-module -emit-module-path %t/second.swiftmodule -emit-module-doc -emit-module-doc-path %t/second.swiftdoc %s -primary-file %S/Inputs/def_comments.swift -emit-module-source-info-path %t/second.swiftsourceinfo
+// RUN: %target-swift-frontend -module-name comments -package-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %t/first.swiftmodule %t/second.swiftmodule -emit-module-source-info-path %t/comments.swiftsourceinfo
 // RUN: llvm-bcanalyzer %t/comments.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
@@ -60,16 +60,26 @@ public protocol P1 { }
 /// Comment for no member extension
 extension first_decl_class_1 : P1 {}
 
+/// Comment on package function
+package func first_package_function() {}
+
+/// Comment on SPI function
+@_spi(DocSPI) public func first_spi_function() {}
+
 // FIRST: comments.swift:26:14: Class/first_decl_generic_class_1 RawComment=[/// first_decl_generic_class_1 Aaa.\n]
 // FIRST: comments.swift:28:3: Destructor/first_decl_generic_class_1.deinit RawComment=[/// deinit of first_decl_generic_class_1 Aaa.\n]
 // FIRST: comments.swift:33:14: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]
 // FIRST: comments.swift:36:15: Func/first_decl_class_1.decl_func_1 RawComment=[/// decl_func_1 Aaa.\n]
 // FIRST: comments.swift:41:15: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
 // FIRST: comments.swift:45:15: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
+// FIRST: comments.swift:64:14: Func/first_package_function RawComment=[/// Comment on package function\n]
+// FIRST: comments.swift:67:27: Func/first_spi_function RawComment=[/// Comment on SPI function\n]
 
 // SECOND: comments.swift:49:1: Extension/ RawComment=[/// Comment for bar1\n] BriefComment=[Comment for bar1]
 // SECOND: comments.swift:54:1: Extension/ RawComment=[/// Comment for bar2\n] BriefComment=[Comment for bar2]
 // SECOND: comments.swift:61:1: Extension/ RawComment=[/// Comment for no member extension\n] BriefComment=[Comment for no member extension]
+// SECOND: comments.swift:64:14: Func/first_package_function RawComment=[/// Comment on package function\n]
+// SECOND: comments.swift:67:27: Func/first_spi_function RawComment=[/// Comment on SPI function\n]
 // SECOND: Inputs/def_comments.swift:2:14: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]
 // SECOND: Inputs/def_comments.swift:5:15: Struct/second_decl_struct_1
 // SECOND: Inputs/def_comments.swift:7:9: Accessor/second_decl_struct_1.<getter for second_decl_struct_1.instanceVar>
@@ -88,13 +98,23 @@ extension first_decl_class_1 : P1 {}
 // SECOND: Inputs/def_comments.swift:28:13: Var/decl_var_2 RawComment=none BriefComment=none DocCommentAsXML=none
 // SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
 // SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: Inputs/def_comments.swift:31:14: Func/second_package_function RawComment=[/// Comment on package function\n]
+// SECOND: Inputs/def_comments.swift:34:27: Func/second_spi_function RawComment=[/// Comment on SPI function\n]
 // SECOND: NonExistingSource.swift:100000:13: Func/functionAfterPoundSourceLoc
+
+// Package and SPI functions won't show up in the (public) swiftinterface
+// INTERFACE: comments.swift:26:14: Class/first_decl_generic_class_1 RawComment=[/// first_decl_generic_class_1 Aaa.\n]
+// INTERFACE: comments.swift:28:3: Destructor/first_decl_generic_class_1.deinit RawComment=[/// deinit of first_decl_generic_class_1 Aaa.\n]
+// INTERFACE: comments.swift:33:14: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]
+// INTERFACE: comments.swift:36:15: Func/first_decl_class_1.decl_func_1 RawComment=[/// decl_func_1 Aaa.\n]
+// INTERFACE: comments.swift:41:15: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
+// INTERFACE: comments.swift:45:15: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
 
 // Test the case when we have to import via a .swiftinterface file.
 //
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Hidden)
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/Hidden/comments.swiftmodule -emit-module-interface-path %t/comments.swiftinterface -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -module-name comments -package-name comments -emit-module -emit-module-path %t/Hidden/comments.swiftmodule -emit-module-interface-path %t/comments.swiftinterface -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s -enable-library-evolution -swift-version 5
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -enable-swiftsourceinfo -source-filename %s -I %t -swift-version 5 | %FileCheck %s -check-prefix=FIRST
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -enable-swiftsourceinfo -source-filename %s -I %t -swift-version 5 | %FileCheck %s -check-prefix=INTERFACE

--- a/test/SourceKit/CodeComplete/complete_docbrief_2.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_2.swift
@@ -1,4 +1,15 @@
-// BEGIN Module.swift
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name DocBriefTest \
+// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
+// RUN:     -emit-module-doc-path %t/Modules/DocBriefTest.swiftdoc \
+// RUN:     %t/Module.swift
+
+//--- Module.swift
 public protocol P {
   /// This is a doc comment of P.foo
   ///
@@ -6,7 +17,7 @@ public protocol P {
   func foo()
 }
 
-// BEGIN User.swift
+//--- User.swift
 import DocBriefTest
 struct S: P {
   func foo() {}
@@ -15,17 +26,6 @@ struct S: P {
 func test() {
   S().
 }
-
-// RUN: %empty-directory(%t)
-// RUN: %empty-directory(%t/Modules)
-// RUN: %{python} %utils/split_file.py -o %t %s
-
-// RUN: %target-swift-frontend \
-// RUN:     -emit-module \
-// RUN:     -module-name DocBriefTest \
-// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
-// RUN:     -emit-module-doc-path %t/Modules/DocBriefTest.swiftdoc \
-// RUN:     %t/Module.swift
 
 // RUN: %sourcekitd-test -req=complete -pos=7:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
 

--- a/test/SourceKit/CodeComplete/complete_docbrief_2.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_2.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Modules)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend \
 // RUN:     -emit-module \
@@ -24,24 +24,22 @@ struct S: P {
 }
 
 func test() {
+  // RUN: %sourcekitd-test -req=complete -pos=%(line+1):7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
   S().
+
+  // CHECK: {
+  // CHECK:   key.results: [
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+  // CHECK-NEXT:       key.name: "foo()",
+  // CHECK-NEXT:       key.sourcetext: "foo()",
+  // CHECK-NEXT:       key.description: "foo()",
+  // CHECK-NEXT:       key.typename: "Void",
+  // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+  // CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+  // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+  // CHECK-NEXT:       key.num_bytes_to_erase: 0,
+  // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefUser1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
+  // CHECK-NEXT:       key.modulename: "DocBriefUser"
+  // CHECK-NEXT:     }
 }
-
-// RUN: %sourcekitd-test -req=complete -pos=7:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
-
-// CHECK: {
-// CHECK:   key.results: [
-// CHECK-NEXT:     {
-// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
-// CHECK-NEXT:       key.name: "foo()",
-// CHECK-NEXT:       key.sourcetext: "foo()",
-// CHECK-NEXT:       key.description: "foo()",
-// CHECK-NEXT:       key.typename: "Void",
-// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
-// CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
-// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
-// CHECK-NEXT:       key.num_bytes_to_erase: 0,
-// CHECK-NEXT:       key.associated_usrs: "s:12DocBriefUser1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
-// CHECK-NEXT:       key.modulename: "DocBriefUser"
-// CHECK-NEXT:     }
-

--- a/test/SourceKit/CodeComplete/complete_docbrief_3.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_3.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Modules)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend \
 // RUN:     -emit-module \
@@ -25,24 +25,22 @@ public struct S: P {
 //--- User.swift
 import DocBriefTest
 func test() {
+  // RUN: %sourcekitd-test -req=complete -pos=%(line+1):7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
   S().foo()
+
+  // CHECK: {
+  // CHECK:   key.results: [
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+  // CHECK-NEXT:       key.name: "foo()",
+  // CHECK-NEXT:       key.sourcetext: "foo()",
+  // CHECK-NEXT:       key.description: "foo()",
+  // CHECK-NEXT:       key.typename: "Void",
+  // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+  // CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+  // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+  // CHECK-NEXT:       key.num_bytes_to_erase: 0,
+  // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
+  // CHECK-NEXT:       key.modulename: "DocBriefTest"
+  // CHECK-NEXT:     }
 }
-
-// RUN: %sourcekitd-test -req=complete -pos=3:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
-
-// CHECK: {
-// CHECK:   key.results: [
-// CHECK-NEXT:     {
-// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
-// CHECK-NEXT:       key.name: "foo()",
-// CHECK-NEXT:       key.sourcetext: "foo()",
-// CHECK-NEXT:       key.description: "foo()",
-// CHECK-NEXT:       key.typename: "Void",
-// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
-// CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
-// CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
-// CHECK-NEXT:       key.num_bytes_to_erase: 0,
-// CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
-// CHECK-NEXT:       key.modulename: "DocBriefTest"
-// CHECK-NEXT:     }
-

--- a/test/SourceKit/CodeComplete/complete_docbrief_3.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_3.swift
@@ -1,4 +1,15 @@
-// BEGIN Module.swift
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name DocBriefTest \
+// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
+// RUN:     -emit-module-doc-path %t/Modules/DocBriefTest.swiftdoc \
+// RUN:     %t/Module.swift
+
+//--- Module.swift
 public protocol P {
   /// This is a doc comment of P.foo
   ///
@@ -11,22 +22,11 @@ public struct S: P {
   public func foo() {}
 }
 
-// BEGIN User.swift
+//--- User.swift
 import DocBriefTest
 func test() {
   S().foo()
 }
-
-// RUN: %empty-directory(%t)
-// RUN: %empty-directory(%t/Modules)
-// RUN: %{python} %utils/split_file.py -o %t %s
-
-// RUN: %target-swift-frontend \
-// RUN:     -emit-module \
-// RUN:     -module-name DocBriefTest \
-// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
-// RUN:     -emit-module-doc-path %t/Modules/DocBriefTest.swiftdoc \
-// RUN:     %t/Module.swift
 
 // RUN: %sourcekitd-test -req=complete -pos=3:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
 

--- a/test/SourceKit/CodeComplete/complete_docbrief_package.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_package.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Modules)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend \
 // RUN:     -emit-module \
@@ -27,19 +27,17 @@ package struct S: P {
 package import DocBriefTest
 
 func test() {
+  // RUN: %sourcekitd-test -req=complete -pos=%(line+1):7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser -package-name DocPackage -enable-experimental-feature AccessLevelOnImport | %FileCheck %s -check-prefix=CHECK
   S().foo()
+
+  // CHECK: {
+  // CHECK:   key.results: [
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+  // CHECK-NEXT:       key.name: "foo()",
+  // CHECK-NEXT:       key.sourcetext: "foo()",
+  // CHECK-NEXT:       key.description: "foo()",
+  // CHECK-NEXT:       key.typename: "Void",
+  // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+  // CHECK:          }
 }
-
-// RUN: %sourcekitd-test -req=complete -pos=4:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser -package-name DocPackage -enable-experimental-feature AccessLevelOnImport | %FileCheck %s -check-prefix=CHECK
-
-// CHECK: {
-// CHECK:   key.results: [
-// CHECK-NEXT:     {
-// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
-// CHECK-NEXT:       key.name: "foo()",
-// CHECK-NEXT:       key.sourcetext: "foo()",
-// CHECK-NEXT:       key.description: "foo()",
-// CHECK-NEXT:       key.typename: "Void",
-// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
-// CHECK:          }
-

--- a/test/SourceKit/CodeComplete/complete_docbrief_package.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_package.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name DocBriefTest \
+// RUN:     -package-name DocPackage \
+// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
+// RUN:     -emit-module-source-info-path %t/Modules/DocBriefTest.swiftsourceinfo \
+// RUN:     %t/Module.swift
+
+//--- Module.swift
+package protocol P {
+  /// This is a doc comment of P.foo
+  ///
+  /// Do whatever.
+  func foo()
+}
+
+package struct S: P {
+  public init() {}
+  public func foo() {}
+}
+
+//--- User.swift
+package import DocBriefTest
+
+func test() {
+  S().foo()
+}
+
+// RUN: %sourcekitd-test -req=complete -pos=4:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser -package-name DocPackage -enable-experimental-feature AccessLevelOnImport | %FileCheck %s -check-prefix=CHECK
+
+// CHECK: {
+// CHECK:   key.results: [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+// CHECK-NEXT:       key.name: "foo()",
+// CHECK-NEXT:       key.sourcetext: "foo()",
+// CHECK-NEXT:       key.description: "foo()",
+// CHECK-NEXT:       key.typename: "Void",
+// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+// CHECK:          }
+

--- a/test/SourceKit/CodeComplete/complete_docbrief_spi.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_spi.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Modules)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend \
 // RUN:     -emit-module \
@@ -28,18 +28,17 @@ public struct S: P {
 @_spi(SomeSPI) import DocBriefTest
 
 func test() {
+  // RUN: %sourcekitd-test -req=complete -pos=%(line+1):7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
   S().foo()
+
+  // CHECK: {
+  // CHECK:   key.results: [
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+  // CHECK-NEXT:       key.name: "foo()",
+  // CHECK-NEXT:       key.sourcetext: "foo()",
+  // CHECK-NEXT:       key.description: "foo()",
+  // CHECK-NEXT:       key.typename: "Void",
+  // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+  // CHECK:          }
 }
-
-// RUN: %sourcekitd-test -req=complete -pos=4:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
-
-// CHECK: {
-// CHECK:   key.results: [
-// CHECK-NEXT:     {
-// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
-// CHECK-NEXT:       key.name: "foo()",
-// CHECK-NEXT:       key.sourcetext: "foo()",
-// CHECK-NEXT:       key.description: "foo()",
-// CHECK-NEXT:       key.typename: "Void",
-// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
-// CHECK:          }

--- a/test/SourceKit/CodeComplete/complete_docbrief_spi.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_spi.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name DocBriefTest \
+// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
+// RUN:     -emit-module-source-info-path %t/Modules/DocBriefTest.swiftsourceinfo \
+// RUN:     %t/Module.swift
+
+//--- Module.swift
+@_spi(SomeSPI)
+public protocol P {
+  /// This is a doc comment of P.foo
+  ///
+  /// Do whatever.
+  func foo()
+}
+
+@_spi(SomeSPI)
+public struct S: P {
+  public init() {}
+  public func foo() {}
+}
+
+//--- User.swift
+@_spi(SomeSPI) import DocBriefTest
+
+func test() {
+  S().foo()
+}
+
+// RUN: %sourcekitd-test -req=complete -pos=4:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
+
+// CHECK: {
+// CHECK:   key.results: [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+// CHECK-NEXT:       key.name: "foo()",
+// CHECK-NEXT:       key.sourcetext: "foo()",
+// CHECK-NEXT:       key.description: "foo()",
+// CHECK-NEXT:       key.typename: "Void",
+// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+// CHECK:          }

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -119,7 +119,7 @@ deliverResults(SourceKit::ConformingMethodListConsumer &SKConsumer,
             memberElem.BriefComment = RC->getBriefText(ClangContext);
         }
       } else {
-        memberElem.BriefComment = member->getBriefComment();
+        memberElem.BriefComment = member->getSemanticBriefComment();
       }
     }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -91,7 +91,7 @@ static void deliverResults(SourceKit::TypeContextInfoConsumer &SKConsumer,
               memberElem.BriefComment = RC->getBriefText(ClangContext);
           }
         } else {
-          memberElem.BriefComment = member->getBriefComment();
+          memberElem.BriefComment = member->getSemanticBriefComment();
         }
       }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1183,10 +1183,10 @@ static int printTypeContextInfo(
             VD->getName().print(llvm::outs());
             llvm::outs() << "\n";
 
-            StringRef BriefDoc = VD->getBriefComment();
+            StringRef BriefDoc = VD->getSemanticBriefComment();
             if (!BriefDoc.empty()) {
               llvm::outs() << "     DocBrief: \"";
-              llvm::outs() << VD->getBriefComment();
+              llvm::outs() << VD->getSemanticBriefComment();
               llvm::outs() << "\"\n";
             }
           }
@@ -1251,10 +1251,10 @@ static int printConformingMethodList(
           resultTy.print(llvm::outs());
           llvm::outs() << "\n";
 
-          StringRef BriefDoc = VD->getBriefComment();
+          StringRef BriefDoc = VD->getSemanticBriefComment();
           if (!BriefDoc.empty()) {
             llvm::outs() << "     DocBrief: \"";
-            llvm::outs() << VD->getBriefComment();
+            llvm::outs() << VD->getSemanticBriefComment();
             llvm::outs() << "\"\n";
           }
         }
@@ -3528,7 +3528,7 @@ public:
       OS << " ";
       printRawComment(D->getRawComment());
       OS << " ";
-      printBriefComment(D->getBriefComment());
+      printBriefComment(D->getSemanticBriefComment());
       OS << " ";
       printDocComment(D);
       OS << "\n";
@@ -3543,7 +3543,7 @@ public:
       OS << " ";
       printRawComment(D->getRawComment());
       OS << " ";
-      printBriefComment(D->getBriefComment());
+      printBriefComment(D->getSemanticBriefComment());
       OS << " ";
       printDocComment(D);
       OS << "\n";


### PR DESCRIPTION
Requestify raw and brief comment computation, and allow `package` and SPI doc comments to be serialized in swiftsourceinfo. In the future we may want to emit a separate private swiftdoc for SPI doc comments, but for now we can just include them in the swiftsourceinfo to at least allow them to be picked up for local builds.