### PR TITLE
[CursorInfo] Don’t crash if we are performing cursor info at EOF

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -214,7 +214,7 @@ void Lexer::initialize(unsigned Offset, unsigned EndOffset) {
     // inserted to mark the code completion token. If the IDE inspection offset
     // points to a normal character, no code completion token should be
     // inserted.
-    if (Ptr >= BufferStart && Ptr <= BufferEnd && *Ptr == '\0') {
+    if (Ptr >= BufferStart && Ptr < BufferEnd && *Ptr == '\0') {
       CodeCompletionPtr = Ptr;
     }
   }

--- a/test/SourceKit/CursorInfo/at_eof.swift
+++ b/test/SourceKit/CursorInfo/at_eof.swift
@@ -1,0 +1,1 @@
+// RUN: %sourcekitd-test -req=cursor -pos=2:1 %s -- %s


### PR DESCRIPTION
When performing code completion at the end of a file, the IDE inspection target would point to the null byte terminating the end of the string. That would cause us to consider this null byte as a code completion marker. When continuing to scan for the actual EOF, we would walk past the end of the buffer.

Simply don’t consider the last null byte as a candidate for the code completion marker to fix the problem.
