### PR TITLE
[5.9] Make type refinement context for macro buffers lazy and correct

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1232,8 +1232,13 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF) {
   // Build refinement contexts, if necessary, for all declarations starting
   // with StartElem.
   TypeRefinementContextBuilder Builder(RootTRC, Context);
-  for (auto D : SF.getTopLevelDecls()) {
-    Builder.build(D);
+  for (auto item : SF.getTopLevelItems()) {
+    if (auto decl = item.dyn_cast<Decl *>())
+      Builder.build(decl);
+    else if (auto expr = item.dyn_cast<Expr *>())
+      Builder.build(expr);
+    else if (auto stmt = item.dyn_cast<Stmt *>())
+      Builder.build(stmt);
   }
 }
 
@@ -1272,7 +1277,11 @@ AvailabilityContext
 TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
                                                    const DeclContext *DC,
                                                    const TypeRefinementContext **MostRefined) {
-  SourceFile *SF = DC->getParentSourceFile();
+  SourceFile *SF;
+  if (loc.isValid())
+    SF = DC->getParentModule()->getSourceFileContainingLocation(loc);
+  else
+    SF = DC->getParentSourceFile();
   auto &Context = DC->getASTContext();
 
   // If our source location is invalid (this may be synthesized code), climb

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -473,7 +473,7 @@ public:
 
 private:
   MacroWalking getMacroWalkingBehavior() const override {
-    return MacroWalking::ArgumentsAndExpansion;
+    return MacroWalking::Arguments;
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {

--- a/test/Macros/Inputs/top_level_freestanding_other.swift
+++ b/test/Macros/Inputs/top_level_freestanding_other.swift
@@ -1,2 +1,1 @@
-// FIXME(rdar://107394143): Circular reference bug
-// #anonymousTypes { "hello2" }
+#anonymousTypes { "hello2" }

--- a/test/Macros/macro_availability_macosx.swift
+++ b/test/Macros/macro_availability_macosx.swift
@@ -1,6 +1,9 @@
-// REQUIRES: swift_swift_parser, OS=macosx
+// REQUIRES: swift_swift_parser, executable_test, OS=macosx
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest -target %target-cpu-apple-macosx11
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest -target %target-cpu-apple-macosx11  -load-plugin-library %t/%target-library-name(MacroDefinition)
 
 @available(macOS 12.0, *)
 struct X { }
@@ -11,3 +14,16 @@ struct X { }
 @available(macOS 12.0, *)
 @freestanding(expression) macro m2() -> X = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type 'A.B' could not be found for macro 'm2()'}}
+
+@freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+@available(macOS 12.0, *)
+func onlyInMacOS12() { }
+
+func test() {
+  _ = #stringify({
+      if #available(macOS 12.0, *) {
+        onlyInMacOS12()
+      }
+    })
+}


### PR DESCRIPTION
* Explanation: Macro expansion buffers will have their type refinement contexts built lazily, associated with the source file for the macro expansion buffer. By not recursing into macro expansions, we break false reference cycles among different files.
* Scope: Narrow; affects code using macros and availability checking.
* Risk: Low, no effect in code that doesn't use macros.
* Reviewed by: @rxwei 
* Issue: rdar://107394143
* Original pull request: https://github.com/apple/swift/pull/65457
