### PR TITLE
[5.9][Rename] Also syntactically rename a macro’s definition

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -591,6 +591,10 @@ public:
   /// TODO: Consider changing this to false by default.
   virtual bool shouldWalkSerializedTopLevelInternalDecls() { return true; }
 
+  /// Whether to walk into the definition of a \c MacroDecl if it hasn't been
+  /// type-checked yet.
+  virtual bool shouldWalkIntoUncheckedMacroDefinitions() { return false; }
+
   /// walkToParameterListPre - This method is called when first visiting a
   /// ParameterList, before walking into its parameters.
   ///

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -379,6 +379,7 @@ class NameMatcher: public ASTWalker {
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override;
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override;
   bool shouldWalkIntoGenericParams() override { return true; }
+  bool shouldWalkIntoUncheckedMacroDefinitions() override { return true; }
 
   PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *ArgList) override;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -425,7 +425,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (auto def = MD->definition) {
       // Don't walk into unchecked definitions.
       if (auto expansion = dyn_cast<MacroExpansionExpr>(def)) {
-        if (!expansion->getType().isNull()) {
+        if (!expansion->getType().isNull() ||
+            Walker.shouldWalkIntoUncheckedMacroDefinitions()) {
           if (auto newDef = doIt(def))
             MD->definition = newDef;
           else

--- a/test/refactoring/SyntacticRename/macro-definition.swift
+++ b/test/refactoring/SyntacticRename/macro-definition.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "StringifyMacro" | %FileCheck %s
+
+// CHECK: struct /*test:def*/<base>StringifyMacro</base> {}
+// CHECK: @freestanding(expression)
+// CHECK: macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacroMacros", type: "/*test:ref*/<base>StringifyMacro</base>")
+
+struct /*test:def*/StringifyMacro {}
+
+@freestanding(expression)
+macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacroMacros", type: "/*test:ref*/StringifyMacro")


### PR DESCRIPTION
* **Explanation**: Previously we were skipping the macro’s definition (i.e. the part after `=` in a macro declaration if it wasn’t type checked. Since syntactic rename doesn’t type-check anything, it was thus skipping the macro definition. Add a flag to `ASTWalker` that allows `NameMatcher` to opt-out of this behavior.
* **Scope**: SourceKit, in particular syntactic rename
* **Risk**: Low, only changes behavior for syntactic rename
* **Testing**: Added regression test
* **Issue**: rdar://108391854
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/65399

