### PR TITLE
[Macros] Diagnose top-level expansion of undefined freestanding macro

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1483,10 +1483,15 @@ ResolveMacroRequest::evaluate(Evaluator &evaluator,
 
   auto &ctx = dc->getASTContext();
   auto roles = macroRef.getMacroRoles();
-  auto foundMacros = TypeChecker::lookupMacros(
-      dc, macroRef.getMacroName(), SourceLoc(), roles);
-  if (foundMacros.empty())
-    return ConcreteDeclRef();
+
+  // When a macro is not found for a custom attribute, it may be a non-macro.
+  // So bail out to prevent diagnostics from the contraint system.
+  if (macroRef.getAttr()) {
+    auto foundMacros = TypeChecker::lookupMacros(
+        dc, macroRef.getMacroName(), SourceLoc(), roles);
+    if (foundMacros.empty())
+      return ConcreteDeclRef();
+  }
 
   // If we already have a MacroExpansionExpr, use that. Otherwise,
   // create one.

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -185,3 +185,7 @@ struct MyStruct<T: MyProto> {
 
 @freestanding(expression) macro myMacro<T : MyProto>(_ value: MyStruct<T>) -> MyStruct<T> = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type}}
+
+#undefinedMacro { definitelyNotDefined }
+// expected-error@-1{{cannot find 'definitelyNotDefined' in scope}}
+// expected-error@-2{{no macro named 'undefinedMacro'}}

--- a/test/Macros/macros_library_mode_diagnostics.swift
+++ b/test/Macros/macros_library_mode_diagnostics.swift
@@ -1,0 +1,13 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -module-name MacrosTest
+
+// We need this test because top-level freestanding macro expansions are parsed
+// differently in library mode.
+
+#undefinedMacro1
+// expected-error@-1{{no macro named 'undefinedMacro1'}}
+
+#undefinedMacro2 { definitelyNotDefined }
+// expected-error@-1{{no macro named 'undefinedMacro2'}}
+// expected-error@-2{{cannot find 'definitelyNotDefined' in scope}}


### PR DESCRIPTION
The root problem is that `ResolveMacroRequest` was shortcuting after calling `lookupMacros`. When type-checking a freestanding macro, it shouldn't need to call `lookupMacros` at all, but should go straight to CSGen.

rdar://108280416