### PR TITLE
[Dependency Scanning] Build libSwiftScan with Swift Modules required for parsing regex

### DIFF
--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -6,7 +6,8 @@ set(LLVM_EXPORTED_SYMBOL_FILE
 
 add_swift_host_library(libSwiftScan SHARED
   libSwiftScan.cpp
-  c-include-check.c)
+  c-include-check.c
+  HAS_SWIFT_MODULES)
 
 if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
   # Workaround for a linker crash related to autolinking: rdar://77839981
@@ -23,7 +24,7 @@ target_link_libraries(libSwiftScan PRIVATE
     swiftDriverTool
     swiftStaticMirror
     swiftRemoteInspection
-    swiftCompilerStub)
+    swiftCompilerModules)
 
 set_target_properties(libSwiftScan
     PROPERTIES

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/InitializeSwiftModules.h"
 #include "swift/DriverTool/DriverTool.h"
 #include "swift/DependencyScan/DependencyScanImpl.h"
 #include "swift/DependencyScan/DependencyScanningTool.h"
@@ -114,6 +115,9 @@ void swiftscan_scanner_cache_reset(swiftscan_scanner_t scanner) {
 
 swiftscan_scanner_t swiftscan_scanner_create(void) {
   INITIALIZE_LLVM();
+  // We must initialize the swift modules responsible for parsing functionality,
+  // such as parsing regex.
+  initializeSwiftParseModules();
   return wrap(new DependencyScanningTool());
 }
 


### PR DESCRIPTION
Otherwise scanning actions which encounter regex literals will fail.

Resolves rdar://108321860
