### PR TITLE
[Sanitizers] Remove obsolete LIT substitution

### DIFF
--- a/test/Interpreter/indirect_enum.swift
+++ b/test/Interpreter/indirect_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -o %t_asan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env ASAN_OPTIONS=detect_leaks=0 %target-run %t_asan-binary
 

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -o %t_asan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
 // RUN: %target-codesign %t_asan-binary
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0 not %target-run %t_asan-binary 2>&1 | %FileCheck %s
 
 // ODR Indicator variant
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address \
+// RUN: %target-swiftc_driver %s -g -sanitize=address \
 // RUN:   -sanitize-address-use-odr-indicator -o %t_asan-binary-odr-indicator
 // RUN: %target-codesign %t_asan-binary-odr-indicator
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0 not %target-run \

--- a/test/Sanitizers/asan/recover.swift
+++ b/test/Sanitizers/asan/recover.swift
@@ -3,9 +3,9 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // Check with recovery instrumentation and the runtime option to continue execution.
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -sanitize-recover=address -import-objc-header %S/asan_interface.h -emit-ir -o %t.asan_recover.ll
+// RUN: %target-swiftc_driver %s -g -sanitize=address -sanitize-recover=address -import-objc-header %S/asan_interface.h -emit-ir -o %t.asan_recover.ll
 // RUN: %FileCheck -check-prefix=CHECK-IR -input-file=%t.asan_recover.ll %s
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -sanitize-recover=address -import-objc-header %S/asan_interface.h -o %t_asan_recover
+// RUN: %target-swiftc_driver %s -g -sanitize=address -sanitize-recover=address -import-objc-header %S/asan_interface.h -o %t_asan_recover
 // RUN: %target-codesign %t_asan_recover
 // RUN: env %env-ASAN_OPTIONS=halt_on_error=0 %target-run %t_asan_recover > %t_asan_recover.stdout 2> %t_asan_recover.stderr
 // RUN: %FileCheck --check-prefixes=CHECK-COMMON-STDERR,CHECK-RECOVER-STDERR -input-file=%t_asan_recover.stderr %s
@@ -17,7 +17,7 @@
 // RUN: %FileCheck --check-prefixes=CHECK-COMMON-STDOUT,CHECK-NO-RECOVER-STDOUT -input-file=%t_asan_no_runtime_recover.stdout %s
 
 // Check that without recovery instrumentation and runtime option to continue execution that error recovery does not happen.
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -import-objc-header %S/asan_interface.h -o %t_asan_no_recover
+// RUN: %target-swiftc_driver %s -g -sanitize=address -import-objc-header %S/asan_interface.h -o %t_asan_no_recover
 // RUN: %target-codesign %t_asan_no_recover
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0,halt_on_error=0 not %target-run %t_asan_no_recover > %t_asan_no_recover.stdout 2> %t_asan_no_recover.stderr
 // RUN: %FileCheck --check-prefixes=CHECK-COMMON-STDERR -input-file=%t_asan_no_recover.stderr %s

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -sanitize=address -sanitize-coverage=edge -target %sanitizers-target-triple %s -o %t_binary
+// RUN: %target-build-swift -sanitize=address -sanitize-coverage=edge %s -o %t_binary
 // RUN: %empty-directory(%t_coverage_dir)
 // RUN: %env-ASAN_OPTIONS=abort_on_error=0,coverage=1,coverage_dir=%t_coverage_dir %target-run %t_binary
 // check the coverage file exists

--- a/test/Sanitizers/scudo.swift
+++ b/test/Sanitizers/scudo.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=scudo -o %t_scudo-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=scudo -o %t_scudo-binary
 // RUN: not %target-run %t_scudo-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu

--- a/test/Sanitizers/symbolication-linux.swift
+++ b/test/Sanitizers/symbolication-linux.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s -sanitize=address -g -target %sanitizers-target-triple -o %t
+// RUN: %target-build-swift %s -sanitize=address -g -o %t
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0                           not %target-run %t 2>&1 | %swift-demangle | %FileCheck %s -check-prefix=OOP
 // In-process symbolication doesn't work on Linux (yet)
 // XXX: env %env-ASAN_OPTIONS=abort_on_error=0,external_symbolizer_path= not %target-run %t 2>&1 | %swift-demangle | %FileCheck %s -check-prefix=IP

--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s -sanitize=address -g -target %sanitizers-target-triple -o %t
+// RUN: %target-build-swift %s -sanitize=address -g -o %t
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0                           not %target-run %t 2>&1 | %FileCheck %s -check-prefix=OOP
 // RUN: env %env-ASAN_OPTIONS=abort_on_error=0,external_symbolizer_path= not %target-run %t 2>&1 | %FileCheck %s -check-prefix=IP
 // REQUIRES: executable_test

--- a/test/Sanitizers/tsan/emptyarraystorage.swift
+++ b/test/Sanitizers/tsan/emptyarraystorage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
 // RUN: %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test

--- a/test/Sanitizers/tsan/norace-block-release.swift
+++ b/test/Sanitizers/tsan/norace-block-release.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -target %sanitizers-target-triple -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
 // RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test

--- a/test/Sanitizers/tsan/norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan/norace-deinit-run-time.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -target %sanitizers-target-triple -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
 // RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --dump-input=fail --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s  -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
+// RUN: %target-swiftc_driver %s  -parse-as-library %import-libdispatch -g -sanitize=thread -o %t
 // RUN: %target-codesign %t
 // RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %swift-demangle --simplified | %FileCheck %s
 

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -Xfrontend -disable-availability-checking -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
+// RUN: %target-swiftc_driver %s -Xfrontend -disable-availability-checking -parse-as-library %import-libdispatch -g -sanitize=thread -o %t
 // RUN: %target-codesign %t
 // RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %swift-demangle --simplified | %FileCheck %s
 

--- a/test/Sanitizers/tsan/tsan.swift
+++ b/test/Sanitizers/tsan/tsan.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread %import-libdispatch -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
 // RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -883,15 +883,6 @@ config.substitutions.append(('%target-next-stable-abi-triple',
 config.substitutions.append(('%target-future-triple',
                              config.future_triple))
 
-# Sanitizers are not supported on iOS7, yet all tests are configured to start
-# testing with the earliest supported platform, which happens to be iOS7 for
-# Swift.
-# Setting target manually makes tests less versatile (a separate test is
-# then required for each OS), thus instead we define a new environment
-# variable which enforces the usage of iOS8+ when iOS is used.
-config.substitutions.append(('%sanitizers-target-triple',
-    config.variant_triple.replace("ios7", "ios8")))
-
 config.substitutions.append(('%target-cpu', run_cpu))
 
 target_os_abi = run_os

--- a/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
+++ b/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -target %sanitizers-target-triple -sanitize=thread %s -o %t_binary
+// RUN: %target-build-swift -sanitize=thread %s -o %t_binary
 // RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/Sanitizers/tsan-inout.swift
+++ b/validation-test/Sanitizers/tsan-inout.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cd %t
-// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -target %sanitizers-target-triple -module-name TSanUninstrumented -emit-module -emit-module-path %t/TSanUninstrumented.swiftmodule -parse-as-library
-// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -target %sanitizers-target-triple -c -module-name TSanUninstrumented -parse-as-library -o %t/TSanUninstrumented.o
-// RUN: %target-swiftc_driver %s %t/TSanUninstrumented.o -target %sanitizers-target-triple -I%t -L%t -g -sanitize=thread %import-libdispatch -o %t/tsan-binary
+// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -module-name TSanUninstrumented -emit-module -emit-module-path %t/TSanUninstrumented.swiftmodule -parse-as-library
+// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -c -module-name TSanUninstrumented -parse-as-library -o %t/TSanUninstrumented.o
+// RUN: %target-swiftc_driver %s %t/TSanUninstrumented.o -I%t -L%t -g -sanitize=thread %import-libdispatch -o %t/tsan-binary
 // RUN: not env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t/tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/Sanitizers/tsan-type-metadata.swift
+++ b/validation-test/Sanitizers/tsan-type-metadata.swift
@@ -1,5 +1,5 @@
 // REQUIRES: rdar64809726
-// RUN: %target-swiftc_driver -target %sanitizers-target-triple -sanitize=thread %import-libdispatch %s -o %t_binary
+// RUN: %target-swiftc_driver -sanitize=thread %import-libdispatch %s -o %t_binary
 // RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/Sanitizers/witness_table_lookup.swift
+++ b/validation-test/Sanitizers/witness_table_lookup.swift
@@ -1,5 +1,5 @@
 // REQUIRES: rdar64809726
-// RUN: %target-build-swift -sanitize=thread %import-libdispatch -target %sanitizers-target-triple %s -o %t_binary
+// RUN: %target-build-swift -sanitize=thread %import-libdispatch %s -o %t_binary
 // RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test


### PR DESCRIPTION
The purpose of this LIT substitution was to ensure we compile test binaries for iOS with an deployment target of >= iOS 8.