### PR TITLE
Disable lexing `#assert` unless experimental static assertions are enabled

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -694,6 +694,11 @@ void Lexer::lexHash() {
 #include "swift/AST/TokenKinds.def"
   .Default(tok::pound);
 
+  // If we found '#assert' but that experimental feature is not enabled,
+  // treat it as '#'.
+  if (Kind == tok::pound_assert && !LangOpts.hasFeature(Feature::StaticAssert))
+    Kind = tok::pound;
+
   // If we didn't find a match, then just return tok::pound.  This is highly
   // dubious in terms of error recovery, but is useful for code completion and
   // SIL parsing.

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -49,6 +49,19 @@ public struct FileIDMacro: ExpressionMacro {
   }
 }
 
+public struct AssertMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.argumentList.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "assert(\(argument))"
+  }
+}
+
 public struct StringifyMacro: ExpressionMacro {
   public static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -94,6 +94,7 @@ struct Bad {}
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 @freestanding(expression) macro fileID<T: ExpressibleByStringLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 @freestanding(expression) macro recurse(_: Bool) = #externalMacro(module: "MacroDefinition", type: "RecursiveMacro")
+@freestanding(expression) macro assert(_: Bool) = #externalMacro(module: "MacroDefinition", type: "AssertMacro")
 
 func testFileID(a: Int, b: Int) {
   // CHECK: MacroUser/macro_expand.swift
@@ -141,6 +142,10 @@ func testStringify(a: Int, b: Int) {
   // CHECK-AST: tuple_expr type='(Double, String)' location=Macro expansion of #stringify
 
   _ = (b, b2, s2, s3)
+}
+
+func testAssert(a: Int, b: Int) {
+  #assert(a == b)
 }
 
 public struct Outer {


### PR DESCRIPTION
`#assert` should be usable as a macro name, but the experimental feature was getting in the way.

Fixes rdar://107894668.
