### PR TITLE
[Tinkering with Windows][cxx-interop] Allow disabling Cxx build when building stdlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ option(SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT
     TRUE)
 
 option(SWIFT_BUILD_STDLIB_CXX_MODULE
-  "If not building stdlib, controls whether to build the Cxx module"
+  "Build the Cxx module and the CxxStdlib overlay module"
   TRUE)
 
 # In many cases, the CMake build system needs to determine whether to include

--- a/cmake/caches/Runtime-Windows-aarch64.cmake
+++ b/cmake/caches/Runtime-Windows-aarch64.cmake
@@ -6,6 +6,8 @@ set(SWIFT_HOST_VARIANT_ARCH aarch64 CACHE STRING "")
 # library.
 set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
 
+set(SWIFT_BUILD_STDLIB_CXX_MODULE YES CACHE BOOL "")
+
 # NOTE(compnerd) cannot build tests since the tests require the toolchain
 set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
 

--- a/cmake/caches/Runtime-Windows-i686.cmake
+++ b/cmake/caches/Runtime-Windows-i686.cmake
@@ -6,6 +6,8 @@ set(SWIFT_HOST_VARIANT_ARCH i686 CACHE STRING "")
 # library.
 set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
 
+set(SWIFT_BUILD_STDLIB_CXX_MODULE YES CACHE BOOL "")
+
 # NOTE(compnerd) cannot build tests since the tests require the toolchain
 set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
 

--- a/cmake/caches/Runtime-Windows-x86_64.cmake
+++ b/cmake/caches/Runtime-Windows-x86_64.cmake
@@ -6,6 +6,8 @@ set(SWIFT_HOST_VARIANT_ARCH x86_64 CACHE STRING "")
 # library.
 set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
 
+set(SWIFT_BUILD_STDLIB_CXX_MODULE YES CACHE BOOL "")
+
 # NOTE(compnerd) cannot build tests since the tests require the toolchain
 set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -65,7 +65,9 @@ endif()
 
 add_subdirectory(SwiftShims/swift/shims)
 add_subdirectory(CommandLineSupport)
-add_subdirectory(Cxx)
+if(SWIFT_BUILD_STDLIB_CXX_MODULE)
+  add_subdirectory(Cxx)
+endif()
 add_subdirectory(Threading)
 
 # This static library is shared across swiftCore and swiftRemoteInspection


### PR DESCRIPTION
This makes it possible to pass `SWIFT_BUILD_STDLIB_CXX_MODULE=FALSE` to CMake to disable Cxx and CxxStdlib modules when building the Swift stdlib or the SDK overlay.

rdar://108206321