### PR TITLE
[🍒 5.9] Fix main executor check in startOnMainActor

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1598,7 +1598,7 @@ SWIFT_CC(swift)
 static void swift_task_startOnMainActorImpl(AsyncTask* task) {
   AsyncTask * originalTask = _swift_task_clearCurrent();
   ExecutorRef mainExecutor = swift_task_getMainExecutor();
-  if (swift_task_getCurrentExecutor() != swift_task_getMainExecutor())
+  if (!swift_task_isCurrentExecutor(mainExecutor))
     swift_Concurrency_fatalError(0, "Not on the main executor");
   swift_retain(task);
   swift_job_run(task, mainExecutor);

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -192,6 +192,7 @@ extension Task where Failure == Error {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
+    @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,
         @_inheritActorContext @_implicitSelfCapture _ work: __owned @Sendable @escaping @MainActor() async throws -> Success
@@ -213,6 +214,7 @@ extension Task where Failure == Never {
     @_spi(MainActorUtilities)
     @MainActor
     @available(SwiftStdlib 5.9, *)
+    @discardableResult
     public static func startOnMainActor(
         priority: TaskPriority? = nil,
         @_inheritActorContext @_implicitSelfCapture _ work: __owned @Sendable @escaping @MainActor() async -> Success


### PR DESCRIPTION
Cherry-picking https://github.com/apple/swift/pull/65271

*Explanation:* Some API's don't set the current executor resulting in the current executor containing a `nullptr` identity. This caused the MainExecutor check in `swift_task_startOnMainActorImpl` to fail, when we were running on the main thread and executing off of the main dispatch queue. `swift_task_isCurrentExecutor` contains additional logic to properly  handle this case, checking that we're running off of the main dispatch queue and that we're running on the main thread. Also adding @discardableResult since we can discard the results from this SPI, like with `Task.detached`.

*Scope:* The `swift_task_startOnMainActorImpl` is only used by the `Task.startOnMainActor` SPI, so this change only impacts the one SPI function. It's replacing a piece of logic with a function that has been in the runtime for two years now,  and is in use in other places in the concurrency runtime for this purpose.

*Risk:* Low. The SPI was added earlier this release so changing this shouldn't break existing code. Additionally, it's SPI.

rdar://108221645
rdar://108222007
