### PR TITLE
[5.9] Improve breaking of cyclic references for member-attribute macros

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7059,6 +7059,28 @@ ERROR(invalid_macro_role_for_macro_syntax,none,
 ERROR(macro_cannot_introduce_names,none,
       "'%0' macros are not allowed to introduce names", (StringRef))
 
+ERROR(macro_resolve_circular_reference, none,
+      "circular reference resolving %select{freestanding|attached}0 macro %1",
+      (bool, DeclName))
+NOTE(macro_resolve_circular_reference_through, none,
+     "while resolving %select{freestanding|attached}0 macro %1",
+     (bool, DeclName))
+
+ERROR(macro_expand_circular_reference, none,
+      "circular reference expanding %0 macro %1", (StringRef, DeclName))
+NOTE(macro_expand_circular_reference_through, none,
+     "circular reference expanding %0 macro %1", (StringRef, DeclName))
+
+ERROR(macro_expand_circular_reference_entity, none,
+      "circular reference expanding %0 macros on %1", (StringRef, DeclName))
+NOTE(macro_expand_circular_reference_entity_through, none,
+     "circular reference expanding %0 macros on %1", (StringRef, DeclName))
+
+ERROR(macro_expand_circular_reference_unnamed, none,
+      "circular reference expanding %0 macros", (StringRef))
+NOTE(macro_expand_circular_reference_unnamed_through, none,
+     "circular reference expanding %0 macros", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Move Only Errors
 //------------------------------------------------------------------------------

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3243,6 +3243,12 @@ public:
   friend llvm::hash_code hash_value(const UnresolvedMacroReference &ref) {
     return reinterpret_cast<ptrdiff_t>(ref.pointer.getOpaqueValue());
   }
+
+  friend SourceLoc extractNearestSourceLoc(
+      const UnresolvedMacroReference &ref
+  ) {
+    return ref.getSigilLoc();
+  }
 };
 
 void simple_display(llvm::raw_ostream &out,
@@ -3266,6 +3272,9 @@ private:
 
 public:
   bool isCached() const { return true; }
+
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 class ResolveTypeEraserTypeRequest
@@ -3917,6 +3926,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 /// Expand all accessor macros attached to the given declaration.
@@ -3937,6 +3948,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 /// Expand all conformance macros attached to the given declaration.
@@ -3957,6 +3970,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 /// Expand all member attribute macros attached to the given
@@ -3977,6 +3992,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 /// Expand synthesized member macros attached to the given declaration.
@@ -3996,6 +4013,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 /// Load a plugin module with the given name.
@@ -4069,6 +4088,8 @@ private:
 
 public:
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 /// Resolve an external macro given its module and type name.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3258,7 +3258,7 @@ void simple_display(llvm::raw_ostream &out,
 class ResolveMacroRequest
     : public SimpleRequest<ResolveMacroRequest,
                            ConcreteDeclRef(UnresolvedMacroReference,
-                                           DeclContext *),
+                                           const Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3268,7 +3268,7 @@ private:
 
   ConcreteDeclRef
   evaluate(Evaluator &evaluator, UnresolvedMacroReference macroRef,
-           DeclContext *dc) const;
+           const Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -349,7 +349,7 @@ SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveMacroRequest,
-              ConcreteDeclRef(UnresolvedMacroReference, DeclContext *),
+              ConcreteDeclRef(UnresolvedMacroReference, const Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,
               Type(ProtocolDecl *, TypeEraserAttr *),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -445,7 +445,7 @@ void Decl::forEachAttachedMacro(MacroRole role,
 MacroDecl *Decl::getResolvedMacro(CustomAttr *customAttr) const {
   auto declRef = evaluateOrDefault(
       getASTContext().evaluator,
-      ResolveMacroRequest{customAttr, getDeclContext()},
+      ResolveMacroRequest{customAttr, this},
       ConcreteDeclRef());
 
   return dyn_cast_or_null<MacroDecl>(declRef.getDecl());

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1792,3 +1792,156 @@ bool swift::operator==(MacroRoles lhs, MacroRoles rhs) {
 llvm::hash_code swift::hash_value(MacroRoles roles) {
   return roles.toRaw();
 }
+
+static bool isAttachedSyntax(const UnresolvedMacroReference &ref) {
+  return ref.getAttr() != nullptr;
+}
+
+void ResolveMacroRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  const auto &storage = getStorage();
+  auto macroRef = std::get<0>(storage);
+  diags.diagnose(macroRef.getSigilLoc(), diag::macro_resolve_circular_reference,
+                 isAttachedSyntax(macroRef),
+                 macroRef.getMacroName().getFullName());
+}
+
+void ResolveMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  const auto &storage = getStorage();
+  auto macroRef = std::get<0>(storage);
+  diags.diagnose(macroRef.getSigilLoc(),
+                 diag::macro_resolve_circular_reference_through,
+                 isAttachedSyntax(macroRef),
+                 macroRef.getMacroName().getFullName());
+}
+
+void ExpandMacroExpansionDeclRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  diags.diagnose(decl->getPoundLoc(),
+                 diag::macro_expand_circular_reference,
+                 "freestanding",
+                 decl->getMacroName().getFullName());
+}
+
+void ExpandMacroExpansionDeclRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  diags.diagnose(decl->getPoundLoc(),
+                 diag::macro_expand_circular_reference_through,
+                 "freestanding",
+                 decl->getMacroName().getFullName());
+}
+
+void ExpandAccessorMacros::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  diags.diagnose(decl->getLoc(),
+                 diag::macro_expand_circular_reference_entity,
+                 "accessor",
+                 decl->getName());
+}
+
+void ExpandAccessorMacros::noteCycleStep(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  diags.diagnose(decl->getLoc(),
+                 diag::macro_expand_circular_reference_entity_through,
+                 "accessor",
+                 decl->getName());
+}
+
+void ExpandConformanceMacros::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  diags.diagnose(decl->getLoc(),
+                 diag::macro_expand_circular_reference_entity,
+                 "conformance",
+                 decl->getName());
+}
+
+void ExpandConformanceMacros::noteCycleStep(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  diags.diagnose(decl->getLoc(),
+                 diag::macro_expand_circular_reference_entity_through,
+                 "conformance",
+                 decl->getName());
+}
+
+void ExpandMemberAttributeMacros::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_entity,
+                   "member attribute",
+                   value->getName());
+  } else {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_unnamed,
+                   "member attribute");
+  }
+}
+
+void ExpandMemberAttributeMacros::noteCycleStep(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_entity_through,
+                   "member attribute",
+                   value->getName());
+  } else {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_unnamed_through,
+                   "member attribute");
+  }
+}
+
+void ExpandSynthesizedMemberMacroRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_entity,
+                   "member",
+                   value->getName());
+  } else {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_unnamed,
+                   "member");
+  }
+}
+
+void ExpandSynthesizedMemberMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_entity_through,
+                   "member",
+                   value->getName());
+  } else {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_unnamed_through,
+                   "member");
+  }
+}
+
+void ExpandPeerMacroRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_entity,
+                   "peer",
+                   value->getName());
+  } else {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_unnamed,
+                   "peer");
+  }
+}
+
+void ExpandPeerMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  auto decl = std::get<0>(getStorage());
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_entity_through,
+                   "peer",
+                   value->getName());
+  } else {
+    diags.diagnose(decl->getLoc(),
+                   diag::macro_expand_circular_reference_unnamed_through,
+                   "peer");
+  }
+}

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3796,7 +3796,7 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
 
   // Resolve macro candidates.
   auto macro = evaluateOrDefault(
-      ctx.evaluator, ResolveMacroRequest{MED, dc},
+      ctx.evaluator, ResolveMacroRequest{MED, MED},
       ConcreteDeclRef());
   if (!macro)
     return None;

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1491,7 +1491,9 @@ swift::expandConformances(CustomAttr *attr, MacroDecl *macro,
 ConcreteDeclRef
 ResolveMacroRequest::evaluate(Evaluator &evaluator,
                               UnresolvedMacroReference macroRef,
-                              DeclContext *dc) const {
+                              const Decl *decl) const {
+  auto dc = decl->getDeclContext();
+
   // Macro expressions and declarations have their own stored macro
   // reference. Use it if it's there.
   if (auto *expr = macroRef.getExpr()) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -474,7 +474,7 @@ ArrayRef<unsigned> ExpandMemberAttributeMacros::evaluate(Evaluator &evaluator,
     return { };
 
   auto *parentDecl = decl->getDeclContext()->getAsDecl();
-  if (!parentDecl)
+  if (!parentDecl || !isa<IterableDeclContext>(parentDecl))
     return { };
 
   if (isa<PatternBindingDecl>(decl))

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -145,9 +145,8 @@ struct S2 {
   }
 
   #if TEST_DIAGNOSTICS
-  // FIXME: Causes reference cycles
-  // should have error {{cannot find 'nonexistent' in scope}}
-  // @addCompletionHandlerArbitrarily(nonexistent)
+  // expected-error@+1 {{cannot find 'nonexistent' in scope}}
+  @addCompletionHandlerArbitrarily(nonexistent)
   func h(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }


### PR DESCRIPTION
* Explanation: Introduce improved cycle-breaking logic for member-attribute macros, by avoiding request key conflicts in `ResolveMacroRequest` and minimizing dependencies for `ExpandMemberAttributeMacrosRequest` for cases that can never perform any expansion here.
* Scope: Narrow; makes dependencies more fine-grained for member-attribute macros, allowing us to reinstate a test case just disabled by https://github.com/apple/swift/pull/65394.
* Risk: Low, narrowly applied to macros.
* Original pull request: https://github.com/apple/swift/pull/65410
