### PR TITLE
SIL: TypeSubstCloner::remapASTType() should not call getLoweredRValueType() [5.9]

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -187,8 +187,10 @@ protected:
             .shouldLookThroughOpaqueTypeArchetypes())
       return substTy;
     // Remap types containing opaque result types in the current context.
-    return getBuilder().getModule().Types.getLoweredRValueType(
-        TypeExpansionContext(getBuilder().getFunction()), substTy);
+    return substOpaqueTypesWithUnderlyingTypes(
+        substTy,
+        TypeExpansionContext(getBuilder().getFunction()),
+        /*allowLoweredTypes=*/false);
   }
 
   ProtocolConformanceRef remapConformance(Type ty,


### PR DESCRIPTION
SILCloner::visitScalarPackIndexInst() was calling remapASTType() on a PackType. This was becoming a SILPackType, which would then crash in a cast<>.