### PR TITLE
[5.9🍒] Add the drop_deinit instruction & consume-on-all-paths checking for `discard`

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -647,6 +647,10 @@ final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {
   public var fromValue: Value { operand.value }
 }
 
+final public class DropDeinitInst : SingleValueInstruction, UnaryInstruction {
+  public var fromValue: Value { operand.value }
+}
+
 final public class StrongCopyUnownedValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class StrongCopyUnmanagedValueInst : SingleValueInstruction, UnaryInstruction  {}

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -125,6 +125,7 @@ public func registerSILClasses() {
   register(ProjectBoxInst.self)
   register(CopyValueInst.self)
   register(MoveValueInst.self)
+  register(DropDeinitInst.self)
   register(EndCOWMutationInst.self)
   register(ClassifyBridgeObjectInst.self)
   register(PartialApplyInst.self)

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6148,6 +6148,29 @@ a type `T` into the move only value space.
 The ``lexical`` attribute specifies that the value corresponds to a local
 variable in the Swift source.
 
+
+drop_deinit
+```````````
+
+::
+
+   sil-instruction ::= 'drop_deinit' sil-operand
+
+   %1 = drop_deinit %0 : $T
+   // T must be a move-only type
+   // %1 is an @owned T
+   %3 = drop_deinit %2 : $*T
+   // T must be a move-only type
+   // %2 has type *T
+
+This instruction is a marker for a following destroy instruction to suppress
+the call of the move-only type's deinitializer.
+The instruction accepts an object or address type.
+If its argument is an object type it takes in an `@owned T` and produces a new
+`@owned T`. If its argument is an address type, it's an identity projection.
+
+The instruction is only valid in ownership SIL.
+
 release_value
 `````````````
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -776,7 +776,11 @@ ERROR(sil_movechecking_notconsumable_but_assignable_was_consumed, none,
 ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
       "cannot partially consume '%0' when it has a deinitializer",
       (StringRef))
+ERROR(sil_movechecking_discard_missing_consume_self, none,
+      "must consume 'self' before exiting method that discards self", ())
 
+NOTE(sil_movechecking_discard_self_here, none,
+     "discarded self here", ())
 NOTE(sil_movechecking_partial_consume_here, none,
      "partially consumed here", ())
 NOTE(sil_movechecking_consuming_use_here, none,

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1632,6 +1632,7 @@ inline bool isAccessStorageIdentityCast(SingleValueInstruction *svi) {
   // Simply pass-thru the incoming address.
   case SILInstructionKind::MarkUninitializedInst:
   case SILInstructionKind::MarkMustCheckInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::CopyValueInst:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1364,6 +1364,14 @@ public:
                                                   operand, isLexical));
   }
 
+  DropDeinitInst *createDropDeinit(SILLocation loc, SILValue operand) {
+    assert(getFunction().hasOwnership());
+    assert(!operand->getType().isTrivial(getFunction()) &&
+           "Should not be passing trivial values to this api.");
+    return insert(new (getModule()) DropDeinitInst(getSILDebugLocation(loc),
+                                                   operand));
+  }
+
   MarkUnresolvedMoveAddrInst *createMarkUnresolvedMoveAddr(SILLocation loc,
                                                            SILValue srcAddr,
                                                            SILValue takeAddr) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1897,6 +1897,17 @@ void SILCloner<ImplClass>::visitMoveValueInst(MoveValueInst *Inst) {
 }
 
 template <typename ImplClass>
+void SILCloner<ImplClass>::visitDropDeinitInst(DropDeinitInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  if (!getBuilder().hasOwnership()) {
+    return recordFoldedValue(Inst, getOpValue(Inst->getOperand()));
+  }
+  auto *MVI = getBuilder().createDropDeinit(getOpLocation(Inst->getLoc()),
+                                            getOpValue(Inst->getOperand()));
+  recordClonedInstruction(Inst, MVI);
+}
+
+template <typename ImplClass>
 void SILCloner<ImplClass>::visitMarkMustCheckInst(MarkMustCheckInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   auto *MVI = getBuilder().createMarkMustCheckInst(

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8301,6 +8301,15 @@ public:
   void removeIsLexical() { lexical = false; }
 };
 
+class DropDeinitInst
+    : public UnaryInstructionBase<SILInstructionKind::DropDeinitInst,
+                                  SingleValueInstruction> {
+  friend class SILBuilder;
+
+  DropDeinitInst(SILDebugLocation DebugLoc, SILValue operand)
+      : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
+};
+
 /// Equivalent to a copy_addr to [init] except that it is used for diagnostics
 /// and should not be pattern matched. During the diagnostic passes, the "move
 /// function" checker for addresses always converts this to a copy_addr [init]

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -463,6 +463,8 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // effects relative to other OSSA values like copy_value.
   SINGLE_VALUE_INST(MoveValueInst, move_value, SingleValueInstruction, None,
                     DoesNotRelease)
+  SINGLE_VALUE_INST(DropDeinitInst, drop_deinit, SingleValueInstruction, None,
+                    DoesNotRelease)
   // A canary value inserted by a SIL generating frontend to signal to the move
   // checker to check a specific value.  Valid only in Raw SIL. The relevant
   // checkers should remove the mark_must_check instruction after successfully

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1248,6 +1248,10 @@ public:
     auto e = getLoweredExplosion(i->getOperand());
     setLoweredExplosion(i, e);
   }
+  void visitDropDeinitInst(DropDeinitInst *i) {
+    auto e = getLoweredExplosion(i->getOperand());
+    setLoweredExplosion(i, e);
+  }
   void visitMarkMustCheckInst(MarkMustCheckInst *i) {
     llvm_unreachable("Invalid in Lowered SIL");
   }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -457,6 +457,12 @@ OperandOwnershipClassifier::visitStoreBorrowInst(StoreBorrowInst *i) {
   return OperandOwnership::TrivialUse;
 }
 
+OperandOwnership
+OperandOwnershipClassifier::visitDropDeinitInst(DropDeinitInst *i) {
+  return i->getType().isAddress() ? OperandOwnership::TrivialUse
+                                  : OperandOwnership::ForwardingConsume;
+}
+
 // Get the OperandOwnership for instantaneous apply, yield, and return uses.
 // This does not apply to uses that begin an explicit borrow scope in the
 // caller, such as begin_apply.

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1999,6 +1999,10 @@ public:
     *this << getIDAndType(I->getOperand());
   }
 
+  void visitDropDeinitInst(DropDeinitInst *I) {
+    *this << getIDAndType(I->getOperand());
+  }
+
   void visitMarkMustCheckInst(MarkMustCheckInst *I) {
     using CheckKind = MarkMustCheckInst::CheckKind;
     switch (I->getCheckKind()) {

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -355,6 +355,10 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitLoadInst(LoadInst *LI) {
   llvm_unreachable("Unhandled LoadOwnershipQualifier in switch.");
 }
 
+ValueOwnershipKind ValueOwnershipKindClassifier::visitDropDeinitInst(DropDeinitInst *ddi) {
+  return ddi->getType().isAddress() ? OwnershipKind::None : OwnershipKind::Owned;
+}
+
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitPartialApplyInst(PartialApplyInst *PA) {
   // partial_apply instructions are modeled as creating an owned value during

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3702,6 +3702,15 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     break;
   }
 
+  case SILInstructionKind::DropDeinitInst: {
+    if (parseTypedValueRef(Val, B))
+      return true;
+    if (parseSILDebugLocation(InstLoc, B))
+      return true;
+    ResultVal = B.createDropDeinit(InstLoc, Val);
+    break;
+  }
+
   case SILInstructionKind::MarkMustCheckInst: {
     StringRef AttrName;
     if (!parseSILOptional(AttrName, *this)) {

--- a/lib/SIL/Utils/AddressWalker.cpp
+++ b/lib/SIL/Utils/AddressWalker.cpp
@@ -157,7 +157,7 @@ AddressUseKind TransitiveAddressWalker::walk(SILValue projectedAddress) && {
         isa<BeginAccessInst>(user) || isa<TailAddrInst>(user) ||
         isa<IndexAddrInst>(user) || isa<StoreBorrowInst>(user) ||
         isa<UncheckedAddrCastInst>(user) || isa<MarkMustCheckInst>(user) ||
-        isa<MarkUninitializedInst>(user) ||
+        isa<MarkUninitializedInst>(user) || isa<DropDeinitInst>(user) ||
         isa<ProjectBlockStorageInst>(user) || isa<UpcastInst>(user) ||
         isa<TuplePackElementAddrInst>(user)) {
       transitiveResultUses(op);

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -441,6 +441,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::ValueToBridgeObjectInst:
   case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::MoveValueInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::MarkMustCheckInst:
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1866,6 +1866,7 @@ AccessPathDefUseTraversal::visitSingleValueUser(SingleValueInstruction *svi,
     return IgnoredUse;
   }
 
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::MarkMustCheckInst: {
     // Mark must check goes on the project_box, so it isn't a ref.
     assert(!dfs.isRef());

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5968,6 +5968,14 @@ public:
             "Result and operand must have the same type, today.");
   }
 
+  void checkDropDeinitInst(DropDeinitInst *ddi) {
+    require(ddi->getType() == ddi->getOperand()->getType(),
+            "Result and operand must have the same type.");
+    require(ddi->getType().isMoveOnlyNominalType(),
+            "drop_deinit only allowed for move-only types");
+    require(F.hasOwnership(), "drop_deinit only allowed in OSSA");
+  }
+
   void checkMarkMustCheckInst(MarkMustCheckInst *i) {
     require(i->getModule().getStage() == SILStage::Raw,
             "Only valid in Raw SIL! Should have been eliminated by /some/ "

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -499,6 +499,7 @@ void SILGenFunction::emitMoveOnlyMemberDestruction(SILValue selfValue,
                                                    NominalTypeDecl *nom,
                                                    CleanupLocation cleanupLoc,
                                                    SILBasicBlock *finishBB) {
+  selfValue = B.createDropDeinit(cleanupLoc, selfValue);
   if (selfValue->getType().isAddress()) {
     if (auto *structDecl = dyn_cast<StructDecl>(nom)) {
       for (VarDecl *vd : nom->getStoredProperties()) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDeinitInsertion.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDeinitInsertion.cpp
@@ -62,7 +62,8 @@ static bool performTransform(SILFunction &fn) {
 
       if (auto *dvi = dyn_cast<DestroyValueInst>(inst)) {
         auto destroyType = dvi->getOperand()->getType();
-        if (destroyType.isMoveOnlyNominalType()) {
+        if (destroyType.isMoveOnlyNominalType() &&
+            !isa<DropDeinitInst>(lookThroughOwnershipInsts(dvi->getOperand()))) {
           LLVM_DEBUG(llvm::dbgs() << "Handling: " << *dvi);
           auto *nom = destroyType.getNominalOrBoundGenericNominal();
           assert(nom);
@@ -100,7 +101,8 @@ static bool performTransform(SILFunction &fn) {
 
       if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
         auto destroyType = dai->getOperand()->getType();
-        if (destroyType.isLoadable(fn) && destroyType.isMoveOnlyNominalType()) {
+        if (destroyType.isLoadable(fn) && destroyType.isMoveOnlyNominalType() &&
+            !isa<DropDeinitInst>(dai->getOperand())) {
           LLVM_DEBUG(llvm::dbgs() << "Handling: " << *dai);
           auto *nom = destroyType.getNominalOrBoundGenericNominal();
           assert(nom);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -119,6 +119,12 @@ public:
   /// way to file a bug.
   void emitCheckedMissedCopyError(SILInstruction *copyInst);
 
+  /// Assuming the given instruction represents the implicit destruction of
+  /// 'self', emits an error saying that you needed to explicitly 'consume self'
+  /// here because you're in a discarding context.
+  void emitMissingConsumeInDiscardingContext(SILInstruction *leftoverDestroy,
+                                             SILInstruction *dropDeinit);
+
   void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectOwnedDiagnostic(MarkMustCheckInst *markedValue);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -116,6 +116,20 @@ struct OSSACanonicalizer {
              return !isa<PartialApplyInst>(user);
            });
   }
+
+  struct DropDeinitFilter {
+    bool operator()(SILInstruction *inst) const {
+      return isa<DropDeinitInst>(inst);
+    }
+  };
+  using DropDeinitIter =
+      llvm::filter_iterator<SILInstruction *const *, DropDeinitFilter>;
+  using DropDeinitRange = iterator_range<DropDeinitIter>;
+
+  /// Returns a range of final uses of the mark_must_check that are drop_deinit
+  DropDeinitRange getDropDeinitUses() const {
+    return llvm::make_filter_range(consumingBoundaryUsers, DropDeinitFilter());
+  }
 };
 
 /// Search for candidate object mark_must_checks. If we find one that does not

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -141,6 +141,10 @@ struct OwnershipModelEliminatorVisitor
     eraseInstructionAndRAUW(mvi, mvi->getOperand());
     return true;
   }
+  bool visitDropDeinitInst(DropDeinitInst *ddi) {
+    eraseInstructionAndRAUW(ddi, ddi->getOperand());
+    return true;
+  }
   bool visitBeginBorrowInst(BeginBorrowInst *bbi) {
     eraseInstructionAndRAUW(bbi, bbi->getOperand());
     return true;

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -205,6 +205,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::CopyValueInst:
   case SILInstructionKind::ExplicitCopyValueInst:
   case SILInstructionKind::MoveValueInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::MarkMustCheckInst:
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -876,6 +876,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::BindMemoryInst:
   case SILInstructionKind::RebindMemoryInst:
   case SILInstructionKind::MoveValueInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::MarkMustCheckInst:
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2206,6 +2206,14 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     break;
   }
 
+  case SILInstructionKind::DropDeinitInst: {
+    auto Ty = MF->getType(TyID);
+    ResultInst = Builder.createDropDeinit(
+        Loc,
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+    break;
+  }
+
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst: {
     using Kind = MarkUnresolvedReferenceBindingInst::Kind;
     auto ty = MF->getType(TyID);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 782; // de/alloc_pack_metadata
+const uint16_t SWIFTMODULE_VERSION_MINOR = 783; // drop_deinit instruction
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1487,6 +1487,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::CopyValueInst:
   case SILInstructionKind::ExplicitCopyValueInst:
   case SILInstructionKind::MoveValueInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -48,6 +48,12 @@ class Class2 {
   init()
 }
 
+@_moveOnly struct MoveOnlyStruct {
+  @_hasStorage var i: Int
+  deinit
+}
+
+
 sil @type_ref1 : $(Class1, Int) -> ()  // CHECK-LABEL: sil @type_ref1 : $@convention(thin) (Class1, Int)
 
 // Instructions
@@ -1657,6 +1663,16 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
   end_lifetime %1 : $Builtin.NativeObject
   return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_drop_deinit :
+sil [ossa] @test_drop_deinit : $@convention(thin) (@owned MoveOnlyStruct) -> () {
+bb0(%0 : @owned $MoveOnlyStruct):
+  // CHECK: drop_deinit %0 : $MoveOnlyStruct
+  %1 = drop_deinit %0 : $MoveOnlyStruct
+  destroy_value %1 : $MoveOnlyStruct
+  %3 = tuple ()
+  return %3 : $()
 }
 
 sil @test_destructure_struct_tuple : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Int32, TestArrayStorage) {

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -23,6 +23,11 @@ struct Int32 {
 
 struct EmptyStruct {}
 
+@_moveOnly struct MoveOnlyStruct {
+  @_hasStorage var i: Int32
+  deinit
+}
+
 // CHECK-LABEL: sil @async_test : $@convention(thin) @async
 sil @async_test : $@async () -> () {
 bb0:
@@ -42,6 +47,17 @@ bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2)
   (%4, %5, %6) = destructure_struct %1 : $TestArray2
   %7 = tuple(%2 : $Builtin.NativeObject, %3 : $Builtin.Int32, %4 : $TestArrayStorage, %5 : $Int32, %6 : $TestArrayStorage)
   return %7 : $(Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Int32, TestArrayStorage)
+}
+
+// CHECK-LABEL: sil [ossa] @test_drop_deinit :
+// CHECK:         %1 = drop_deinit %0 : $MoveOnlyStruct
+// CHECK-LABEL: } // end sil function 'test_drop_deinit'
+sil [ossa] @test_drop_deinit : $@convention(thin) (@owned MoveOnlyStruct) -> () {
+bb0(%0 : @owned $MoveOnlyStruct):
+  %1 = drop_deinit %0 : $MoveOnlyStruct
+  destroy_value %1 : $MoveOnlyStruct
+  %3 = tuple ()
+  return %3 : $()
 }
 
 sil @test_empty_destructure : $@convention(thin) () -> () {

--- a/test/SILGen/discard.swift
+++ b/test/SILGen/discard.swift
@@ -68,6 +68,8 @@ func invokedDeinit() {}
   consuming func tryDestroy(doDiscard: Bool) throws {
     if doDiscard {
       discard self
+    } else {
+     _ = consume self
     }
     throw E.err
   }
@@ -136,17 +138,19 @@ final class Wallet {
 
   consuming func changeTicket(inWallet wallet: Wallet? = nil) {
     if let existingWallet = wallet {
-      discard self
       self = .within(existingWallet)
+      _ = consume self
+    } else {
+      discard self
     }
   }
-  // As of now, we allow reinitialization after discard. Not sure if this is intended.
+
   // CHECK-LABEL: sil hidden [ossa] @$s4test6TicketO06changeB08inWalletyAA0E0CSg_tF : $@convention(method) (@guaranteed Optional<Wallet>, @owned Ticket) -> () {
   // CHECK:    [[SELF_REF:%.*]] = project_box [[SELF_BOX:%.*]] : ${ var Ticket }, 0
-  // CHECK:    switch_enum {{.*}} : $Optional<Wallet>, case #Optional.some!enumelt: [[HAVE_WALLET_BB:bb.*]], case #Optional.none!enumelt: {{.*}}
+  // CHECK:    switch_enum {{.*}} : $Optional<Wallet>, case #Optional.some!enumelt: {{.*}}, case #Optional.none!enumelt: [[NO_WALLET_BB:bb[0-9]+]]
   //
   // >> now we begin the destruction sequence, which involves pattern matching on self to destroy its innards
-  // CHECK:  [[HAVE_WALLET_BB]]({{%.*}} : @owned $Wallet):
+  // CHECK:  [[NO_WALLET_BB]]
   // CHECK:    [[SELF_ACCESS:%.*]] = begin_access [read] [unknown] {{%.*}} : $*Ticket
   // CHECK:    [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_ACCESS]]
   // CHECK:    [[SELF_COPY:%.*]] = load [copy] [[SELF_MMC]] : $*Ticket
@@ -157,13 +161,7 @@ final class Wallet {
   // CHECK:  [[TICKET_WITHIN]]([[PREV_SELF_WALLET:%.*]] : @owned $Wallet):
   // CHECK:    destroy_value [[PREV_SELF_WALLET]] : $Wallet
   // CHECK:    br [[JOIN_POINT]]
-  // >> from here on we are reinitializing self.
   // CHECK:  [[JOIN_POINT]]:
-  // CHECK:    [[NEW_SELF_VAL:%.*]] = enum $Ticket, #Ticket.within!enumelt, {{.*}} : $Wallet
-  // CHECK:    [[SELF_ACCESS2:%.*]] = begin_access [modify] [unknown] [[SELF_REF]] : $*Ticket
-  // CHECK:    [[SELF_MMC2:%.*]] = mark_must_check [assignable_but_not_consumable] [[SELF_ACCESS2]] : $*Ticket
-  // CHECK:    assign [[NEW_SELF_VAL]] to [[SELF_MMC2]] : $*Ticket
-  // CHECK:    end_access [[SELF_ACCESS2]] : $*Ticket
 
   deinit {
     print("destroying ticket")

--- a/test/SILGen/discard.swift
+++ b/test/SILGen/discard.swift
@@ -24,7 +24,8 @@ func invokedDeinit() {}
   // CHECK:    store {{.*}} to [init]
   // CHECK:    [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_REF]] : $*MaybeFile
   // CHECK:    [[SELF_VAL:%.*]] = load [copy] [[SELF_MMC]] : $*MaybeFile
-  // CHECK:    switch_enum [[SELF_VAL]] : $MaybeFile, case #MaybeFile.some!enumelt: bb1, case #MaybeFile.none!enumelt: bb2
+  // CHECK:    [[DD:%.*]] = drop_deinit [[SELF_VAL]] : $MaybeFile
+  // CHECK:    switch_enum [[DD]] : $MaybeFile, case #MaybeFile.some!enumelt: bb1, case #MaybeFile.none!enumelt: bb2
   //
   // CHECK:  bb1([[FILE:%.*]] : @owned $File):
   // CHECK:    destroy_value [[FILE]] : $File
@@ -52,7 +53,8 @@ func invokedDeinit() {}
   // CHECK:  load_borrow {{.*}} : $*File
   // CHECK:  [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_REF]] : $*File
   // CHECK:  [[SELF_VAL:%.*]] = load [copy] [[SELF_MMC]] : $*File
-  // CHECK:  end_lifetime [[SELF_VAL]] : $File
+  // CHECK:  [[DD:%.*]] = drop_deinit [[SELF_VAL]] : $File
+  // CHECK:  end_lifetime [[DD]] : $File
 
   deinit {
     invokedDeinit()
@@ -87,7 +89,8 @@ func invokedDeinit() {}
 // CHECK:     [[MMC:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]] : $*PointerTree
 // CHECK:     [[COPIED_SELF:%.*]] = load [copy] [[MMC]] : $*PointerTree
 // CHECK:     end_access [[ACCESS]] : $*PointerTree
-// CHECK:     end_lifetime [[COPIED_SELF]]
+// CHECK:     [[DD:%.*]] = drop_deinit [[COPIED_SELF]]
+// CHECK:     end_lifetime [[DD]]
 // CHECK:     br bb3
 //
 // CHECK:   bb2:
@@ -155,7 +158,8 @@ final class Wallet {
   // CHECK:    [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_ACCESS]]
   // CHECK:    [[SELF_COPY:%.*]] = load [copy] [[SELF_MMC]] : $*Ticket
   // CHECK:    end_access [[SELF_ACCESS:%.*]] : $*Ticket
-  // CHECK:    switch_enum [[SELF_COPY]] : $Ticket, case #Ticket.empty!enumelt: [[TICKET_EMPTY:bb[0-9]+]], case #Ticket.within!enumelt: [[TICKET_WITHIN:bb[0-9]+]]
+  // CHECK:    [[DD:%.*]] = drop_deinit [[SELF_COPY]] : $Ticket
+  // CHECK:    switch_enum [[DD]] : $Ticket, case #Ticket.empty!enumelt: [[TICKET_EMPTY:bb[0-9]+]], case #Ticket.within!enumelt: [[TICKET_WITHIN:bb[0-9]+]]
   // CHECK:  [[TICKET_EMPTY]]:
   // CHECK:    br [[JOIN_POINT:bb[0-9]+]]
   // CHECK:  [[TICKET_WITHIN]]([[PREV_SELF_WALLET:%.*]] : @owned $Wallet):

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -1,6 +1,5 @@
-// TODO: re-enable the simplification passes once rdar://104875010 is fixed
-// RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=SILGEN %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck -check-prefix=SILGEN %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck -check-prefix=SIL %s
 
 // Test that makes sure that throughout the pipeline we properly handle
 // conditional releases for trivial and non-trivial move only types.

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -66,7 +66,8 @@ var value: Bool { false }
 // SILGEN-LABEL: sil hidden [ossa] @$s16moveonly_deinits19KlassPairWithDeinitVfD : $@convention(method) (@owned KlassPairWithDeinit) -> () {
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
-// SILGEN:   ([[LHS:%.*]], [[RHS:%.*]]) = destructure_struct [[MARK]]
+// SILGEN:   [[DD:%.*]] = drop_deinit [[MARK]]
+// SILGEN:   ([[LHS:%.*]], [[RHS:%.*]]) = destructure_struct [[DD]]
 // SILGEN:   destroy_value [[LHS]]
 // SILGEN:   destroy_value [[RHS]]
 // SILGEN: } // end sil function '$s16moveonly_deinits19KlassPairWithDeinitVfD'
@@ -74,7 +75,8 @@ var value: Bool { false }
 // SILGEN-LABEL: sil hidden [ossa] @$s16moveonly_deinits17IntPairWithDeinitVfD : $@convention(method) (@owned IntPairWithDeinit) -> () {
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARKED:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
-// SILGEN:   end_lifetime [[MARKED]]
+// SILGEN:   [[DD:%.*]] = drop_deinit [[MARKED]]
+// SILGEN:   end_lifetime [[DD]]
 // SILGEN: } // end sil function '$s16moveonly_deinits17IntPairWithDeinitVfD'
 
 ////////////////////////
@@ -330,7 +332,8 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 // SILGEN-LABEL: sil hidden [ossa] @$s16moveonly_deinits23KlassEnumPairWithDeinitOfD : $@convention(method) (@owned KlassEnumPairWithDeinit) -> () {
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
-// SILGEN:   switch_enum [[MARK]] : $KlassEnumPairWithDeinit, case #KlassEnumPairWithDeinit.lhs!enumelt: [[BB_LHS:bb[0-9]+]], case #KlassEnumPairWithDeinit.rhs!enumelt: [[BB_RHS:bb[0-9]+]]
+// SILGEN:   [[DD:%.*]] = drop_deinit [[MARK]]
+// SILGEN:   switch_enum [[DD]] : $KlassEnumPairWithDeinit, case #KlassEnumPairWithDeinit.lhs!enumelt: [[BB_LHS:bb[0-9]+]], case #KlassEnumPairWithDeinit.rhs!enumelt: [[BB_RHS:bb[0-9]+]]
 //
 // SILGEN: [[BB_LHS]]([[ARG:%.*]] :
 // SILGEN-NEXT: destroy_value [[ARG]]
@@ -348,7 +351,8 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 // SILGEN-LABEL: sil hidden [ossa] @$s16moveonly_deinits21IntEnumPairWithDeinitOfD : $@convention(method) (@owned IntEnumPairWithDeinit) -> () {
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
-// SILGEN:   switch_enum [[MARK]] : $IntEnumPairWithDeinit, case #IntEnumPairWithDeinit.lhs!enumelt: [[BB_LHS:bb[0-9]+]], case #IntEnumPairWithDeinit.rhs!enumelt: [[BB_RHS:bb[0-9]+]]
+// SILGEN:   [[DD:%.*]] = drop_deinit [[MARK]]
+// SILGEN:   switch_enum [[DD]] : $IntEnumPairWithDeinit, case #IntEnumPairWithDeinit.lhs!enumelt: [[BB_LHS:bb[0-9]+]], case #IntEnumPairWithDeinit.rhs!enumelt: [[BB_RHS:bb[0-9]+]]
 //
 // SILGEN: [[BB_LHS]]([[ARG:%.*]] :
 // SILGEN-NEXT: br [[BB_CONT:bb[0-9]+]]

--- a/test/SILGen/non_loadable_move_only.swift
+++ b/test/SILGen/non_loadable_move_only.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-silgen -module-name=test -primary-file %s | %FileCheck %s
+
+@_moveOnly
+public struct GenericMoveOnly<T> {
+  var i: Int
+  var s: T
+
+  // CHECK-LABEL: sil [ossa] @$s4test15GenericMoveOnlyVfD : $@convention(method) <T> (@in GenericMoveOnly<T>) -> ()
+  // CHECK:         [[DD:%.*]] = drop_deinit %0 : $*GenericMoveOnly<T>
+  // CHECK:         [[SE:%.*]] = struct_element_addr %2 : $*GenericMoveOnly<T>, #GenericMoveOnly.s
+  // CHECK:         [[A:%.*]] = begin_access [deinit] [static] %3 : $*T
+  // CHECK:         destroy_addr [[A]] : $*T
+  // CHECK:       } // end sil function '$s4test15GenericMoveOnlyVfD'
+  deinit {
+  }
+}
+
+

--- a/test/SILOptimizer/discard_checking.swift
+++ b/test/SILOptimizer/discard_checking.swift
@@ -1,0 +1,479 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s -disable-availability-checking
+
+// REQUIRES: concurrency
+
+enum Color {
+  case red, green, blue, none
+}
+enum E: Error {
+  case someError
+}
+
+func globalConsumingFn(_ b: consuming Basics) {}
+
+struct Basics: ~Copyable {
+  consuming func test1(_ b: Bool) {
+    guard b else {
+      fatalError("bah!") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+    discard self // expected-note {{discarded self here}}
+  }
+
+  consuming func test1_fixed(_ b: Bool) {
+    guard b else {
+      _ = consume self
+      fatalError("bah!")
+    }
+    discard self
+  }
+
+  consuming func test2(_ c: Color) throws {
+    repeat {
+      switch c {
+      case .red:
+        fatalError("bah!") // expected-error {{must consume 'self' before exiting method that discards self}}
+      case .blue:
+        throw E.someError // expected-error {{must consume 'self' before exiting method that discards self}}
+      case .green:
+        self = Basics()
+      default: print("hi")
+      }
+    } while true
+    discard self // expected-note 2{{discarded self here}}
+  }
+
+  consuming func test2_fixed(_ c: Color) throws {
+    repeat {
+      switch c {
+      case .red:
+        discard self
+        fatalError("bah!")
+      case .blue:
+        discard self
+        throw E.someError
+      case .green:
+        self = Basics()
+      default: print("hi")
+      }
+    } while true
+    discard self
+  }
+
+  consuming func test3(_ c: Color) {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    } else if case .blue = c {
+      try! test2(c)
+      return
+    } else if case .green = c {
+      return // expected-error {{must consume 'self' before exiting method that discards self}}
+    } else {
+      _ = consume self
+    }
+  }
+
+  consuming func test3_fixed(_ c: Color) {
+    if case .red = c {
+      discard self
+      return
+    } else if case .blue = c {
+      try! test2(c)
+      return
+    } else if case .green = c {
+      _ = consume self
+      return
+    } else {
+      _ = consume self
+    }
+  }
+
+  consuming func test4(_ c: Color) {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    }
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
+
+  consuming func test4_fixed(_ c: Color) {
+    if case .red = c {
+      discard self
+    } else {
+      _ = consume self
+    }
+  }
+
+  consuming func test5(_ c: Color) {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    } else {
+      return // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+  }
+
+  consuming func test5_fixed(_ c: Color) {
+    if case .red = c {
+      discard self
+    } else {
+      discard self
+      return
+    }
+  }
+
+  // TODO: rdar://110239743 (diagnostic locations for missing consume-before-exit in discarding methods are wonky)
+  consuming func test6(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    } else {
+      mutator() // expected-error {{must consume 'self' before exiting method that discards self}}
+      throw E.someError // <- better spot
+    }
+  }
+
+  consuming func test6_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+    } else {
+      mutator()
+      globalConsumingFn(self)
+      throw E.someError
+    }
+  }
+
+  consuming func test7(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    }
+    fatalError("oh no") // expected-error {{must consume 'self' before exiting method that discards self}}
+  }
+
+  consuming func test7_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+      return
+    }
+    _ = consume self
+    fatalError("oh no")
+  }
+
+  consuming func test8(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    }
+    if case .blue = c {
+      fatalError("hi") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+  }
+
+  consuming func test8_stillMissingAConsume1(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    if case .blue = c {
+      _ = consume self
+      fatalError("hi")
+    }
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
+
+  consuming func test8_stillMissingAConsume2(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    if case .blue = c {
+      fatalError("hi") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+    _ = consume self
+  }
+
+  consuming func test8_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+      return
+    }
+    if case .blue = c {
+      _ = consume self
+      fatalError("hi")
+    }
+    _ = consume self
+  }
+
+  consuming func test9(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+
+    do {
+      throw E.someError
+    } catch E.someError {
+      try test8(c)
+      return
+    } catch {
+      print("hi")
+      return  // <- better spot!!
+    }
+    _ = consume self // expected-warning {{will never be executed}}
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
+
+  consuming func test9_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+      return
+    }
+
+    do {
+      throw E.someError
+    } catch E.someError {
+      try test8(c)
+      return
+    } catch {
+      print("hi")
+      _ = consume self
+      return
+    }
+    _ = consume self // expected-warning {{will never be executed}}
+  }
+
+  consuming func test10(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+
+    do {
+      throw E.someError // expected-error {{must consume 'self' before exiting method that discards self}}
+    } catch E.someError {
+      return // <- better spot
+    } catch {
+      return // <- ok spot
+    }
+  }
+
+  consuming func test11(_ c: Color) {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    defer { print("hi") }
+    mutator()
+    _ = consume self
+    self = Basics()
+    borrower()
+    let x = self
+    self = x
+    mutator() // expected-error {{must consume 'self' before exiting method that discards self}}
+  }
+
+  consuming func test11_fixed(_ c: Color) {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    defer { print("hi") }
+    mutator()
+    _ = consume self
+    self = Basics()
+    borrower()
+    let x = self
+    self = x
+    mutator()
+    discard self
+  }
+
+  consuming func test12(_ c: Color) throws {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    try thrower() // expected-error {{must consume 'self' before exiting method that discards self}}
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test12_fixed1(_ c: Color) throws {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    try? thrower()
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test12_fixed2(_ c: Color) throws {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    do {
+      try thrower()
+    } catch {
+      print("hi")
+      _ = consume self
+      throw error
+    }
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test12Bang(_ c: Color) throws {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    try! thrower() // expected-error {{must consume 'self' before exiting method that discards self}}
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test13(_ c: Color) async { // expected-error {{must consume 'self' before exiting method that discards self}}
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    await asyncer()
+  } // <- better spot
+
+  consuming func test13_fixed(_ c: Color) async {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    await asyncer()
+    _ = consume self
+  }
+
+  consuming func test14(_ c: Color) async {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    await withCheckedContinuation { cont in // expected-error {{must consume 'self' before exiting method that discards self}}
+      cont.resume()
+    }
+    print("back!")
+  } // <- better spot
+
+  consuming func test14_fixed(_ c: Color) async {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    await withCheckedContinuation { cont in
+      cont.resume()
+    }
+    print("back!")
+    _ = consume self
+  }
+
+  consuming func positiveTest(_ i: Int) {
+    switch i {
+    case 0: _ = self
+    case 1: let _ = self
+    case 2:
+      let other = self
+      _ = other
+    case 3:
+      _ = consume self
+    case 4:
+      self.test11(.red)
+    case 5:
+      globalConsumingFn(self)
+    default:
+      discard self
+    }
+  }
+
+  // FIXME move checker is treating the defer like a closure capture (rdar://100468597)
+  // not expecting any errors here
+  consuming func brokenPositiveTest(_ i: Int) { // expected-error {{missing reinitialization of inout parameter 'self' after consume}}
+    defer { discard self } // expected-note {{consumed here}}
+    switch i {
+    case 0, 1, 2, 3: return
+    default:
+      break
+    }
+  }
+
+  consuming func negativeTest(_ i: Int) throws {
+    switch i {
+    case 0:
+      fallthrough
+    case 1:
+      throw E.someError // expected-error 2{{must consume 'self' before exiting method that discards self}}
+    case 2:
+      return // expected-error {{must consume 'self' before exiting method that discards self}}
+    case 3:
+      fatalError("no") // expected-error {{must consume 'self' before exiting method that discards self}}
+    case 4:
+      globalConsumingFn(self)
+    default:
+      discard self // expected-note 4{{discarded self here}}
+    }
+  }
+
+  consuming func loopyExit_bad(_ i: Int) {
+    if i < 0 {
+      discard self // expected-note 2{{discarded self here}}
+      return
+    }
+
+    // TODO: rdar://110239087 (avoid duplicate consume-before-exit diagnostics for loop in discarding method)
+    for _ in 0..<i {  // expected-error {{must consume 'self' before exiting method that discards self}}
+      self = Basics() // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+
+    return
+  }
+
+  consuming func loopyExit_good(_ i: Int) {
+    if i < 0 {
+      discard self
+      return
+    }
+
+    for _ in 0..<i {
+      self = Basics()
+    }
+
+    _ = consume self
+    return
+  }
+
+  mutating func mutator() { self = Basics() }
+  borrowing func borrower() {}
+  borrowing func thrower() throws {}
+
+  @MainActor borrowing func asyncer() async {}
+
+  deinit { print("hi") }
+}
+
+struct Money: ~Copyable {
+  enum Error: Swift.Error {
+    case insufficientFunds
+  }
+
+  let balance: Int
+
+  consuming func spend(_ charge: Int) throws -> Money {
+    guard charge > 0 else {
+      fatalError("can't charge a negative amount!") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+
+    if balance < charge  {
+      throw Error.insufficientFunds // expected-error {{must consume 'self' before exiting method that discards self}}
+    } else if balance > charge {
+      self = Money(balance: balance - charge)
+      return self
+    }
+
+    discard self // expected-note 2{{discarded self here}}
+    return Money(balance: 0)
+  }
+
+  deinit {
+    assert(balance > 0)
+  }
+}

--- a/test/SILOptimizer/moveonly_deinit_insertion.sil
+++ b/test/SILOptimizer/moveonly_deinit_insertion.sil
@@ -309,6 +309,48 @@ bb6:
   return %14 : $()
 }
 
+//===----------------------------------------------------------------------===//
+//                              drop_deinit Tests
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK:         %1 = drop_deinit %0
+// CHECK-NEXT:    destroy_value %1
+// CHECK:       } // end sil function 'dropDeinitOnStruct'
+sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+bb0(%0 : @owned $TrivialStruct):
+  %1 = drop_deinit %0 : $TrivialStruct
+  destroy_value %1 : $TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK:         %1 = drop_deinit %0
+// CHECK-NEXT:    %2 = move_value %1
+// CHECK-NEXT:    destroy_value %2
+// CHECK:       } // end sil function 'dropDeinitOnMovedStruct'
+sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+bb0(%0 : @owned $TrivialStruct):
+  %1 = drop_deinit %0 : $TrivialStruct
+  %2 = move_value %1 : $TrivialStruct
+  destroy_value %2 : $TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in TrivialStruct) -> () {
+// CHECK:         %1 = drop_deinit %0
+// CHECK-NEXT:    destroy_addr %1
+// CHECK:       } // end sil function 'dropDeinitOnIndirectStruct'
+sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in TrivialStruct) -> () {
+bb0(%0 : $*TrivialStruct):
+  %1 = drop_deinit %0 : $*TrivialStruct
+  destroy_addr %1 : $*TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 sil @$s4main5KlassCfD : $@convention(method) (@owned Klass) -> ()
 sil @$s4main5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass
 sil @$s4main5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject


### PR DESCRIPTION
Cherry-pick of 
- https://github.com/apple/swift/pull/65060
- https://github.com/apple/swift/pull/66190

• Description: Adds a missing piece of SE-390 where exits from a method that uses `discard self` that did not consume `self` explicitly are now flagged as errors. The purpose is to prevent mistakenly invoking the deinit in such contexts.
• Risk: Medium. Will introduce a source break in functions that are using `discard self` and do not consume `self` on all possible exits of the function (see `test/SILOptimizer/discard_checking.swift` for examples). The set of programs using `discard` is probably quite small currently and we'd want to introduce this change early, though the error could be downgraded into a warning for 5.9 upon request.
• Original PR: https://github.com/apple/swift/pull/66190 + dependency https://github.com/apple/swift/pull/65060
• Reviewed By: pending
• Testing: regression tests included
• Resolves: rdar://106099027