### PR TITLE
[SIL] Accesses to globals are deinit barriers.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -237,8 +237,8 @@ inline bool accessKindMayConflict(SILAccessKind a, SILAccessKind b) {
   return !(a == SILAccessKind::Read && b == SILAccessKind::Read);
 }
 
-/// Whether \p instruction accesses storage whose representation is unidentified
-/// such as by reading a pointer.
+/// Whether \p instruction accesses storage whose representation is either (1)
+/// unidentified such as by reading a pointer or (2) global.
 bool mayAccessPointer(SILInstruction *instruction);
 
 /// Whether this instruction loads or copies a value whose storage does not

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -406,13 +406,15 @@ bool swift::isLetAddress(SILValue address) {
 bool swift::mayAccessPointer(SILInstruction *instruction) {
   if (!instruction->mayReadOrWriteMemory())
     return false;
-  bool isUnidentified = false;
-  visitAccessedAddress(instruction, [&isUnidentified](Operand *operand) {
+  bool retval = false;
+  visitAccessedAddress(instruction, [&retval](Operand *operand) {
     auto accessStorage = AccessStorage::compute(operand->get());
-    if (accessStorage.getKind() == AccessRepresentation::Kind::Unidentified)
-      isUnidentified = true;
+    auto kind = accessStorage.getKind();
+    if (kind == AccessRepresentation::Kind::Unidentified ||
+        kind == AccessRepresentation::Kind::Global)
+      retval = true;
   });
-  return isUnidentified;
+  return retval;
 }
 
 bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -2,6 +2,13 @@
 
 // REQUIRES: swift_in_compiler
 
+import Builtin
+
+typealias Int32 = Builtin.Int32
+
+sil_global public @my_errno : $Int32
+sil_global shared @global_var : $Int32
+
 sil [ossa] @unknown : $@convention(thin) () -> ()
 
 sil [ossa] @unknown_caller : $@convention(thin) () -> () {
@@ -90,10 +97,10 @@ actor A {}
 sil @getA : $() -> (@owned A)
 sil @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
 
-// CHECK-LABEL: begin running test 1 of 1 on test_hop_to_executor: is-deinit-barrier
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_hop_to_executor: is-deinit-barrier
 // CHECK:  hop_to_executor
 // CHECK:  true
-// CHECK-LABEL: end running test 1 of 1 on test_hop_to_executor: is-deinit-barrier
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_hop_to_executor: is-deinit-barrier
 sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   %borrowA = function_ref @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
   (%a, %token) = begin_apply %borrowA() : $@yield_once @convention(thin) () -> @yields @guaranteed A
@@ -104,14 +111,31 @@ sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
 // CHECK:  debug_step
 // CHECK:  false
-// CHECK-LABEL: end running test 1 of 1 on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: begin running test 2 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK:  load [trivial] {{%[^,]+}} : $*Builtin.Int32
+// CHECK:  true
+// CHECK-LABEL: end running test 2 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK-LABEL: begin running test 3 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
+// CHECK:  load [trivial] {{%[^,]+}} : $*Builtin.Int32
+// CHECK:  true
+// CHECK-LABEL: end running test 3 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
 sil [ossa] @test_instructions_1 : $@convention(thin) () -> () {
 entry:
   test_specification "is-deinit-barrier @instruction"
   debug_step
+
+  %my_errno = global_addr @my_errno : $*Builtin.Int32
+  test_specification "is-deinit-barrier @instruction"
+  %my_errno_value = load [trivial] %my_errno : $*Int32
+
+  %global_var = global_addr @global_var : $*Builtin.Int32
+  test_specification "is-deinit-barrier @instruction"
+  %global_var_value = load [trivial] %global_var : $*Int32
+
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -429,7 +429,7 @@ bb5(%10 : $X):
 }
 
 // CHECK-LABEL: sil @load_from_global_var
-// CHECK-NEXT:  [global: read]
+// CHECK-NEXT:  [global: read,deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
 sil @load_from_global_var : $@convention(thin) () -> Int32 {
 bb0:


### PR DESCRIPTION
Accesses to globals which can be used externally (e.g. errno being written to elsewhere) can't be reordered with deinits since deinits could read such globals.

rdar://98542123