### PR TITLE
[5.9] [Macros] Improve parsing, representation, and serialization of role attributes

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2028,8 +2028,6 @@ ERROR(foreign_diagnostic,none,
 //------------------------------------------------------------------------------
 // MARK: macros
 //------------------------------------------------------------------------------
-ERROR(expected_macro_value_type,PointsToFirstBadToken,
-      "expected macro value type following ':'", ())
 ERROR(expected_lparen_macro,PointsToFirstBadToken,
       "expected '(' for macro parameters or ':' for a value-like macro", ())
 ERROR(expected_type_macro_result,PointsToFirstBadToken,
@@ -2042,12 +2040,13 @@ ERROR(macro_expansion_expr_expected_macro_identifier,PointsToFirstBadToken,
 ERROR(macro_expansion_decl_expected_macro_identifier,PointsToFirstBadToken,
       "expected a macro identifier for a pound literal declaration", ())
 
-ERROR(declaration_attr_expected_kind,PointsToFirstBadToken,
-      "expected a declaration macro kind ('freestanding' or 'attached')", ())
-
 ERROR(macro_role_attr_expected_kind,PointsToFirstBadToken,
       "expected %select{a freestanding|an attached}0 macro role such as "
       "%select{'expression'|'accessor'}0", (bool))
+ERROR(macro_role_attr_expected_attached_kind,PointsToFirstBadToken,
+      "expected an attached macro role such as 'peer'", ())
+ERROR(macro_role_attr_expected_freestanding_kind,PointsToFirstBadToken,
+      "expected a freestanding macro role such as 'expression'", ())
 ERROR(macro_role_syntax_mismatch,PointsToFirstBadToken,
       "%select{a freestanding|an attached}0 macro cannot have the %1 role",
       (bool, Identifier))
@@ -2056,14 +2055,14 @@ ERROR(macro_attribute_unknown_label,PointsToFirstBadToken,
       (bool, Identifier))
 ERROR(macro_attribute_duplicate_label,PointsToFirstBadToken,
       "@%select{freestanding|attached}0 already has an argument with "
-      "label %1", (bool, Identifier))
-ERROR(macro_attribute_missing_label,PointsToFirstBadToken,
+      "label %1", (bool, StringRef))
+ERROR(macro_attribute_missing_label,none,
       "@%select{freestanding|attached}0 argument is missing label '%1'",
       (bool, StringRef))
 ERROR(macro_attribute_unknown_name_kind,PointsToFirstBadToken,
       "unknown introduced name kind %0", (Identifier))
 ERROR(macro_attribute_unknown_argument_form,PointsToFirstBadToken,
-      "introduced name argument should be an identifier", ())
+      "introduced name argument should be a name", ())
 ERROR(macro_attribute_introduced_name_requires_argument,PointsToFirstBadToken,
       "introduced name kind %0 requires a single argument '(name)'", (Identifier))
 ERROR(macro_attribute_introduced_name_requires_no_argument,PointsToFirstBadToken,

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -111,13 +111,13 @@ public:
 
 private:
   Kind kind;
-  Identifier identifier;
+  DeclName name;
 
 public:
-  MacroIntroducedDeclName(Kind kind, Identifier identifier = Identifier())
-      : kind(kind), identifier(identifier) {};
+  MacroIntroducedDeclName(Kind kind, DeclName name = DeclName())
+      : kind(kind), name(name) {};
 
-  static MacroIntroducedDeclName getNamed(Identifier name) {
+  static MacroIntroducedDeclName getNamed(DeclName name) {
     return MacroIntroducedDeclName(Kind::Named, name);
   }
 
@@ -138,7 +138,7 @@ public:
   }
 
   Kind getKind() const { return kind; }
-  Identifier getIdentifier() const { return identifier; }
+  DeclName getName() const { return name; }
 };
 
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1382,9 +1382,9 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
           [&](MacroIntroducedDeclName name) {
             Printer << getMacroIntroducedDeclNameString(name.getKind());
             if (macroIntroducedNameRequiresArgument(name.getKind())) {
-              StringRef nameText = name.getIdentifier().str();
-              bool shouldEscape = escapeKeywordInContext(
-                  nameText, PrintNameContext::Normal) || nameText == "$";
+              SmallString<32> buffer;
+              StringRef nameText = name.getName().getString(buffer);
+              bool shouldEscape = nameText == "$";
               Printer << "(";
               if (shouldEscape)
                 Printer << "`";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10256,7 +10256,7 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
   for (auto expandedName : attr->getNames()) {
     switch (expandedName.getKind()) {
     case MacroIntroducedDeclNameKind::Named: {
-      names.push_back(DeclName(expandedName.getIdentifier()));
+      names.push_back(DeclName(expandedName.getName()));
       break;
     }
 
@@ -10276,7 +10276,7 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
       std::string prefixedName;
       {
         llvm::raw_string_ostream out(prefixedName);
-        out << expandedName.getIdentifier();
+        out << expandedName.getName();
         out << baseName.getIdentifier();
       }
 
@@ -10294,7 +10294,7 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
       {
         llvm::raw_string_ostream out(suffixedName);
         out << baseName.getIdentifier();
-        out << expandedName.getIdentifier();
+        out << expandedName.getName();
       }
 
       Identifier nameId = ctx.getIdentifier(suffixedName);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2158,81 +2158,6 @@ Parser::parseDocumentationAttribute(SourceLoc AtLoc, SourceLoc Loc) {
   return makeParserResult(new (Context) DocumentationAttr(Loc, range, FinalMetadata, Visibility, false));
 }
 
-/// If the given argument is effectively a bare identifier, extract that
-/// identifier.
-static Optional<Identifier> getIdentifierFromArgument(Argument argument) {
-  // Handle '_'.
-  if (isa<DiscardAssignmentExpr>(argument.getExpr()))
-    return Identifier();
-
-  auto declRef = dyn_cast<UnresolvedDeclRefExpr>(argument.getExpr());
-  if (argument.isInOut() ||
-      !declRef || !declRef->hasName() ||
-      declRef->getRefKind() != DeclRefKind::Ordinary ||
-      declRef->getName().isCompoundName() ||
-      declRef->getName().isSpecial()) {
-    return None;
-  }
-
-  return declRef->getName().getBaseIdentifier();
-}
-
-/// Retrieve the macro role from the given argument list.
-///
-/// \c returns the role, or None if the role is missing or incorrect. In the
-/// latter case, a diagnostic is produced.
-static Optional<MacroRole> getMacroRole(
-    DiagnosticEngine &diags, ArgumentList *argList, bool attached
-) {
-  // Make sure there's a first argument.
-  if (argList->size() == 0) {
-    diags.diagnose(
-        argList->getEndLoc(), diag::macro_role_attr_expected_kind, attached);
-    return None;
-  }
-
-  // Make sure it's a simple reference to a name.
-  auto roleArg = argList->get(0);
-  auto roleName = getIdentifierFromArgument(roleArg);
-  if (roleArg.hasLabel() || !roleName) {
-    diags.diagnose(
-        roleArg.getStartLoc(), diag::macro_role_attr_expected_kind, attached);
-    return None;
-  }
-
-  // Match the role string to the known set of roles.
-  auto role = llvm::StringSwitch<Optional<MacroRole>>(roleName->str())
-      .Case("declaration", MacroRole::Declaration)
-      .Case("expression", MacroRole::Expression)
-      .Case("codeItem", MacroRole::CodeItem)
-      .Case("accessor", MacroRole::Accessor)
-      .Case("memberAttribute", MacroRole::MemberAttribute)
-      .Case("member", MacroRole::Member)
-      .Case("peer", MacroRole::Peer)
-      .Case("conformance", MacroRole::Conformance)
-      .Default(None);
-
-  if (!role) {
-    diags.diagnose(
-        roleArg.getStartLoc(), diag::macro_role_attr_expected_kind,
-        attached
-    );
-    return None;
-  }
-
-  // Check that the role makes sense.
-  if (attached == !isAttachedMacro(*role)) {
-    diags.diagnose(
-        roleArg.getStartLoc(), diag::macro_role_syntax_mismatch, attached,
-        *roleName
-    );
-
-    return None;
-  }
-
-  return role;
-}
-
 static Optional<MacroIntroducedDeclNameKind>
 getMacroIntroducedDeclNameKind(Identifier name) {
   return llvm::StringSwitch<Optional<MacroIntroducedDeclNameKind>>(name.str())
@@ -2244,121 +2169,19 @@ getMacroIntroducedDeclNameKind(Identifier name) {
     .Default(None);
 }
 
-/// Get the set of names that are introduced by the @freestanding/@attached
-/// macro argument.
-static SmallVector<MacroIntroducedDeclName, 2> getMacroIntroducedNames(
-    DiagnosticEngine &diags, ArgumentList *argList, bool attached
-) {
-  SmallVector<MacroIntroducedDeclName, 2> names;
-
-  bool sawNamesLabel = false;
-  for (unsigned index : range(1, argList->size())) {
-    Argument arg = argList->get(index);
-
-    // Make sure that the label "names" occurs on the first name, and no other
-    // labels occur anywhere else.
-    if (arg.hasLabel()) {
-      if (arg.getLabel().str() != "names") {
-        diags.diagnose(arg.getStartLoc(), diag::macro_attribute_unknown_label,
-                       attached, arg.getLabel());
-        return names;
-      }
-
-      if (sawNamesLabel) {
-        diags.diagnose(arg.getStartLoc(), diag::macro_attribute_duplicate_label,
-                       attached, arg.getLabel());
-      }
-
-      sawNamesLabel = true;
-    } else if (!sawNamesLabel) {
-      diags.diagnose(arg.getStartLoc(), diag::macro_attribute_missing_label,
-                     attached, "names");
-      sawNamesLabel = true;
-    }
-
-    // Handle cases where we have a bare identifier, which can be a name
-    // such as "overloaded" or "arbitrary".
-    if (auto introducedKindName = getIdentifierFromArgument(arg)) {
-      auto introducedKind = getMacroIntroducedDeclNameKind(*introducedKindName);
-      if (!introducedKind) {
-        diags.diagnose(
-            arg.getExpr()->getLoc(), diag::macro_attribute_unknown_name_kind,
-            *introducedKindName
-        );
-
-        continue;
-      }
-
-      if (macroIntroducedNameRequiresArgument(*introducedKind)) {
-        diags.diagnose(
-            arg.getExpr()->getLoc(),
-            diag::macro_attribute_introduced_name_requires_argument,
-            *introducedKindName
-        );
-
-        continue;
-      }
-
-      names.push_back(MacroIntroducedDeclName(*introducedKind));
-      continue;
-    }
-
-    // Handle cases where the have a(b), where each is a bare identifier,
-    // for things like "prefixed(_)".
-    auto call = dyn_cast<CallExpr>(arg.getExpr());
-    if (!call || call->getArgs()->size() != 1) {
-      diags.diagnose(
-          arg.getExpr()->getLoc(),
-          diag::macro_attribute_unknown_argument_form
-      );
-      continue;
-    }
-
-    auto fnName = getIdentifierFromArgument(Argument::unlabeled(call->getFn()));
-    if (!fnName) {
-      diags.diagnose(
-          call->getFn()->getLoc(),
-          diag::macro_attribute_unknown_argument_form
-      );
-
-      continue;
-    }
-
-    auto introducedKind = getMacroIntroducedDeclNameKind(*fnName);
-    if (!introducedKind) {
-      diags.diagnose(
-          call->getFn()->getLoc(), diag::macro_attribute_unknown_name_kind,
-          *fnName
-      );
-
-      continue;
-    }
-
-    if (!macroIntroducedNameRequiresArgument(*introducedKind)) {
-      diags.diagnose(
-          call->getArgs()->getLoc(),
-          diag::macro_attribute_introduced_name_requires_no_argument,
-          *fnName
-      );
-
-      names.push_back(MacroIntroducedDeclName(*introducedKind));
-      continue;
-    }
-
-    auto argument = getIdentifierFromArgument(call->getArgs()->get(0));
-    if (!argument) {
-      diags.diagnose(
-          call->getArgs()->get(0).getStartLoc(),
-          diag::macro_attribute_unknown_argument_form
-      );
-
-      continue;
-    }
-
-    names.push_back(MacroIntroducedDeclName(*introducedKind, *argument));
-  }
-
-  return names;
+/// Determine the macro role based on its name.
+Optional<MacroRole> getMacroRole(StringRef roleName) {
+  // Match the role string to the known set of roles.
+  return llvm::StringSwitch<Optional<MacroRole>>(roleName)
+      .Case("declaration", MacroRole::Declaration)
+      .Case("expression", MacroRole::Expression)
+      .Case("codeItem", MacroRole::CodeItem)
+      .Case("accessor", MacroRole::Accessor)
+      .Case("memberAttribute", MacroRole::MemberAttribute)
+      .Case("member", MacroRole::Member)
+      .Case("peer", MacroRole::Peer)
+      .Case("conformance", MacroRole::Conformance)
+      .Default(None);
 }
 
 ParserResult<MacroRoleAttr>
@@ -2384,28 +2207,158 @@ Parser::parseMacroRoleAttribute(
     return makeParserError();
   }
 
-  // Parse an argument list. We'll pick out the pieces from here.
-  auto argListResult = parseArgumentList(
-      tok::l_paren, tok::r_paren, /*isExprBasic*/ true,
-      /*allowTrailingClosure=*/false
-  );
+  // Parse the argments.
+  SourceLoc lParenLoc = consumeToken();
+  SourceLoc rParenLoc;
+  Optional<MacroRole> role;
+  bool sawRole = false;
+  bool sawNames = false;
+  SmallVector<MacroIntroducedDeclName, 2> names;
+  auto argumentsStatus = parseList(tok::r_paren, lParenLoc, rParenLoc,
+                                   /*AllowSepAfterLast=*/false,
+                                   diag::expected_rparen_expr_list,
+                                   [&] {
+    // Parse the argment label, if there is one.
+    Identifier fieldName;
+    SourceLoc fieldNameLoc;
+    parseOptionalArgumentLabel(fieldName, fieldNameLoc);
 
-  if (argListResult.isParseErrorOrHasCompletion())
-    return ParserStatus(argListResult);
+    // If there is a field name, it better be 'names'.
+    if (!(fieldName.empty() || fieldName.is("names"))) {
+      diagnose(
+         fieldNameLoc, diag::macro_attribute_unknown_label, isAttached,
+         fieldName);
+      return makeParserError();
+    }
 
-  ArgumentList *argList = argListResult.get();
+    // If there is no field name and we haven't seen either names or the role,
+    // this is the role.
+    if (fieldName.empty() && !sawNames && !sawRole) {
+      // Whether we saw anything we tried to treat as a role.
+      sawRole = true;
 
-  // Figure out the role.
-  auto role = getMacroRole(Diags, argList, isAttached);
-  if (!role)
+      auto diagKind = isAttached
+        ? diag::macro_role_attr_expected_attached_kind
+        : diag::macro_role_attr_expected_freestanding_kind;
+      Identifier roleName;
+      SourceLoc roleNameLoc;
+      if (parseIdentifier(roleName, roleNameLoc, diagKind,
+                          /*diagnoseDollarPrefix=*/true)) {
+        return makeParserError();
+      }
+
+      role = getMacroRole(roleName.str());
+      if (!role) {
+        diagnose(roleNameLoc, diag::macro_role_attr_expected_kind, isAttached);
+        return makeParserError();
+      }
+
+      // Check that the role makes sense.
+      if (isAttached == !isAttachedMacro(*role)) {
+        diagnose(
+            roleNameLoc, diag::macro_role_syntax_mismatch, isAttached, roleName
+        );
+
+        return makeParserError();
+      }
+
+      return makeParserSuccess();
+    }
+
+    // If the field name is empty and we haved seen "names", or the field name
+    // is "names" but we've already seen the argument label, complain.
+    if (fieldName.empty() != sawNames) {
+      diagnose(fieldNameLoc.isValid() ? fieldNameLoc : Tok.getLoc(),
+               sawNames ? diag::macro_attribute_duplicate_label
+                        : diag::macro_attribute_missing_label,
+               isAttached,
+               "names");
+    }
+    sawNames = true;
+
+    // Parse the introduced name kind.
+    Identifier introducedNameKind;
+    SourceLoc introducedNameKindLoc;
+    if (parseIdentifier(
+            introducedNameKind, introducedNameKindLoc,
+            diag::macro_attribute_unknown_argument_form,
+            /*diagnoseDollarPrefix=*/true)) {
+      return makeParserError();
+    }
+
+    auto introducedKind = getMacroIntroducedDeclNameKind(introducedNameKind);
+    if (!introducedKind) {
+      diagnose(
+          introducedNameKindLoc, diag::macro_attribute_unknown_name_kind,
+          introducedNameKind
+      );
+      return makeParserError();
+    }
+
+    // If we don't need an argument, we're done.
+    if (!macroIntroducedNameRequiresArgument(*introducedKind)) {
+      // If there is an argument, complain about it.
+      if (Tok.is(tok::l_paren)) {
+        diagnose(
+            Tok, diag::macro_attribute_introduced_name_requires_no_argument,
+            introducedNameKind);
+        skipSingle();
+      }
+
+      names.push_back(MacroIntroducedDeclName(*introducedKind));
+      return makeParserSuccess();
+    }
+
+    if (!Tok.is(tok::l_paren)) {
+      diagnose(
+          Tok, diag::macro_attribute_introduced_name_requires_argument,
+          introducedNameKind);
+      return makeParserError();
+    }
+
+    // Parse the name.
+    (void)consumeToken(tok::l_paren);
+    DeclNameLoc nameLoc;
+    DeclNameRef name = parseDeclNameRef(
+        nameLoc, diag::macro_attribute_unknown_argument_form,
+        (DeclNameFlag::AllowOperators |
+         DeclNameFlag::AllowKeywords |
+         DeclNameFlag::AllowKeywordsUsingSpecialNames |
+         DeclNameFlag::AllowCompoundNames |
+         DeclNameFlag::AllowZeroArgCompoundNames));
+    if (!name)
+      return makeParserError();
+
+    SourceLoc rParenLoc;
+    if (!consumeIf(tok::r_paren, rParenLoc)) {
+      diagnose(Tok, diag::attr_expected_rparen, attrName, false);
+      rParenLoc = Tok.getLoc();
+    }
+
+    // Add the name we introduced.
+    names.push_back(
+        MacroIntroducedDeclName(*introducedKind, name.getFullName()));
+
+    return makeParserSuccess();
+  });
+
+  if (argumentsStatus.isErrorOrHasCompletion())
+    return argumentsStatus;
+
+  // Diagnose a missing role.
+  if (!role) {
+    // If we saw a role of any kind, we already diagnosed this.
+    if (!sawRole) {
+      diagnose(lParenLoc, diag::macro_role_attr_expected_kind, isAttached);
+    }
+
     return makeParserError();
+  }
 
-  auto names = getMacroIntroducedNames(Diags, argList, isAttached);
-
-  SourceRange range(Loc, argList->getEndLoc());
+  SourceRange range(Loc, rParenLoc);
   return makeParserResult(MacroRoleAttr::create(
-      Context, AtLoc, range, syntax, argList->getLParenLoc(), *role, names,
-      argList->getRParenLoc(), /*isImplicit*/ false));
+      Context, AtLoc, range, syntax, lParenLoc, *role, names,
+      rParenLoc, /*isImplicit*/ false));
 }
 
 /// Guts of \c parseSingleAttrOption and \c parseSingleAttrOptionIdentifier.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -592,23 +592,20 @@ static void validateMacroExpansion(SourceFile *expansionBuffer,
 
     // Diagnose value decls with names not covered by the macro
     if (auto *value = dyn_cast<ValueDecl>(decl)) {
-      auto baseName = value->getBaseName();
-      if (baseName.isSpecial()) {
-        baseName = ctx.getIdentifier(baseName.userFacingName());
-      }
+      auto name = value->getName();
 
-      // $-prefixed names are unique names. These are always allowed.
-      if (baseName.getIdentifier().hasDollarPrefix()) {
+      // Unique names are always permitted.
+      if (MacroDecl::isUniqueMacroName(name.getBaseName().userFacingName()))
         continue;
-      }
 
-      if (coversName.count(baseName) ||
+      if (coversName.count(name) ||
+          coversName.count(name.getBaseName()) ||
           coversName.count(MacroDecl::getArbitraryName())) {
         continue;
       }
 
       value->diagnose(diag::invalid_macro_introduced_name,
-                      baseName, macro->getBaseName());
+                      name, macro->getBaseName());
     }
   }
 }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 780; // serialize PackConformance
+const uint16_t SWIFTMODULE_VERSION_MINOR = 781; // compound introduced names
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2277,7 +2277,11 @@ namespace decls_block {
     BCFixed<1>,                // macro syntax
     MacroRoleField,            // macro role
     BCVBR<5>,                  // number of names
-    BCArray<IdentifierIDField> // introduced decl name kind and identifier pairs
+    BCArray<IdentifierIDField> // introduced names, where each is encoded as
+                               //   - introduced kind
+                               //   - base name
+                               //   - # of argument labels + 1 (or 0 if none)
+                               //   - argument labels
   >;
 
 #undef SYNTAX_SUGAR_TYPE_LAYOUT

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3040,17 +3040,27 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto rawMacroRole =
           getRawStableMacroRole(theAttr->getMacroRole());
       SmallVector<IdentifierID, 4> introducedDeclNames;
-      for (auto name : theAttr->getNames()) {
+      for (auto introducedName : theAttr->getNames()) {
         introducedDeclNames.push_back(IdentifierID(
-            getRawStableMacroIntroducedDeclNameKind(name.getKind())));
-        introducedDeclNames.push_back(
-            S.addDeclBaseNameRef(name.getIdentifier()));
+            getRawStableMacroIntroducedDeclNameKind(introducedName.getKind())));
+
+        auto name = introducedName.getName();
+        introducedDeclNames.push_back(S.addDeclBaseNameRef(name.getBaseName()));
+        if (name.isSimpleName()) {
+          introducedDeclNames.push_back(0);
+          continue;
+        }
+
+        auto argumentLabels = name.getArgumentNames();
+        introducedDeclNames.push_back(argumentLabels.size() + 1);
+        for (auto label : argumentLabels)
+          introducedDeclNames.push_back(S.addDeclBaseNameRef(label));
       }
 
       MacroRoleDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
           static_cast<uint8_t>(theAttr->getMacroSyntax()),
-          rawMacroRole, theAttr->getNames().size(),
+          rawMacroRole, introducedDeclNames.size(),
           introducedDeclNames);
       return;
     }

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -9,7 +9,7 @@
 
 @attached(
   member,
-  names: named(Storage), named(storage), named(getStorage), named(method), named(`init`)
+  names: named(init), named(Storage), named(storage), named(getStorage()), named(method), named(init(other:))
 )
 macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
 
@@ -55,7 +55,7 @@ print(MyType.MyType3.self)
 
 @attached(
   member,
-  names: named(RawValue), named(rawValue), named(`init`)
+  names: named(RawValue), named(rawValue), named(init)
 )
 public macro NewType<T>() = #externalMacro(module: "MacroDefinition", type: "NewTypeMacro")
 

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -24,6 +24,7 @@ protocol Q { associatedtype Assoc }
 // expected-error @+1 {{macro 'm7' must declare its applicable roles}}
 @freestanding macro m7(_: String) = #externalMacro(module: "A", type: "M4")
 // expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm7'; the type must be public and provided via '-load-plugin-library'}}
+
 // expected-error @+2 {{expected a freestanding macro role such as 'expression'}}
 // expected-error @+1 {{macro 'm8' must declare its applicable roles}}
 @freestanding(abc) macro m8(_: String) = #externalMacro(module: "A", type: "M4")

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -38,9 +38,9 @@
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK: @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 // CHECK-NEXT: #endif
-@attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 
 // CHECK-NOT: internalStringify
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")

--- a/test/Serialization/Inputs/def_macro_plugin.swift
+++ b/test/Serialization/Inputs/def_macro_plugin.swift
@@ -36,3 +36,18 @@ public struct WrapAllProperties: MemberAttributeMacro {
   }
 }
 
+public struct ArbitraryMembersMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      init(coding: String) {
+        fatalError("boom")
+      }
+      """
+    ]
+  }
+}

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -34,3 +34,5 @@ public struct Builder {
 }
 @freestanding(expression)
 public macro macroWithBuilderArgs(@Builder _: () -> Void) = #externalMacro(module: "A", type: "B")
+
+@attached(member, names: named(init(coding:))) public macro ArbitraryMembers() = #externalMacro(module: "MacroDefinition", type: "ArbitraryMembersMacro")

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -23,6 +23,10 @@ struct TestStruct {
   @myWrapper var x: Int
 }
 
+@ArbitraryMembers
+struct OtherTestStruct {
+}
+
 // CHECK: MACRO_DECL
 
 // CHECK-NOT: UnknownCode


### PR DESCRIPTION
* Explanation: Parse compound and special names in the macro role attributes (`@freestanding` and `@attached`). This allows both compound names and initializers, e.g., `init(coding:)`.
* Scope: Affects code declaring macros that generate declarations.
* Risk: Low, narrowly applied to macros that introduce declarations.
* Issue: rdar://107967344.
* Original pull request: https://github.com/apple/swift/pull/65362