### PR TITLE
[Executors] Make move to ExecutorJob binary compatible; deprecate Job

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3884,6 +3884,8 @@ public:
   /// This method should be deprecated and removed
   /// Get the move-only `enqueue(Job)` protocol requirement function on the `Executor` protocol.
   AbstractFunctionDecl *getExecutorLegacyOwnedEnqueueFunction() const;
+  /// Get the move-only `enqueue(UnownedJob)` protocol requirement function on the `Executor` protocol.
+  AbstractFunctionDecl *getExecutorLegacyUnownedEnqueueFunction() const;
 
   /// Collect the set of protocols to which this type should implicitly
   /// conform, such as AnyObject (for classes).

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3879,8 +3879,11 @@ public:
   /// Find the 'RemoteCallArgument(label:name:value:)' initializer function.
   ConstructorDecl *getDistributedRemoteCallArgumentInitFunction() const;
 
-  /// Get the move-only `enqueue(Job)` protocol requirement function on the `Executor` protocol.
+  /// Get the move-only `enqueue(ExecutorJob)` protocol requirement function on the `Executor` protocol.
   AbstractFunctionDecl *getExecutorOwnedEnqueueFunction() const;
+  /// This method should be deprecated and removed
+  /// Get the move-only `enqueue(Job)` protocol requirement function on the `Executor` protocol.
+  AbstractFunctionDecl *getExecutorLegacyOwnedEnqueueFunction() const;
 
   /// Collect the set of protocols to which this type should implicitly
   /// conform, such as AnyObject (for classes).

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6517,7 +6517,11 @@ WARNING(hashvalue_implementation,Deprecation,
 
 WARNING(executor_enqueue_unowned_implementation,Deprecation,
         "'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; "
-        "conform type %0 to 'Executor' by implementing 'func enqueue(Job)' instead",
+        "conform type %0 to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead",
+        (Type))
+WARNING(executor_enqueue_deprecated_owned_job_implementation,Deprecation,
+        "'Executor.enqueue(Job)' is deprecated as a protocol requirement; "
+        "conform type %0 to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead",
         (Type))
 
 //------------------------------------------------------------------------------

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5318,6 +5318,9 @@ VarDecl *NominalTypeDecl::getGlobalActorInstance() const {
 AbstractFunctionDecl *
 NominalTypeDecl::getExecutorOwnedEnqueueFunction() const {
   auto &C = getASTContext();
+  StructDecl *executorJobDecl = C.getExecutorJobDecl();
+  if (!executorJobDecl)
+    return nullptr;
 
   auto proto = dyn_cast<ProtocolDecl>(this);
   if (!proto)
@@ -5335,11 +5338,51 @@ NominalTypeDecl::getExecutorOwnedEnqueueFunction() const {
       continue;
 
     if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(candidate)) {
-      if (funcDecl->getParameters()->size() != 1)
+      auto params = funcDecl->getParameters();
+
+      if (params->size() != 1)
         continue;
 
+      if (params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned && // TODO: make this Consuming
+          params->get(0)->getInterfaceType()->isEqual(executorJobDecl->getDeclaredInterfaceType())) {
+        return funcDecl;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+AbstractFunctionDecl *
+NominalTypeDecl::getExecutorLegacyOwnedEnqueueFunction() const {
+  auto &C = getASTContext();
+  StructDecl *legacyJobDecl = C.getJobDecl();
+  if (!legacyJobDecl)
+    return nullptr;
+
+  auto proto = dyn_cast<ProtocolDecl>(this);
+  if (!proto)
+    return nullptr;
+
+  llvm::SmallVector<ValueDecl *, 2> results;
+  lookupQualified(getSelfNominalTypeDecl(),
+                  DeclNameRef(C.Id_enqueue),
+                  NL_ProtocolMembers,
+                  results);
+
+  for (auto candidate: results) {
+    // we're specifically looking for the Executor protocol requirement
+    if (!isa<ProtocolDecl>(candidate->getDeclContext()))
+      continue;
+
+    if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(candidate)) {
       auto params = funcDecl->getParameters();
-      if (params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned) { // TODO: make this Consuming
+
+      if (params->size() != 1)
+        continue;
+
+      if (params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned && // TODO: make this Consuming
+          params->get(0)->getType()->isEqual(legacyJobDecl->getDeclaredInterfaceType())) {
         return funcDecl;
       }
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5343,7 +5343,8 @@ NominalTypeDecl::getExecutorOwnedEnqueueFunction() const {
       if (params->size() != 1)
         continue;
 
-      if (params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned && // TODO: make this Consuming
+      if ((params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned ||
+           params->get(0)->getSpecifier() == ParamSpecifier::Consuming) &&
           params->get(0)->getInterfaceType()->isEqual(executorJobDecl->getDeclaredInterfaceType())) {
         return funcDecl;
       }
@@ -5381,8 +5382,46 @@ NominalTypeDecl::getExecutorLegacyOwnedEnqueueFunction() const {
       if (params->size() != 1)
         continue;
 
-      if (params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned && // TODO: make this Consuming
+      if ((params->get(0)->getSpecifier() == ParamSpecifier::LegacyOwned ||
+          params->get(0)->getSpecifier() == ParamSpecifier::Consuming) &&
           params->get(0)->getType()->isEqual(legacyJobDecl->getDeclaredInterfaceType())) {
+        return funcDecl;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+AbstractFunctionDecl *
+NominalTypeDecl::getExecutorLegacyUnownedEnqueueFunction() const {
+  auto &C = getASTContext();
+  StructDecl *unownedJobDecl = C.getUnownedJobDecl();
+  if (!unownedJobDecl)
+    return nullptr;
+
+  auto proto = dyn_cast<ProtocolDecl>(this);
+  if (!proto)
+    return nullptr;
+
+  llvm::SmallVector<ValueDecl *, 2> results;
+  lookupQualified(getSelfNominalTypeDecl(),
+                  DeclNameRef(C.Id_enqueue),
+                  NL_ProtocolMembers,
+                  results);
+
+  for (auto candidate: results) {
+    // we're specifically looking for the Executor protocol requirement
+    if (!isa<ProtocolDecl>(candidate->getDeclContext()))
+      continue;
+
+    if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(candidate)) {
+      auto params = funcDecl->getParameters();
+
+      if (params->size() != 1)
+        continue;
+
+      if (params->get(0)->getType()->isEqual(unownedJobDecl->getDeclaredInterfaceType())) {
         return funcDecl;
       }
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1269,8 +1269,9 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
   // enqueue(_:)
   auto enqueueDeclName = DeclName(C, DeclBaseName(C.Id_enqueue), { Identifier() });
 
-  FuncDecl *unownedEnqueueRequirement = nullptr;
   FuncDecl *moveOnlyEnqueueRequirement = nullptr;
+  FuncDecl *legacyMoveOnlyEnqueueRequirement = nullptr; // TODO: preferably we'd want to remove handling of `enqueue(Job)` when able to
+  FuncDecl *unownedEnqueueRequirement = nullptr;
   for (auto req: proto->getProtocolRequirements()) {
     auto *funcDecl = dyn_cast<FuncDecl>(req);
     if (!funcDecl)
@@ -1282,62 +1283,74 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
     // look for the first parameter being a Job or UnownedJob
     if (funcDecl->getParameters()->size() != 1)
       continue;
-    if (auto param = funcDecl->getParameters()->front()) {
-      StructDecl *unownedJobDecl = C.getUnownedJobDecl();
-      StructDecl *jobDecl = nullptr;
-      if (auto executorJobDecl = C.getExecutorJobDecl()) {
-        jobDecl = executorJobDecl;
-      } else if (auto plainJobDecl = C.getJobDecl()) {
-        // old standard library, before we introduced the `typealias Job = ExecutorJob`
-        jobDecl = plainJobDecl;
-      }
 
-      if (jobDecl &&
-          param->getType()->isEqual(jobDecl->getDeclaredInterfaceType())) {
+    if (auto param = funcDecl->getParameters()->front()) {
+      StructDecl *executorJobDecl = C.getExecutorJobDecl();
+      StructDecl *legacyJobDecl = C.getJobDecl();
+      StructDecl *unownedJobDecl = C.getUnownedJobDecl();
+
+      if (executorJobDecl && param->getType()->isEqual(executorJobDecl->getDeclaredInterfaceType())) {
         assert(moveOnlyEnqueueRequirement == nullptr);
         moveOnlyEnqueueRequirement = funcDecl;
-      } else if (unownedJobDecl &&
-                 param->getType()->isEqual(unownedJobDecl->getDeclaredInterfaceType())) {
+      } else if (legacyJobDecl && param->getType()->isEqual(legacyJobDecl->getDeclaredInterfaceType())) {
+        assert(legacyMoveOnlyEnqueueRequirement == nullptr);
+        legacyMoveOnlyEnqueueRequirement = funcDecl;
+      } else if (unownedJobDecl && param->getType()->isEqual(unownedJobDecl->getDeclaredInterfaceType())) {
         assert(unownedEnqueueRequirement == nullptr);
         unownedEnqueueRequirement = funcDecl;
       }
     }
 
-    // if we found both, we're done here and break out of the loop
-    if (unownedEnqueueRequirement && moveOnlyEnqueueRequirement)
+    // if we found all potential requirements, we're done here and break out of the loop
+    if (unownedEnqueueRequirement &&
+        moveOnlyEnqueueRequirement &&
+        legacyMoveOnlyEnqueueRequirement)
       break; // we're done looking for the requirements
   }
 
   auto conformance = module->lookupConformance(nominalTy, proto);
   auto concreteConformance = conformance.getConcrete();
   assert(unownedEnqueueRequirement && "could not find the enqueue(UnownedJob) requirement, which should be always there");
-  ConcreteDeclRef unownedEnqueueWitness = concreteConformance->getWitnessDeclRef(unownedEnqueueRequirement);
 
-  if (auto enqueueUnownedDecl = unownedEnqueueWitness.getDecl()) {
-    // Old UnownedJob based impl is present, warn about it suggesting the new protocol requirement.
-    if (enqueueUnownedDecl->getLoc().isValid()) {
-      diags.diagnose(enqueueUnownedDecl->getLoc(), diag::executor_enqueue_unowned_implementation, nominalTy);
-    }
+  // try to find at least a single implementations of enqueue(_:)
+  ConcreteDeclRef unownedEnqueueWitness = concreteConformance->getWitnessDeclRef(unownedEnqueueRequirement);
+  ValueDecl *unownedEnqueueWitnessDecl = unownedEnqueueWitness.getDecl();
+  ValueDecl *moveOnlyEnqueueWitnessDecl = nullptr;
+  ValueDecl *legacyMoveOnlyEnqueueWitnessDecl = nullptr;
+
+  if (moveOnlyEnqueueRequirement) {
+    moveOnlyEnqueueWitnessDecl = concreteConformance->getWitnessDeclRef(
+        moveOnlyEnqueueRequirement).getDecl();
+  }
+  if (legacyMoveOnlyEnqueueRequirement) {
+    legacyMoveOnlyEnqueueWitnessDecl = concreteConformance->getWitnessDeclRef(
+        legacyMoveOnlyEnqueueRequirement).getDecl();
   }
 
-  if (auto unownedEnqueueDecl = unownedEnqueueWitness.getDecl()) {
-    if (moveOnlyEnqueueRequirement) {
-      ConcreteDeclRef moveOnlyEnqueueWitness = concreteConformance->getWitnessDeclRef(moveOnlyEnqueueRequirement);
-      if (auto moveOnlyEnqueueDecl = moveOnlyEnqueueWitness.getDecl()) {
-        if (unownedEnqueueDecl && unownedEnqueueDecl->getLoc().isInvalid() &&
-            moveOnlyEnqueueDecl && moveOnlyEnqueueDecl->getLoc().isInvalid()) {
-          // Neither old nor new implementation have been found, but we provide default impls for them
-          // that are mutually recursive, so we must error and suggest implementing the right requirement.
-          auto ownedRequirement = C.getExecutorDecl()->getExecutorOwnedEnqueueFunction();
-          nominal->diagnose(diag::type_does_not_conform, nominalTy, proto->getDeclaredInterfaceType());
-          ownedRequirement->diagnose(diag::no_witnesses,
-                                     getProtocolRequirementKind(ownedRequirement),
-                                     ownedRequirement->getName(),
-                                     proto->getDeclaredInterfaceType(),
-                                     /*AddFixIt=*/true);
-        }
-      }
-    }
+  // --- Diagnose warnings and errors
+
+  // Old UnownedJob based impl is present, warn about it suggesting the new protocol requirement.
+  if (unownedEnqueueWitnessDecl && unownedEnqueueWitnessDecl->getLoc().isValid()) {
+    diags.diagnose(unownedEnqueueWitnessDecl->getLoc(), diag::executor_enqueue_unowned_implementation, nominalTy);
+  }
+  // Old Job based impl is present, warn about it suggesting the new protocol requirement.
+  if (legacyMoveOnlyEnqueueWitnessDecl && legacyMoveOnlyEnqueueWitnessDecl->getLoc().isValid()) {
+    diags.diagnose(legacyMoveOnlyEnqueueWitnessDecl->getLoc(), diag::executor_enqueue_deprecated_owned_job_implementation, nominalTy);
+  }
+
+  if ((!unownedEnqueueWitnessDecl || unownedEnqueueWitnessDecl->getLoc().isInvalid()) &&
+      (!moveOnlyEnqueueWitnessDecl || moveOnlyEnqueueWitnessDecl->getLoc().isInvalid()) &&
+      (!legacyMoveOnlyEnqueueWitnessDecl || legacyMoveOnlyEnqueueWitnessDecl->getLoc().isInvalid())) {
+    // Neither old nor new implementation have been found, but we provide default impls for them
+    // that are mutually recursive, so we must error and suggest implementing the right requirement.
+    auto ownedRequirement = C.getExecutorDecl()->getExecutorOwnedEnqueueFunction();
+    nominal->diagnose(diag::type_does_not_conform, nominalTy, proto->getDeclaredInterfaceType());
+    ownedRequirement->diagnose(diag::no_witnesses,
+                               getProtocolRequirementKind(ownedRequirement),
+                               ownedRequirement->getName(),
+                               ownedRequirement->getParameters()->get(0)->getInterfaceType(),
+                               /*AddFixIt=*/true);
+    return;
   }
 }
 

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -25,6 +25,12 @@ public protocol Executor: AnyObject, Sendable {
   func enqueue(_ job: UnownedJob)
 
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(*, deprecated, message: "Use enqueue(ExecutorJob) instead")
+  func enqueue(_ job: __owned Job)
+  #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+
+  #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(SwiftStdlib 5.9, *)
   func enqueue(_ job: __owned ExecutorJob)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -45,6 +51,17 @@ public protocol SerialExecutor: Executor {
   @available(tvOS, introduced: 13.0, deprecated: 9999, message: "Implement 'enqueue(_: __owned ExecutorJob)' instead")
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   func enqueue(_ job: UnownedJob)
+
+  #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+  // This requirement is repeated here as a non-override so that we
+  // get a redundant witness-table entry for it.  This allows us to
+  // avoid drilling down to the base conformance just for the basic
+  // work-scheduling operation.
+  @_nonoverride
+  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(*, deprecated, message: "Use enqueue(ExecutorJob) instead")
+  func enqueue(_ job: __owned Job)
+  #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   // This requirement is repeated here as a non-override so that we
@@ -90,6 +107,10 @@ extension Executor {
   }
 
   public func enqueue(_ job: __owned ExecutorJob) {
+    self.enqueue(UnownedJob(job))
+  }
+
+  public func enqueue(_ job: __owned Job) {
     self.enqueue(UnownedJob(job))
   }
 }

--- a/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
+++ b/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
@@ -10,6 +10,12 @@
 // REQUIRES: concurrency_runtime
 
 final class InlineExecutor: SerialExecutor, CustomStringConvertible {
+  public func enqueue(_ job: UnownedJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+  public func enqueue(_ job: __owned Job) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
   public func enqueue(_ job: __owned ExecutorJob) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }

--- a/test/Concurrency/Runtime/custom_executors_tryDiagnoseExecutorConformance_with_sdk_typealias_struct_job_types.swift
+++ b/test/Concurrency/Runtime/custom_executors_tryDiagnoseExecutorConformance_with_sdk_typealias_struct_job_types.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-concurrency-typealias-struct-job) -typecheck -parse-as-library %s -verify
+
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://106849189 move-only types should be supported in freestanding mode
+// UNSUPPORTED: freestanding
+
+// UNSUPPORTED: back_deployment_runtime
+// REQUIRES: concurrency_runtime
+
+import _Concurrency
+
+final class FakeExecutor1: SerialExecutor {
+  func enqueue(_ job: __owned ExecutorJob) {}
+}
+
+final class FakeExecutor2: SerialExecutor {
+  func enqueue(_ job: __owned Job) {}
+}

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -12,7 +12,7 @@
 //
 // We keep support for them, but also log a deprecation warning that they should move to the new signature.
 final class OldExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'OldExecutor' to 'Executor' by implementing 'func enqueue(Job)' instead}}
+  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'OldExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     UnownedSerialExecutor(ordinary: self)
@@ -24,7 +24,23 @@ final class OldExecutor: SerialExecutor {
 ///
 /// That's why we do log the deprecation warning, people should use the move-only version.
 final class BothExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutor' to 'Executor' by implementing 'func enqueue(Job)' instead}}
+  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
+  func enqueue(_ job: __owned ExecutorJob) {}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// For now we must keep all 3 implementation kinds and warn about deprecated ones
+final class TripleExecutor: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
+  // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
+  // expected-note@+1{{use 'ExecutorJob' instead}}
+  func enqueue(_ job: __owned Job) {} // expected-warning{{'Executor.enqueue(Job)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
   func enqueue(_ job: __owned ExecutorJob) {}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
@@ -37,6 +53,17 @@ final class BothExecutor: SerialExecutor {
 ///
 /// We do so because we implement them recursively, so one of them must be implemented basically.
 final class NoneExecutor: SerialExecutor { // expected-error{{type 'NoneExecutor' does not conform to protocol 'Executor'}}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// Job still is deprecated
+final class StillDeprecated: SerialExecutor {
+  // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
+  // expected-note@+1{{use 'ExecutorJob' instead}}
+  func enqueue(_ job: __owned Job) {} // expected-warning{{'Executor.enqueue(Job)' is deprecated as a protocol requirement; conform type 'StillDeprecated' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     UnownedSerialExecutor(ordinary: self)

--- a/test/Inputs/clang-importer-sdk/swift-modules-concurrency-typealias-struct-job/_Concurrency.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-concurrency-typealias-struct-job/_Concurrency.swift
@@ -1,0 +1,9 @@
+
+@_moveOnly
+public struct ExecutorJob {}
+
+public typealias Job = ExecutorJob
+
+public protocol SerialExecutor {
+  func enqueue(_ job: __owned ExecutorJob)
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -616,15 +616,22 @@ config.substitutions.append(('%build-clang-importer-objc-overlays',
 # FIXME: BEGIN -enable-source-import hackaround
 config.substitutions.append(('%clang-importer-sdk-concurrency-without-job-path',
                              '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
-
 config.substitutions.append(('%clang-importer-sdk-concurrency-without-job-nosource',
                              '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 # FIXME: END -enable-source-import hackaround
-
 config.substitutions.append(('%clang-importer-sdk-concurrency-without-job',
                              '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
                                                                        make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules-concurrency-without-job'))))
 
+# FIXME: BEGIN -enable-source-import hackaround
+config.substitutions.append(('%clang-importer-sdk-concurrency-typealias-struct-job-path',
+                             '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+config.substitutions.append(('%clang-importer-sdk-concurrency-typealias-struct-job-nosource',
+                             '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+# FIXME: END -enable-source-import hackaround
+config.substitutions.append(('%clang-importer-sdk-concurrency-typealias-struct-job',
+                             '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                                                       make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules-concurrency-typealias-struct-job'))))
 
 # FIXME: BEGIN -enable-source-import hackaround
 config.substitutions.append(('%clang-importer-sdk-path',


### PR DESCRIPTION
In https://github.com/apple/swift/pull/65038 we renamed Job to ExecutorJob and introduced a typealias. We knew this would be binary breaking however we hoped the change would not cause problems since noone had adopted this new API yet -- we were wrong.

This change introduces a binary compatible way to introduce `ExecutorJob` while keeping `Job` as deprecated and hopefully we'd be able to remove it still.

Diagnostics were adjusted to handle the new type and push developers towards the right implementation method.