### PR TITLE
[5.9] Handle vanishing tuples when emitting a result plan into an initialization

### DIFF
--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -98,7 +98,7 @@ struct ResultPlanBuilder {
   ResultPlanPtr buildForTuple(Initialization *emitInto,
                               AbstractionPattern origType,
                               CanType substType);
-  ResultPlanPtr buildForPackExpansion(Optional<MutableArrayRef<InitializationPtr>> inits,
+  ResultPlanPtr buildForPackExpansion(Optional<ArrayRef<Initialization*>> inits,
                                       AbstractionPattern origExpansionType,
                                       CanTupleEltTypeArrayRef substTypes);
   ResultPlanPtr buildPackExpansionIntoPack(SILValue packAddr,

--- a/test/SILGen/variadic-generic-vanishing-tuples.swift
+++ b/test/SILGen/variadic-generic-vanishing-tuples.swift
@@ -75,3 +75,29 @@ public func testArgPassingExpansion<X>(arg: G<X>) {
 public func testArgPassingPartial() {
   Holder< >.takePartial(arg: 0)
 }
+
+func makeTuple<each T>(_ t: repeat each T) -> (repeat each T) {
+  return (repeat each t)
+}
+
+// rdar://107972801
+// CHECK-LABEL: sil {{.*}}@$s4main7makeOneyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
+// CHECK:       bb0(%0 : $*T, %1 : $*T):
+// CHECK:         [[RET_PACK:%.*]] = alloc_pack $Pack{T}
+// CHECK-NEXT:    [[INDEX:%.*]] = scalar_pack_index 0 of $Pack{T}
+// CHECK-NEXT:    pack_element_set %0 : $*T into [[INDEX]] of [[RET_PACK]] :
+// CHECK-NEXT:    [[ARG_PACK:%.*]] = alloc_pack $Pack{T}
+// CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $T
+// CHECK-NEXT:    copy_addr %1 to [init] [[TEMP]] : $*T
+// CHECK-NEXT:    [[INDEX:%.*]] = scalar_pack_index 0 of $Pack{T}
+// CHECK-NEXT:    pack_element_set [[TEMP]] : $*T into [[INDEX]] of [[ARG_PACK]] :
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @$s4main9makeTupleyxxQp_txxQpRvzlF : $@convention(thin) <each τ_0_0> (@pack_guaranteed Pack{repeat each τ_0_0}) -> @pack_out Pack{repeat each τ_0_0}
+// CHECK-NEXT:    apply [[FN]]<Pack{T}>([[RET_PACK]], [[ARG_PACK]])
+// CHECK-NEXT:    destroy_addr [[TEMP]] : $*T
+// CHECK-NEXT:    dealloc_stack [[TEMP]] : $*T
+// CHECK-NEXT:    dealloc_pack [[ARG_PACK]] : $*Pack{T}
+// CHECK-NEXT:    dealloc_pack [[RET_PACK]] : $*Pack{T}
+public func makeOne<T>(_ t: T) -> T {
+  return makeTuple(t)
+}


### PR DESCRIPTION
Explanation: Vanishing tuples will require a long tail of fixes to handle; this is one. 5.9 version of #65295.
Scope: Affects calls to functions that return tuples that become singleton under variadic substitution
Issue: rdar://107972801
Risk: Low. Change should only have impact on variadic generic code because only tuples containing pack expansions can vanish.
Testing: Added a regression test