### PR TITLE
[Serialization] Keep indirect conformances knowledge with safety

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3124,14 +3124,11 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       if (hasSafeMembers)
         return true;
 
-      // We can mark the extension unsafe only if it has no  public
+      // We can mark the extension unsafe only if it has no public
       // conformances.
       auto protocols = ext->getLocalProtocols(
                                         ConformanceLookupKind::OnlyExplicit);
-      bool hasSafeConformances = std::any_of(protocols.begin(),
-                                             protocols.end(),
-                                             isDeserializationSafe);
-      if (hasSafeConformances)
+      if (!protocols.empty())
         return true;
 
       // Truly empty extensions are safe, it may happen in swiftinterfaces.
@@ -3140,6 +3137,9 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       return false;
     }
+
+    if (isa<ProtocolDecl>(decl))
+      return true;
 
     auto value = cast<ValueDecl>(decl);
 

--- a/test/Serialization/Safety/indirect-conformance.swift
+++ b/test/Serialization/Safety/indirect-conformance.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: asserts
+
+//--- Lib.swift
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface
+
+// RUN: cat %t/Lib.swiftinterface | %FileCheck %t/Lib.swift
+
+public protocol PublicProtocol : AnyObject {}
+// CHECK: public protocol PublicProtocol : AnyObject
+
+protocol InternalProtocol: PublicProtocol {}
+// CHECK-NOT: InternalProtocol
+
+public class IndirectConformant {
+    public init() {}
+}
+extension IndirectConformant: InternalProtocol {}
+// CHECK: extension Lib.IndirectConformant : Lib.PublicProtocol {}
+
+//--- Client.swift
+
+/// Works without safety.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+
+/// Works with safety.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   | %FileCheck %t/Client.swift
+
+/// Works with swiftinterface.
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+
+import Lib
+
+func requireConformanceToPublicProtocol(_ a: PublicProtocol) {}
+requireConformanceToPublicProtocol(IndirectConformant())
+
+/// Deserialization safety should keep the original chain. We're mostly
+/// documenting the current safety implementation details here, if we can get
+/// without deserializing 'InternalProtocol' it would be even better.
+// CHECK: Deserialized: 'IndirectConformant'
+// CHECK: Deserialized: 'PublicProtocol'
+// CHECK: Deserialized: 'InternalProtocol'

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -34,12 +34,12 @@
 public protocol PublicProto {}
 // SAFETY-PRIVATE: Serialization safety, safe: 'PublicProto'
 internal protocol InternalProto {}
-// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
+// SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
 // NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
 private protocol PrivateProto {}
-// SAFETY-PRIVATE: Serialization safety, unsafe: 'PrivateProto'
+// SAFETY-PRIVATE: Serialization safety, safe: 'PrivateProto'
 fileprivate protocol FileprivateProto {}
-// SAFETY-PRIVATE: Serialization safety, unsafe: 'FileprivateProto'
+// SAFETY-PRIVATE: Serialization safety, safe: 'FileprivateProto'
 
 internal struct InternalStruct : PublicProto {
 // SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalStruct'

--- a/test/Serialization/Safety/unsafe-extensions.swift
+++ b/test/Serialization/Safety/unsafe-extensions.swift
@@ -47,7 +47,7 @@ extension ExtendedPublic : PublicProto {
 
 /// Internal
 internal protocol InternalProto {}
-// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
+// SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
 // NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
 internal struct ExtendedInternal {}
 // SAFETY-INTERNAL: Serialization safety, unsafe: 'ExtendedInternal'
@@ -63,7 +63,7 @@ extension ExtendedInternal : InternalProto {}
 
 /// Private
 private protocol PrivateProto {}
-// SAFETY-PRIVATE: Serialization safety, unsafe: 'PrivateProto'
+// SAFETY-PRIVATE: Serialization safety, safe: 'PrivateProto'
 private struct ExtendedPrivate {}
 // SAFETY-PRIVATE: Serialization safety, unsafe: 'ExtendedPrivate'
 extension ExtendedPrivate {
@@ -75,7 +75,7 @@ extension ExtendedPrivate : PrivateProto {}
 
 /// Fileprivate
 private protocol FileprivateProto {}
-// SAFETY-PRIVATE: Serialization safety, unsafe: 'FileprivateProto'
+// SAFETY-PRIVATE: Serialization safety, safe: 'FileprivateProto'
 private struct ExtendedFileprivate {}
 // SAFETY-PRIVATE: Serialization safety, unsafe: 'ExtendedFileprivate'
 extension ExtendedFileprivate {
@@ -87,14 +87,14 @@ extension ExtendedFileprivate : FileprivateProto {}
 
 /// Back to public
 extension ExtendedPublic : InternalProto {
-// SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedPublic'
+// SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedPublic'
 // NO-SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedPublic'
 }
 extension ExtendedPublic : PrivateProto {
-// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
+// SAFETY-PRIVATE: Serialization safety, safe: 'extension ExtendedPublic'
 }
 extension ExtendedPublic : FileprivateProto {
-// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
+// SAFETY-PRIVATE: Serialization safety, safe: 'extension ExtendedPublic'
 }
 
 extension ExtendedPublic {


### PR DESCRIPTION
Given a scenario where a public type `A`, conforms to an internal protocol `B`, which conforms to a public protocol `C`. `A` conforms indirectly to `C` through a protocol that's hidden from the clients.

This is handled in module interface by printing the indirect conformance of `A` to `C` explicitly at the end of the swiftinterface.

We have the same problem with deserialization safety that used to hide the internal protocols from clients, thus breaking the knowledge of the indirect dependency. To keep the indirect conformances, let's consider all protocols as safe and preserve extensions declaring conformances.

rdar://105241772