### PR TITLE
[5.9] [Macros] "Subsume" the initializer when an accessor macros adds non-observing accessors

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5742,6 +5742,16 @@ public:
     return false;
   }
 
+  /// Return the initializer that will initializer this VarDecl at runtime.
+  /// This is equivalent to `getParentInitializer()`, but returns `null` if the
+  /// initializer itself was subsumed, e.g., by a macro or property wrapper.
+  Expr *getParentExecutableInitializer() const;
+
+  /// Whether this variable has an initializer that will be code-generated.
+  bool isParentExecutabledInitialized() const {
+    return getParentExecutableInitializer() != nullptr;
+  }
+
   // Return whether this VarDecl has an initial value, either by checking
   // if it has an initializer in its parent pattern binding or if it has
   // the @_hasInitialValue attribute.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6644,6 +6644,15 @@ bool VarDecl::isLazilyInitializedGlobal() const {
   return !isTopLevelGlobal();
 }
 
+Expr *VarDecl::getParentExecutableInitializer() const {
+  if (auto *PBD = getParentPatternBinding()) {
+    const auto i = PBD->getPatternEntryIndexForVarDecl(this);
+    return PBD->getExecutableInit(i);
+  }
+
+  return nullptr;
+}
+
 SourceRange VarDecl::getSourceRange() const {
   if (auto Param = dyn_cast<ParamDecl>(this))
     return Param->getSourceRange();

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -401,7 +401,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
         ++elti;
       } else {
         assert(field->getType()->getReferenceStorageReferent()->isEqual(
-                   field->getParentInitializer()->getType()) &&
+                   field->getParentExecutableInitializer()->getType()) &&
                "Initialization of field with mismatched type!");
 
         // Cleanup after this initialization.
@@ -422,7 +422,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
           }
         }
 
-        SGF.emitExprInto(field->getParentInitializer(), init.get());
+        SGF.emitExprInto(field->getParentExecutableInitializer(), init.get());
       }
       if (SGF.getOptions().EnableImportPtrauthFieldFunctionPointers &&
           field->getPointerAuthQualifier().isPresent()) {
@@ -454,8 +454,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       ++elti;
     } else {
       // Otherwise, use its initializer.
-      assert(field->isParentInitialized());
-      Expr *init = field->getParentInitializer();
+      assert(field->isParentExecutabledInitialized());
+      Expr *init = field->getParentExecutableInitializer();
 
       // If this is a property wrapper backing storage var that isn't
       // memberwise initialized, use the original wrapped value if it exists.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -640,7 +640,8 @@ public:
 
     assert(!isa<ParamDecl>(vd)
            && "should not bind function params on this path");
-    if (vd->getParentPatternBinding() && !vd->getParentInitializer()) {
+    if (vd->getParentPatternBinding() &&
+        !vd->getParentExecutableInitializer()) {
       // If this is a let-value without an initializer, then we need a temporary
       // buffer.  DI will make sure it is only assigned to once.
       needsTemporaryBuffer = true;
@@ -1427,8 +1428,8 @@ SILGenFunction::emitInitializationForVarDecl(VarDecl *vd, bool forceImmutable,
   // If the variable has no initial value, emit a mark_uninitialized instruction
   // so that DI tracks and enforces validity of it.
   bool isUninitialized =
-    vd->getParentPatternBinding() && !vd->getParentInitializer();
-  
+    vd->getParentPatternBinding() && !vd->getParentExecutableInitializer();
+
   // If this is a global variable, initialize it without allocations or
   // cleanups.
   InitializationPtr Result;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1358,7 +1358,7 @@ void LifetimeChecker::handleStoreUse(unsigned UseID) {
                StringRef(PropertyName));
 
       if (auto *Var = dyn_cast<VarDecl>(VD)) {
-        if (Var->getParentInitializer())
+        if (Var->getParentExecutableInitializer())
           diagnose(Module, SILLocation(VD),
                    diag::initial_value_provided_in_let_decl);
         Var->emitLetToVarNoteIfSimple(nullptr);

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -184,7 +184,7 @@ private:
 
     // Don't capture variables which aren't default-initialized.
     if (auto *VD = dyn_cast<VarDecl>(DstDecl))
-      if (!VD->isParentInitialized() &&
+      if (!VD->isParentExecutabledInitialized() &&
           !(isa<ParamDecl>(VD) &&
             cast<ParamDecl>(VD)->isInOut()))
         return Action::Continue(OriginalExpr);

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -468,7 +468,7 @@ public:
         if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
           // FIXME: Should iterate all var decls
           if (VarDecl *VD = PBD->getSingleVar()) {
-            if (VD->getParentInitializer()) {
+            if (VD->getParentExecutableInitializer()) {
 
               SourceRange SR = PBD->getSourceRange();
               if (!SR.isValid()) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -581,7 +581,7 @@ public:
         if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
           if (!PBD->isAsyncLet()) {
             if (VarDecl *VD = PBD->getSingleVar()) {
-              if (VD->getParentInitializer()) {
+              if (VD->getParentExecutableInitializer()) {
                 Added<Stmt *> Log = logVarDecl(VD);
                 if (*Log) {
                   Elements.insert(Elements.begin() + (EI + 1), *Log);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1311,7 +1311,6 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
 Optional<unsigned> swift::expandAccessors(
     AbstractStorageDecl *storage, CustomAttr *attr, MacroDecl *macro
 ) {
-  (void)storage->getInterfaceType();
   // Evaluate the macro.
   auto macroSourceFile = evaluateAttachedMacro(macro, storage, attr,
                                                /*passParentContext*/false,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1332,12 +1332,12 @@ Optional<unsigned> swift::expandAccessors(
     if (accessor->isObservingAccessor())
       continue;
 
-    // If any non-observing accessor was added, remove the initializer if
-    // there is one.
+    // If any non-observing accessor was added, mark the initializer as
+    // subsumed.
     if (auto var = dyn_cast<VarDecl>(storage)) {
       if (auto binding = var->getParentPatternBinding()) {
         unsigned index = binding->getPatternEntryIndexForVarDecl(var);
-        binding->setInit(index, nullptr);
+        binding->setInitializerSubsumed(index);
         break;
       }
     }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3292,10 +3292,10 @@ static void finishNSManagedImplInfo(VarDecl *var,
   if (info.isSimpleStored()) {
     // @NSManaged properties end up being computed; complain if there is
     // an initializer.
-    if (var->getParentInitializer()) {
+    if (var->getParentExecutableInitializer()) {
       auto &Diags = var->getASTContext().Diags;
       Diags.diagnose(attr->getLocation(), diag::attr_NSManaged_initial_value)
-           .highlight(var->getParentInitializer()->getSourceRange());
+           .highlight(var->getParentExecutableInitializer()->getSourceRange());
     }
 
     // Otherwise, ok.
@@ -3312,13 +3312,22 @@ static void finishNSManagedImplInfo(VarDecl *var,
   }
 }
 
+static Expr *getParentExecutableInitializer(VarDecl *var) {
+  if (auto *PBD = var->getParentPatternBinding()) {
+    const auto i = PBD->getPatternEntryIndexForVarDecl(var);
+    return PBD->getExecutableInit(i);
+  }
+
+  return nullptr;
+}
+
 static void finishStorageImplInfo(AbstractStorageDecl *storage,
                                   StorageImplInfo &info) {
   auto dc = storage->getDeclContext();
 
   if (auto var = dyn_cast<VarDecl>(storage)) {
     if (!info.hasStorage()) {
-      if (auto *init = var->getParentInitializer()) {
+      if (auto *init = var->getParentExecutableInitializer()) {
         auto &Diags = var->getASTContext().Diags;
         Diags.diagnose(init->getLoc(), diag::getset_init)
              .highlight(init->getSourceRange());

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -10,6 +10,18 @@ import StdlibUnittest
 import _Observation
 import _Concurrency
 
+@available(SwiftStdlib 5.9, *)
+@MainActor @Observable
+final class StateMachine {
+  enum State {
+    case initializing
+    case running
+    case complete
+  }
+
+  var state: State = .initializing
+}
+
 @usableFromInline
 @inline(never)
 func _blackHole<T>(_ value: T) { }


### PR DESCRIPTION
* **Explanation**: When an accessor macro adds a non-observing accessor to a property, it subsumes the initializer. Model this using the same scheme as when a property wrapper subsumes the initializer of a stored property when it turns it into a computed property. This eliminates a problem where applying an accessor macro to a stored property was preventing inference of the property type from an initializer, the prior fix for which had introduced cyclic references. This property modeling addresses both issues at once.
* Scope: Affects the handling of stored property initializers with accessor macros.
* Risk: Low, leverages existing handling of subsumed initializers (from property wrappers) for accessor macros.
* Issue: rdar://108565923
* Original pull request: https://github.com/apple/swift/pull/65501
