### PR TITLE
Use diff instead of cmp in `test/InterfaceHash/edited_method_body.swift`

### DIFF
--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -14,7 +14,8 @@
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
 // RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
 
-// RUN: cmp %t/{a,b}-processed.swiftdeps 
+// We can use `diff` here because this test isn't run on Windows
+// RUN: diff %t/{a,b}-processed.swiftdeps
 
 // BEGIN a.swift
 class C {


### PR DESCRIPTION
We're seeing some flakiness in this test, but aren't sure what it's complaining about. `cmp` only says where the difference was, but doesn't print what was different. `diff` prints what was difference so we have a chance to figure out what happened.

This should be fine since the test is not run on Windows.