### PR TITLE
[CSDiagnostics] Teach `diagnoseConflictingGenericArguments` about holes

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4422,6 +4422,12 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     std::tie(GP, loc) = conflict.first;
     auto conflictingArguments = conflict.second;
 
+    // If there are any substitutions that are not fully resolved
+    // solutions cannot be considered conflicting for the given parameter.
+    if (llvm::any_of(conflictingArguments,
+                     [](const auto &arg) { return arg->hasPlaceholder(); }))
+      continue;
+
     llvm::SmallString<64> arguments;
     llvm::raw_svector_ostream OS(arguments);
 

--- a/validation-test/Sema/SwiftUI/rdar108534555.swift
+++ b/validation-test/Sema/SwiftUI/rdar108534555.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -disable-availability-checking
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct Item: Identifiable {
+  var id: Int
+  var title: String
+}
+
+struct MyGroup<Content> {
+  init(@ViewBuilder _: () -> Content) {}
+}
+
+struct Test {
+  let s: [Item]
+
+  func test() {
+    MyGroup {
+      ForEach(s) {
+        Button($0.title) // expected-error {{value of type 'String' to expected argument type 'PrimitiveButtonStyleConfiguration'}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Only fully resolved substitutions are eligible to be considered as conflicting,
if holes are involved in any position that automatically disqualifies a generic parameter.

Resolves: rdar://108534555
Resolves: https://github.com/apple/swift/issues/63450


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
