### PR TITLE
[5.9][Macros] Remove usages of deprecated methods in SwiftSyntaxMacros

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -88,7 +88,7 @@ extension SourceManager.MacroExpansionContext: MacroExpansionContext {
     of node: Node,
     at position: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
-  ) -> SourceLocation? {
+  ) -> AbstractSourceLocation? {
     guard let (sourceFile, rootPosition) = sourceManager.rootSourceFile(of: node),
         let exportedSourceFile =
             sourceManager.exportedSourceFilesBySyntax[sourceFile]?.pointee
@@ -127,6 +127,6 @@ extension SourceManager.MacroExpansionContext: MacroExpansionContext {
 
     // Do the location lookup.
     let converter = SourceLocationConverter(file: fileName, tree: sourceFile)
-    return converter.location(for: rootPosition.advanced(by: offsetWithinSyntaxNode))
+    return AbstractSourceLocation(converter.location(for: rootPosition.advanced(by: offsetWithinSyntaxNode)))
   }
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -42,7 +42,7 @@ public struct FileIDMacro: ExpressionMacro {
       throw CustomError.message("can't find location for macro")
     }
 
-    let fileLiteral: ExprSyntax = "\(literal: sourceLoc.file)"
+    let fileLiteral: ExprSyntax = "\(sourceLoc.file)"
     return fileLiteral
   }
 }
@@ -588,7 +588,7 @@ public struct AddExtMembers: MemberMacro {
     providingMembersOf decl: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let uniqueClassName = context.createUniqueName("uniqueClass")
+    let uniqueClassName = context.makeUniqueName("uniqueClass")
 
     let instanceMethod: DeclSyntax =
       """

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -278,8 +278,8 @@ func testAddBlocker(a: Int, b: Int, c: Int, oa: OnlyAdds) {
 
 // Test source location information.
 func testSourceLocations(x: Int, yolo: Int, zulu: Int) {
-  // CHECK-MACRO-PRINTED: Source range for LHS is MacroUser/macro_expand.swift: [[@LINE+3]]:5-[[@LINE+3]]:13
-  // CHECK-MACRO-PRINTED: Source range for LHS is MacroUser/macro_expand.swift: [[@LINE+2]]:5-[[@LINE+2]]:6
+  // CHECK-MACRO-PRINTED: Source range for LHS is "MacroUser/macro_expand.swift": [[@LINE+3]]:5-[[@LINE+3]]:13
+  // CHECK-MACRO-PRINTED: Source range for LHS is "MacroUser/macro_expand.swift": [[@LINE+2]]:5-[[@LINE+2]]:6
   _ = #leftHandOperandFinder(
     x + yolo + zulu
   )


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1575