### PR TITLE
[SILGen] Consuming a param implies it's eager-move.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1094,14 +1094,19 @@ public:
   /// Check if this is a declaration defined at the top level of the Swift module
   bool isStdlibDecl() const;
 
-  LifetimeAnnotation getLifetimeAnnotation() const {
-    auto &attrs = getAttrs();
-    if (attrs.hasAttribute<EagerMoveAttr>())
-      return LifetimeAnnotation::EagerMove;
-    if (attrs.hasAttribute<NoEagerMoveAttr>())
-      return LifetimeAnnotation::Lexical;
-    return LifetimeAnnotation::None;
-  }
+  /// The effective lifetime resulting from the decorations on the declaration.
+  ///
+  /// Usually, this, not getLifetimeAnnotationFromAttributes should be used.
+  LifetimeAnnotation getLifetimeAnnotation() const;
+
+  /// The source-level lifetime attribute, either @_eagerMove or @_noEagerMove
+  /// that the declaration bears.
+  ///
+  /// Usually getLifetimeAnnotation should be used.
+  ///
+  /// Needed to access the attributes before the AST has been fully formed, such
+  /// as when printing.
+  LifetimeAnnotation getLifetimeAnnotationFromAttributes() const;
 
   bool isNoImplicitCopy() const {
     return getAttrs().hasAttribute<NoImplicitCopyAttr>();
@@ -6318,6 +6323,8 @@ public:
   Specifier getSpecifier() const;
   void setSpecifier(Specifier Spec);
 
+  LifetimeAnnotation getLifetimeAnnotation() const;
+
   /// Is the type of this parameter 'inout'?
   bool isInOut() const { return getSpecifier() == Specifier::InOut; }
 
@@ -7328,6 +7335,8 @@ public:
   bool isMainTypeMainMethod() const;
 
   SelfAccessKind getSelfAccessKind() const;
+
+  LifetimeAnnotation getLifetimeAnnotation() const;
 
   void setSelfAccessKind(SelfAccessKind mod) {
     Bits.FuncDecl.SelfAccess = static_cast<unsigned>(mod);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3520,6 +3520,8 @@ ERROR(lifetime_invalid_global_scope,none, "%0 is only valid on methods",
 ERROR(eagermove_and_lexical_combined,none,
       "@_eagerMove and @_noEagerMove attributes are alternate styles of lifetimes "
       "and can't be combined", ())
+ERROR(eagermove_and_noncopyable_combined,none,
+      "@_eagerMove cannot be applied to NonCopyable types", ())
 
 ERROR(autoclosure_function_type,none,
       "@autoclosure attribute only applies to function types",

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1030,7 +1030,7 @@ namespace {
       if (P->getAttrs().hasAttribute<NonEphemeralAttr>())
         OS << " nonEphemeral";
 
-      switch (P->getLifetimeAnnotation()) {
+      switch (P->getLifetimeAnnotationFromAttributes()) {
       case LifetimeAnnotation::EagerMove:
         OS << " _eagerMove";
         break;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7049,8 +7049,11 @@ LifetimeAnnotation ParamDecl::getLifetimeAnnotation() const {
   auto specifier = getSpecifier();
   // Copyable parameters which are consumed have eager-move semantics.
   if (specifier == ParamDecl::Specifier::Consuming &&
-      !getType()->isPureMoveOnly())
+      !getType()->isPureMoveOnly()) {
+    if (getAttrs().hasAttribute<NoEagerMoveAttr>())
+      return LifetimeAnnotation::Lexical;
     return LifetimeAnnotation::EagerMove;
+  }
   return getLifetimeAnnotationFromAttributes();
 }
 
@@ -9243,8 +9246,11 @@ LifetimeAnnotation FuncDecl::getLifetimeAnnotation() const {
   // Copyable parameters which are consumed have eager-move semantics.
   if (getSelfAccessKind() == SelfAccessKind::Consuming) {
     auto *selfDecl = getImplicitSelfDecl();
-    if (selfDecl && !selfDecl->getType()->isPureMoveOnly())
+    if (selfDecl && !selfDecl->getType()->isPureMoveOnly()) {
+      if (getAttrs().hasAttribute<NoEagerMoveAttr>())
+        return LifetimeAnnotation::Lexical;
       return LifetimeAnnotation::EagerMove;
+    }
   }
   return getLifetimeAnnotationFromAttributes();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1080,6 +1080,25 @@ bool Decl::isStdlibDecl() const {
          DC->getParentModule()->isStdlibModule();
 }
 
+LifetimeAnnotation Decl::getLifetimeAnnotationFromAttributes() const {
+  auto &attrs = getAttrs();
+  if (attrs.hasAttribute<EagerMoveAttr>())
+    return LifetimeAnnotation::EagerMove;
+  if (attrs.hasAttribute<NoEagerMoveAttr>())
+    return LifetimeAnnotation::Lexical;
+  return LifetimeAnnotation::None;
+}
+
+LifetimeAnnotation Decl::getLifetimeAnnotation() const {
+  if (auto *pd = dyn_cast<ParamDecl>(this)) {
+    return pd->getLifetimeAnnotation();
+  }
+  if (auto *fd = dyn_cast<FuncDecl>(this)) {
+    return fd->getLifetimeAnnotation();
+  }
+  return getLifetimeAnnotationFromAttributes();
+}
+
 AvailabilityContext Decl::getAvailabilityForLinkage() const {
   ASTContext &ctx = getASTContext();
 
@@ -7026,6 +7045,15 @@ ParamDecl::Specifier ParamDecl::getSpecifier() const {
                            ParamDecl::Specifier::Default);
 }
 
+LifetimeAnnotation ParamDecl::getLifetimeAnnotation() const {
+  auto specifier = getSpecifier();
+  // Copyable parameters which are consumed have eager-move semantics.
+  if (specifier == ParamDecl::Specifier::Consuming &&
+      !getType()->isPureMoveOnly())
+    return LifetimeAnnotation::EagerMove;
+  return getLifetimeAnnotationFromAttributes();
+}
+
 StringRef ParamDecl::getSpecifierSpelling(ParamSpecifier specifier) {
   switch (specifier) {
   case ParamSpecifier::Default:
@@ -9209,6 +9237,16 @@ SelfAccessKind FuncDecl::getSelfAccessKind() const {
   return evaluateOrDefault(ctx.evaluator,
                            SelfAccessKindRequest{const_cast<FuncDecl *>(this)},
                            SelfAccessKind::NonMutating);
+}
+
+LifetimeAnnotation FuncDecl::getLifetimeAnnotation() const {
+  // Copyable parameters which are consumed have eager-move semantics.
+  if (getSelfAccessKind() == SelfAccessKind::Consuming) {
+    auto *selfDecl = getImplicitSelfDecl();
+    if (selfDecl && !selfDecl->getType()->isPureMoveOnly())
+      return LifetimeAnnotation::EagerMove;
+  }
+  return getLifetimeAnnotationFromAttributes();
 }
 
 bool FuncDecl::isCallAsFunctionMethod() const {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6888,6 +6888,25 @@ bool AttributeChecker::visitLifetimeAttr(DeclAttribute *attr) {
 void AttributeChecker::visitEagerMoveAttr(EagerMoveAttr *attr) {
   if (visitLifetimeAttr(attr))
     return;
+  if (auto *nominal = dyn_cast<NominalTypeDecl>(D)) {
+    if (nominal->getDeclaredInterfaceType()->isPureMoveOnly()) {
+      diagnoseAndRemoveAttr(attr, diag::eagermove_and_noncopyable_combined);
+      return;
+    }
+  }
+  if (auto *func = dyn_cast<FuncDecl>(D)) {
+    auto *self = func->getImplicitSelfDecl();
+    if (self && self->getType()->isPureMoveOnly()) {
+      diagnoseAndRemoveAttr(attr, diag::eagermove_and_noncopyable_combined);
+      return;
+    }
+  }
+  if (auto *pd = dyn_cast<ParamDecl>(D)) {
+    if (pd->getType()->isPureMoveOnly()) {
+      diagnoseAndRemoveAttr(attr, diag::eagermove_and_noncopyable_combined);
+      return;
+    }
+  }
 }
 
 void AttributeChecker::visitNoEagerMoveAttr(NoEagerMoveAttr *attr) {

--- a/test/SILGen/consuming_parameter.swift
+++ b/test/SILGen/consuming_parameter.swift
@@ -4,7 +4,7 @@ func bar(_: String) {}
 
 // CHECK-LABEL: sil {{.*}} @${{.*}}3foo
 func foo(y: consuming String, z: String) -> () -> String {
-    // CHECK: bb0(%0 : @owned $String, %1 : @guaranteed $String):
+    // CHECK: bb0(%0 : @_eagerMove @owned $String, %1 : @guaranteed $String):
     // CHECK:   [[BOX:%.*]] = alloc_box ${ var String }
     // CHECK:   [[Y:%.*]] = project_box [[BOX]]
     // CHECK:   store %0 to [init] [[Y]]
@@ -33,7 +33,7 @@ struct Butt {
 
     // CHECK-LABEL: sil {{.*}} @${{.*}}4Butt{{.*}}6merged
     consuming func merged(with other: Butt) -> () -> Butt {
-        // CHECK: bb0(%0 : @guaranteed $Butt, %1 : @owned $Butt):
+        // CHECK: bb0(%0 : @guaranteed $Butt, %1 : @_eagerMove @owned $Butt):
         // CHECK:   [[BOX:%.*]] = alloc_box ${ var Butt }
         // CHECK:   [[SELF:%.*]] = project_box [[BOX]]
         // CHECK:   store %1 to [init] [[SELF]]

--- a/test/SILOptimizer/consuming_parameter.swift
+++ b/test/SILOptimizer/consuming_parameter.swift
@@ -1,0 +1,75 @@
+// RUN: %target-swift-frontend -c -disable-availability-checking -Xllvm --sil-print-final-ossa-module -O -module-name=main -o /dev/null %s 2>&1 | %FileCheck %s
+ 
+// REQUIRES: concurrency
+
+// CHECK-LABEL: sil [ossa] @async_dead_arg_call : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @_eagerMove @owned
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[EXECUTOR:%[^,]+]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt 
+// CHECK:         [[CALLEE:%[^,]+]] = function_ref @async_callee
+// CHECK:         apply [[CALLEE]]()
+// CHECK:         hop_to_executor [[EXECUTOR]]
+// CHECK-LABEL: } // end sil function 'async_dead_arg_call'
+@_silgen_name("async_dead_arg_call")
+public func async_dead_arg_call(o: consuming AnyObject) async {
+  // o should be destroyed here
+  await bar()
+}
+ 
+public class C {
+  // CHECK-LABEL: sil [ossa] @async_dead_arg_call_method : {{.*}} {
+  // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @_eagerMove @owned
+  // CHECK:         destroy_value [[INSTANCE]]
+  // CHECK:         [[EXECUTOR:%[^,]+]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt 
+  // CHECK:         [[CALLEE:%[^,]+]] = function_ref @async_callee : $@convention(thin) @async () -> () 
+  // CHECK:         apply [[CALLEE]]() : $@convention(thin) @async () -> () 
+  // CHECK:         hop_to_executor [[EXECUTOR]]
+  // CHECK-LABEL: } // end sil function 'async_dead_arg_call_method'
+  @_silgen_name("async_dead_arg_call_method")
+  consuming
+  public func async_dead_arg_call() async {
+    // self should be destroyed here
+    await bar()
+  }
+}
+
+@inline(never)
+@_silgen_name("async_callee")
+func bar() async {}
+
+// CHECK-LABEL: sil [ossa] @write_to_pointer : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[CONSUMED_INSTANCE:%[^,]+]] : @_eagerMove @owned $AnyObject, [[UMP:%[^,]+]] :
+// CHECK:         [[PTR:%[^,]+]] = struct_extract [[UMP]]
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[PTR]]
+// CHECK:         store [[CONSUMED_INSTANCE]] to [assign] [[ADDR]]
+// CHECK:         [[PTR2:%[^,]+]] = struct_extract [[UMP]]
+// CHECK:         [[ADDR2:%[^,]+]] = pointer_to_address [[PTR2]]
+// CHECK:         [[OUT:%[^,]+]] = load [copy] [[ADDR2]]
+// CHECK:         return [[OUT]]
+// CHECK-LABEL: } // end sil function 'write_to_pointer'
+@_silgen_name("write_to_pointer")
+public func write_to_pointer(o: consuming AnyObject, p: UnsafeMutablePointer<AnyObject>) -> AnyObject {
+  // o should be destroyed here
+  p.pointee = o
+  return p.pointee
+}
+
+extension C {
+  // CHECK-LABEL: sil [ossa] @write_to_pointer_method : {{.*}} {
+  // CHECK:       {{bb[0-9]+}}([[UMP:%[^,]+]] : $UnsafeMutablePointer<C>, [[INSTANCE:%[^,]+]] : @_eagerMove @owned
+  // CHECK:         [[PTR:%[^,]+]] = struct_extract [[UMP]]
+  // CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[PTR]]
+  // CHECK:         store [[INSTANCE]] to [assign] [[ADDR]]
+  // CHECK:         [[ADDR2:%[^,]+]] = struct_extract [[UMP]]
+  // CHECK:         [[PTR2:%[^,]+]] = pointer_to_address [[ADDR2]]
+  // CHECK:         [[OUT:%[^,]+]] = load [copy] [[PTR2]]
+  // CHECK:         return [[OUT]]
+  // CHECK-LABEL: } // end sil function 'write_to_pointer_method'
+  @_silgen_name("write_to_pointer_method")
+  consuming
+  public func write_to_pointer(p: UnsafeMutablePointer<C>) -> C {
+    // o should be destroyed here
+    p.pointee = self
+    return p.pointee
+  }
+}

--- a/test/SILOptimizer/consuming_parameter.swift
+++ b/test/SILOptimizer/consuming_parameter.swift
@@ -16,6 +16,34 @@ public func async_dead_arg_call(o: consuming AnyObject) async {
   await bar()
 }
  
+// CHECK-LABEL: sil [ossa] @async_dead_arg_call_lexical : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @_lexical @owned
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[EXECUTOR:%[^,]+]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt 
+// CHECK:         [[CALLEE:%[^,]+]] = function_ref @async_callee
+// CHECK:         apply [[CALLEE]]()
+// CHECK:         hop_to_executor [[EXECUTOR]]
+// CHECK:         destroy_value [[MOVE]]
+// CHECK-LABEL: } // end sil function 'async_dead_arg_call_lexical'
+@_silgen_name("async_dead_arg_call_lexical")
+public func async_dead_arg_call_lexical(@_noEagerMove o: consuming AnyObject) async {
+  await bar()
+  // o should be destroyed here
+}
+
+extension C {
+  // CHECK-LABEL: sil [ossa] @async_dead_arg_call_lexical_method : {{.*}} {
+  // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @_lexical @owned
+  // CHECK-LABEL: } // end sil function 'async_dead_arg_call_lexical_method'
+  @_silgen_name("async_dead_arg_call_lexical_method")
+  @_noEagerMove
+  consuming
+  public func async_dead_arg_call_lexical_method() async {
+    await bar()
+    // self should be destroyed here
+  }
+}
+
 public class C {
   // CHECK-LABEL: sil [ossa] @async_dead_arg_call_method : {{.*}} {
   // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @_eagerMove @owned

--- a/test/attr/lexical.swift
+++ b/test/attr/lexical.swift
@@ -43,3 +43,16 @@ func foo() {
   _ = s2
   _ = s3
 }
+
+@_moveOnly struct MoveOnly {}
+
+@_eagerMove @_moveOnly struct MoveOnlyEagerly {} // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}
+
+func zoo(@_eagerMove _ : consuming MoveOnly) {} // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}
+
+func zooo(@_noEagerMove  _ : consuming C) {} // ok, only way to spell this behavior
+
+extension MoveOnly {
+  @_eagerMove // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}
+  func zoo() {}
+}


### PR DESCRIPTION
If a parameter is marked consuming and its type is Copyable, that parameter has eager-move semantics.  Apply that attribute to the `SILFunctionArgument` corresponding to the parameter.

rdar://108385761
