### PR TITLE
[5.9][CSDiagnostics] Teach `diagnoseConflictingGenericArguments` about holes

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4422,6 +4422,12 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     std::tie(GP, loc) = conflict.first;
     auto conflictingArguments = conflict.second;
 
+    // If there are any substitutions that are not fully resolved
+    // solutions cannot be considered conflicting for the given parameter.
+    if (llvm::any_of(conflictingArguments,
+                     [](const auto &arg) { return arg->hasPlaceholder(); }))
+      continue;
+
     llvm::SmallString<64> arguments;
     llvm::raw_svector_ostream OS(arguments);
 

--- a/validation-test/Sema/SwiftUI/rdar108534555.swift
+++ b/validation-test/Sema/SwiftUI/rdar108534555.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -disable-availability-checking
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct Item: Identifiable {
+  var id: Int
+  var title: String
+}
+
+struct MyGroup<Content> {
+  init(@ViewBuilder _: () -> Content) {}
+}
+
+struct Test {
+  let s: [Item]
+
+  func test() {
+    MyGroup {
+      ForEach(s) {
+        Button($0.title) // expected-error {{value of type 'String' to expected argument type 'PrimitiveButtonStyleConfiguration'}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65479

---

- Explanation:

Only fully resolved substitutions are eligible to be considered as conflicting, if holes are involved in any position that automatically disqualifies a generic parameter. Any conflicting argument diagnostics with holes hide actual issues.

- Scope: result builders or any other complex generic code that could have un-inferred or partially inferred generic parameters at multiple locations.

- Main Branch PR: https://github.com/apple/swift/pull/65479

- Resolves: rdar://108534555

- Risk: Low

- Reviewed By: @hborla

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://108534555
Resolves: https://github.com/apple/swift/issues/63450 

(cherry picked from commit 0b7aeed4b8ca493095eefa846adc09510d18b8b9)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
