### PR TITLE
Some methods swap the number of elements and the size arguments

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInterop.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInterop.h
@@ -667,7 +667,7 @@ swift_reflection_interop_createReflectionContextWithDataLayout(
     GetSymbolAddressFunction GetSymbolAddress) { 
  
   SwiftReflectionInteropContextRef ContextRef =
-    (SwiftReflectionInteropContextRef)calloc(sizeof(*ContextRef), 1);
+    (SwiftReflectionInteropContextRef)calloc(1, sizeof(*ContextRef));
   
   ContextRef->ReaderContext = ReaderContext;
   ContextRef->DataLayout = DataLayout;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3638,10 +3638,10 @@ initGenericObjCClass(ClassMetadata *self, size_t numFields,
       if (numFields <= NumInlineGlobalIvarOffsets) {
         _globalIvarOffsets = _inlineGlobalIvarOffsets;
         // Make sure all the entries start out null.
-        memset(_globalIvarOffsets, 0, sizeof(size_t *) * numFields);
+        memset(_globalIvarOffsets, 0, numFields * sizeof(size_t *));
       } else {
         _globalIvarOffsets =
-            static_cast<size_t **>(calloc(sizeof(size_t *), numFields));
+            static_cast<size_t **>(calloc(numFields, sizeof(size_t *)));
       }
     }
     return _globalIvarOffsets;

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -114,7 +114,7 @@ static TestActor *createActor() {
     // swift_getTypeName will tolerate it. Otherwise we crash when trying to
     // signpost actor creation.
     descriptor =
-        reinterpret_cast<ClassDescriptor *>(calloc(sizeof(*descriptor), 1));
+        reinterpret_cast<ClassDescriptor *>(calloc(1, sizeof(*descriptor)));
     TestActorMetadata.setDescription(descriptor);
   }
   return new TestActor();


### PR DESCRIPTION
For calloc, the variable denoting the of elements comes first, then the variable denoting the size of each element. However, both arguments are swapped when calling this function in many places in this codebase.