### PR TITLE
[interop] Ensure an FRT or a pointer to struct/class gets a Swift typ…

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2237,9 +2237,44 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
                 return;
               }
             }
-          } else if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(ty->getAsTagDecl())) {
-            importNameImpl(namedArg, version, clang::DeclarationName()).getDeclName().print(buffer);
-            return;
+          } else {
+            // FIXME: Generalize this to cover pointer to
+            // builtin type too.
+            // Check if this a struct/class
+            // or a pointer/reference to a struct/class.
+            auto *tagDecl = ty->getAsTagDecl();
+            enum class TagTypeDecorator {
+              None,
+              UnsafePointer,
+              UnsafeMutablePointer
+            };
+            TagTypeDecorator decorator = TagTypeDecorator::None;
+            if (!tagDecl && ty->isPointerType()) {
+              tagDecl = ty->getPointeeType()->getAsTagDecl();
+              if (tagDecl) {
+                bool isReferenceType = false;
+                if (auto *rd = dyn_cast<clang::RecordDecl>(tagDecl))
+                  isReferenceType = ClangImporter::Implementation::
+                      recordHasReferenceSemantics(rd, swiftCtx);
+                if (!isReferenceType)
+                  decorator = ty->getPointeeType().isConstQualified()
+                                  ? TagTypeDecorator::UnsafePointer
+                                  : TagTypeDecorator::UnsafeMutablePointer;
+              }
+            }
+            if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(tagDecl)) {
+              if (decorator != TagTypeDecorator::None)
+                buffer << (decorator == TagTypeDecorator::UnsafePointer
+                               ? "UnsafePointer"
+                               : "UnsafeMutablePointer")
+                       << '<';
+              importNameImpl(namedArg, version, clang::DeclarationName())
+                  .getDeclName()
+                  .print(buffer);
+              if (decorator != TagTypeDecorator::None)
+                buffer << '>';
+              return;
+            }
           }
         }
         buffer << "_";

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1763,6 +1763,11 @@ public:
       return *SinglePCHImport;
     return StringRef();
   }
+
+  /// Returns true if the given C/C++ record should be imported as a reference
+  /// type into Swift.
+  static bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
+                                          ASTContext &ctx);
 };
 
 class ImportDiagnosticAdder {

--- a/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -swift-version 5 -print-module -module-to-print=IncludesCxxStdlib -I %t/Inputs -source-filename=test.swift -enable-experimental-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t/cache | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+//--- Inputs/module.modulemap
+module IncludesCxxStdlib {
+    header "header.h"
+    export *
+}
+
+//--- Inputs/header.h
+#include <vector>
+
+class SimplePOD {
+public:
+    int x;
+};
+
+class __attribute__((swift_attr("import_reference"), swift_attr("retain:immortal"), swift_attr("release:immortal"))) FRTType {
+public:
+    int y;
+};
+
+// Type aliases are needed as a temporary workaround for
+// https://github.com/apple/swift/issues/65446.
+using T_1 = std::vector<SimplePOD> ;
+using T_2 = std::vector<FRTType *> ;
+using T_3 = std::vector<const SimplePOD *> ;
+using T_4 = std::vector<SimplePOD *> ;
+
+class VecOwner {
+public:
+    std::vector<SimplePOD> getPODItems() const;
+
+    std::vector<FRTType *> getFRTItems() const;
+
+    std::vector<const SimplePOD * _Nonnull> getPODPtrItems() const;
+
+    std::vector<SimplePOD * _Nullable> getMutPODPtrItems() const;
+};
+
+// CHECK: func getPODItems() -> std{{\.__1\.|\.}}vector<SimplePOD, allocator<SimplePOD>>
+// CHECK: func getFRTItems() -> std{{\.__1\.|\.}}vector<FRTType, allocator<FRTType>>
+// CHECK: func getPODPtrItems() -> std{{\.__1\.|\.}}vector<UnsafePointer<SimplePOD>, allocator<UnsafePointer<SimplePOD>>>
+// CHECK: func getMutPODPtrItems() -> std{{\.__1\.|\.}}vector<UnsafeMutablePointer<SimplePOD>, allocator<UnsafeMutablePointer<SimplePOD>>>


### PR DESCRIPTION
…e name for a C++ template parameter

In the follow-up, I should also expand this to cover pointers to builtin types too, but for now lets go with a miminal fix here
