### PR TITLE
add QuietMisdreavus as code owner for SymbolGraphGen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,6 +74,7 @@
 /include/swift/Sema/                               @hborla @slavapestov @xedin
 /include/swift/Sema/CS*                            @hborla @xedin
 /include/swift/Sema/Constraint*                    @hborla @xedin
+/include/swift/SymbolGraphGen/                     @QuietMisdreavus
 /include/swift/Threading                           @al45tair
 
 # lib
@@ -93,6 +94,7 @@
 /lib/ClangImporter/DWARFImporter*                   @adrian-prantl
 /lib/DependencyScan                                 @artemcm
 /lib/Driver                                         @artemcm
+/lib/DriverTool/swift_symbolgraph_extract_main.cpp  @QuietMisdreavus
 /lib/Frontend/*ModuleInterface*                     @artemcm @tshortli
 # TODO: /lib/IRGen/
 /lib/IDE/                                           @ahoppen @bnbarham @rintaro
@@ -121,6 +123,7 @@
 /lib/Sema/TypeCheckProtocol*                        @AnthonyLatsis @hborla @slavapestov
 /lib/Sema/TypeCheckType*                            @AnthonyLatsis @hborla @slavapestov @xedin
 /lib/Serialization/SerializedModuleLoader.cpp       @artemcm
+/lib/SymbolGraphGen                                 @QuietMisdreavus
 /lib/Threading                                      @al45tair
 
 # localization
@@ -153,6 +156,7 @@
 # TODO: /test/SILOptimizer/
 /test/ScanDependencies/                             @artemcm
 /test/Sema/                                         @hborla @slavapestov @xedin
+/test/SymbolGraph/                                  @QuietMisdreavus
 /test/decl/                                         @hborla @slavapestov
 /test/decl/protocol/                                @AnthonyLatsis @hborla @slavapestov
 # FIXME: This file could have a dedicated directory.


### PR DESCRIPTION
I'm listed in `CODE_OWNERS.TXT` as the point person for SymbolGraphGen, but i'm not in `.github/CODEOWNERS` to get automatically tagged in PRs. I'm adding myself to SymbolGraphGen's directories (and the `swift-symbolgraph-extract` tool file in DriverTool) here.