### PR TITLE
Fix main executor check in `startOnMainActor`

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1598,7 +1598,7 @@ SWIFT_CC(swift)
 static void swift_task_startOnMainActorImpl(AsyncTask* task) {
   AsyncTask * originalTask = _swift_task_clearCurrent();
   ExecutorRef mainExecutor = swift_task_getMainExecutor();
-  if (swift_task_getCurrentExecutor() != swift_task_getMainExecutor())
+  if (!swift_task_isCurrentExecutor(mainExecutor))
     swift_Concurrency_fatalError(0, "Not on the main executor");
   swift_retain(task);
   swift_job_run(task, mainExecutor);

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -192,6 +192,7 @@ extension Task where Failure == Error {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
+    @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,
         @_inheritActorContext @_implicitSelfCapture _ work: __owned @Sendable @escaping @MainActor() async throws -> Success
@@ -213,6 +214,7 @@ extension Task where Failure == Never {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
+    @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,
         @_inheritActorContext @_implicitSelfCapture _ work: __owned @Sendable @escaping @MainActor() async -> Success


### PR DESCRIPTION
Fix the main executor check in `swift_task_startOnMainActorImpl`.
Some API's don't set the current executor. In that case, the current executor is a nullptr and the direct check fails.
Using `swift_task_isCurrentExecutor` checks that we're actually on the main executor in those cases by checking the current dispatch queue identity, and checking that we're on the main thread.

Also adding `@discardableResult` since we can discard the results from this SPI.

rdar://108221645
rdar://108222007