### PR TITLE
[5.9][Serialization] Write down SPI-only dependencies as required in swiftmodules

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1214,8 +1214,9 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   // distinguish them.
   ImportSet publicImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Exported);
-  ImportSet privateImportSet =
-      getImportsAsSet(M, ModuleDecl::ImportFilterKind::Default);
+  ImportSet defaultImportSet =
+      getImportsAsSet(M, {ModuleDecl::ImportFilterKind::Default,
+                          ModuleDecl::ImportFilterKind::SPIOnly});
   ImportSet packageOnlyImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::PackageOnly);
   ImportSet internalOrBelowImportSet =
@@ -1265,7 +1266,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
     // form here.
     if (publicImportSet.count(import))
       stableImportControl = ImportControl::Exported;
-    else if (privateImportSet.count(import))
+    else if (defaultImportSet.count(import))
       stableImportControl = ImportControl::Normal;
     else if (packageOnlyImportSet.count(import))
       stableImportControl = ImportControl::PackageOnly;

--- a/test/Serialization/spi-only-dependency.swift
+++ b/test/Serialization/spi-only-dependency.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+//--- SPIDependency.swift
+
+// RUN: %target-swift-frontend -emit-module %t/SPIDependency.swift -o %t \
+// RUN:   -enable-library-evolution -swift-version 5
+
+//--- Lib.swift
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Lib.private.swiftinterface \
+// RUN:   -experimental-spi-only-imports
+
+@_spiOnly import SPIDependency
+
+//--- Client.swift
+
+/// SPIDependency is visible when using the swiftmodule or private interface.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
+// VISIBLE-DEP: loaded module 'SPIDependency'
+
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
+
+/// SPIDependency is not visible when using the public swiftinterface.
+// RUN: rm %t/Lib.private.swiftinterface
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP-NOT %s
+// VISIBLE-DEP-NOT-NOT: loaded module 'SPIDependency'
+
+import Lib


### PR DESCRIPTION
Ensure clients load transitive `@_spiOnly` dependencies by writing them down in the same category as default imports in swiftmodules. These dependencies will be required for clients loading from swiftmodule and swiftinterface, but hidden from clients loading from a public swiftinterface.

The lack of this information was revealed by #64260, as previously clients would see `@_spiOnly` dependencies as normal dependencies.

rdar://108326858

Cherry-pick of #65337