### PR TITLE
Re-enable now-passing 'Reflection/typeref_decoding.swift'

### DIFF
--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -2,7 +2,6 @@
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
-// XFAIL: OS=linux-gnu && CPU=aarch64
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
We are now seeing this test UPASS in various Linux aarch64 package bots. 

e.g. https://ci.swift.org/job/oss-swift-package-ubuntu-20_04-aarch64/1837/