### PR TITLE
driver: add swift-frontend options to select the tool to run

### DIFF
--- a/lib/DriverTool/driver.cpp
+++ b/lib/DriverTool/driver.cpp
@@ -208,6 +208,15 @@ static bool appendSwiftDriverName(SmallString<256> &buffer) {
   return false;
 }
 
+static llvm::SmallVector<const char *, 32> eraseFirstArg(ArrayRef<const char *> argv){
+  llvm::SmallVector<const char *, 32> newArgv;
+  newArgv.push_back(argv[0]);
+  for (const char *arg : argv.slice(2)) {
+    newArgv.push_back(arg);
+  }
+  return newArgv;
+}
+
 static int run_driver(StringRef ExecName,
                        ArrayRef<const char *> argv,
                        const ArrayRef<const char *> originalArgv) {
@@ -231,6 +240,34 @@ static int run_driver(StringRef ExecName,
       return modulewrap_main(llvm::makeArrayRef(argv.data()+2,
                                                 argv.data()+argv.size()),
                              argv[0], (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-sil-opt") {
+      return sil_opt_main(eraseFirstArg(argv),
+                          (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-sil-func-extractor") {
+      return sil_func_extractor_main(eraseFirstArg(argv),
+                                     (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-sil-nm") {
+      return sil_nm_main(eraseFirstArg(argv),
+                         (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-sil-llvm-gen") {
+      return sil_llvm_gen_main(eraseFirstArg(argv),
+                               (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-sil-passpipeline-dumper") {
+      return sil_passpipeline_dumper_main(eraseFirstArg(argv),
+                                          (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-swift-dependency-tool") {
+      return swift_dependency_tool_main(eraseFirstArg(argv),
+                                        (void *)(intptr_t)getExecutablePath);
+    }
+    if (FirstArg == "-swift-llvm-opt") {
+      return swift_llvm_opt_main(eraseFirstArg(argv),
+                                 (void *)(intptr_t)getExecutablePath);
     }
 
     // Run the integrated Swift frontend when called as "swift-frontend" but

--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -6,7 +6,10 @@
 // RUN: cp -r %S/Inputs/bindings-build-record/* %t
 // RUN: %swift-dependency-tool --from-yaml --input-filename=%t/main.swiftdeps.yaml --output-filename=%t/main.swiftdeps
 // RUN: %swift-dependency-tool --from-yaml --input-filename=%t/other.swiftdeps.yaml --output-filename=%t/other.swiftdeps
-// RUN: %swift-dependency-tool --from-yaml --input-filename=%t/yet-another.swiftdeps.yaml --output-filename=%t/yet-another.swiftdeps
+
+// Use this testfile to check if the `swift-frontend -swift-dependency-tool` option works.
+// RUN: %swift_frontend_plain -swift-dependency-tool --from-yaml --input-filename=%t/yet-another.swiftdeps.yaml --output-filename=%t/yet-another.swiftdeps
+
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -driver-show-incremental -output-file-map %t/output.json 2>&1 |%FileCheck %s -check-prefix=MUST-EXEC

--- a/test/LLVMPasses/basic.ll
+++ b/test/LLVMPasses/basic.ll
@@ -1,5 +1,8 @@
 ; RUN: %swift-llvm-opt -swift-llvm-arc-optimize %s | %FileCheck %s
 
+; Use this testfile to check if the `swift-frontend -swift-dependency-tool` option works.
+; RUN: %swift_frontend_plain -swift-llvm-opt -swift-llvm-arc-optimize %s | %FileCheck %s
+
 target datalayout = "e-p:64:64:64-S128-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f16:16:16-f32:32:32-f64:64:64-f128:128:128-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "x86_64-apple-macosx10.9"
 

--- a/test/SIL/instruction_iteration.sil
+++ b/test/SIL/instruction_iteration.sil
@@ -2,6 +2,10 @@
 // RUN: %target-sil-opt %s -test-instruction-iteration -o %t/out.sil | %FileCheck --check-prefix=LOG %s
 // RUN: %FileCheck %s < %t/out.sil
 
+// Use this testfile to check if the `swift-frontend -sil-opt` option works.
+// RUN: %swift_frontend_plain -sil-opt %s -test-instruction-iteration -o %t/out.sil | %FileCheck --check-prefix=LOG %s
+// RUN: %FileCheck %s < %t/out.sil
+
 // REQUIRES: swift_in_compiler
 
 sil_stage canonical

--- a/test/sil-func-extractor/basic.sil
+++ b/test/sil-func-extractor/basic.sil
@@ -2,6 +2,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-func-extractor %s -func=use_before_init -emit-sib -o %t/out.sib -module-name main && %target-sil-opt %t/out.sib -module-name main | %FileCheck %s
 
+// Use this testfile to check if the `swift-frontend -sil-func-extractr` option works.
+// RUN: %swift_frontend_plain -sil-func-extractor %s -func=use_before_init | %FileCheck %s
+
 import Builtin
 import Swift
 

--- a/test/sil-llvm-gen/alloc.sil
+++ b/test/sil-llvm-gen/alloc.sil
@@ -5,6 +5,9 @@
 // RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target arm64-apple-ios7.0 %s -module-name main -o - | %FileCheck %s
 // RUN: %sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target x86_64-unknown-linux-gnu %s -module-name main -o - | %FileCheck %s
 
+// Use this testfile to check if the `swift-frontend -sil-llvm-gen` option works.
+// RUN: %swift_frontend_plain -sil-llvm-gen -disable-legacy-type-info -output-kind=llvm-as -target x86_64-apple-macosx10.9 -module-name main %s -o - | %FileCheck %s
+
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM
 

--- a/test/sil-nm/basic.sil
+++ b/test/sil-nm/basic.sil
@@ -5,6 +5,9 @@
 // RUN: %target-sil-nm -module-name main %t/out.sib | %FileCheck %s
 // RUN: %target-sil-nm -module-name main -demangle %t/out.sib | %FileCheck -check-prefix=DEMANGLE %s
 
+// Use this testfile to check if the `swift-frontend -sil-nm` option works.
+// RUN: %swift_frontend_plain -sil-nm %s | %FileCheck -check-prefix=SIL-NM -check-prefix=CHECK %s
+
 import Builtin
 
 public class C {

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -1,5 +1,8 @@
 // RUN: %sil-passpipeline-dumper -Onone | %FileCheck %s
 
+// Use this testfile to check if the `swift-frontend -sil-passpipeline-dumper` option works.
+// RUN: %swift_frontend_plain -sil-passpipeline-dumper -Onone | %FileCheck %s
+
 // REQUIRES: swift_in_compiler
 
 // CHECK: ---


### PR DESCRIPTION
Tool selection is primarily done by checking the executable (= symlink) name. But sometimes (e.g. if the tool symlink is not there) it's useful to have an option for selecting the tool. The selection option (e.g. -sil-opt) must be the first argument of swift-frontend.

This is a follow-up of https://github.com/apple/swift/pull/65387