### PR TITLE
[5.9] Fix #64757: Unexpected "Implicit use of 'self' in closure" error in closure nested in result builder

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2020,6 +2020,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       DC = DC->getParent();
     }
   }
+  
   const_cast<Expr *>(E)->walk(DiagnoseWalker(ctx, ACE));
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -461,7 +461,7 @@ void typeCheckASTNode(ASTNode &node, DeclContext *DC,
 /// value if an error occurred while type checking the transformed body.
 Optional<BraceStmt *> applyResultBuilderBodyTransform(
     FuncDecl *func, Type builderType,
-    bool ClosuresInResultBuilderDontParticipateInInference = true);
+    bool ClosuresInResultBuilderDontParticipateInInference = false);
 
 /// Find the return statements within the body of the given function.
 std::vector<ReturnStmt *> findReturnStatements(AnyFunctionRef fn);


### PR DESCRIPTION
This PR cherry picks #64786 into the Swift 5.9 release branch.

- **Explanation**: This fixes #64757, where shorthand `guard let self` and `if let self` conditions would unexpectedly be rejected inside result builders.
- **Scope**: This fixes a source-break accidentally introduced by Swift 5.8
- **Issue**: fixes https://github.com/apple/swift/issues/64757
- **Risk**: There is somewhat limited risk here since this change was merged to master just three weeks after 5.9 branch cut, and because the change itself is small. This change updates a flag related to handling code completion (this flag was first added in https://github.com/apple/swift/commit/2c5b193892f0f414d517870c2b6e84e92963b2f6). The worst case risk of this CP would be returning the code-completion experience back to what it was before https://github.com/apple/swift/commit/2c5b193892f0f414d517870c2b6e84e92963b2f6.
- **Testing**: CI test suite and SourceKit stress tests
- **Reviewers**: @DougGregor (5.9 release manager), @xedin (original reviewer of #64786)

----

Example of https://github.com/apple/swift/issues/64757:

```swift
@resultBuilder
struct VoidBuilder {
    static func buildBlock() -> Void { }
    static func buildPartialBlock<T>(first: T) -> Void { }
    static func buildPartialBlock<T>(accumulated: Void, next: T) -> Void { }
}

final class EscapingWrapper {
    static func wrapper(_ closure: @escaping () -> Void) {
        closure()
    }
}

final class Sample {
    @VoidBuilder
    var void: Void {
        EscapingWrapper.wrapper { [weak self] in
            guard let self else { return } // Unexpected error: Implicit use of 'self' in closure; use 'self.' to make capture semantics explicit
        }
    }
}
```