### PR TITLE
[Macros] Track plugin dependencies

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -95,7 +95,7 @@ namespace swift {
   class ModuleDependencyInfo;
   class PatternBindingDecl;
   class PatternBindingInitializer;
-  class PluginRegistry;
+  class PluginLoader;
   class SourceFile;
   class SourceLoc;
   class Type;
@@ -1488,6 +1488,12 @@ public:
 
   Type getNamedSwiftType(ModuleDecl *module, StringRef name);
 
+  /// Set the plugin loader.
+  void setPluginLoader(std::unique_ptr<PluginLoader> loader);
+
+  /// Get the plugin loader.
+  PluginLoader &getPluginLoader();
+
   /// Lookup a library plugin that can handle \p moduleName and return the path
   /// to it.
   /// The path is valid within the VFS, use `FS.getRealPath()` for the
@@ -1521,15 +1527,6 @@ public:
   /// instance is simply returned.
   LoadedExecutablePlugin *loadExecutablePlugin(StringRef path);
 
-  /// Get the plugin registry this ASTContext is using.
-  PluginRegistry *getPluginRegistry() const;
-
-  /// Set the plugin registory this ASTContext should use.
-  /// This should be called before any plugin is loaded.
-  void setPluginRegistry(PluginRegistry *newValue);
-
-  const llvm::StringSet<> &getLoadedPluginLibraryPaths() const;
-
   /// Get the output backend. The output backend needs to be initialized via
   /// constructor or `setOutputBackend`.
   llvm::vfs::OutputBackend &getOutputBackend() const {
@@ -1553,8 +1550,6 @@ private:
 
   Optional<StringRef> getBriefComment(const Decl *D);
   void setBriefComment(const Decl *D, StringRef Comment);
-
-  void createModuleToExecutablePluginMap();
 
   friend TypeBase;
   friend ArchetypeType;

--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -1,0 +1,91 @@
+//===--- PluginLoader.h -----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_AST_PLUGIN_LOADER_H
+#define SWIFT_AST_PLUGIN_LOADER_H
+
+#include "swift/AST/ModuleLoader.h"
+#include "swift/AST/PluginRegistry.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+
+class ASTContext;
+
+/// Compiler plugin loader tied to an ASTContext. This is responsible for:
+///  * Find plugins based on the module name
+///  * Load plugins resolving VFS paths
+///  * Track plugin dependencies
+class PluginLoader {
+  /// Plugin registry. Lazily populated by get/setRegistry().
+  /// NOTE: Do not reference this directly. Use getRegistry().
+  PluginRegistry *Registry = nullptr;
+
+  /// `Registry` storage if this owns it.
+  std::unique_ptr<PluginRegistry> OwnedRegistry = nullptr;
+
+  ASTContext &Ctx;
+  DependencyTracker *DepTracker;
+
+  /// Map a module name to an executable plugin path that provides the module.
+  llvm::DenseMap<swift::Identifier, llvm::StringRef> ExecutablePluginPaths;
+
+  void createModuleToExecutablePluginMap();
+
+public:
+  PluginLoader(ASTContext &Ctx, DependencyTracker *DepTracker)
+      : Ctx(Ctx), DepTracker(DepTracker) {
+    createModuleToExecutablePluginMap();
+  }
+
+  void setRegistry(PluginRegistry *newValue);
+  PluginRegistry *getRegistry();
+
+  /// Lookup a library plugin that can handle \p moduleName and return the path
+  /// to it from `-plugin-path` or `-load-plugin-library`.
+  /// The path returned can be loaded by 'loadLibraryPlugin' method.
+  llvm::Optional<std::string>
+  lookupLibraryPluginByModuleName(Identifier moduleName);
+
+  /// Lookup an executable plugin that is declared to handle \p moduleName
+  /// module by '-load-plugin-executable'.
+  /// The path returned can be loaded by 'loadExecutablePlugin' method.
+  llvm::Optional<StringRef>
+  lookupExecutablePluginByModuleName(Identifier moduleName);
+
+  /// Look for dynamic libraries in paths from `-external-plugin-path` and
+  /// return a pair of `(library path, plugin server executable)` if found.
+  /// These paths are valid within the VFS, use `FS.getRealPath()` for their
+  /// underlying path.
+  llvm::Optional<std::pair<std::string, std::string>>
+  lookupExternalLibraryPluginByModuleName(Identifier moduleName);
+
+  /// Load the specified dylib plugin path resolving the path with the
+  /// current VFS. If it fails to load the plugin, a diagnostic is emitted, and
+  /// returns a nullptr.
+  /// NOTE: This method is idempotent. If the plugin is already loaded, the same
+  /// instance is simply returned.
+  LoadedLibraryPlugin *loadLibraryPlugin(llvm::StringRef path);
+
+  /// Launch the specified executable plugin path resolving the path with the
+  /// current VFS. If it fails to load the plugin, a diagnostic is emitted, and
+  /// returns a nullptr.
+  /// NOTE: This method is idempotent. If the plugin is already loaded, the same
+  /// instance is simply returned.
+  LoadedExecutablePlugin *loadExecutablePlugin(llvm::StringRef path);
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_PLUGIN_LOADER_H

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -671,6 +671,7 @@ private:
   void setUpLLVMArguments();
   void setUpDiagnosticOptions();
   bool setUpModuleLoaders();
+  bool setUpPluginLoader();
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -72,6 +72,7 @@ add_swift_host_library(swiftAST STATIC
   Parameter.cpp
   Pattern.cpp
   PlatformKind.cpp
+  PluginLoader.cpp
   PluginRegistry.cpp
   PrettyStackTrace.cpp
   ProtocolConformance.cpp

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -1,0 +1,150 @@
+//===--- PluginLoader.cpp -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/PluginLoader.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/SourceManager.h"
+#include "llvm/Config/config.h"
+
+using namespace swift;
+
+void PluginLoader::createModuleToExecutablePluginMap() {
+  for (auto &arg : Ctx.SearchPathOpts.getCompilerPluginExecutablePaths()) {
+    // Create a moduleName -> pluginPath mapping.
+    assert(!arg.ExecutablePath.empty() && "empty plugin path");
+    StringRef pathStr = Ctx.AllocateCopy(arg.ExecutablePath);
+    for (auto moduleName : arg.ModuleNames) {
+      ExecutablePluginPaths[Ctx.getIdentifier(moduleName)] = pathStr;
+    }
+  }
+}
+
+void PluginLoader::setRegistry(PluginRegistry *newValue) {
+  assert(Registry == nullptr && "Too late to set a new plugin registry");
+  Registry = newValue;
+}
+
+PluginRegistry *PluginLoader::getRegistry() {
+  // Create a new one if it hasn't been set.
+  if (!Registry) {
+    Registry = new PluginRegistry();
+    OwnedRegistry.reset(Registry);
+  }
+
+  assert(Registry != nullptr);
+  return Registry;
+}
+
+llvm::Optional<std::string>
+PluginLoader::lookupLibraryPluginByModuleName(Identifier moduleName) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+
+  // Look for 'lib${module name}(.dylib|.so)'.
+  SmallString<64> expectedBasename;
+  expectedBasename.append("lib");
+  expectedBasename.append(moduleName.str());
+  expectedBasename.append(LTDL_SHLIB_EXT);
+
+  // Try '-load-plugin-library'.
+  for (const auto &libPath :
+       Ctx.SearchPathOpts.getCompilerPluginLibraryPaths()) {
+    if (llvm::sys::path::filename(libPath) == expectedBasename) {
+      return libPath;
+    }
+  }
+
+  // Try '-plugin-path'.
+  for (const auto &searchPath : Ctx.SearchPathOpts.PluginSearchPaths) {
+    SmallString<128> fullPath(searchPath);
+    llvm::sys::path::append(fullPath, expectedBasename);
+    if (fs->exists(fullPath)) {
+      return std::string(fullPath);
+    }
+  }
+
+  return None;
+}
+
+Optional<std::pair<std::string, std::string>>
+PluginLoader::lookupExternalLibraryPluginByModuleName(Identifier moduleName) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+
+  for (auto &pair : Ctx.SearchPathOpts.ExternalPluginSearchPaths) {
+    SmallString<128> fullPath(pair.SearchPath);
+    llvm::sys::path::append(fullPath,
+                            "lib" + moduleName.str() + LTDL_SHLIB_EXT);
+
+    if (fs->exists(fullPath)) {
+      return {{std::string(fullPath), pair.ServerPath}};
+    }
+  }
+  return None;
+}
+
+Optional<StringRef>
+PluginLoader::lookupExecutablePluginByModuleName(Identifier moduleName) {
+  auto &execPluginPaths = ExecutablePluginPaths;
+  auto found = execPluginPaths.find(moduleName);
+  if (found == execPluginPaths.end())
+    return None;
+  return found->second;
+}
+
+LoadedLibraryPlugin *PluginLoader::loadLibraryPlugin(StringRef path) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+  SmallString<128> resolvedPath;
+  if (auto err = fs->getRealPath(path, resolvedPath)) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       err.message());
+    return nullptr;
+  }
+
+  // Track the dependency.
+  if (DepTracker)
+    DepTracker->addDependency(resolvedPath, /*IsSystem=*/false);
+
+  // Load the plugin.
+  auto plugin = getRegistry()->loadLibraryPlugin(resolvedPath);
+  if (!plugin) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       llvm::toString(plugin.takeError()));
+    return nullptr;
+  }
+
+  return plugin.get();
+}
+
+LoadedExecutablePlugin *PluginLoader::loadExecutablePlugin(StringRef path) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+  SmallString<128> resolvedPath;
+  if (auto err = fs->getRealPath(path, resolvedPath)) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       err.message());
+    return nullptr;
+  }
+
+  // Track the dependency.
+  if (DepTracker)
+    DepTracker->addDependency(resolvedPath, /*IsSystem=*/false);
+
+  // Load the plugin.
+  auto plugin = getRegistry()->loadExecutablePlugin(resolvedPath);
+  if (!plugin) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       llvm::toString(plugin.takeError()));
+    return nullptr;
+  }
+
+  return plugin.get();
+}

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/FileSystem.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleDependencies.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/SourceManager.h"
@@ -288,6 +289,8 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
 
   if (setUpModuleLoaders())
     return true;
+  if (setUpPluginLoader())
+    return true;
 
   return false;
 }
@@ -393,11 +396,6 @@ void CompilerInstance::setupDependencyTrackerIfNeeded() {
     return;
 
   DepTracker = std::make_unique<DependencyTracker>(*collectionMode);
-
-  // Collect compiler plugin dependencies.
-  auto &searchPathOpts = Invocation.getSearchPathOptions();
-  for (auto &path : searchPathOpts.getCompilerPluginLibraryPaths())
-    DepTracker->addDependency(path, /*isSystem=*/false);
 }
 
 bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
@@ -750,6 +748,14 @@ bool CompilerInstance::setUpModuleLoaders() {
     Context->addModuleLoader(std::move(PSMS));
   }
 
+  return false;
+}
+
+bool CompilerInstance::setUpPluginLoader() {
+  /// FIXME: If Invocation has 'PluginRegistry', we can set it. But should we?
+  auto loader =
+      std::make_unique<PluginLoader>(*Context, getDependencyTracker());
+  Context->setPluginLoader(std::move(loader));
   return false;
 }
 

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -759,10 +759,6 @@ bool swift::emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
         std::make_pair(loadedDecl->getModuleFilename(), loadedDecl));
   }
 
-  // Add compiler plugin libraries as dependencies.
-  for (auto &pluginEntry : ctxt.getLoadedPluginLibraryPaths())
-    depTracker->addDependency(pluginEntry.getKey(), /*IsSystem*/ false);
-
   std::vector<SwiftModuleTraceInfo> swiftModules;
   computeSwiftModuleTraceInfo(ctxt, abiDependencies, pathToModuleDecl,
                               *depTracker, opts.PrebuiltModuleCachePath,

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Defer.h"
@@ -303,7 +304,7 @@ bool CompileInstance::setupCI(
     assert(Diags.hadAnyError());
     return false;
   }
-  CI->getASTContext().setPluginRegistry(Plugins.get());
+  CI->getASTContext().getPluginLoader().setRegistry(Plugins.get());
 
   return true;
 }

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Defer.h"
@@ -482,7 +483,7 @@ void IDEInspectionInstance::performNewOperation(
           InstanceSetupError));
       return;
     }
-    CI->getASTContext().setPluginRegistry(Plugins.get());
+    CI->getASTContext().getPluginLoader().setRegistry(Plugins.get());
     CI->getASTContext().CancellationFlag = CancellationFlag;
     registerIDERequestFunctions(CI->getASTContext().evaluator);
 

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
 // RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule -module-cache-path %t/cache
@@ -34,3 +35,5 @@
 // CHECK-CONFIRM-ONELINE: {"name":{{.*}}]}
 
 import Module2
+
+@freestanding(expression) macro echo<T>(_: T) -> T = #externalMacro(module: "Plugin", type: "EchoMacro")

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -1,0 +1,125 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/plugin)
+// RUN: %empty-directory(%t/lib)
+// RUN: %empty-directory(%t/src)
+
+// RUN: split-file %s %t/src
+
+//#-- Prepare the macro dylib plugin.
+// RUN: %host-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-library -o %t/plugin/%target-library-name(MacroDefinition) \
+// RUN:   -module-name MacroDefinition \
+// RUN:   %S/Inputs/syntax_macro_definitions.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath
+
+//#-- Prepare the macro executable plugin.
+// RUN: %clang \
+// RUN:  -isysroot %host_sdk \
+// RUN:  -I %swift_src_root/include \
+// RUN:  -L %swift-lib-dir -l_swiftMockPlugin \
+// RUN:  -Wl,-rpath,%swift-lib-dir \
+// RUN:  -o %t/mock-plugin \
+// RUN:  %t/src/plugin.c
+
+//#-- Prepare the macro library.
+// RUN: %target-swift-frontend \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-module -o %t/lib/MacroLib.swiftmodule \
+// RUN:   -module-name MacroLib \
+// RUN:   -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -primary-file %t/src/macro_library.swift \
+// RUN:   -emit-reference-dependencies-path %t/macro_library.swiftdeps \
+// RUN:   -emit-dependencies-path %t/macro_library.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/macro_library.swiftdeps %t/macro_library.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITH_PLUGIN %s < %t/macro_library.swiftdeps.processed
+
+//#-- Without macro (no -D USE_MACRO)
+// RUN: %target-swift-frontend \
+// RUN:   -swift-version 5 -typecheck \
+// RUN:   -primary-file %t/src/test.swift \
+// RUN:   %t/src/other.swift \
+// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -emit-reference-dependencies-path %t/without_macro.swiftdeps \
+// RUN:   -emit-dependencies-path %t/without_macro.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/without_macro.swiftdeps %t/without_macro.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/without_macro.swiftdeps.processed
+
+//#-- With macro - primary (-D USE_MACRO)
+// RUN: %target-swift-frontend \
+// RUN:   -D USE_MACRO \
+// RUN:   -swift-version 5 -typecheck \
+// RUN:   -primary-file %t/src/test.swift \
+// RUN:   %t/src/other.swift \
+// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -emit-reference-dependencies-path %t/with_macro_primary.swiftdeps \
+// RUN:   -emit-dependencies-path %t/with_macro_primary.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/with_macro_primary.swiftdeps %t/with_macro_primary.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITH_PLUGIN %s < %t/with_macro_primary.swiftdeps.processed
+
+//#-- With macro - non-primary (-D USE_MACRO)
+// RUN: %target-swift-frontend \
+// RUN:   -D USE_MACRO \
+// RUN:   -swift-version 5 -typecheck \
+// RUN:   %t/src/test.swift \
+// RUN:   -primary-file %t/src/other.swift \
+// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -emit-reference-dependencies-path %t/with_macro_nonprimary.swiftdeps \
+// RUN:   -emit-dependencies-path %t/with_macro_nonprimary.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/with_macro_nonprimary.swiftdeps %t/with_macro_nonprimary.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/with_macro_nonprimary.swiftdeps.processed
+
+// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}mock-plugin' false
+// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}libMacroDefinition.dylib' false
+
+// WITHOUT_PLUGIN-NOT:  MacroDefinition
+// WITHOUT_PLUGIN-NOT:  mock-plugin
+
+//--- macro_library.swift
+@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+@freestanding(expression) public macro testString(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "TestStringMacro")
+
+public func funcInMacroLib() {}
+
+//--- test.swift
+import MacroLib
+
+func test(a: Int, b: Int) {
+  // Just using MacroLib without macro
+  funcInMacroLib()
+
+#if USE_MACRO
+  _ = #stringify(a + b)
+  _ = #testString(123)
+#endif
+}
+
+//--- other.swift
+import MacroLib
+
+func test() {
+  // Just using MacroLib without macro
+  funcInMacroLib()
+}
+
+//--- plugin.c
+#include "swift-c/MockPlugin/MockPlugin.h"
+
+MOCK_PLUGIN([
+  {
+    "expect": {"getCapability": {}},
+    "response": {"getCapabilityResult": {"capability": {"protocolVersion": 1}}}
+  },
+  {
+    "expect": {"expandFreestandingMacro": {
+                "macro": {"moduleName": "TestPlugin", "typeName": "TestStringMacro"},
+                "syntax": {"kind": "expression", "source": "#testString(123)"}}},
+    "response": {"expandFreestandingMacroResult": {"expandedSource": "\"test\"", "diagnostics": []}}
+  }
+])

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -20,6 +20,7 @@
 #include "SourceKit/Support/Logging.h"
 #include "SourceKit/Support/Tracing.h"
 
+#include "swift/AST/PluginLoader.h"
 #include "swift/Basic/Cache.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
@@ -1077,7 +1078,8 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
     }
     return nullptr;
   }
-  CompIns.getASTContext().setPluginRegistry(ASTManager->Impl.Plugins.get());
+  CompIns.getASTContext().getPluginLoader().setRegistry(
+      ASTManager->Impl.Plugins.get());
   CompIns.getASTContext().CancellationFlag = CancellationFlag;
   registerIDERequestFunctions(CompIns.getASTContext().evaluator);
   if (TracedOp.enabled()) {


### PR DESCRIPTION
* Factor out ASTContext plugin loading to newly introduced 'PluginLoader'
* Insert 'DependencyTracker' to 'PluginLoader'
* Add dependencies right before loading the plugins

rdar://104938481
