### PR TITLE
[CanonicalizeBorrowScope] Allow inner forwarding value unmapped to outer value during outer rewriting.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -638,7 +638,9 @@ protected:
     assert(succeed && "should be filtered by FindBorrowScopeUses");
 
     auto iter = innerToOuterMap.find(innerValue);
-    assert(iter != innerToOuterMap.end());
+    if (iter == innerToOuterMap.end()) {
+      return SILValue();
+    }
     SILValue outerValue = iter->second;
     cleanupOuterValue(outerValue);
     return outerValue;

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -200,14 +200,14 @@ SILValue CanonicalizeBorrowScope::findDefInBorrowScope(SILValue value) {
   return value;
 }
 
-/// Visit all extended uses within the borrow scope, looking through copies.
-/// Call visitUse for uses which could potentially be outside the borrow scope.
-/// Call visitForwardingUse for hoistable forwarding operations which could
-/// potentially be inside the borrow scope.
+/// Visit all extended uses within the borrow scope, looking through copies and
+/// moves. Call visitUse for uses which could potentially be outside the borrow
+/// scope. Call visitForwardingUse for hoistable forwarding operations which
+/// could potentially be inside the borrow scope.
 ///
 /// The visitor may or may not be able to determine which uses are outside the
 /// scope, but it can filter uses that are definitely within the scope. For
-/// example, guaranteed uses and uses in live-out blocks must be both be within
+/// example, guaranteed uses and uses in live-out blocks must both be within
 /// the scope.
 ///
 /// This def-use traversal is similar to findExtendedTransitiveGuaranteedUses(),

--- a/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
+++ b/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
@@ -4,6 +4,12 @@ import Builtin
 
 typealias AnyObject = Builtin.AnyObject
 
+class C {}
+class D : C {}
+
+sil @getD : $() -> (@owned D)
+sil @takeC : $(@owned C) -> ()
+
 struct Unmanaged<Instance> where Instance : AnyObject {
   unowned(unsafe) var _value: @sil_unmanaged Instance
 }
@@ -56,4 +62,38 @@ bb0(%instance : @guaranteed $Instance):
   destroy_value %copy_1 : $Instance
   %retval = struct $Unmanaged<Instance> (%unmanaged : $@sil_unmanaged Instance)
   return %retval : $Unmanaged<Instance>
+}
+
+// CHECK-LABEL: begin running test {{.*}} on dont_rewrite_inner_forwarding_user: canonicalize-borrow-scope
+// CHECK-LABEL: sil [ossa] @dont_rewrite_inner_forwarding_user : {{.*}} {
+// CHECK:         [[GET_C:%[^,]+]] = function_ref @getD
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         [[C:%[^,]+]] = apply [[GET_C]]()
+// CHECK:         [[OUTER_COPY:%[^,]+]] = copy_value [[C]]
+// CHECK:         [[OUTER_UPCAST:%[^,]+]] = upcast [[OUTER_COPY]]
+// CHECK:         [[B:%[^,]+]] = begin_borrow [[C]]
+// CHECK:         [[DEAD_INNER_COPY:%[^,]+]] = copy_value [[B]]
+// CHECK:         destroy_value [[DEAD_INNER_COPY]]
+// CHECK:         [[U:%[^,]+]] = upcast [[B]]
+// CHECK:         [[C1:%[^,]+]] = copy_value [[U]]
+// CHECK:         apply [[TAKE_C]]([[C1]])
+// CHECK:         end_borrow [[B]]
+// CHECK:         destroy_value [[C]]
+// CHECK:         return [[OUTER_UPCAST]]
+// CHECK-LABEL: } // end sil function 'dont_rewrite_inner_forwarding_user'
+// CHECK-LABEL: end running test {{.*}} on dont_rewrite_inner_forwarding_user: canonicalize-borrow-scope
+sil [ossa] @dont_rewrite_inner_forwarding_user : $@convention(thin) () -> (@owned C) {
+    %getD = function_ref @getD : $@convention(thin) () -> (@owned D)
+    %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
+    %d = apply %getD() : $@convention(thin) () -> (@owned D)
+    test_specification "canonicalize-borrow-scope @instruction"
+    %b = begin_borrow %d : $D
+    %c2 = copy_value %b : $D
+    %u2 = upcast %c2 : $D to $C
+    %c1 = copy_value %b : $D
+    %u1 = upcast %c1 : $D to $C
+    apply %takeC(%u1) : $@convention(thin) (@owned C) -> ()
+    end_borrow %b : $D
+    destroy_value %d : $D
+    return %u2 : $C
 }


### PR DESCRIPTION
When rewriting outer uses of the borrow, `recursivelyRewriterOuterUses` is called recursively.  First, it is called with the borrow itself. Subsequently, it is called with forwarding users of the borrow.  Such a user may not be rewriteable as outer uses.  If it isn't `innerToOuterMap` won't have an entry for it.

Previously, failing to find an entry would raise an assertion.  Here, the function is made to return a "null" `SILValue`.  Its caller `RewriteOuterBorrowUses::visitForwardingUse` was already written to handle such a result.

