### PR TITLE
🍒[cxx-interop] Make `CxxConvertibleToCollection.forEach` public

### DIFF
--- a/benchmark/cxx-source/CxxSetToCollection.swift
+++ b/benchmark/cxx-source/CxxSetToCollection.swift
@@ -36,6 +36,11 @@ public let benchmarks = [
     runFunction: run_CxxSetOfU32_to_Set,
     tags: [.validation, .bridging, .cxxInterop],
     setUpFunction: makeSetOnce),
+  BenchmarkInfo(
+    name: "CxxSetU32.forEach",
+    runFunction: run_CxxSetOfU32_forEach,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSetOnce),
 ]
 
 func makeSetOnce() {
@@ -55,6 +60,15 @@ public func run_CxxSetOfU32_to_Array(_ n: Int) {
 public func run_CxxSetOfU32_to_Set(_ n: Int) {
   for _ in 0..<n {
     blackHole(Set(set))
+  }
+}
+
+@inline(never)
+public func run_CxxSetOfU32_forEach(_ n: Int) {
+  for _ in 0..<n {
+    set.forEach {
+      blackHole($0)
+    }
   }
 }
 

--- a/stdlib/public/Cxx/CxxConvertibleToCollection.swift
+++ b/stdlib/public/Cxx/CxxConvertibleToCollection.swift
@@ -25,12 +25,22 @@ public protocol CxxConvertibleToCollection<Element> {
 
 extension CxxConvertibleToCollection {
   @inlinable
-  internal func forEach(_ body: (RawIterator.Pointee) -> Void) {
+  public func forEach(_ body: (RawIterator.Pointee) throws -> Void) rethrows {
     var rawIterator = __beginUnsafe()
     let endIterator = __endUnsafe()
     while rawIterator != endIterator {
-      body(rawIterator.pointee)
+      try body(rawIterator.pointee)
       rawIterator = rawIterator.successor()
+    }
+  }
+}
+
+// Break the ambiguity between Sequence.forEach and CxxConvertibleToCollection.forEach.
+extension CxxConvertibleToCollection where Self: Sequence {
+  @inlinable
+  public func forEach(_ body: (Element) throws -> Void) rethrows {
+    for element in self {
+      try body(element)
     }
   }
 }

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -18,6 +18,12 @@ CxxCollectionTestSuite.test("SimpleCollectionNoSubscript as Swift.Collection") {
   expectEqual(c[0], 1)
   expectEqual(c[1], 2)
   expectEqual(c[4], 5)
+
+  var array: [Int32] = []
+  c.forEach {
+    array.append($0)
+  }
+  expectEqual([1, 2, 3, 4, 5] as [Int32], array)
 }
 
 CxxCollectionTestSuite.test("SimpleCollectionReadOnly as Swift.Collection") {

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -39,4 +39,13 @@ CxxSequenceTestSuite.test("SimpleEmptySequence to Swift.Set") {
   expectTrue(set.isEmpty)
 }
 
+CxxSequenceTestSuite.test("SimpleSequence.forEach") {
+  let seq = SimpleSequence()
+  var array: [Int32] = []
+  seq.forEach {
+    array.append($0)
+  }
+  expectEqual([1, 2, 3, 4] as [Int32], array)
+}
+
 runAllTests()


### PR DESCRIPTION
**Explanation**: This allows clients to iterate over a C++ container which doesn't provide random access with a `.forEach` call.
**Scope**: This only alters the Cxx module, which contains utilities for clients of C++ interop.
**Risk**: Low: only affects clients who use C++ interop, which is an opt-in feature.

rdar://107995558
(cherry picked from commit d5f5d4bd552d14d1553e7ae0c5893203f2078c7d)
