### PR TITLE
[interop][SwiftToCxx] do not expose unsupported enums yet

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1685,6 +1685,12 @@ ERROR(expose_generic_requirement_to_cxx,none,
       "generic requirements for %0 %1 can not yet be represented in C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(expose_throwing_to_cxx,none,
       "%0 %1 can not yet be represented in C++ as it may throw an error", (DescriptiveDeclKind, ValueDecl *))
+ERROR(expose_indirect_enum_cxx,none,
+      "indirect enum %0 can not yet be represented in C++", (ValueDecl *))
+ERROR(expose_enum_case_type_to_cxx,none,
+      "enum %0 can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++", (ValueDecl *))
+ERROR(expose_enum_case_tuple_to_cxx,none,
+      "enum %0 can not yet be represented in C++ as one of its cases has multiple associated values", (ValueDecl *))
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -72,7 +72,10 @@ enum RepresentationError {
   UnrepresentableRequiresClientEmission,
   UnrepresentableGeneric,
   UnrepresentableGenericRequirements,
-  UnrepresentableThrows
+  UnrepresentableThrows,
+  UnrepresentableIndirectEnum,
+  UnrepresentableEnumCaseType,
+  UnrepresentableEnumCaseTuple,
 };
 
 struct DeclRepresentation {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2067,6 +2067,15 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
       diagnose(attr->getLocation(), diag::expose_throwing_to_cxx,
                VD->getDescriptiveKind(), VD);
       break;
+    case UnrepresentableIndirectEnum:
+      diagnose(attr->getLocation(), diag::expose_indirect_enum_cxx, VD);
+      break;
+    case UnrepresentableEnumCaseType:
+      diagnose(attr->getLocation(), diag::expose_enum_case_type_to_cxx, VD);
+      break;
+    case UnrepresentableEnumCaseTuple:
+      diagnose(attr->getLocation(), diag::expose_enum_case_tuple_to_cxx, VD);
+      break;
     }
   }
 

--- a/test/Interop/SwiftToCxx/cross-module-refs/Inputs/enums.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/Inputs/enums.swift
@@ -1,6 +1,11 @@
+
+public struct IntTuple {
+    let values: (Int64, Int64, Int64, Int64, Int64, Int64)
+}
+
 // Large enum passed indirectly.
 public enum LargeEnum {
-    case A(x1: Int64, x2: Int64, x3: Int64, x4: Int64, x5: Int64)
+    case A(IntTuple)
     case B
 }
 

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -4,20 +4,23 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
 
+public struct IntTuple {
+    let values: (Int64, Int64, Int64, Int64, Int64, Int64)
+}
+
 public enum Large {
-    case first(Int64, Int64, Int64, Int64, Int64, Int64)
+    case first(IntTuple)
     case second
 }
 
 public func makeLarge(_ x: Int) -> Large {
-    return x >= 0 ? .first(0, 1, 2, 3, 4, 5) : .second
+    return x >= 0 ? .first(IntTuple(values: (0, 1, 2, 3, 4, 5))) : .second
 }
 
 public func printLarge(_ en: Large) {
     switch en {
-    case let .first(a, b, c, d, e, f):
-        let x = (a, b, c, d, e, f)
-        print("Large.first\(x)")
+    case let .first(x):
+        print("Large.first\(x.values)")
     case .second:
         print("Large.second")
     }
@@ -29,7 +32,7 @@ public func passThroughLarge(_ en: Large) -> Large {
 
 public func inoutLarge(_ en: inout Large, _ x: Int) {
     if x >= 0 {
-        en = .first(-1, -2, -3, -4, -5, -6)
+        en = .first(IntTuple(values: (-1, -2, -3, -4, -5, -6)))
     } else {
         en = .second
     }

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/functions.h
+
+// RUN: cat %s | grep -v _expose > %t/clean.swift
+// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
+// RUN: %FileCheck %s < %t/header.h
+
+// CHECK-NOT: unsupported
+
+public typealias FnType = () -> ()
+
+@_expose(Cxx) // expected-error {{enum 'unsupportedEnumAssociatedValueType' can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++}}
+public enum unsupportedEnumAssociatedValueType {
+    case A
+    case B(FnType)
+}
+
+@_expose(Cxx) // expected-error {{enum 'unsupportedEnumMultipleAssociatedValues' can not yet be represented in C++ as one of its cases has multiple associated values}}
+public enum unsupportedEnumMultipleAssociatedValues {
+    case A
+    case B(Int, Int)
+}
+
+@_expose(Cxx) // expected-error {{indirect enum 'unsupportedEnumIndirect' can not yet be represented in C++}}
+public indirect enum unsupportedEnumIndirect {
+    case A
+    case B
+}
+


### PR DESCRIPTION
This includes indirect enums, enums with multiple associated values, or enums whose associated value is a type we don't yet support
