### PR TITLE
🍒[5.9][Executors] Remove accidentally added availability on asUnownedSerial Executor 

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -58,7 +58,6 @@ public protocol SerialExecutor: Executor {
 
   /// Convert this executor value to the optimized form of borrowed
   /// executor references.
-  @available(SwiftStdlib 5.9, *)
   func asUnownedSerialExecutor() -> UnownedSerialExecutor
 
   /// If this executor has complex equality semantics, and the runtime needs to compare


### PR DESCRIPTION
**Description:** The previously existing declaration of the protocol requirement did accidentally gain an SwiftStdlib 5.9 availability, while only the default implementation should (we added a default impl that implements using the UnownedSerialExecutor(ordinary:) and that properly has the 5.9 availability.)
**Risk:** Low, this undoes a too restrictive limitation being added
**Review by:** @DougGregor @tbkka 
**Testing:** CI testing, automation caught this regression
**Original PR:** https://github.com/apple/swift/pull/65407
**Radar:** rdar://108447637