### PR TITLE
[5.9] Allow all unicode characters in package-name input

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -192,9 +192,9 @@ ERROR(error_bad_export_as_name,none,
       "export-as name \"%0\" is not a valid identifier",
       (StringRef))
 
-ERROR(error_bad_package_name,none,
-      "package name \"%0\" is not a valid identifier",
-      (StringRef))
+ERROR(error_empty_package_name,none,
+      "package-name is empty",
+      ())
 ERROR(error_stdlib_not_found,Fatal,
       "unable to load standard library for target '%0'", (StringRef))
 ERROR(error_module_alias_invalid_format,none,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -804,8 +804,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (const Arg *A = Args.getLastArg(OPT_package_name)) {
     auto pkgName = A->getValue();
-    if (!Lexer::isIdentifier(pkgName))
-      Diags.diagnose(SourceLoc(), diag::error_bad_package_name, pkgName);
+    if (StringRef(pkgName).empty())
+      Diags.diagnose(SourceLoc(), diag::error_empty_package_name);
     else
       Opts.PackageName = pkgName;
   }

--- a/test/diagnostics/package-name-diagnostics.swift
+++ b/test/diagnostics/package-name-diagnostics.swift
@@ -1,14 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// Package name should have valid characters
-// RUN: not %target-swift-frontend -module-name Logging -package-name My-Logging%Pkg %s -emit-module -emit-module-path %t/Logging.swiftmodule 2> %t/resultA.output
-// RUN: %FileCheck %s -input-file %t/resultA.output -check-prefix CHECK-BAD
-// CHECK-BAD: error: package name "My-Logging%Pkg" is not a valid identifier
-// CHECK-BAD: error: decl has a package access level but no -package-name was passed
-
 // Package name should not be empty
 // RUN: not %target-swift-frontend -typecheck %s -package-name "" 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
-// CHECK-EMPTY: error: package name "" is not a valid identifier
+// CHECK-EMPTY: error: package-name is empty
 // CHECK-EMPTY: error: decl has a package access level but no -package-name was passed
 
 // If package access level is used but no package-name is passed, it should error
@@ -23,5 +17,31 @@
 // RUN: %target-swift-frontend -module-name Logging -package-name Swift %s -emit-module -emit-module-path %t/Logging.swiftmodule
 // RUN: test -f %t/Logging.swiftmodule
 
-package func log() {}
+// Package name can have any unicode characters
 
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name " "
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift-util.log"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift$util.log"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift\$util.log"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift*util.log"
+
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "-swift*util.log"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name ".swift*util-log"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "\#swift#utillog"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift^util\&lo\(g+@"
+
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift-util$tools*log"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "swift/utils/tools/log.git"
+
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "foo bar baz git"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "My-Logging%Pkg"
+
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name Προϊόν
+
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name “\n”
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name “\\n”
+
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "a\\nb"
+// RUN: %target-swift-frontend %s -typecheck -verify -package-name "a\nde-f.g ~!@#$%^&<>?/|:"
+
+package func log() {}


### PR DESCRIPTION
Allow all unicode characters in package-name input
Error if the input is empty
Resolves rdar://104617274
