### PR TITLE
[Macros] Use private discriminators for expression macros 

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -496,7 +496,7 @@ public:
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;
 
   Identifier getDiscriminatorForPrivateDecl(const Decl *D) const override;
-  Identifier getPrivateDiscriminator() const { return PrivateDiscriminator; }
+  Identifier getPrivateDiscriminator() const;
   Optional<ExternalSourceLocs::RawLocs>
   getExternalRawLocsForDecl(const Decl *D) const override;
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -496,7 +496,7 @@ public:
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;
 
   Identifier getDiscriminatorForPrivateDecl(const Decl *D) const override;
-  Identifier getPrivateDiscriminator() const;
+  Identifier getPrivateDiscriminator(bool createIfMissing = false) const;
   Optional<ExternalSourceLocs::RawLocs>
   getExternalRawLocsForDecl(const Decl *D) const override;
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3994,10 +3994,40 @@ void ASTMangler::appendMacroExpansionOperator(
   }
 }
 
+static StringRef getPrivateDiscriminatorIfNecessary(
+      const MacroExpansionExpr *expansion) {
+  auto dc = MacroDiscriminatorContext::getInnermostMacroContext(
+      expansion->getDeclContext());
+  auto decl = dc->getAsDecl();
+  if (decl && !decl->isOutermostPrivateOrFilePrivateScope())
+    return StringRef();
+
+  // Mangle non-local private declarations with a textual discriminator
+  // based on their enclosing file.
+  auto topLevelSubcontext = dc->getModuleScopeContext();
+  SourceFile *sf = dyn_cast<SourceFile>(topLevelSubcontext);
+  if (!sf)
+    return StringRef();
+
+  Identifier discriminator = sf->getPrivateDiscriminator();
+  assert(!discriminator.empty());
+  assert(!isNonAscii(discriminator.str()) &&
+         "discriminator contains non-ASCII characters");
+  (void)&isNonAscii;
+  assert(!clang::isDigit(discriminator.str().front()) &&
+         "not a valid identifier");
+  return discriminator.str();
+}
+
 std::string ASTMangler::mangleMacroExpansion(
     const MacroExpansionExpr *expansion) {
   beginMangling();
   appendMacroExpansionContext(expansion->getLoc(), expansion->getDeclContext());
+  auto privateDiscriminator = getPrivateDiscriminatorIfNecessary(expansion);
+  if (!privateDiscriminator.empty()) {
+    appendIdentifier(privateDiscriminator);
+    appendOperator("Ll");
+  }
   appendMacroExpansionOperator(
       expansion->getMacroName().getBaseName().userFacingName(),
       MacroRole::Expression,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4009,7 +4009,8 @@ static StringRef getPrivateDiscriminatorIfNecessary(
   if (!sf)
     return StringRef();
 
-  Identifier discriminator = sf->getPrivateDiscriminator();
+  Identifier discriminator =
+      sf->getPrivateDiscriminator(/*createIfMissing=*/true);
   assert(!discriminator.empty());
   assert(!isNonAscii(discriminator.str()) &&
          "discriminator contains non-ASCII characters");

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3852,8 +3852,8 @@ ASTScope &SourceFile::getScope() {
   return *Scope.get();
 }
 
-Identifier SourceFile::getPrivateDiscriminator() const {
-  if (!PrivateDiscriminator.empty())
+Identifier SourceFile::getPrivateDiscriminator(bool createIfMissing) const {
+  if (!PrivateDiscriminator.empty() || !createIfMissing)
     return PrivateDiscriminator;
 
   StringRef name = getFilename();
@@ -3894,7 +3894,7 @@ Identifier
 SourceFile::getDiscriminatorForPrivateDecl(const Decl *D) const {
   assert(D->getDeclContext()->getModuleScopeContext() == this ||
          D->getDeclContext()->getModuleScopeContext() == getSynthesizedFile());
-  return getPrivateDiscriminator();
+  return getPrivateDiscriminator(/*createIfMissing=*/true);
 }
 
 SynthesizedFileUnit *FileUnit::getSynthesizedFile() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3852,11 +3852,7 @@ ASTScope &SourceFile::getScope() {
   return *Scope.get();
 }
 
-Identifier
-SourceFile::getDiscriminatorForPrivateDecl(const Decl *D) const {
-  assert(D->getDeclContext()->getModuleScopeContext() == this ||
-         D->getDeclContext()->getModuleScopeContext() == getSynthesizedFile());
-
+Identifier SourceFile::getPrivateDiscriminator() const {
   if (!PrivateDiscriminator.empty())
     return PrivateDiscriminator;
 
@@ -3892,6 +3888,13 @@ SourceFile::getDiscriminatorForPrivateDecl(const Decl *D) const {
   buffer += hashString;
   PrivateDiscriminator = getASTContext().getIdentifier(buffer.str().upper());
   return PrivateDiscriminator;
+}
+
+Identifier
+SourceFile::getDiscriminatorForPrivateDecl(const Decl *D) const {
+  assert(D->getDeclContext()->getModuleScopeContext() == this ||
+         D->getDeclContext()->getModuleScopeContext() == getSynthesizedFile());
+  return getPrivateDiscriminator();
 }
 
 SynthesizedFileUnit *FileUnit::getSynthesizedFile() const {

--- a/test/Macros/Inputs/top_level_freestanding_other.swift
+++ b/test/Macros/Inputs/top_level_freestanding_other.swift
@@ -1,3 +1,15 @@
 #anonymousTypes { "hello2" }
 
 var globalVar = #stringify(1 + 1)
+var globalVar2 = { #stringify(1 + 1) }()
+
+@available(*, deprecated)
+func deprecated() -> Int { 0 }
+
+var globalVar3 = #stringify({ deprecated() })
+// expected-note@-1 2{{in expansion of macro 'stringify' here}}
+// expected-warning@-2{{'deprecated()' is deprecated}}
+
+var globalVar4 = #stringify({ deprecated() })
+// expected-note@-1 2{{in expansion of macro 'stringify' here}}
+// expected-warning@-2{{'deprecated()' is deprecated}}

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -71,5 +71,5 @@ func testArbitraryAtGlobal() {
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
-// DIAG_BUFFERS: @__swiftmacro_9MacroUser9stringifyfMf1_{{.*}}warning: 'deprecated()' is deprecated
-// DIAG_BUFFERS: @__swiftmacro_9MacroUser9stringifyfMf2_{{.*}}warning: 'deprecated()' is deprecated
+// DIAG_BUFFERS: @__swiftmacro_9MacroUser33_{{.*}}9stringifyfMf1_{{.*}}warning: 'deprecated()' is deprecated
+// DIAG_BUFFERS: @__swiftmacro_9MacroUser33_{{.*}}9stringifyfMf2_{{.*}}warning: 'deprecated()' is deprecated

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -7,6 +7,10 @@
 // Type check testing
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5  %S/Inputs/top_level_freestanding_other.swift
 
+// Check diagnostic buffer names
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 %s %S/Inputs/top_level_freestanding_other.swift 2> %t.diags
+// RUN: %FileCheck -check-prefix DIAG_BUFFERS %s < %t.diags
+
 // Execution testing
 // RUN: %target-build-swift -g -swift-version 5 -enable-experimental-feature FreestandingMacros -parse-as-library -load-plugin-library %t/%target-library-name(MacroDefinition) %s %S/Inputs/top_level_freestanding_other.swift -o %t/main -module-name MacroUser -swift-version 5
 // RUN: %target-codesign %t/main
@@ -66,3 +70,6 @@ func testArbitraryAtGlobal() {
 }
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+// DIAG_BUFFERS: @__swiftmacro_9MacroUser9stringifyfMf1_{{.*}}warning: 'deprecated()' is deprecated
+// DIAG_BUFFERS: @__swiftmacro_9MacroUser9stringifyfMf2_{{.*}}warning: 'deprecated()' is deprecated


### PR DESCRIPTION
Expression macros ascribed to non-private contexts need private
discriminators so they don't conflict with other uses of the same macro
in other source files.

Thank you, Richard, for noticing this omission!