### PR TITLE
Enable mem2reg and temprvalueopt on lexical enums

### DIFF
--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -142,7 +142,8 @@ static bool endLifetimeAtUnreachableBlocks(SILValue value,
 /// This is only meant to cleanup lifetimes that lead to dead-end blocks. After
 /// recursively completing all nested scopes, it then simply ends the lifetime
 /// at the Unreachable instruction.
-bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(SILValue value) {
+bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(
+    SILValue value, bool forceBoundaryCompletion) {
   // Called for inner borrows, inner adjacent reborrows, inner reborrows, and
   // scoped addresses.
   auto handleInnerScope = [this](SILValue innerBorrowedValue) {
@@ -152,7 +153,7 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(SILValue value) {
   liveness.compute(domInfo, handleInnerScope);
 
   bool changed = false;
-  if (value->isLexical()) {
+  if (value->isLexical() && !forceBoundaryCompletion) {
     changed |= endLifetimeAtUnreachableBlocks(value, liveness.getLiveness());
   } else {
     changed |= endLifetimeAtBoundary(value, liveness.getLiveness());

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
@@ -1061,7 +1061,7 @@ enum KlassOptional {
 sil @return_optional_or_error : $@convention(thin) () -> (@owned KlassOptional, @error Error)
 
 // CHECK-LABEL: sil [ossa] @test_deadphi4 :
-// CHECK:         alloc_stack
+// CHECK-NOT:         alloc_stack
 // CHECK-LABEL: } // end sil function 'test_deadphi4'
 sil [ossa] @test_deadphi4 : $@convention(thin) (@owned KlassOptional) -> () {
 bb0(%0 : @owned $KlassOptional):

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -516,7 +516,7 @@ bb7:
 }
 
 // CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks_lexical :
-// CHECK:         alloc_stack
+// CHECK-NOT:         alloc_stack
 // CHECK:       } // end sil function 'test_optional_in_multiple_blocks_lexical'
 sil [ossa] @test_optional_in_multiple_blocks_lexical : $@convention(method) (@guaranteed Optional<Klass>) -> () {
 bb0(%0 : @guaranteed $Optional<Klass>):
@@ -542,7 +542,7 @@ bb7:
 }
 
 // CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue :
-// CHECK:         alloc_stack
+// CHECK-NOT:         alloc_stack
 // CHECK:       } // end sil function 'test_optional_in_multiple_blocks_lexical_storedvalue'
 sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue : $@convention(method) (@owned Optional<Klass>) -> () {
 bb0(%0 : @owned $Optional<Klass>):

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1364,7 +1364,7 @@ bb7:
 }
 
 // CHECK-LABEL: sil [ossa] @test_optimize_store_of_enum2
-// CHECK:      alloc_stack
+// CHECK-NOT:      alloc_stack
 // CHECK:       } // end sil function 'test_optimize_store_of_enum2'
 sil [ossa] @test_optimize_store_of_enum2 : $@convention(method) <Element> (@owned Optional<Klass>) -> () {
 bb0(%0 : @owned $Optional<Klass>):


### PR DESCRIPTION
Support lifetime completion at boundary for lexical values when `forceBoundaryCompletion` is specified.

Enable mem2reg and temprvalueopt on lexical enums with`forceBoundaryCompletion` since we know such values are incomplete on trivial paths only.