### PR TITLE
[5.9][SourceKit] Expand editor placeholder to trailing closures inside a `TryExpr`

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -10,6 +10,22 @@ foo(x: <#T##() -> Void#>, y: <#T##Int#>)
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }, y: Int)
 
+try foo(x: <#T##() -> Void#>)
+// CHECK:      try foo {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+await foo(x: <#T##() -> Void#>)
+// CHECK:      await foo {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+!foo(x: <#T##() -> Void#>)
+// CHECK:      !foo {
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }
+
+
 anArr.indexOfObjectPassingTest(<#T##predicate: ((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?##((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?#>)
 // CHECK:      anArr.indexOfObjectPassingTest { <#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#> in
 // CHECK-NEXT: <#code#>

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1658,7 +1658,14 @@ private:
         auto SR = E->getSourceRange();
         if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc) &&
             !checkCallExpr(E) && !EnclosingCallAndArg.first) {
-          OuterExpr = E;
+          if (!isa<TryExpr>(E) && !isa<AwaitExpr>(E) &&
+              !isa<PrefixUnaryExpr>(E)) {
+            // We don't want to expand to trailing closures if the call is
+            // nested inside another expression that has closing characters,
+            // like a `)` for a function call. This is not the case for
+            // `try`, `await` and prefix operator applications.
+            OuterExpr = E;
+          }
         }
         return true;
       }


### PR DESCRIPTION
* **Explanation**: When you had a function call with an argument that represents a closure we would not convert it to a trailing closure if the call had `try` in front of it.
* **Scope**: Just SourceKit, expanding of placeholders in particular
* **Risk**: Very low
* **Testing**: Added regression test
* **Issue**:  rdar://108391690
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/65376 
