### PR TITLE
[5.9] SE-0365 bug fixes

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -583,6 +583,11 @@ public:
     Condition = Info;
   }
 
+  /// Whether or not this conditional stmt rebinds self with a `let self`
+  /// or `let self = self` condition. If `requireLoadExpr` is `true`,
+  /// additionally requires that the RHS of the self condition is a `LoadExpr`.
+  bool rebindsSelf(ASTContext &Ctx, bool requireLoadExpr = false) const;
+
   SourceLoc getStartLoc() const;
   SourceLoc getEndLoc() const;
   SourceRange getSourceRange() const;
@@ -685,6 +690,11 @@ public:
   /// FIXME: Find a better way to implement this. Allows conditions to be
   ///        stored in \c ASTNode.
   StmtCondition *getCondPointer() { return &Cond; }
+
+  /// Whether or not this conditional stmt rebinds self with a `let self`
+  /// or `let self = self` condition. If `requireLoadExpr` is `true`,
+  /// additionally requires that the RHS of the self condition is a `LoadExpr`.
+  bool rebindsSelf(ASTContext &Ctx, bool requireLoadExpr = false) const;
 
   static bool classof(const Stmt *S) {
     return S->getKind() >= StmtKind::First_LabeledConditionalStmt &&

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -545,11 +545,17 @@ public:
     assert(getKind() == CK_PatternBinding && "Not a pattern binding condition");
     ThePattern = P;
   }
+  
+  /// Pattern Binding Accessors.
+  Expr *getInitializerOrNull() const {
+    return getKind() == CK_PatternBinding ? Condition.get<Expr *>() : nullptr;
+  }
 
   Expr *getInitializer() const {
     assert(getKind() == CK_PatternBinding && "Not a pattern binding condition");
     return Condition.get<Expr *>();
   }
+  
   void setInitializer(Expr *E) {
     assert(getKind() == CK_PatternBinding && "Not a pattern binding condition");
     Condition = E;

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -440,6 +440,71 @@ void LabeledConditionalStmt::setCond(StmtCondition e) {
   Cond = e;
 }
 
+/// Whether or not this conditional stmt rebinds self with a `let self`
+/// or `let self = self` condition. If `requireLoadExpr` is `true`,
+/// additionally requires that the RHS of the self condition is a `LoadExpr`.
+bool LabeledConditionalStmt::rebindsSelf(ASTContext &Ctx,
+                                         bool requireLoadExpr) const {
+  return llvm::any_of(getCond(), [&Ctx, requireLoadExpr](const auto &cond) {
+    return cond.rebindsSelf(Ctx, requireLoadExpr);
+  });
+}
+
+/// Whether or not this conditional stmt rebinds self with a `let self`
+/// or `let self = self` condition. If `requireLoadExpr` is `true`,
+/// additionally requires that the RHS of the self condition is a `LoadExpr`.
+bool StmtConditionElement::rebindsSelf(ASTContext &Ctx,
+                                       bool requireLoadExpr) const {
+  auto pattern = getPatternOrNull();
+  if (!pattern) {
+    return false;
+  }
+
+  // Check whether or not this pattern defines a new `self` decl
+  bool isSelfRebinding = false;
+  if (pattern->getBoundName() == Ctx.Id_self) {
+    isSelfRebinding = true;
+  }
+
+  else if (auto OSP = dyn_cast<OptionalSomePattern>(pattern)) {
+    if (auto subPattern = OSP->getSubPattern()) {
+      isSelfRebinding = subPattern->getBoundName() == Ctx.Id_self;
+    }
+  }
+
+  if (!isSelfRebinding) {
+    return false;
+  }
+
+  // Check that the RHS expr is exactly `self` and not something else
+  Expr *exprToCheckForDRE = getInitializerOrNull();
+  if (!exprToCheckForDRE) {
+    return false;
+  }
+
+  // The RHS could be a `LoadExpr` or `DeclRefExpr`
+  Expr *loadExprSubExpr = nullptr;
+  if (auto LE = dyn_cast<LoadExpr>(exprToCheckForDRE)) {
+    loadExprSubExpr = LE->getSubExpr();
+  }
+
+  if (requireLoadExpr) {
+    exprToCheckForDRE = loadExprSubExpr;
+  } else {
+    if (loadExprSubExpr) {
+      exprToCheckForDRE = loadExprSubExpr;
+    }
+    exprToCheckForDRE = exprToCheckForDRE->getSemanticsProvidingExpr();
+  }
+
+  DeclRefExpr *condDRE = dyn_cast_or_null<DeclRefExpr>(exprToCheckForDRE);
+  if (!condDRE || !condDRE->getDecl()->hasName()) {
+    return false;
+  }
+
+  return condDRE->getDecl()->getName().isSimpleName(Ctx.Id_self);
+}
+
 PoundAvailableInfo *
 PoundAvailableInfo::create(ASTContext &ctx, SourceLoc PoundLoc,
                            SourceLoc LParenLoc,

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -401,17 +401,66 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
   // and check that both its LHS and RHS are 'self'
   for (auto cond : conditionalStmt->getCond()) {
     if (auto pattern = cond.getPattern()) {
-      if (pattern->getBoundName() != Ctx.Id_self) {
+      bool isSelfRebinding = false;
+
+      if (pattern->getBoundName() == Ctx.Id_self) {
+        isSelfRebinding = true;
+      }
+
+      else if (auto OSP = dyn_cast<OptionalSomePattern>(pattern)) {
+        if (auto subPattern = OSP->getSubPattern()) {
+          if (subPattern->getBoundName() == Ctx.Id_self) {
+            isSelfRebinding = true;
+          }
+        }
+      }
+
+      if (!isSelfRebinding) {
         continue;
       }
     }
 
-    if (auto selfDRE = dyn_cast<DeclRefExpr>(cond.getInitializer())) {
-      return (selfDRE->getDecl()->getName().isSimpleName(Ctx.Id_self));
+    DeclRefExpr *condDRE = nullptr;
+    if (auto DRE = dyn_cast<DeclRefExpr>(cond.getInitializer())) {
+      condDRE = DRE;
     }
+
+    if (auto LE = dyn_cast<LoadExpr>(cond.getInitializer())) {
+      if (auto DRE = dyn_cast_or_null<DeclRefExpr>(LE->getSubExpr())) {
+        condDRE = DRE;
+      }
+    }
+
+    if (!condDRE) {
+      return false;
+    }
+
+    return condDRE->getDecl()->getName().isSimpleName(Ctx.Id_self);
   }
 
   return false;
+}
+
+// Finds the nearest parent closure, which would define the
+// permitted usage of implicit self. In closures this is most
+// often just `dc` itself, but in functions defined in the
+// closure body this would be some parent context.
+AbstractClosureExpr *closestParentClosure(DeclContext *dc) {
+  if (!dc) {
+    return nullptr;
+  }
+
+  if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
+    return closure;
+  }
+
+  // Stop searching if we find a type decl, since types always
+  // redefine what 'self' means, even when nested inside a closure.
+  if (dc->getContextKind() == DeclContextKind::GenericTypeDecl) {
+    return nullptr;
+  }
+
+  return closestParentClosure(dc->getParent());
 }
 
 ValueDecl *UnqualifiedLookupFactory::ResultFinderForTypeContext::lookupBaseDecl(
@@ -425,7 +474,8 @@ ValueDecl *UnqualifiedLookupFactory::ResultFinderForTypeContext::lookupBaseDecl(
   // self _always_ refers to the context's self `ParamDecl`, even if there
   // is another local decl with the name `self` that would be found by
   // `lookupSingleLocalDecl`.
-  auto closureExpr = dyn_cast<ClosureExpr>(factory->DC);
+  auto parentACE = closestParentClosure(factory->DC);
+  auto closureExpr = dyn_cast_or_null<ClosureExpr>(parentACE);
   if (!closureExpr) {
     return nullptr;
   }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -409,9 +409,7 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
 
       else if (auto OSP = dyn_cast<OptionalSomePattern>(pattern)) {
         if (auto subPattern = OSP->getSubPattern()) {
-          if (subPattern->getBoundName() == Ctx.Id_self) {
-            isSelfRebinding = true;
-          }
+          isSelfRebinding = subPattern->getBoundName() == Ctx.Id_self;
         }
       }
 
@@ -445,12 +443,12 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
 // permitted usage of implicit self. In closures this is most
 // often just `dc` itself, but in functions defined in the
 // closure body this would be some parent context.
-AbstractClosureExpr *closestParentClosure(DeclContext *dc) {
+ClosureExpr *closestParentClosure(DeclContext *dc) {
   if (!dc) {
     return nullptr;
   }
 
-  if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
+  if (auto closure = dyn_cast<ClosureExpr>(dc)) {
     return closure;
   }
 
@@ -474,8 +472,7 @@ ValueDecl *UnqualifiedLookupFactory::ResultFinderForTypeContext::lookupBaseDecl(
   // self _always_ refers to the context's self `ParamDecl`, even if there
   // is another local decl with the name `self` that would be found by
   // `lookupSingleLocalDecl`.
-  auto parentACE = closestParentClosure(factory->DC);
-  auto closureExpr = dyn_cast_or_null<ClosureExpr>(parentACE);
+  auto closureExpr = closestParentClosure(factory->DC);
   if (!closureExpr) {
     return nullptr;
   }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -400,6 +400,10 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
   // Find the condition that defined the self decl,
   // and check that both its LHS and RHS are 'self'
   for (auto cond : conditionalStmt->getCond()) {
+    if (cond.getKind() != StmtConditionElement::CK_PatternBinding) {
+      continue;
+    }
+    
     if (auto pattern = cond.getPattern()) {
       bool isSelfRebinding = false;
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -397,49 +397,7 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
     return false;
   }
 
-  // Find the condition that defined the self decl,
-  // and check that both its LHS and RHS are 'self'
-  for (auto cond : conditionalStmt->getCond()) {
-    if (cond.getKind() != StmtConditionElement::CK_PatternBinding) {
-      continue;
-    }
-    
-    if (auto pattern = cond.getPattern()) {
-      bool isSelfRebinding = false;
-
-      if (pattern->getBoundName() == Ctx.Id_self) {
-        isSelfRebinding = true;
-      }
-
-      else if (auto OSP = dyn_cast<OptionalSomePattern>(pattern)) {
-        if (auto subPattern = OSP->getSubPattern()) {
-          isSelfRebinding = subPattern->getBoundName() == Ctx.Id_self;
-        }
-      }
-
-      if (!isSelfRebinding) {
-        continue;
-      }
-    }
-
-    Expr *exprToCheckForDRE = cond.getInitializer();
-    if (auto LE = dyn_cast<LoadExpr>(exprToCheckForDRE)) {
-      if (auto subexpr = LE->getSubExpr()) {
-        exprToCheckForDRE = subexpr;
-      }
-    }
-
-    exprToCheckForDRE = exprToCheckForDRE->getSemanticsProvidingExpr();
-
-    DeclRefExpr *condDRE = dyn_cast<DeclRefExpr>(exprToCheckForDRE);
-    if (!condDRE || !condDRE->getDecl()->hasName()) {
-      return false;
-    }
-
-    return condDRE->getDecl()->getName().isSimpleName(Ctx.Id_self);
-  }
-
-  return false;
+  return conditionalStmt->rebindsSelf(Ctx);
 }
 
 // Finds the nearest parent closure, which would define the

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -418,18 +418,17 @@ bool implicitSelfReferenceIsUnwrapped(const ValueDecl *selfDecl,
       }
     }
 
-    DeclRefExpr *condDRE = nullptr;
-    if (auto DRE = dyn_cast<DeclRefExpr>(cond.getInitializer())) {
-      condDRE = DRE;
-    }
-
-    if (auto LE = dyn_cast<LoadExpr>(cond.getInitializer())) {
-      if (auto DRE = dyn_cast_or_null<DeclRefExpr>(LE->getSubExpr())) {
-        condDRE = DRE;
+    Expr *exprToCheckForDRE = cond.getInitializer();
+    if (auto LE = dyn_cast<LoadExpr>(exprToCheckForDRE)) {
+      if (auto subexpr = LE->getSubExpr()) {
+        exprToCheckForDRE = subexpr;
       }
     }
 
-    if (!condDRE) {
+    exprToCheckForDRE = exprToCheckForDRE->getSemanticsProvidingExpr();
+
+    DeclRefExpr *condDRE = dyn_cast<DeclRefExpr>(exprToCheckForDRE);
+    if (!condDRE || !condDRE->getDecl()->hasName()) {
       return false;
     }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1708,6 +1708,10 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       // Find the condition that defined the self decl,
       // and check that both its LHS and RHS are 'self'
       for (auto cond : conditionalStmt->getCond()) {
+        if (cond.getKind() != StmtConditionElement::CK_PatternBinding) {
+          continue;
+        }
+        
         if (auto OSP = dyn_cast<OptionalSomePattern>(cond.getPattern())) {
           if (OSP->getSubPattern()->getBoundName() != Ctx.Id_self) {
             continue;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1705,27 +1705,14 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         return false;
       }
 
-      // Find the condition that defined the self decl,
-      // and check that both its LHS and RHS are 'self'
-      for (auto cond : conditionalStmt->getCond()) {
-        if (cond.getKind() != StmtConditionElement::CK_PatternBinding) {
-          continue;
-        }
-        
-        if (auto OSP = dyn_cast<OptionalSomePattern>(cond.getPattern())) {
-          if (OSP->getSubPattern()->getBoundName() != Ctx.Id_self) {
-            continue;
-          }
-
-          if (auto LE = dyn_cast<LoadExpr>(cond.getInitializer())) {
-            if (auto selfDRE = dyn_cast<DeclRefExpr>(LE->getSubExpr())) {
-              return (selfDRE->getDecl()->getName().isSimpleName(Ctx.Id_self));
-            }
-          }
-        }
-      }
-
-      return false;
+      // Require `LoadExpr`s when validating the self binding.
+      // This lets us reject invalid examples like:
+      //
+      //   let `self` = self ?? .somethingElse
+      //   guard let self = self else { return }
+      //   method() // <- implicit self is not allowed
+      //
+      return conditionalStmt->rebindsSelf(Ctx, /*requireLoadExpr*/ true);
     }
 
     /// Return true if this is a closure expression that will require explicit

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -983,6 +983,82 @@ class NoImplicitSelfInInnerClass {
     }
     
   }
+  
+  func foo(condition: Bool) {
+    doVoidStuff { [weak self] in
+      guard condition, let self else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self, condition else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard condition, let self else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self, condition else { return }
+      method()
+    }
+  }
+
+  func foo(optionalCondition: Bool?) {
+    doVoidStuff { [weak self] in
+      guard let optionalCondition, optionalCondition, let self else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self, let optionalCondition, optionalCondition else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let optionalCondition, let self, optionalCondition else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let optionalCondition, optionalCondition, let self else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self, let optionalCondition, optionalCondition else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let optionalCondition, let self, optionalCondition else { return }
+      method()
+    }
+  }
+  
+  func foo() {
+    doVoidStuff { [weak self] in
+      guard #available(SwiftStdlib 5.8, *), let self else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self, #available(SwiftStdlib 5.8, *) else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard #available(SwiftStdlib 5.8, *), let self else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self, #available(SwiftStdlib 5.8, *) else { return }
+      method()
+    }
+  }
 }
 
 public class TestRebindingSelfIsDisallowed {

--- a/test/expr/closure/closures_swift6.swift
+++ b/test/expr/closure/closures_swift6.swift
@@ -210,6 +210,82 @@ class NoImplicitSelfInInnerClass {
       }
     }
   }
+  
+  func foo(condition: Bool) {
+    doVoidStuff { [weak self] in
+      guard condition, let self else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self, condition else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard condition, let self else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self, condition else { return }
+      method()
+    }
+  }
+
+  func foo(optionalCondition: Bool?) {
+    doVoidStuff { [weak self] in
+      guard let optionalCondition, optionalCondition, let self else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self, let optionalCondition, optionalCondition else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let optionalCondition, let self, optionalCondition else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let optionalCondition, optionalCondition, let self else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self, let optionalCondition, optionalCondition else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let optionalCondition, let self, optionalCondition else { return }
+      method()
+    }
+  }
+  
+  func foo() {
+    doVoidStuff { [weak self] in
+      guard #available(SwiftStdlib 5.8, *), let self else { return }
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self, #available(SwiftStdlib 5.8, *) else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard #available(SwiftStdlib 5.8, *), let self else { return }
+      method()
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self, #available(SwiftStdlib 5.8, *) else { return }
+      method()
+    }
+  }
 }
 
 public class TestRebindingSelfIsDisallowed {


### PR DESCRIPTION
This PR cherry picks two bug fixes for [SE-0365](https://github.com/apple/swift-evolution/blob/main/proposals/0365-implicit-self-weak-capture.md) into the Swift 5.9 release branch. 

- **Explanation**: This fixes two bugs in the implementation of SE-0365, where code that is expected to compile would unexpectedly result in an error (examples below).
- **Scope**: This fixes two bugs in the implementation of SE-0365, which originally landed in Swift 5.8.
- **Issue**: fixes issues described in https://github.com/apple/swift/pull/65310 / https://github.com/apple/swift/pull/65211 and shown below (I didn't see or file an issue or radar for these issues, I just fixed them once I found them)
- **Risk**: These are targeted fixes than only affect the behavior of implicit self in `weak self` closures. There is little risk that this would cause a source compatibility issue, since these changes allow code that was previously rejected. It is also unlikely that this would cause a regression since there are pretty extensive unit tests for the expected behavior.
- **Testing**: CI test suite and source compatibility tests
- **Reviewers**: @DougGregor (5.9 release manager), @xedin 

I CP'd both of these changes in the same PR because the implementation of https://github.com/apple/swift/pull/65310 depends on changes in https://github.com/apple/swift/pull/65211

---

Examples of code that is currently rejected in Swift 5.8 / 5.9 but compiles successfully with these changes as expected by SE-0365:

```swift
class Test {
  func method() { }
  
  func foo(condition: Bool) {
    doVoidStuff { [weak self] in
      guard condition, let self else { return }
      method() // 🛑 Unexpected error: call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit
    }
  }
}
```

```swift
doVoidStuff { [weak self] in
  guard let self else { return }
  func innerFunction() {
    // 🛑 Error: call to method 'test' in closure requires explicit use of 'self' to make capture semantics explicit
    test()
  }
}
```
