### PR TITLE
[5.9\[interop][SwiftToCxx] add additional type representation emission checks

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -249,9 +249,11 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
             return {Unsupported, UnrepresentableEnumCaseTuple};
           for (const auto *param : *params) {
             auto paramType = param->getInterfaceType();
-            if (!paramType->is<GenericTypeParamType>() &&
-                !paramType->getNominalOrBoundGenericNominal())
-              return {Unsupported, UnrepresentableEnumCaseType};
+            if (!paramType->is<GenericTypeParamType>()) {
+              auto *nominal = paramType->getNominalOrBoundGenericNominal();
+              if (!nominal || isa<ProtocolDecl>(nominal))
+                return {Unsupported, UnrepresentableEnumCaseType};
+            }
           }
         }
       }

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -75,6 +75,8 @@ public:
         requiresExposedAttribute(requiresExposedAttribute),
         exposedModules(exposedModules), outputLang(outputLang) {}
 
+  PrimitiveTypeMapping &getTypeMapping() { return typeMapping; }
+
   SwiftToClangInteropContext &getInteropContext() { return interopContext; }
 
   /// Returns true if \p VD should be included in a compatibility header for

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1581,3 +1581,16 @@ void DeclAndTypeClangFunctionPrinter::printCustomCxxFunction(
   bodyPrinter(typeRefs);
   outOfLineOS << "}\n";
 }
+
+ClangRepresentation DeclAndTypeClangFunctionPrinter::getTypeRepresentation(
+    PrimitiveTypeMapping &typeMapping,
+    SwiftToClangInteropContext &interopContext, DeclAndTypePrinter &declPrinter,
+    const ModuleDecl *emittedModule, Type ty) {
+  CFunctionSignatureTypePrinterModifierDelegate delegate;
+  CFunctionSignatureTypePrinter typePrinter(
+      llvm::nulls(), llvm::nulls(), typeMapping, OutputLanguageMode::Cxx,
+      interopContext, delegate, emittedModule, declPrinter,
+      FunctionSignatureTypeUse::TypeReference);
+  return typePrinter.visit(ty, OptionalTypeKind::OTK_None,
+                           /*isInOutParam=*/false);
+}

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -164,6 +164,12 @@ public:
                               ModuleDecl *emittedModule,
                               raw_ostream &outOfLineOS);
 
+  static ClangRepresentation
+  getTypeRepresentation(PrimitiveTypeMapping &typeMapping,
+                        SwiftToClangInteropContext &interopContext,
+                        DeclAndTypePrinter &declPrinter,
+                        const ModuleDecl *emittedModule, Type ty);
+
 private:
   void printCxxToCFunctionParameterUse(Type type, StringRef name,
                                        const ModuleDecl *moduleContext,

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseFoundation -enable-experimental-cxx-interop -emit-clang-header-path %t/UseFoundation.h
+// RUN: %FileCheck %s < %t/UseFoundation.h
+
+#if canImport(Foundation)
+
+import Foundation
+
+public enum UseFoundationEnum {
+    case A(Data)
+    case B
+}
+
+#endif
+
+// CHECK-NOT: UseFoundationEnum

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
@@ -27,3 +27,8 @@ public indirect enum unsupportedEnumIndirect {
     case B
 }
 
+@_expose(Cxx) // expected-error {{enum 'unsupportedEnumProtocolType' can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++}}
+public enum unsupportedEnumProtocolType {
+    case A
+    case B(Error)
+}


### PR DESCRIPTION
Explanation: Not all Swift enums types can be represented in C++ at the moment. This change ensures that both:
- enums whose associated value is of protocol type.
- enums whose associated value is from a dependent, not exposed Swift module
Do not get exposed to C++.

Scope: Swift's and C++ interoperability, Header generator.
Risk: Low. This is not yet adopted.
Testing: Swift unit tests.
Reviewer: @ravikandhadai 