### PR TITLE
[5.9][interop] Ensure an FRT or a pointer to struct/class gets a Swift typ…

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2237,9 +2237,44 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
                 return;
               }
             }
-          } else if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(ty->getAsTagDecl())) {
-            importNameImpl(namedArg, version, clang::DeclarationName()).getDeclName().print(buffer);
-            return;
+          } else {
+            // FIXME: Generalize this to cover pointer to
+            // builtin type too.
+            // Check if this a struct/class
+            // or a pointer/reference to a struct/class.
+            auto *tagDecl = ty->getAsTagDecl();
+            enum class TagTypeDecorator {
+              None,
+              UnsafePointer,
+              UnsafeMutablePointer
+            };
+            TagTypeDecorator decorator = TagTypeDecorator::None;
+            if (!tagDecl && ty->isPointerType()) {
+              tagDecl = ty->getPointeeType()->getAsTagDecl();
+              if (tagDecl) {
+                bool isReferenceType = false;
+                if (auto *rd = dyn_cast<clang::RecordDecl>(tagDecl))
+                  isReferenceType = ClangImporter::Implementation::
+                      recordHasReferenceSemantics(rd, swiftCtx);
+                if (!isReferenceType)
+                  decorator = ty->getPointeeType().isConstQualified()
+                                  ? TagTypeDecorator::UnsafePointer
+                                  : TagTypeDecorator::UnsafeMutablePointer;
+              }
+            }
+            if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(tagDecl)) {
+              if (decorator != TagTypeDecorator::None)
+                buffer << (decorator == TagTypeDecorator::UnsafePointer
+                               ? "UnsafePointer"
+                               : "UnsafeMutablePointer")
+                       << '<';
+              importNameImpl(namedArg, version, clang::DeclarationName())
+                  .getDeclName()
+                  .print(buffer);
+              if (decorator != TagTypeDecorator::None)
+                buffer << '>';
+              return;
+            }
           }
         }
         buffer << "_";

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1760,6 +1760,11 @@ public:
       return *SinglePCHImport;
     return StringRef();
   }
+
+  /// Returns true if the given C/C++ record should be imported as a reference
+  /// type into Swift.
+  static bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
+                                          ASTContext &ctx);
 };
 
 class ImportDiagnosticAdder {

--- a/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -swift-version 5 -print-module -module-to-print=IncludesCxxStdlib -I %t/Inputs -source-filename=test.swift -enable-experimental-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t/cache | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+//--- Inputs/module.modulemap
+module IncludesCxxStdlib {
+    header "header.h"
+    export *
+}
+
+//--- Inputs/header.h
+#include <vector>
+
+class SimplePOD {
+public:
+    int x;
+};
+
+class __attribute__((swift_attr("import_reference"), swift_attr("retain:immortal"), swift_attr("release:immortal"))) FRTType {
+public:
+    int y;
+};
+
+// Type aliases are needed as a temporary workaround for
+// https://github.com/apple/swift/issues/65446.
+using T_1 = std::vector<SimplePOD> ;
+using T_2 = std::vector<FRTType *> ;
+using T_3 = std::vector<const SimplePOD *> ;
+using T_4 = std::vector<SimplePOD *> ;
+
+class VecOwner {
+public:
+    std::vector<SimplePOD> getPODItems() const;
+
+    std::vector<FRTType *> getFRTItems() const;
+
+    std::vector<const SimplePOD * _Nonnull> getPODPtrItems() const;
+
+    std::vector<SimplePOD * _Nullable> getMutPODPtrItems() const;
+};
+
+// CHECK: func getPODItems() -> std{{\.__1\.|\.}}vector<SimplePOD, allocator<SimplePOD>>
+// CHECK: func getFRTItems() -> std{{\.__1\.|\.}}vector<FRTType, allocator<FRTType>>
+// CHECK: func getPODPtrItems() -> std{{\.__1\.|\.}}vector<UnsafePointer<SimplePOD>, allocator<UnsafePointer<SimplePOD>>>
+// CHECK: func getMutPODPtrItems() -> std{{\.__1\.|\.}}vector<UnsafeMutablePointer<SimplePOD>, allocator<UnsafeMutablePointer<SimplePOD>>>


### PR DESCRIPTION
…e name for a C++ template parameter

In the follow-up, I should also expand this to cover pointers to builtin types too, but for now lets go with a miminal fix here

(cherry picked from commit 0fff76915b0d04d23bb5df66f3586f562a6f942a)


Explanation: Swift type name importer imports C++ template parameters as `_` in cases where it can't provide a good Swift name. This logic did not handle the case where the template parameter was a pointer type, either a pointer to a foreign reference type, or a regular C++ record that's brought in as a value type. This patch expands this logic and ensures that these types are printed clearly, so that the user can see them when code-completing APIs or looking at the module interface print out of an API that uses such a type.
Scope: Swift's and C++ interoperability, Clang importer.
Risk: Low. This change only touches on C++ template parameters, which are only reached when C++ interoperability is enabled.
Testing: Swift unit tests.
Reviewer: @zoecarver
