### PR TITLE
SIL: Bridge 'any Sendable' via the id-as-Any path [5.9]

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -601,6 +601,9 @@ public:
   /// Is this the 'Any' type?
   bool isAny();
 
+  /// Is this an existential containing only marker protocols?
+  bool isMarkerExistential();
+
   bool isPlaceholder();
 
   /// Returns true if this is a move-only type.

--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -172,8 +172,9 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
     }
   }
   
-  // `Any` can bridge to `AnyObject` (`id` in ObjC).
-  if (t->isAny())
+  // Existentials consisting of only marker protocols can bridge to
+  // `AnyObject` (`id` in ObjC).
+  if (t->isMarkerExistential())
     return Context.getAnyObjectType();
   
   if (auto funTy = t->getAs<FunctionType>()) {

--- a/test/SILGen/Inputs/objc_bridging_sendable.h
+++ b/test/SILGen/Inputs/objc_bridging_sendable.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface NSBlah: NSObject
+- (void) takeSendable: (id __attribute__((swift_attr("@Sendable")))) x;
+@end

--- a/test/SILGen/objc_bridging_sendable.swift
+++ b/test/SILGen/objc_bridging_sendable.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_bridging_sendable.h %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: sil [ossa] @$s22objc_bridging_sendable18passSendableToObjCyys0E0_pF : $@convention(thin) (@in_guaranteed any Sendable) -> () {
+// CHECK:  function_ref @$ss27_bridgeAnythingToObjectiveCyyXlxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+// CHECK: objc_method {{%.*}} : $NSBlah, #NSBlah.takeSendable!foreign : (NSBlah) -> ((any Sendable)?) -> (), $@convention(objc_method) (Optional<AnyObject>, NSBlah) -> ()
+// CHECK: return
+public func passSendableToObjC(_ s: Sendable) {
+  NSBlah().takeSendable(s)
+}


### PR DESCRIPTION
* Description: We introduced a new Clang attribute to bridge Objective-C parameter and return types as 'Sendable', but this wasn't plumbed through, so calling such a method from Swift would pass the address of the Swift existential as `id`, causing a crash on the Objective-C side. This patch handles this case via the "id as Any" code path, performing the correct bridging.
* Risk: Low; this generalizes the "isAny()" check in two places to also allow existentials containing only marker protocols.
* Reviewed by: @DougGregor 
* Radar: Fixes rdar://problem/107264240.