### PR TITLE
Fix mem2reg error due to multi block mem2reg with store_borrows

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1328,13 +1328,12 @@ void StackAllocationPromoter::fixPhiPredBlock(BlockSetVector &phiBlocks,
   LLVM_DEBUG(llvm::dbgs() << "*** Fixing the terminator " << *ti << ".\n");
 
   LiveValues values = getEffectiveLiveOutValues(phiBlocks, predBlock);
-  auto ownedValues = values.getOwned();
 
   LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: "
-                          << ownedValues.stored);
+                          << values.getStored());
 
   SmallVector<SILValue> vals;
-  vals.push_back(ownedValues.replacement(asi, nullptr));
+  vals.push_back(values.replacement(asi, nullptr));
 
   addArgumentsToBranch(vals, destBlock, ti);
   deleter.forceDelete(ti);

--- a/test/SILOptimizer/mem2reg_borrows.sil
+++ b/test/SILOptimizer/mem2reg_borrows.sil
@@ -372,3 +372,39 @@ bb3:
   %retval = tuple ()
   return %retval : $()
 }
+
+// Ensure we don't have an ownership verification error
+sil [ossa] @test_store_borrow_phi : $@convention(thin) () -> () {
+bb0:
+  br bb1
+
+bb1:
+  %1 = apply undef() : $@convention(thin) () -> @owned Klass
+  %2 = begin_borrow %1 : $Klass
+  %3 = alloc_stack $Klass
+  %4 = store_borrow %2 to %3 : $*Klass
+  %5 = load_borrow %4 : $*Klass
+  %6 = apply undef(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %5 : $Klass
+  end_borrow %4 : $*Klass
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %3 : $*Klass
+  end_borrow %2 : $Klass
+  destroy_value %1 : $Klass
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
+  %17 = tuple ()
+  return %17 : $()
+}

--- a/test/SILOptimizer/mem2reg_lifetime_borrows.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_borrows.sil
@@ -526,3 +526,38 @@ bb0(%0 : @guaranteed $WrapperStruct):
   return %33 : $()
 }
 
+// Ensure we don't have an ownership verification error
+sil [ossa] @test_store_borrow_phi : $@convention(thin) () -> () {
+bb0:
+  br bb1
+
+bb1:
+  %1 = apply undef() : $@convention(thin) () -> @owned Klass
+  %2 = begin_borrow %1 : $Klass
+  %3 = alloc_stack [lexical] $Klass
+  %4 = store_borrow %2 to %3 : $*Klass
+  %5 = load_borrow %4 : $*Klass
+  %6 = apply undef(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %5 : $Klass
+  end_borrow %4 : $*Klass
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %3 : $*Klass
+  end_borrow %2 : $Klass
+  destroy_value %1 : $Klass
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1
+
+bb6:
+  %17 = tuple ()
+  return %17 : $()
+}


### PR DESCRIPTION
@guaranteed stored values will never be added to a phi in mem2reg because any uses of store borrowed locations have to be accessed via the store borrow return address and since we ban address phis altogether we will never have input sil which necessitates this.

But, the DJ-edges based algorithm for inserting phi blocks in mem2reg can insert unnecessary phis which are removed later.

Ensure fixPhiPredBlock handles both owned and guaranteed stored values correctly for this reason.

