### PR TITLE
5.9: [SemanticARCOpts] Promote moved load [copy]s to load_borrows.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1063,6 +1063,9 @@ public:
     /// memory location.
     LoadTake,
 
+    /// An owned value produced by moving from another owned value.
+    Move,
+
     /// An owned value that is a result of a true phi argument.
     ///
     /// A true phi argument here is defined as an SIL phi argument that only has
@@ -1137,6 +1140,8 @@ public:
         return Kind::LoadCopy;
       return Kind::Invalid;
     }
+    case ValueKind::MoveValueInst:
+      return Kind::Move;
     case ValueKind::PartialApplyInst:
       return Kind::PartialApplyInit;
     case ValueKind::AllocBoxInst:
@@ -1209,6 +1214,7 @@ struct OwnedValueIntroducer {
     case OwnedValueIntroducerKind::BeginApply:
     case OwnedValueIntroducerKind::TryApply:
     case OwnedValueIntroducerKind::LoadTake:
+    case OwnedValueIntroducerKind::Move:
     case OwnedValueIntroducerKind::Phi:
     case OwnedValueIntroducerKind::Struct:
     case OwnedValueIntroducerKind::Tuple:
@@ -1239,6 +1245,7 @@ struct OwnedValueIntroducer {
     case OwnedValueIntroducerKind::BeginApply:
     case OwnedValueIntroducerKind::TryApply:
     case OwnedValueIntroducerKind::LoadTake:
+    case OwnedValueIntroducerKind::Move:
     case OwnedValueIntroducerKind::FunctionArgument:
     case OwnedValueIntroducerKind::PartialApplyInit:
     case OwnedValueIntroducerKind::AllocBoxInit:

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1237,6 +1237,9 @@ void OwnedValueIntroducerKind::print(llvm::raw_ostream &os) const {
   case OwnedValueIntroducerKind::LoadTake:
     os << "LoadTake";
     return;
+  case OwnedValueIntroducerKind::Move:
+    os << "Move";
+    return;
   case OwnedValueIntroducerKind::Phi:
     os << "Phi";
     return;

--- a/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
@@ -332,16 +332,28 @@ bool SemanticARCOptVisitor::visitLoadInst(LoadInst *li) {
   if (li->getOwnershipQualifier() != LoadOwnershipQualifier::Copy)
     return false;
 
-  // Ok, we have our load [copy].  Try to optimize.
-  return performLoadCopyToLoadBorrowOptimization(li);
+  // Ok, we have our load [copy].  Try to optimize considering its live range.
+  if (performLoadCopyToLoadBorrowOptimization(li, li))
+    return true;
+  // Check whether the load [copy]'s only use is as an operand to a move_value.
+  auto *use = li->getSingleUse();
+  if (!use)
+    return false;
+  auto *mvi = dyn_cast<MoveValueInst>(use->getUser());
+  if (!mvi)
+    return false;
+  // Try to optimize considering the move_value's live range.
+  return performLoadCopyToLoadBorrowOptimization(li, mvi);
 }
 
-// Convert a load [copy] from unique storage [read] that has all uses that can
+// Convert a load [copy] from unique storage [read] whose representative
+// (either the load [copy] itself or a move from it) has all uses that can
 // accept a guaranteed parameter to a load_borrow.
 bool SemanticARCOptVisitor::performLoadCopyToLoadBorrowOptimization(
-    LoadInst *li) {
+    LoadInst *li, SILValue original) {
   assert(li->getOwnershipQualifier() == LoadOwnershipQualifier::Copy);
-
+  assert(li == original || li->getSingleUse()->getUser() ==
+                               cast<SingleValueInstruction>(original));
   // Make sure its value is truly a dead live range implying it is only ever
   // consumed by destroy_value instructions. If it is consumed, we need to pass
   // off a +1 value, so bail.
@@ -349,7 +361,7 @@ bool SemanticARCOptVisitor::performLoadCopyToLoadBorrowOptimization(
   // FIXME: We should consider if it is worth promoting a load [copy]
   // -> load_borrow if we can put a copy_value on a cold path and thus
   // eliminate RR traffic on a hot path.
-  OwnershipLiveRange lr(li);
+  OwnershipLiveRange lr(original);
   if (bool(lr.hasUnknownConsumingUse()))
     return false;
 
@@ -365,6 +377,15 @@ bool SemanticARCOptVisitor::performLoadCopyToLoadBorrowOptimization(
       SILBuilderWithScope(li).createLoadBorrow(li->getLoc(), li->getOperand());
   lr.insertEndBorrowsAtDestroys(lbi, getDeadEndBlocks(), ctx.lifetimeFrontier);
   SILValue replacement = lbi;
+  if (original != li) {
+    getCallbacks().eraseAndRAUWSingleValueInst(li, lbi);
+    auto *bbi =
+        SILBuilderWithScope(cast<SingleValueInstruction>(original))
+            .createBeginBorrow(li->getLoc(), lbi, original->isLexical());
+    replacement = bbi;
+    lr.insertEndBorrowsAtDestroys(bbi, getDeadEndBlocks(),
+                                  ctx.lifetimeFrontier);
+  }
   std::move(lr).convertToGuaranteedAndRAUW(replacement, getCallbacks());
   return true;
 }

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -296,6 +296,7 @@ static SILValue convertIntroducerToGuaranteed(OwnedValueIntroducer introducer) {
   case OwnedValueIntroducerKind::BeginApply:
   case OwnedValueIntroducerKind::TryApply:
   case OwnedValueIntroducerKind::LoadTake:
+  case OwnedValueIntroducerKind::Move:
   case OwnedValueIntroducerKind::FunctionArgument:
   case OwnedValueIntroducerKind::PartialApplyInit:
   case OwnedValueIntroducerKind::AllocBoxInit:

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -202,6 +202,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool optimize();
   bool optimizeWithoutFixedPoint();
 
+  bool performLoadCopyToLoadBorrowOptimization(LoadInst *li);
   bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi);
   bool eliminateDeadLiveRangeCopyValue(CopyValueInst *cvi);
   bool tryJoiningCopyValueLiveRangeWithOperand(CopyValueInst *cvi);

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -202,7 +202,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool optimize();
   bool optimizeWithoutFixedPoint();
 
-  bool performLoadCopyToLoadBorrowOptimization(LoadInst *li);
+  bool performLoadCopyToLoadBorrowOptimization(LoadInst *li, SILValue original);
   bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi);
   bool eliminateDeadLiveRangeCopyValue(CopyValueInst *cvi);
   bool tryJoiningCopyValueLiveRangeWithOperand(CopyValueInst *cvi);

--- a/test/SILOptimizer/semantic-arc-opts-loadcopy-to-loadborrow.sil
+++ b/test/SILOptimizer/semantic-arc-opts-loadcopy-to-loadborrow.sil
@@ -54,6 +54,10 @@ final class Klass {
   let baseLet: Klass
 }
 
+class C {}
+
+sil @getC : $@convention(thin) () -> (@owned C)
+
 extension Klass : MyFakeAnyObject {
   func myFakeMethod()
 }
@@ -1551,4 +1555,49 @@ bb2(%7 : @owned $NonTrivialStruct):
 
 bb3:
  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @promote_moved_from_load_copy : {{.*}} {
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         [[GET_C:%[^,]+]] = function_ref @getC
+// CHECK:         [[STORED:%[^,]+]] = apply [[GET_C]]()
+// CHECK:         store [[STORED]] to [init] [[ADDR]]
+// CHECK:         [[LOADED:%[^,]+]] = load_borrow [[ADDR]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[LOADED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         end_borrow [[LOADED]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK-LABEL: } // end sil function 'promote_moved_from_load_copy'
+sil [ossa] @promote_moved_from_load_copy : $@convention(thin) () -> () {
+bb0:
+  %addr = alloc_stack $C
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  %stored = apply %getC() : $@convention(thin) () -> (@owned C)
+  store %stored to [init] %addr : $*C
+  %loaded = load [copy] %addr : $*C
+  %lifetime = move_value [lexical] %loaded : $C
+  destroy_value %lifetime : $C
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_promote_moved_from_load_copy_with_destroy_addr_above_range : {{.*}} {
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'dont_promote_moved_from_load_copy_with_destroy_addr_above_range'
+sil [ossa] @dont_promote_moved_from_load_copy_with_destroy_addr_above_range : $@convention(thin) () -> () {
+bb0:
+  %addr = alloc_stack $C
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  %stored = apply %getC() : $@convention(thin) () -> (@owned C)
+  store %stored to [init] %addr : $*C
+  %loaded = load [copy] %addr : $*C
+  destroy_addr %addr : $*C
+  %lifetime = move_value [lexical] %loaded : $C
+  destroy_value %lifetime : $C
+  dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
 }


### PR DESCRIPTION
• Description: Adds a peephole to SemanticARCOpts' LoadCopyToLoadBorrowOpt to enable `load [copy]`s to be promoted to `load_borrow`s, eliminating a copy, when the unique user of the `load [copy]` is a `move_value`.  In that case, the `move_value` is promoted to a `begin_borrow`.
• Risk: Low.  This slightly extends the existing LoadCopyToLoadBorrowOpt (which already promotes `load [copy]`s to `load_borrow`s) to handle one additional case.
• Original PR: https://github.com/apple/swift/pull/65417 .
• Reviewed By: Andrew Trick ( @atrick )
• Testing: Added tests.
• Resolves: rdar://108514447
