### PR TITLE
[interop][SwiftToCxx] do not assert when emitting non-resilient struc…

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -198,11 +198,11 @@ void ClangValueTypePrinter::printValueTypeDecl(
     // FIXME: Can we make some better layout than opaque layout for generic
     // types.
   } else if (!typeDecl->isResilient()) {
-
     typeSizeAlign =
         interopContext.getIrABIDetails().getTypeSizeAlignment(typeDecl);
-    assert(typeSizeAlign && "unknown layout for non-resilient type!");
-    if (typeSizeAlign->size == 0) {
+    // typeSizeAlign can be null if this is not a fixed-layout type,
+    // e.g. it has resilient fields.
+    if (typeSizeAlign && typeSizeAlign->size == 0) {
       // FIXME: How to represent 0 sized structs?
       return;
     }

--- a/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx-execution.cpp
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/resilient-struct-in-cxx.swift -enable-library-evolution -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule
+
+// RUN: %target-swift-frontend %S/struct-with-opaque-layout-resilient-member-in-cxx.swift -typecheck -module-name UseStructs -clang-header-expose-decls=all-public -emit-clang-header-path %t/useStructs.h -I %t
+
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-structs-execution.o
+
+// RUN: %target-interop-build-swift -c %S/resilient-struct-in-cxx.swift -enable-library-evolution -module-name Structs -o %t/resilient-struct-in-cxx.o -Xfrontend -entry-point-function-name -Xfrontend swiftMain2
+
+// RUN: %target-interop-build-swift %S/struct-with-opaque-layout-resilient-member-in-cxx.swift -o %t/swift-structs-execution -Xlinker %t/resilient-struct-in-cxx.o -Xlinker %t/swift-structs-execution.o -module-name UseStructs -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t
+
+// RUN: %target-codesign %t/swift-structs-execution
+// RUN: %target-run %t/swift-structs-execution | %FileCheck --check-prefixes=CHECK,CURRENT %s
+
+// REQUIRES: executable_test
+
+#include <assert.h>
+#include "useStructs.h"
+
+int main() {
+  using namespace UseStructs;
+  auto s = createUsesResilientSmallStruct();
+  s.dump();
+// CHECK: UsesResilientSmallStruct(97,FirstSmallStruct(x: 65)
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/struct-with-opaque-layout-resilient-member-in-cxx.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/resilient-struct-in-cxx.swift -enable-library-evolution -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule
+
+// RUN: %target-swift-frontend %s -typecheck -module-name UseStructs -clang-header-expose-decls=all-public -emit-clang-header-path %t/useStructs.h -I %t
+// RUN: %FileCheck %s < %t/useStructs.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/useStructs.h)
+
+import Structs
+
+public struct UsesResilientSmallStruct {
+    let x: UInt32
+    let y: FirstSmallStruct
+
+    public func dump() {
+        print("UsesResilientSmallStruct(\(x),\(y)")
+    }
+}
+
+// CHECK: class SWIFT_SYMBOL("s:10UseStructs24UsesResilientSmallStructV") UsesResilientSmallStruct final {
+// CHECK:   SWIFT_INLINE_THUNK const char * _Nonnull _getOpaquePointer() const noexcept { return _storage.getOpaquePointer(); }
+// CHECK: swift::_impl::OpaqueStorage _storage;
+
+public func createUsesResilientSmallStruct() -> UsesResilientSmallStruct {
+    UsesResilientSmallStruct(x: 97, y: createLargeStruct(45).firstSmallStruct)
+}


### PR DESCRIPTION
…ts with opaque layout

(cherry picked from commit e6e43c6b802cc85a1824ce2089cc71a82e34c012)


Explanation: Swift value types with opaque layout but who are not resilient should be emitted as types with opaque layout in the C++ section of the generated header. Right now this causes an assertion when generating a value type like this, but this assertion can be removed as we can handle this case correctly as we can generate an interface for a type with opaque layout.
Scope: Swift's and C++ interoperability, generated header generator.
Risk: Low.
Testing: Swift unit tests.
Reviewer: @zoecarver
