### PR TITLE
Build lsan with -gline-tables-only

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1211,6 +1211,11 @@ sourcekit-lsp=0
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=RDA,test=no]
 build-subdir=buildbot_incremental_lsan
 
+# Reduce the size of the final toolchain, limit debug info
+extra-cmake-options=
+   -DCMAKE_C_FLAGS="-gline-tables-only"
+   -DCMAKE_CXX_FLAGS="-gline-tables-only"
+
 release-debuginfo
 assertions
 enable-lsan
@@ -1220,6 +1225,11 @@ reconfigure
 
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=DA,test=no]
 build-subdir=buildbot_incremental_lsan
+
+# Reduce the size of the final toolchain, limit debug info
+extra-cmake-options=
+   -DCMAKE_C_FLAGS="-gline-tables-only"
+   -DCMAKE_CXX_FLAGS="-gline-tables-only"
 
 llvm-cmake-options=-DLLVM_PARALLEL_LINK_JOBS=12
 swift-cmake-options=-DSWIFT_PARALLEL_LINK_JOBS=12


### PR DESCRIPTION
<!-- What's in this pull request? -->
Update LSAN builds to build with `-gline-tables-only` which will greatly reduce the build size and prevent CI jobs from failing due to lack of space
