### PR TITLE
Remove an obsolete workaround for error variables.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1060,15 +1060,6 @@ SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc, SILType ty,
   if (generateDebugInfo)
     if (auto *VD = loc.getAsASTNode<VarDecl>())
       DbgVar = SILDebugVariable(VD->isLet(), 0);
-  // Recognize "catch let errorvar" bindings.
-  if (auto *DRE = loc.getAsASTNode<DeclRefExpr>())
-    if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
-      if (!isa<ParamDecl>(VD) && VD->isImplicit() &&
-          VD->getType()->isExistentialType() &&
-          VD->getType()->getExistentialLayout().isErrorExistential()) {
-        DbgVar = SILDebugVariable(VD->isLet(), 0);
-        loc = SILLocation(VD);
-      }
   auto *alloc =
       B.createAllocStack(loc, ty, DbgVar, hasDynamicLifetime, isLexical, false
 #ifndef NDEBUG

--- a/test/DebugInfo/catch_error.swift
+++ b/test/DebugInfo/catch_error.swift
@@ -1,0 +1,20 @@
+// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-debuginfo %s \
+// RUN:  -parse-as-library | %FileCheck %s
+import Foundation
+
+open class Cache<T> {
+  let _negativeCache: NSMutableDictionary = NSMutableDictionary()
+  func cachedValue(creationBlock: () throws -> T) throws -> T {
+    do {
+      let value = try creationBlock()
+      return value
+    } catch {
+      // CHECK:   debug_value {{.*}} : $any Error, let, name "error", implicit, loc "{{.*}}":[[@LINE-1]]:13, scope [[SCOPE:[0-9]+]]
+      // CHECK: alloc_stack $@opened({{.*}}, any Error) Self, loc{{.*}}, scope [[SCOPE]]
+
+      _negativeCache.setObject(error, forKey: NSNumber(1))
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
This is a revert  of the workaround for creating debug  info for error variables in b2109ab4db10, while leaving the test  added back then in place.  The compiler is now emitting debug info for the error pattern binding as it's supposed to and after the  recent migration to  stricter debug  scope generation, there  are now situations where the  variable added for the workaround and  the correct one are in conflict.

rdar://108576484
