### PR TITLE
presets: force `--enable-experimental-cxx-interop`

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -193,6 +193,7 @@ skip-test-watchos-host
 # Test the full bootstrapping on at least some jobs
 # (the default is bootstrapping-with-hostlibs)
 bootstrapping=bootstrapping
+enable-experimental-cxx-interop
 
 [preset: buildbot,tools=RA,stdlib=RD,test=non_executable]
 mixin-preset=
@@ -230,6 +231,7 @@ skip-test-watchos-simulator
 # Test the full bootstrapping on at least some jobs
 # (the default is bootstrapping-with-hostlibs)
 bootstrapping=bootstrapping
+enable-experimental-cxx-interop
 
 [preset: buildbot,tools=RA,stdlib=RDA]
 mixin-preset=


### PR DESCRIPTION
When building with bootstrapping, we need to enable the C++ interop because the bootstrapping builds depend on the C++ interop mode.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
