### PR TITLE
Sema: fix for 61440 (lib/AST/GenericEnvironment) no generic environme…

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2575,9 +2575,9 @@ static bool fixItOverrideDeclarationTypesImpl(
       });
     }
 
-    auto resultType = subscript->getDeclContext()->mapTypeIntoContext(
-        subscript->getElementInterfaceType());
-    auto baseResultType = baseSubscript->getDeclContext()->mapTypeIntoContext(
+    auto resultType =
+        subscript->mapTypeIntoContext(subscript->getElementInterfaceType());
+    auto baseResultType = baseSubscript->mapTypeIntoContext(
         baseSubscript->getElementInterfaceType());
     fixedAny |= checkType(resultType, ParamDecl::Specifier::Default,
                           baseResultType, ParamDecl::Specifier::Default,

--- a/test/Sema/generic-subscript.swift
+++ b/test/Sema/generic-subscript.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift
+
+
+protocol P
+{
+    subscript<Value>(x:Value) -> Int // expected-note {{protocol requires subscript with type '<Value> (Value) -> Int'; do you want to add a stub?}}
+    {
+        get 
+    } 
+}
+
+struct S:P // expected-error {{type 'S' does not conform to protocol 'P'}}
+{
+    subscript<Value>(x:Int) -> Value // expected-note {{candidate has non-matching type '<Value> (Int) -> Value'}}
+    {
+    } // expected-error {{missing return in subscript expected to return 'Value'}}
+}
+
+
+
+struct S2:P 
+{
+    subscript<Value>(x:Value) -> Int 
+    {
+			return 123;
+    } 
+}
+
+protocol P2
+{
+    subscript(x:Int) -> Int 
+    {
+        get 
+    } 
+}
+
+struct S3:P2
+{
+    subscript(x:Int) -> Int
+    {
+        return x;
+    } 
+}
+


### PR DESCRIPTION
…nt provided for type with type parameter

<!-- What's in this pull request? -->
Instead of trying to map an element type of a subscriptDecl into it's parent context which causes an assert to fail (e.g. The parent context might not have a generic env). This change uses the generic environment of the subscriptDecl itself.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/61440

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
