### PR TITLE
[interop][SwiftToCxx] add additional type representation emission che…

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -75,6 +75,8 @@ public:
         requiresExposedAttribute(requiresExposedAttribute),
         exposedModules(exposedModules), outputLang(outputLang) {}
 
+  PrimitiveTypeMapping &getTypeMapping() { return typeMapping; }
+
   SwiftToClangInteropContext &getInteropContext() { return interopContext; }
 
   /// Returns true if \p VD should be included in a compatibility header for

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1581,3 +1581,16 @@ void DeclAndTypeClangFunctionPrinter::printCustomCxxFunction(
   bodyPrinter(typeRefs);
   outOfLineOS << "}\n";
 }
+
+ClangRepresentation DeclAndTypeClangFunctionPrinter::getTypeRepresentation(
+    PrimitiveTypeMapping &typeMapping,
+    SwiftToClangInteropContext &interopContext, DeclAndTypePrinter &declPrinter,
+    const ModuleDecl *emittedModule, Type ty) {
+  CFunctionSignatureTypePrinterModifierDelegate delegate;
+  CFunctionSignatureTypePrinter typePrinter(
+      llvm::nulls(), llvm::nulls(), typeMapping, OutputLanguageMode::Cxx,
+      interopContext, delegate, emittedModule, declPrinter,
+      FunctionSignatureTypeUse::TypeReference);
+  return typePrinter.visit(ty, OptionalTypeKind::OTK_None,
+                           /*isInOutParam=*/false);
+}

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -164,6 +164,12 @@ public:
                               ModuleDecl *emittedModule,
                               raw_ostream &outOfLineOS);
 
+  static ClangRepresentation
+  getTypeRepresentation(PrimitiveTypeMapping &typeMapping,
+                        SwiftToClangInteropContext &interopContext,
+                        DeclAndTypePrinter &declPrinter,
+                        const ModuleDecl *emittedModule, Type ty);
+
 private:
   void printCxxToCFunctionParameterUse(Type type, StringRef name,
                                        const ModuleDecl *moduleContext,

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseFoundation -enable-experimental-cxx-interop -emit-clang-header-path %t/UseFoundation.h
+// RUN: %FileCheck %s < %t/UseFoundation.h
+
+#if canImport(Foundation)
+
+import Foundation
+
+public enum UseFoundationEnum {
+    case A(Data)
+    case B
+}
+
+#endif
+
+// CHECK-NOT: UseFoundationEnum


### PR DESCRIPTION
…ck for associated enum element types

This ensures that we do not try to emit enums whose associated values come from dependent modules that don't have a C++ representation

Also remove outdated FIXME for enum availability.