### PR TITLE
[stdlib] Improve readability by replacing `if let` with `guard let` in lexicographicallyPrecedes method

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -412,20 +412,18 @@ extension Sequence {
     var iter1 = self.makeIterator()
     var iter2 = other.makeIterator()
     while true {
-      if let e1 = iter1.next() {
-        if let e2 = iter2.next() {
-          if try areInIncreasingOrder(e1, e2) {
-            return true
-          }
-          if try areInIncreasingOrder(e2, e1) {
-            return false
-          }
-          continue // Equivalent
-        }
+      guard let e1 = iter1.next() else {
+        return iter2.next() != nil
+      }
+      guard let e2 = iter2.next() else {
         return false
       }
-
-      return iter2.next() != nil
+      if try areInIncreasingOrder(e1, e2) {
+        return true
+      }
+      if try areInIncreasingOrder(e2, e1) {
+        return false
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
In the `lexicographicallyPrecedes` method, replace `if let` with `guard let` to decrease nesting levels and enhance readability.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
