### PR TITLE
Fix MemoryLifetimeVerifier and SIL verifier to handle trivial deinitialization

### DIFF
--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -726,3 +726,34 @@ entry:
   %retval = tuple ()
   return %retval : $()
 }
+
+// Reloading a trivial value is ok after the aggregate is deinitialized.
+sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> Int {
+bb0(%0 : $*Mixed, %1 : $Int):
+  %2 = struct_element_addr %0 : $*Mixed, #Mixed.i
+  store %1 to [trivial] %2 : $*Int
+  destroy_addr %0 : $*Mixed
+  %3 = load [trivial] %2 : $*Int
+  return %3 : $Int
+}
+
+// rdar://108001491 (SIL verification failed: Found mutating or
+// consuming use of an in_guaranteed parameter?!:
+// !ImmutableAddressUseVerifier().isMutatingOrConsuming(fArg))
+//
+// Allow an argument of guaranteed trivial type to be consumed.
+
+// Passed by address, but does not need to be resilient for this SIL test.
+struct ResilientValue {
+  var value: Builtin.Int32
+}
+
+sil @takeResilientValue : $@convention(thin) (@in ResilientValue) -> ()
+
+sil [thunk] [ossa] @testImutableAddressArgument : $@convention(thin) (@in_guaranteed ResilientValue) -> () {
+bb0(%0 : $*ResilientValue):
+  %1 = function_ref @takeResilientValue : $@convention(thin) (@in ResilientValue) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@in ResilientValue) -> ()
+  %v = tuple ()
+  return %v : $()
+}

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -142,13 +142,14 @@ bb0(%0 : @owned $T):
 }
 
 // CHECK: SIL memory lifetime failure in @test_mixed: memory is not initialized, but should be
-sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> Int {
+sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> @owned T {
 bb0(%0 : $*Mixed, %1 : $Int):
   %2 = struct_element_addr %0 : $*Mixed, #Mixed.i
   store %1 to [trivial] %2 : $*Int
   destroy_addr %0 : $*Mixed
-  %3 = load [trivial] %2 : $*Int
-  return %3 : $Int
+  %5 = struct_element_addr %0 : $*Mixed, #Mixed.t
+  %6 = load [copy] %5 : $*T
+  return %6 : $T
 }
 
 // CHECK: SIL memory lifetime failure in @test_missing_store_to_trivial: memory is not initialized, but should be

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -206,3 +206,24 @@ public func resilientIfCase(_ e: MyResilientEnum) -> Bool {
   case .loki: ()
   }
 }
+
+
+// -----------------------------------------------------------------------------
+// rdar://108001491 (SIL verification failed: Found mutating or
+// consuming use of an in_guaranteed parameter?!:
+// !ImmutableAddressUseVerifier().isMutatingOrConsuming(fArg))
+//
+// The entityReference thunk requires @in_guaranteed ownership, but
+// the enum initializer takes its argument @in.
+
+public struct EntityIdentifier {
+  public let value: Swift.UInt64
+}
+
+public protocol ObjectProtocol {
+  static func entityReference(_ id: EntityIdentifier) -> Self
+}
+
+public enum Object : ObjectProtocol {
+  case entityReference(EntityIdentifier)
+}


### PR DESCRIPTION
Fix SILVerifier isConsumingOrMutatingArgumentConvention

    Consuming a trivial type has no effect, so we return false in that
    case. SILGen avoids generating copies and destroys for trivial types when
    ownership would otherwise require it.

Fix MemoryLifetimeVerifier to handle trivial deinitialization

    Nontrivial values are never deinitialized. SILGen knows this and
    avoids emitting copies and destroys for trivial types. This results in
    apparent violations of the memory's initialization state.

Fixes rdar://108001491 (SIL verification failed:
    Found mutating consuming use of an in_guaranteed parameter?!:
    !ImmutableAddressUseVerifier().isMutatingOrConsuming(fArg))