### PR TITLE
Add support for nested ASTScopes inside of macro expansions.

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -413,6 +413,7 @@ public:
   NullablePtr<const void> addressForPrinting() const override { return SF; }
 
   ASTContext &getASTContext() const override;
+  bool ignoreInDebugInfo() const override { return true; }
 
 protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &scopeCreator) override;

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2165,6 +2165,14 @@ void IRGenDebugInfoImpl::setCurrentLoc(IRBuilder &Builder,
   assert(parentScopesAreSane(DS) && "parent scope sanity check failed");
   auto DL = llvm::DILocation::get(IGM.getLLVMContext(), L.line, L.column, Scope,
                                   InlinedAt);
+#ifndef NDEBUG
+  {
+    llvm::DILocalScope *Scope = DL->getInlinedAtScope();
+    llvm::DISubprogram *SP = Scope->getSubprogram();
+    llvm::Function *F = Builder.GetInsertBlock()->getParent();
+    assert((!F || SP->describes(F)) && "location points to different function");
+  }
+#endif
   Builder.SetCurrentDebugLocation(DL);
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -367,8 +367,10 @@ public:
   using ASTScopeTy = ast_scope::ASTScopeImpl;
   const ASTScopeTy *FnASTScope = nullptr;
   /// Caches one SILDebugScope for each ASTScope.
-  llvm::SmallDenseMap<const ASTScopeTy *, const SILDebugScope *, 16> ScopeMap;
-  /// Caches one inline SILDebugScope for each macro BufferID.
+  llvm::SmallDenseMap<std::pair<const ASTScopeTy *, const SILDebugScope *>,
+                      const SILDebugScope *, 16>
+      ScopeMap;
+  /// Caches one toplevel inline SILDebugScope for each macro BufferID.
   llvm::SmallDenseMap<unsigned, const SILDebugScope *, 16> InlinedScopeMap;
 
   /// The cleanup depth and BB for when the operand of a
@@ -720,7 +722,9 @@ private:
   const SILDebugScope *getOrCreateScope(SourceLoc SLoc);
   const SILDebugScope *getMacroScope(SourceLoc SLoc);
   const SILDebugScope *
-  getOrCreateScope(const ast_scope::ASTScopeImpl *ASTScope);
+  getOrCreateScope(const ast_scope::ASTScopeImpl *ASTScope,
+                   const SILDebugScope *FnScope,
+                   const SILDebugScope *InlinedAt = nullptr);
 
 public:
   /// Enter the debug scope for \p Loc, creating it if necessary.

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -99,9 +99,9 @@ struct Bad {}
 func testFileID(a: Int, b: Int) {
   // CHECK: MacroUser/macro_expand.swift
   print("Result is \(#customFileID)")
-  // CHECK-SIL: sil_scope [[SRC_SCOPE:[0-9]+]] { loc "{{.*}}macro_expand.swift":[[@LINE-3]]
+  // CHECK-SIL: sil_scope [[SRC_SCOPE:[0-9]+]] { loc "{{.*}}macro_expand.swift":[[@LINE-3]]:6 parent {{.*}}testFileID
   // CHECK-SIL: sil_scope [[EXPANSION_SCOPE:[0-9]+]] { loc "{{.*}}macro_expand.swift":[[@LINE-2]]:22 parent [[SRC_SCOPE]]
-  // CHECK-SIL: sil_scope [[MACRO_SCOPE:[0-9]+]] { loc "{{.*}}":[[@LINE-3]]:22 parent @$s9MacroUser10testFileID1a1bySi_SitF06customdE0fMf_ {{.*}} inlined_at [[EXPANSION_SCOPE]] }
+  // CHECK-SIL: sil_scope [[MACRO_SCOPE:[0-9]+]] { loc "@__swiftmacro{{.*}}":1:1 parent @$s9MacroUser10testFileID1a1bySi_SitF06customdE0fMf_ {{.*}} inlined_at [[EXPANSION_SCOPE]] }
   // CHECK-SIL: string_literal utf8 "MacroUser/macro_expand.swift", loc "@__swiftmacro_9MacroUser10testFileID1a1bySi_SitF06customdE0fMf_.swift":1:1, scope [[MACRO_SCOPE]]
   // CHECK-IR-DAG: !DISubprogram(name: "customFileID", linkageName: "$s9MacroUser10testFileID1a1bySi_SitF06customdE0fMf_"
 


### PR DESCRIPTION
Before this patch the parents of SILDebugScopes representing macro expansions were missing the inlinedAt field, which resulted in incorrent LLVM IR being produced. This is fixed by first computing the inlined call site for a macro expansion and then computing the nested SILDebugScope for the ASTScope of the expanded nodes; adding the inlinedAt field to all of levels of parent scopes.

rdar://108323748
___

Cherry pick of #65402.