### PR TITLE
Revert "[Macros] Ensure that we compute the interface type before we add accessors"

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1303,7 +1303,6 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
 Optional<unsigned> swift::expandAccessors(
     AbstractStorageDecl *storage, CustomAttr *attr, MacroDecl *macro
 ) {
-  (void)storage->getInterfaceType();
   // Evaluate the macro.
   auto macroSourceFile = evaluateAttachedMacro(macro, storage, attr,
                                                /*passParentContext*/false,

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -12,6 +12,18 @@ import StdlibUnittest
 import _Observation
 import _Concurrency
 
+@available(SwiftStdlib 5.9, *)
+@MainActor @Observable
+final class StateMachine {
+  enum State {
+    case initializing
+    case running
+    case complete
+  }
+
+  var state: State = .initializing
+}
+
 @usableFromInline
 @inline(never)
 func _blackHole<T>(_ value: T) { }


### PR DESCRIPTION
This commit is causing a reference cycle when checking whether a type has storage, and shouldn't be needed.

Fixes rdar://108565923.