### PR TITLE
5.9: [AllocBoxToStack] Specialize moved PAIs.

### DIFF
--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -254,10 +254,11 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
 
     auto *User = Op->getUser();
 
-    // If we have a copy_value, the copy value does not cause an escape, but its
-    // uses might do so... so add the copy_value's uses to the worklist and
-    // continue.
-    if (isa<CopyValueInst>(User) || isa<BeginBorrowInst>(User)) {
+    // If we have a copy_value, begin_borrow, or move_value, that instruction
+    // does not cause an escape, but its uses might do so... so add the
+    // its uses to the worklist and continue.
+    if (isa<CopyValueInst>(User) || isa<BeginBorrowInst>(User) ||
+        isa<MoveValueInst>(User)) {
       llvm::copy(cast<SingleValueInstruction>(User)->getUses(),
                  std::back_inserter(Worklist));
       continue;

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -1194,3 +1194,35 @@ bb4:
   %v = tuple ()
   return %v : $()
 }
+
+
+sil [ossa] @move_closure_callee : $@convention(thin) (@guaranteed { var Builtin.Int32 }) -> () {
+bb0(%box : @closureCapture @guaranteed ${ var Builtin.Int32 }):
+  %13 = integer_literal $Builtin.Int32, 13
+  %addr = project_box %box : ${ var Builtin.Int32 }, 0
+  store %13 to [trivial] %addr : $*Builtin.Int32
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @move_closure : {{.*}} {
+// CHECK:         [[SPECIALIZED_CLOSURE:%[^,]+]] = function_ref @$s19move_closure_calleeTf0s_n : $@convention(thin) (@inout_aliasable Builtin.Int32) -> ()
+// CHECK:         partial_apply [callee_guaranteed] [[SPECIALIZED_CLOSURE]]
+// CHECK-LABEL: } // end sil function 'move_closure'
+sil [ossa] @move_closure : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %box = alloc_box ${ var Builtin.Int32 }
+  %addr = project_box %box : ${ var Builtin.Int32 }, 0
+  %42 = integer_literal $Builtin.Int32, 42
+  store %42 to [trivial] %addr : $*Builtin.Int32
+  %callee = function_ref @move_closure_callee : $@convention(thin) (@guaranteed { var Builtin.Int32 }) -> ()
+  %box_copy = copy_value %box : ${ var Builtin.Int32 }
+  mark_function_escape %addr : $*Builtin.Int32
+  %closure = partial_apply [callee_guaranteed] %callee(%box_copy) : $@convention(thin) (@guaranteed { var Builtin.Int32 }) -> ()
+  %closure_move = move_value %closure : $@callee_guaranteed () -> ()
+  apply %closure_move() : $@callee_guaranteed () -> ()
+  destroy_value %closure_move : $@callee_guaranteed () -> ()
+  %value = load [trivial] %addr : $*Builtin.Int32
+  destroy_value %box : ${ var Builtin.Int32 }
+  return %value : $Builtin.Int32
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65359 .

Added `move_value` to the list of instructions looked through when determining whether a `partial_apply` instruction escapes.

rdar://108376960
