### PR TITLE
Sema: Ban unavailable overrides of available decls

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2908,6 +2908,9 @@ ERROR(override_unavailable, none,
 NOTE(suggest_removing_override, none,
      "remove 'override' modifier to declare a new %0",
      (DeclBaseName))
+ERROR(unavailable_override, none,
+      "override of %0 cannot be marked unavailable with '@available'",
+      (DeclName))
 
 ERROR(override_less_available,none,
       "overriding %0 must be as available as declaration it overrides",

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2755,9 +2755,9 @@ bool TypeChecker::diagnoseIfDeprecated(SourceLoc loc,
   return true;
 }
 
-void swift::diagnoseUnavailableOverride(ValueDecl *override,
-                                        const ValueDecl *base,
-                                        const AvailableAttr *attr) {
+void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
+                                              const ValueDecl *base,
+                                              const AvailableAttr *attr) {
   ASTContext &ctx = override->getASTContext();
   auto &diags = ctx.Diags;
   if (attr->Rename.empty()) {

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -245,9 +245,11 @@ bool diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
                               const Expr *call, const ExportContext &where,
                               DeclAvailabilityFlags flags = None);
 
-void diagnoseUnavailableOverride(ValueDecl *override,
-                                 const ValueDecl *base,
-                                 const AvailableAttr *attr);
+/// Emit a diagnostic for an available declaration that overrides an
+/// unavailable declaration.
+void diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
+                                       const ValueDecl *base,
+                                       const AvailableAttr *attr);
 
 /// Emit a diagnostic for references to declarations that have been
 /// marked as unavailable, either through "unavailable" or "obsoleted:".

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4384,7 +4384,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
 
     case CheckKind::Unavailable: {
       auto *attr = requirement->getAttrs().getUnavailable(getASTContext());
-      diagnoseUnavailableOverride(witness, requirement, attr);
+      diagnoseOverrideOfUnavailableDecl(witness, requirement, attr);
       break;
     }
 

--- a/test/SILGen/vtables.swift
+++ b/test/SILGen/vtables.swift
@@ -35,7 +35,7 @@ class A {
   func bar() {}
   func bas() {}
   func qux() {}
-  func flux() {}
+  @available(*, unavailable) func flux() {}
 }
 
 // CHECK: sil_vtable A {

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -31,64 +31,6 @@ func foo(x : NSUInteger) { // expected-error {{'NSUInteger' is unavailable: use 
   // expected-error@-1 {{cannot convert value of type 'Int' to specified type 'Outer.NSUInteger'}}
 }
 
-// Test preventing overrides (but allowing shadowing) of unavailable methods.
-class ClassWithUnavailable {
-  @available(*, unavailable)
-  func doNotOverride() {} // expected-note {{'doNotOverride()' has been explicitly marked unavailable here}}
-
-  // FIXME: extraneous diagnostic here
-  @available(*, unavailable)
-  init(int _: Int) {} // expected-note 3 {{'init(int:)' has been explicitly marked unavailable here}}
-
-  @available(*, unavailable)
-  convenience init(otherInt: Int) {
-    self.init(int: otherInt) // expected-error {{'init(int:)' is unavailable}}
-  }
-
-  @available(*, unavailable)
-  required init(necessaryInt: Int) {}
-
-  @available(*, unavailable)
-  subscript (i: Int) -> Int { // expected-note 2 {{'subscript(_:)' has been explicitly marked unavailable here}}
-    return i
-  }
-}
-
-class ClassWithOverride : ClassWithUnavailable {
-  override func doNotOverride() {}
-  // expected-error@-1 {{cannot override 'doNotOverride' which has been marked unavailable}}
-  // expected-note@-2 {{remove 'override' modifier to declare a new 'doNotOverride'}} {{3-12=}}
-
-  override init(int: Int) {}
-  // expected-error@-1 {{cannot override 'init' which has been marked unavailable}}
-  // expected-note@-2 {{remove 'override' modifier to declare a new 'init'}} {{3-12=}}
-
-  // can't override convenience inits
-  // can't override required inits
-
-  override subscript (i: Int) -> Int { return i }
-  // expected-error@-1 {{cannot override 'subscript' which has been marked unavailable}}
-  // expected-note@-2 {{remove 'override' modifier to declare a new 'subscript'}} {{3-12=}}
-}
-
-class ClassWithShadowing : ClassWithUnavailable {
-  func doNotOverride() {} // no-error
-  init(int: Int) {} // no-error
-  convenience init(otherInt: Int) { self.init(int: otherInt) } // no-error
-  required init(necessaryInt: Int) {} // no-error
-  subscript (i: Int) -> Int { return i } // no-error
-}
-
-func testInit() {
-  ClassWithUnavailable(int: 0) // expected-error {{'init(int:)' is unavailable}} // expected-warning{{unused}}
-  ClassWithShadowing(int: 0) // expected-warning {{unused}}
-}
-
-func testSubscript(cwu: ClassWithUnavailable, cws: ClassWithShadowing) {
-  _ = cwu[5] // expected-error{{'subscript(_:)' is unavailable}}
-  _ = cws[5] // no-error
-}
-
 /* FIXME 'nil == a' fails to type-check with a bogus error message
  * <rdar://problem/17540796>
 func markUsed<T>(t: T) {}

--- a/test/Sema/availability_unavailable_overrides.swift
+++ b/test/Sema/availability_unavailable_overrides.swift
@@ -1,0 +1,267 @@
+// RUN: %target-typecheck-verify-swift
+
+func testAvailableOverrideOfUnavailableDecl() {
+  class Base {
+    @available(*, unavailable)
+    func unavailableMethod() {}
+    // expected-note@-1 2 {{'unavailableMethod()' has been explicitly marked unavailable here}}
+
+    @available(*, unavailable)
+    init(x: Int) {}
+    // expected-note@-1 2 {{'init(x:)' has been explicitly marked unavailable here}}
+
+    @available(*, unavailable)
+    required init(requiredX: Int) {}
+    // expected-note@-1 {{'init(requiredX:)' has been explicitly marked unavailable here}}
+
+    @available(*, unavailable)
+    subscript (i: Int) -> Int { return i }
+    // expected-note@-1 2 {{'subscript(_:)' has been explicitly marked unavailable here}}
+
+    @available(*, unavailable)
+    var unavailableComputedProperty: Int {
+      // expected-note@-1 2 {{'unavailableComputedProperty' has been explicitly marked unavailable here}}
+      get { 0 }
+      set {}
+    }
+
+    var computedPropertyWithUnavailableSet: Int {
+      get { 0 }
+      @available(*, unavailable)
+      set {} // expected-note {{setter for 'computedPropertyWithUnavailableSet' has been explicitly marked unavailable here}}
+    }
+  }
+
+  class Overrides: Base {
+    override func unavailableMethod() {}
+    // expected-error@-1 {{cannot override 'unavailableMethod' which has been marked unavailable}}
+    // expected-note@-2 {{remove 'override' modifier to declare a new 'unavailableMethod'}}
+
+    override init(x: Int) {}
+    // expected-error@-1 {{cannot override 'init' which has been marked unavailable}}
+    // expected-note@-2 {{remove 'override' modifier to declare a new 'init'}} {{5-14=}}
+
+    // Required inits cannot be overridden using the `override` keyword.
+
+    override subscript (i: Int) -> Int { return i }
+    // expected-error@-1 {{cannot override 'subscript' which has been marked unavailable}}
+    // expected-note@-2 {{remove 'override' modifier to declare a new 'subscript'}} {{5-14=}}
+
+    override var unavailableComputedProperty: Int {
+      // expected-error@-1 {{cannot override 'unavailableComputedProperty' which has been marked unavailable}}
+      // expected-note@-2 {{remove 'override' modifier to declare a new 'unavailableComputedProperty'}} {{5-14=}}
+      get { 1 }
+      set {}
+    }
+
+    override var computedPropertyWithUnavailableSet: Int {
+      get { 0 }
+      // FIXME: Diagnostic should refer to "setter for 'computedPropertyWithUnavailableSet'" rather than '_'.
+      set {} // expected-error {{cannot override '_' which has been marked unavailable}}
+    }
+  }
+
+  // Redeclarations of the unavailable declarations (without `override`) are ok.
+  class Shadows: Base {
+    func unavailableMethod() {}
+    init(x: Int) {}
+    // NOTE: This is allowed by typechecking but it's actually uncallable and
+    // will be rejected by flow sensitive analysis since it doesn't call
+    // super.init(requiredX:).
+    required init(requiredX: Int) {}
+    subscript (i: Int) -> Int { return i }
+    var unavailableComputedProperty: Int {
+      get { 1 }
+      set {}
+    }
+  }
+
+  func use(base: Base, overrides: Overrides, shadows: Shadows) {
+    base.unavailableMethod() // expected-error {{'unavailableMethod()' is unavailable}}
+    overrides.unavailableMethod()
+    shadows.unavailableMethod()
+
+    _ = Base(x: 0) // expected-error {{'init(x:)' is unavailable}}
+    _ = Overrides(x: 0)
+    _ = Shadows(x: 0)
+
+    _ = Base(requiredX: 0) // expected-error {{'init(requiredX:)' is unavailable}}
+    _ = Shadows(requiredX: 0)
+
+    _ = base[0] // expected-error {{'subscript(_:)' is unavailable}}
+    _ = overrides[0]
+    _ = shadows[0]
+
+    _ = base.unavailableComputedProperty // expected-error {{'unavailableComputedProperty' is unavailable}}
+    _ = overrides.unavailableComputedProperty
+    _ = shadows.unavailableComputedProperty
+  }
+}
+
+func testUnavailableOverrideOfAvailableDecl() {
+  class Base {
+    func availableMethod() {}
+    init(x: Int) {}
+    required init(requiredX: Int) {}
+    subscript (i: Int) -> Int { return i }
+    var availableComputedProperty: Int {
+      get { 0 }
+      set {}
+    }
+    var computedPropertyWithUnavailableSetterOverride: Int {
+      get { 0 }
+      set {}
+    }
+  }
+
+  class Overrides: Base {
+    // expected-error@+1 {{override of 'availableMethod()' cannot be marked unavailable with '@available'}}
+    @available(*, unavailable)
+    override func availableMethod() {}
+
+    // expected-error@+1 {{override of 'init(x:)' cannot be marked unavailable with '@available'}}
+    @available(*, unavailable)
+    override init(x: Int) {}
+
+    // expected-error@+1 {{override of 'init(requiredX:)' cannot be marked unavailable with '@available'}}
+    @available(*, unavailable)
+    required init(requiredX: Int) {}
+
+    // expected-error@+1 {{override of 'subscript(_:)' cannot be marked unavailable with '@available'}}
+    @available(*, unavailable)
+    override subscript (i: Int) -> Int { return i }
+
+    // expected-error@+1 {{override of 'availableComputedProperty' cannot be marked unavailable with '@available'}}
+    @available(*, unavailable)
+    override var availableComputedProperty: Int {
+      get { 1 }
+      set {}
+    }
+
+    override var computedPropertyWithUnavailableSetterOverride: Int {
+      get { 0 }
+      // FIXME: Diagnostic should refer to "setter for 'computedPropertyWithUnavailableSetterOverride'" rather than '_'.
+      // expected-error@+1 {{override of '_' cannot be marked unavailable with '@available'}}
+      @available(*, unavailable)
+      set {}
+    }
+  }
+}
+
+func testUnavailableOverrideOfUnavailableDecl() {
+  class Base {
+    @available(*, unavailable)
+    func unavailableMethod() {}
+
+    @available(*, unavailable)
+    init(x: Int) {}
+
+    @available(*, unavailable)
+    required init(requiredX: Int) {}
+
+    @available(*, unavailable)
+    subscript (i: Int) -> Int { return i }
+
+    @available(*, unavailable)
+    var unavailableComputedProperty: Int {
+      get { 0 }
+      set {}
+    }
+
+    var computedPropertyWithUnavailableSetterOverride: Int {
+      get { 0 }
+      @available(*, unavailable)
+      set {}
+    }
+  }
+
+  class Derived: Base {
+    @available(*, unavailable)
+    override func unavailableMethod() {}
+
+    @available(*, unavailable)
+    override init(x: Int) {}
+
+    @available(*, unavailable)
+    required init(requiredX: Int) {}
+
+    @available(*, unavailable)
+    override subscript (i: Int) -> Int { return i }
+
+    @available(*, unavailable)
+    override var unavailableComputedProperty: Int {
+      get { 1 }
+      set {}
+    }
+
+    override var computedPropertyWithUnavailableSetterOverride: Int {
+      get { 0 }
+      @available(*, unavailable)
+      set {}
+    }
+  }
+}
+
+func testUnavailableOverrideOfDeclInAvailableBaseType() {
+  class Base {
+    func availableMethod() {}
+    init(x: Int) {}
+    required init(requiredX: Int) {}
+    subscript (i: Int) -> Int { return i }
+    var availableComputedProperty: Int {
+      get { 0 }
+      set {}
+    }
+    var computedPropertyWithUnavailableSetterOverride: Int {
+      get { 0 }
+      set {}
+    }
+  }
+
+  // Since Derived is unavailable, its OK that the members are also explicitly
+  // marked unavailable.
+  @available(*, unavailable)
+  class Derived: Base {
+    @available(*, unavailable)
+    override func availableMethod() {}
+
+    @available(*, unavailable)
+    override init(x: Int) {}
+
+    @available(*, unavailable)
+    required init(requiredX: Int) {}
+
+    @available(*, unavailable)
+    override subscript (i: Int) -> Int { return i }
+
+    @available(*, unavailable)
+    override var availableComputedProperty: Int {
+      get { 1 }
+      set {}
+    }
+
+    override var computedPropertyWithUnavailableSetterOverride: Int {
+      get { 0 }
+      @available(*, unavailable)
+      set {}
+    }
+  }
+}
+
+
+func testImplicitSuperInit() {
+  // FIXME: The diagnostics for the implicit call to super.init() could be
+  // relaxed since both initialziers are unreachable and the developer cannot
+  // wrap the call to super in a conditional compilation block.
+  class Base {
+    @available(*, unavailable)
+    init() {} // expected-note {{'init()' has been explicitly marked unavailable here}}
+  }
+
+  class Derived: Base {
+    @available(*, unavailable) // OK, matches base
+    override init() {}
+    // expected-error@-1 {{'init()' is unavailable}}
+    // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'Base' occurs implicitly at the end of this initializer}}
+  }
+}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1193,17 +1193,6 @@ func testBadRename() {
 struct AvailableGenericParam<@available(*, deprecated) T> {}
 // expected-error@-1 {{'@available' attribute cannot be applied to this declaration}}
 
-class UnavailableNoArgsSuperclassInit {
-  @available(*, unavailable)
-  init() {} // expected-note {{'init()' has been explicitly marked unavailable here}}
-}
-
-class UnavailableNoArgsSubclassInit: UnavailableNoArgsSuperclassInit {
-  init(marker: ()) {}
-  // expected-error@-1 {{'init()' is unavailable}}
-  // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'UnavailableNoArgsSuperclassInit' occurs implicitly at the end of this initializer}}
-}
-
 struct TypeWithTrailingClosures {
   func twoTrailingClosures(a: () -> Void, b: () -> Void) {}
   func threeTrailingClosures(a: () -> Void, b: () -> Void, c: () -> Void) {}


### PR DESCRIPTION
Unavailable decls should not be allowed to override available decls since overrides can be invoked at runtime through vtables and are therefore reachable at runtime if the base declaration is available. For example:

```swift
@available(*, unavailable)
struct Unavailable {
  init() { print("Oops") }
}

class Base {
  required init() {}

  class func factory() -> Self {
    Self.init()
  }
}

class Derived: Base {
  @available(*, unavailable)
  required init() {
    super.init()
    _ = Unavailable()
  }
}

_ = Derived.factory() // Oops
```

Resolves rdar://108396778
