### PR TITLE
[5.9] [Macros] Diagnose top-level expansion of undefined freestanding macro

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1506,10 +1506,15 @@ ResolveMacroRequest::evaluate(Evaluator &evaluator,
 
   auto &ctx = dc->getASTContext();
   auto roles = macroRef.getMacroRoles();
-  auto foundMacros = TypeChecker::lookupMacros(
-      dc, macroRef.getMacroName(), SourceLoc(), roles);
-  if (foundMacros.empty())
-    return ConcreteDeclRef();
+
+  // When a macro is not found for a custom attribute, it may be a non-macro.
+  // So bail out to prevent diagnostics from the contraint system.
+  if (macroRef.getAttr()) {
+    auto foundMacros = TypeChecker::lookupMacros(
+        dc, macroRef.getMacroName(), SourceLoc(), roles);
+    if (foundMacros.empty())
+      return ConcreteDeclRef();
+  }
 
   // If we already have a MacroExpansionExpr, use that. Otherwise,
   // create one.

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -185,3 +185,7 @@ struct MyStruct<T: MyProto> {
 
 @freestanding(expression) macro myMacro<T : MyProto>(_ value: MyStruct<T>) -> MyStruct<T> = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type}}
+
+#undefinedMacro { definitelyNotDefined }
+// expected-error@-1{{cannot find 'definitelyNotDefined' in scope}}
+// expected-error@-2{{no macro named 'undefinedMacro'}}

--- a/test/Macros/macros_library_mode_diagnostics.swift
+++ b/test/Macros/macros_library_mode_diagnostics.swift
@@ -1,0 +1,13 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -module-name MacrosTest
+
+// We need this test because top-level freestanding macro expansions are parsed
+// differently in library mode.
+
+#undefinedMacro1
+// expected-error@-1{{no macro named 'undefinedMacro1'}}
+
+#undefinedMacro2 { definitelyNotDefined }
+// expected-error@-1{{no macro named 'undefinedMacro2'}}
+// expected-error@-2{{cannot find 'definitelyNotDefined' in scope}}


### PR DESCRIPTION
Cherry-pick of #65429

---------------------------------------------

- **Explanation**: Expanding an undefined macro succeeds silently and causes its arguments to not be type-checked. This is a bad state where incorrect freestanding macro expansion code would slip by and compile to nothing.
- **Scope of Issue**: Macro resolution where there is a shortcut only meant to apply to custom attributes.
- **Risk**: No risk to custom attributes, or to defined freestanding macro expanisons. All undefined freestanding macro expansions now go through the constraint system, which is an existing code path that those parsed as `MacroExpansionExpr` already go through, so the risk should be minimal.
- **Testing**: Added additional diagnostics tests for top-level freestanding macro expansions in library mode.

rdar://108280416
