### PR TITLE
[5.9][Macros] Track plugin dependencies 

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -80,6 +80,7 @@ namespace swift {
   class ExtensionDecl;
   struct ExternalSourceLocs;
   class LoadedExecutablePlugin;
+  class LoadedLibraryPlugin;
   class ForeignRepresentationInfo;
   class FuncDecl;
   class GenericContext;
@@ -1487,7 +1488,7 @@ public:
   /// returns a nullptr.
   /// NOTE: This method is idempotent. If the plugin is already loaded, the same
   /// instance is simply returned.
-  void *loadLibraryPlugin(StringRef path);
+  LoadedLibraryPlugin *loadLibraryPlugin(StringRef path);
 
   /// Lookup an executable plugin that is declared to handle \p moduleName
   /// module by '-load-plugin-executable'.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -93,7 +93,7 @@ namespace swift {
   class ModuleDependencyInfo;
   class PatternBindingDecl;
   class PatternBindingInitializer;
-  class PluginRegistry;
+  class PluginLoader;
   class SourceFile;
   class SourceLoc;
   class Type;
@@ -1477,6 +1477,12 @@ public:
 
   Type getNamedSwiftType(ModuleDecl *module, StringRef name);
 
+  /// Set the plugin loader.
+  void setPluginLoader(std::unique_ptr<PluginLoader> loader);
+
+  /// Get the plugin loader.
+  PluginLoader &getPluginLoader();
+
   /// Lookup a library plugin that can handle \p moduleName and return the path
   /// to it.
   /// The path is valid within the VFS, use `FS.getRealPath()` for the
@@ -1510,15 +1516,6 @@ public:
   /// instance is simply returned.
   LoadedExecutablePlugin *loadExecutablePlugin(StringRef path);
 
-  /// Get the plugin registry this ASTContext is using.
-  PluginRegistry *getPluginRegistry() const;
-
-  /// Set the plugin registory this ASTContext should use.
-  /// This should be called before any plugin is loaded.
-  void setPluginRegistry(PluginRegistry *newValue);
-
-  const llvm::StringSet<> &getLoadedPluginLibraryPaths() const;
-
 private:
   friend Decl;
 
@@ -1530,8 +1527,6 @@ private:
 
   Optional<StringRef> getBriefComment(const Decl *D);
   void setBriefComment(const Decl *D, StringRef Comment);
-
-  void createModuleToExecutablePluginMap();
 
   friend TypeBase;
   friend ArchetypeType;

--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -1,0 +1,91 @@
+//===--- PluginLoader.h -----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_AST_PLUGIN_LOADER_H
+#define SWIFT_AST_PLUGIN_LOADER_H
+
+#include "swift/AST/ModuleLoader.h"
+#include "swift/AST/PluginRegistry.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+
+class ASTContext;
+
+/// Compiler plugin loader tied to an ASTContext. This is responsible for:
+///  * Find plugins based on the module name
+///  * Load plugins resolving VFS paths
+///  * Track plugin dependencies
+class PluginLoader {
+  /// Plugin registry. Lazily populated by get/setRegistry().
+  /// NOTE: Do not reference this directly. Use getRegistry().
+  PluginRegistry *Registry = nullptr;
+
+  /// `Registry` storage if this owns it.
+  std::unique_ptr<PluginRegistry> OwnedRegistry = nullptr;
+
+  ASTContext &Ctx;
+  DependencyTracker *DepTracker;
+
+  /// Map a module name to an executable plugin path that provides the module.
+  llvm::DenseMap<swift::Identifier, llvm::StringRef> ExecutablePluginPaths;
+
+  void createModuleToExecutablePluginMap();
+
+public:
+  PluginLoader(ASTContext &Ctx, DependencyTracker *DepTracker)
+      : Ctx(Ctx), DepTracker(DepTracker) {
+    createModuleToExecutablePluginMap();
+  }
+
+  void setRegistry(PluginRegistry *newValue);
+  PluginRegistry *getRegistry();
+
+  /// Lookup a library plugin that can handle \p moduleName and return the path
+  /// to it from `-plugin-path` or `-load-plugin-library`.
+  /// The path returned can be loaded by 'loadLibraryPlugin' method.
+  llvm::Optional<std::string>
+  lookupLibraryPluginByModuleName(Identifier moduleName);
+
+  /// Lookup an executable plugin that is declared to handle \p moduleName
+  /// module by '-load-plugin-executable'.
+  /// The path returned can be loaded by 'loadExecutablePlugin' method.
+  llvm::Optional<StringRef>
+  lookupExecutablePluginByModuleName(Identifier moduleName);
+
+  /// Look for dynamic libraries in paths from `-external-plugin-path` and
+  /// return a pair of `(library path, plugin server executable)` if found.
+  /// These paths are valid within the VFS, use `FS.getRealPath()` for their
+  /// underlying path.
+  llvm::Optional<std::pair<std::string, std::string>>
+  lookupExternalLibraryPluginByModuleName(Identifier moduleName);
+
+  /// Load the specified dylib plugin path resolving the path with the
+  /// current VFS. If it fails to load the plugin, a diagnostic is emitted, and
+  /// returns a nullptr.
+  /// NOTE: This method is idempotent. If the plugin is already loaded, the same
+  /// instance is simply returned.
+  LoadedLibraryPlugin *loadLibraryPlugin(llvm::StringRef path);
+
+  /// Launch the specified executable plugin path resolving the path with the
+  /// current VFS. If it fails to load the plugin, a diagnostic is emitted, and
+  /// returns a nullptr.
+  /// NOTE: This method is idempotent. If the plugin is already loaded, the same
+  /// instance is simply returned.
+  LoadedExecutablePlugin *loadExecutablePlugin(llvm::StringRef path);
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_PLUGIN_LOADER_H

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -22,6 +22,21 @@
 
 namespace swift {
 
+/// Represent a 'dlopen'ed plugin library.
+class LoadedLibraryPlugin {
+  // Opaque handle used to interface with OS-specific dynamic library.
+  void *handle;
+
+  /// Cache of loaded symbols.
+  llvm::StringMap<void *> resolvedSymbols;
+
+public:
+  LoadedLibraryPlugin(void *handle) : handle(handle) {}
+
+  /// Finds the address of the given symbol within the library.
+  void *getAddressOfSymbol(const char *symbolName);
+};
+
 /// Represent a "resolved" exectuable plugin.
 ///
 /// Plugin clients usually deal with this object to communicate with the actual
@@ -130,7 +145,7 @@ public:
 
 class PluginRegistry {
   /// Record of loaded plugin library modules.
-  llvm::StringMap<void *> LoadedPluginLibraries;
+  llvm::StringMap<std::unique_ptr<LoadedLibraryPlugin>> LoadedPluginLibraries;
 
   /// Record of loaded plugin executables.
   llvm::StringMap<std::unique_ptr<LoadedExecutablePlugin>>
@@ -146,7 +161,7 @@ public:
 
   /// Load a dynamic link library specified by \p path.
   /// If \p path plugin is already loaded, this returns the cached object.
-  llvm::Expected<void *> loadLibraryPlugin(llvm::StringRef path);
+  llvm::Expected<LoadedLibraryPlugin *> loadLibraryPlugin(llvm::StringRef path);
 
   /// Load an executable plugin specified by \p path .
   /// If \p path plugin is already loaded, this returns the cached object.

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -9,6 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+#ifndef SWIFT_PLUGIN_REGISTRY_H
+#define SWIFT_PLUGIN_REGISTRY_H
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
@@ -170,3 +172,5 @@ public:
 };
 
 } // namespace swift
+
+#endif // SWIFT_PLUGIN_REGISTRY_H

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -26,6 +26,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PluginRegistry.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/AST/SourceFile.h"
@@ -49,8 +50,6 @@ struct ExternalMacroDefinition;
 class ClosureExpr;
 class GenericParamList;
 class LabeledStmt;
-class LoadedExecutablePlugin;
-class LoadedLibraryPlugin;
 class MacroDefinition;
 class PrecedenceGroupDecl;
 class PropertyWrapperInitializerInfo;
@@ -4018,41 +4017,20 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
-/// Load a plugin module with the given name.
-///
-///
+/// Represent a loaded plugin either an in-process library or an executable.
 class LoadedCompilerPlugin {
-  enum class PluginKind : uint8_t {
-    None,
-    InProcess,
-    Executable,
-  };
-  PluginKind kind;
-  void *ptr;
-
-  LoadedCompilerPlugin(PluginKind kind, void *ptr) : kind(kind), ptr(ptr) {
-    assert(ptr != nullptr || kind == PluginKind::None);
-  }
+  llvm::PointerUnion<LoadedLibraryPlugin *, LoadedExecutablePlugin *> ptr;
 
 public:
-  LoadedCompilerPlugin(std::nullptr_t) : kind(PluginKind::None), ptr(nullptr) {}
+  LoadedCompilerPlugin(std::nullptr_t) : ptr(nullptr) {}
+  LoadedCompilerPlugin(LoadedLibraryPlugin *ptr) : ptr(ptr){};
+  LoadedCompilerPlugin(LoadedExecutablePlugin *ptr) : ptr(ptr){};
 
-  static LoadedCompilerPlugin inProcess(LoadedLibraryPlugin *ptr) {
-    return {PluginKind::InProcess, ptr};
-  }
-  static LoadedCompilerPlugin executable(LoadedExecutablePlugin *ptr) {
-    return {PluginKind::Executable, ptr};
-  }
-
-  LoadedLibraryPlugin *getAsInProcessPlugin() const {
-    return kind == PluginKind::InProcess
-               ? static_cast<LoadedLibraryPlugin *>(ptr)
-               : nullptr;
+  LoadedLibraryPlugin *getAsLibraryPlugin() const {
+    return ptr.dyn_cast<LoadedLibraryPlugin *>();
   }
   LoadedExecutablePlugin *getAsExecutablePlugin() const {
-    return kind == PluginKind::Executable
-               ? static_cast<LoadedExecutablePlugin *>(ptr)
-               : nullptr;
+    return ptr.dyn_cast<LoadedExecutablePlugin *>();
   }
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -50,6 +50,7 @@ class ClosureExpr;
 class GenericParamList;
 class LabeledStmt;
 class LoadedExecutablePlugin;
+class LoadedLibraryPlugin;
 class MacroDefinition;
 class PrecedenceGroupDecl;
 class PropertyWrapperInitializerInfo;
@@ -4036,15 +4037,17 @@ class LoadedCompilerPlugin {
 public:
   LoadedCompilerPlugin(std::nullptr_t) : kind(PluginKind::None), ptr(nullptr) {}
 
-  static LoadedCompilerPlugin inProcess(void *ptr) {
+  static LoadedCompilerPlugin inProcess(LoadedLibraryPlugin *ptr) {
     return {PluginKind::InProcess, ptr};
   }
   static LoadedCompilerPlugin executable(LoadedExecutablePlugin *ptr) {
     return {PluginKind::Executable, ptr};
   }
 
-  void *getAsInProcessPlugin() const {
-    return kind == PluginKind::InProcess ? ptr : nullptr;
+  LoadedLibraryPlugin *getAsInProcessPlugin() const {
+    return kind == PluginKind::InProcess
+               ? static_cast<LoadedLibraryPlugin *>(ptr)
+               : nullptr;
   }
   LoadedExecutablePlugin *getAsExecutablePlugin() const {
     return kind == PluginKind::Executable

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -625,6 +625,7 @@ private:
   void setUpLLVMArguments();
   void setUpDiagnosticOptions();
   bool setUpModuleLoaders();
+  bool setUpPluginLoader();
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6403,7 +6403,7 @@ LoadedExecutablePlugin *ASTContext::loadExecutablePlugin(StringRef path) {
   return plugin.get();
 }
 
-void *ASTContext::loadLibraryPlugin(StringRef path) {
+LoadedLibraryPlugin *ASTContext::loadLibraryPlugin(StringRef path) {
   // Remember the path (even if it fails to load.)
   getImpl().LoadedPluginLibraryPaths.insert(path);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -41,7 +41,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PackConformance.h"
 #include "swift/AST/ParameterList.h"
-#include "swift/AST/PluginRegistry.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -67,7 +67,6 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
-#include "llvm/Config/config.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
@@ -524,17 +523,8 @@ struct ASTContext::Implementation {
 
   llvm::StringMap<OptionSet<SearchPathKind>> SearchPathsSet;
 
-  /// Plugin registry. Lazily populated by get/setPluginRegistry().
-  /// NOTE: Do not reference this directly. Use ASTContext::getPluginRegistry().
-  PluginRegistry *Plugins = nullptr;
-
-  /// `Plugins` storage if this ASTContext owns it.
-  std::unique_ptr<PluginRegistry> OwnedPluginRegistry = nullptr;
-
-  /// Map a module name to an executable plugin path that provides the module.
-  llvm::DenseMap<Identifier, StringRef> ExecutablePluginPaths;
-
-  llvm::StringSet<> LoadedPluginLibraryPaths;
+  /// Plugin loader.
+  std::unique_ptr<swift::PluginLoader> Plugins;
 
   /// The permanent arena.
   Arena Permanent;
@@ -705,8 +695,6 @@ ASTContext::ASTContext(
   // Register any request-evaluator functions available at the AST layer.
   registerAccessRequestFunctions(evaluator);
   registerNameLookupRequestFunctions(evaluator);
-
-  createModuleToExecutablePluginMap();
 }
 
 ASTContext::~ASTContext() {
@@ -6266,34 +6254,33 @@ BuiltinTupleType *ASTContext::getBuiltinTupleType() {
   return result;
 }
 
-void ASTContext::setPluginRegistry(PluginRegistry *newValue) {
-  assert(getImpl().Plugins == nullptr &&
-         "Too late to set a new plugin registry");
-  getImpl().Plugins = newValue;
+void ASTContext::setPluginLoader(std::unique_ptr<PluginLoader> loader) {
+  getImpl().Plugins = std::move(loader);
 }
 
-PluginRegistry *ASTContext::getPluginRegistry() const {
-  PluginRegistry *&registry = getImpl().Plugins;
+PluginLoader &ASTContext::getPluginLoader() { return *getImpl().Plugins; }
 
-  // Create a new one if it hasn't been set.
-  if (!registry) {
-    registry = new PluginRegistry();
-    getImpl().OwnedPluginRegistry.reset(registry);
-  }
-
-  assert(registry != nullptr);
-  return registry;
+Optional<std::string>
+ASTContext::lookupLibraryPluginByModuleName(Identifier moduleName) {
+  return getImpl().Plugins->lookupLibraryPluginByModuleName(moduleName);
 }
 
-void ASTContext::createModuleToExecutablePluginMap() {
-  for (auto &arg : SearchPathOpts.getCompilerPluginExecutablePaths()) {
-    // Create a moduleName -> pluginPath mapping.
-    assert(!arg.ExecutablePath.empty() && "empty plugin path");
-    auto pathStr = AllocateCopy(arg.ExecutablePath);
-    for (auto moduleName : arg.ModuleNames) {
-      getImpl().ExecutablePluginPaths[getIdentifier(moduleName)] = pathStr;
-    }
-  }
+Optional<StringRef>
+ASTContext::lookupExecutablePluginByModuleName(Identifier moduleName) {
+  return getImpl().Plugins->lookupExecutablePluginByModuleName(moduleName);
+}
+
+Optional<std::pair<std::string, std::string>>
+ASTContext::lookupExternalLibraryPluginByModuleName(Identifier moduleName) {
+  return getImpl().Plugins->lookupExternalLibraryPluginByModuleName(moduleName);
+}
+
+LoadedLibraryPlugin *ASTContext::loadLibraryPlugin(StringRef path) {
+  return getImpl().Plugins->loadLibraryPlugin(path);
+}
+
+LoadedExecutablePlugin *ASTContext::loadExecutablePlugin(StringRef path) {
+  return getImpl().Plugins->loadExecutablePlugin(path);
 }
 
 Type ASTContext::getNamedSwiftType(ModuleDecl *module, StringRef name) {
@@ -6329,105 +6316,6 @@ Type ASTContext::getNamedSwiftType(ModuleDecl *module, StringRef name) {
   if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
     return nominalDecl->getDeclaredType();
   return decl->getDeclaredInterfaceType();
-}
-
-Optional<std::string>
-ASTContext::lookupLibraryPluginByModuleName(Identifier moduleName) {
-  auto fs = SourceMgr.getFileSystem();
-
-  // Look for 'lib${module name}(.dylib|.so)'.
-  SmallString<64> expectedBasename;
-  expectedBasename.append("lib");
-  expectedBasename.append(moduleName.str());
-  expectedBasename.append(LTDL_SHLIB_EXT);
-
-  // Try '-plugin-path'.
-  for (const auto &searchPath : SearchPathOpts.PluginSearchPaths) {
-    SmallString<128> fullPath(searchPath);
-    llvm::sys::path::append(fullPath, expectedBasename);
-    if (fs->exists(fullPath)) {
-      return std::string(fullPath);
-    }
-  }
-
-  // Try '-load-plugin-library'.
-  for (const auto &libPath : SearchPathOpts.getCompilerPluginLibraryPaths()) {
-    if (llvm::sys::path::filename(libPath) == expectedBasename) {
-      return libPath;
-    }
-  }
-
-  return None;
-}
-
-Optional<StringRef>
-ASTContext::lookupExecutablePluginByModuleName(Identifier moduleName) {
-  auto &execPluginPaths = getImpl().ExecutablePluginPaths;
-  auto found = execPluginPaths.find(moduleName);
-  if (found == execPluginPaths.end())
-    return None;
-  return found->second;
-}
-
-Optional<std::pair<std::string, std::string>>
-ASTContext::lookupExternalLibraryPluginByModuleName(Identifier moduleName) {
-  auto fs = this->SourceMgr.getFileSystem();
-  for (auto &pair : SearchPathOpts.ExternalPluginSearchPaths) {
-    SmallString<128> fullPath(pair.SearchPath);
-    llvm::sys::path::append(fullPath, "lib" + moduleName.str() + LTDL_SHLIB_EXT);
-
-    if (fs->exists(fullPath)) {
-      return {{std::string(fullPath), pair.ServerPath}};
-    }
-  }
-  return None;
-}
-
-LoadedExecutablePlugin *ASTContext::loadExecutablePlugin(StringRef path) {
-  SmallString<128> resolvedPath;
-  auto fs = this->SourceMgr.getFileSystem();
-  if (auto err = fs->getRealPath(path, resolvedPath)) {
-    Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
-                   err.message());
-    return nullptr;
-  }
-
-  // Load the plugin.
-  auto plugin = getPluginRegistry()->loadExecutablePlugin(resolvedPath);
-  if (!plugin) {
-    Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
-                   llvm::toString(plugin.takeError()));
-    return nullptr;
-  }
-
-  return plugin.get();
-}
-
-LoadedLibraryPlugin *ASTContext::loadLibraryPlugin(StringRef path) {
-  // Remember the path (even if it fails to load.)
-  getImpl().LoadedPluginLibraryPaths.insert(path);
-
-  SmallString<128> resolvedPath;
-  auto fs = this->SourceMgr.getFileSystem();
-  if (auto err = fs->getRealPath(path, resolvedPath)) {
-    Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
-                   err.message());
-    return nullptr;
-  }
-
-  // Load the plugin.
-  auto plugin = getPluginRegistry()->loadLibraryPlugin(resolvedPath);
-  if (!plugin) {
-    Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
-                   llvm::toString(plugin.takeError()));
-    return nullptr;
-  }
-
-  return plugin.get();
-}
-
-const llvm::StringSet<> &ASTContext::getLoadedPluginLibraryPaths() const {
-  return getImpl().LoadedPluginLibraryPaths;
 }
 
 bool ASTContext::supportsMoveOnlyTypes() const {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -72,6 +72,7 @@ add_swift_host_library(swiftAST STATIC
   Parameter.cpp
   Pattern.cpp
   PlatformKind.cpp
+  PluginLoader.cpp
   PluginRegistry.cpp
   PrettyStackTrace.cpp
   ProtocolConformance.cpp

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -1,0 +1,150 @@
+//===--- PluginLoader.cpp -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/PluginLoader.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/SourceManager.h"
+#include "llvm/Config/config.h"
+
+using namespace swift;
+
+void PluginLoader::createModuleToExecutablePluginMap() {
+  for (auto &arg : Ctx.SearchPathOpts.getCompilerPluginExecutablePaths()) {
+    // Create a moduleName -> pluginPath mapping.
+    assert(!arg.ExecutablePath.empty() && "empty plugin path");
+    StringRef pathStr = Ctx.AllocateCopy(arg.ExecutablePath);
+    for (auto moduleName : arg.ModuleNames) {
+      ExecutablePluginPaths[Ctx.getIdentifier(moduleName)] = pathStr;
+    }
+  }
+}
+
+void PluginLoader::setRegistry(PluginRegistry *newValue) {
+  assert(Registry == nullptr && "Too late to set a new plugin registry");
+  Registry = newValue;
+}
+
+PluginRegistry *PluginLoader::getRegistry() {
+  // Create a new one if it hasn't been set.
+  if (!Registry) {
+    Registry = new PluginRegistry();
+    OwnedRegistry.reset(Registry);
+  }
+
+  assert(Registry != nullptr);
+  return Registry;
+}
+
+llvm::Optional<std::string>
+PluginLoader::lookupLibraryPluginByModuleName(Identifier moduleName) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+
+  // Look for 'lib${module name}(.dylib|.so)'.
+  SmallString<64> expectedBasename;
+  expectedBasename.append("lib");
+  expectedBasename.append(moduleName.str());
+  expectedBasename.append(LTDL_SHLIB_EXT);
+
+  // Try '-load-plugin-library'.
+  for (const auto &libPath :
+       Ctx.SearchPathOpts.getCompilerPluginLibraryPaths()) {
+    if (llvm::sys::path::filename(libPath) == expectedBasename) {
+      return libPath;
+    }
+  }
+
+  // Try '-plugin-path'.
+  for (const auto &searchPath : Ctx.SearchPathOpts.PluginSearchPaths) {
+    SmallString<128> fullPath(searchPath);
+    llvm::sys::path::append(fullPath, expectedBasename);
+    if (fs->exists(fullPath)) {
+      return std::string(fullPath);
+    }
+  }
+
+  return None;
+}
+
+Optional<std::pair<std::string, std::string>>
+PluginLoader::lookupExternalLibraryPluginByModuleName(Identifier moduleName) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+
+  for (auto &pair : Ctx.SearchPathOpts.ExternalPluginSearchPaths) {
+    SmallString<128> fullPath(pair.SearchPath);
+    llvm::sys::path::append(fullPath,
+                            "lib" + moduleName.str() + LTDL_SHLIB_EXT);
+
+    if (fs->exists(fullPath)) {
+      return {{std::string(fullPath), pair.ServerPath}};
+    }
+  }
+  return None;
+}
+
+Optional<StringRef>
+PluginLoader::lookupExecutablePluginByModuleName(Identifier moduleName) {
+  auto &execPluginPaths = ExecutablePluginPaths;
+  auto found = execPluginPaths.find(moduleName);
+  if (found == execPluginPaths.end())
+    return None;
+  return found->second;
+}
+
+LoadedLibraryPlugin *PluginLoader::loadLibraryPlugin(StringRef path) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+  SmallString<128> resolvedPath;
+  if (auto err = fs->getRealPath(path, resolvedPath)) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       err.message());
+    return nullptr;
+  }
+
+  // Track the dependency.
+  if (DepTracker)
+    DepTracker->addDependency(resolvedPath, /*IsSystem=*/false);
+
+  // Load the plugin.
+  auto plugin = getRegistry()->loadLibraryPlugin(resolvedPath);
+  if (!plugin) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       llvm::toString(plugin.takeError()));
+    return nullptr;
+  }
+
+  return plugin.get();
+}
+
+LoadedExecutablePlugin *PluginLoader::loadExecutablePlugin(StringRef path) {
+  auto fs = Ctx.SourceMgr.getFileSystem();
+  SmallString<128> resolvedPath;
+  if (auto err = fs->getRealPath(path, resolvedPath)) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       err.message());
+    return nullptr;
+  }
+
+  // Track the dependency.
+  if (DepTracker)
+    DepTracker->addDependency(resolvedPath, /*IsSystem=*/false);
+
+  // Load the plugin.
+  auto plugin = getRegistry()->loadExecutablePlugin(resolvedPath);
+  if (!plugin) {
+    Ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                       llvm::toString(plugin.takeError()));
+    return nullptr;
+  }
+
+  return plugin.get();
+}

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -67,7 +67,7 @@ PluginRegistry::loadLibraryPlugin(StringRef path) {
   }
 #endif
 
-  storage = std::unique_ptr<LoadedLibraryPlugin>(new LoadedLibraryPlugin(lib));
+  storage = std::make_unique<LoadedLibraryPlugin>(lib);
   return storage.get();
 }
 
@@ -111,8 +111,8 @@ PluginRegistry::loadExecutablePlugin(StringRef path) {
                                    "not executable");
   }
 
-  auto plugin = std::unique_ptr<LoadedExecutablePlugin>(
-      new LoadedExecutablePlugin(path, stat.getLastModificationTime()));
+  auto plugin = std::make_unique<LoadedExecutablePlugin>(
+      path, stat.getLastModificationTime());
 
   plugin->setDumpMessaging(dumpMessaging);
 
@@ -153,9 +153,9 @@ llvm::Error LoadedExecutablePlugin::spawnIfNeeded() {
     return llvm::errorCodeToError(childInfo.getError());
   }
 
-  Process = std::unique_ptr<PluginProcess>(
-      new PluginProcess(childInfo->Pid, childInfo->ReadFileDescriptor,
-                        childInfo->WriteFileDescriptor));
+  Process = std::make_unique<PluginProcess>(childInfo->Pid,
+                                            childInfo->ReadFileDescriptor,
+                                            childInfo->WriteFileDescriptor);
 
   // Call "on reconnect" callbacks.
   for (auto *callback : onReconnect) {

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -759,10 +759,6 @@ bool swift::emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
         std::make_pair(loadedDecl->getModuleFilename(), loadedDecl));
   }
 
-  // Add compiler plugin libraries as dependencies.
-  for (auto &pluginEntry : ctxt.getLoadedPluginLibraryPaths())
-    depTracker->addDependency(pluginEntry.getKey(), /*IsSystem*/ false);
-
   std::vector<SwiftModuleTraceInfo> swiftModules;
   computeSwiftModuleTraceInfo(ctxt, abiDependencies, pathToModuleDecl,
                               *depTracker, opts.PrebuiltModuleCachePath,

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Defer.h"
@@ -303,7 +304,7 @@ bool CompileInstance::setupCI(
     assert(Diags.hadAnyError());
     return false;
   }
-  CI->getASTContext().setPluginRegistry(Plugins.get());
+  CI->getASTContext().getPluginLoader().setRegistry(Plugins.get());
 
   return true;
 }

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Defer.h"
@@ -482,7 +483,7 @@ void IDEInspectionInstance::performNewOperation(
           InstanceSetupError));
       return;
     }
-    CI->getASTContext().setPluginRegistry(Plugins.get());
+    CI->getASTContext().getPluginLoader().setRegistry(Plugins.get());
     CI->getASTContext().CancellationFlag = CancellationFlag;
     registerIDERequestFunctions(CI->getASTContext().evaluator);
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -358,13 +358,14 @@ CompilerPluginLoadRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
                                     Identifier moduleName) const {
   // Check dynamic link library plugins.
   // i.e. '-plugin-path', and '-load-plugin-library'.
-  if (auto found = loadLibraryPluginByName(*ctx, moduleName))
-    return LoadedCompilerPlugin::inProcess(found);
+  if (auto found = loadLibraryPluginByName(*ctx, moduleName)) {
+    return found;
+  }
 
   // Fall back to executable plugins.
   // i.e. '-external-plugin-path', and '-load-plugin-executable'.
   if (auto *found = loadExecutablePluginByName(*ctx, moduleName)) {
-    return LoadedCompilerPlugin::executable(found);
+    return found;
   }
 
   return nullptr;
@@ -421,7 +422,7 @@ ExternalMacroDefinitionRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
   LoadedCompilerPlugin loaded =
       evaluateOrDefault(evaluator, loadRequest, nullptr);
 
-  if (auto loadedLibrary = loaded.getAsInProcessPlugin()) {
+  if (auto loadedLibrary = loaded.getAsLibraryPlugin()) {
     if (auto inProcess = resolveInProcessMacro(
             *ctx, moduleName, typeName, loadedLibrary))
       return *inProcess;

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
 // RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule -module-cache-path %t/cache
@@ -34,3 +35,5 @@
 // CHECK-CONFIRM-ONELINE: {"name":{{.*}}]}
 
 import Module2
+
+@freestanding(expression) macro echo<T>(_: T) -> T = #externalMacro(module: "Plugin", type: "EchoMacro")

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -1,0 +1,125 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/plugin)
+// RUN: %empty-directory(%t/lib)
+// RUN: %empty-directory(%t/src)
+
+// RUN: split-file %s %t/src
+
+//#-- Prepare the macro dylib plugin.
+// RUN: %host-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-library -o %t/plugin/%target-library-name(MacroDefinition) \
+// RUN:   -module-name MacroDefinition \
+// RUN:   %S/Inputs/syntax_macro_definitions.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath
+
+//#-- Prepare the macro executable plugin.
+// RUN: %clang \
+// RUN:  -isysroot %host_sdk \
+// RUN:  -I %swift_src_root/include \
+// RUN:  -L %swift-lib-dir -l_swiftMockPlugin \
+// RUN:  -Wl,-rpath,%swift-lib-dir \
+// RUN:  -o %t/mock-plugin \
+// RUN:  %t/src/plugin.c
+
+//#-- Prepare the macro library.
+// RUN: %target-swift-frontend \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-module -o %t/lib/MacroLib.swiftmodule \
+// RUN:   -module-name MacroLib \
+// RUN:   -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -primary-file %t/src/macro_library.swift \
+// RUN:   -emit-reference-dependencies-path %t/macro_library.swiftdeps \
+// RUN:   -emit-dependencies-path %t/macro_library.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/macro_library.swiftdeps %t/macro_library.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITH_PLUGIN %s < %t/macro_library.swiftdeps.processed
+
+//#-- Without macro (no -D USE_MACRO)
+// RUN: %target-swift-frontend \
+// RUN:   -swift-version 5 -typecheck \
+// RUN:   -primary-file %t/src/test.swift \
+// RUN:   %t/src/other.swift \
+// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -emit-reference-dependencies-path %t/without_macro.swiftdeps \
+// RUN:   -emit-dependencies-path %t/without_macro.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/without_macro.swiftdeps %t/without_macro.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/without_macro.swiftdeps.processed
+
+//#-- With macro - primary (-D USE_MACRO)
+// RUN: %target-swift-frontend \
+// RUN:   -D USE_MACRO \
+// RUN:   -swift-version 5 -typecheck \
+// RUN:   -primary-file %t/src/test.swift \
+// RUN:   %t/src/other.swift \
+// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -emit-reference-dependencies-path %t/with_macro_primary.swiftdeps \
+// RUN:   -emit-dependencies-path %t/with_macro_primary.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/with_macro_primary.swiftdeps %t/with_macro_primary.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITH_PLUGIN %s < %t/with_macro_primary.swiftdeps.processed
+
+//#-- With macro - non-primary (-D USE_MACRO)
+// RUN: %target-swift-frontend \
+// RUN:   -D USE_MACRO \
+// RUN:   -swift-version 5 -typecheck \
+// RUN:   %t/src/test.swift \
+// RUN:   -primary-file %t/src/other.swift \
+// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -emit-reference-dependencies-path %t/with_macro_nonprimary.swiftdeps \
+// RUN:   -emit-dependencies-path %t/with_macro_nonprimary.d
+// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/with_macro_nonprimary.swiftdeps %t/with_macro_nonprimary.swiftdeps.processed
+// RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/with_macro_nonprimary.swiftdeps.processed
+
+// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}mock-plugin' false
+// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}libMacroDefinition.dylib' false
+
+// WITHOUT_PLUGIN-NOT:  MacroDefinition
+// WITHOUT_PLUGIN-NOT:  mock-plugin
+
+//--- macro_library.swift
+@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+@freestanding(expression) public macro testString(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "TestStringMacro")
+
+public func funcInMacroLib() {}
+
+//--- test.swift
+import MacroLib
+
+func test(a: Int, b: Int) {
+  // Just using MacroLib without macro
+  funcInMacroLib()
+
+#if USE_MACRO
+  _ = #stringify(a + b)
+  _ = #testString(123)
+#endif
+}
+
+//--- other.swift
+import MacroLib
+
+func test() {
+  // Just using MacroLib without macro
+  funcInMacroLib()
+}
+
+//--- plugin.c
+#include "swift-c/MockPlugin/MockPlugin.h"
+
+MOCK_PLUGIN([
+  {
+    "expect": {"getCapability": {}},
+    "response": {"getCapabilityResult": {"capability": {"protocolVersion": 1}}}
+  },
+  {
+    "expect": {"expandFreestandingMacro": {
+                "macro": {"moduleName": "TestPlugin", "typeName": "TestStringMacro"},
+                "syntax": {"kind": "expression", "source": "#testString(123)"}}},
+    "response": {"expandFreestandingMacroResult": {"expandedSource": "\"test\"", "diagnostics": []}}
+  }
+])

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -20,6 +20,7 @@
 #include "SourceKit/Support/Logging.h"
 #include "SourceKit/Support/Tracing.h"
 
+#include "swift/AST/PluginLoader.h"
 #include "swift/Basic/Cache.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
@@ -1077,7 +1078,8 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
     }
     return nullptr;
   }
-  CompIns.getASTContext().setPluginRegistry(ASTManager->Impl.Plugins.get());
+  CompIns.getASTContext().getPluginLoader().setRegistry(
+      ASTManager->Impl.Plugins.get());
   CompIns.getASTContext().CancellationFlag = CancellationFlag;
   registerIDERequestFunctions(CompIns.getASTContext().evaluator);
   if (TracedOp.enabled()) {


### PR DESCRIPTION
Cherry-pick #65322 (and depending #64845) into `release/5.9`

**Explanation**: Plugin dependencies were not tracked in swiftdeps. Because of that, files using plugins (using macros) were not correctly rebuilt even when the plugin implementation was modified. With this change, plugin dependencies (dylib plugins and executable plugins) are tracked by normal `DependencyTracker` facility just like module file dependencies.
**Scope**: swiftdeps when plugins are used
**Risk**: Low-Mid. This adds new elements to existing dependency tracking facility
**Testing**: Added regression test case for checking plugins are tracked by `swiftdeps` files
**Issue**: rdar://104938481
**Reviewer**: Doug Gregor (@DougGregor), Artem Chikin (@artemcm), Richard Wei (@rxwei), Alex Hoppen (@ahoppen)

llvm-project changes: https://github.com/apple/llvm-project/pull/6720