### PR TITLE
[stdlib] Adopt _pointerBitWidth conditional

### DIFF
--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -65,12 +65,14 @@ internal func _swift_stdlib_atomicCompareExchangeStrongInt(
   object target: UnsafeMutablePointer<Int>,
   expected: UnsafeMutablePointer<Int>,
   desired: Int) -> Bool {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
     target._rawValue, expected.pointee._value, desired._value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int64(
     target._rawValue, expected.pointee._value, desired._value)
+#else
+#error("Unknown platform")
 #endif
   expected.pointee._value = oldValue
   return Bool(won)
@@ -82,12 +84,14 @@ internal func _swift_stdlib_atomicCompareExchangeStrongInt(
 public // Existing uses outside stdlib
 func _swift_stdlib_atomicLoadInt(
   object target: UnsafeMutablePointer<Int>) -> Int {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
   return Int(value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   let value = Builtin.atomicload_seqcst_Int64(target._rawValue)
   return Int(value)
+#else
+#error("Unknown platform")
 #endif
 }
 
@@ -95,10 +99,12 @@ func _swift_stdlib_atomicLoadInt(
 internal func _swift_stdlib_atomicStoreInt(
   object target: UnsafeMutablePointer<Int>,
   desired: Int) {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
+#else
+#error("Unknown platform")
 #endif
 }
 
@@ -111,14 +117,16 @@ func _swift_stdlib_atomicFetch${operation}Int(
   object target: UnsafeMutablePointer<Int>,
   operand: Int) -> Int {
   let rawTarget = UnsafeMutableRawPointer(target)
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   let value = _swift_stdlib_atomicFetch${operation}Int32(
     object: rawTarget.assumingMemoryBound(to: Int32.self),
     operand: Int32(operand))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   let value = _swift_stdlib_atomicFetch${operation}Int64(
     object: rawTarget.assumingMemoryBound(to: Int64.self),
     operand: Int64(operand))
+#else
+#error("Unknown platform")
 #endif
   return Int(value)
 }

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -65,11 +65,11 @@ internal func _swift_stdlib_atomicCompareExchangeStrongInt(
   object target: UnsafeMutablePointer<Int>,
   expected: UnsafeMutablePointer<Int>,
   desired: Int) -> Bool {
-#if _pointerBitWidth(_32)
-  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
-    target._rawValue, expected.pointee._value, desired._value)
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int64(
+    target._rawValue, expected.pointee._value, desired._value)
+#elseif _pointerBitWidth(_32)
+  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
     target._rawValue, expected.pointee._value, desired._value)
 #else
 #error("Unknown platform")
@@ -84,11 +84,11 @@ internal func _swift_stdlib_atomicCompareExchangeStrongInt(
 public // Existing uses outside stdlib
 func _swift_stdlib_atomicLoadInt(
   object target: UnsafeMutablePointer<Int>) -> Int {
-#if _pointerBitWidth(_32)
-  let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
-  return Int(value)
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
   let value = Builtin.atomicload_seqcst_Int64(target._rawValue)
+  return Int(value)
+#elseif _pointerBitWidth(_32)
+  let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
   return Int(value)
 #else
 #error("Unknown platform")
@@ -99,10 +99,10 @@ func _swift_stdlib_atomicLoadInt(
 internal func _swift_stdlib_atomicStoreInt(
   object target: UnsafeMutablePointer<Int>,
   desired: Int) {
-#if _pointerBitWidth(_32)
-  Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
   Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
+#elseif _pointerBitWidth(_32)
+  Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
 #else
 #error("Unknown platform")
 #endif
@@ -117,14 +117,14 @@ func _swift_stdlib_atomicFetch${operation}Int(
   object target: UnsafeMutablePointer<Int>,
   operand: Int) -> Int {
   let rawTarget = UnsafeMutableRawPointer(target)
-#if _pointerBitWidth(_32)
-  let value = _swift_stdlib_atomicFetch${operation}Int32(
-    object: rawTarget.assumingMemoryBound(to: Int32.self),
-    operand: Int32(operand))
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
   let value = _swift_stdlib_atomicFetch${operation}Int64(
     object: rawTarget.assumingMemoryBound(to: Int64.self),
     operand: Int64(operand))
+#elseif _pointerBitWidth(_32)
+  let value = _swift_stdlib_atomicFetch${operation}Int32(
+    object: rawTarget.assumingMemoryBound(to: Int32.self),
+    operand: Int32(operand))
 #else
 #error("Unknown platform")
 #endif

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -61,7 +61,7 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
     rawValue = Builtin.reinterpretCast(native)
   }
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32))
+#if _pointerBitWidth(_64)
   @inlinable
   @inline(__always)
   internal init(taggedPayload: UInt) {

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -406,19 +406,18 @@ internal var _objectPointerLowSpareBitShift: UInt {
     }
 }
 
-#if _pointerBitWidth(_32)
 @inlinable
 internal var _objectPointerIsObjCBit: UInt {
-    @inline(__always) get { return 0x0000_0002 }
-}
-#elseif _pointerBitWidth(_64)
-@inlinable
-internal var _objectPointerIsObjCBit: UInt {
-  @inline(__always) get { return 0x4000_0000_0000_0000 }
-}
+  @inline(__always) get {
+#if _pointerBitWidth(_64)
+    return 0x4000_0000_0000_0000
+#elseif _pointerBitWidth(_32)
+    return 0x0000_0002
 #else
 #error("Unknown platform")
 #endif
+  }
+}
 
 /// Extract the raw bits of `x`.
 @inlinable

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -406,17 +406,18 @@ internal var _objectPointerLowSpareBitShift: UInt {
     }
 }
 
-#if arch(i386) || arch(arm) || arch(wasm32) || arch(powerpc) || arch(powerpc64) || arch(
-  powerpc64le) || arch(s390x) || arch(arm64_32)
+#if _pointerBitWidth(_32)
 @inlinable
 internal var _objectPointerIsObjCBit: UInt {
     @inline(__always) get { return 0x0000_0002 }
 }
-#else
+#elseif _pointerBitWidth(_64)
 @inlinable
 internal var _objectPointerIsObjCBit: UInt {
   @inline(__always) get { return 0x4000_0000_0000_0000 }
 }
+#else
+#error("Unknown platform")
 #endif
 
 /// Extract the raw bits of `x`.

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -46,10 +46,12 @@ extension Dictionary {
     @inlinable
     @inline(__always)
     init(dummy: Void) {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
       self.init(native: _NativeDictionary())
-#else
+#elseif _pointerBitWidth(_64)
       self.object = _BridgeStorage(taggedPayload: 0)
+#else
+#error("Unknown platform")
 #endif
     }
 

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -46,10 +46,10 @@ extension Dictionary {
     @inlinable
     @inline(__always)
     init(dummy: Void) {
-#if _pointerBitWidth(_32)
-      self.init(native: _NativeDictionary())
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
       self.object = _BridgeStorage(taggedPayload: 0)
+#elseif _pointerBitWidth(_32)
+      self.init(native: _NativeDictionary())
 #else
 #error("Unknown platform")
 #endif

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -160,10 +160,10 @@ extension Hasher {
 
     @inline(__always)
     internal mutating func combine(_ value: UInt) {
-#if _pointerBitWidth(_32)
-      combine(UInt32(truncatingIfNeeded: value))
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
       combine(UInt64(truncatingIfNeeded: value))
+#elseif _pointerBitWidth(_32)
+      combine(UInt32(truncatingIfNeeded: value))
 #else
 #error("Unknown platform")
 #endif
@@ -425,15 +425,15 @@ public struct Hasher {
   @usableFromInline
   internal static func _hash(seed: Int, _ value: UInt) -> Int {
     var state = _State(seed: seed)
-#if _pointerBitWidth(_32)
+#if _pointerBitWidth(_64)
+    _internalInvariant(UInt.bitWidth == UInt64.bitWidth)
+    state.compress(UInt64(truncatingIfNeeded: value))
+    let tbc = _TailBuffer(tail: 0, byteCount: 8)
+#elseif _pointerBitWidth(_32)
     _internalInvariant(UInt.bitWidth < UInt64.bitWidth)
     let tbc = _TailBuffer(
       tail: UInt64(truncatingIfNeeded: value),
       byteCount: UInt.bitWidth &>> 3)
-#elseif _pointerBitWidth(_64)
-    _internalInvariant(UInt.bitWidth == UInt64.bitWidth)
-    state.compress(UInt64(truncatingIfNeeded: value))
-    let tbc = _TailBuffer(tail: 0, byteCount: 8)
 #else
 #error("Unknown platform")
 #endif

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -160,10 +160,12 @@ extension Hasher {
 
     @inline(__always)
     internal mutating func combine(_ value: UInt) {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
       combine(UInt32(truncatingIfNeeded: value))
-#else
+#elseif _pointerBitWidth(_64)
       combine(UInt64(truncatingIfNeeded: value))
+#else
+#error("Unknown platform")
 #endif
     }
 
@@ -423,15 +425,17 @@ public struct Hasher {
   @usableFromInline
   internal static func _hash(seed: Int, _ value: UInt) -> Int {
     var state = _State(seed: seed)
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
     _internalInvariant(UInt.bitWidth < UInt64.bitWidth)
     let tbc = _TailBuffer(
       tail: UInt64(truncatingIfNeeded: value),
       byteCount: UInt.bitWidth &>> 3)
-#else
+#elseif _pointerBitWidth(_64)
     _internalInvariant(UInt.bitWidth == UInt64.bitWidth)
     state.compress(UInt64(truncatingIfNeeded: value))
     let tbc = _TailBuffer(tail: 0, byteCount: 8)
+#else
+#error("Unknown platform")
 #endif
     return Int(truncatingIfNeeded: state.finalize(tailAndByteCount: tbc.value))
   }

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1515,7 +1515,7 @@ ${assignmentOperatorComment(x.operator, True)}
 
 %   dbits = bits*2
 %   if bits == 64:
-  #if !(arch(arm) || arch(i386) || arch(wasm32))
+  #if _pointerBitWidth(_64) || arch(arm64_32)
   //  On 32b architectures we fall back on the generic implementation,
   //  because LLVM doesn't know how to codegen the 128b multiply we use.
   //

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -36,10 +36,12 @@ extension Set {
     @inlinable
     @inline(__always)
     init(dummy: ()) {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
       self.init(native: _NativeSet())
-#else
+#elseif _pointerBitWidth(_64)
       self.object = _BridgeStorage(taggedPayload: 0)
+#else
+#error("Unknown platform")
 #endif
     }
 

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -36,10 +36,10 @@ extension Set {
     @inlinable
     @inline(__always)
     init(dummy: ()) {
-#if _pointerBitWidth(_32)
-      self.init(native: _NativeSet())
-#elseif _pointerBitWidth(_64)
+#if _pointerBitWidth(_64)
       self.object = _BridgeStorage(taggedPayload: 0)
+#elseif _pointerBitWidth(_32)
+      self.init(native: _NativeSet())
 #else
 #error("Unknown platform")
 #endif

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -79,12 +79,14 @@ internal struct _SmallString {
 extension _SmallString {
   @inlinable @inline(__always)
   internal static var capacity: Int {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
     return 10
 #elseif os(Android) && arch(arm64)
     return 14
-#else
+#elseif _pointerBitWidth(_64)
     return 15
+#else
+#error("Unknown platform")
 #endif
   }
 
@@ -346,7 +348,7 @@ extension _SmallString {
   }
 }
 
-#if _runtime(_ObjC) && !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _runtime(_ObjC) && _pointerBitWidth(_64)
 // Cocoa interop
 extension _SmallString {
   // Resiliently create from a tagged cocoa string

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -313,7 +313,7 @@ internal enum _KnownCocoaString {
   case storage
   case shared
   case cocoa
-#if !(arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32))
+#if _pointerBitWidth(_64)
   case tagged
 #endif
 #if arch(arm64)
@@ -323,7 +323,7 @@ internal enum _KnownCocoaString {
   @inline(__always)
   init(_ str: _CocoaString) {
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
     if _isObjCTaggedPointer(str) {
 #if arch(arm64)
       if let _ = getConstantTaggedCocoaContents(str) {
@@ -349,8 +349,7 @@ internal enum _KnownCocoaString {
   }
 }
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
-
+#if _pointerBitWidth(_64)
 // Resiliently write a tagged _CocoaString's contents into a buffer.
 // The Foundation overlay takes care of bridging tagged pointer strings before
 // they reach us, but this may still be called by older code, or by strings
@@ -393,7 +392,7 @@ private func _withCocoaASCIIPointer<R>(
   requireStableAddress: Bool,
   work: (UnsafePointer<UInt8>) -> R?
 ) -> R? {
-  #if !(arch(i386) || arch(arm) || arch(arm64_32))
+  #if _pointerBitWidth(_64)
   if _isObjCTaggedPointer(str) {
     if let ptr = getConstantTaggedCocoaContents(str)?.asciiContentsPointer {
       return work(ptr)
@@ -421,7 +420,7 @@ private func _withCocoaUTF8Pointer<R>(
   requireStableAddress: Bool,
   work: (UnsafePointer<UInt8>) -> R?
 ) -> R? {
-  #if !(arch(i386) || arch(arm) || arch(arm64_32))
+  #if _pointerBitWidth(_64)
   if _isObjCTaggedPointer(str) {
     if let ptr = getConstantTaggedCocoaContents(str)?.asciiContentsPointer {
       return work(ptr)
@@ -577,7 +576,7 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
   case .shared:
     return _unsafeUncheckedDowncast(
       cocoaString, to: __SharedStringStorage.self).asString._guts
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
   case .tagged:
     // Foundation should be taking care of tagged pointer strings before they
     // reach here, so the only ones reaching this point should be back deployed,
@@ -608,7 +607,7 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
     let immutableCopy
       = _stdlib_binary_CFStringCreateCopy(cocoaString)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
     if _isObjCTaggedPointer(immutableCopy) {
       // Copying a tagged pointer can produce a tagged pointer, but only if it's
       // small enough to definitely fit in a _SmallString

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -179,13 +179,13 @@ extension _StringGuts {
   #else
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
-    #if _pointerBitWidth(_32)
-    _internalInvariant(MemoryLayout<String>.size == 12, """
+    #if _pointerBitWidth(_64)
+    _internalInvariant(MemoryLayout<String>.size == 16, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)
-    #elseif _pointerBitWidth(_64)
-    _internalInvariant(MemoryLayout<String>.size == 16, """
+    #elseif _pointerBitWidth(_32)
+    _internalInvariant(MemoryLayout<String>.size == 12, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -179,16 +179,18 @@ extension _StringGuts {
   #else
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
-    #if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+    #if _pointerBitWidth(_32)
     _internalInvariant(MemoryLayout<String>.size == 12, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)
-    #else
+    #elseif _pointerBitWidth(_64)
     _internalInvariant(MemoryLayout<String>.size == 16, """
     the runtime is depending on this, update Reflection.mm and \
     this if you change it
     """)
+    #else
+    #error("Unknown platform")
     #endif
   }
   #endif // INTERNAL_CHECKS_ENABLED

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -37,10 +37,12 @@ func testAnonEnum() {
   a = AnonConst2
 #if os(Windows)
   verifyIsInt(&a)
-#elseif arch(i386) || arch(arm) || arch(arm64_32)
+#elseif _pointerBitWidth(_32)
   verifyIsUInt64(&a)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   verifyIsUInt(&a)
+#else
+#error("Unknown platform")
 #endif
 }
 

--- a/test/Inputs/SmallStringTestUtilities.swift
+++ b/test/Inputs/SmallStringTestUtilities.swift
@@ -71,7 +71,7 @@ extension _SmallString {
  
 #if _runtime(_ObjC)
   init?(_cocoaString ns: NSString) {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
     return nil
 #else
     guard _isObjCTaggedPointer(ns) else { return nil }

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreFoundation.swift
@@ -4,10 +4,12 @@ protocol _CFObject: Hashable {}
 
 #if CGFLOAT_IN_COREFOUNDATION
 public struct CGFloat {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   public typealias UnderlyingType = Float
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   public typealias UnderlyingType = Double
+#else
+#error("Unknown platform")
 #endif
 
   public init() { 

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
@@ -7,10 +7,12 @@ public func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
 
 #if !CGFLOAT_IN_COREFOUNDATION
 public struct CGFloat {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   public typealias UnderlyingType = Float
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   public typealias UnderlyingType = Double
+#else
+#error("Unknown platform")
 #endif
 
   public init() { 

--- a/test/Interpreter/SDK/objc_bridge_cast.swift
+++ b/test/Interpreter/SDK/objc_bridge_cast.swift
@@ -255,7 +255,7 @@ func testValueToObjectBridgingInSwitch() {
     }
   }
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
   // Small strings should be immortal on new enough 64-bit Apple platforms.
   if #available(macOS 10.10, *) {
     autoreleasepool {

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -13,7 +13,7 @@ class C {
   deinit { print("deallocated") }
 }
 
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(powerpc)
+#if _pointerBitWidth(_32)
 
 // We have no ObjC tagged pointers, and two low spare bits due to alignment.
 let NATIVE_SPARE_BITS: UInt = 0x0000_0003

--- a/test/stdlib/Inputs/FloatingPointConversion.swift.gyb
+++ b/test/stdlib/Inputs/FloatingPointConversion.swift.gyb
@@ -134,9 +134,9 @@ FloatingPointConversionFailures.test("${OtherFloat}To${Self}Conversion/AlwaysSuc
 
 %  end # for in all_floating_point_types (Other)
 
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(powerpc)
+#if _pointerBitWidth(_32)
 % int_types = all_integer_types(32)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
 % int_types = all_integer_types(64)
 #else
 _UnimplementedError()

--- a/test/stdlib/PrintPointer.swift
+++ b/test/stdlib/PrintPointer.swift
@@ -10,12 +10,12 @@ PrintTests.test("Printable") {
   let lowUP = UnsafeMutablePointer<Float>(bitPattern: 0x1)!
   let fourByteUP = UnsafeMutablePointer<Float>(bitPattern: 0xabcd1234 as UInt)!
   
-#if !(arch(i386) || arch(arm) || arch(wasm32) || arch(arm64_32))
+#if _pointerBitWidth(_64)
   let eightByteAddr: UInt = 0xabcddcba12344321
   let eightByteUP = UnsafeMutablePointer<Float>(bitPattern: eightByteAddr)!
 #endif
   
-#if arch(i386) || arch(arm) || arch(wasm32) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   let expectedLow = "0x00000001"
   expectPrinted("0xabcd1234", fourByteUP)
 #else

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -689,9 +689,9 @@ Reflection.test("multiprotocolTypes") {
 var BitTwiddlingTestSuite = TestSuite("BitTwiddling")
 
 BitTwiddlingTestSuite.test("_pointerSize") {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   expectEqual(4, MemoryLayout<Optional<AnyObject>>.size)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   expectEqual(8, MemoryLayout<Optional<AnyObject>>.size)
 #else
   fatalError("implement")
@@ -713,9 +713,9 @@ BitTwiddlingTestSuite.test("_isPowerOf2/Int") {
   expectTrue(_isPowerOf2(asInt(2)))
   expectFalse(_isPowerOf2(asInt(3)))
   expectTrue(_isPowerOf2(asInt(1024)))
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
   // Not applicable to 32-bit architectures.
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   expectTrue(_isPowerOf2(asInt(0x8000_0000)))
 #else
   fatalError("implement")

--- a/test/stdlib/StaticBigInt.swift
+++ b/test/stdlib/StaticBigInt.swift
@@ -71,13 +71,13 @@ extension StaticBigIntTests {
     for (actual, expected) in keyValuePairs {
       expectEqual(expected.signum,   actual.signum())
       expectEqual(expected.bitWidth, actual.bitWidth)
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
       expectEqual(expected._32bit[0], actual[0])
       expectEqual(expected._32bit[1], actual[1])
       expectEqual(expected._32bit[2], actual[2])
       expectEqual(expected._32bit[3], actual[3])
       expectEqual(expected._32bit[4], actual[4])
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
       expectEqual(expected._64bit[0], actual[0])
       expectEqual(expected._64bit[1], actual[1])
       expectEqual(expected._64bit[2], actual[2])
@@ -185,14 +185,14 @@ extension StaticBigIntTests {
     let negative = Wrapper(-0x00112233_44556677_8899AABB_CCDDEEFF)
     expectEqual( -1, negative.actual.signum())
     expectEqual(118, negative.actual.bitWidth)
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
     expectEqual(0x33221101, negative.actual[0])
     expectEqual(0x77665544, negative.actual[1])
     expectEqual(0xBBAA9988, negative.actual[2])
     expectEqual(0xFFEEDDCC, negative.actual[3])
     expectEqual(0xFFFFFFFF, negative.actual[4])
     expectEqual(0xFFFFFFFF, negative.actual[.max])
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
     expectEqual(0x77665544_33221101, negative.actual[0])
     expectEqual(0xFFEEDDCC_BBAA9988, negative.actual[1])
     expectEqual(0xFFFFFFFF_FFFFFFFF, negative.actual[2])
@@ -207,14 +207,14 @@ extension StaticBigIntTests {
     let positive = Wrapper(0x00112233_44556677_8899AABB_CCDDEEFF)
     expectEqual( +1, positive.actual.signum())
     expectEqual(118, positive.actual.bitWidth)
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
     expectEqual(0xCCDDEEFF, positive.actual[0])
     expectEqual(0x8899AABB, positive.actual[1])
     expectEqual(0x44556677, positive.actual[2])
     expectEqual(0x00112233, positive.actual[3])
     expectEqual(0x00000000, positive.actual[4])
     expectEqual(0x00000000, positive.actual[.max])
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
     expectEqual(0x8899AABB_CCDDEEFF, positive.actual[0])
     expectEqual(0x00112233_44556677, positive.actual[1])
     expectEqual(0x00000000_00000000, positive.actual[2])
@@ -226,12 +226,12 @@ extension StaticBigIntTests {
 
   @available(SwiftStdlib 5.8, *)
   func testWrapperFibonacciSequence() {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+#if _pointerBitWidth(_32)
     let wordCount = 48
     let fibonacciSequence = Wrapper(
       0xB11924E1_6D73E55F_43A53F82_29CEA5DD_19D699A5_0FF80C38_09DE8D6D_06197ECB_03C50EA2_02547029_01709E79_00E3D1B0_008CCCC9_005704E7_0035C7E2_00213D05_00148ADD_000CB228_0007D8B5_0004D973_0002FF42_0001DA31_00012511_0000B520_00006FF1_0000452F_00002AC2_00001A6D_00001055_00000A18_0000063D_000003DB_00000262_00000179_000000E9_00000090_00000059_00000037_00000022_00000015_0000000D_00000008_00000005_00000003_00000002_00000001_00000001_00000000
     )
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
     let wordCount = 94
     let fibonacciSequence = Wrapper(
       0xA94FAD42221F2702_68A3DD8E61ECCFBD_40ABCFB3C0325745_27F80DDAA1BA7878_18B3C1D91E77DECD_0F444C01834299AB_096F75D79B354522_05D4D629E80D5489_039A9FADB327F099_023A367C34E563F0_016069317E428CA9_00D9CD4AB6A2D747_00869BE6C79FB562_00533163EF0321E5_00336A82D89C937D_001FC6E116668E68_0013A3A1C2360515_000C233F54308953_000780626E057BC2_0004A2DCE62B0D91_0002DD8587DA6E31_0001C5575E509F60_0001182E2989CED1_0000AD2934C6D08F_00006B04F4C2FE42_000042244003D24D_000028E0B4BF2BF5_000019438B44A658_00000F9D297A859D_000009A661CA20BB_000005F6C7B064E2_000003AF9A19BBD9_000002472D96A909_000001686C8312D0_000000DEC1139639_00000089AB6F7C97_0000005515A419A2_0000003495CB62F5_000000207FD8B6AD_0000001415F2AC48_0000000C69E60A65_00000007AC0CA1E3_00000004BDD96882_00000002EE333961_00000001CFA62F21_000000011E8D0A40_00000000B11924E1_000000006D73E55F_0000000043A53F82_0000000029CEA5DD_0000000019D699A5_000000000FF80C38_0000000009DE8D6D_0000000006197ECB_0000000003C50EA2_0000000002547029_0000000001709E79_0000000000E3D1B0_00000000008CCCC9_00000000005704E7_000000000035C7E2_0000000000213D05_0000000000148ADD_00000000000CB228_000000000007D8B5_000000000004D973_000000000002FF42_000000000001DA31_0000000000012511_000000000000B520_0000000000006FF1_000000000000452F_0000000000002AC2_0000000000001A6D_0000000000001055_0000000000000A18_000000000000063D_00000000000003DB_0000000000000262_0000000000000179_00000000000000E9_0000000000000090_0000000000000059_0000000000000037_0000000000000022_0000000000000015_000000000000000D_0000000000000008_0000000000000005_0000000000000003_0000000000000002_0000000000000001_0000000000000001_0000000000000000

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -23,8 +23,7 @@ extension String {
 
 StringBridgeTests.test("Tagged NSString") {
   guard #available(macOS 10.13, iOS 11.0, tvOS 11.0, *) else { return }
-#if arch(i386) || arch(arm) || arch(arm64_32)
-#else
+#if _pointerBitWidth(_64)
   // Bridge tagged strings as small
   expectSmall((("0123456" as NSString) as String))
   expectSmall((("012345678" as NSString) as String))
@@ -75,8 +74,7 @@ StringBridgeTests.test("Bridging") {
 
   // Pass tests
 
-  #if arch(i386) || arch(arm) || arch(arm64_32)
-  #else
+  #if _pointerBitWidth(_64)
   if #available(macOS 10.15, iOS 13, *) {
     expectDoesNotThrow({ try runTestSmall("abc") })
     expectDoesNotThrow({ try runTestSmall("defghijk") })

--- a/test/stdlib/StringDeconstruction.swift
+++ b/test/stdlib/StringDeconstruction.swift
@@ -94,7 +94,7 @@ func id<T>(_ a: T) -> T { a }
 StringDeconstructTests.test("deconstruct") {
   let smallASCII = "abcd"
 
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
   let smallUTF8 = "ジッパ"
 #else
   let smallUTF8 = "ジッパー"
@@ -119,10 +119,12 @@ StringDeconstructTests.test("deconstruct cocoa") {
   let largeASCIICocoa: NSString = "the quick fox jumped over the lazy brown dog"
   let largeCocoa: NSString = "the quick 🧟‍♀️ ate the slow 🧠"
 
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
   expectDeconstruct(smallCocoa as String, .interiorPointer)
-#else
+#elseif _pointerBitWidth(_64)
   expectDeconstruct(smallCocoa as String, .scratchIfAvailable)
+#else
+#error("Unknown platform")
 #endif
 
   expectDeconstruct(largeASCIICocoa as String, .interiorPointer)

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -407,9 +407,9 @@ ${SelfName}TestSuite.test("customMirror") {
   let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   let mirror = ptr.customMirror
   expectEqual(1, mirror.children.count)
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
   expectEqual("18446744071562067968", String(describing: mirror.children.first!.1))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   expectEqual("9223372036854775808", String(describing: mirror.children.first!.1))
 #else
   fatalError("Unimplemented")
@@ -422,9 +422,9 @@ ${SelfName}TestSuite.test("customPlaygroundQuickLook") {
   let reallyBigInt: UInt = UInt(Int.max) + 1
   let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   if case let .text(desc) = ptr.customPlaygroundQuickLook {
-#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+#if _pointerBitWidth(_32)
     expectEqual("${SelfName}(0xFFFFFFFF80000000)", desc)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
     expectEqual("${SelfName}(0x8000000000000000)", desc)
 #else
     fatalError("Unimplemented")

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -292,7 +292,7 @@ ArrayTestSuite.test("${array_type}<TestValueTy>/subscript(_: Range<Int>)/COW")
 
 ArrayTestSuite.test("sizeof") {
   var a = [ 10, 20, 30 ]
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   expectEqual(4, MemoryLayout.size(ofValue: a))
 #else
   expectEqual(8, MemoryLayout.size(ofValue: a))

--- a/validation-test/stdlib/Bitset.swift
+++ b/validation-test/stdlib/Bitset.swift
@@ -7,7 +7,7 @@ var BitsetTests = TestSuite("Bitset")
 
 BitsetTests.test("_UnsafeBitset.wordCount(forCapacity:)") {
   expectEqual(0, _UnsafeBitset.wordCount(forCapacity: 0))
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   for i in 1...32 {
     expectEqual(1, _UnsafeBitset.wordCount(forCapacity: i), "i=\(i)")
   }
@@ -20,7 +20,7 @@ BitsetTests.test("_UnsafeBitset.wordCount(forCapacity:)") {
   for i in 97...128 {
     expectEqual(4, _UnsafeBitset.wordCount(forCapacity: i), "i=\(i)")
   }
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   for i in 1...64 {
     expectEqual(1, _UnsafeBitset.wordCount(forCapacity: i), "i=\(i)")
   }
@@ -36,7 +36,7 @@ BitsetTests.test("_UnsafeBitset.wordCount(forCapacity:)") {
 }
 
 BitsetTests.test("_UnsafeBitset.split(_:)") {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   for i in 0...31 {
     let comps = _UnsafeBitset.split(i)
     expectEqual(0, comps.word, "i=\(i)")
@@ -57,7 +57,7 @@ BitsetTests.test("_UnsafeBitset.split(_:)") {
     expectEqual(3, comps.word, "i=\(i)")
     expectEqual(i - 96, comps.bit, "i=\(i)")
   }
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
   for i in 0...63 {
     let comps = _UnsafeBitset.split(i)
     expectEqual(0, comps.word, "i=\(i)")

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -61,7 +61,7 @@ DictionaryTestSuite.test("AssociatedTypes") {
 
 DictionaryTestSuite.test("sizeof") {
   var dict = [1: "meow", 2: "meow"]
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   expectEqual(4, MemoryLayout.size(ofValue: dict))
 #else
   expectEqual(8, MemoryLayout.size(ofValue: dict))

--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -62,14 +62,14 @@ def prepare_bit_pattern(bit_pattern, dst_bits, dst_signed):
 //===----------------------------------------------------------------------===//
 
 FixedPoint.test("Integers.Stride") {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
 
 % for self_ty in all_integer_types(32):
 %   Self = self_ty.stdlib_name
   expectEqualType(Int.self, ${Self}.Stride.self)
 % end
 
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
 
 % for self_ty in all_integer_types(64):
 %   Self = self_ty.stdlib_name
@@ -130,7 +130,7 @@ FixedPoint.test("${Dst}(truncatingIfNeeded:) from ${Src}(${bit_pattern})") {
 
 }%
 
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
 
   ${gyb.execute_template(
       truncating_bit_pattern_test_template,
@@ -138,7 +138,7 @@ FixedPoint.test("${Dst}(truncatingIfNeeded:) from ${Src}(${bit_pattern})") {
       test_bit_patterns=test_bit_patterns,
       word_bits=32)}
 
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
 
   ${gyb.execute_template(
       truncating_bit_pattern_test_template,
@@ -202,7 +202,7 @@ FixedPoint.test("${Dst}(bitPattern:) from ${Src}(${bit_pattern})") {
 
 }%
 
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
 
   ${gyb.execute_template(
       bit_pattern_test_template,
@@ -210,7 +210,7 @@ FixedPoint.test("${Dst}(bitPattern:) from ${Src}(${bit_pattern})") {
       test_bit_patterns=test_bit_patterns,
       word_bits=32)}
 
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
 
   ${gyb.execute_template(
       bit_pattern_test_template,
@@ -267,7 +267,7 @@ FixedPoint.test("${Self}.hash(into:)") {
 
 }%
 
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
 
   ${gyb.execute_template(
       hash_value_test_template,
@@ -275,7 +275,7 @@ FixedPoint.test("${Self}.hash(into:)") {
       test_bit_patterns=test_bit_patterns,
       word_bits=32)}
 
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
 
   ${gyb.execute_template(
       hash_value_test_template,

--- a/validation-test/stdlib/Hashing.swift
+++ b/validation-test/stdlib/Hashing.swift
@@ -41,7 +41,7 @@ HashingTestSuite.test("Hasher/CustomKeys") {
   checkHash(for: 1, withSeed: 0xFFFFFFFF, expected: 0xd7da861471fc35dc)
   checkHash(for: .max, withSeed: 0xFFFFFFFF, expected: 0xf6e3047fc114dbc0)
 
-#if !(arch(i386) || arch(arm) || arch(arm64_32))
+#if _pointerBitWidth(_64)
   checkHash(for: 0, withSeed: 0xFFFFFFFF_FFFFFFFF, expected: 0x8d0ea5ad8d6a55c7)
   checkHash(for: 1, withSeed: 0xFFFFFFFF_FFFFFFFF, expected: 0x2899f60d6b5bc847)
   checkHash(for: .max, withSeed: 0xFFFFFFFF_FFFFFFFF, expected: 0xc4d7726fff5e65a0)

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -193,9 +193,9 @@ struct _${name}Bitmap {
 
   var setBitCount: Int {
 %   if underlyingType == 'UInt':
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
     return Int(Builtin.int_ctpop_Int32(_bits._value))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+#elseif _pointerBitWidth(_64)
     return Int(Builtin.int_ctpop_Int64(_bits._value))
 #endif
 %   elif underlyingType == 'UInt32':

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -284,7 +284,7 @@ SetTestSuite.test("AssociatedTypes") {
 
 SetTestSuite.test("sizeof") {
   var s = Set(["Hello", "world"])
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   expectEqual(4, MemoryLayout.size(ofValue: s))
 #else
   expectEqual(8, MemoryLayout.size(ofValue: s))

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -108,7 +108,7 @@ struct StringFauxUTF16Collection: RangeReplaceableCollection, RandomAccessCollec
 var StringTests = TestSuite("StringTests")
 
 StringTests.test("sizeof") {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
   expectEqual(12, MemoryLayout<String>.size)
 #else
   expectEqual(16, MemoryLayout<String>.size)
@@ -964,7 +964,7 @@ StringTests.test("stringGutsReserve")
     case 0: (base, startedNative) = (String(), true)
     case 1: (base, startedNative) = (asciiString("x"), true)
     case 2: (base, startedNative) = ("Ξ", true)
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if _pointerBitWidth(_32)
     case 3: (base, startedNative) = ("x" as NSString as String, false)
     case 4: (base, startedNative) = ("x" as NSMutableString as String, false)
 #else


### PR DESCRIPTION
Replace `arch(foo) || arch(bar) || arch(fred)` incantations with the new `_pointerBitWidth` conditional.