### PR TITLE
[Dependency Scanning] Consider scanned module name a part of the scanning context (hash)

### DIFF
--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -96,16 +96,16 @@ public:
   /// Discared the collection of diagnostics encountered so far.
   void resetDiagnostics();
 
+  /// Using the specified invocation command, instantiate a CompilerInstance
+  /// that will be used for this scan.
+  llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
+  initCompilerInstanceForScan(ArrayRef<const char *> Command);
+
 private:
   /// Using the specified invocation command, initialize the scanner instance
   /// for this scan. Returns the `CompilerInstance` that will be used.
   llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
   initScannerForAction(ArrayRef<const char *> Command);
-
-  /// Using the specified invocation command, instantiate a CompilerInstance
-  /// that will be used for this scan.
-  llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
-  initCompilerInstanceForScan(ArrayRef<const char *> Command);
 
   /// Shared cache of module dependencies, re-used by individual full-scan queries
   /// during the lifetime of this Tool.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -454,7 +454,12 @@ public:
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Dependency Scanning hash.
   llvm::hash_code getModuleScanningHashComponents() const {
-    return llvm::hash_value(0);
+    return hash_combine(ModuleName,
+                        ModuleABIName,
+                        ModuleLinkName,
+                        ImplicitObjCHeaderPath,
+                        PrebuiltModuleCachePath,
+                        UserModuleVersion);
   }
 
   StringRef determineFallbackModuleName() const;


### PR DESCRIPTION
As well as a couple of additional frontend options that seem like they may impact scanning result.

Part of rdar://108464467