### PR TITLE
[5.9][interop][SwiftToCxx] do not assert when emitting a public var and fu…

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -669,6 +669,13 @@ public:
       // Two overloaded functions can have the same name when emitting C++.
       if (isa<AbstractFunctionDecl>(*rhs) && isa<AbstractFunctionDecl>(*lhs))
         return result;
+      // A function and a global variable can have the same name in C++,
+      // even when the variable might not actually be emitted by the emitter.
+      // In that case, order the function before the variable.
+      if (isa<AbstractFunctionDecl>(*rhs) && isa<VarDecl>(*lhs))
+        return 1;
+      if (isa<AbstractFunctionDecl>(*lhs) && isa<VarDecl>(*rhs))
+        return -1;
 
       // Prefer value decls to extensions.
       assert(!(isa<ValueDecl>(*lhs) && isa<ValueDecl>(*rhs)));

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -48,3 +48,8 @@ public func passVoidReturnVoid() { print("passVoidReturnVoid") }
 // CHECK: SWIFT_INLINE_THUNK void passVoidReturnVoid() noexcept SWIFT_SYMBOL("s:9Functions014passVoidReturnC0yyF") {
 // CHECK: return _impl::$s9Functions014passVoidReturnC0yyF();
 // CHECK: }
+
+// CHECK: SWIFT_INLINE_THUNK void varFunctionSameName
+public func varFunctionSameName(_ x: CInt) {}
+
+public var varFunctionSameName: CInt = 0


### PR DESCRIPTION
…nction with the same C++ name

Explanation: C++ header generator asserts when sorting a Swift var and a Swift global function when they have the same . This fixes that assertion.
Scope: Swift's and C++ interoperability, Clang importer.
Risk: Low.
Testing: Swift unit tests.
Reviewer: @ravikandhadai 