### PR TITLE
[Macros] Adjust starting context for macro expansion mangling

### DIFF
--- a/include/swift/AST/MacroDiscriminatorContext.h
+++ b/include/swift/AST/MacroDiscriminatorContext.h
@@ -31,6 +31,10 @@ struct MacroDiscriminatorContext
   static MacroDiscriminatorContext getParentOf(
       SourceLoc loc, DeclContext *origDC
   );
+
+  /// Return the innermost declaration context that is suitable for
+  /// use in identifying a macro.
+  static DeclContext *getInnermostMacroContext(DeclContext *dc);
 };
 
 }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3845,6 +3845,8 @@ std::string ASTMangler::mangleRuntimeAttributeGeneratorEntity(
 void ASTMangler::appendMacroExpansionContext(
     SourceLoc loc, DeclContext *origDC
 ) {
+  origDC = MacroDiscriminatorContext::getInnermostMacroContext(origDC);
+
   if (loc.isInvalid())
     return appendContext(origDC, StringRef());
 

--- a/test/Macros/Inputs/top_level_freestanding_other.swift
+++ b/test/Macros/Inputs/top_level_freestanding_other.swift
@@ -1,1 +1,3 @@
 #anonymousTypes { "hello2" }
+
+var globalVar = #stringify(1 + 1)

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -64,3 +64,5 @@ struct HasInnerClosure {
 func testArbitraryAtGlobal() {
   _ = MyIntGlobal16()
 }
+
+@freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")


### PR DESCRIPTION
Eliminate another circular reference through macro expansion mangling by adjusting the starting declaration context to ensure that it is from a suitable "outer" context.

Fixes rdar://108511666.
