### PR TITLE
[5.9] Don't visit synthesized extensions twice.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -4072,7 +4072,8 @@ void FileUnit::getTopLevelDeclsWithAuxiliaryDecls(
   getTopLevelDecls(nonExpandedDecls);
   for (auto *decl : nonExpandedDecls) {
     decl->visitAuxiliaryDecls([&](Decl *auxDecl) {
-      results.push_back(auxDecl);
+      if (!isa<ExtensionDecl>(auxDecl))
+        results.push_back(auxDecl);
     });
     results.push_back(decl);
   }

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5 -emit-tbd -emit-tbd-path %t/MacroUser.tbd
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 


### PR DESCRIPTION
* Explanation: Teach `getTopLevelDeclsWithAuxiliaryDecls` not to provide extension declarations, because those are covered by the synthesized file, which all clients need to walk anyway. Without this, we end up asserting in TBD generation about duplicate symbol visitation.
* Scope: Affects code using conformance macros.
* Risk: Low, narrowly applied to macros to squelch an assertion.
* Issue: rdar://108056018
* Original pull request: https://github.com/apple/swift/pull/65291