### PR TITLE
[CodeComplete] Offer completions for the `names:` argument of a macro declaration

### DIFF
--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -97,7 +97,13 @@ enum class MacroIntroducedDeclNameKind {
   Prefixed,
   Suffixed,
   Arbitrary,
+
+  // NOTE: When adding a new name kind, also add it to
+  // `getAllMacroIntroducedDeclNameKinds`.
 };
+
+/// Returns an enumeratable list of all macro introduced decl name kinds.
+std::vector<MacroIntroducedDeclNameKind> getAllMacroIntroducedDeclNameKinds();
 
 /// Whether a macro-introduced name of this kind requires an argument.
 bool macroIntroducedNameRequiresArgument(MacroIntroducedDeclNameKind kind);

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -449,8 +449,8 @@ public:
       CodeCompletionKeywordKind KeyKind = CodeCompletionKeywordKind::None,
       CodeCompletionFlair flair = {});
 
-  void addDeclAttrParamKeyword(StringRef Name, StringRef Annotation,
-                               bool NeedSpecify);
+  void addDeclAttrParamKeyword(StringRef Name, ArrayRef<StringRef> Parameters,
+                               StringRef Annotation, bool NeedSpecify);
 
   void addDeclAttrKeyword(StringRef Name, StringRef Annotation);
 
@@ -586,7 +586,7 @@ public:
   void getAttributeDeclCompletions(bool IsInSil, Optional<DeclKind> DK);
 
   void getAttributeDeclParamCompletions(CustomSyntaxAttributeKind AttrKind,
-                                        int ParamIndex);
+                                        int ParamIndex, bool HasLabel);
 
   void getTypeAttributeKeywordCompletions();
 

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -194,7 +194,10 @@ public:
 
   /// Complete the parameters in attribute, for instance, version specifier for
   /// @available.
-  virtual void completeDeclAttrParam(CustomSyntaxAttributeKind DK, int Index){};
+  /// If `HasLabel` is `true`, then the argument already has a label specified,
+  /// e.g. we're completing after `names: ` in a macro declaration.
+  virtual void completeDeclAttrParam(CustomSyntaxAttributeKind DK, int Index,
+                                     bool HasLabel){};
 
   /// Complete 'async' and 'throws' at effects specifier position.
   virtual void completeEffectsSpecifier(bool hasAsync, bool hasThrows) {};

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10149,6 +10149,17 @@ StringRef swift::getMacroRoleString(MacroRole role) {
   }
 }
 
+std::vector<MacroIntroducedDeclNameKind>
+swift::getAllMacroIntroducedDeclNameKinds() {
+  return {
+      MacroIntroducedDeclNameKind::Named,
+      MacroIntroducedDeclNameKind::Overloaded,
+      MacroIntroducedDeclNameKind::Prefixed,
+      MacroIntroducedDeclNameKind::Suffixed,
+      MacroIntroducedDeclNameKind::Arbitrary,
+  };
+}
+
 bool swift::macroIntroducedNameRequiresArgument(
   MacroIntroducedDeclNameKind kind
 ) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -127,6 +127,7 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks,
   CodeCompletionCallbacks::PrecedenceGroupCompletionKind SyntxKind;
 
   int AttrParamIndex;
+  bool AttrParamHasLabel;
   bool IsInSil = false;
   bool HasSpace = false;
   bool ShouldCompleteCallPatternAfterParen = true;
@@ -270,7 +271,8 @@ public:
   void completeCaseStmtKeyword() override;
   void completeCaseStmtBeginning(CodeCompletionExpr *E) override;
   void completeDeclAttrBeginning(bool Sil, bool isIndependent) override;
-  void completeDeclAttrParam(CustomSyntaxAttributeKind DK, int Index) override;
+  void completeDeclAttrParam(CustomSyntaxAttributeKind DK, int Index,
+                             bool HasLabel) override;
   void completeEffectsSpecifier(bool hasAsync, bool hasThrows) override;
   void completeInPrecedenceGroup(
       CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK) override;
@@ -457,10 +459,11 @@ void CodeCompletionCallbacksImpl::completeTypeSimpleBeginning() {
 }
 
 void CodeCompletionCallbacksImpl::completeDeclAttrParam(
-    CustomSyntaxAttributeKind DK, int Index) {
+    CustomSyntaxAttributeKind DK, int Index, bool HasLabel) {
   Kind = CompletionKind::AttributeDeclParen;
   AttrKind = DK;
   AttrParamIndex = Index;
+  AttrParamHasLabel = HasLabel;
   CurDeclContext = P.CurDeclContext;
 }
 
@@ -1844,7 +1847,8 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
     break;
   }
   case CompletionKind::AttributeDeclParen: {
-    Lookup.getAttributeDeclParamCompletions(AttrKind, AttrParamIndex);
+    Lookup.getAttributeDeclParamCompletions(AttrKind, AttrParamIndex,
+                                            AttrParamHasLabel);
     break;
   }
   case CompletionKind::PoundAvailablePlatform: {

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -345,10 +345,17 @@ public:
     addChunkWithTextNoCopy(CodeCompletionString::Chunk::ChunkKind::Equal, "=");
   }
 
-  void addDeclAttrParamKeyword(StringRef Name, StringRef Annotation,
-                               bool NeedSpecify) {
+  void addDeclAttrParamKeyword(StringRef Name, ArrayRef<StringRef> Parameters,
+                               StringRef Annotation, bool NeedSpecify) {
     addChunkWithText(CodeCompletionString::Chunk::ChunkKind::
                      DeclAttrParamKeyword, Name);
+    if (!Parameters.empty()) {
+      addLeftParen();
+      for (auto Parameter : Parameters) {
+        addSimpleNamedParameter(Parameter);
+      }
+      addRightParen();
+    }
     if (NeedSpecify)
       addChunkWithText(CodeCompletionString::Chunk::ChunkKind::
                        DeclAttrParamColon, ": ");

--- a/test/IDE/complete_macro_attribute.swift
+++ b/test/IDE/complete_macro_attribute.swift
@@ -24,3 +24,13 @@ macro FreestandingDeclarationMacro
 
 // NAMES_POSITION: Begin completions, 1 item
 // NAMES_POSITION-DAG: Keyword/None:                       names: [#Specify declared names#]; name=names
+
+@attached(member, names: #^NAMES_ARGUMENT^#)
+
+// NAMES_ARGUMENT: Begin completions, 5 items
+// NAMES_ARGUMENT-DAG: Keyword/None:                       named({#(name)#}); name=named()
+// NAMES_ARGUMENT-DAG: Keyword/None:                       overloaded; name=overloaded
+// NAMES_ARGUMENT-DAG: Keyword/None:                       prefixed({#(name)#}); name=prefixed()
+// NAMES_ARGUMENT-DAG: Keyword/None:                       suffixed({#(name)#}); name=suffixed()
+// NAMES_ARGUMENT-DAG: Keyword/None:                       arbitrary; name=arbitrary
+


### PR DESCRIPTION
When completing after `names:`, completion should offer the different ways you can specify the names, i.e. `arbitrary`, `named`, etc.

```swift
@attached(member, names: #^COMPLETE^#)
```

rdar://108535077