### PR TITLE
[5.9] [Compiler plugins] Fix missing `return` along error-handling paths

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6415,6 +6415,7 @@ void *ASTContext::loadLibraryPlugin(StringRef path) {
   if (!plugin) {
     Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
                    llvm::toString(plugin.takeError()));
+    return nullptr;
   }
 
   return plugin.get();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6393,6 +6393,7 @@ LoadedExecutablePlugin *ASTContext::loadExecutablePlugin(StringRef path) {
   if (!plugin) {
     Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
                    llvm::toString(plugin.takeError()));
+    return nullptr;
   }
 
   return plugin.get();


### PR DESCRIPTION
* Explanation: When failing to load a compiler plugin, we correctly reported an error and then failed to return. This causes an assertion in asserting builds, and oddly random failures in non-asserting builds. Add the missing `return`.
* Scope: Affects code using macros via shared library plugins.
* Risk: Low, fix along an error path.
* Issue: rdar://107797992
* Original pull request: https://github.com/apple/swift/pull/65275
