### PR TITLE
Reordering autolink-extract runtime orderings

### DIFF
--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -217,35 +217,31 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
   // in most object files
 
   std::vector<std::string> SwiftRuntimeLibsOrdered = {
-      // Common Swift runtime libs
+      "-lFoundationXML",
+      "-lFoundationNetworking",
+      "-lFoundation",
+      "-lswiftDispatch",
+      "-lswiftRegexBuilder",
+      "-lswift_Backtracing",
+      "-lswift_StringProcessing",
+      "-lswift_RegexParser",
+      "-lswift_Concurrency",
+      "-lswiftGlibc",
       "-lswiftSwiftOnoneSupport",
       "-lswiftCore",
-      "-lswift_Concurrency",
-      "-lswift_StringProcessing",
-      "-lswift_RegexBuilder",
-      "-lswift_RegexParser",
-      "-lswift_Backtracing",
-      "-lswiftGlibc",
-      "-lBlocksRuntime",
-      // Dispatch-specific Swift runtime libs
-      "-ldispatch",
-      "-lDispatchStubs",
-      "-lswiftDispatch",
-      // CoreFoundation and Foundation Swift runtime libs
       "-lCoreFoundation",
-      "-lFoundation",
-      "-lFoundationNetworking",
-      "-lFoundationXML",
-      // Foundation support libs
+      "-licui18nswift",
+      "-licuucswift",
+      "-licudataswift",
+      "-ldispatch",
+      "-lBlocksRuntime",
+      "-lDispatchStubs",
       "-lcurl",
       "-lxml2",
       "-luuid",
       // XCTest runtime libs (must be first due to http://github.com/apple/swift-corelibs-xctest/issues/432)
       "-lXCTest",
       // ICU Swift runtime libs
-      "-licui18nswift",
-      "-licuucswift",
-      "-licudataswift",
       // Common-use ordering-agnostic Linux system libs
       "-lm",
       "-lpthread",


### PR DESCRIPTION
Order is important. The ordering generated by autolink-extract is nonsensical in main and 5.9. I haven't had a chance to actually build the full symbol dependency graph to generate the proper ordering so I expect that I'm missing something, but this gets us closer to the actual library link order, so it might hopefully unblock some folks who are running into the "missing" symbols.

rdar://107643395
rdar://107445812