### PR TITLE
[5.9] SILGen: Emit move-only bases for lvalues in a borrow scope.

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -105,6 +105,7 @@ public:
     CoroutineAccessorKind,      // coroutine accessor
     ValueKind,                  // random base pointer as an lvalue
     PhysicalKeyPathApplicationKind, // applying a key path
+    BorrowValueKind,            // load_borrow the base rvalue for a projection
 
     // Logical LValue kinds
     GetterSetterKind,           // property or subscript getter/setter
@@ -114,6 +115,7 @@ public:
     WritebackPseudoKind,        // a fake component to customize writeback
     OpenNonOpaqueExistentialKind,  // opened class or metatype existential
     LogicalKeyPathApplicationKind, // applying a key path
+    
     // Translation LValue kinds (a subtype of logical)
     OrigToSubstKind,            // generic type substitution
     SubstToOrigKind,            // generic type substitution

--- a/test/Interpreter/moveonly_computed_property_in_class.swift
+++ b/test/Interpreter/moveonly_computed_property_in_class.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+@_moveOnly
+struct FileDescriptor {
+  let desc: Int
+
+  var empty: Bool { return desc == Int.min }
+  func isEmpty() -> Bool { return empty }
+}
+
+final class Wrapper {
+  var val: FileDescriptor = FileDescriptor(desc: 0)
+
+  func isEmpty_bug() -> Bool {
+    // error: 'self.val' has consuming use that cannot 
+    // be eliminated due to a tight exclusivity scope
+    return val.empty // note: consuming use here
+  }
+
+  func isEmpty_ok() -> Bool {
+    return val.isEmpty()
+  }
+}
+
+let w = Wrapper()
+// CHECK: is not empty
+print(w.isEmpty_bug() ? "is empty" : "is not empty")
+w.val = FileDescriptor(desc: Int.min)
+// CHECK: is empty
+print(w.isEmpty_bug() ? "is empty" : "is not empty")

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -377,47 +377,38 @@ public func classAssignToVar5Arg2(_ x: __shared Klass, _ x2: inout Klass) { // e
 
 public func classAccessAccessField(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = Klass()
-    borrowVal(x2.k) // expected-note {{consuming use here}}
+    borrowVal(x2.k)
     for _ in 0..<1024 {
-        borrowVal(x2.k) // expected-note {{consuming use here}}
+        borrowVal(x2.k)
     }
 }
 
 public func classAccessAccessFieldArg(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    borrowVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        borrowVal(x2.k) // expected-note {{consuming use here}}
+        borrowVal(x2.k)
     }
 }
 
 public func classAccessConsumeField(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = Klass()
     // Since a class is a reference type, we do not emit an error here.
-    consumeVal(x2.k) // expected-note {{consuming use here}}
+    consumeVal(x2.k)
     // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-note {{consuming use here}}
+        consumeVal(x2.k)
         // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
 public func classAccessConsumeFieldArg(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // Since a class is a reference type, we do not emit an error here.
-    consumeVal(x2.k) // expected-note {{consuming use here}}
+    consumeVal(x2.k)
     // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-note {{consuming use here}}
+        consumeVal(x2.k)
         // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
@@ -682,45 +673,37 @@ public func finalClassAssignToVar5Arg2(_ x2: inout FinalKlass) {
 
 public func finalClassAccessField() {
     var x2 = FinalKlass()
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = FinalKlass()
-    borrowVal(x2.k) // expected-note {{consuming use here}}
+    borrowVal(x2.k)
     for _ in 0..<1024 {
-        borrowVal(x2.k) // expected-note {{consuming use here}}
+        borrowVal(x2.k)
     }
 }
 
 public func finalClassAccessFieldArg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    borrowVal(x2.k) // expected-note {{consuming use here}}
+    borrowVal(x2.k)
     for _ in 0..<1024 {
-        borrowVal(x2.k) // expected-note {{consuming use here}}
+        borrowVal(x2.k)
     }
 }
 
 public func finalClassConsumeField() {
     var x2 = FinalKlass()
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = FinalKlass()
 
-    consumeVal(x2.k) // expected-note {{consuming use here}}
+    consumeVal(x2.k)
     // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-note {{consuming use here}}
+        consumeVal(x2.k)
         // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    consumeVal(x2.k) // expected-note {{consuming use here}}
+    consumeVal(x2.k)
     // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-note {{consuming use here}}
+        consumeVal(x2.k)
         // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }

--- a/test/SILOptimizer/moveonly_computed_property.swift
+++ b/test/SILOptimizer/moveonly_computed_property.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// Applying a computed property to a move-only field in a class should occur
+// entirely within a formal access to the class property. rdar://105794506
+
+@_moveOnly
+struct FileDescriptor {
+  private let desc: Int
+
+  var empty: Bool { return desc == Int.min }
+}
+
+final class Wrapper {
+  private var val: FileDescriptor
+
+  func isEmpty_bug() -> Bool {
+    return val.empty
+  }
+
+  init() { fatalError() }
+}


### PR DESCRIPTION
Normally, if we project from a mutable class ivar or global variable, we'll load a copy in a tight access scope and then project from the copy, in order to minimize the potential for exclusivity violations while working with classes and copyable values. However, this is undesirable when a value is move-only, since copying is not allowed; borrowing the value in place is the expected and only possible behavior. rdar://105794506

Reviewed by @kavon on main in https://github.com/apple/swift/pull/65302.