### PR TITLE
5.9: [SILOptimizer] Use BitfieldRef instead of invalidating SSAPrunedLiveness.

### DIFF
--- a/include/swift/SIL/SILBitfield.h
+++ b/include/swift/SIL/SILBitfield.h
@@ -186,8 +186,9 @@ template <typename BitfieldContainer> struct BitfieldRef {
     BitfieldRef &ref;
     BitfieldContainer container;
 
-    StackState(BitfieldRef &ref, SILFunction *function)
-        : ref(ref), container(function) {
+    template <typename... ArgTypes>
+    StackState(BitfieldRef &ref, ArgTypes &&...Args)
+        : ref(ref), container(std::forward<ArgTypes>(Args)...) {
       ref.ref = &container;
     }
 


### PR DESCRIPTION
• Description: The `PrunedLiveness` utility has a method named invalidate that clients expect to reset its state.  That method doesn't actually do that, though.  `PrunedLiveness` uses an extremely performant gadget to record a flag for each block in a function; this gadget requires stack storage.  To reset `PrunedLiveness`, a new instance of the gadget must be constructed on the stack and provided to a newly created instance of the utility.  In this patch, an existing tool to manage such allocation and creation (which is used elsewhere for exactly this purpose) is used in place of calls to invalidate.
• Risk: Low.  The patch replaces an invalid approach to reset the utility's state with a valid one that is used already elsewhere.
• Original PR: https://github.com/apple/swift/pull/65478 , https://github.com/apple/swift/pull/65590
• Reviewed By: Andrew Trick ( @atrick )
• Testing: Existing unit and source compatibility tests were run.
• Resolves: rdar://108627366
