### PR TITLE
[SILOptimizer] Use BitfieldRef instead of invalidating SSAPrunedLiveness.

### DIFF
--- a/include/swift/SIL/SILBitfield.h
+++ b/include/swift/SIL/SILBitfield.h
@@ -186,8 +186,9 @@ template <typename BitfieldContainer> struct BitfieldRef {
     BitfieldRef &ref;
     BitfieldContainer container;
 
-    StackState(BitfieldRef &ref, SILFunction *function)
-        : ref(ref), container(function) {
+    template <typename... ArgTypes>
+    StackState(BitfieldRef &ref, ArgTypes &&...Args)
+        : ref(ref), container(std::forward<ArgTypes>(Args)...) {
       ref.ref = &container;
     }
 


### PR DESCRIPTION
`SSAPrunedLiveness::invalidate` is used as though it reset the state of the instance it is called on.  Clients then reuse the instance with the expectation that it has been reset.  But since it has not been reset, this results in unexpected liveness results.

rdar://108627366
