### PR TITLE
Revert "Revert "[Test] Disable failing async_task_locals tests on ARM64e.""

### DIFF
--- a/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
+++ b/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
@@ -8,6 +8,9 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
+// rdar://105496007
+// UNSUPPORTED: CPU=arm64e
+
 @available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal

--- a/test/Concurrency/Runtime/async_task_locals_wrapper.swift
+++ b/test/Concurrency/Runtime/async_task_locals_wrapper.swift
@@ -8,6 +8,9 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
+// rdar://105496007
+// UNSUPPORTED: CPU=arm64e
+
 @available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal


### PR DESCRIPTION
Reverts apple/swift#65244

The failures showed up again on some CI jobs