### PR TITLE
fix `Builtin.sizeof` et al for metatypes

### DIFF
--- a/lib/SILOptimizer/IRGenTransforms/TargetConstantFolding.cpp
+++ b/lib/SILOptimizer/IRGenTransforms/TargetConstantFolding.cpp
@@ -141,7 +141,8 @@ private:
 
   const TypeInfo &getTypeInfoOfBuiltin(BuiltinInst *bi, IRGenModule &IGM) {
     SubstitutionMap subs = bi->getSubstitutions();
-    SILType lowered = IGM.getLoweredType(subs.getReplacementTypes()[0]);
+    SILType lowered = IGM.getLoweredType(AbstractionPattern::getOpaque(),
+                                         subs.getReplacementTypes()[0]);
     return IGM.getTypeInfo(lowered);
   }
 };

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -1,7 +1,7 @@
 
-// RUN: %target-swift-frontend -module-name builtins -parse-stdlib  -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -module-name builtins -parse-stdlib -Xllvm -sil-disable-pass=target-constant-folding -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
-// REQUIRES: CPU=x86_64
+// REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
 
 import Swift
 
@@ -208,6 +208,16 @@ func sizeof_alignof_test() {
   // CHECK: store i64 1, i64*
   var ya = Builtin.alignof(Bool.self) 
 
+}
+
+// CHECK: define hidden {{.*}}void @"$s8builtins28sizeof_alignof_metatype_testyyF"()
+func sizeof_alignof_metatype_test() {
+  // CHECK: store i64 8, i64*
+  var xs = Builtin.sizeof(Int.Type.self) 
+  // CHECK: store i64 8, i64*
+  var xa = Builtin.alignof(Int.Type.self) 
+  // CHECK: store i64 8, i64*
+  var xt = Builtin.strideof(Int.Type.self) 
 }
 
 // CHECK: define hidden {{.*}}void @"$s8builtins27generic_sizeof_alignof_testyyxlF"

--- a/test/SILOptimizer/target-const-prop.swift
+++ b/test/SILOptimizer/target-const-prop.swift
@@ -74,6 +74,15 @@ func testit() {
 
   // CHECK-OUTPUT: doubleSize: true
   print("doubleSize: \(S.doubleSize == getSize(S.self) * 2)")
+
+  // CHECK-OUTPUT: metatype-size-1: true
+  print("metatype-size-1: \(MemoryLayout<S.Type>.size == MemoryLayout<UnsafeRawPointer>.size)")
+  // CHECK-OUTPUT: metatype-size-2: true
+  print("metatype-size-2: \(getSize(S.Type.self) == MemoryLayout<UnsafeRawPointer>.size)")
+  // CHECK-OUTPUT: metatype-alignment: true
+  print("metatype-alignment: \(getAlignment(S.Type.self) == MemoryLayout<UnsafeRawPointer>.alignment)")
+  // CHECK-OUTPUT: metatype-stride: true
+  print("metatype-stride: \(getStride(S.Type.self) == MemoryLayout<UnsafeRawPointer>.stride)")
 }
 
 testit()


### PR DESCRIPTION
Those builtins always need to assume a thick metatype which is a pointer. In other words the builtins need to use the maximally abstracted type.

rdar://108308786
