### PR TITLE
[5.9 cherry-pick] Add -runtime-compatibility-version none to the VFE/WME LTO tests to workaround a linker failure

### DIFF
--- a/test/IRGen/virtual-function-elimination-two-modules.swift
+++ b/test/IRGen/virtual-function-elimination-two-modules.swift
@@ -20,7 +20,7 @@
 // (4) Now produce the .dylib with just the symbols needed by the client
 // RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-vfe -Xfrontend -internalize-at-link \
 // RUN:     %s -DLIBRARY -lto=llvm-full %lto_flags -module-name Library \
-// RUN:     -emit-library -o %t/libLibrary.dylib \
+// RUN:     -emit-library -o %t/libLibrary.dylib -runtime-compatibility-version none \
 // RUN:     -Xlinker -exported_symbols_list -Xlinker %t/used-symbols -Xlinker -dead_strip
 
 // (5) Check list of symbols in library

--- a/test/IRGen/witness-method-elimination-two-modules.swift
+++ b/test/IRGen/witness-method-elimination-two-modules.swift
@@ -21,7 +21,7 @@
 // (4) Now produce the .dylib with just the symbols needed by the client
 // RUN: %target-build-swift -parse-as-library -Onone -Xfrontend -enable-llvm-wme -Xfrontend -internalize-at-link \
 // RUN:     %s -DLIBRARY -lto=llvm-full %lto_flags -module-name Library \
-// RUN:     -emit-library -o %t/libLibrary.dylib \
+// RUN:     -emit-library -o %t/libLibrary.dylib -runtime-compatibility-version none \
 // RUN:     -Xlinker -exported_symbols_list -Xlinker %t/used-symbols -Xlinker -dead_strip
 
 // (5) Check list of symbols in library


### PR DESCRIPTION
Add -runtime-compatibility-version none to the VFE/WME LTO tests to workaround a linker failure

rdar://107987502