### PR TITLE
[5.9][Macros] Automatically format expanded macros

### DIFF
--- a/include/swift/Refactoring/RefactoringKinds.def
+++ b/include/swift/Refactoring/RefactoringKinds.def
@@ -66,6 +66,8 @@ CURSOR_REFACTORING(AddAsyncWrapper, "Add Async Wrapper", add.async-wrapper)
 
 CURSOR_REFACTORING(ExpandMacro, "Expand Macro", expand.macro)
 
+CURSOR_REFACTORING(InlineMacro, "Inline Macro", inline.macro)
+
 RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr)
 
 RANGE_REFACTORING(ExtractFunction, "Extract Method", extract.function)

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -25,6 +25,7 @@ add_pure_swift_host_library(swiftASTGen STATIC
   DEPENDENCIES
     swiftAST
   SWIFT_DEPENDENCIES
+    SwiftSyntax::SwiftBasicFormat
     SwiftSyntax::SwiftDiagnostics
     SwiftSyntax::SwiftOperators
     SwiftSyntax::SwiftParser

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -8756,18 +8756,53 @@ getMacroExpansionBuffers(SourceManager &sourceMgr, ResolvedCursorInfoPtr Info) {
   return {};
 }
 
-bool RefactoringActionExpandMacro::isApplicable(ResolvedCursorInfoPtr Info,
-                                                DiagnosticEngine &Diag) {
-  return !getMacroExpansionBuffers(Diag.SourceMgr, Info).empty();
+/// Given the expanded code for a particular macro, perform whitespace
+/// adjustments to make the refactoring more suitable for inline insertion.
+static StringRef adjustMacroExpansionWhitespace(
+    GeneratedSourceInfo::Kind kind, StringRef expandedCode,
+    llvm::SmallString<64> &scratch) {
+  scratch.clear();
+
+  switch (kind) {
+  case GeneratedSourceInfo::MemberAttributeMacroExpansion:
+    // Attributes are added to the beginning, add a space to separate from
+    // any existing.
+    scratch += expandedCode;
+    scratch += " ";
+    return scratch;
+
+  case GeneratedSourceInfo::MemberMacroExpansion:
+  case GeneratedSourceInfo::PeerMacroExpansion:
+  case GeneratedSourceInfo::ConformanceMacroExpansion:
+    // All added to the end. Note that conformances are always expanded as
+    // extensions, hence treating them the same as peer.
+    scratch += "\n\n";
+    scratch += expandedCode;
+    scratch += "\n";
+    return scratch;
+
+  case GeneratedSourceInfo::ExpressionMacroExpansion:
+  case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
+  case GeneratedSourceInfo::AccessorMacroExpansion:
+  case GeneratedSourceInfo::ReplacedFunctionBody:
+  case GeneratedSourceInfo::PrettyPrinted:
+    return expandedCode;
+  }
 }
 
-bool RefactoringActionExpandMacro::performChange() {
-  auto bufferIDs = getMacroExpansionBuffers(SM, CursorInfo);
+static bool expandMacro(SourceManager &SM, ResolvedCursorInfoPtr cursorInfo,
+                        SourceEditConsumer &editConsumer, bool adjustExpansion) {
+  auto bufferIDs = getMacroExpansionBuffers(SM, cursorInfo);
   if (bufferIDs.empty())
+    return true;
+
+  SourceFile *containingSF = cursorInfo->getSourceFile();
+  if (!containingSF)
     return true;
 
   // Send all of the rewritten buffer snippets.
   CustomAttr *attachedMacroAttr = nullptr;
+  SmallString<64> scratchBuffer;
   for (auto bufferID: bufferIDs) {
     auto generatedInfo = SM.getGeneratedSourceInfo(bufferID);
     if (!generatedInfo || generatedInfo->originalSourceRange.isInvalid())
@@ -8781,8 +8816,12 @@ bool RefactoringActionExpandMacro::performChange() {
         rewrittenBuffer.empty())
       continue;
 
-    // `TheFile` is the file of the actual expansion site, where as
-    // `OriginalFile` is the possibly enclosing buffer. Concretely:
+    if (adjustExpansion) {
+      rewrittenBuffer = adjustMacroExpansionWhitespace(generatedInfo->kind, rewrittenBuffer, scratchBuffer);
+    }
+
+    // `containingFile` is the file of the actual expansion site, where as
+    // `originalFile` is the possibly enclosing buffer. Concretely:
     // ```
     // // m.swift
     // @AddMemberAttributes
@@ -8801,14 +8840,14 @@ bool RefactoringActionExpandMacro::performChange() {
     // expansion.
     auto originalSourceRange = generatedInfo->originalSourceRange;
     SourceFile *originalFile =
-        MD->getSourceFileContainingLocation(originalSourceRange.getStart());
+        containingSF->getParentModule()->getSourceFileContainingLocation(originalSourceRange.getStart());
     StringRef originalPath;
     if (originalFile->getBufferID().hasValue() &&
-        TheFile->getBufferID() != originalFile->getBufferID()) {
+        containingSF->getBufferID() != originalFile->getBufferID()) {
       originalPath = SM.getIdentifierForBuffer(*originalFile->getBufferID());
     }
 
-    EditConsumer.accept(SM, {originalPath,
+    editConsumer.accept(SM, {originalPath,
                              originalSourceRange,
                              SM.getIdentifierForBuffer(bufferID),
                              rewrittenBuffer,
@@ -8823,10 +8862,29 @@ bool RefactoringActionExpandMacro::performChange() {
   if (attachedMacroAttr) {
     SourceRange range = attachedMacroAttr->getRangeWithAt();
     auto charRange = Lexer::getCharSourceRangeFromSourceRange(SM, range);
-    EditConsumer.accept(SM, charRange, StringRef());
+    editConsumer.accept(SM, charRange, StringRef());
   }
 
   return false;
+}
+
+bool RefactoringActionExpandMacro::isApplicable(ResolvedCursorInfoPtr Info,
+                                                DiagnosticEngine &Diag) {
+  // Never list in available refactorings. Only allow requesting directly.
+  return false;
+}
+
+bool RefactoringActionExpandMacro::performChange() {
+  return expandMacro(SM, CursorInfo, EditConsumer, /*adjustExpansion=*/false);
+}
+
+bool RefactoringActionInlineMacro::isApplicable(ResolvedCursorInfoPtr Info,
+                                                DiagnosticEngine &Diag) {
+  return !getMacroExpansionBuffers(Diag.SourceMgr, Info).empty();
+}
+
+bool RefactoringActionInlineMacro::performChange() {
+  return expandMacro(SM, CursorInfo, EditConsumer, /*adjustExpansion=*/true);
 }
 
 } // end of anonymous namespace
@@ -8940,8 +8998,8 @@ swift::ide::collectRefactorings(ResolvedCursorInfoPtr CursorInfo,
 
   // Only macro expansion is available within generated buffers
   if (CursorInfo->getSourceFile()->Kind == SourceFileKind::MacroExpansion) {
-    if (RefactoringActionExpandMacro::isApplicable(CursorInfo, DiagEngine)) {
-      Infos.emplace_back(RefactoringKind::ExpandMacro,
+    if (RefactoringActionInlineMacro::isApplicable(CursorInfo, DiagEngine)) {
+      Infos.emplace_back(RefactoringKind::InlineMacro,
                          RefactorAvailableKind::Available);
     }
     return Infos;
@@ -9019,6 +9077,7 @@ refactorSwiftModule(ModuleDecl *M, RefactoringOptions Opts,
 case RefactoringKind::KIND: {                                                  \
       RefactoringAction##KIND Action(M, Opts, EditConsumer, DiagConsumer);     \
       if (RefactoringKind::KIND == RefactoringKind::LocalRename ||             \
+          RefactoringKind::KIND == RefactoringKind::ExpandMacro ||             \
           Action.isApplicable())                                               \
         return Action.performChange();                                         \
       return true;                                                             \

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -26,7 +26,7 @@ public struct ColorLiteralMacro: ExpressionMacro {
       of: macro.argumentList, with: "_colorLiteralRed"
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
-    return initSyntax.with(\.leadingTrivia, macro.leadingTrivia)
+    return initSyntax
   }
 }
 
@@ -45,7 +45,7 @@ public struct FileIDMacro: ExpressionMacro {
     }
 
     let fileLiteral: ExprSyntax = "\(literal: fileID)"
-    return fileLiteral.with(\.leadingTrivia, macro.leadingTrivia)
+    return fileLiteral
   }
 }
 
@@ -646,7 +646,6 @@ public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
           name: .identifier(wrapperName.content.text)
         )
       )
-      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }
@@ -766,7 +765,7 @@ public struct AddCompletionHandler: PeerMacro {
     let completionHandlerParam =
       FunctionParameterSyntax(
         firstName: .identifier("completionHandler"),
-        colon: .colonToken(trailingTrivia: .space),
+        colon: .colonToken(),
         type: "@escaping (\(resultType ?? "")) -> Void" as TypeSyntax
       )
 
@@ -779,7 +778,7 @@ public struct AddCompletionHandler: PeerMacro {
         .appending(
           lastParam.with(
             \.trailingComma,
-            .commaToken(trailingTrivia: .space)
+            .commaToken()
           )
         )
         .appending(completionHandlerParam)
@@ -804,11 +803,9 @@ public struct AddCompletionHandler: PeerMacro {
     // so that the full body could go here.
     let newBody: ExprSyntax =
       """
-
         Task {
           completionHandler(await \(call))
         }
-
       """
 
     // Drop the @addCompletionHandler attribute from the new declaration.
@@ -844,15 +841,14 @@ public struct AddCompletionHandler: PeerMacro {
       .with(
         \.body,
         CodeBlockSyntax(
-          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          leftBrace: .leftBraceToken(),
           statements: CodeBlockItemListSyntax(
             [CodeBlockItemSyntax(item: .expr(newBody))]
           ),
-          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+          rightBrace: .rightBraceToken()
         )
       )
       .with(\.attributes, newAttributeList)
-      .with(\.leadingTrivia, .newlines(2))
 
     return [DeclSyntax(newFunc)]
   }
@@ -954,12 +950,11 @@ public struct WrapInType: PeerMacro {
       .with(
         \.body,
         CodeBlockSyntax(
-          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          leftBrace: .leftBraceToken(),
           statements: CodeBlockItemListSyntax(
             [CodeBlockItemSyntax(item: .expr(call))]
-          )
-          .with(\.leadingTrivia, [.newlines(1), .spaces(2)]),
-          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+          ),
+          rightBrace: .rightBraceToken()
         )
       )
       .with(\.attributes, newAttributeList)

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -71,10 +71,12 @@ struct Bad {}
 // CHECK-DIAGS: import Swift
 // CHECK-DIAGS: precedencegroup MyPrecedence {}
 // CHECK-DIAGS: @attached(member) macro myMacro()
-// CHECK-DIAGS: extension Int {}
+// CHECK-DIAGS: extension Int {
+// CHECK-DIAGS: }
 // CHECK-DIAGS: @main
 // CHECK-DIAGS: struct MyMain {
-// CHECK-DIAGS:   static func main() {}
+// CHECK-DIAGS:   static func main() {
+// CHECK-DIAGS:   }
 // CHECK-DIAGS: }
 // CHECK-DIAGS: typealias Array = Void
 // CHECK-DIAGS: typealias Dictionary = Void
@@ -259,7 +261,7 @@ func testNestedDeclInExpr() {
 macro defineDeclsWithKnownNames() = #externalMacro(module: "MacroDefinition", type: "DefineDeclsWithKnownNamesMacro")
 
 // Freestanding macros are not in inlined scopes.
-// CHECK-SIL: sil_scope {{.*}} { loc "@__swiftmacro_9MacroUser016testFreestandingA9ExpansionyyF4Foo2L_V25defineDeclsWithKnownNamesfMf0_.swift":9:14 {{.*}} -> Int }
+// CHECK-SIL: sil_scope {{.*}} { loc "@__swiftmacro_9MacroUser016testFreestandingA9ExpansionyyF4Foo2L_V25defineDeclsWithKnownNamesfMf0_.swift"{{.*}} -> Int }
 
 // FIXME: Macros producing arbitrary names are not supported yet
 #if false

--- a/test/Macros/macro_expand_primary.swift
+++ b/test/Macros/macro_expand_primary.swift
@@ -59,7 +59,9 @@ final class Dog: Observable {
   var isHappy: Bool = true
   // CHECK-DUMP: get {
   // CHECK-DUMP:   _registrar.beginAccess(\.isHappy)
-  // CHECK-DUMP:   defer { _registrar.endAccess() }
+  // CHECK-DUMP:   defer {
+  // CHECK-DUMP:     _registrar.endAccess()
+  // CHECK-DUMP:   }
   // CHECK-DUMP:   return _storage.isHappy
   // CHECK-DUMP: }
   // CHECK-DUMP: set {

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -94,8 +94,8 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_MACRO_EXPR-LABEL: ACTIONS BEGIN
 // CURSOR_MACRO_EXPR: source.refactoring.kind.rename.global
 // CURSOR_MACRO_EXPR-NEXT: Global Rename
-// CURSOR_MACRO_EXPR: source.refactoring.kind.expand.macro
-// CURSOR_MACRO_EXPR-NEXT: Expand Macro
+// CURSOR_MACRO_EXPR: source.refactoring.kind.inline.macro
+// CURSOR_MACRO_EXPR-NEXT: Inline Macro
 // CURSOR_MACRO_EXPR: ACTIONS END
 
 //##-- Expansion on macro expression
@@ -119,8 +119,8 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_MACRO_DECL-NEXT: },
 // CURSOR_MACRO_DECL: SYMBOL GRAPH END
 // CURSOR_MACRO_DECL-LABEL: ACTIONS BEGIN
-// CURSOR_MACRO_DECL: source.refactoring.kind.expand.macro
-// CURSOR_MACRO_DECL-NEXT: Expand Macro
+// CURSOR_MACRO_DECL: source.refactoring.kind.inline.macro
+// CURSOR_MACRO_DECL-NEXT: Inline Macro
 // CURSOR_MACRO_DECL: ACTIONS END
 
 //##-- Expansion on macro declaration
@@ -131,7 +131,10 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:   func hello() -> String {
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
-// EXPAND_MACRO_DECL:        func getSelf() -> Any.Type { return Self.self }
+// EXPAND_MACRO_DECL-EMPTY:
+// EXPAND_MACRO_DECL-NEXT:   func getSelf() -> Any .Type {
+// EXPAND_MACRO_DECL-NEXT:      return Self.self
+// EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-NEXT: }
 // EXPAND_MACRO_DECL-NEXT: enum $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu0_ {
 // EXPAND_MACRO_DECL-NEXT:   case apple
@@ -157,27 +160,24 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // CURSOR_ATTACHED-NEXT: },
 // CURSOR_ATTACHED: SYMBOL GRAPH END
 // CURSOR_ATTACHED-LABEL: ACTIONS BEGIN
-// CURSOR_ATTACHED: source.refactoring.kind.expand.macro
-// CURSOR_ATTACHED-NEXT: Expand Macro
+// CURSOR_ATTACHED: source.refactoring.kind.inline.macro
+// CURSOR_ATTACHED-NEXT: Inline Macro
 // CURSOR_ATTACHED: ACTIONS END
 
 //##-- Expansion on attached macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:1 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift) "@accessViaStorage"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV1y13myTypeWrapperfMA0_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV1y13myTypeWrapperfMA0_.swift) "@accessViaStorage"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 25:1-25:1 (@__swiftmacro_9MacroUser1S13myTypeWrapperfMm_.swift) "
-// ATTACHED_EXPAND-EMPTY:
-// ATTACHED_EXPAND-NEXT: private var _storage = _Storage()
-// ATTACHED_EXPAND-NEXT: "
+// ATTACHED_EXPAND-NEXT: 25:1-25:1 (@__swiftmacro_9MacroUser1S13myTypeWrapperfMm_.swift) "private var _storage = _Storage()"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 21:1-21:15 ""
 
 //##-- Cursor info on the attribute expanded by @myTypeWrapper
-// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=2 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=1 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
 // NESTED_ATTACHED_CURSOR: source.lang.swift.ref.macro
 // NESTED_ATTACHED_CURSOR-SAME: macro_basic.swift:10:27-10:43
 // NESTED_ATTACHED_CURSOR-LABEL: SYMBOL GRAPH BEGIN
@@ -191,17 +191,21 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_CURSOR-NEXT: },
 // NESTED_ATTACHED_CURSOR: SYMBOL GRAPH END
 // NESTED_ATTACHED_CURSOR-LABEL: ACTIONS BEGIN
-// NESTED_ATTACHED_CURSOR-NEXT: source.refactoring.kind.expand.macro
-// NESTED_ATTACHED_CURSOR-NEXT: Expand Macro
+// NESTED_ATTACHED_CURSOR-NEXT: source.refactoring.kind.inline.macro
+// NESTED_ATTACHED_CURSOR-NEXT: Inline Macro
 // NESTED_ATTACHED_CURSOR-NEXT: ACTIONS END
 
 //##-- Expansion on the attribute expanded by @myTypeWrapper
-// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:1 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
 // NESTED_ATTACHED_EXPAND: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1x16accessViaStoragefMa_.swift) "{
-// NESTED_ATTACHED_EXPAND-NEXT:  get { _storage.x }
+// NESTED_ATTACHED_EXPAND-NEXT:  get {
+// NESTED_ATTACHED_EXPAND-NEXT:    _storage.x
+// NESTED_ATTACHED_EXPAND-NEXT:  }
 // NESTED_ATTACHED_EXPAND-EMPTY:
-// NESTED_ATTACHED_EXPAND-NEXT:  set { _storage.x = newValue }
+// NESTED_ATTACHED_EXPAND-NEXT:  set {
+// NESTED_ATTACHED_EXPAND-NEXT:    _storage.x = newValue
+// NESTED_ATTACHED_EXPAND-NEXT:  }
 // NESTED_ATTACHED_EXPAND-NEXT: }"
 // NESTED_ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: 1:1-1:18 ""
@@ -210,9 +214,13 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s
 // ACCESSOR1_EXPAND: source.edit.kind.active:
 // ACCESSOR1_EXPAND-NEXT: 31:13-31:13 (@__swiftmacro_9MacroUser2S2V1x16accessViaStoragefMa_.swift) "{
-// ACCESSOR1_EXPAND-NEXT:  get { _storage.x }
+// ACCESSOR1_EXPAND-NEXT:  get {
+// ACCESSOR1_EXPAND-NEXT:    _storage.x
+// ACCESSOR1_EXPAND-NEXT:  }
 // ACCESSOR1_EXPAND-EMPTY:
-// ACCESSOR1_EXPAND-NEXT:  set { _storage.x = newValue }
+// ACCESSOR1_EXPAND-NEXT:  set {
+// ACCESSOR1_EXPAND-NEXT:    _storage.x = newValue
+// ACCESSOR1_EXPAND-NEXT:  }
 // ACCESSOR1_EXPAND-NEXT: }"
 // ACCESSOR1_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR1_EXPAND-NEXT: 30:3-30:20 ""
@@ -221,9 +229,13 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=33:13 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR2_EXPAND %s
 // ACCESSOR2_EXPAND: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 34:14-34:18 (@__swiftmacro_9MacroUser2S2V1y16accessViaStoragefMa_.swift) "{
-// ACCESSOR2_EXPAND-NEXT:  get { _storage.y }
+// ACCESSOR2_EXPAND-NEXT:  get {
+// ACCESSOR2_EXPAND-NEXT:    _storage.y
+// ACCESSOR2_EXPAND-NEXT:  }
 // ACCESSOR2_EXPAND-EMPTY:
-// ACCESSOR2_EXPAND-NEXT:  set { _storage.y = newValue }
+// ACCESSOR2_EXPAND-NEXT:  set {
+// ACCESSOR2_EXPAND-NEXT:    _storage.y = newValue
+// ACCESSOR2_EXPAND-NEXT:  }
 // ACCESSOR2_EXPAND-NEXT: }"
 // ACCESSOR2_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 33:3-33:20 ""
@@ -231,24 +243,18 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on the addCompletionHandler macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=42:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=PEER_EXPAND %s
 // PEER_EXPAND: source.edit.kind.active:
-// PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f20addCompletionHandlerfMp_.swift) "
-// PEER_EXPAND-EMPTY:
-// PEER_EXPAND-NEXT: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
+// PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f20addCompletionHandlerfMp_.swift) "func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
 // PEER_EXPAND-NEXT:  Task {
 // PEER_EXPAND-NEXT:    completionHandler(await f(a: a, for: b, value))
 // PEER_EXPAND-NEXT:  }
-// PEER_EXPAND-NEXT: }
-// PEER_EXPAND-NEXT: "
+// PEER_EXPAND-NEXT: }"
 // PEER_EXPAND-NEXT: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 42:3-42:24 ""
 
 //##-- Expansion on a conformance macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=51:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CONFORMANCE_EXPAND %s
 // CONFORMANCE_EXPAND: source.edit.kind.active:
-// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S48HashablefMc_.swift) "
-// CONFORMANCE_EXPAND-EMPTY:
-// CONFORMANCE_EXPAND-NEXT: extension S4 : Hashable {}
-// CONFORMANCE_EXPAND-NEXT: "
+// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S48HashablefMc_.swift) "extension S4 : Hashable {}"
 // CONFORMANCE_EXPAND-NEXT: source.edit.kind.active:
 // CONFORMANCE_EXPAND-NEXT: 51:1-51:10 ""
 

--- a/test/SourceKit/Macros/macro_formatting.swift
+++ b/test/SourceKit/Macros/macro_formatting.swift
@@ -1,0 +1,113 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// Check that a macro is automatically formatted and that it keeps any leading
+// comments (but not whitespace).
+
+// Create a plugin that adds a new function as a member without any trivia
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+
+//--- MacroPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddNamedFuncMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // TODO: Newline shouldn't be required here. BasicFormat should be adding
+    // it.
+    let newFunc = FunctionDeclSyntax(
+      leadingTrivia: [.newlines(1), .docLineComment("/// My member macro function!"), .newlines(1)],
+      modifiers: ModifierListSyntax([
+        DeclModifierSyntax(name: .keyword(.public))
+      ]),
+      identifier: .identifier("newFunc"),
+      signature: FunctionSignatureSyntax(
+        input: ParameterClauseSyntax(
+          parameterList: FunctionParameterListSyntax([]))
+      ),
+      body: CodeBlockSyntax(
+        statements: CodeBlockItemListSyntax([
+          CodeBlockItemSyntax(item: .expr(ExprSyntax("_ = 1")))
+        ])
+      )
+    )
+    return [
+      DeclSyntax(newFunc),
+    ]
+  }
+}
+
+public struct AddPreformattedFuncMacro: MemberMacro {
+  public static var formatMode: FormatMode = .disabled
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let newFunc: DeclSyntax = """
+
+       /// My preformatted member macro function!
+    public func preformattedFunc() {
+    _ = 2
+    }
+
+    """
+    return [
+      newFunc,
+    ]
+  }
+}
+
+//--- test.swift
+@attached(
+  member,
+  names: named(newFunc)
+)
+public macro AddNamedFunc() = #externalMacro(module: "MacroPlugin", type: "AddNamedFuncMacro")
+
+@attached(
+  member,
+  names: named(preformattedFunc)
+)
+public macro AddPreformattedFunc() = #externalMacro(module: "MacroPlugin", type: "AddPreformattedFuncMacro")
+
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=%(line+1):2 %t/test.swift -- -target %target-triple -load-plugin-library %t/%target-library-name(MacroPlugin) %t/test.swift | %FileCheck -check-prefix=EXPAND -strict-whitespace %s
+@AddNamedFunc
+public struct ExpandTest {
+  public func existingFunc() {}
+}
+// EXPAND: [[@LINE-1]]:1-[[@LINE-1]]:1 (@__swiftmacro_4test10ExpandTest12AddNamedFuncfMm_.swift) "/// My member macro function!
+// EXPAND-NEXT: {{^}}public func newFunc() {
+// EXPAND-NEXT: {{^}}    _ = 1
+// EXPAND-NEXT: {{^}}}"
+
+// RUN: %sourcekitd-test -req=refactoring.inline.macro -pos=%(line+1):1 %t/test.swift -- -target %target-triple -load-plugin-library %t/%target-library-name(MacroPlugin) %t/test.swift | %FileCheck -check-prefix=INLINE %s
+@AddNamedFunc
+public struct InlineTest {
+  public func existingFunc() {}
+}
+// INLINE: [[@LINE-1]]:1-[[@LINE-1]]:1 (@__swiftmacro_4test10InlineTest12AddNamedFuncfMm_.swift) "
+// INLINE-EMPTY:
+// INLINE-NEXT: /// My member macro function!
+// INLINE-NEXT: {{^}}public func newFunc() {
+// INLINE-NEXT: {{^}}    _ = 1
+// INLINE-NEXT: {{^}}}
+// INLINE-NEXT: {{^}}"
+
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=%(line+1):2 %t/test.swift -- -target %target-triple -load-plugin-library %t/%target-library-name(MacroPlugin) %t/test.swift | %FileCheck -check-prefix=PREFORMATTED -strict-whitespace %s
+@AddPreformattedFunc
+public struct PreformattedTest {
+  public func existingFunc() {}
+}
+// PREFORMATTED: [[@LINE-1]]:1-[[@LINE-1]]:1 (@__swiftmacro_4test16PreformattedTest03AddB4FuncfMm_.swift) "/// My preformatted member macro function!
+// PREFORMATTED-NEXT: {{^}}public func preformattedFunc() {
+// PREFORMATTED-NEXT: {{^}}_ = 2
+// PREFORMATTED-NEXT: {{^}}}"


### PR DESCRIPTION
* Explanation: Macro formatting patch. Primarily this is aimed to reduce the previous burden on expansions having to add required trivia and to be at least *somewhat* formatted. We now basic format all macro expansions, which both adds required trivia and adds some basic newlines and indentation. Macros can opt-out by implementing `formatMode` and setting to `.disabled`. This also fixes up the expansion buffers to not include the newlines that eg. an inline macro refactoring would expect.
* Scope: All macro expansions
* Risk: Low; we may end up with some oddly-formatted macros, but implementors can always disable it if they want
* Testing: Added tests for macro formatting (on and off)
* Original PR: https://github.com/apple/swift/pull/65450