### PR TITLE
[5.9] Sema: Relax distributed actor typechecking for swiftinterfaces

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -68,7 +68,6 @@ static VarDecl*
    if (!var->getInterfaceType()->isEqual(expectedType))
      return nullptr;
 
-   assert(var->isSynthesized() && "Expected compiler synthesized property");
    return var;
  }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6666,9 +6666,8 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         // The synthesized "id" and "actorSystem" are the only exceptions,
         // because the implementation mirrors them.
         if (nominal->isDistributedActor() &&
-            !(var->isImplicit() &&
-              (var->getName() == Ctx.Id_id ||
-               var->getName() == Ctx.Id_actorSystem))) {
+            !(var->getName() == Ctx.Id_id ||
+              var->getName() == Ctx.Id_actorSystem)) {
           diagnoseAndRemoveAttr(attr,
                                 diag::nonisolated_distributed_actor_storage);
           return;

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -643,6 +643,12 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
 void swift::checkDistributedActorProperties(const NominalTypeDecl *decl) {
   auto &C = decl->getASTContext();
 
+  auto sourceFile = decl->getDeclContext()->getParentSourceFile();
+  if (sourceFile && sourceFile->Kind == SourceFileKind::Interface) {
+    // Don't diagnose properties in swiftinterfaces.
+    return;
+  }
+
   if (isa<ProtocolDecl>(decl)) {
     // protocols don't matter for stored property checking
     return;

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: distributed
+
+import Distributed
+
+// CHECK:      #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT: distributed public actor DA {
+@available(SwiftStdlib 5.7, *)
+public distributed actor DA {
+  // CHECK: @_compilerInitialized nonisolated final public let id: Distributed.LocalTestingDistributedActorSystem.ActorID
+  // CHECK: nonisolated final public let actorSystem: Library.DA.ActorSystem
+  // CHECK: public typealias ActorSystem = Distributed.LocalTestingDistributedActorSystem
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  // CHECK:       public static func resolve(id: Distributed.LocalTestingDistributedActorSystem.ActorID, using system: Library.DA.ActorSystem) throws -> Library.DA
+  // CHECK:       public typealias ID = Distributed.LocalTestingDistributedActorSystem.ActorID
+  // CHECK:       public typealias SerializationRequirement = any Swift.Decodable & Swift.Encodable
+  // CHECK:       {{@objc deinit|deinit}}
+  // CHECK:       nonisolated public var hashValue: Swift.Int {
+  // CHECK-NEXT:    get
+  // CHECK-NEXT:  }
+  // CHECK:       public init(actorSystem system: Library.DA.ActorSystem)
+  // CHECK:       @available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *)
+  // CHECK-NEXT:  @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT:    get
+  // CHECK-NEXT:  }
+}
+// CHECK: #endif
+
+
+// CHECK:       #if compiler(>=5.3) && $Actors
+// CHECK-NEXT:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT:  extension Library.DA : Distributed.DistributedActor {}
+// CHECK-NEXT:  #endif
+// CHECK:       #if compiler(>=5.3) && $Actors
+// CHECK-NEXT:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT:  extension Library.DA : Swift.Encodable {}
+// CHECK-NEXT:  #endif
+// CHECK:       #if compiler(>=5.3) && $Actors
+// CHECK-NEXT:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT:  extension Library.DA : Swift.Decodable {}
+// CHECK-NEXT:  #endif


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/65431.

Some decls that are expected to be synthesized for distributed actors are printed explicitly in swiftinterfaces so diagnostics and assertions need to take that possibility into account.

Resolves rdar://108533918
