### PR TITLE
[5.9][Completion] Add convertible type relation for attached macros

### DIFF
--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -549,6 +549,14 @@ public:
     return NotRecommended;
   }
 
+  ContextualNotRecommendedReason calculateContextualNotRecommendedReason(
+      ContextualNotRecommendedReason explicitReason,
+      bool canCurrDeclContextHandleAsync) const;
+
+  CodeCompletionResultTypeRelation calculateContextualTypeRelation(
+      const DeclContext *dc, const ExpectedTypeContext *typeContext,
+      const USRBasedTypeContext *usrTypeContext) const;
+
   CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
     return DiagnosticSeverity;
   }
@@ -611,6 +619,7 @@ private:
   CodeCompletionResultTypeRelation TypeDistance : 3;
   static_assert(int(CodeCompletionResultTypeRelation::MAX_VALUE) < 1 << 3, "");
 
+public:
   /// Memberwise initializer
   /// The \c ContextFree result must outlive this result. Typically, this is
   /// done by allocating the two in the same sink or adopting the context free
@@ -623,25 +632,6 @@ private:
       : ContextFree(ContextFree), SemanticContext(SemanticContext),
         Flair(Flair.toRaw()), NotRecommended(NotRecommended),
         NumBytesToErase(NumBytesToErase), TypeDistance(TypeDistance) {}
-
-public:
-  /// Enrich a \c ContextFreeCodeCompletionResult with the following contextual
-  /// information.
-  /// This computes the type relation between the completion item and its
-  /// expected type context.
-  /// See \c CodeCompletionResultType::calculateTypeRelation for documentation
-  /// on \p USRTypeContext.
-  /// The \c ContextFree result must outlive this result. Typically, this is
-  /// done by allocating the two in the same sink or adopting the context free
-  /// sink in the sink that allocates this result.
-  CodeCompletionResult(const ContextFreeCodeCompletionResult &ContextFree,
-                       SemanticContextKind SemanticContext,
-                       CodeCompletionFlair Flair, uint8_t NumBytesToErase,
-                       const ExpectedTypeContext *TypeContext,
-                       const DeclContext *DC,
-                       const USRBasedTypeContext *USRTypeContext,
-                       bool CanCurrDeclContextHandleAsync,
-                       ContextualNotRecommendedReason NotRecommended);
 
   const ContextFreeCodeCompletionResult &getContextFreeResult() const {
     return ContextFree;

--- a/lib/IDE/CodeCompletionConsumer.cpp
+++ b/lib/IDE/CodeCompletionConsumer.cpp
@@ -80,11 +80,19 @@ static MutableArrayRef<CodeCompletionResult *> copyCodeCompletionResults(
     if (!shouldIncludeResult(contextFreeResult)) {
       continue;
     }
+
+    CodeCompletionResultTypeRelation typeRelation =
+        contextFreeResult->calculateContextualTypeRelation(DC, TypeContext,
+                                                           &USRTypeContext);
+    ContextualNotRecommendedReason notRecommendedReason =
+        contextFreeResult->calculateContextualNotRecommendedReason(
+            ContextualNotRecommendedReason::None,
+            CanCurrDeclContextHandleAsync);
+
     auto contextualResult = new (*targetSink.Allocator) CodeCompletionResult(
         *contextFreeResult, SemanticContextKind::OtherModule,
         CodeCompletionFlair(),
-        /*numBytesToErase=*/0, TypeContext, DC, &USRTypeContext,
-        CanCurrDeclContextHandleAsync, ContextualNotRecommendedReason::None);
+        /*numBytesToErase=*/0, typeRelation, notRecommendedReason);
     targetSink.Results.push_back(contextualResult);
   }
 

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -162,22 +162,27 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     // we don't need to compute any contextual properties.
     return new (Allocator) CodeCompletionResult(
         *ContextFreeResult, SemanticContextKind::None, CodeCompletionFlair(),
-        /*NumBytesToErase=*/0, /*TypeContext=*/nullptr,
-        /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
-        /*CanCurrDeclContextHandleAsync=*/false,
+        /*NumBytesToErase=*/0, CodeCompletionResultTypeRelation::Unrelated,
         ContextualNotRecommendedReason::None);
   } else {
     assert(
         ContextFreeResult != nullptr &&
         "ContextFreeResult should have been constructed by the switch above");
+
     // We know that the ContextFreeResult has an AST-based type because it was
     // just computed and not read from the cache and
     // Sink.shouldProduceContextFreeResults() is false. So we can pass nullptr
     // for USRTypeContext.
+    CodeCompletionResultTypeRelation typeRelation =
+        ContextFreeResult->calculateContextualTypeRelation(
+            DC, TypeContext, /*usrTypeContext=*/nullptr);
+    ContextualNotRecommendedReason notRecommendedReason =
+        ContextFreeResult->calculateContextualNotRecommendedReason(
+            ContextualNotRecReason, CanCurrDeclContextHandleAsync);
+
     return new (Allocator) CodeCompletionResult(
         *ContextFreeResult, SemanticContext, Flair, NumBytesToErase,
-        TypeContext, DC, /*USRTypeContext=*/nullptr,
-        CanCurrDeclContextHandleAsync, ContextualNotRecReason);
+        typeRelation, notRecommendedReason);
   }
 }
 

--- a/test/IDE/complete_macros.swift
+++ b/test/IDE/complete_macros.swift
@@ -65,12 +65,12 @@ import MacroDefinitions
 @#^STRUCT_ATTR?check=NOMINAL_ATTR^# struct S{}
 // NOMINAL_ATTR-NOT: freestanding
 // NOMINAL_ATTR-NOT: AttachedAccessorMacro
-// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacro[#Void#]; name=AttachedMemberMacro
-// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacroWithArgs({#arg1: Int#})[#Void#]; name=AttachedMemberMacroWithArgs
-// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberAttributeMacro[#Void#]; name=AttachedMemberAttributeMacro
-// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
-// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedConformanceMacro[#Void#]; name=AttachedConformanceMacro
-// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedMemberMacro[#Void#]; name=AttachedMemberMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedMemberMacroWithArgs({#arg1: Int#})[#Void#]; name=AttachedMemberMacroWithArgs
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedMemberAttributeMacro[#Void#]; name=AttachedMemberAttributeMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedConformanceMacro[#Void#]; name=AttachedConformanceMacro
+// NOMINAL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: EverythingMacro[#Void#]; name=EverythingMacro
 
 @#^FUNC_ATTR?check=DECL_ATTR^# func method() {}
 struct MethodAttrs {
@@ -83,8 +83,8 @@ struct MethodAttrs {
 // DECL_ATTR-NOT: AttachedMemberMacro
 // DECL_ATTR-NOT: AttachedMemberMacroWithArgs
 // DECL_ATTR-NOT: AttachedConformanceMacro
-// DECL_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
-// DECL_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+// DECL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// DECL_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: EverythingMacro[#Void#]; name=EverythingMacro
 
 @#^GLOBAL_ATTR?check=VAR_ATTR^# var globalVar
 struct PropAttr {
@@ -98,9 +98,9 @@ struct PropAttr {
 // VAR_ATTR-NOT: AttachedMemberMacroWithArgs
 // VAR_ATTR-NOT: AttachedMemberAttributeMacro
 // VAR_ATTR-NOT: AttachedConformanceMacro
-// VAR_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedAccessorMacro[#Void#]; name=AttachedAccessorMacro
-// VAR_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
-// VAR_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+// VAR_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedAccessorMacro[#Void#]; name=AttachedAccessorMacro
+// VAR_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// VAR_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: EverythingMacro[#Void#]; name=EverythingMacro
 
 func paramAttr(@#^PARAM_ATTR?check=PARAM_ATTR^#) {}
 func paramAttr2(@#^PARAM2_ATTR?check=PARAM_ATTR^# arg: Int) {}
@@ -163,10 +163,10 @@ struct LastMember {
 @#^INDEPENDENT?check=INDEPENDENT_ATTR^#
 // INDEPENDENT_ATTR-NOT: freestandingExprMacro
 // INDEPENDENT_ATTR-NOT: freestandingDeclMacro
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedAccessorMacro[#Void#]; name=AttachedAccessorMacro
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacro[#Void#]; name=AttachedMemberMacro
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberMacroWithArgs({#arg1: Int#})[#Void#]; name=AttachedMemberMacroWithArgs
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedMemberAttributeMacro[#Void#]; name=AttachedMemberAttributeMacro
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: AttachedConformanceMacro[#Void#]; name=AttachedConformanceMacro
-// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedAccessorMacro[#Void#]; name=AttachedAccessorMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedMemberMacro[#Void#]; name=AttachedMemberMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedMemberMacroWithArgs({#arg1: Int#})[#Void#]; name=AttachedMemberMacroWithArgs
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedMemberAttributeMacro[#Void#]; name=AttachedMemberAttributeMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedPeerMacro[#Void#]; name=AttachedPeerMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: AttachedConformanceMacro[#Void#]; name=AttachedConformanceMacro
+// INDEPENDENT_ATTR-DAG: Decl[Macro]/{{.*}}/TypeRelation[Convertible]: EverythingMacro[#Void#]; name=EverythingMacro

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -142,8 +142,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     auto *swiftResult = new (sink.allocator) CodeCompletion::SwiftResult(
         *contextFreeResult, SemanticContextKind::Local,
         CodeCompletionFlairBit::ExpressionSpecific,
-        /*NumBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-        /*USRTypeContext=*/nullptr, /*CanCurrDeclContextHandleAsync=*/false,
+        /*NumBytesToErase=*/0, CodeCompletionResultTypeRelation::Unrelated,
         ContextualNotRecommendedReason::None);
 
     CompletionBuilder builder(sink, *swiftResult);

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -920,8 +920,7 @@ static void transformAndForwardResults(
         *contextFreeResult, SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0,
-        /*TypeContext=*/nullptr, /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
-        /*CanCurrDeclContextHandleAsync=*/false,
+        CodeCompletionResultTypeRelation::Unrelated,
         ContextualNotRecommendedReason::None);
 
     SwiftCompletionInfo info;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4305,8 +4305,7 @@ int main(int argc, char *argv[]) {
         auto contextualResult = new CodeCompletionResult(
             *contextFreeResult, SemanticContextKind::OtherModule,
             CodeCompletionFlair(),
-            /*numBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-            /*USRTypeContext=*/nullptr, /*CanCurrDeclContextHandleAsync=*/false,
+            /*numBytesToErase=*/0, CodeCompletionResultTypeRelation::Unrelated,
             ContextualNotRecommendedReason::None);
         contextualResults.push_back(contextualResult);
       }


### PR DESCRIPTION
* Explanation: Prior to this change, there's no way to differentiate an attached macro from a type in `@<here>` position. This adds a `convertible` type relation to attached macros in this case, so that they can be ranked higher than regular types (which are only provided since they could contain eg. property wrappers).
* Scope: Code completion
* Risk: Very low; only impacts completion and only adds a type relation where there was none previously.
* Testing: Updated macro completion tests to check for the type relation
* Original PR: https://github.com/apple/swift/pull/65515