### PR TITLE
[5.9 🍒][Dependency Scanning] Consider scanned module name a part of the scanning context (hash)

### DIFF
--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -96,16 +96,16 @@ public:
   /// Discared the collection of diagnostics encountered so far.
   void resetDiagnostics();
 
+  /// Using the specified invocation command, instantiate a CompilerInstance
+  /// that will be used for this scan.
+  llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
+  initCompilerInstanceForScan(ArrayRef<const char *> Command);
+
 private:
   /// Using the specified invocation command, initialize the scanner instance
   /// for this scan. Returns the `CompilerInstance` that will be used.
   llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
   initScannerForAction(ArrayRef<const char *> Command);
-
-  /// Using the specified invocation command, instantiate a CompilerInstance
-  /// that will be used for this scan.
-  llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
-  initCompilerInstanceForScan(ArrayRef<const char *> Command);
 
   /// Shared cache of module dependencies, re-used by individual full-scan queries
   /// during the lifetime of this Tool.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -445,7 +445,12 @@ public:
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Dependency Scanning hash.
   llvm::hash_code getModuleScanningHashComponents() const {
-    return llvm::hash_value(0);
+    return hash_combine(ModuleName,
+                        ModuleABIName,
+                        ModuleLinkName,
+                        ImplicitObjCHeaderPath,
+                        PrebuiltModuleCachePath,
+                        UserModuleVersion);
   }
 
   StringRef determineFallbackModuleName() const;


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65415
----------------------------------------------------------------------------------
As well as a couple of additional frontend options that seem like they may impact scanning result.

• Release: Swift 5.9
• Explanation: To have these options missing from the dependency scanning context hash means that clients that may be running multiple concurrent scans on targets/modules that have identical command-lines other than the module name would encounter concurrency issues due to not isolating their respective scans' state.
• Scope of Issue: Scanner crashes when scanning multiple source modules simultaneously where the scanner invocations only differ in module name.
• Origination: Synchronization of concurrent scans was recently moved to the scanner itself, from the client (SwiftDriver).
• Risk: Zero risk to implicit module builds, minimal risk to explicit module builds - this change is more restrictive than we were before and will result in more distinct scanning contexts
• Automated Testing: Added unit test that verifies scanning hash difference for relevant use-cases

Resolves rdar://108464467
