### PR TITLE
[Macros] Allow the back-ticked `named(`init`)` to be treated like `named(init)`.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10307,6 +10307,15 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
     switch (expandedName.getKind()) {
     case MacroIntroducedDeclNameKind::Named: {
       names.push_back(DeclName(expandedName.getName()));
+
+      // Temporary hack: we previously allowed named(`init`) to mean the same
+      // thing as named(init), before the latter was supported. Smooth over the
+      // difference by treating the former as the latter, for a short time.
+      if (expandedName.getName().isSimpleName() &&
+          !expandedName.getName().getBaseName().isSpecial() &&
+          expandedName.getName().getBaseIdentifier().is("init"))
+        names.push_back(DeclName(DeclBaseName::createConstructor()));
+
       break;
     }
 

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -13,6 +13,12 @@
 )
 macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
 
+@attached(
+  member,
+  names: named(`init`), named(Storage), named(storage), named(getStorage()), named(method)
+)
+macro addMembersQuotedInit() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+
 @addMembers
 struct S {
   func useSynthesized() {
@@ -89,3 +95,11 @@ enum ElementType {
 }
 
 print(ElementType.paper.unknown())
+
+@addMembersQuotedInit
+struct S2 {
+  func useSynthesized() {
+    S.method()
+    print(type(of: getStorage()))
+  }
+}


### PR DESCRIPTION
My recent change to parse initializer names in the macro role introduced names now correctly distinguishes between the two forms, but this breaks any existing macros written with the back-ticked form. Treat the former as the latter to provide a grace period for such macros.

Fixes rdar://108571834.
