### PR TITLE
5.9 [RemoteMirror] Fix lookup of generic type parameters

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2959,19 +2959,13 @@ private:
           // Only consider generic contexts of type class, enum or struct.
           // There are other context types that can be generic, but they should
           // not affect the generic shape.
-          if (current->getKind() == ContextDescriptorKind::Class ||
-              current->getKind() == ContextDescriptorKind::Enum ||
-              current->getKind() == ContextDescriptorKind::Struct) {
-            if (genericContext) {
-              auto contextHeader = genericContext->getGenericContextHeader();
-              paramsPerLevel.emplace_back(contextHeader.NumParams -
-                                          runningCount);
-              runningCount += paramsPerLevel.back();
-            } else {
-              // If there is no generic context, this is a non-generic type
-              // which has 0 generic parameters.
-              paramsPerLevel.emplace_back(0);
-            }
+          if (genericContext &&
+              (current->getKind() == ContextDescriptorKind::Class ||
+               current->getKind() == ContextDescriptorKind::Enum ||
+               current->getKind() == ContextDescriptorKind::Struct)) {
+            auto contextHeader = genericContext->getGenericContextHeader();
+            paramsPerLevel.emplace_back(contextHeader.NumParams - runningCount);
+            runningCount += paramsPerLevel.back();
           }
         };
     countLevels(descriptor, runningCount);

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -615,13 +615,9 @@ public:
           break;
         }
       }
-      if (parentNode) {
-        if (shapeIndex > 0)
-          parent = createBoundGenericTypeReconstructingParent(
-              parentNode, decl, --shapeIndex, args, argsIndex + numGenericArgs);
-        else
-          return nullptr;
-      }
+      if (parentNode)
+        parent = createBoundGenericTypeReconstructingParent(
+            parentNode, decl, --shapeIndex, args, argsIndex + numGenericArgs);
     }
 
     return BoundGenericTypeRef::create(*this, mangling.result(), genericParams,

--- a/validation-test/Reflection/reflect_nested.swift
+++ b/validation-test/Reflection/reflect_nested.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_nested
 // RUN: %target-codesign %t/reflect_nested
-// RUN: %target-run %target-swift-reflection-test %t/reflect_nested 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_nested 2>&1 | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
@@ -26,24 +26,14 @@ var obj = OuterGeneric.Inner.Innermost(x: 17, y: "hello")
 
 reflect(object: obj)
 
-// CHECK-64: Reflecting an object.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
-// CHECK-64-NEXT:   (struct Swift.String)
-// CHECK-64-NEXT:   (bound_generic_class reflect_nested.OuterGeneric.Inner
-// CHECK-64-NEXT:     (bound_generic_class reflect_nested.OuterGeneric
-// CHECK-64-NEXT:       (struct Swift.Int))))
+// CHECK: Reflecting an object.
+// CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK: Type reference:
+// CHECK: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
+// CHECK-NEXT:   (struct Swift.String)
+// CHECK-NEXT:   (bound_generic_class reflect_nested.OuterGeneric
+// CHECK-NEXT:     (struct Swift.Int)))
 
-// CHECK-32: Reflecting an object.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
-// CHECK-32-NEXT:   (struct Swift.String)
-// CHECK-32-NEXT:   (bound_generic_class reflect_nested.OuterGeneric.Inner
-// CHECK-32-NEXT:     (bound_generic_class reflect_nested.OuterGeneric
-// CHECK-32-NEXT:       (struct Swift.Int))))
-  
 class OuterNonGeneric {
   class InnerGeneric<T, U> {
     var x: T
@@ -59,24 +49,13 @@ class OuterNonGeneric {
 var obj2 = OuterNonGeneric.InnerGeneric(x: 17, y: "hello")
 reflect(object: obj2)
 
-// CHECK-64: Reflecting an object.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
-// CHECK-64-NEXT:   (struct Swift.Int)
-// CHECK-64-NEXT:   (struct Swift.String)
-// CHECK-64-NEXT:     (bound_generic_class reflect_nested.OuterNonGeneric))
-
-// CHECK-32: Reflecting an object.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
-// CHECK-32-NEXT:   (struct Swift.Int)
-// CHECK-32-NEXT:   (struct Swift.String)
-// CHECK-32-NEXT:     (bound_generic_class reflect_nested.OuterNonGeneric))
+// CHECK: Reflecting an object.
+// CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK: Type reference:
+// CHECK: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT:   (struct Swift.String))
 
 doneReflecting()
 
-// CHECK-64: Done.
-
-// CHECK-32: Done.
+// CHECK: Done.

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -37,6 +37,10 @@ reflect(enum: Outer1.C<Void>.Inner.S<(Int,Int)>?.none)
 
 //CHECK: Type info:
 
+// This is the layout for 64-bit targets (Note, this example
+// has no pointer-based elements, so we don't need to distinguish
+// extra inhabitants for platforms with varying pointer layouts.)
+
 //X64-NEXT: (single_payload_enum size=19 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 //X64-NEXT:   (case name=some index=0 offset=0
 //X64-NEXT:     (struct size=18 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
@@ -60,7 +64,7 @@ reflect(enum: Outer1.C<Void>.Inner.S<(Int,Int)>?.none)
 //X64-NEXT:           (case name=none index=1)))))
 //X64-NEXT:   (case name=none index=1))
 
-//TODO:  X32
+//TODO:  Work out the layout for 32-bit targets
 
 //CHECK: Mangled name: $s22reflect_nested_generic6Outer1O1CC1SVy_yt_Si_SitGSg
 //CHECK-NEXT: Demangled name: Swift.Optional<reflect_nested_generic.Outer1.C<()>.S<(Swift.Int, Swift.Int)>>
@@ -78,6 +82,9 @@ struct Outer2 {
   enum E<T: P> {
     struct Inner {
       enum F<U: P> {
+        struct Innerer {
+	  var u: U? = nil
+	}
       case u(U)
       case a
       case b
@@ -96,7 +103,7 @@ reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
 //CHECK-NEXT:   (bound_generic_enum reflect_nested_generic.Outer2.E
 //CHECK-NEXT:     (struct reflect_nested_generic.S1)))
 
-// Note: layout here is correct for both 32- and 64-bit platforms
+// Note: layout here is same for both 32- and 64-bit platforms
 
 //CHECK: Type info:
 //CHECK-NEXT: (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
@@ -110,6 +117,37 @@ reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
 
 //CHECK: Enum value:
 //CHECK-NEXT: (enum_value name=b index=2)
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.Innerer?.none)
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+//CHECK-NEXT: Type reference:
+//CHECK-NEXT: (bound_generic_enum Swift.Optional
+//CHECK-NEXT:   (bound_generic_struct reflect_nested_generic.Outer2.E.Inner.F.Innerer
+//CHECK-NEXT:     (bound_generic_enum reflect_nested_generic.Outer2.E.Inner.F
+//CHECK-NEXT:       (struct reflect_nested_generic.S2)
+//CHECK-NEXT:       (bound_generic_enum reflect_nested_generic.Outer2.E
+//CHECK-NEXT:         (struct reflect_nested_generic.S1)))))
+
+// This layout is the same for 32-bit or 64-bit platforms
+
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=some index=0 offset=0
+//CHECK-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:       (field name=u offset=0
+//CHECK-NEXT:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:           (case name=some index=0 offset=0
+//CHECK-NEXT:             (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//CHECK-NEXT:           (case name=none index=1)))))
+//CHECK-NEXT:   (case name=none index=1))
+
+//CHECK-NEXT: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FO7InnererVy_AA2S1V_AA2S2V_GSg
+//CHECK-NEXT: Demangled name: Swift.Optional<reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>.Innerer<>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=none index=1)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -1,0 +1,117 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_nested_generic
+// RUN: %target-codesign %t/reflect_nested_generic
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_nested_generic | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+enum Outer1 {
+  class C<T> {
+    enum Inner {
+      struct S<U> {
+	var u: U? = nil
+	var t: T? = nil
+      }
+    }
+  }
+}
+
+reflect(enum: Outer1.C<Void>.Inner.S<(Int,Int)>?.none)
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+//CHECK-NEXT: Type reference:
+//CHECK-NEXT: (bound_generic_enum Swift.Optional
+//CHECK-NEXT:   (bound_generic_struct reflect_nested_generic.Outer1.C.Inner.S
+//CHECK-NEXT:     (tuple
+//CHECK-NEXT:       (struct Swift.Int)
+//CHECK-NEXT:       (struct Swift.Int))
+//CHECK-NEXT:     (bound_generic_class reflect_nested_generic.Outer1.C
+//CHECK-NEXT:       (tuple))))
+
+//CHECK: Type info:
+
+//X64-NEXT: (single_payload_enum size=19 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:   (case name=some index=0 offset=0
+//X64-NEXT:     (struct size=18 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:       (field name=u offset=0
+//X64-NEXT:         (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:           (case name=some index=0 offset=0
+//X64-NEXT:             (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:               (field offset=0
+//X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:                   (field name=_value offset=0
+//X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+//X64-NEXT:               (field offset=8
+//X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:                   (field name=_value offset=0
+//X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+//X64-NEXT:           (case name=none index=1)))
+//X64-NEXT:       (field name=t offset=17
+//X64-NEXT:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:           (case name=some index=0 offset=0
+//X64-NEXT:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//X64-NEXT:           (case name=none index=1)))))
+//X64-NEXT:   (case name=none index=1))
+
+//TODO:  X32
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer1O1CC1SVy_yt_Si_SitGSg
+//CHECK-NEXT: Demangled name: Swift.Optional<reflect_nested_generic.Outer1.C<()>.S<(Swift.Int, Swift.Int)>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=none index=1)
+
+
+protocol P {}
+
+struct S1: P { var a: Int; var b: Int }
+struct S2: P { }
+
+struct Outer2 {
+  enum E<T: P> {
+    struct Inner {
+      enum F<U: P> {
+      case u(U)
+      case a
+      case b
+      }
+    }
+  }
+}
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+//CHECK-NEXT: Type reference:
+//CHECK-NEXT: (bound_generic_enum reflect_nested_generic.Outer2.E.Inner.F
+//CHECK-NEXT:   (struct reflect_nested_generic.S2)
+//CHECK-NEXT:   (bound_generic_enum reflect_nested_generic.Outer2.E
+//CHECK-NEXT:     (struct reflect_nested_generic.S1)))
+
+// Note: layout here is correct for both 32- and 64-bit platforms
+
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=u index=0 offset=0
+//CHECK-NEXT:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//CHECK-NEXT:   (case name=a index=1)
+//CHECK-NEXT:   (case name=b index=2))
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S1V_AA2S2VG
+//CHECK-NEXT: Demangled name: reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=b index=2)
+
+doneReflecting()
+
+// CHECK: Done.
+


### PR DESCRIPTION
**Explanation**: Fixes lookup of generic type parameters for nested generics, partially reverts #62854 which attempted to fix the same issue in a different way
**Risk**: Only affects RemoteMirror library for a particular type structure that crashes without this fix
**Reviewed by**: @augusto2112 @mikeash 
**Resolves**: rdar://106790077
**Original PR**: #65332 
**Tests**: Added new unit tests for this specific case