### PR TITLE
Fix tokenizer assertion crash with code completion at end of file

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2661,8 +2661,16 @@ void Lexer::lexImpl() {
   case 0:
     switch (getNulCharacterKind(CurPtr - 1)) {
     case NulCharacterKind::CodeCompletion:
-      while (advanceIfValidContinuationOfIdentifier(CurPtr, BufferEnd))
-        ;
+      if (CurPtr == BufferEnd + 1) {
+        // This is also the real end of the buffer.
+        // Put CurPtr back into buffer bounds.
+        --CurPtr;
+        // Next time report the EOF at the same position
+        CodeCompletionPtr = nullptr;
+      } else {
+        while (advanceIfValidContinuationOfIdentifier(CurPtr, BufferEnd))
+          ;
+      }
       return formToken(tok::code_complete, TokStart);
 
     case NulCharacterKind::BufferEnd:


### PR DESCRIPTION
Handle cases where the code completion nul overlaps the end-of-file nul. We need to report both token at the same location so clear out the `CodeCompletionPtr` flag after reporting it such that we report the eof the next time around.

I wasn't successful in writing a test for this, but the repro through the VSCode SourceKit-LSP is trivial.

Resolves #65507