### PR TITLE
[Compiler plugins] Fix missing `return` along error-handling paths

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6407,6 +6407,7 @@ LoadedExecutablePlugin *ASTContext::loadExecutablePlugin(StringRef path) {
   if (!plugin) {
     Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
                    llvm::toString(plugin.takeError()));
+    return nullptr;
   }
 
   return plugin.get();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6429,6 +6429,7 @@ LoadedLibraryPlugin *ASTContext::loadLibraryPlugin(StringRef path) {
   if (!plugin) {
     Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
                    llvm::toString(plugin.takeError()));
+    return nullptr;
   }
 
   return plugin.get();


### PR DESCRIPTION
Fixes a crash when we cannot load a compiler plugin for some reason, tracked by rdar://107797992.
