### PR TITLE
Preserve substituions maps while calculating derivative types

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -855,7 +855,7 @@ static SILFunctionType *getConstrainedAutoDiffOriginalFunctionType(
       original->getExtInfo(), original->getCoroutineKind(),
       original->getCalleeConvention(), newParameters, original->getYields(),
       newResults, original->getOptionalErrorResult(),
-      /*patternSubstitutions*/ SubstitutionMap(),
+      original->getPatternSubstitutions(),
       /*invocationSubstitutions*/ SubstitutionMap(), original->getASTContext(),
       original->getWitnessMethodConformanceOrInvalid());
 }
@@ -945,12 +945,12 @@ CanSILFunctionType SILFunctionType::getAutoDiffDerivativeFunctionType(
   // Put everything together to get the derivative function type. Then, store in
   // cache and return.
   cachedResult = SILFunctionType::get(
-      constrainedOriginalFnTy->getSubstGenericSignature(), extInfo,
+      constrainedOriginalFnTy->getInvocationGenericSignature(), extInfo,
       constrainedOriginalFnTy->getCoroutineKind(),
       constrainedOriginalFnTy->getCalleeConvention(), newParameters,
       constrainedOriginalFnTy->getYields(), newResults,
       constrainedOriginalFnTy->getOptionalErrorResult(),
-      /*patternSubstitutions*/ SubstitutionMap(),
+      constrainedOriginalFnTy->getPatternSubstitutions(),
       /*invocationSubstitutions*/ SubstitutionMap(),
       constrainedOriginalFnTy->getASTContext(),
       constrainedOriginalFnTy->getWitnessMethodConformanceOrInvalid());

--- a/test/AutoDiff/compiler_crashers_fixed/issue-65073-substmap.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-65073-substmap.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -emit-sil -O %s
+
+// Fix for https://github.com/apple/swift/issues/65073:
+// We need to ensure we are not dropping the substitution map during the
+// derivative type calculation in sil combiner that causes errors in the
+// subsequent optimizations as we're ending with invalid "recursive" 
+// subsitutions
+
+import _Differentiation;
+
+@differentiable(reverse)
+func f(array: [Double]) -> Double {
+    var array = array
+    for index in withoutDerivative(at: 0 ..< array.count) {array.update(at: index, byCalling: { (element: inout Double) in let initialElement = element; for _ in withoutDerivative(at: 0 ..< index) {element *= 
+initialElement}})}
+    return 0.0
+}
+public func valueWithPullback<T>(at x: T, of f: @differentiable(reverse) (inout T) -> Void) -> (value: Void, pullback: (inout T.TangentVector) -> Void) {fatalError()}
+public func pullback<T>(at x: T, of f: @differentiable(reverse) (inout T) -> Void) -> (inout T.TangentVector) -> Void {return valueWithPullback(at: x, of: f).pullback}
+public extension Array {@differentiable(reverse) mutating func update(at index: Int, byCalling closure: @differentiable(reverse) (inout Element) -> Void) where Element: Differentiable {closure(&self[index])}}
+public extension Array where Element: Differentiable {
+    @derivative(of: update(at:byCalling:))
+    mutating func vjpUpdate(at index: Int,byCalling closure: @differentiable(reverse) (inout Element) -> Void) -> (value: Void, pullback: (inout Self.TangentVector) -> Void){
+        let closurePullback = pullback(at: self[index], of: closure)
+        return (value: (), pullback: { closurePullback(&$0.base[index]) })
+    }
+}
+public struct D<I: Equatable, D> {public subscript(_ index: I) -> D? {get {fatalError()} set {fatalError()}}}


### PR DESCRIPTION
The substition map might contain a proper specialization (e.g. t_0_0 -> Double) that is required to fully specify a derivate type (e.g. during reabstraction conversion from fully specified function type to a substituted one)

Fixes #65073