### PR TITLE
Add username/email to bare git config in repo

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -118,9 +118,9 @@ def setup_mock_remote(base_dir, base_config):
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=remote_repo_path)
         call_quietly(['git', 'clone', '-l', remote_repo_path, local_repo_path])
-        call_quietly(['git', 'config', 'user.name', 'apple_test'], 
+        call_quietly(['git', 'config', 'user.name', 'swift_test'], 
                      cwd=local_repo_path)
-        call_quietly(['git', 'config', 'user.email', 'apple_test@apple.com'], 
+        call_quietly(['git', 'config', 'user.email', 'no-reply@swift.org'], 
                      cwd=local_repo_path)
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=local_repo_path)

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -118,6 +118,10 @@ def setup_mock_remote(base_dir, base_config):
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=remote_repo_path)
         call_quietly(['git', 'clone', '-l', remote_repo_path, local_repo_path])
+        call_quietly(['git', 'config', 'user.name', 'apple_test'], 
+                     cwd=local_repo_path)
+        call_quietly(['git', 'config', 'user.email', 'apple_test@apple.com'], 
+                     cwd=local_repo_path)
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=local_repo_path)
         for (i, (filename, contents)) in enumerate(v):

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -118,9 +118,9 @@ def setup_mock_remote(base_dir, base_config):
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=remote_repo_path)
         call_quietly(['git', 'clone', '-l', remote_repo_path, local_repo_path])
-        call_quietly(['git', 'config', 'user.name', 'swift_test'], 
+        call_quietly(['git', 'config', 'user.name', 'swift_test'],
                      cwd=local_repo_path)
-        call_quietly(['git', 'config', 'user.email', 'no-reply@swift.org'], 
+        call_quietly(['git', 'config', 'user.email', 'no-reply@swift.org'],
                      cwd=local_repo_path)
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=local_repo_path)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add a fake git username/password to the update_checkout tests so they don't fail in differently configured git environments. Currently if a user doesn't have a global email/username setup in their git config the tests will fail with
```
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
```

This PR sets the config for the local mock repository accordingly and ensures that the test is self contained and doesn't rely on the end-users global git environment 
