### PR TITLE
[OwnershipUtils] Undef isn't introduced/enclosed.

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -2230,12 +2230,16 @@ protected:
 
 bool swift::visitEnclosingDefs(SILValue value,
                                function_ref<bool(SILValue)> visitor) {
+  if (isa<SILUndef>(value))
+    return true;
   return FindEnclosingDefs(value->getFunction())
     .visitEnclosingDefs(value, visitor);
 }
 
 bool swift::visitBorrowIntroducers(SILValue value,
                                    function_ref<bool(SILValue)> visitor) {
+  if (isa<SILUndef>(value))
+    return true;
   return FindEnclosingDefs(value->getFunction())
     .visitBorrowIntroducers(value, visitor);
 }

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -3,6 +3,7 @@
 class C {}
 sil @getOwned : $@convention(thin) () -> @owned C
 sil @barrier : $@convention(thin) () -> ()
+struct S {}
 
 // When access scopes are respected, the lifetime which previously extended
 // beyond the access scope still extends beyond it.
@@ -112,6 +113,24 @@ bb0(%0 : $*C, %instance : @owned $C):
   store %copy to [init] %0 : $*C
   apply %barrier() : $@convention(thin) () -> ()
   destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't crash on an adjacent phi with an incoming undef.
+sil [ossa] @adjacent_phi_with_incoming_undef : $@convention(thin) () -> () {
+entry:
+  %getC = function_ref @getOwned : $@convention(thin) () -> @owned C
+  %c2 = apply %getC() : $@convention(thin) () -> @owned C
+  br right2(%c2 : $C)
+
+right2(%c2p : @owned $C):
+  br exit(%c2p : $C, undef : $S)
+
+exit(%phi : @owned $C, %typhi : $S):
+  debug_value [trace] %phi : $C
+  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  destroy_value %phi : $C
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
Previously, calling `visitEnclosingDefs` or `visitBorrowIntroducers` would crash if the `SILValue` argument were an instance of `SILUndef` because both instantiate a `::FindEnclosingDefs` with the the result of calling `getFunction()` on that argument and `::FindEnclosingDefs` in turn uses that result to create a `ValueSet`; but `SILUndef::getFunction` returns `nullptr`, which is illegal to use as the function for a `ValueSet`(or any other data structure relying on `NodeBits`).

If the function specified as a separate argument, no values would be visited and `true` would be returned.  Instead of burdening the API with a separate argument, check for `SILUndef` up front and return `true`.
