### PR TITLE
[Compile Time Constant Extraction] Extract the instance type for typevalues - not the metatype

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -312,7 +312,11 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
 
     case ExprKind::DotSelf: {
       auto dotSelfExpr = cast<DotSelfExpr>(expr);
-      return std::make_shared<TypeValue>(dotSelfExpr->getType());
+      auto dotSelfMetaType = dotSelfExpr->getType()->getAs<AnyMetatypeType>();
+      if (dotSelfMetaType)
+        return std::make_shared<TypeValue>(dotSelfMetaType->getInstanceType());
+      else
+        break;
     }
 
     case ExprKind::UnderlyingToOpaque: {

--- a/test/ConstExtraction/ExtractTypeValue.swift
+++ b/test/ConstExtraction/ExtractTypeValue.swift
@@ -26,22 +26,22 @@ struct TypeValuePropertyStruct : MyProto {
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "valueKind": "Type",
 // CHECK-NEXT:            "value": {
-// CHECK-NEXT:              "type": "ExtractTypeValue.Warbler<Swift.String>.Type",
-// CHECK-NEXT:              "mangledName": "16ExtractTypeValue7WarblerVySSGm"
+// CHECK-NEXT:              "type": "ExtractTypeValue.Warbler<Swift.String>",
+// CHECK-NEXT:              "mangledName": "16ExtractTypeValue7WarblerVySSG"
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "valueKind": "Type",
 // CHECK-NEXT:            "value": {
-// CHECK-NEXT:              "type": "ExtractTypeValue.Avocet.Type",
-// CHECK-NEXT:              "mangledName": "16ExtractTypeValue6AvocetVm"
+// CHECK-NEXT:              "type": "ExtractTypeValue.Avocet",
+// CHECK-NEXT:              "mangledName": "16ExtractTypeValue6AvocetV"
 // CHECK-NEXT:            }
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "valueKind": "Type",
 // CHECK-NEXT:            "value": {
-// CHECK-NEXT:              "type": "ExtractTypeValue.RainbowLorikeet.Type",
-// CHECK-NEXT:              "mangledName": "16ExtractTypeValue15RainbowLorikeetVm"
+// CHECK-NEXT:              "type": "ExtractTypeValue.RainbowLorikeet",
+// CHECK-NEXT:              "mangledName": "16ExtractTypeValue15RainbowLorikeetV"
 // CHECK-NEXT:            }
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ]

--- a/test/ConstExtraction/ExtractTypes.swift
+++ b/test/ConstExtraction/ExtractTypes.swift
@@ -26,22 +26,22 @@ public struct Types : MyProto {
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "valueKind": "Type",
 // CHECK-NEXT:      "value": {
-// CHECK-NEXT:        "type": "ExtractTypes.TypeA.Type"
-// CHECK-NEXT:        "mangledName": "12ExtractTypes5TypeAVm"
+// CHECK-NEXT:        "type": "ExtractTypes.TypeA"
+// CHECK-NEXT:        "mangledName": "12ExtractTypes5TypeAV"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "valueKind": "Type",
 // CHECK-NEXT:      "value": {
-// CHECK-NEXT:        "type": "ExtractTypes.TypeB.Type"
-// CHECK-NEXT:        "mangledName": "12ExtractTypes5TypeBOm"
+// CHECK-NEXT:        "type": "ExtractTypes.TypeB"
+// CHECK-NEXT:        "mangledName": "12ExtractTypes5TypeBO"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "valueKind": "Type",
 // CHECK-NEXT:      "value": {
-// CHECK-NEXT:        "type": "ExtractTypes.TypeC.Type"
-// CHECK-NEXT:        "mangledName": "12ExtractTypes5TypeCCm"
+// CHECK-NEXT:        "type": "ExtractTypes.TypeC"
+// CHECK-NEXT:        "mangledName": "12ExtractTypes5TypeCC"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  ]


### PR DESCRIPTION
The intended design is to extract actual types of type values appearing in conformance properties, whereas the original extraction code-path queried and recorded the type values' types - their metatypes.
