### PR TITLE
[CAS] Teach swift compiler to compute cache key and store outputs into CAS

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -485,6 +485,10 @@ ERROR(error_output_missing,none,
 REMARK(matching_output_produced,none,
       "produced matching output file '%0' for deterministic check: hash '%1'", (StringRef, StringRef))
 
+// Caching related diagnostics
+ERROR(error_caching_no_cas_fs, none,
+    "caching is enabled without -cas-fs option, input is not immutable", ())
+
 // CAS related diagnostics
 ERROR(error_create_cas, none, "failed to create CAS '%0' (%1)", (StringRef, StringRef))
 ERROR(error_invalid_cas_id, none, "invalid CASID '%0' (%1)", (StringRef, StringRef))

--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -98,5 +98,8 @@ TYPE("pch",                 PCH,                       "pch",             "")
 TYPE("none",                Nothing,                   "",                "")
 
 TYPE("abi-baseline-json",   SwiftABIDescriptor,        "abi.json",        "")
+TYPE("fixit",               SwiftFixIt,                "",                "")
+TYPE("module-semantic-info", ModuleSemanticInfo,       "",                "")
+TYPE("cached-diagnostics",  CachedDiagnostics,         "",                "")
 
 #undef TYPE

--- a/include/swift/Basic/SupplementaryOutputPaths.def
+++ b/include/swift/Basic/SupplementaryOutputPaths.def
@@ -1,0 +1,156 @@
+//===--- SupplementaryOutputPaths.def - Output Names and Types --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines all the Supplemtary Output Path variables and their
+// output types.
+//
+//===----------------------------------------------------------------------===//
+
+/// The path to which we should emit a header file that exposes the Swift
+/// declarations to C, Objective-C and C++ clients for the module.
+///
+/// Currently only makes sense when the compiler has whole module knowledge.
+/// The modes for which it makes sense incuide both WMO and the "merge
+/// modules" job that happens after the normal compilation jobs. That's where
+/// the header is emitted in single-file mode, since it needs whole-module
+/// information.
+///
+/// \sa swift::printAsClangHeader
+OUTPUT(ClangHeaderOutputPath, TY_ClangHeader)
+
+/// The path to which we should emit a serialized module.
+/// It is valid whenever there are any inputs.
+///
+/// This binary format is used to describe the interface of a module when
+/// imported by client source code. The swiftmodule format is described in
+/// docs/Serialization.md.
+///
+/// \sa swift::serialize
+OUTPUT(ModuleOutputPath, TY_SwiftModuleFile)
+
+/// The path to which we should emit a module source information file.
+/// It is valid whenever there are any inputs.
+///
+/// This binary format stores source locations and other information about the
+/// declarations in a module.
+///
+/// \sa swift::serialize
+OUTPUT(ModuleSourceInfoOutputPath, TY_SwiftSourceInfoFile)
+
+/// The path to which we should emit a module documentation file.
+/// It is valid whenever there are any inputs.
+///
+/// This binary format stores doc comments and other information about the
+/// declarations in a module.
+///
+/// \sa swift::serialize
+OUTPUT(ModuleDocOutputPath, TY_SwiftModuleDocFile)
+
+/// The path to which we should output a Make-style dependencies file.
+/// It is valid whenever there are any inputs.
+///
+/// Swift's compilation model means that Make-style dependencies aren't
+/// well-suited to model fine-grained dependencies. See docs/Driver.md for
+/// more information.
+///
+/// \sa ReferenceDependenciesFilePath
+OUTPUT(DependenciesFilePath, TY_Dependencies)
+
+/// The path to which we should output a Swift "reference dependencies" file.
+/// It is valid whenever there are any inputs.
+///
+/// "Reference dependencies" track dependencies on a more fine-grained level
+/// than just "this file depends on that file". With Swift's "implicit
+/// visibility" within a module, that becomes very important for any sort of
+/// incremental build. These files are consumed by the Swift driver to decide
+/// whether a source file needs to be recompiled during a build. See
+/// docs/DependencyAnalysis.md for more information.
+///
+/// \sa swift::emitReferenceDependencies
+/// \sa DependencyGraph
+OUTPUT(ReferenceDependenciesFilePath, TY_SwiftDeps)
+
+/// Path to a file which should contain serialized diagnostics for this
+/// frontend invocation.
+///
+/// This uses the same serialized diagnostics format as Clang, for tools that
+/// want machine-parseable diagnostics. There's a bit more information on
+/// how clients might use this in docs/Driver.md.
+///
+/// \sa swift::serialized_diagnostics::createConsumer
+OUTPUT(SerializedDiagnosticsPath, TY_SerializedDiagnostics)
+
+/// The path to which we should output fix-its as source edits.
+///
+/// This is a JSON-based format that is used by the migrator, but is not
+/// really vetted for anything else.
+///
+/// \sa swift::writeEditsInJson
+OUTPUT(FixItsOutputPath, TY_SwiftFixIt)
+
+/// The path to which we should output a loaded module trace file.
+/// It is valid whenever there are any inputs.
+///
+/// The file is appended to, and consists of line-delimited JSON objects,
+/// where each line is of the form `{ "name": NAME, "target": TARGET,
+/// "swiftmodules": [PATH, PATH, ...] }`, representing the (real-path) PATHs
+/// to each .swiftmodule that was loaded while building module NAME for target
+/// TARGET. This format is subject to arbitrary change, however.
+OUTPUT(LoadedModuleTracePath, TY_ModuleTrace)
+
+/// The path to which we should output a TBD file.
+///
+/// "TBD" stands for "text-based dylib". It's a YAML-based format that
+/// describes the public ABI of a library, which clients can link against
+/// without having an actual dynamic library binary.
+///
+/// Only makes sense when the compiler has whole-module knowledge.
+///
+/// \sa swift::writeTBDFile
+OUTPUT(TBDPath, TY_TBD)
+
+/// The path to which we should emit a module interface, which can
+/// be used by a client source file to import this module.
+///
+/// This format is similar to the binary format used for #ModuleOutputPath,
+/// but is intended to be stable across compiler versions.
+///
+/// Currently only makes sense when the compiler has whole-module knowledge.
+///
+/// \sa swift::emitSwiftInterface
+OUTPUT(ModuleInterfaceOutputPath, TY_SwiftModuleInterfaceFile)
+
+/// The path to which we should emit a private module interface.
+///
+/// The private module interface contains all SPI decls and attributes.
+///
+/// \sa ModuleInterfaceOutputPath
+OUTPUT(PrivateModuleInterfaceOutputPath,
+            TY_PrivateSwiftModuleInterfaceFile)
+
+/// The path to which we should emit module summary file.
+OUTPUT(ModuleSummaryOutputPath, TY_SwiftModuleSummaryFile)
+
+/// The output path to generate ABI baseline.
+OUTPUT(ABIDescriptorOutputPath, TY_SwiftABIDescriptor)
+
+/// The output path for extracted compile-time-known value information
+OUTPUT(ConstValuesOutputPath, TY_ConstValues)
+
+/// The output path of Swift semantic info for this module.
+OUTPUT(ModuleSemanticInfoOutputPath, TY_ModuleSemanticInfo)
+
+/// The output path for YAML optimization record file.
+OUTPUT(YAMLOptRecordPath, TY_YAMLOptRecord)
+
+/// The output path for bitstream optimization record file.
+OUTPUT(BitstreamOptRecordPath, TY_BitstreamOptRecord)

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H
 #define SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H
 
+#include "swift/Basic/FileTypes.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/IR/Function.h"
 
@@ -199,6 +200,48 @@ struct SupplementaryOutputPaths {
       fn(BitstreamOptRecordPath);
     if (!ModuleSemanticInfoOutputPath.empty())
       fn(ModuleSemanticInfoOutputPath);
+  }
+
+  void forEachSetOutputAndType(
+      llvm::function_ref<void(const std::string &, file_types::ID)> fn) const {
+    if (!ClangHeaderOutputPath.empty())
+      fn(ClangHeaderOutputPath, file_types::ID::TY_ClangHeader);
+    if (!ModuleOutputPath.empty())
+      fn(ModuleOutputPath, file_types::ID::TY_SwiftModuleFile);
+    if (!ModuleSourceInfoOutputPath.empty())
+      fn(ModuleSourceInfoOutputPath, file_types::ID::TY_SwiftSourceInfoFile);
+    if (!ModuleDocOutputPath.empty())
+      fn(ModuleDocOutputPath, file_types::ID::TY_SwiftModuleDocFile);
+    if (!DependenciesFilePath.empty())
+      fn(DependenciesFilePath, file_types::ID::TY_Dependencies);
+    if (!ReferenceDependenciesFilePath.empty())
+      fn(ReferenceDependenciesFilePath, file_types::ID::TY_SwiftDeps);
+    if (!SerializedDiagnosticsPath.empty())
+      fn(SerializedDiagnosticsPath, file_types::ID::TY_SerializedDiagnostics);
+    if (!FixItsOutputPath.empty())
+      fn(FixItsOutputPath, file_types::ID::TY_SwiftFixIt);
+    if (!LoadedModuleTracePath.empty())
+      fn(LoadedModuleTracePath, file_types::ID::TY_ModuleTrace);
+    if (!TBDPath.empty())
+      fn(TBDPath, file_types::ID::TY_TBD);
+    if (!ModuleInterfaceOutputPath.empty())
+      fn(ModuleInterfaceOutputPath,
+         file_types::ID::TY_SwiftModuleInterfaceFile);
+    if (!PrivateModuleInterfaceOutputPath.empty())
+      fn(PrivateModuleInterfaceOutputPath,
+         file_types::ID::TY_PrivateSwiftModuleInterfaceFile);
+    if (!ModuleSummaryOutputPath.empty())
+      fn(ModuleSummaryOutputPath, file_types::ID::TY_SwiftModuleSummaryFile);
+    if (!ABIDescriptorOutputPath.empty())
+      fn(ABIDescriptorOutputPath, file_types::ID::TY_SwiftABIDescriptor);
+    if (!ConstValuesOutputPath.empty())
+      fn(ConstValuesOutputPath, file_types::ID::TY_ConstValues);
+    if (!YAMLOptRecordPath.empty())
+      fn(YAMLOptRecordPath, file_types::ID::TY_YAMLOptRecord);
+    if (!BitstreamOptRecordPath.empty())
+      fn(BitstreamOptRecordPath, file_types::ID::TY_BitstreamOptRecord);
+    if (!ModuleSemanticInfoOutputPath.empty())
+      fn(ModuleSemanticInfoOutputPath, file_types::ID::TY_ModuleSemanticInfo);
   }
 
   bool empty() const {

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -21,240 +21,36 @@
 
 namespace swift {
 struct SupplementaryOutputPaths {
-  /// The path to which we should emit a header file that exposes the Swift
-  /// declarations to C, Objective-C and C++ clients for the module.
-  ///
-  /// Currently only makes sense when the compiler has whole module knowledge.
-  /// The modes for which it makes sense incuide both WMO and the "merge
-  /// modules" job that happens after the normal compilation jobs. That's where
-  /// the header is emitted in single-file mode, since it needs whole-module
-  /// information.
-  ///
-  /// \sa swift::printAsClangHeader
-  std::string ClangHeaderOutputPath;
-
-  /// The path to which we should emit a serialized module.
-  /// It is valid whenever there are any inputs.
-  ///
-  /// This binary format is used to describe the interface of a module when
-  /// imported by client source code. The swiftmodule format is described in
-  /// docs/Serialization.md.
-  ///
-  /// \sa swift::serialize
-  std::string ModuleOutputPath;
-
-  /// The path to which we should emit a module source information file.
-  /// It is valid whenever there are any inputs.
-  ///
-  /// This binary format stores source locations and other information about the
-  /// declarations in a module.
-  ///
-  /// \sa swift::serialize
-  std::string ModuleSourceInfoOutputPath;
-
-  /// The path to which we should emit a module documentation file.
-  /// It is valid whenever there are any inputs.
-  ///
-  /// This binary format stores doc comments and other information about the
-  /// declarations in a module.
-  ///
-  /// \sa swift::serialize
-  std::string ModuleDocOutputPath;
-
-  /// The path to which we should output a Make-style dependencies file.
-  /// It is valid whenever there are any inputs.
-  ///
-  /// Swift's compilation model means that Make-style dependencies aren't
-  /// well-suited to model fine-grained dependencies. See docs/Driver.md for
-  /// more information.
-  ///
-  /// \sa ReferenceDependenciesFilePath
-  std::string DependenciesFilePath;
-
-  /// The path to which we should output a Swift "reference dependencies" file.
-  /// It is valid whenever there are any inputs.
-  ///
-  /// "Reference dependencies" track dependencies on a more fine-grained level
-  /// than just "this file depends on that file". With Swift's "implicit
-  /// visibility" within a module, that becomes very important for any sort of
-  /// incremental build. These files are consumed by the Swift driver to decide
-  /// whether a source file needs to be recompiled during a build. See
-  /// docs/DependencyAnalysis.md for more information.
-  ///
-  /// \sa swift::emitReferenceDependencies
-  /// \sa DependencyGraph
-  std::string ReferenceDependenciesFilePath;
-
-  /// Path to a file which should contain serialized diagnostics for this
-  /// frontend invocation.
-  ///
-  /// This uses the same serialized diagnostics format as Clang, for tools that
-  /// want machine-parseable diagnostics. There's a bit more information on
-  /// how clients might use this in docs/Driver.md.
-  ///
-  /// \sa swift::serialized_diagnostics::createConsumer
-  std::string SerializedDiagnosticsPath;
-
-  /// The path to which we should output fix-its as source edits.
-  ///
-  /// This is a JSON-based format that is used by the migrator, but is not
-  /// really vetted for anything else.
-  ///
-  /// \sa swift::writeEditsInJson
-  std::string FixItsOutputPath;
-
-  /// The path to which we should output a loaded module trace file.
-  /// It is valid whenever there are any inputs.
-  ///
-  /// The file is appended to, and consists of line-delimited JSON objects,
-  /// where each line is of the form `{ "name": NAME, "target": TARGET,
-  /// "swiftmodules": [PATH, PATH, ...] }`, representing the (real-path) PATHs
-  /// to each .swiftmodule that was loaded while building module NAME for target
-  /// TARGET. This format is subject to arbitrary change, however.
-  std::string LoadedModuleTracePath;
-
-  /// The path to which we should output a TBD file.
-  ///
-  /// "TBD" stands for "text-based dylib". It's a YAML-based format that
-  /// describes the public ABI of a library, which clients can link against
-  /// without having an actual dynamic library binary.
-  ///
-  /// Only makes sense when the compiler has whole-module knowledge.
-  ///
-  /// \sa swift::writeTBDFile
-  std::string TBDPath;
-
-  /// The path to which we should emit a module interface, which can
-  /// be used by a client source file to import this module.
-  ///
-  /// This format is similar to the binary format used for #ModuleOutputPath,
-  /// but is intended to be stable across compiler versions.
-  ///
-  /// Currently only makes sense when the compiler has whole-module knowledge.
-  ///
-  /// \sa swift::emitSwiftInterface
-  std::string ModuleInterfaceOutputPath;
-
-  /// The path to which we should emit a private module interface.
-  ///
-  /// The private module interface contains all SPI decls and attributes.
-  ///
-  /// \sa ModuleInterfaceOutputPath
-  std::string PrivateModuleInterfaceOutputPath;
-
-  /// The path to which we should emit module summary file.
-  std::string ModuleSummaryOutputPath;
-
-  /// The output path to generate ABI baseline.
-  std::string ABIDescriptorOutputPath;
-
-  /// The output path for extracted compile-time-known value information
-  std::string ConstValuesOutputPath;
-
-  /// The output path of Swift semantic info for this module.
-  std::string ModuleSemanticInfoOutputPath;
-
-  /// The output path for YAML optimization record file.
-  std::string YAMLOptRecordPath;
-
-  /// The output path for bitstream optimization record file.
-  std::string BitstreamOptRecordPath;
+#define OUTPUT(NAME, TYPE) std::string NAME;
+#include "swift/Basic/SupplementaryOutputPaths.def"
+#undef OUTPUT
 
   SupplementaryOutputPaths() = default;
 
   /// Apply a given function for each existing (non-empty string) supplementary output
   void forEachSetOutput(llvm::function_ref<void(const std::string&)> fn) const {
-    if (!ClangHeaderOutputPath.empty())
-      fn(ClangHeaderOutputPath);
-    if (!ModuleOutputPath.empty())
-      fn(ModuleOutputPath); 
-    if (!ModuleSourceInfoOutputPath.empty())
-      fn(ModuleSourceInfoOutputPath); 
-    if (!ModuleDocOutputPath.empty())
-      fn(ModuleDocOutputPath); 
-    if (!DependenciesFilePath.empty())
-      fn(DependenciesFilePath); 
-    if (!ReferenceDependenciesFilePath.empty())
-      fn(ReferenceDependenciesFilePath); 
-    if (!SerializedDiagnosticsPath.empty())
-      fn(SerializedDiagnosticsPath); 
-    if (!FixItsOutputPath.empty())
-      fn(FixItsOutputPath); 
-    if (!LoadedModuleTracePath.empty())
-      fn(LoadedModuleTracePath); 
-    if (!TBDPath.empty())
-      fn(TBDPath); 
-    if (!ModuleInterfaceOutputPath.empty())
-      fn(ModuleInterfaceOutputPath); 
-    if (!PrivateModuleInterfaceOutputPath.empty())
-      fn(PrivateModuleInterfaceOutputPath); 
-    if (!ModuleSummaryOutputPath.empty())
-      fn(ModuleSummaryOutputPath);
-    if (!ABIDescriptorOutputPath.empty())
-      fn(ABIDescriptorOutputPath);
-    if (!ConstValuesOutputPath.empty())
-      fn(ConstValuesOutputPath);
-    if (!YAMLOptRecordPath.empty())
-      fn(YAMLOptRecordPath);
-    if (!BitstreamOptRecordPath.empty())
-      fn(BitstreamOptRecordPath);
-    if (!ModuleSemanticInfoOutputPath.empty())
-      fn(ModuleSemanticInfoOutputPath);
+#define OUTPUT(NAME, TYPE)                                                     \
+  if (!NAME.empty())                                                           \
+    fn(NAME);
+#include "swift/Basic/SupplementaryOutputPaths.def"
+#undef OUTPUT
   }
 
   void forEachSetOutputAndType(
       llvm::function_ref<void(const std::string &, file_types::ID)> fn) const {
-    if (!ClangHeaderOutputPath.empty())
-      fn(ClangHeaderOutputPath, file_types::ID::TY_ClangHeader);
-    if (!ModuleOutputPath.empty())
-      fn(ModuleOutputPath, file_types::ID::TY_SwiftModuleFile);
-    if (!ModuleSourceInfoOutputPath.empty())
-      fn(ModuleSourceInfoOutputPath, file_types::ID::TY_SwiftSourceInfoFile);
-    if (!ModuleDocOutputPath.empty())
-      fn(ModuleDocOutputPath, file_types::ID::TY_SwiftModuleDocFile);
-    if (!DependenciesFilePath.empty())
-      fn(DependenciesFilePath, file_types::ID::TY_Dependencies);
-    if (!ReferenceDependenciesFilePath.empty())
-      fn(ReferenceDependenciesFilePath, file_types::ID::TY_SwiftDeps);
-    if (!SerializedDiagnosticsPath.empty())
-      fn(SerializedDiagnosticsPath, file_types::ID::TY_SerializedDiagnostics);
-    if (!FixItsOutputPath.empty())
-      fn(FixItsOutputPath, file_types::ID::TY_SwiftFixIt);
-    if (!LoadedModuleTracePath.empty())
-      fn(LoadedModuleTracePath, file_types::ID::TY_ModuleTrace);
-    if (!TBDPath.empty())
-      fn(TBDPath, file_types::ID::TY_TBD);
-    if (!ModuleInterfaceOutputPath.empty())
-      fn(ModuleInterfaceOutputPath,
-         file_types::ID::TY_SwiftModuleInterfaceFile);
-    if (!PrivateModuleInterfaceOutputPath.empty())
-      fn(PrivateModuleInterfaceOutputPath,
-         file_types::ID::TY_PrivateSwiftModuleInterfaceFile);
-    if (!ModuleSummaryOutputPath.empty())
-      fn(ModuleSummaryOutputPath, file_types::ID::TY_SwiftModuleSummaryFile);
-    if (!ABIDescriptorOutputPath.empty())
-      fn(ABIDescriptorOutputPath, file_types::ID::TY_SwiftABIDescriptor);
-    if (!ConstValuesOutputPath.empty())
-      fn(ConstValuesOutputPath, file_types::ID::TY_ConstValues);
-    if (!YAMLOptRecordPath.empty())
-      fn(YAMLOptRecordPath, file_types::ID::TY_YAMLOptRecord);
-    if (!BitstreamOptRecordPath.empty())
-      fn(BitstreamOptRecordPath, file_types::ID::TY_BitstreamOptRecord);
-    if (!ModuleSemanticInfoOutputPath.empty())
-      fn(ModuleSemanticInfoOutputPath, file_types::ID::TY_ModuleSemanticInfo);
+#define OUTPUT(NAME, TYPE)                                                     \
+  if (!NAME.empty())                                                           \
+    fn(NAME, file_types::ID::TYPE);
+#include "swift/Basic/SupplementaryOutputPaths.def"
+#undef OUTPUT
   }
 
   bool empty() const {
-    return ClangHeaderOutputPath.empty() && ModuleOutputPath.empty() &&
-           ModuleDocOutputPath.empty() && DependenciesFilePath.empty() &&
-           ReferenceDependenciesFilePath.empty() &&
-           SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
-           TBDPath.empty() && ModuleInterfaceOutputPath.empty() &&
-           ModuleSourceInfoOutputPath.empty() &&
-           ABIDescriptorOutputPath.empty() &&
-           ConstValuesOutputPath.empty() &&
-           ModuleSemanticInfoOutputPath.empty() && YAMLOptRecordPath.empty() &&
-           BitstreamOptRecordPath.empty();
+    return
+#define OUTPUT(NAME, TYPE) NAME.empty() &&
+#include "swift/Basic/SupplementaryOutputPaths.def"
+#undef OUTPUT
+        true;
   }
 };
 } // namespace swift

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -170,7 +170,8 @@ public:
     SwiftIndent,     // swift-indent
     SymbolGraph,     // swift-symbolgraph
     APIExtract,      // swift-api-extract
-    APIDigester      // swift-api-digester
+    APIDigester,     // swift-api-digester
+    CacheTool        // swift-cache-tool
   };
 
   class InputInfoMap;

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -1,0 +1,50 @@
+//===--- CachingUtils.h -----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_CACHINGUTILS_H
+#define SWIFT_FRONTEND_CACHINGUTILS_H
+
+#include "swift/Frontend/FrontendInputsAndOutputs.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/CAS/CASReference.h"
+#include "llvm/Support/VirtualOutputBackend.h"
+#include <memory>
+
+namespace swift {
+
+/// Create a swift caching output backend that stores the output from
+/// compiler into a CAS.
+llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend>
+createSwiftCachingOutputBackend(
+    llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
+    llvm::cas::ObjectRef BaseKey,
+    const FrontendInputsAndOutputs &InputsAndOutputs);
+
+/// Load the cached compile result from cache.
+std::unique_ptr<llvm::MemoryBuffer> loadCachedCompileResultFromCacheKey(
+    llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
+    DiagnosticEngine &Diag, llvm::StringRef CacheKey,
+    llvm::StringRef Filename = "");
+
+/// Store compiler output.
+llvm::Error storeCachedCompilerOutput(llvm::cas::ObjectStore &CAS,
+                                      llvm::cas::ActionCache &Cache,
+                                      StringRef Path, StringRef Bytes,
+                                      llvm::cas::ObjectRef BaseKey,
+                                      StringRef CorrespondingInput,
+                                      file_types::ID OutputKind);
+
+}
+
+#endif

--- a/include/swift/Frontend/CompileJobCacheKey.h
+++ b/include/swift/Frontend/CompileJobCacheKey.h
@@ -1,0 +1,48 @@
+//===--- CompileJobCacheKey.h - compile cache key methods -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains declarations of utility methods for creating cache keys
+// for compilation jobs.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_COMPILEJOBCACHEKEY_H
+#define SWIFT_COMPILEJOBCACHEKEY_H
+
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/Basic/FileTypes.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Error.h"
+
+namespace swift {
+
+/// Compute CompileJobBaseKey from swift-frontend command-line arguments.
+/// CompileJobBaseKey represents the core inputs and arguments, and is used as a
+/// base to compute keys for each compiler outputs.
+// TODO: switch to create key from CompilerInvocation after we can canonicalize
+// arguments.
+llvm::Expected<llvm::cas::ObjectRef>
+createCompileJobBaseCacheKey(llvm::cas::ObjectStore &CAS,
+                             ArrayRef<const char *> Args);
+
+/// Compute CompileJobKey for the compiler outputs. The key for the output
+/// is computed from the base key for the compilation, the output kind and the
+/// input file path that is associated with this specific output.
+llvm::Expected<llvm::cas::ObjectRef>
+createCompileJobCacheKeyForOutput(llvm::cas::ObjectStore &CAS,
+                                  llvm::cas::ObjectRef BaseKey,
+                                  StringRef ProducingInput,
+                                  file_types::ID OutputType);
+}
+
+#endif

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -633,6 +633,9 @@ public:
   /// i.e. if it can be found.
   bool canImportCxxShim() const;
 
+  /// Whether this compiler instance supports caching.
+  bool supportCaching() const;
+
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
   /// \returns the primary SourceFile, or nullptr if there is no primary input;
   /// if there are _multiple_ primary inputs, fails with an assertion.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -455,6 +455,7 @@ class CompilerInstance {
   /// the file buffer provided by CAS needs to outlive the SourceMgr.
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> ResultCache;
+  Optional<llvm::cas::ObjectRef> CompileJobBaseKey;
 
   SourceManager SourceMgr;
   DiagnosticEngine Diagnostics{SourceMgr};
@@ -543,6 +544,9 @@ public:
   }
   std::shared_ptr<llvm::cas::ObjectStore> getSharedCASInstance() const {
     return CAS;
+  }
+  Optional<llvm::cas::ObjectRef> getCompilerBaseKey() const {
+    return CompileJobBaseKey;
   }
 
   ASTContext &getASTContext() { return *Context; }
@@ -646,7 +650,8 @@ public:
   }
 
   /// Returns true if there was an error during setup.
-  bool setup(const CompilerInvocation &Invocation, std::string &Error);
+  bool setup(const CompilerInvocation &Invocation, std::string &Error,
+             ArrayRef<const char *> Args = {});
 
   const CompilerInvocation &getInvocation() const { return Invocation; }
 
@@ -667,7 +672,7 @@ private:
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();
   void setupDependencyTrackerIfNeeded();
-  bool setupCASIfNeeded();
+  bool setupCASIfNeeded(ArrayRef<const char *> Args);
   void setupOutputBackend();
 
   /// \return false if successful, true on error.

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -39,6 +39,10 @@ class FrontendInputsAndOutputs {
   llvm::StringMap<unsigned> PrimaryInputsByName;
   std::vector<unsigned> PrimaryInputsInOrder;
 
+  /// The file type for main output files. Assuming all inputs produce the
+  /// same kind of output.
+  file_types::ID PrincipalOutputType = file_types::ID::TY_INVALID;
+
   /// In Single-threaded WMO mode, all inputs are used
   /// both for importing and compiling.
   bool IsSingleThreadedWMO = false;
@@ -190,6 +194,9 @@ private:
       ArrayRef<std::string> outputFiles,
       ArrayRef<SupplementaryOutputPaths> supplementaryOutputs,
       ArrayRef<std::string> outputFilesForIndexUnits = None);
+  void setPrincipalOutputType(file_types::ID type) {
+    PrincipalOutputType = type;
+  }
 
 public:
   unsigned countOfInputsProducingMainOutputs() const;
@@ -197,6 +204,7 @@ public:
   bool hasInputsProducingMainOutputs() const {
     return countOfInputsProducingMainOutputs() != 0;
   }
+  file_types::ID getPrincipalOutputType() const { return PrincipalOutputType; }
 
   const InputFile &firstInputProducingOutput() const;
   const InputFile &lastInputProducingOutput() const;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -445,6 +445,9 @@ public:
   /// \return true if the given action requires input files to be provided.
   static bool doesActionPerformEndOfPipelineActions(ActionType action);
 
+  /// \return true if the given action supports caching.
+  static bool supportCompilationCaching(ActionType action);
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1814,6 +1814,10 @@ def cas_path: Separate<["-"], "cas-path">,
   Flags<[FrontendOption, NewDriverOnlyOption]>,
   HelpText<"Path to CAS">, MetaVarName<"<path>">;
 
+def allow_unstable_cache_key_for_testing: Flag<["-"], "allow-unstable-cache-key-for-testing">,
+  Flags<[FrontendOption, HelpHidden, NoDriverOption]>,
+  HelpText<"Allow compilation caching with unstable inputs for testing purpose">;
+
 // END ONLY SUPPORTED IN NEW DRIVER
 
 def enable_cas: Flag<["-"], "enable-cas">,

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -109,6 +109,9 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_IndexData:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_IndexUnitOutputPath:
+  case file_types::TY_SwiftFixIt:
+  case file_types::TY_ModuleSemanticInfo:
+  case file_types::TY_CachedDiagnostics:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -162,6 +165,9 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_ConstValues:
+  case file_types::TY_SwiftFixIt:
+  case file_types::TY_ModuleSemanticInfo:
+  case file_types::TY_CachedDiagnostics:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -215,6 +221,9 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_ConstValues:
+  case file_types::TY_SwiftFixIt:
+  case file_types::TY_ModuleSemanticInfo:
+  case file_types::TY_CachedDiagnostics:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2084,6 +2084,9 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_JSONFeatures:
       case file_types::TY_SwiftABIDescriptor:
       case file_types::TY_ConstValues:
+      case file_types::TY_SwiftFixIt:
+      case file_types::TY_ModuleSemanticInfo:
+      case file_types::TY_CachedDiagnostics:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -104,6 +104,7 @@ void Driver::parseDriverKind(ArrayRef<const char *> Args) {
           .Case("swift-symbolgraph-extract", DriverKind::SymbolGraph)
           .Case("swift-api-extract", DriverKind::APIExtract)
           .Case("swift-api-digester", DriverKind::APIDigester)
+          .Case("swift-cache-tool", DriverKind::CacheTool)
           .Default(None);
 
   if (Kind.has_value())
@@ -3563,6 +3564,7 @@ void Driver::printHelp(bool ShowHidden) const {
   case DriverKind::SymbolGraph:
   case DriverKind::APIExtract:
   case DriverKind::APIDigester:
+  case DriverKind::CacheTool:
     ExcludedFlagsBitmask |= options::NoBatchOption;
     break;
   }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -753,6 +753,9 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_ConstValues:
+  case file_types::TY_SwiftFixIt:
+  case file_types::TY_ModuleSemanticInfo:
+  case file_types::TY_CachedDiagnostics:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -1014,6 +1017,9 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_IndexUnitOutputPath:
     case file_types::TY_SwiftABIDescriptor:
     case file_types::TY_ConstValues:
+    case file_types::TY_SwiftFixIt:
+    case file_types::TY_ModuleSemanticInfo:
+    case file_types::TY_CachedDiagnostics:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/DriverTool/CMakeLists.txt
+++ b/lib/DriverTool/CMakeLists.txt
@@ -3,6 +3,7 @@ set(driver_sources_and_options
                 autolink_extract_main.cpp
                 modulewrap_main.cpp
                 swift_api_digester_main.cpp
+                swift_cache_tool_main.cpp
                 swift_indent_main.cpp
                 swift_symbolgraph_extract_main.cpp
                 swift_api_extract_main.cpp)
@@ -27,3 +28,9 @@ if(NOT SWIFT_BUILT_STANDALONE)
 endif()
 
 set_swift_llvm_is_available(swiftDriverTool)
+
+set(LLVM_TARGET_DEFINITIONS SwiftCacheToolOptions.td)
+swift_tablegen(SwiftCacheToolOptions.inc -gen-opt-parser-defs)
+swift_add_public_tablegen_target(SwiftCacheToolOptions)
+
+add_dependencies(swiftDriverTool SwiftCacheToolOptions)

--- a/lib/DriverTool/SwiftCacheToolOptions.td
+++ b/lib/DriverTool/SwiftCacheToolOptions.td
@@ -1,0 +1,17 @@
+// Include the common option parsing interfaces.
+include "llvm/Option/OptParser.td"
+
+/////////
+// Flags
+
+def help : Flag<["-", "--"], "help">,
+  HelpText<"Display available options">;
+
+def _DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>;
+
+def cache_tool_action: JoinedOrSeparate<["-"], "cache-tool-action">,
+  HelpText<"Swift Cache Tool Action Kind">,
+  MetaVarName<"<print-base-key|print-output-keys|...>">;
+
+def cas_path: Separate<["-"], "cas-path">,
+  HelpText<"Path to CAS">, MetaVarName<"<path>">;

--- a/lib/DriverTool/driver.cpp
+++ b/lib/DriverTool/driver.cpp
@@ -86,6 +86,10 @@ extern int swift_api_digester_main(ArrayRef<const char *> Args,
 extern int swift_api_extract_main(ArrayRef<const char *> Args,
                                   const char *Argv0, void *MainAddr);
 
+/// Run 'swift-cache-tool'
+extern int swift_cache_tool_main(ArrayRef<const char *> Args, const char *Argv0,
+                                 void *MainAddr);
+
 /// Determine if the given invocation should run as a "subcommand".
 ///
 /// Examples of "subcommands" are 'swift build' or 'swift test', which are
@@ -297,6 +301,10 @@ static int run_driver(StringRef ExecName,
         (void *)(intptr_t)getExecutablePath);
   case Driver::DriverKind::APIDigester:
     return swift_api_digester_main(
+        TheDriver.getArgsWithoutProgramNameAndDriverMode(argv), argv[0],
+        (void *)(intptr_t)getExecutablePath);
+  case Driver::DriverKind::CacheTool:
+    return swift_cache_tool_main(
         TheDriver.getArgsWithoutProgramNameAndDriverMode(argv), argv[0],
         (void *)(intptr_t)getExecutablePath);
   default:

--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -1,0 +1,308 @@
+//===--- swift_cache_tool_main.cpp - Swift caching tool for inspection ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Utility tool for inspecting and accessing swift cache.
+//
+//===----------------------------------------------------------------------===//
+//
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/Version.h"
+#include "swift/Frontend/CompileJobCacheKey.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/Parse/ParseVersion.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Option/OptTable.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include <memory>
+
+using namespace swift;
+using namespace llvm::opt;
+using namespace llvm::cas;
+
+namespace {
+
+enum class SwiftCacheToolAction {
+  Invalid,
+  PrintBaseKey,
+  PrintOutputKeys
+};
+
+enum ID {
+  OPT_INVALID = 0, // This is not an option ID.
+#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
+               HELPTEXT, METAVAR, VALUES)                                      \
+  OPT_##ID,
+#include "SwiftCacheToolOptions.inc"
+  LastOption
+#undef OPTION
+};
+
+#define PREFIX(NAME, VALUE) static const char *const NAME[] = VALUE;
+#include "SwiftCacheToolOptions.inc"
+#undef PREFIX
+
+static const OptTable::Info InfoTable[] = {
+#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
+               HELPTEXT, METAVAR, VALUES)                                      \
+  {PREFIX, NAME,  HELPTEXT,    METAVAR,     OPT_##ID,  Option::KIND##Class,    \
+   PARAM,  FLAGS, OPT_##GROUP, OPT_##ALIAS, ALIASARGS, VALUES},
+#include "SwiftCacheToolOptions.inc"
+#undef OPTION
+};
+
+class CacheToolOptTable : public llvm::opt::OptTable {
+public:
+  CacheToolOptTable() : OptTable(InfoTable) {}
+};
+
+class SwiftCacheToolInvocation {
+private:
+  CompilerInstance Instance;
+  CompilerInvocation Invocation;
+  PrintingDiagnosticConsumer PDC;
+  std::string MainExecutablePath;
+  std::string CASPath;
+  std::vector<std::string> FrontendArgs;
+  SwiftCacheToolAction ActionKind = SwiftCacheToolAction::Invalid;
+
+public:
+  SwiftCacheToolInvocation(const std::string &ExecPath)
+      : MainExecutablePath(ExecPath) {
+    Instance.addDiagnosticConsumer(&PDC);
+  }
+
+  std::unique_ptr<llvm::opt::OptTable> createOptTable() {
+    return std::unique_ptr<OptTable>(new CacheToolOptTable());
+  }
+
+  int parseArgs(ArrayRef<const char *> Args) {
+    auto &Diags = Instance.getDiags();
+
+    std::unique_ptr<llvm::opt::OptTable> Table = createOptTable();
+    unsigned MissingIndex;
+    unsigned MissingCount;
+    llvm::opt::InputArgList ParsedArgs =
+        Table->ParseArgs(Args, MissingIndex, MissingCount);
+    if (MissingCount) {
+      Diags.diagnose(SourceLoc(), diag::error_missing_arg_value,
+                     ParsedArgs.getArgString(MissingIndex), MissingCount);
+      return 1;
+    }
+
+    if (ParsedArgs.getLastArg(OPT_help)) {
+      std::string ExecutableName =
+          llvm::sys::path::stem(MainExecutablePath).str();
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(), "Swift Cache Tool",
+                       0, 0, /*ShowAllAliases*/ false);
+      return 0;
+    }
+
+    CASPath =
+        ParsedArgs.getLastArgValue(OPT_cas_path, getDefaultOnDiskCASPath());
+
+    FrontendArgs = ParsedArgs.getAllArgValues(OPT__DASH_DASH);
+    if (auto *A = ParsedArgs.getLastArg(OPT_cache_tool_action))
+      ActionKind =
+          llvm::StringSwitch<SwiftCacheToolAction>(A->getValue())
+              .Case("print-base-key", SwiftCacheToolAction::PrintBaseKey)
+              .Case("print-output-keys", SwiftCacheToolAction::PrintOutputKeys)
+              .Default(SwiftCacheToolAction::Invalid);
+
+    if (ActionKind == SwiftCacheToolAction::Invalid) {
+      llvm::errs() << "Invalid option specified for -cache-tool-action: "
+                   << "use print-base-key|print-output-keys\n";
+      return 1;
+    }
+
+    return 0;
+  }
+
+  int run() {
+    switch (ActionKind) {
+    case SwiftCacheToolAction::PrintBaseKey:
+      return printBaseKey();
+    case SwiftCacheToolAction::PrintOutputKeys:
+      return printOutputKeys();
+    case SwiftCacheToolAction::Invalid:
+      return 0; // No action. Probably just print help. Return.
+    }
+  }
+
+private:
+  bool setupCompiler() {
+    // Setup invocation.
+    SmallString<128> workingDirectory;
+    llvm::sys::fs::current_path(workingDirectory);
+
+    // Parse arguments.
+    if (FrontendArgs.empty()) {
+      llvm::errs() << "missing swift-frontend command-line after --\n";
+      return true;
+    }
+    // drop swift-frontend executable path from command-line.
+    if (StringRef(FrontendArgs[0]).endswith("swift-frontend"))
+      FrontendArgs.erase(FrontendArgs.begin());
+
+    SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 4>
+        configurationFileBuffers;
+    std::vector<const char*> Args;
+    for (auto &A: FrontendArgs)
+      Args.emplace_back(A.c_str());
+
+    // Make sure CASPath is the same between invocation and cache-tool by
+    // appending the cas-path since the option doesn't affect cache key.
+    Args.emplace_back("-cas-path");
+    Args.emplace_back(CASPath.c_str());
+
+    if (Invocation.parseArgs(Args, Instance.getDiags(),
+                             &configurationFileBuffers, workingDirectory,
+                             MainExecutablePath))
+      return true;
+
+    if (!Invocation.getFrontendOptions().EnableCAS) {
+      llvm::errs() << "Requested command-line arguments do not enable CAS\n";
+      return true;
+    }
+
+    // Setup instance.
+    std::string InstanceSetupError;
+    if (Instance.setup(Invocation, InstanceSetupError, Args)) {
+      llvm::errs() << "swift-frontend invocation setup error: "
+                   << InstanceSetupError << "\n";
+      return true;
+    }
+
+    return false;
+  }
+
+  Optional<ObjectRef> getBaseKey() {
+    auto BaseKey = Instance.getCompilerBaseKey();
+    if (!BaseKey) {
+      Instance.getDiags().diagnose(SourceLoc(), diag::error_cas,
+                                   "Base Key doesn't exist");
+      return None;
+    }
+
+    return *BaseKey;
+  }
+
+  int printBaseKey() {
+    if (setupCompiler())
+      return 1;
+
+    auto &CAS = Instance.getObjectStore();
+    auto BaseKey = getBaseKey();
+    if (!BaseKey)
+      return 1;
+
+    if (ActionKind == SwiftCacheToolAction::PrintBaseKey)
+      llvm::outs() << CAS.getID(*BaseKey).toString() << "\n";
+
+    return 0;
+  }
+
+  int printOutputKeys();
+};
+
+} // end anonymous namespace
+
+int SwiftCacheToolInvocation::printOutputKeys() {
+  if (setupCompiler())
+    return 1;
+
+  auto &CAS = Instance.getObjectStore();
+  auto BaseKey = getBaseKey();
+  if (!BaseKey)
+    return 1;
+
+  struct OutputEntry {
+    std::string InputPath;
+    std::string OutputPath;
+    std::string OutputKind;
+    std::string CacheKey;
+  };
+  std::vector<OutputEntry> OutputKeys;
+  bool hasError = false;
+  auto addOutputKey = [&](StringRef InputPath, file_types::ID OutputKind,
+                          StringRef OutputPath) {
+    auto OutputKey =
+        createCompileJobCacheKeyForOutput(CAS, *BaseKey, InputPath, OutputKind);
+    if (!OutputKey) {
+      llvm::errs() << "cannot create cache key for " << OutputPath << ": "
+                   << toString(OutputKey.takeError()) << "\n";
+      hasError = true;
+    }
+    OutputKeys.emplace_back(
+        OutputEntry{InputPath.str(), OutputPath.str(),
+                    file_types::getTypeName(OutputKind).str(),
+                    CAS.getID(*OutputKey).toString()});
+  };
+  auto addFromInputFile = [&](const InputFile &Input) {
+    auto InputPath = Input.getFileName();
+    if (!Input.outputFilename().empty())
+      addOutputKey(InputPath,
+                   Invocation.getFrontendOptions()
+                       .InputsAndOutputs.getPrincipalOutputType(),
+                   Input.outputFilename());
+    Input.getPrimarySpecificPaths()
+        .SupplementaryOutputs.forEachSetOutputAndType(
+            [&](const std::string &File, file_types::ID ID) {
+              // Dont print serialized diagnostics.
+              if (ID == file_types::ID::TY_SerializedDiagnostics)
+                return;
+
+              addOutputKey(InputPath, ID, File);
+            });
+  };
+  llvm::for_each(
+      Invocation.getFrontendOptions().InputsAndOutputs.getAllInputs(),
+      addFromInputFile);
+
+  if (hasError)
+    return 1;
+
+  llvm::json::OStream Out(llvm::outs(), /*IndentSize=*/4);
+  Out.array([&] {
+    for (const auto &E : OutputKeys) {
+      Out.object([&] {
+        Out.attribute("OutputPath", E.OutputPath);
+        Out.attribute("OutputKind", E.OutputKind);
+        Out.attribute("Input", E.InputPath);
+        Out.attribute("CacheKey", E.CacheKey);
+      });
+    }
+  });
+
+  return 0;
+}
+
+int swift_cache_tool_main(ArrayRef<const char *> Args, const char *Argv0,
+                          void *MainAddr) {
+  INITIALIZE_LLVM();
+
+  SwiftCacheToolInvocation Invocation(
+      llvm::sys::fs::getMainExecutable(Argv0, MainAddr));
+
+  if (Invocation.parseArgs(Args) != 0)
+    return EXIT_FAILURE;
+
+  if (Invocation.run() != 0)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -355,6 +355,13 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.CASPath =
       Args.getLastArgValue(OPT_cas_path, llvm::cas::getDefaultOnDiskCASPath());
   Opts.CASFSRootID = Args.getLastArgValue(OPT_cas_fs);
+  if (Opts.EnableCAS && Opts.CASFSRootID.empty() &&
+      FrontendOptions::supportCompilationCaching(Opts.RequestedAction)) {
+    if (!Args.hasArg(OPT_allow_unstable_cache_key_for_testing)) {
+        Diags.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
+        return true;
+    }
+  }
 
   return false;
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -675,6 +675,12 @@ bool ArgsToFrontendOptionsConverter::
   Opts.InputsAndOutputs.setMainAndSupplementaryOutputs(mainOutputs,
                                                        supplementaryOutputs,
                                                        mainOutputForIndexUnits);
+  // set output type.
+  const file_types::ID outputType =
+      FrontendOptions::formatForPrincipalOutputFileForAction(
+          Opts.RequestedAction);
+  Opts.InputsAndOutputs.setPrincipalOutputType(outputType);
+
   return false;
 }
 

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_host_library(swiftFrontend STATIC
   ArgsToFrontendInputsConverter.cpp
   ArgsToFrontendOptionsConverter.cpp
   ArgsToFrontendOutputsConverter.cpp
+  CompileJobCacheKey.cpp
   CompilerInvocation.cpp
   DependencyVerifier.cpp
   DiagnosticVerifier.cpp

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_host_library(swiftFrontend STATIC
   ArgsToFrontendInputsConverter.cpp
   ArgsToFrontendOptionsConverter.cpp
   ArgsToFrontendOutputsConverter.cpp
+  CachingUtils.cpp
   CompileJobCacheKey.cpp
   CompilerInvocation.cpp
   DependencyVerifier.cpp

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -1,0 +1,217 @@
+//===--- CachingUtils.cpp ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Frontend/CachingUtils.h"
+
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/FileTypes.h"
+#include "swift/Frontend/CompileJobCacheKey.h"
+#include "clang/Frontend/CompileJobCacheResult.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualOutputBackends.h"
+#include "llvm/Support/VirtualOutputFile.h"
+#include <memory>
+
+#define DEBUG_TYPE "cache-util"
+
+using namespace swift;
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::vfs;
+
+namespace {
+class SwiftCASOutputFile final : public OutputFileImpl {
+public:
+  Error keep() override { return OnKeep(Path, Bytes); }
+  Error discard() override { return Error::success(); }
+  raw_pwrite_stream &getOS() override { return OS; }
+
+  using OnKeepType = llvm::unique_function<Error(StringRef, StringRef)>;
+  SwiftCASOutputFile(StringRef Path, OnKeepType OnKeep)
+      : Path(Path.str()), OS(Bytes), OnKeep(std::move(OnKeep)) {}
+
+private:
+  std::string Path;
+  SmallString<16> Bytes;
+  raw_svector_ostream OS;
+  OnKeepType OnKeep;
+};
+
+class SwiftCASOutputBackend final : public OutputBackend {
+  void anchor() override {}
+
+protected:
+  IntrusiveRefCntPtr<OutputBackend> cloneImpl() const override {
+    return makeIntrusiveRefCnt<SwiftCASOutputBackend>(CAS, Cache, BaseKey,
+                                                      InputsAndOutputs);
+  }
+
+  Expected<std::unique_ptr<OutputFileImpl>>
+  createFileImpl(StringRef ResolvedPath,
+                 Optional<OutputConfig> Config) override {
+    auto ProducingInput = OutputToInputMap.find(ResolvedPath);
+    assert(ProducingInput != OutputToInputMap.end() && "Unknown output file");
+
+    std::string InputFilename = ProducingInput->second.first.getFileName();
+    auto OutputType = ProducingInput->second.second;
+
+    // Uncached output kind.
+    if (OutputType == file_types::ID::TY_SerializedDiagnostics)
+      return std::make_unique<llvm::vfs::NullOutputFileImpl>();
+
+    return std::make_unique<SwiftCASOutputFile>(
+        ResolvedPath, [=](StringRef Path, StringRef Bytes) -> Error {
+          return storeCachedCompilerOutput(CAS, Cache, Path, Bytes, BaseKey,
+                                           InputFilename, OutputType);
+        });
+  }
+
+private:
+  void initBackend(const FrontendInputsAndOutputs &InputsAndOutputs) {
+    // FIXME: The output to input map might not be enough for example all the
+    // outputs can be written to `-`, but the backend cannot distinguish which
+    // input it actually comes from. Maybe the solution is just not to cache
+    // any commands write output to `-`.
+    file_types::ID mainOutputType = InputsAndOutputs.getPrincipalOutputType();
+    auto addInput = [&](const InputFile &Input) {
+      if (!Input.outputFilename().empty())
+        OutputToInputMap.insert(
+            {Input.outputFilename(), {Input, mainOutputType}});
+      Input.getPrimarySpecificPaths()
+          .SupplementaryOutputs.forEachSetOutputAndType(
+              [&](const std::string &Out, file_types::ID ID) {
+                OutputToInputMap.insert({Out, {Input, ID}});
+              });
+    };
+    llvm::for_each(InputsAndOutputs.getAllInputs(), addInput);
+  }
+
+  file_types::ID getOutputFileType(StringRef Path) const {
+    return file_types::lookupTypeForExtension(llvm::sys::path::extension(Path));
+  }
+
+public:
+  SwiftCASOutputBackend(ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
+                        const FrontendInputsAndOutputs &InputsAndOutputs)
+      : CAS(CAS), Cache(Cache), BaseKey(BaseKey),
+        InputsAndOutputs(InputsAndOutputs) {
+    initBackend(InputsAndOutputs);
+  }
+
+private:
+  ObjectStore &CAS;
+  ActionCache &Cache;
+  ObjectRef BaseKey;
+
+  StringMap<std::pair<const InputFile &, file_types::ID>> OutputToInputMap;
+  const FrontendInputsAndOutputs &InputsAndOutputs;
+};
+}
+
+namespace swift {
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend>
+createSwiftCachingOutputBackend(
+    llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
+    llvm::cas::ObjectRef BaseKey,
+    const FrontendInputsAndOutputs &InputsAndOutputs) {
+  return makeIntrusiveRefCnt<SwiftCASOutputBackend>(CAS, Cache, BaseKey,
+                                                    InputsAndOutputs);
+}
+
+static Expected<std::unique_ptr<llvm::MemoryBuffer>>
+loadCachedCompileResultFromCacheKeyImpl(ObjectStore &CAS, ActionCache &Cache,
+                                        StringRef CacheKey,
+                                        StringRef Filename) {
+  auto ID = CAS.parseID(CacheKey);
+  if (!ID)
+    return ID.takeError();
+
+  auto Result = Cache.get(*ID);
+  if (!Result)
+    return Result.takeError();
+  if (!*Result)
+    return nullptr;
+
+  auto OutputRef = CAS.getReference(**Result);
+  if (!OutputRef)
+    return nullptr;
+  clang::cas::CompileJobResultSchema Schema(CAS);
+  auto CachedOutput = Schema.load(*OutputRef);
+
+  if (!CachedOutput)
+    return CachedOutput.takeError();
+
+  auto Output = CachedOutput->getOutput(
+      clang::cas::CompileJobCacheResult::OutputKind::MainOutput);
+  if (!Output)
+    return nullptr;
+
+  auto Proxy = CAS.getProxy(Output->Object);
+  if (!Proxy)
+    return Proxy.takeError();
+
+  return Proxy->getMemoryBuffer(Filename);
+}
+
+std::unique_ptr<llvm::MemoryBuffer>
+loadCachedCompileResultFromCacheKey(ObjectStore &CAS, ActionCache &Cache,
+                                    DiagnosticEngine &Diag, StringRef CacheKey,
+                                    StringRef Filename) {
+  auto Output =
+      loadCachedCompileResultFromCacheKeyImpl(CAS, Cache, CacheKey, Filename);
+  if (!Output) {
+    Diag.diagnose(SourceLoc(), diag::error_cas, toString(Output.takeError()));
+    return nullptr;
+  }
+  return std::move(*Output);
+}
+
+Error storeCachedCompilerOutput(llvm::cas::ObjectStore &CAS,
+                                llvm::cas::ActionCache &Cache, StringRef Path,
+                                StringRef Bytes, llvm::cas::ObjectRef BaseKey,
+                                StringRef CorrespondingInput,
+                                file_types::ID OutputKind) {
+  Optional<ObjectRef> BytesRef;
+  if (Error E = CAS.storeFromString(None, Bytes).moveInto(BytesRef))
+    return E;
+
+  auto CacheKey = createCompileJobCacheKeyForOutput(
+      CAS, BaseKey, CorrespondingInput, OutputKind);
+  if (!CacheKey)
+    return CacheKey.takeError();
+
+  LLVM_DEBUG(llvm::dbgs() << "DEBUG: writing output \'" << Path << "\' type \'"
+                          << file_types::getTypeName(OutputKind)
+                          << "\' input \'" << CorrespondingInput << "\' hash \'"
+                          << CAS.getID(*CacheKey).toString() << "\'\n";);
+
+  // Use clang compiler job output for now.
+  clang::cas::CompileJobCacheResult::Builder Builder;
+  Builder.addOutput(clang::cas::CompileJobCacheResult::OutputKind::MainOutput,
+                    *BytesRef);
+  auto Result = Builder.build(CAS);
+  if (!Result)
+    return Result.takeError();
+
+  if (auto E = Cache.put(CAS.getID(*CacheKey), CAS.getID(*Result)))
+    return E;
+
+  return Error::success();
+}
+
+} // namespace swift

--- a/lib/Frontend/CompileJobCacheKey.cpp
+++ b/lib/Frontend/CompileJobCacheKey.cpp
@@ -1,0 +1,83 @@
+//===--- CompileJobCacheKey.cpp - compile cache key methods ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains utility methods for creating compile job cache keys.
+//
+//===----------------------------------------------------------------------===//
+
+#include <swift/Frontend/CompileJobCacheKey.h>
+#include <swift/Basic/Version.h>
+#include <llvm/ADT/SmallString.h>
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/CAS/HierarchicalTreeBuilder.h"
+#include "llvm/CAS/ObjectStore.h"
+
+using namespace swift;
+
+// TODO: Rewrite this into CASNodeSchema.
+llvm::Expected<llvm::cas::ObjectRef> swift::createCompileJobBaseCacheKey(
+    llvm::cas::ObjectStore &CAS, ArrayRef<const char *> Args) {
+  SmallString<256> CommandLine;
+
+  // TODO: Improve this list.
+  static const std::vector<std::string> removeArgAndNext = {
+      "-o", "-supplementary-output-file-map", "-serialize-diagnostics-path",
+      "-num-threads", "-cas-path"};
+
+  // Don't count the `-frontend` in the first location since only frontend
+  // invocation can have a cache key.
+  if (Args.size() > 1 && StringRef(Args.front()) == "-frontend")
+    Args = Args.drop_front();
+
+  bool SkipNext = false;
+  for (StringRef Arg : Args) {
+    if (SkipNext) {
+      SkipNext = false;
+      continue;
+    }
+    if (llvm::is_contained(removeArgAndNext, Arg)) {
+      SkipNext = true;
+      continue;
+    }
+    CommandLine.append(Arg);
+    CommandLine.push_back(0);
+  }
+
+  llvm::cas::HierarchicalTreeBuilder Builder;
+  auto CMD = CAS.storeFromString(None, CommandLine);
+  if (!CMD)
+    return CMD.takeError();
+  Builder.push(*CMD, llvm::cas::TreeEntry::Regular, "command-line");
+
+  // FIXME: The version is maybe insufficient...
+  auto Version = CAS.storeFromString(None, version::getSwiftFullVersion());
+  if (!Version)
+    return Version.takeError();
+  Builder.push(*Version, llvm::cas::TreeEntry::Regular, "version");
+
+  if (auto Out = Builder.create(CAS))
+    return Out->getRef();
+  else
+    return Out.takeError();
+}
+
+llvm::Expected<llvm::cas::ObjectRef> swift::createCompileJobCacheKeyForOutput(
+    llvm::cas::ObjectStore &CAS, llvm::cas::ObjectRef BaseKey,
+    StringRef ProducingInput, file_types::ID OutputType) {
+  SmallString<256> OutputInfo;
+
+  // Encode the OutputType as first byte, then append the input file path.
+  OutputInfo.emplace_back((char)OutputType);
+  OutputInfo.append(ProducingInput);
+
+  return CAS.storeFromString({BaseKey}, OutputInfo);
+}

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -39,6 +39,7 @@ FrontendInputsAndOutputs::FrontendInputsAndOutputs(
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
   ShouldRecoverMissingInputs = other.ShouldRecoverMissingInputs;
+  OutputType = other.OutputType;
 }
 
 FrontendInputsAndOutputs &FrontendInputsAndOutputs::
@@ -48,6 +49,7 @@ operator=(const FrontendInputsAndOutputs &other) {
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
   ShouldRecoverMissingInputs = other.ShouldRecoverMissingInputs;
+  OutputType = other.OutputType;
   return *this;
 }
 

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -39,7 +39,7 @@ FrontendInputsAndOutputs::FrontendInputsAndOutputs(
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
   ShouldRecoverMissingInputs = other.ShouldRecoverMissingInputs;
-  OutputType = other.OutputType;
+  PrincipalOutputType = other.PrincipalOutputType;
 }
 
 FrontendInputsAndOutputs &FrontendInputsAndOutputs::
@@ -49,7 +49,7 @@ operator=(const FrontendInputsAndOutputs &other) {
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
   ShouldRecoverMissingInputs = other.ShouldRecoverMissingInputs;
-  OutputType = other.OutputType;
+  PrincipalOutputType = other.PrincipalOutputType;
   return *this;
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -215,6 +215,50 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   llvm_unreachable("Unknown ActionType");
 }
 
+bool FrontendOptions::supportCompilationCaching(ActionType action) {
+  // TODO: need to audit this list to make sure everything marked as true are
+  // all supported and tested.
+  switch (action) {
+  case ActionType::NoneAction:
+  case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
+  case ActionType::DumpPCM:
+  case ActionType::REPL:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::EmitImportedModules:
+  case ActionType::ScanDependencies:
+  case ActionType::TypecheckModuleFromInterface:
+  case ActionType::ResolveImports:
+  case ActionType::Typecheck:
+  case ActionType::DumpAST:
+  case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::MergeModules:
+  case ActionType::Immediate:
+  case ActionType::DumpTypeInfo:
+    return false;
+  case ActionType::CompileModuleFromInterface:
+  case ActionType::EmitPCH:
+  case ActionType::EmitPCM:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIRGen:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitModuleOnly:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+    return true;
+  }
+  llvm_unreachable("Unknown ActionType");
+}
+
 void FrontendOptions::forAllOutputPaths(
     const InputFile &input, llvm::function_ref<void(StringRef)> fn) const {
   if (RequestedAction != FrontendOptions::ActionType::EmitModuleOnly &&

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2313,7 +2313,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   bool verifierEnabled = diagOpts.VerifyMode != DiagnosticOptions::NoVerify;
 
   std::string InstanceSetupError;
-  if (Instance->setup(Invocation, InstanceSetupError)) {
+  if (Instance->setup(Invocation, InstanceSetupError, Args)) {
     int ReturnCode = 1;
     if (Invocation.getFrontendOptions().FrontendParseableOutput)
       emitParseableFinishedMessage(ReturnCode);
@@ -2339,7 +2339,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
         std::make_unique<CompilerInstance>();
     std::string InstanceSetupError;
     // This should not fail because it passed already.
-    (void)VerifyInstance->setup(Invocation, InstanceSetupError);
+    (void)VerifyInstance->setup(Invocation, InstanceSetupError, Args);
 
     // Run the first time without observer and discard return value;
     int ReturnValueTest = 0;

--- a/test/CAS/cache_key_compute.swift
+++ b/test/CAS/cache_key_compute.swift
@@ -2,18 +2,24 @@
 // RUN: mkdir -p %t/cas
 
 /// Doesn't run because the command doesn't have CAS enabled.
-// RUN: not %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend %s -c 2>&1 | %FileCheck %s --check-prefix=NO-CAS
+// RUN: not %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend %s -c -allow-unstable-cache-key-for-testing 2>&1 | \
+// RUN:   %FileCheck %s --check-prefix=NO-CAS
 
 // NO-CAS: Requested command-line arguments do not enable CAS
 
 /// Check few working cases.
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c > %t1.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -enable-cas %s -c -allow-unstable-cache-key-for-testing > %t1.casid
 /// A different CAS doesn't affect base key.
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c -cas-path %t > %t2.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -enable-cas %s -c -allow-unstable-cache-key-for-testing -cas-path %t > %t2.casid
 /// Output path doesn't affect base key.
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c -o %t/test.o > %t3.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -enable-cas %s -c -allow-unstable-cache-key-for-testing -o %t/test.o > %t3.casid
 /// Add -D will change.
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c -DTEST > %t4.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
+// RUN:   %target-swift-frontend -enable-cas %s -c -allow-unstable-cache-key-for-testing -DTEST > %t4.casid
 
 // RUN: diff %t1.casid %t2.casid
 // RUN: diff %t1.casid %t3.casid
@@ -22,7 +28,7 @@
 /// Test output keys.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -enable-cas %s -emit-module -c -emit-dependencies \
-// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o | %FileCheck %s
+// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o -allow-unstable-cache-key-for-testing | %FileCheck %s
 
 // CHECK: test.o
 // CHECK-NEXT: "OutputKind": "object"

--- a/test/CAS/cache_key_compute.swift
+++ b/test/CAS/cache_key_compute.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/cas
+
+/// Doesn't run because the command doesn't have CAS enabled.
+// RUN: not %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend %s -c 2>&1 | %FileCheck %s --check-prefix=NO-CAS
+
+// NO-CAS: Requested command-line arguments do not enable CAS
+
+/// Check few working cases.
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c > %t1.casid
+/// A different CAS doesn't affect base key.
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c -cas-path %t > %t2.casid
+/// Output path doesn't affect base key.
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c -o %t/test.o > %t3.casid
+/// Add -D will change.
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- %target-swift-frontend -enable-cas %s -c -DTEST > %t4.casid
+
+// RUN: diff %t1.casid %t2.casid
+// RUN: diff %t1.casid %t3.casid
+// RUN: not diff %t1.casid %t4.casid
+
+/// Test output keys.
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend -enable-cas %s -emit-module -c -emit-dependencies \
+// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o | %FileCheck %s
+
+// CHECK: test.o
+// CHECK-NEXT: "OutputKind": "object"
+// CHECK-NEXT: "Input"
+// CHECK-NEXT: "CacheKey"
+
+// CHECK: test.swiftmodule
+// CHECK-NEXT: "OutputKind": "swiftmodule"
+// CHECK-NEXT: "Input"
+// CHECK-NEXT: "CacheKey"
+
+// CHECK: test.d
+// CHECK-NEXT: "OutputKind": "dependencies"
+// CHECK-NEXT: "Input"
+// CHECK-NEXT: "CacheKey"
+
+// CHECK: test.tbd
+// CHECK-NEXT: "OutputKind": "tbd"
+// CHECK-NEXT: "Input"
+// CHECK-NEXT: "CacheKey"

--- a/test/CAS/cas_output_backend.swift
+++ b/test/CAS/cas_output_backend.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/cas
+
+// RUN: not %target-swift-frontend -c -enable-cas -cas-path %t/cas %s -o %t/test.o 2>&1 | %FileCheck %s --check-prefix=NO-CASFS
+// NO-CASFS: caching is enabled without -cas-fs option
+
+// RUN: %target-swift-frontend -c -enable-cas -cas-path %t/cas %s -o %t/test.o -allow-unstable-cache-key-for-testing
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend -c -enable-cas -cas-path %t/cas %s -o %t/test.o -allow-unstable-cache-key-for-testing > %t/cache_key.json
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action validate-outputs %t/cache_key.json
+
+/// make sure validate fails if the cas is cleared.
+// RUN: rm -rf %t/cas
+// RUN: not %cache-tool -cas-path %t/cas -cache-tool-action validate-outputs %t/cache_key.json 2>&1 | %FileCheck %s
+
+// CHECK: failed to find output for cache key
+
+func testFunc() {}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -336,6 +336,7 @@ config.llvm_size = inferSwiftBinary('llvm-size')
 config.sourcekitd_test = inferSwiftBinary('sourcekitd-test')
 config.complete_test = inferSwiftBinary('complete-test')
 config.swift_api_digester = inferSwiftBinary('swift-api-digester')
+config.swift_cache_tool = inferSwiftBinary('swift-cache-tool')
 config.swift_refactor = inferSwiftBinary('swift-refactor')
 config.swift_demangle_yamldump = inferSwiftBinary('swift-demangle-yamldump')
 config.swift_demangle = inferSwiftBinary('swift-demangle')
@@ -1838,6 +1839,8 @@ else:
 config.swift_api_digester = (
     '%s -target %s' % (config.swift_api_digester, config.variant_triple))
 config.substitutions.append(('%api-digester', config.swift_api_digester))
+
+config.substitutions.append(('%cache-tool', config.swift_cache_tool))
 
 # Enable typo-correction for testing purposes.
 config.target_swift_frontend += " -typo-correction-limit 10 "

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -114,6 +114,11 @@ swift_create_post_build_symlink(swift-frontend
   DESTINATION "swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
+swift_create_post_build_symlink(swift-frontend
+  SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+  DESTINATION "swift-cache-tool${CMAKE_EXECUTABLE_SUFFIX}"
+  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
 add_swift_tool_symlink(swift swift-frontend compiler)
 add_swift_tool_symlink(swiftc swift-frontend compiler)
 add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)
@@ -121,6 +126,7 @@ add_swift_tool_symlink(swift-api-extract swift-frontend compiler)
 add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver)
 add_swift_tool_symlink(swift-indent swift-frontend editor-integration)
 add_swift_tool_symlink(swift-api-digester swift-frontend compiler)
+add_swift_tool_symlink(swift-cache-tool swift-frontend compiler)
 
 add_dependencies(compiler swift-frontend)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift${CMAKE_EXECUTABLE_SUFFIX}"
@@ -136,6 +142,9 @@ swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-extra
                            DESTINATION "bin"
                            COMPONENT compiler)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
+                           DESTINATION "bin"
+                           COMPONENT compiler)
+swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-cache-tool${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"
                            COMPONENT compiler)
 add_dependencies(autolink-driver swift-frontend)


### PR DESCRIPTION
Teach swift compiler how to compute cache key and store outputs into CAS. It contains:

* Cache key computation logic
* CAS output backend that mirrors the output into CAS
* Add cache lookup entry for outputs in ActionCache
* A swift-driver tool that can be used to inspect caching functions.