### PR TITLE
5.9: [PartialApplyCombiner] Handled moved PAIs.

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -820,9 +820,10 @@ static bool useHasTransitiveOwnership(const SILInstruction *inst) {
   if (isa<ConvertEscapeToNoEscapeInst>(inst))
     return true;
 
-  // Look through copy_value, begin_borrow. They are inert for our purposes, but
-  // we need to look through it.
-  return isa<CopyValueInst>(inst) || isa<BeginBorrowInst>(inst);
+  // Look through copy_value, begin_borrow, move_value. They are inert for our
+  // purposes, but we need to look through it.
+  return isa<CopyValueInst>(inst) || isa<BeginBorrowInst>(inst) ||
+         isa<MoveValueInst>(inst);
 }
 
 static bool shouldDestroyPartialApplyCapturedArg(SILValue arg,

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -239,10 +239,11 @@ bool PartialApplyCombiner::combine() {
     auto *use = worklist.pop_back_val();
     auto *user = use->getUser();
 
-    // Recurse through copy_value
-    if (isa<CopyValueInst>(user) || isa<BeginBorrowInst>(user)) {
-      for (auto *copyUse : cast<SingleValueInstruction>(user)->getUses())
-        worklist.push_back(copyUse);
+    // Recurse through ownership instructions.
+    if (isa<CopyValueInst>(user) || isa<BeginBorrowInst>(user) ||
+        isa<MoveValueInst>(user)) {
+      for (auto *ownershipUse : cast<SingleValueInstruction>(user)->getUses())
+        worklist.push_back(ownershipUse);
       continue;
     }
 

--- a/test/SILOptimizer/mandatory_generic_specialization.sil
+++ b/test/SILOptimizer/mandatory_generic_specialization.sil
@@ -3,6 +3,7 @@
 import Builtin
 
 sil @paable : $@convention(thin) (Builtin.Int64) -> ()
+sil @moved_pai_callee : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
 
 sil [ossa] [transparent] @partial_apply_on_stack_nesting_violator : $@convention(thin) <T> () -> () {
     %paable = function_ref @paable : $@convention(thin) (Builtin.Int64) -> ()
@@ -34,4 +35,23 @@ sil [no_locks] @test_inline_stack_violating_ossa_func : $@convention(thin) () ->
     return %retval : $()
 }
 
-
+// CHECK-LABEL: sil hidden [no_allocation] [ossa] @moved_pai : {{.*}} {
+// CHECK-NOT:     partial_apply
+// CHECK-LABEL: } // end sil function 'moved_pai'
+sil hidden [no_allocation] [ossa] @moved_pai : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %addr = alloc_stack $Builtin.Int64
+  %42 = integer_literal $Builtin.Int64, 42
+  store %42 to [trivial] %addr : $*Builtin.Int64
+  %callee = function_ref @moved_pai_callee : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %closure = partial_apply [callee_guaranteed] %callee(%addr) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %closure_lifetime = move_value [lexical] %closure : $@callee_guaranteed () -> ()
+  debug_value %closure_lifetime : $@callee_guaranteed () -> ()
+  %copy = copy_value %closure_lifetime : $@callee_guaranteed () -> ()
+  apply %copy() : $@callee_guaranteed () -> ()
+  destroy_value %copy : $@callee_guaranteed () -> ()
+  %retval = load [trivial] %addr : $*Builtin.Int64
+  destroy_value %closure_lifetime : $@callee_guaranteed () -> ()
+  dealloc_stack %addr : $*Builtin.Int64
+  return %retval : $Builtin.Int64
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65369 .

Look through `move_value` instructions when combining `partial_apply` instructions.

rdar://108386395
