### PR TITLE
[Concurrency] Handle missing Job type in old SDKs in tryDiagnoseExecutor

### DIFF
--- a/test/Concurrency/Runtime/custom_executors_tryDiagnoseExecutorConformance_with_sdk_missing_job_type.swift
+++ b/test/Concurrency/Runtime/custom_executors_tryDiagnoseExecutorConformance_with_sdk_missing_job_type.swift
@@ -19,5 +19,5 @@ import _Concurrency
 // This is a regression test for that situation
 
 final class FakeExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'FakeExecutor' to 'Executor' by implementing 'func enqueue(Job)' instead}}
+  func enqueue(_ job: UnownedJob) {}
 }

--- a/test/Concurrency/Runtime/custom_executors_tryDiagnoseExecutorConformance_with_sdk_missing_job_type.swift
+++ b/test/Concurrency/Runtime/custom_executors_tryDiagnoseExecutorConformance_with_sdk_missing_job_type.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-concurrency-without-job) -typecheck -parse-as-library %s -verify
+
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://106849189 move-only types should be supported in freestanding mode
+// UNSUPPORTED: freestanding
+
+// UNSUPPORTED: back_deployment_runtime
+// REQUIRES: concurrency_runtime
+
+import _Concurrency
+
+// NOTE: This test simulates what happens when we have an SDK with some missing concurrency types.
+// Specifically, we're missing the ExecutorJob and Job declarations.
+// This simulates a pre-Swift-5.9 SDK being used with a Swift 5.9+ compiler,
+// which would have failed previously due to missing handling of missing types.
+//
+// This is a regression test for that situation
+
+final class FakeExecutor: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {} // expected-warning{{Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'FakeExecutor' to 'Executor' by implementing 'func enqueue(Job)' instead}}
+}

--- a/test/Inputs/clang-importer-sdk/swift-modules-concurrency-without-job/_Concurrency.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-concurrency-without-job/_Concurrency.swift
@@ -1,0 +1,10 @@
+
+// This simulates a pre-Swift5.9 concurrency library with `Job` and `ExecutorJob` not being defined at all.
+// This is used to verify missing type handling in the SDK when a latest compiler is used.
+
+public struct UnownedJob {}
+
+public protocol SerialExecutor {
+  // pretend to be a broken, empty serial executor
+  func enqueue(_ job: UnownedJob)
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -611,6 +611,20 @@ config.substitutions.append(('%build-clang-importer-objc-overlays',
                              '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreFoundation.swift && '
                              '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift'))
 
+
+# FIXME: BEGIN -enable-source-import hackaround
+config.substitutions.append(('%clang-importer-sdk-concurrency-without-job-path',
+                             '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+
+config.substitutions.append(('%clang-importer-sdk-concurrency-without-job-nosource',
+                             '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+# FIXME: END -enable-source-import hackaround
+
+config.substitutions.append(('%clang-importer-sdk-concurrency-without-job',
+                             '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                                                       make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules-concurrency-without-job'))))
+
+
 # FIXME: BEGIN -enable-source-import hackaround
 config.substitutions.append(('%clang-importer-sdk-path',
                              '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))


### PR DESCRIPTION
This replaces, or complements, https://github.com/apple/swift/pull/65406 with adding a test that would have triggered the issue -- an SDK that is missing Job and ExecutorJob declarations.

Resolves rdar://108458906