### PR TITLE
[Dependency Scanning] Always tokenize scanning query command-line strings

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -254,7 +254,23 @@ DependencyScanningTool::initCompilerInstanceForScan(
   // We must do so because LLVM options parsing is done using a managed
   // static `GlobalParser`.
   llvm::cl::ResetAllOptionOccurrences();
-  if (Invocation.parseArgs(CommandArgs, Instance->getDiags(),
+  // Parse/tokenize arguments.
+  std::string CommandString;
+  for (const auto *c : CommandArgs) {
+    CommandString.append(c);
+    CommandString.append(" ");
+  }
+  SmallVector<const char *, 4> Args;
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringSaver Saver(Alloc);
+  // Ensure that we use the Windows command line parsing on Windows as we need
+  // to ensure that we properly handle paths.
+  if (llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows())
+    llvm::cl::TokenizeWindowsCommandLine(CommandString, Saver, Args);
+  else
+    llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);
+
+  if (Invocation.parseArgs(Args, Instance->getDiags(),
                            nullptr, WorkingDirectory, "/tmp/foo")) {
     return std::make_error_code(std::errc::invalid_argument);
   }


### PR DESCRIPTION
Other parts of the scanner lib (e.g. target-info query) already do this. We must always make sure to process the incoming command-line strings and run them through `llvm::cl::TokenizeGNUCommandLine` in order to process escaped paths.

Part of rdar://106712169
