### PR TITLE
[stdlib] Slice.subscript: Forward slicing to the base collection

### DIFF
--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -171,7 +171,17 @@ extension Slice: Collection {
   public subscript(bounds: Range<Index>) -> Slice<Base> {
     get {
       _failEarlyRangeCheck(bounds, bounds: _bounds)
-      return Slice(base: _base, bounds: bounds)
+      // Allow the underlying collection to have a say about what indices can be
+      // slice boundaries. This is crucial for cases where the same index type
+      // is used in multiple collection types of varying granularity (similar to
+      // `String` views) -- in these cases, the bounds of the given range may
+      // happen to fall in between valid indices in the base collection, which
+      // `Slice` isn't prepared to handle. Letting the base collection do the
+      // actual slicing allows it to properly validate indices, and to
+      // optionally handle unaligned slices by rounding their boundaries down to
+      // the nearest valid index.
+      let slice = _base[bounds]
+      return Slice(base: _base, bounds: slice.startIndex ..< slice.endIndex)
     }
   }
 
@@ -285,7 +295,17 @@ extension Slice: MutableCollection where Base: MutableCollection {
   public subscript(bounds: Range<Index>) -> Slice<Base> {
     get {
       _failEarlyRangeCheck(bounds, bounds: _bounds)
-      return Slice(base: _base, bounds: bounds)
+      // Allow the underlying collection to have a say about what indices can be
+      // slice boundaries. This is crucial for cases where the same index type
+      // is used in multiple collection types of varying granularity (similar to
+      // `String` views) -- in these cases, the bounds of the given range may
+      // happen to fall in between valid indices in the base collection, which
+      // `Slice` isn't prepared to handle. Letting the base collection do the
+      // actual slicing allows it to properly validate indices, and to
+      // optionally handle unaligned slices by rounding their boundaries down to
+      // the nearest valid index.
+      let slice = _base[bounds]
+      return Slice(base: _base, bounds: slice.startIndex ..< slice.endIndex)
     }
     set {
       _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)

--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -25,8 +25,16 @@ internal func _writeBackMutableSlice<C, Slice_>(
   // _withUnsafeMutableBufferPointerIfSupported?  Would that create inout
   // aliasing violations if the newValue points to the same buffer?
 
-  var selfElementIndex = bounds.lowerBound
-  let selfElementsEndIndex = bounds.upperBound
+  // Allow the underlying collection to have a say about what indices can be
+  // slice boundaries. This is crucial for cases where the same index type is
+  // used in multiple collection types of varying granularity (similar to
+  // `String` views). Letting the base collection do the actual slicing allows
+  // it to properly validate indices, and to optionally handle unaligned slices
+  // by rounding their boundaries down to the nearest valid index.
+  let orig = self_[bounds]
+  var selfElementIndex = orig.startIndex
+  let selfElementsEndIndex = orig.endIndex
+
   var newElementIndex = slice.startIndex
   let newElementsEndIndex = slice.endIndex
 


### PR DESCRIPTION
This is an exploratory PR for adjusting the implementation of `Slice`. This will need targeted testing before landing (_if_ we end up wanting to land it), but it seems a good idea to put this up anyway, to play with the idea a little.

Most `Slice` operations forward to the underlying base collection to perform the actual work, with one major exception: the slicing subscript is implemented as a standalone method, only dispatching to the base collection for basic index validation purposes, without giving it a chance to adjust the boundaries of the returned slice.

This is a problem if the index type of the base collection supports addressing positions in between valid elements in the collection. (Such as is the case with `String` views or `LazyFilterCollection`.) `Slice` algorithms are, by and large, ill-prepared to handle such indices; however, forwarding to the base collection normally lets the base work around the problem by e.g. rounding indices down to the nearest element boundary. This doesn't work for the slicing subscript, so it is all too easy for a `Slice` to get created with an unaligned `startIndex` or `endIndex` -- and these slices aren't valid collection types.

The immediate motivating use case is `AttributedString`, whose `CharacterView` and `UnicodeScalarView` are sharing the same `Index` type, and they were [erroneously defined with `SubSequence` set to `Slice`](https://github.com/apple/swift-foundation/blob/main/Sources/FoundationEssentials/AttributedString/AttributedString%2BCharacterView.swift#L194). (This choice is now baked into Foundation's ABI, but I'd still like to clean up the most aggravating consequences, such as the ability to create nonsensical character view slices that crash on basic collection operations.)

```swift
import Foundation

var s: AttributedString = "Cafe\u{301} "
let i = s.unicodeScalars.index(s.startIndex, offsetBy: 4)
let slice = s.characters[...][..<i]
print(slice.contains("q")) // 💥
```

`AttributedString.CharacterView` [does not do the right thing](https://github.com/apple/swift-foundation/pull/92) in its own slicing subscript yet. However, once we fix that problem, this change in the stdlib would let that fix also apply to code that makes slices of slices.

The binary compatibility risk seems minimal here -- the base collection's slicing subscript is already used to create the first slice; this change simply starts calling it when such slices are sliced even further. It seems unlikely that a bug in the base collection could harmlessly pass through the first slice, but then trigger a regression in subsequent sub-slicing operations. Additionally, I expect the implementation of `Slice.subscript` would be specialized into most client modules, so this change would generally only affect code that gets rebuilt with whatever stdlib version ends up shipping it.