### PR TITLE
[SymbolGraphGen] allow any ValueDecl to take part in picking a best candidate

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -276,15 +276,21 @@ void SymbolGraph::recordMemberRelationship(Symbol S) {
 
 bool SymbolGraph::synthesizedMemberIsBestCandidate(const ValueDecl *VD,
     const NominalTypeDecl *Owner) const {
-  const auto *FD = dyn_cast<FuncDecl>(VD);
-  if (!FD) {
+  DeclName Name;
+  if (const auto *FD = dyn_cast<FuncDecl>(VD)) {
+    Name = FD->getEffectiveFullName();
+  } else {
+    Name = VD->getName();
+  }
+
+  if (!Name) {
     return true;
   }
+
   auto *DC = const_cast<DeclContext*>(Owner->getDeclContext());
 
   ResolvedMemberResult Result =
-    resolveValueMember(*DC, Owner->getSelfTypeInContext(),
-                       FD->getEffectiveFullName());
+    resolveValueMember(*DC, Owner->getSelfTypeInContext(), Name);
 
   const auto ViableCandidates =
     Result.getMemberDecls(InterestedMemberKind::All);

--- a/test/SymbolGraph/Relationships/Synthesized/PickBestCandidate.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/PickBestCandidate.swift
@@ -6,24 +6,36 @@
 public protocol P {
   func foo()
   func bar()
+
+  var baz: Int { get }
+  var qux: Int { get }
 }
 
 public protocol Q : P {}
 extension Q {
   public func foo() {}
   public func bar() {}
+
+  public var baz: Int { 0 }
+  public var qux: Int { 0 }
 }
 
 public protocol R : Q {}
 extension R {
   public func foo() {}
   public func bar() {}
+
+  public var baz: Int { 1 }
+  public var qux: Int { 1 }
 }
 
 public struct MyStruct: R {
   public func bar() {}
+
+  public var qux: Int { 2 }
 }
 
-// MyStruct gets one and only one synthesized `foo`.
-// MyStruct gets no synthesized `bar`, because it has its own implementation.
-// CHECK-COUNT-1: ::SYNTHESIZED::
+// MyStruct gets one and only one synthesized `foo` and `baz`.
+// MyStruct gets no synthesized `bar` and `qux`, because it has its own implementation.
+// CHECK-COUNT-2: "precise": {{.*}}::SYNTHESIZED::
+// CHECK-NOT:     "precise": {{.*}}::SYNTHESIZED::


### PR DESCRIPTION
Resolves rdar://105099207

When determining whether a synthesized symbol is the best candidate for emitting into a symbol graph, the check only handles function decls when doing the lookup. This prevents synthesized properties from having their synthesized symbol overridden by a local one, since the check short-circuits. This PR updates the "synthesized member is best candidate" check to allow any decl with a valid name to be looked up, not just methods.