### PR TITLE
[5.9] [SymbolGraphGen] allow any ValueDecl to take part in picking a best candidate

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -276,15 +276,21 @@ void SymbolGraph::recordMemberRelationship(Symbol S) {
 
 bool SymbolGraph::synthesizedMemberIsBestCandidate(const ValueDecl *VD,
     const NominalTypeDecl *Owner) const {
-  const auto *FD = dyn_cast<FuncDecl>(VD);
-  if (!FD) {
+  DeclName Name;
+  if (const auto *FD = dyn_cast<FuncDecl>(VD)) {
+    Name = FD->getEffectiveFullName();
+  } else {
+    Name = VD->getName();
+  }
+
+  if (!Name) {
     return true;
   }
+
   auto *DC = const_cast<DeclContext*>(Owner->getDeclContext());
 
   ResolvedMemberResult Result =
-    resolveValueMember(*DC, Owner->getSelfTypeInContext(),
-                       FD->getEffectiveFullName());
+    resolveValueMember(*DC, Owner->getSelfTypeInContext(), Name);
 
   const auto ViableCandidates =
     Result.getMemberDecls(InterestedMemberKind::All);

--- a/test/SymbolGraph/Relationships/Synthesized/PickBestCandidate.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/PickBestCandidate.swift
@@ -6,24 +6,36 @@
 public protocol P {
   func foo()
   func bar()
+
+  var baz: Int { get }
+  var qux: Int { get }
 }
 
 public protocol Q : P {}
 extension Q {
   public func foo() {}
   public func bar() {}
+
+  public var baz: Int { 0 }
+  public var qux: Int { 0 }
 }
 
 public protocol R : Q {}
 extension R {
   public func foo() {}
   public func bar() {}
+
+  public var baz: Int { 1 }
+  public var qux: Int { 1 }
 }
 
 public struct MyStruct: R {
   public func bar() {}
+
+  public var qux: Int { 2 }
 }
 
-// MyStruct gets one and only one synthesized `foo`.
-// MyStruct gets no synthesized `bar`, because it has its own implementation.
-// CHECK-COUNT-1: ::SYNTHESIZED::
+// MyStruct gets one and only one synthesized `foo` and `baz`.
+// MyStruct gets no synthesized `bar` and `qux`, because it has its own implementation.
+// CHECK-COUNT-2: "precise": {{.*}}::SYNTHESIZED::
+// CHECK-NOT:     "precise": {{.*}}::SYNTHESIZED::


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65441

- **Explanation**: Expands the "synthesized member is best candidate" check to include decls that aren't just functions.
- **Scope**: When a protocol property requirement that has a default implementation is overridden in an implementation, the synthesized version of that property would still be emitted in the symbol graph, creating a duplicate symbol.
- **Issue**: rdar://105099207
- **Risk**: Low. The fix is targeted to emitting synthesized symbols, and does not affect normal compilation.
- **Testing**: Automated tests have been added.
- **Reviewer**: @daniel-grumberg 