### PR TITLE
Address asserts raised when conforming pseudogeneric type to protocol with coroutine requirement.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4594,8 +4594,9 @@ CanSILFunctionType SILFunctionType::get(
     ProtocolConformanceRef witnessMethodConformance) {
   assert(coroutineKind == SILCoroutineKind::None || normalResults.empty());
   assert(coroutineKind != SILCoroutineKind::None || yields.empty());
-  assert(!ext.isPseudogeneric() || genericSig);
-  
+  assert(!ext.isPseudogeneric() || genericSig ||
+         coroutineKind != SILCoroutineKind::None);
+
   patternSubs = patternSubs.getCanonical();
   invocationSubs = invocationSubs.getCanonical();
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1212,8 +1212,7 @@ ManglingError Remangler::mangleDependentMemberType(Node *node, unsigned depth) {
 
 ManglingError Remangler::mangleDependentPseudogenericSignature(Node *node,
                                                                unsigned depth) {
-  // handled inline
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+  return mangleDependentGenericSignature(node, depth + 1);
 }
 
 ManglingError Remangler::mangleDestructor(Node *node, unsigned depth) {

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -456,3 +456,4 @@ $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfM
 @__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_  ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_ ---> peer macro @addCompletionHandler expansion #1 of f in macro_expand_peers.S
 @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_ ---> freestanding macro expansion #2 of NotCovered(in _4361AD9339943F52AE6186DD51E04E91) in MacroUser.MemberNotCovered
+$sxSo8_NSRangeVRlzCRl_Cr0_llySo12ModelRequestCyxq_GIsPetWAlYl_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(witness_method) @yield_once <A, B where A: AnyObject, B: AnyObject> @substituted <A> (@inout A) -> (@yields @inout __C._NSRange) for <__C.ModelRequest<A, B>>

--- a/validation-test/SILGen/Inputs/rdar81421394.h
+++ b/validation-test/SILGen/Inputs/rdar81421394.h
@@ -1,0 +1,10 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface Ranger<__covariant SectionType, __covariant ItemType> : NSObject {
+  NSRange _range;
+}
+@property(nonatomic) NSRange range;
+@end
+#pragma clang assume_nonnull end

--- a/validation-test/SILGen/Inputs/rdar81421394.m
+++ b/validation-test/SILGen/Inputs/rdar81421394.m
@@ -1,0 +1,22 @@
+#include "rdar81421394.h"
+
+#pragma clang assume_nonnull begin
+@implementation Ranger
+- (instancetype)init {
+  if (self = [super init]) {
+    NSLog(@"calling init");
+    self->_range = NSMakeRange(0, 0);
+  }
+  return self;
+}
+- (void)setRange:(NSRange)newRange {
+  NSLog(@"%s: %@->%@", __PRETTY_FUNCTION__, NSStringFromRange(_range),
+        NSStringFromRange(newRange));
+  _range = newRange;
+}
+- (NSRange)range {
+  NSLog(@"%s: %@", __PRETTY_FUNCTION__, NSStringFromRange(_range));
+  return _range;
+}
+@end
+#pragma clang assume_nonnull end

--- a/validation-test/SILGen/rdar81421394.swift
+++ b/validation-test/SILGen/rdar81421394.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81421394.m -I %S/Inputs -c -o %t/rdar81421394.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81421394.h -Xlinker %t/rdar81421394.o %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+protocol RangeFinder {
+    var range: NSRange { get set }
+}
+
+extension Ranger : RangeFinder {}
+
+class Wrapper {
+  let instance: Ranger<AnyObject, NSObject>
+
+  init() {
+    instance = Ranger()
+  }
+
+  var range: NSRange {
+    _read {
+      yield instance.range
+    }
+    _modify {
+      print("staring modify")
+      yield &instance.range
+      print("ending modify")
+    }
+  }
+}
+
+let w = Wrapper()
+print("begin:", w.range)
+// CHECK: begin: {0, 0}
+w.range = NSRange(location: 3, length: 5)
+// CHECK: end: {3, 5}
+print("end:", w.range)


### PR DESCRIPTION
Implemented `Remangler::mangleDependentPseudogenericSignature` (with the same one-line implementation as `OldRemangler`'s implementation) to fix the assertion that the coroutine continuation prototype's mangling could be roundtripped.

And loosened an assertion in `SILFunctionType::get` so that instances for pseudogeneric coroutines without signatures to be created.  Such instances are created by `SILTypeSubstituter::substSILFunctionType` when SILGen'ing a conformance of a pseudogeneric type to a protocol featuring a coroutine requirement.

rdar://81421394
