### PR TITLE
Add -runtime-compatibility-version none to the VFE/WME LTO tests to workaround a linker failure

### DIFF
--- a/test/IRGen/virtual-function-elimination-two-modules.swift
+++ b/test/IRGen/virtual-function-elimination-two-modules.swift
@@ -20,7 +20,7 @@
 // (4) Now produce the .dylib with just the symbols needed by the client
 // RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-vfe -Xfrontend -internalize-at-link \
 // RUN:     %s -DLIBRARY -lto=llvm-full %lto_flags -module-name Library \
-// RUN:     -emit-library -o %t/libLibrary.dylib \
+// RUN:     -emit-library -o %t/libLibrary.dylib -runtime-compatibility-version none \
 // RUN:     -Xlinker -exported_symbols_list -Xlinker %t/used-symbols -Xlinker -dead_strip
 
 // (5) Check list of symbols in library

--- a/test/IRGen/witness-method-elimination-two-modules.swift
+++ b/test/IRGen/witness-method-elimination-two-modules.swift
@@ -21,7 +21,7 @@
 // (4) Now produce the .dylib with just the symbols needed by the client
 // RUN: %target-build-swift -parse-as-library -Onone -Xfrontend -enable-llvm-wme -Xfrontend -internalize-at-link \
 // RUN:     %s -DLIBRARY -lto=llvm-full %lto_flags -module-name Library \
-// RUN:     -emit-library -o %t/libLibrary.dylib \
+// RUN:     -emit-library -o %t/libLibrary.dylib -runtime-compatibility-version none \
 // RUN:     -Xlinker -exported_symbols_list -Xlinker %t/used-symbols -Xlinker -dead_strip
 
 // (5) Check list of symbols in library


### PR DESCRIPTION
This is a speculative change to address the ongoing test failures on <https://ci.swift.org/view/Dashboard/job/oss-swift_tools-RA_stdlib-DA_test-simulators/2311/console>. I don't actually understand why they're failing, and it also doesn't look like we can pinpoint a particular commit where this started happening. But we can't leave the tests failing, so trying this for now.

```
Failed Tests (2):
  Swift(macosx-x86_64) :: IRGen/virtual-function-elimination-two-modules.swift
  Swift(macosx-x86_64) :: IRGen/witness-method-elimination-two-modules.swift

ld: reference to symbol (which has not been assigned an address) __ZN5swift7FlagSetIjE10lowMaskForILj1EEEjv in '__ZN5swift7FlagSetIjE7maskForILj26ELj1EEEjv' from /Users/ec2-user/jenkins/workspace/oss-swift_tools-RA_stdlib-DA_test-simulators/build/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/libswiftCompatibility56.a(Task.cpp.o)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
```

rdar://107987502
