### PR TITLE
[Diagnostics] Suppress unused expression warning if result is discard…

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2459,6 +2459,10 @@ public:
   
   bool containsPackExpansionType() const;
 
+  /// Check whether this tuple consists of a single unlabeled element
+  /// of \c PackExpansionType.
+  bool isSingleUnlabeledPackExpansion() const;
+
 private:
   TupleType(ArrayRef<TupleTypeElt> elements, const ASTContext *CanCtx,
             RecursiveTypeProperties properties)

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -134,6 +134,14 @@ bool CanTupleType::containsPackExpansionTypeImpl(CanTupleType tuple) {
   return false;
 }
 
+bool TupleType::isSingleUnlabeledPackExpansion() const {
+  if (getNumElements() != 1)
+    return false;
+
+  const auto &elt = getElement(0);
+  return !elt.hasName() && elt.getType()->is<PackExpansionType>();
+}
+
 bool AnyFunctionType::containsPackExpansionType(ArrayRef<Param> params) {
   for (auto param : params) {
     if (param.getPlainType()->is<PackExpansionType>())

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1749,6 +1749,16 @@ Stmt *PreCheckReturnStmtRequest::evaluate(Evaluator &evaluator, ReturnStmt *RS,
 }
 
 static bool isDiscardableType(Type type) {
+  // If type is `(_: repeat ...)`, it can be discardable.
+  if (auto *tuple = type->getAs<TupleType>()) {
+    if (tuple->isSingleUnlabeledPackExpansion()) {
+      type = tuple->getElementType(0);
+    }
+  }
+
+  if (auto *expansion = type->getAs<PackExpansionType>())
+    return isDiscardableType(expansion->getPatternType());
+
   return (type->hasError() ||
           type->isUninhabited() ||
           type->lookThroughAllOptionalTypes()->isVoid());

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -397,3 +397,14 @@ do {
   _ = Defaulted(t: "b", 0) // Ok
   _ = Defaulted(t: "c", 1.0, u: "d", 0) // Ok
 }
+
+// rdar://108064941 - unused result diagnostic is unaware of Void packs
+func test_no_unused_result_warning(arr: inout [Any]) {
+  func test1<each T>(_ value: (repeat each T)) {
+    repeat arr.append(each value.element) // no warning
+  }
+
+  func test2<each T>(_ value: repeat each T) {
+    ((repeat arr.append(each value))) // no warning
+  }
+}


### PR DESCRIPTION
…able pack expansion

Examine pack expansion pattern to determine whether expression 
result could be discarded without a warning (applies to tuples with 
a single unlabeled pack expansion element as well).

Resolves: rdar://108064941

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
