### PR TITLE
5.9 [RemoteMirror] Fix handling of generic and zero-sized cases in MPEs

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2959,19 +2959,13 @@ private:
           // Only consider generic contexts of type class, enum or struct.
           // There are other context types that can be generic, but they should
           // not affect the generic shape.
-          if (current->getKind() == ContextDescriptorKind::Class ||
-              current->getKind() == ContextDescriptorKind::Enum ||
-              current->getKind() == ContextDescriptorKind::Struct) {
-            if (genericContext) {
-              auto contextHeader = genericContext->getGenericContextHeader();
-              paramsPerLevel.emplace_back(contextHeader.NumParams -
-                                          runningCount);
-              runningCount += paramsPerLevel.back();
-            } else {
-              // If there is no generic context, this is a non-generic type
-              // which has 0 generic parameters.
-              paramsPerLevel.emplace_back(0);
-            }
+          if (genericContext &&
+              (current->getKind() == ContextDescriptorKind::Class ||
+               current->getKind() == ContextDescriptorKind::Enum ||
+               current->getKind() == ContextDescriptorKind::Struct)) {
+            auto contextHeader = genericContext->getGenericContextHeader();
+            paramsPerLevel.emplace_back(contextHeader.NumParams - runningCount);
+            runningCount += paramsPerLevel.back();
           }
         };
     countLevels(descriptor, runningCount);

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -216,6 +216,10 @@ public:
   const TypeRef *subst(TypeRefBuilder &Builder,
                        const GenericArgumentMap &Subs) const;
 
+  const TypeRef *subst(TypeRefBuilder &Builder,
+                       const GenericArgumentMap &Subs,
+                       bool &DidSubstitute) const;
+
   llvm::Optional<GenericArgumentMap> getSubstMap() const;
 
   virtual ~TypeRef() = default;

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -288,21 +288,18 @@ struct FieldTypeInfo {
   int Value;
   const TypeRef *TR;
   bool Indirect;
+  bool Generic;
 
-  FieldTypeInfo() : Name(""), Value(0), TR(nullptr), Indirect(false) {}
-  FieldTypeInfo(const std::string &Name, int Value, const TypeRef *TR, bool Indirect)
-    : Name(Name), Value(Value), TR(TR), Indirect(Indirect) {}
+  FieldTypeInfo() : Name(""), Value(0), TR(nullptr), Indirect(false), Generic(false) {}
+  FieldTypeInfo(const std::string &Name, int Value, const TypeRef *TR, bool Indirect, bool Generic)
+    : Name(Name), Value(Value), TR(TR), Indirect(Indirect), Generic(Generic) {}
 
   static FieldTypeInfo forEmptyCase(std::string Name, int Value) {
-    return FieldTypeInfo(Name, Value, nullptr, false);
-  }
-
-  static FieldTypeInfo forIndirectCase(std::string Name, int Value, const TypeRef *TR) {
-    return FieldTypeInfo(Name, Value, TR, true);
+    return FieldTypeInfo(Name, Value, nullptr, false, false);
   }
 
   static FieldTypeInfo forField(std::string Name, int Value, const TypeRef *TR) {
-    return FieldTypeInfo(Name, Value, TR, false);
+    return FieldTypeInfo(Name, Value, TR, false, false);
   }
 };
 

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -615,13 +615,9 @@ public:
           break;
         }
       }
-      if (parentNode) {
-        if (shapeIndex > 0)
-          parent = createBoundGenericTypeReconstructingParent(
-              parentNode, decl, --shapeIndex, args, argsIndex + numGenericArgs);
-        else
-          return nullptr;
-      }
+      if (parentNode)
+        parent = createBoundGenericTypeReconstructingParent(
+            parentNode, decl, --shapeIndex, args, argsIndex + numGenericArgs);
     }
 
     return BoundGenericTypeRef::create(*this, mangling.result(), genericParams,

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -400,7 +400,10 @@ public:
   EmptyEnumTypeInfo(const std::vector<FieldInfo> &Cases)
     : EnumTypeInfo(/*Size*/ 0, /* Alignment*/ 1, /*Stride*/ 1,
                    /*NumExtraInhabitants*/ 0, /*BitwiseTakable*/ true,
-                   EnumKind::NoPayloadEnum, Cases) {}
+                   EnumKind::NoPayloadEnum, Cases) {
+    // No cases
+    assert(Cases.size() == 0);
+  }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
@@ -424,7 +427,12 @@ public:
                    /*Stride*/ 1,
                    /*NumExtraInhabitants*/ 0,
                    /*BitwiseTakable*/ true,
-                   Kind, Cases) {}
+                   Kind, Cases) {
+    // Exactly one case
+    assert(Cases.size() == 1);
+    // The only case has no payload
+    assert(Cases[0].TR == 0);
+  }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
                        remote::RemoteAddress address,
@@ -451,7 +459,10 @@ public:
     : EnumTypeInfo(Size, Alignment, Stride, NumExtraInhabitants,
                    /*BitwiseTakable*/ true,
                    Kind, Cases) {
+    // There are at least 2 cases
+    // (one case would be trivial, zero is impossible)
     assert(Cases.size() >= 2);
+    // No non-empty payloads
     assert(getNumNonEmptyPayloadCases() == 0);
   }
 
@@ -496,8 +507,10 @@ public:
                             const std::vector<FieldInfo> &Cases)
     : EnumTypeInfo(Size, Alignment, Stride, NumExtraInhabitants,
                    BitwiseTakable, Kind, Cases) {
+    // The first case has a payload (possibly empty)
     assert(Cases[0].TR != 0);
-    assert(getNumNonEmptyPayloadCases() == 1);
+    // At most one non-empty payload case
+    assert(getNumNonEmptyPayloadCases() <= 1);
   }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
@@ -579,8 +592,10 @@ public:
   }
 };
 
-// *Simple* Multi-payload enums have 2 or more payload cases and no common
-// "spare bits" in the payload area. This includes cases such as:
+// *Tagged* Multi-payload enums use a separate tag value exclusively.
+// This may be because it only has one payload (with no XIs) or
+// because it's a true MPE but with no "spare bits" in the payload area.
+// This includes cases such as:
 //
 // ```
 // // Enums with non-pointer payloads (only pointers carry spare bits)
@@ -602,20 +617,33 @@ public:
 //   case b(ClassTypeB)
 //   case c(Int)
 // }
+//
+// // Enums with one payload with no XIs
+// // (This is almost but not quite the same as the single-payload
+// // case.  Different in that this MPE exposes extra tag values
+// // as XIs to an enclosing enum; SPEs don't do that.)
+// enum A {
+//   case a(Int)
+//   case b(Void)
+// }
 // ```
-class SimpleMultiPayloadEnumTypeInfo: public EnumTypeInfo {
+class TaggedMultiPayloadEnumTypeInfo: public EnumTypeInfo {
 public:
-  SimpleMultiPayloadEnumTypeInfo(unsigned Size, unsigned Alignment,
+  TaggedMultiPayloadEnumTypeInfo(unsigned Size, unsigned Alignment,
                            unsigned Stride, unsigned NumExtraInhabitants,
                            bool BitwiseTakable,
                            const std::vector<FieldInfo> &Cases)
     : EnumTypeInfo(Size, Alignment, Stride, NumExtraInhabitants,
                    BitwiseTakable, EnumKind::MultiPayloadEnum, Cases) {
-    assert(Cases[0].TR != 0);
-    assert(Cases[1].TR != 0);
-    assert(getNumNonEmptyPayloadCases() > 1);
-    assert(getSize() > getPayloadSize());
-    assert(getCases().size() > 1);
+    // Definition of "multi-payload enum"
+    assert(getCases().size() > 1); // At least 2 cases
+    assert(Cases[0].TR != 0); // At least 2 payloads
+    // assert(Cases[1].TR != 0);
+    // At least one payload is non-empty (otherwise this
+    // would get laid out as a non-payload enum)
+    assert(getNumNonEmptyPayloadCases() > 0);
+    // There's a tag, so the total size must be bigger than any payload
+    // assert(getSize() > getPayloadSize());
   }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
@@ -2027,10 +2055,14 @@ public:
 
   const TypeInfo *build(const TypeRef *TR, RemoteRef<FieldDescriptor> FD,
                         remote::TypeInfoProvider *ExternalTypeInfo) {
-    // Sort enum into payload and no-payload cases.
-    unsigned TrueNoPayloadCases = 0;
-    unsigned EmptyPayloadCases = 0;
-    std::vector<FieldTypeInfo> PayloadCases;
+    // Count various categories of cases:
+    unsigned NonPayloadCases = 0; // `case a`
+    unsigned NonGenericEmptyPayloadCases = 0; // `case a(Void)` or `case b(Never)`
+    unsigned NonGenericNonEmptyPayloadCases = 0; // `case a(Int)` or `case d([Int?])`
+    unsigned GenericPayloadCases = 0; // `case a(T)` or `case a([String : (Int, T)])`
+
+    // For a single-payload enum, this is the only payload
+    const TypeRef *LastPayloadCaseTR = nullptr;
 
     std::vector<FieldTypeInfo> Fields;
     if (!TC.getBuilder().getFieldTypeRefs(TR, FD, ExternalTypeInfo, Fields)) {
@@ -2040,30 +2072,33 @@ public:
 
     for (auto Case : Fields) {
       if (Case.TR == nullptr) {
-        ++TrueNoPayloadCases;
+        ++NonPayloadCases;
         addCase(Case.Name);
       } else {
         auto *CaseTR = getCaseTypeRef(Case);
         assert(CaseTR != nullptr);
         auto *CaseTI = TC.getTypeInfo(CaseTR, ExternalTypeInfo);
-	if (CaseTI == nullptr) {
-	  // We don't have typeinfo; assume it's not
-	  // zero-sized to match earlier behavior.
-	  // TODO: Maybe this should prompt us to fall
-	  // back to UnsupportedEnumTypeInfo??
-          PayloadCases.push_back(Case);
-	} else if (CaseTI->getSize() == 0) {
-          // Zero-sized payloads get special treatment
-          ++EmptyPayloadCases;
+        if (CaseTI == nullptr) {
+          // We don't have typeinfo; something is very broken.
+          Invalid = true;
+          return nullptr;
+        } else if (Case.Generic) {
+          ++GenericPayloadCases;
+          LastPayloadCaseTR = CaseTR;
+        } else if (CaseTI->getSize() == 0) {
+          ++NonGenericEmptyPayloadCases;
         } else {
-          PayloadCases.push_back(Case);
+          ++NonGenericNonEmptyPayloadCases;
+          LastPayloadCaseTR = CaseTR;
         }
         addCase(Case.Name, CaseTR, CaseTI);
       }
     }
-    // For layout purposes, cases w/ empty payload are
-    // treated the same as cases with no payload.
-    unsigned EffectiveNoPayloadCases = TrueNoPayloadCases + EmptyPayloadCases;
+    // For determining a layout strategy, cases w/ empty payload are treated the
+    // same as cases with no payload, and generic cases are always considered
+    // non-empty.
+    unsigned EffectiveNoPayloadCases = NonPayloadCases + NonGenericEmptyPayloadCases;
+    unsigned EffectivePayloadCases = GenericPayloadCases + NonGenericNonEmptyPayloadCases;
 
     if (Cases.empty()) {
       return TC.makeTypeInfo<EmptyEnumTypeInfo>(Cases);
@@ -2071,58 +2106,72 @@ public:
 
     // `Kind` is used when dumping data, so it reflects how the enum was
     // declared in source; the various *TypeInfo classes mentioned below reflect
-    // the in-memory layout, which may be different because cases whose
-    // payload is zero-sized get treated (for layout purposes) as non-payload
+    // the in-memory layout, which may be different because non-generic cases
+    // with zero-sized payloads get treated for layout purposes as non-payload
     // cases.
     EnumKind Kind;
-    switch (PayloadCases.size() + EmptyPayloadCases) {
+    switch (GenericPayloadCases + NonGenericEmptyPayloadCases + NonGenericNonEmptyPayloadCases) {
     case 0: Kind = EnumKind::NoPayloadEnum; break;
     case 1: Kind = EnumKind::SinglePayloadEnum; break;
     default: Kind = EnumKind::MultiPayloadEnum; break;
     }
 
-    if (PayloadCases.empty()) {
-      // NoPayloadEnumImplStrategy
-      if (EffectiveNoPayloadCases == 1) {
+    if (Cases.size() == 1) {
+      if (EffectivePayloadCases == 0) {
+        // Zero-sized enum with only one empty case
         return TC.makeTypeInfo<TrivialEnumTypeInfo>(Kind, Cases);
       } else {
-        unsigned Size, NumExtraInhabitants;
-        if (EffectiveNoPayloadCases < 256) {
-          Size = 1;
-          NumExtraInhabitants = 256 - EffectiveNoPayloadCases;
-        } else if (EffectiveNoPayloadCases < 65536) {
-          Size = 2;
-          NumExtraInhabitants = 65536 - EffectiveNoPayloadCases;
-        } else {
-          Size = 4;
-          NumExtraInhabitants = std::numeric_limits<uint32_t>::max() - EffectiveNoPayloadCases + 1;
-        }
-        if (EmptyPayloadCases > 0) {
-          // This enum uses no-payload layout, but the source actually does
-          // have payloads (they're just all zero-sized).
-          // If this is really a single-payload enum, we take extra inhabitants
-          // from the first payload, which is zero sized in this case.
-          // If this is really a multi-payload enum, ...
-          NumExtraInhabitants = 0;
-        }
-        if (NumExtraInhabitants > ValueWitnessFlags::MaxNumExtraInhabitants) {
-          NumExtraInhabitants = ValueWitnessFlags::MaxNumExtraInhabitants;
-        }
-        return TC.makeTypeInfo<NoPayloadEnumTypeInfo>(
-          /* Size */ Size, /* Alignment */ Size, /* Stride */ Size,
-          NumExtraInhabitants, Kind, Cases);
+        // Enum that has only one payload case is represented as that case
+        return TC.getTypeInfo(LastPayloadCaseTR, ExternalTypeInfo);
       }
-    } else if (PayloadCases.size() == 1) {
+    }
+
+    if (EffectivePayloadCases == 0) {
+      // Enum with no non-empty payloads.  (It may
+      // formally be a single-payload or multi-payload enum,
+      // but all the actual payloads have zero size.)
+
+      // Represent it as a 1-, 2-, or 4-byte integer
+      unsigned Size, NumExtraInhabitants;
+      if (EffectiveNoPayloadCases < 256) {
+        Size = 1;
+        NumExtraInhabitants = 256 - EffectiveNoPayloadCases;
+      } else if (EffectiveNoPayloadCases < 65536) {
+        Size = 2;
+        NumExtraInhabitants = 65536 - EffectiveNoPayloadCases;
+      } else {
+        Size = 4;
+        NumExtraInhabitants = std::numeric_limits<uint32_t>::max() - EffectiveNoPayloadCases + 1;
+      }
+      if (NonGenericEmptyPayloadCases > 0) {
+        // This enum uses no-payload layout, but the source actually does
+        // have payloads (they're just all zero-sized).
+        // If this is really a single-payload or multi-payload enum, we
+        // formally take extra inhabitants from the first payload, which is
+        // zero sized in this case.
+        NumExtraInhabitants = 0;
+      }
+      if (NumExtraInhabitants > ValueWitnessFlags::MaxNumExtraInhabitants) {
+        NumExtraInhabitants = ValueWitnessFlags::MaxNumExtraInhabitants;
+      }
+      return TC.makeTypeInfo<NoPayloadEnumTypeInfo>(
+        /* Size */ Size, /* Alignment */ Size, /* Stride */ Size,
+        NumExtraInhabitants, Kind, Cases);
+    }
+
+    if (EffectivePayloadCases == 1) {
       // SinglePayloadEnumImplStrategy
-      auto *CaseTR = getCaseTypeRef(PayloadCases[0]);
+
+      // This is a true single-payload enum with
+      // a single non-zero-sized payload, or an MPE
+      // with a single payload that is not statically empty.
+      // It also has at least one non-payload (or empty) case.
+
+      auto *CaseTR = LastPayloadCaseTR;
       auto *CaseTI = TC.getTypeInfo(CaseTR, ExternalTypeInfo);
       if (CaseTR == nullptr || CaseTI == nullptr) {
         return nullptr;
       }
-      // An enum consisting of a single payload case and nothing else
-      // is lowered as the payload type.
-      if (EffectiveNoPayloadCases == 0)
-        return CaseTI;
       // Below logic should match the runtime function
       // swift_initEnumMetadataSinglePayload().
       auto PayloadExtraInhabitants = CaseTI->getNumExtraInhabitants();
@@ -2141,127 +2190,137 @@ public:
       unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
       return TC.makeTypeInfo<SinglePayloadEnumTypeInfo>(
         Size, Alignment, Stride, NumExtraInhabitants, BitwiseTakable, Kind, Cases);
-    } else {
-      // MultiPayloadEnumImplStrategy
 
-      // Uncomment the following line to dump the MPE section every time we come through here...
-      //TC.getBuilder().dumpMultiPayloadEnumSection(std::cerr); // DEBUG helper
+    }
 
-      // Check if this is a dynamic or static multi-payload enum
+    //
+    // Multi-Payload Enum strategies
+    //
+    // We now know this is a multi-payload enum with at least one non-zero-sized
+    // payload case.
+    //
 
-      // If we have a fixed descriptor for this type, it is a fixed-size
-      // multi-payload enum that possibly uses payload spare bits.
-      auto FixedDescriptor = TC.getBuilder().getBuiltinTypeInfo(TR);
-      if (FixedDescriptor) {
-        Size = FixedDescriptor->Size;
-        Alignment = FixedDescriptor->getAlignment();
-        NumExtraInhabitants = FixedDescriptor->NumExtraInhabitants;
-        BitwiseTakable = FixedDescriptor->isBitwiseTakable();
-        unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
-        if (Stride == 0)
-          Stride = 1;
-        auto PayloadSize = EnumTypeInfo::getPayloadSizeForCases(Cases);
-
-        // If there's a multi-payload enum descriptor, then we
-        // have layout information from the compiler.
-        auto MPEDescriptor = TC.getBuilder().getMultiPayloadEnumInfo(TR);
-        if (MPEDescriptor) {
-          if (MPEDescriptor->usesPayloadSpareBits()) {
-            auto PayloadSpareBitMaskByteCount = MPEDescriptor->getPayloadSpareBitMaskByteCount();
-            auto PayloadSpareBitMaskByteOffset = MPEDescriptor->getPayloadSpareBitMaskByteOffset();
-            auto SpareBitMask = MPEDescriptor->getPayloadSpareBits();
-            BitMask spareBitsMask(PayloadSize, SpareBitMask,
-                                  PayloadSpareBitMaskByteCount, PayloadSpareBitMaskByteOffset);
-
-            if (!spareBitsMask.isZero()) {
-
-#if 0  // TODO: This should be !defined(NDEBUG)
-              // DEBUG verification that compiler mask and locally-computed
-              // mask are the same (whenever both are available).
-              BitMask locallyComputedSpareBitsMask(PayloadSize);
-              auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
-              auto locallyComputedSpareBitsMaskIsValid
-                = populateSpareBitsMask(Cases, locallyComputedSpareBitsMask, mpePointerSpareBits);
-              // If the local computation were always correct, we could:
-              // assert(locallyComputedSpareBitsMaskIsValid);
-              if (locallyComputedSpareBitsMaskIsValid) {
-                // Whenever the compiler and local computation both produce
-                // data, they should agree.
-                // TODO: Make this true, then change `#if 0` above
-                assert(locallyComputedSpareBitsMask == spareBitsMask);
-              }
-#endif
-
-              // Use compiler-provided spare bit information
-              return TC.makeTypeInfo<MultiPayloadEnumTypeInfo>(
-                Size, Alignment, Stride, NumExtraInhabitants,
-                BitwiseTakable, Cases, spareBitsMask);
-            } else {
-              // The MPE descriptor doesn't make sense: It has a spare bit mask,
-              // but that mask is empty?  If this ever happens, fall through to
-              // the local calculation.
-            }
-          } else {
-            // If there are no spare bits, use the "simple" tag-only implementation.
-            return TC.makeTypeInfo<SimpleMultiPayloadEnumTypeInfo>(
-              Size, Alignment, Stride, NumExtraInhabitants,
-              BitwiseTakable, Cases);
-          }
-        }
-
-        // If there was no compiler data, try computing the mask ourselves
-        // (This is less robust, but necessary to support images from older
-        // compilers.)
-        BitMask spareBitsMask(PayloadSize);
-        auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
-        auto validSpareBitsMask = populateSpareBitsMask(Cases, spareBitsMask, mpePointerSpareBits);
-        // For DEBUGGING, disable fallback to local computation to
-        // make missing compiler data more obvious:
-        // validSpareBitsMask = false;
-        if (!validSpareBitsMask) {
-          // If we couldn't correctly determine the spare bits mask,
-          // return a TI that will always fail when asked for XIs or value.
-          return TC.makeTypeInfo<UnsupportedEnumTypeInfo>(
-            Size, Alignment, Stride, NumExtraInhabitants,
-            BitwiseTakable, EnumKind::MultiPayloadEnum, Cases);
-        } else if (spareBitsMask.isZero()) {
-          // Simple case that does not use spare bits
-          // This is correct as long as our local spare bits calculation
-          // above only returns an empty mask when the mask is really empty,
-          return TC.makeTypeInfo<SimpleMultiPayloadEnumTypeInfo>(
-            Size, Alignment, Stride, NumExtraInhabitants,
-            BitwiseTakable, Cases);
-        } else {
-          // General case can mix spare bits and extra discriminator
-          // It obviously relies on having an accurate spare bit mask.
-          return TC.makeTypeInfo<MultiPayloadEnumTypeInfo>(
-            Size, Alignment, Stride, NumExtraInhabitants,
-            BitwiseTakable, Cases, spareBitsMask);
-        }
+    // Do we have a fixed layout?
+    // TODO: Test whether a missing FixedDescriptor is actually relevant.
+    auto FixedDescriptor = TC.getBuilder().getBuiltinTypeInfo(TR);
+    if (!FixedDescriptor || GenericPayloadCases > 0) {
+      // This is a "dynamic multi-payload enum".  For example,
+      // this occurs with:
+      // ```
+      // class ClassWithEnum<T> {
+      //   enum E {
+      //   case t(T)
+      //   case u(Int)
+      //   }
+      //   var e: E?
+      // }
+      // ```
+      auto tagCounts = getEnumTagCounts(Size, EffectiveNoPayloadCases,
+                                        EffectivePayloadCases);
+      Size += tagCounts.numTagBytes;
+      if (tagCounts.numTagBytes >= 4) {
+        NumExtraInhabitants = ValueWitnessFlags::MaxNumExtraInhabitants;
       } else {
-        // Dynamic multi-payload enums cannot use spare bits, so they
-        // always use a separate tag value:
-        auto tagCounts = getEnumTagCounts(Size, EffectiveNoPayloadCases,
-                                          PayloadCases.size());
-        Size += tagCounts.numTagBytes;
-        // Dynamic multi-payload enums use the tag representations not assigned
-        // to cases for extra inhabitants.
-        if (tagCounts.numTagBytes >= 4) {
+        NumExtraInhabitants =
+          (1 << (tagCounts.numTagBytes * 8)) - tagCounts.numTags;
+        if (NumExtraInhabitants > ValueWitnessFlags::MaxNumExtraInhabitants) {
           NumExtraInhabitants = ValueWitnessFlags::MaxNumExtraInhabitants;
-        } else {
-          NumExtraInhabitants =
-            (1 << (tagCounts.numTagBytes * 8)) - tagCounts.numTags;
-          if (NumExtraInhabitants > ValueWitnessFlags::MaxNumExtraInhabitants) {
-            NumExtraInhabitants = ValueWitnessFlags::MaxNumExtraInhabitants;
-          }
         }
-        unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
-        if (Stride == 0)
-          Stride = 1;
-        return TC.makeTypeInfo<SimpleMultiPayloadEnumTypeInfo>(
+      }
+      unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
+      if (Stride == 0)
+        Stride = 1;
+      return TC.makeTypeInfo<TaggedMultiPayloadEnumTypeInfo>(
+        Size, Alignment, Stride, NumExtraInhabitants,
+        BitwiseTakable, Cases);
+    }
+
+    // This is a multi-payload enum that:
+    //  * Has no generic cases
+    //  * Has at least two cases with non-zero payload size
+    //  * Has a descriptor stored as BuiltinTypeInfo
+    Size = FixedDescriptor->Size;
+    Alignment = FixedDescriptor->getAlignment();
+    NumExtraInhabitants = FixedDescriptor->NumExtraInhabitants;
+    BitwiseTakable = FixedDescriptor->isBitwiseTakable();
+    unsigned Stride = ((Size + Alignment - 1) & ~(Alignment - 1));
+    if (Stride == 0)
+      Stride = 1;
+    auto PayloadSize = EnumTypeInfo::getPayloadSizeForCases(Cases);
+
+    // If there's a multi-payload enum descriptor, then we
+    // have spare bits information from the compiler.
+
+    // Uncomment the following line to dump the MPE section every time we come through here...
+    //TC.getBuilder().dumpMultiPayloadEnumSection(std::cerr); // DEBUG helper
+
+    auto MPEDescriptor = TC.getBuilder().getMultiPayloadEnumInfo(TR);
+    if (MPEDescriptor && MPEDescriptor->usesPayloadSpareBits()) {
+      auto PayloadSpareBitMaskByteCount = MPEDescriptor->getPayloadSpareBitMaskByteCount();
+      auto PayloadSpareBitMaskByteOffset = MPEDescriptor->getPayloadSpareBitMaskByteOffset();
+      auto SpareBitMask = MPEDescriptor->getPayloadSpareBits();
+      BitMask spareBitsMask(PayloadSize, SpareBitMask,
+                            PayloadSpareBitMaskByteCount, PayloadSpareBitMaskByteOffset);
+      
+      if (spareBitsMask.isZero()) {
+        // If there are no spare bits, use the "simple" tag-only implementation.
+        return TC.makeTypeInfo<TaggedMultiPayloadEnumTypeInfo>(
           Size, Alignment, Stride, NumExtraInhabitants,
           BitwiseTakable, Cases);
       }
+
+#if 0  // TODO: This should be !defined(NDEBUG)
+      // DEBUG verification that compiler mask and locally-computed
+      // mask are the same (whenever both are available).
+      BitMask locallyComputedSpareBitsMask(PayloadSize);
+      auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
+      auto locallyComputedSpareBitsMaskIsValid
+        = populateSpareBitsMask(Cases, locallyComputedSpareBitsMask, mpePointerSpareBits);
+      // If the local computation were always correct, we could:
+      // assert(locallyComputedSpareBitsMaskIsValid);
+      if (locallyComputedSpareBitsMaskIsValid) {
+        // Whenever the compiler and local computation both produce
+        // data, they should agree.
+        // TODO: Make this true, then change `#if 0` above
+        assert(locallyComputedSpareBitsMask == spareBitsMask);
+      }
+#endif
+
+      // Use compiler-provided spare bit information
+      return TC.makeTypeInfo<MultiPayloadEnumTypeInfo>(
+        Size, Alignment, Stride, NumExtraInhabitants,
+        BitwiseTakable, Cases, spareBitsMask);
+    }
+
+    // Either there was no compiler data or it didn't make sense
+    // (existed but claimed to have no mask).
+    // Try computing the mask ourselves: This is less robust, but necessary to
+    // support images from older compilers.
+    BitMask spareBitsMask(PayloadSize);
+    auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
+    auto validSpareBitsMask = populateSpareBitsMask(Cases, spareBitsMask, mpePointerSpareBits);
+    // For DEBUGGING, disable fallback to local computation to
+    // make missing compiler data more obvious:
+    // validSpareBitsMask = false;
+    if (!validSpareBitsMask) {
+      // If we couldn't correctly determine the spare bits mask,
+      // return a TI that will always fail when asked for XIs or value.
+      return TC.makeTypeInfo<UnsupportedEnumTypeInfo>(
+        Size, Alignment, Stride, NumExtraInhabitants,
+        BitwiseTakable, EnumKind::MultiPayloadEnum, Cases);
+    } else if (spareBitsMask.isZero()) {
+      // Simple case that does not use spare bits
+      // This is correct as long as our local spare bits calculation
+      // above only returns an empty mask when the mask is really empty,
+      return TC.makeTypeInfo<TaggedMultiPayloadEnumTypeInfo>(
+        Size, Alignment, Stride, NumExtraInhabitants,
+        BitwiseTakable, Cases);
+    } else {
+      // General case can mix spare bits and extra discriminator
+      // It obviously relies on having an accurate spare bit mask.
+      return TC.makeTypeInfo<MultiPayloadEnumTypeInfo>(
+        Size, Alignment, Stride, NumExtraInhabitants,
+        BitwiseTakable, Cases, spareBitsMask);
     }
   }
 };

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -373,12 +373,11 @@ bool TypeRefBuilder::getFieldTypeRefs(
     if (!Unsubstituted)
       return false;
 
-    // TODO: Consider `struct S<T> { enum E { case a(T); case b(T?) }}`
-    // This test identifies `a` as a generic case, but not `b`
-    bool IsGeneric = isa<GenericTypeParameterTypeRef>(Unsubstituted);
-
-    auto Substituted = Unsubstituted->subst(*this, *Subs);
-
+    // We need this for enums; an enum case "is generic" if any generic type
+    // parameter substitutions occurred on the payload.  E.g.,
+    // `case a([T?])` is generic, but `case a([Int?])` is not.
+    bool IsGeneric = false;
+    auto Substituted = Unsubstituted->subst(*this, *Subs, IsGeneric);
     bool IsIndirect = FD->isEnum() && Field->isIndirectCase();
 
     auto FieldTI = FieldTypeInfo(FieldName.str(), FieldValue, Substituted, IsIndirect, IsGeneric);

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -373,14 +373,16 @@ bool TypeRefBuilder::getFieldTypeRefs(
     if (!Unsubstituted)
       return false;
 
+    // TODO: Consider `struct S<T> { enum E { case a(T); case b(T?) }}`
+    // This test identifies `a` as a generic case, but not `b`
+    bool IsGeneric = isa<GenericTypeParameterTypeRef>(Unsubstituted);
+
     auto Substituted = Unsubstituted->subst(*this, *Subs);
 
-    if (FD->isEnum() && Field->isIndirectCase()) {
-      Fields.push_back(FieldTypeInfo::forIndirectCase(FieldName.str(), FieldValue, Substituted));
-      continue;
-    }
+    bool IsIndirect = FD->isEnum() && Field->isIndirectCase();
 
-    Fields.push_back(FieldTypeInfo::forField(FieldName.str(), FieldValue, Substituted));
+    auto FieldTI = FieldTypeInfo(FieldName.str(), FieldValue, Substituted, IsIndirect, IsGeneric);
+    Fields.push_back(FieldTI);
   }
   return true;
 }

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -2,6 +2,7 @@
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
+// XFAIL: OS=linux-gnu && CPU=aarch64
 
 // RUN: %empty-directory(%t)
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_degenerate
 // RUN: %target-codesign %t/reflect_Enum_MultiPayload_degenerate
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_degenerate | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_degenerate | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
@@ -31,15 +31,15 @@ reflect(enum: FooVoid.a([]))
 // Aside: In TypeLowering.cpp, enum FooVoid does not have a FixedDescriptor even though
 // its not generic.  This is why we check for having only a single payload first.
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=a index=0 offset=0
@@ -72,15 +72,15 @@ reflect(enum: FooVoid.b(()))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=a index=0 offset=0
@@ -118,15 +118,15 @@ reflect(enum: FooVoid2.a(()))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=b index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=b index=0 offset=0
@@ -157,15 +157,15 @@ reflect(enum: FooVoid2.b([]))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=b index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=b index=0 offset=0
@@ -206,15 +206,15 @@ reflect(enum: FooEmptyStruct.a([]))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=a index=0 offset=0
@@ -246,15 +246,15 @@ reflect(enum: FooEmptyStruct.b(B()))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))))))
+// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=a index=0 offset=0

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
@@ -10,14 +10,16 @@
 
 import SwiftReflectionTest
 
+class C {}
+
 // Only one case has a non-zero-sized payload, so this gets
 // laid out the same as a single-payload enum
 enum FooVoid {
-case a([Int])
+case a(C)
 case b(Void)
 }
 
-reflect(enum: FooVoid.a([]))
+reflect(enum: FooVoid.a(C()))
 
 // CHECK: Reflecting an enum.
 // CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -27,29 +29,17 @@ reflect(enum: FooVoid.a([]))
 // CHECK: Type info:
 
 // Note: MemoryLayout<FooVoid> says that this really is size=8, alignment=8, stride=8
-// Explanation: [Int] is a pointer, so this enum can use NULL to represent the other case
+// Explanation: C is a pointer, so this enum can use NULL to represent the other case
 // Aside: In TypeLowering.cpp, enum FooVoid does not have a FixedDescriptor even though
 // its not generic.  This is why we check for having only a single payload first.
 
 // CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
+// CHECK-64:     (reference kind=strong refcounting=native))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=a index=0 offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))))
+// CHECK-32:     (reference kind=strong refcounting=native))
 
 // CHECK:   (case name=b index=1 offset=0
 // CHECK:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
@@ -58,10 +48,9 @@ reflect(enum: FooVoid.a([]))
 // CHECK: Demangled name: reflect_Enum_MultiPayload_degenerate.FooVoid
 
 // CHECK: Enum value:
-// CHECK: (enum_value name=a index=0
-// CHECK: (bound_generic_struct Swift.Array
-// CHECK:   (struct Swift.Int))
-// CHECK: )
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT: (class reflect_Enum_MultiPayload_degenerate.C)
+// CHECK-NEXT: )
 
 reflect(enum: FooVoid.b(()))
 
@@ -72,41 +61,19 @@ reflect(enum: FooVoid.b(()))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
-// CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
-
-// CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
-// CHECK-32:   (case name=a index=0 offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))))
-
-// CHECK:   (case name=b index=1 offset=0
-// CHECK:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 // CHECK: Mangled name: $s36reflect_Enum_MultiPayload_degenerate7FooVoidO
 // CHECK: Demangled name: reflect_Enum_MultiPayload_degenerate.FooVoid
 
 // CHECK: Enum value:
-// CHECK: (enum_value name=b index=1
-// CHECK:   (tuple)
-// CHECK: )
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
 
 
 // Same as above, except the first payload has zero size
 enum FooVoid2 {
 case a(Void)
-case b([Int])
+case b(C)
 }
 
 reflect(enum: FooVoid2.a(()))
@@ -120,23 +87,11 @@ reflect(enum: FooVoid2.a(()))
 
 // CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=b index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
+// CHECK-64:     (reference kind=strong refcounting=native))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=b index=0 offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))))
+// CHECK-32:     (reference kind=strong refcounting=native))
 
 // CHECK:   (case name=a index=1 offset=0
 // CHECK:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
@@ -148,56 +103,29 @@ reflect(enum: FooVoid2.a(()))
 // CHECK:   (tuple)
 // CHECK: )
 
-reflect(enum: FooVoid2.b([]))
+reflect(enum: FooVoid2.b(C()))
 
 // CHECK: Reflecting an enum.
-// CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK: Type reference:
-// CHECK: (enum reflect_Enum_MultiPayload_degenerate.FooVoid2)
 
 // CHECK: Type info:
-
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
-// CHECK-64:   (case name=b index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
-
-// CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
-// CHECK-32:   (case name=b index=0 offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))))
-
-// CHECK:   (case name=a index=1 offset=0
-// CHECK:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 // CHECK: Mangled name: $s36reflect_Enum_MultiPayload_degenerate8FooVoid2O
 // CHECK: Demangled name: reflect_Enum_MultiPayload_degenerate.FooVoid2
 
 // CHECK: Enum value:
-// CHECK: (enum_value name=b index=0
-// CHECK: (bound_generic_struct Swift.Array
-// CHECK:   (struct Swift.Int))
-// CHECK: )
+// CHECK-NEXT: (enum_value name=b index=0
+// CHECK-NEXT: (class reflect_Enum_MultiPayload_degenerate.C)
+// CHECK-NEXT: )
 
 
 // As above, this is laid out as a single-payload enum
 // because the `b` case payload has zero size
 struct B {}
 enum FooEmptyStruct {
-case a([Int])
+case a(C)
 case b(B)
 }
 
-reflect(enum: FooEmptyStruct.a([]))
+reflect(enum: FooEmptyStruct.a(C()))
 
 // CHECK: Reflecting an enum.
 // CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -208,23 +136,11 @@ reflect(enum: FooEmptyStruct.a([]))
 
 // CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
+// CHECK-64:     (reference kind=strong refcounting=native))
 
 // CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
 // CHECK-32:   (case name=a index=0 offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))))
+// CHECK-32:     (reference kind=strong refcounting=native))
 
 // CHECK:   (case name=b index=1 offset=0
 // CHECK:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
@@ -232,10 +148,9 @@ reflect(enum: FooEmptyStruct.a([]))
 // CHECK: Demangled name: reflect_Enum_MultiPayload_degenerate.FooEmptyStruct
 
 // CHECK: Enum value:
-// CHECK: (enum_value name=a index=0
-// CHECK: (bound_generic_struct Swift.Array
-// CHECK:   (struct Swift.Int))
-// CHECK: )
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT: (class reflect_Enum_MultiPayload_degenerate.C)
+// CHECK-NEXT: )
 
 reflect(enum: FooEmptyStruct.b(B()))
 
@@ -246,36 +161,13 @@ reflect(enum: FooEmptyStruct.b(B()))
 
 // CHECK: Type info:
 
-// CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
-// CHECK-64:   (case name=a index=0 offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:       (field name=_buffer offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:           (field name=_storage offset=0
-// CHECK-64:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
-// CHECK-64:               (field name=rawValue offset=0
-// CHECK-64:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))))))
-
-// CHECK-32: (multi_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095 bitwise_takable=1
-// CHECK-32:   (case name=a index=0 offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:       (field name=_buffer offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:           (field name=_storage offset=0
-// CHECK-32:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
-// CHECK-32:               (field name=rawValue offset=0
-// CHECK-32:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))))))))
-
-// CHECK:   (case name=b index=1 offset=0
-// CHECK:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 // CHECK: Mangled name: $s36reflect_Enum_MultiPayload_degenerate14FooEmptyStructO
 // CHECK: Demangled name: reflect_Enum_MultiPayload_degenerate.FooEmptyStruct
 
 // CHECK: Enum value:
-// CHECK: (enum_value name=b index=1
-// CHECK:   (struct reflect_Enum_MultiPayload_degenerate.B)
-// CHECK: )
-
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (struct reflect_Enum_MultiPayload_degenerate.B)
+// CHECK-NEXT: )
 
 // TODO: Variations of Foo where `b` payload is class, Bool
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
@@ -26,6 +26,11 @@ reflect(enum: FooVoid.a([]))
 
 // CHECK: Type info:
 
+// Note: MemoryLayout<FooVoid> says that this really is size=8, alignment=8, stride=8
+// Explanation: [Int] is a pointer, so this enum can use NULL to represent the other case
+// Aside: In TypeLowering.cpp, enum FooVoid does not have a FixedDescriptor even though
+// its not generic.  This is why we check for having only a single payload first.
+
 // CHECK-64: (multi_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483646 bitwise_takable=1
 // CHECK-64:   (case name=a index=0 offset=0
 // CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
@@ -25,6 +25,15 @@ class ClassWithEnumDepth0<T> {
   var e: E?
 }
 
+/*
+print("ClassWithEnumDepth0:  ",
+  MemoryLayout<ClassWithEnumDepth0<S>.E?>.size,
+  " ",
+  MemoryLayout<ClassWithEnumDepth0<S>.E?>.alignment,
+  " ",
+  MemoryLayout<ClassWithEnumDepth0<S>.E?>.stride)
+*/
+
 reflect(object: ClassWithEnumDepth0<S>())
 
 // CHECK: Reflecting an object.
@@ -84,7 +93,6 @@ reflect(object: ClassWithEnumDepth0<S>())
 // X32-NEXT:               (field name=_value offset=0
 // X32-NEXT:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // X32-NEXT:       (case name=none index=1))))
-
 
 class ClassWithEnumDepth1<T> {
   enum E<T> {
@@ -153,6 +161,7 @@ reflect(object: ClassWithEnumDepth1<S>())
 // X32-NEXT:               (field name=_value offset=0
 // X32-NEXT:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // X32-NEXT:       (case name=none index=1))))
+
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic2
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic2
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic2 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+class ClassTypeA {}
+class ClassTypeB {}
+enum SimplePayload1<T, U>{
+case a(T)
+case b(U)
+}
+
+reflect(enum: SimplePayload1<ClassTypeA, Void>.a(ClassTypeA()))
+
+// X64: Reflecting an enum.
+// X64-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// X64-NEXT: Type reference:
+// X64-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic2.SimplePayload1
+// X64-NEXT:   (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
+// X64-NEXT:   (tuple))
+
+// MemoryLayout<SimplePayload1<ClassTypeA, Void>> gives 9,8,16
+// SimplePayload1 is a BoundGenericTypeRef
+// It's getting laid out as a tagged MPE, not as an SPE
+// (an SPE would use the XIs of the ptr) XXXXXX OR WOULD IT???  Hmmmmm....
+
+// X64: Type info:
+// X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// X64-NEXT:   (case name=a index=0 offset=0
+// X64-NEXT:     (reference kind=strong refcounting=native))
+// X64-NEXT:   (case name=b index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
+// X64-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
+
+// X64: Enum value:
+// X64-NEXT: (enum_value name=a index=0
+// X64-NEXT: (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
+// X64-NEXT: )
+
+// X32: FAIL
+
+reflect(enum: SimplePayload1<ClassTypeA, Void>.b(()))
+
+// X64: Reflecting an enum.
+// X64-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// X64-NEXT: Type reference:
+// X64-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic2.SimplePayload1
+// X64-NEXT:   (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
+// X64-NEXT:   (tuple))
+
+// X64: Type info:
+// X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// X64-NEXT:   (case name=a index=0 offset=0
+// X64-NEXT:     (reference kind=strong refcounting=native))
+// X64-NEXT:   (case name=b index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
+// X64-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
+
+// X64: Enum value:
+// X64-NEXT: (enum_value name=b index=1
+// X64-NEXT: (tuple)
+// X64-NEXT: )
+
+// X32: FAIL
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
@@ -20,44 +20,43 @@ case b(U)
 
 reflect(enum: SimplePayload1<ClassTypeA, Void>.a(ClassTypeA()))
 
-// X64: Reflecting an enum.
-// X64-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// X64-NEXT: Type reference:
-// X64-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic2.SimplePayload1
-// X64-NEXT:   (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
-// X64-NEXT:   (tuple))
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic2.SimplePayload1
+// CHECK-NEXT:   (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
+// CHECK-NEXT:   (tuple))
 
 // MemoryLayout<SimplePayload1<ClassTypeA, Void>> gives 9,8,16
 // SimplePayload1 is a BoundGenericTypeRef
 // It's getting laid out as a tagged MPE, not as an SPE
 // (an SPE would use the XIs of the ptr) XXXXXX OR WOULD IT???  Hmmmmm....
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
 // X64-NEXT:   (case name=a index=0 offset=0
 // X64-NEXT:     (reference kind=strong refcounting=native))
 // X64-NEXT:   (case name=b index=1 offset=0
 // X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
-// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
-// X64-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
 
-// X64: Enum value:
-// X64-NEXT: (enum_value name=a index=0
-// X64-NEXT: (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
-// X64-NEXT: )
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
 
-// X32: FAIL
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT: (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
+// CHECK-NEXT: )
 
 reflect(enum: SimplePayload1<ClassTypeA, Void>.b(()))
 
-// X64: Reflecting an enum.
-// X64-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// X64-NEXT: Type reference:
-// X64-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic2.SimplePayload1
-// X64-NEXT:   (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
-// X64-NEXT:   (tuple))
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic2.SimplePayload1
+// CHECK-NEXT:   (class reflect_Enum_MultiPayload_generic2.ClassTypeA)
+// CHECK-NEXT:   (tuple))
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
 // X64-NEXT:   (case name=a index=0 offset=0
 // X64-NEXT:     (reference kind=strong refcounting=native))
@@ -66,12 +65,10 @@ reflect(enum: SimplePayload1<ClassTypeA, Void>.b(()))
 // X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
 // X64-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
 
-// X64: Enum value:
-// X64-NEXT: (enum_value name=b index=1
-// X64-NEXT: (tuple)
-// X64-NEXT: )
-
-// X32: FAIL
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT: (tuple)
+// CHECK-NEXT: )
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
@@ -39,7 +39,7 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 //   MemoryLayout<StructWithEnumDepth0<Int>>.size => 10
 //   MemoryLayout<StructWithEnumDepth0<Int>?>.size => 11
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // X64-NEXT:   (case name=some index=0 offset=0
 // X64-NEXT:     (struct size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
@@ -55,10 +55,9 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 // X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // X64-NEXT:           (case name=none index=1)))))
 // X64-NEXT:   (case name=none index=1))
-// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic3010StructWithB6Depth0VySiGSg
-// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic3.StructWithEnumDepth0<Swift.Int>>
 
-// X32: FAIL
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic3010StructWithB6Depth0VySiGSg
+// CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic3.StructWithEnumDepth0<Swift.Int>>
 
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=none index=1)

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic3
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic3
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic3 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Darwin
+
+private func debugLog(_ message: @autoclosure () -> String) {
+  fputs("Child: \(message())\n", stderr)
+  fflush(stderr)
+}
+
+struct StructWithEnumDepth0<T> {
+  enum E {
+  case t(T)
+  case u(Void)
+  }
+  var e: E?
+}
+
+reflect(enum: StructWithEnumDepth0<Int>?.none)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum Swift.Optional
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic3.StructWithEnumDepth0
+// CHECK-NEXT:     (struct Swift.Int)))
+
+// MemoryLayout<> on ARM64 macOS gives
+//   MemoryLayout<StructWithEnumDepth0<Int>.E>.size => 9
+//   MemoryLayout<StructWithEnumDepth0<Int>>.size => 10
+//   MemoryLayout<StructWithEnumDepth0<Int>?>.size => 11
+
+// X64: Type info:
+// X64-NEXT: (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:   (case name=some index=0 offset=0
+// X64-NEXT:     (struct size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=e offset=0
+// X64-NEXT:         (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (case name=some index=0 offset=0
+// X64-NEXT:             (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:               (case name=t index=0 offset=0
+// X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:                   (field name=_value offset=0
+// X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:               (case name=u index=1 offset=0
+// X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:           (case name=none index=1)))))
+// X64-NEXT:   (case name=none index=1))
+// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic3010StructWithB6Depth0VySiGSg
+// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic3.StructWithEnumDepth0<Swift.Int>>
+
+// X32: FAIL
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=none index=1)
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic4
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic4
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic4 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Darwin
+
+private func debugLog(_ message: @autoclosure () -> String) {
+  fputs("Child: \(message())\n", stderr)
+  fflush(stderr)
+}
+
+struct StructWithEnumDepth0<T> {
+  enum E {
+  case t(T)
+  case u(Int)
+  }
+  var e: E?
+}
+
+reflect(enum: StructWithEnumDepth0<Int>?.none)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum Swift.Optional
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic4.StructWithEnumDepth0
+// CHECK-NEXT:     (struct Swift.Int)))
+
+// MemoryLayout<> on ARM64 macOS gives 9,8,16 as the sizes of both SWED0<Int>? and SWED0<Int>.E
+// from that, we can infer that SWED0<Int>.E must have a non-zero number of extra inhabitants
+
+// X64: Type info:
+// X64-NEXT: (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=252 bitwise_takable=1
+// X64-NEXT:   (case name=some index=0 offset=0
+// X64-NEXT:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// X64-NEXT:       (field name=e offset=0
+// X64-NEXT:         (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// X64-NEXT:           (case name=some index=0 offset=0
+// X64-NEXT:             (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
+// X64-NEXT:               (case name=t index=0 offset=0
+// X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:                   (field name=_value offset=0
+// X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:               (case name=u index=1 offset=0
+// X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:                   (field name=_value offset=0
+// X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// X64-NEXT:           (case name=none index=1)))))
+// X64-NEXT:   (case name=none index=1))
+// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic4010StructWithB6Depth0VySiGSg
+// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic4.StructWithEnumDepth0<Swift.Int>>
+
+// X32: FAIL
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=none index=1)
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
@@ -37,7 +37,7 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 // MemoryLayout<> on ARM64 macOS gives 9,8,16 as the sizes of both SWED0<Int>? and SWED0<Int>.E
 // from that, we can infer that SWED0<Int>.E must have a non-zero number of extra inhabitants
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=252 bitwise_takable=1
 // X64-NEXT:   (case name=some index=0 offset=0
 // X64-NEXT:     (struct size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
@@ -55,10 +55,9 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 // X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // X64-NEXT:           (case name=none index=1)))))
 // X64-NEXT:   (case name=none index=1))
-// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic4010StructWithB6Depth0VySiGSg
-// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic4.StructWithEnumDepth0<Swift.Int>>
 
-// X32: FAIL
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic4010StructWithB6Depth0VySiGSg
+// CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic4.StructWithEnumDepth0<Swift.Int>>
 
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=none index=1)

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
@@ -34,7 +34,7 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 //   MemoryLayout<StructWithEnumDepth0<Int>>.size => 10
 //   MemoryLayout<StructWithEnumDepth0<Int>?>.size => 11
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // X64-NEXT:   (case name=some index=0 offset=0
 // X64-NEXT:     (struct size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
@@ -50,10 +50,9 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 // X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // X64-NEXT:           (case name=none index=1)))))
 // X64-NEXT:   (case name=none index=1))
-// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic5010StructWithB6Depth0VySiGSg
-// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0<Swift.Int>>
 
-// X32: FAIL
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic5010StructWithB6Depth0VySiGSg
+// CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0<Swift.Int>>
 
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=none index=1)

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
@@ -1,0 +1,89 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic5
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic5
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic5 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Darwin
+
+struct StructWithEnumDepth0<T> {
+  enum E {
+  case t(Void)
+  case u(T)
+  }
+  var e: E?
+}
+
+reflect(enum: StructWithEnumDepth0<Int>?.none)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum Swift.Optional
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0
+// CHECK-NEXT:     (struct Swift.Int)))
+
+// MemoryLayout<> on ARM64 macOS gives
+//   MemoryLayout<StructWithEnumDepth0<Int>.E>.size => 9
+//   MemoryLayout<StructWithEnumDepth0<Int>>.size => 10
+//   MemoryLayout<StructWithEnumDepth0<Int>?>.size => 11
+
+// X64: Type info:
+// X64-NEXT: (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:   (case name=some index=0 offset=0
+// X64-NEXT:     (struct size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=e offset=0
+// X64-NEXT:         (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (case name=some index=0 offset=0
+// X64-NEXT:             (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:               (case name=u index=0 offset=0
+// X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:                   (field name=_value offset=0
+// X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:               (case name=t index=1 offset=0
+// X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:           (case name=none index=1)))))
+// X64-NEXT:   (case name=none index=1))
+// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic5010StructWithB6Depth0VySiGSg
+// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0<Swift.Int>>
+
+// X32: FAIL
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=none index=1)
+
+let example = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.u(17))
+reflect(enum: example as StructWithEnumDepth0<Int>?)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0
+// CHECK-NEXT:    (struct Swift.Int))
+// CHECK-NEXT: )
+
+reflect(enum: example.e)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0.E
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic5.StructWithEnumDepth0
+// CHECK-NEXT:     (struct Swift.Int)))
+// CHECK-NEXT: )
+
+reflect(enum: example.e!)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=u index=0
+// CHECK-NEXT: (struct Swift.Int)
+// CHECK-NEXT: )
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
@@ -42,7 +42,7 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 // The TR for E is not a BoundGenericTypeRef
 // The compiler is not providing a BuiltinTypeInfo
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // X64-NEXT:   (case name=some index=0 offset=0
 // X64-NEXT:     (struct size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
@@ -64,10 +64,9 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 // X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // X64-NEXT:           (case name=none index=1)))))
 // X64-NEXT:   (case name=none index=1))
-// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic6010StructWithB6Depth0VySiGSg
-// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0<Swift.Int>>
 
-// X32: FAIL
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic6010StructWithB6Depth0VySiGSg
+// CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0<Swift.Int>>
 
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=none index=1)
@@ -75,6 +74,8 @@ reflect(enum: StructWithEnumDepth0<Int>?.none)
 let example = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.w(17))
 reflect(enum: example as StructWithEnumDepth0<Int>?)
 
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=some index=0
 // CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0
@@ -83,6 +84,8 @@ reflect(enum: example as StructWithEnumDepth0<Int>?)
 
 reflect(enum: example.e)
 
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=some index=0
 // CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0.E
@@ -92,6 +95,8 @@ reflect(enum: example.e)
 
 reflect(enum: example.e!)
 
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=w index=0
 // CHECK-NEXT: (struct Swift.Int)
@@ -100,6 +105,8 @@ reflect(enum: example.e!)
 let example2 = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.t(()))
 reflect(enum: example2 as StructWithEnumDepth0<Int>?)
 
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=some index=0
 // CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0
@@ -108,6 +115,8 @@ reflect(enum: example2 as StructWithEnumDepth0<Int>?)
 
 reflect(enum: example2.e!)
 
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=t index=1
 // CHECK-NEXT: (tuple)
@@ -116,6 +125,8 @@ reflect(enum: example2.e!)
 let example3 = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.x(()))
 reflect(enum: example3.e!)
 
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=x index=4
 // CHECK-NEXT: (tuple)

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
@@ -1,0 +1,128 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic6
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic6
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic6 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Darwin
+
+struct StructWithEnumDepth0<T> {
+  enum E {
+  case t(Void)
+  case u(Void)
+  case v(Never)
+  case w(T)
+  case x(Void)
+  }
+  var e: E?
+}
+
+reflect(enum: StructWithEnumDepth0<Int>?.none)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum Swift.Optional
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0
+// CHECK-NEXT:     (struct Swift.Int)))
+
+// MemoryLayout<> on ARM64 macOS gives
+//   MemoryLayout<StructWithEnumDepth0<Int>.E>.size => 9
+//   MemoryLayout<StructWithEnumDepth0<Int>>.size => 10
+//   MemoryLayout<StructWithEnumDepth0<Int>?>.size => 11
+
+// Based on the above, E is not exporting any XIs, so it's
+// getting handled as an SPE (MPEs export tag values as XIs).
+// The TR for E is not a BoundGenericTypeRef
+// The compiler is not providing a BuiltinTypeInfo
+
+// X64: Type info:
+// X64-NEXT: (single_payload_enum size=11 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:   (case name=some index=0 offset=0
+// X64-NEXT:     (struct size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=e offset=0
+// X64-NEXT:         (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (case name=some index=0 offset=0
+// X64-NEXT:             (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:               (case name=w index=0 offset=0
+// X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:                   (field name=_value offset=0
+// X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:               (case name=t index=1 offset=0
+// X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:               (case name=u index=2 offset=0
+// X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:               (case name=v index=3 offset=0
+// X64-NEXT:                 (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:               (case name=x index=4 offset=0
+// X64-NEXT:                 (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:           (case name=none index=1)))))
+// X64-NEXT:   (case name=none index=1))
+// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic6010StructWithB6Depth0VySiGSg
+// X64-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0<Swift.Int>>
+
+// X32: FAIL
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=none index=1)
+
+let example = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.w(17))
+reflect(enum: example as StructWithEnumDepth0<Int>?)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0
+// CHECK-NEXT:    (struct Swift.Int))
+// CHECK-NEXT: )
+
+reflect(enum: example.e)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0.E
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0
+// CHECK-NEXT:     (struct Swift.Int)))
+// CHECK-NEXT: )
+
+reflect(enum: example.e!)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=w index=0
+// CHECK-NEXT: (struct Swift.Int)
+// CHECK-NEXT: )
+
+let example2 = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.t(()))
+reflect(enum: example2 as StructWithEnumDepth0<Int>?)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic6.StructWithEnumDepth0
+// CHECK-NEXT:    (struct Swift.Int))
+// CHECK-NEXT: )
+
+reflect(enum: example2.e!)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=t index=1
+// CHECK-NEXT: (tuple)
+// CHECK-NEXT: )
+
+let example3 = StructWithEnumDepth0<Int>(e: StructWithEnumDepth0<Int>.E.x(()))
+reflect(enum: example3.e!)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=x index=4
+// CHECK-NEXT: (tuple)
+// CHECK-NEXT: )
+
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
@@ -41,9 +41,7 @@ reflect(enum: A<Int>.a(7))
 // X64-NEXT:   (case name=c index=2 offset=0
 // X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 
-// X32: FAIL
-
-// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71AOySiG
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic71AOySiG
 // CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.A<Swift.Int>
 
 // CHECK: Enum value:
@@ -65,17 +63,15 @@ reflect(enum: A<Void>.a(()))
 // CHECK: Reflecting an enum.
 
 // CHECK: Type info:
-// X64-NEXT: (multi_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
-// X64-NEXT:   (case name=a index=0 offset=0
-// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
-// X64-NEXT:   (case name=b index=1 offset=0
-// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
-// X64-NEXT:   (case name=c index=2 offset=0
-// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+// CHECK-NEXT: (multi_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-NEXT:   (case name=a index=0 offset=0
+// CHECK-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-NEXT:   (case name=b index=1 offset=0
+// CHECK-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK-NEXT:   (case name=c index=2 offset=0
+// CHECK-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 
-// X32: FAIL
-
-// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71AOyytG
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic71AOyytG
 // CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.A<()>
 
 // CHECK: Enum value:
@@ -123,9 +119,7 @@ reflect(enum: B<Int>.a(1))
 // X64-NEXT:   (case name=c index=2 offset=0
 // X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 
-// X32: FAIL
-
-// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71BOySiG
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic71BOySiG
 // CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.B<Swift.Int>
 
 // CHECK: Enum value:
@@ -165,9 +159,7 @@ reflect(enum: B<Void>.a(8))
 // X64-NEXT:   (case name=c index=2 offset=0
 // X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
 
-// X32: FAIL
-
-// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71BOyytG
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic71BOyytG
 // CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.B<()>
 
 // CHECK: Enum value:

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
@@ -1,0 +1,199 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic7
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic7
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic7 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Darwin
+
+// This will always get treated as a single-payload enum
+enum A<T> {
+case a(T)
+case b(Void)
+case c(Void)
+}
+
+reflect(enum: A<Int>.a(7))
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic7.A
+// CHECK-NEXT:   (struct Swift.Int))
+
+// According to MemoryLayout<>, A<Int> is 9 bytes, A<Int>? is 10 bytes
+// the latter shows that there are no XIs in A<Int>.
+
+// CHECK: Type info:
+// X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:   (case name=a index=0 offset=0
+// X64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=_value offset=0
+// X64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:   (case name=b index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:   (case name=c index=2 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+
+// X32: FAIL
+
+// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71AOySiG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.A<Swift.Int>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT: )
+
+reflect(enum: A<Int>.b(()))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+reflect(enum: A<Void>.a(()))
+
+// CHECK: Reflecting an enum.
+
+// CHECK: Type info:
+// X64-NEXT: (multi_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:   (case name=a index=0 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:   (case name=b index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:   (case name=c index=2 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+
+// X32: FAIL
+
+// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71AOyytG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.A<()>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+
+reflect(enum: A<Void>.b(()))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+
+
+// This is always laid out like an MPE
+enum B<T> {
+case a(Int)
+case b(T)
+case c(Void)
+}
+
+reflect(enum: B<Int>.a(1))
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic7.B
+// CHECK-NEXT:     (struct Swift.Int))
+
+// CHECK: Type info:
+// X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// X64-NEXT:   (case name=a index=0 offset=0
+// X64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=_value offset=0
+// X64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:   (case name=b index=1 offset=0
+// X64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=_value offset=0
+// X64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:   (case name=c index=2 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+
+// X32: FAIL
+
+// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71BOySiG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.B<Swift.Int>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT: )
+
+reflect(enum: B<Int>.b(2))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT: )
+
+reflect(enum: B<Int>.c(()))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=c index=2
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+reflect(enum: B<Void>.a(8))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// X64-NEXT:   (case name=a index=0 offset=0
+// X64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field name=_value offset=0
+// X64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:   (case name=b index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:   (case name=c index=2 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
+
+// X32: FAIL
+
+// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic71BOyytG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic7.B<()>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT: )
+
+reflect(enum: B<Void>.b(()))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=1
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+reflect(enum: B<Void>.c(()))
+
+// CHECK: Reflecting an enum.
+// CHECK: Type info:
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=c index=2
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
@@ -9,7 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest
-import Darwin
 
 struct S<T> { var t: T }
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
@@ -49,9 +49,7 @@ reflect(enum: A<Void>.a(S<Void>(t: ())) as A<Void>?)
 // X64-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // X64-NEXT:   (case name=none index=1))
 
-// X32: FAIL
-
-// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic81AOyytGSg
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic81AOyytGSg
 // CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic8.A<()>>
 
 // CHECK: Enum value:
@@ -114,9 +112,7 @@ reflect(enum: B<Int>.a(S<Void>(t: ())) as B<Int>?)
 // X64-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
 // X64-NEXT:   (case name=none index=1))
 
-// X32: FAIL
-
-// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic81BOySiGSg
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic81BOySiGSg
 // CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic8.B<Swift.Int>>
 
 // CHECK: Enum value:

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
@@ -1,0 +1,161 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic8
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic8
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic8 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Darwin
+
+struct S<T> { var t: T }
+
+enum A<T> {
+case a(S<T>)
+case b(Int)
+case c(Void)
+}
+
+reflect(enum: A<Void>.a(S<Void>(t: ())) as A<Void>?)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum Swift.Optional
+// CHECK-NEXT:   (bound_generic_enum reflect_Enum_MultiPayload_generic8.A
+// CHECK-NEXT:     (tuple)))
+
+// Note: MemoryLayout<A<Void>?>.size == MemoryLayout<A<Void>>.size == 9
+// This means the MPE is exporting XIs from the tag, which means
+// it's an MPE layout, not an SPE layout.
+// Explanation:  S<T> is generic, thus treated as a non-empty payload
+// even though it is in fact zero-sized.
+
+// CHECK: Type info:
+// X64-NEXT: (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=252 bitwise_takable=1
+// X64-NEXT:   (case name=some index=0 offset=0
+// X64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
+// X64-NEXT:       (case name=a index=0 offset=0
+// X64-NEXT:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (field name=t offset=0
+// X64-NEXT:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:       (case name=b index=1 offset=0
+// X64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (field name=_value offset=0
+// X64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:       (case name=c index=2 offset=0
+// X64-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:   (case name=none index=1))
+
+// X32: FAIL
+
+// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic81AOyytGSg
+// CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic8.A<()>>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic8.A
+// CHECK-NEXT:   (tuple))
+// CHECK-NEXT: )
+
+reflect(enum: A<Void>.a(S<Void>(t: ())))
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=0
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic8.S
+// CHECK-NEXT:     (tuple))
+// CHECK-NEXT: )
+
+reflect(enum: A<Void>?.none)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=none index=1)
+
+reflect(enum: A<Void>.c(()))
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=c index=2
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+
+enum B<T> {
+case a(S<Void>)
+case b(S<T>)
+case c(Void)
+}
+
+reflect(enum: B<Int>.a(S<Void>(t: ())) as B<Int>?)
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum Swift.Optional
+// CHECK-NEXT:   (bound_generic_enum reflect_Enum_MultiPayload_generic8.B
+// CHECK-NEXT:     (struct Swift.Int)))
+
+// X64: Type info:
+// X64-NEXT: (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:   (case name=some index=0 offset=0
+// X64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (case name=b index=0 offset=0
+// X64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (field name=t offset=0
+// X64-NEXT:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:               (field name=_value offset=0
+// X64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// X64-NEXT:       (case name=a index=1 offset=0
+// X64-NEXT:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:           (field name=t offset=0
+// X64-NEXT:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:       (case name=c index=2 offset=0
+// X64-NEXT:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// X64-NEXT:   (case name=none index=1))
+
+// X32: FAIL
+
+// CHECK-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic81BOySiGSg
+// CHECK-NEXT: Demangled name: Swift.Optional<reflect_Enum_MultiPayload_generic8.B<Swift.Int>>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=some index=0
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic8.B
+// CHECK-NEXT:   (struct Swift.Int))
+// CHECK-NEXT: )
+
+reflect(enum: B<Int>?.none)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=none index=1)
+
+reflect(enum: B<Int>.a(S<Void>(t: ())))
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=1
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic8.S
+// CHECK-NEXT:     (tuple))
+// CHECK-NEXT: )
+
+
+reflect(enum: B<Int>.b(S<Int>(t: 17)))
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=0
+// CHECK-NEXT:   (bound_generic_struct reflect_Enum_MultiPayload_generic8.S
+// CHECK-NEXT:     (struct Swift.Int))
+// CHECK-NEXT: )
+
+reflect(enum: B<Int>.c(()))
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=c index=2
+// CHECK-NEXT:   (tuple)
+// CHECK-NEXT: )
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
+++ b/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SinglePayload_generic1
+// RUN: %target-codesign %t/reflect_Enum_SinglePayload_generic1
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SinglePayload_generic1 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+class ClassTypeA {}
+class ClassTypeB {}
+enum SimplePayload1<T>{
+case a
+case b(T)
+case c
+}
+
+reflect(enum: SimplePayload1<ClassTypeA>.b(ClassTypeA()))
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_SinglePayload_generic1.SimplePayload1
+// CHECK-NEXT:   (class reflect_Enum_SinglePayload_generic1.ClassTypeA))
+
+// MemoryLayout<SimplePayload1<ClassTypeA>> gives 8,8,8
+// So it is using the pointer for XIs
+// (Unlike MPEs, SPEs do not automatically use a tag just because they're generic)
+
+// CHECK: Type info:
+// X64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// X32-NEXT: FAIL XXX TODO XXX
+// CHECK-NEXT:   (case name=b index=0 offset=0
+// CHECK-NEXT:     (reference kind=strong refcounting=native))
+// CHECK-NEXT:   (case name=a index=1)
+// CHECK-NEXT:   (case name=c index=2))
+// CHECK-NEXT: Mangled name: $s35reflect_Enum_SinglePayload_generic114SimplePayload1OyAA10ClassTypeACG
+// CHECK-NEXT: Demangled name: reflect_Enum_SinglePayload_generic1.SimplePayload1<reflect_Enum_SinglePayload_generic1.ClassTypeA>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=b index=0
+// CHECK-NEXT: (class reflect_Enum_SinglePayload_generic1.ClassTypeA)
+// CHECK-NEXT: )
+
+reflect(enum: SimplePayload1<ClassTypeA>.a)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=a index=1)
+
+reflect(enum: SimplePayload1<ClassTypeA>.c)
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=c index=2)
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_nested.swift
+++ b/validation-test/Reflection/reflect_nested.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_nested
 // RUN: %target-codesign %t/reflect_nested
-// RUN: %target-run %target-swift-reflection-test %t/reflect_nested 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_nested 2>&1 | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
@@ -26,24 +26,14 @@ var obj = OuterGeneric.Inner.Innermost(x: 17, y: "hello")
 
 reflect(object: obj)
 
-// CHECK-64: Reflecting an object.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
-// CHECK-64-NEXT:   (struct Swift.String)
-// CHECK-64-NEXT:   (bound_generic_class reflect_nested.OuterGeneric.Inner
-// CHECK-64-NEXT:     (bound_generic_class reflect_nested.OuterGeneric
-// CHECK-64-NEXT:       (struct Swift.Int))))
+// CHECK: Reflecting an object.
+// CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK: Type reference:
+// CHECK: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
+// CHECK-NEXT:   (struct Swift.String)
+// CHECK-NEXT:   (bound_generic_class reflect_nested.OuterGeneric
+// CHECK-NEXT:     (struct Swift.Int)))
 
-// CHECK-32: Reflecting an object.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
-// CHECK-32-NEXT:   (struct Swift.String)
-// CHECK-32-NEXT:   (bound_generic_class reflect_nested.OuterGeneric.Inner
-// CHECK-32-NEXT:     (bound_generic_class reflect_nested.OuterGeneric
-// CHECK-32-NEXT:       (struct Swift.Int))))
-  
 class OuterNonGeneric {
   class InnerGeneric<T, U> {
     var x: T
@@ -59,24 +49,13 @@ class OuterNonGeneric {
 var obj2 = OuterNonGeneric.InnerGeneric(x: 17, y: "hello")
 reflect(object: obj2)
 
-// CHECK-64: Reflecting an object.
-// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
-// CHECK-64-NEXT:   (struct Swift.Int)
-// CHECK-64-NEXT:   (struct Swift.String)
-// CHECK-64-NEXT:     (bound_generic_class reflect_nested.OuterNonGeneric))
-
-// CHECK-32: Reflecting an object.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
-// CHECK-32-NEXT:   (struct Swift.Int)
-// CHECK-32-NEXT:   (struct Swift.String)
-// CHECK-32-NEXT:     (bound_generic_class reflect_nested.OuterNonGeneric))
+// CHECK: Reflecting an object.
+// CHECK: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK: Type reference:
+// CHECK: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT:   (struct Swift.String))
 
 doneReflecting()
 
-// CHECK-64: Done.
-
-// CHECK-32: Done.
+// CHECK: Done.

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -37,6 +37,10 @@ reflect(enum: Outer1.C<Void>.Inner.S<(Int,Int)>?.none)
 
 //CHECK: Type info:
 
+// This is the layout for 64-bit targets (Note, this example
+// has no pointer-based elements, so we don't need to distinguish
+// extra inhabitants for platforms with varying pointer layouts.)
+
 //X64-NEXT: (single_payload_enum size=19 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 //X64-NEXT:   (case name=some index=0 offset=0
 //X64-NEXT:     (struct size=18 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
@@ -60,7 +64,7 @@ reflect(enum: Outer1.C<Void>.Inner.S<(Int,Int)>?.none)
 //X64-NEXT:           (case name=none index=1)))))
 //X64-NEXT:   (case name=none index=1))
 
-//TODO:  X32
+//TODO:  Work out the layout for 32-bit targets
 
 //CHECK: Mangled name: $s22reflect_nested_generic6Outer1O1CC1SVy_yt_Si_SitGSg
 //CHECK-NEXT: Demangled name: Swift.Optional<reflect_nested_generic.Outer1.C<()>.S<(Swift.Int, Swift.Int)>>
@@ -78,6 +82,9 @@ struct Outer2 {
   enum E<T: P> {
     struct Inner {
       enum F<U: P> {
+        struct Innerer {
+	  var u: U? = nil
+	}
       case u(U)
       case a
       case b
@@ -96,7 +103,7 @@ reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
 //CHECK-NEXT:   (bound_generic_enum reflect_nested_generic.Outer2.E
 //CHECK-NEXT:     (struct reflect_nested_generic.S1)))
 
-// Note: layout here is correct for both 32- and 64-bit platforms
+// Note: layout here is same for both 32- and 64-bit platforms
 
 //CHECK: Type info:
 //CHECK-NEXT: (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
@@ -110,6 +117,37 @@ reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
 
 //CHECK: Enum value:
 //CHECK-NEXT: (enum_value name=b index=2)
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.Innerer?.none)
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+//CHECK-NEXT: Type reference:
+//CHECK-NEXT: (bound_generic_enum Swift.Optional
+//CHECK-NEXT:   (bound_generic_struct reflect_nested_generic.Outer2.E.Inner.F.Innerer
+//CHECK-NEXT:     (bound_generic_enum reflect_nested_generic.Outer2.E.Inner.F
+//CHECK-NEXT:       (struct reflect_nested_generic.S2)
+//CHECK-NEXT:       (bound_generic_enum reflect_nested_generic.Outer2.E
+//CHECK-NEXT:         (struct reflect_nested_generic.S1)))))
+
+// This layout is the same for 32-bit or 64-bit platforms
+
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=some index=0 offset=0
+//CHECK-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:       (field name=u offset=0
+//CHECK-NEXT:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:           (case name=some index=0 offset=0
+//CHECK-NEXT:             (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//CHECK-NEXT:           (case name=none index=1)))))
+//CHECK-NEXT:   (case name=none index=1))
+
+//CHECK-NEXT: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FO7InnererVy_AA2S1V_AA2S2V_GSg
+//CHECK-NEXT: Demangled name: Swift.Optional<reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>.Innerer<>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=none index=1)
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -1,0 +1,117 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_nested_generic
+// RUN: %target-codesign %t/reflect_nested_generic
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_nested_generic | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+enum Outer1 {
+  class C<T> {
+    enum Inner {
+      struct S<U> {
+	var u: U? = nil
+	var t: T? = nil
+      }
+    }
+  }
+}
+
+reflect(enum: Outer1.C<Void>.Inner.S<(Int,Int)>?.none)
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+//CHECK-NEXT: Type reference:
+//CHECK-NEXT: (bound_generic_enum Swift.Optional
+//CHECK-NEXT:   (bound_generic_struct reflect_nested_generic.Outer1.C.Inner.S
+//CHECK-NEXT:     (tuple
+//CHECK-NEXT:       (struct Swift.Int)
+//CHECK-NEXT:       (struct Swift.Int))
+//CHECK-NEXT:     (bound_generic_class reflect_nested_generic.Outer1.C
+//CHECK-NEXT:       (tuple))))
+
+//CHECK: Type info:
+
+//X64-NEXT: (single_payload_enum size=19 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:   (case name=some index=0 offset=0
+//X64-NEXT:     (struct size=18 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:       (field name=u offset=0
+//X64-NEXT:         (single_payload_enum size=17 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:           (case name=some index=0 offset=0
+//X64-NEXT:             (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:               (field offset=0
+//X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:                   (field name=_value offset=0
+//X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+//X64-NEXT:               (field offset=8
+//X64-NEXT:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:                   (field name=_value offset=0
+//X64-NEXT:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+//X64-NEXT:           (case name=none index=1)))
+//X64-NEXT:       (field name=t offset=17
+//X64-NEXT:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//X64-NEXT:           (case name=some index=0 offset=0
+//X64-NEXT:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//X64-NEXT:           (case name=none index=1)))))
+//X64-NEXT:   (case name=none index=1))
+
+//TODO:  X32
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer1O1CC1SVy_yt_Si_SitGSg
+//CHECK-NEXT: Demangled name: Swift.Optional<reflect_nested_generic.Outer1.C<()>.S<(Swift.Int, Swift.Int)>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=none index=1)
+
+
+protocol P {}
+
+struct S1: P { var a: Int; var b: Int }
+struct S2: P { }
+
+struct Outer2 {
+  enum E<T: P> {
+    struct Inner {
+      enum F<U: P> {
+      case u(U)
+      case a
+      case b
+      }
+    }
+  }
+}
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+//CHECK-NEXT: Type reference:
+//CHECK-NEXT: (bound_generic_enum reflect_nested_generic.Outer2.E.Inner.F
+//CHECK-NEXT:   (struct reflect_nested_generic.S2)
+//CHECK-NEXT:   (bound_generic_enum reflect_nested_generic.Outer2.E
+//CHECK-NEXT:     (struct reflect_nested_generic.S1)))
+
+// Note: layout here is correct for both 32- and 64-bit platforms
+
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=u index=0 offset=0
+//CHECK-NEXT:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//CHECK-NEXT:   (case name=a index=1)
+//CHECK-NEXT:   (case name=b index=2))
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S1V_AA2S2VG
+//CHECK-NEXT: Demangled name: reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=b index=2)
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -237,6 +237,29 @@ reflect(enum: Outer2.E<S2>.Inner.F<S3>??.none)
 //CHECK: Enum value:
 //CHECK-NEXT: (enum_value name=none index=1)
 
+struct S4: P { var a: Bool = true }
+
+reflect(enum: Outer2.E<S3>.Inner.F<S4>.b)
+
+//CHECK: Reflecting an enum.
+//CHECK: Type reference:
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=252 bitwise_takable=1
+//CHECK-NEXT:   (case name=u index=0 offset=0
+//CHECK-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
+//CHECK-NEXT:       (field name=a offset=0
+//CHECK-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
+//CHECK-NEXT:           (field name=_value offset=0
+//CHECK-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1))))))
+//CHECK-NEXT:   (case name=a index=1)
+//CHECK-NEXT:   (case name=b index=2))
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S3V_AA2S4VG
+//CHECK: Demangled name: reflect_nested_generic.Outer2.E<reflect_nested_generic.S3>.F<reflect_nested_generic.S4>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=b index=2)
+
 reflect(enum: Outer2.E<S1>.Inner.F<S2>.Innerer?.none)
 
 //CHECK: Reflecting an enum.

--- a/validation-test/Reflection/reflect_nested_generic.swift
+++ b/validation-test/Reflection/reflect_nested_generic.swift
@@ -93,7 +93,7 @@ struct Outer2 {
   }
 }
 
-reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.u(S2()))
 
 //CHECK: Reflecting an enum.
 //CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -116,7 +116,126 @@ reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
 //CHECK-NEXT: Demangled name: reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>
 
 //CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=u index=0
+//CHECK-NEXT:   (struct reflect_nested_generic.S2)
+//CHECK-NEXT: )
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.b)
+
+//CHECK: Reflecting an enum.
+//CHECK: Type info:
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S1V_AA2S2VG
+
+//CHECK: Enum value:
 //CHECK-NEXT: (enum_value name=b index=2)
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>.b as Outer2.E<S1>.Inner.F<S2>??)
+
+//CHECK: Reflecting an enum.
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=some index=0 offset=0
+//CHECK-NEXT:     (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:       (case name=some index=0 offset=0
+//CHECK-NEXT:         (single_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:           (case name=u index=0 offset=0
+//CHECK-NEXT:             (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+//CHECK-NEXT:           (case name=a index=1)
+//CHECK-NEXT:           (case name=b index=2)))
+//CHECK-NEXT:       (case name=none index=1)))
+//CHECK-NEXT:   (case name=none index=1))
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S1V_AA2S2VGSgSg
+//CHECK-NEXT: Demangled name: Swift.Optional<Swift.Optional<reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=some index=0
+//CHECK-NEXT: (bound_generic_enum Swift.Optional
+//CHECK-NEXT:   (bound_generic_enum reflect_nested_generic.Outer2.E.Inner.F
+//CHECK-NEXT:     (struct reflect_nested_generic.S2)
+//CHECK-NEXT:     (bound_generic_enum reflect_nested_generic.Outer2.E
+//CHECK-NEXT:       (struct reflect_nested_generic.S1))))
+//CHECK-NEXT: )
+
+reflect(enum: Outer2.E<S1>.Inner.F<S2>??.none)
+
+//CHECK: Reflecting an enum.
+//CHECK: Type info:
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S1V_AA2S2VGSgSg
+//CHECK: Demangled name: Swift.Optional<Swift.Optional<reflect_nested_generic.Outer2.E<reflect_nested_generic.S1>.F<reflect_nested_generic.S2>>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=none index=1)
+
+struct S3: P { var a: UInt8 = 0 }
+
+reflect(enum: Outer2.E<S2>.Inner.F<S3>.u(S3()))
+
+//CHECK: Reflecting an enum.
+//CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+
+//CHECK: Type reference:
+//CHECK-NEXT: (bound_generic_enum reflect_nested_generic.Outer2.E.Inner.F
+//CHECK-NEXT:   (struct reflect_nested_generic.S3)
+//CHECK-NEXT:   (bound_generic_enum reflect_nested_generic.Outer2.E
+//CHECK-NEXT:     (struct reflect_nested_generic.S2)))
+
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=u index=0 offset=0
+//CHECK-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:       (field name=a offset=0
+//CHECK-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:           (field name=_value offset=0
+//CHECK-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
+//CHECK-NEXT:   (case name=a index=1)
+//CHECK-NEXT:   (case name=b index=2))
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S2V_AA2S3VG
+//CHECK-NEXT: Demangled name: reflect_nested_generic.Outer2.E<reflect_nested_generic.S2>.F<reflect_nested_generic.S3>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=u index=0
+//CHECK-NEXT: (struct reflect_nested_generic.S3)
+//CHECK-NEXT: )
+
+
+reflect(enum: Outer2.E<S2>.Inner.F<S3>.b)
+
+//CHECK: Reflecting an enum.
+//CHECK: Type reference:
+//CHECK: Type info:
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S2V_AA2S3VG
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=b index=2)
+
+reflect(enum: Outer2.E<S2>.Inner.F<S3>??.none)
+
+//CHECK: Reflecting an enum.
+//CHECK: Type reference:
+//CHECK: Type info:
+//CHECK-NEXT: (single_payload_enum size=4 alignment=1 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:   (case name=some index=0 offset=0
+//CHECK-NEXT:     (single_payload_enum size=3 alignment=1 stride=3 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:       (case name=some index=0 offset=0
+//CHECK-NEXT:         (single_payload_enum size=2 alignment=1 stride=2 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:           (case name=u index=0 offset=0
+//CHECK-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:               (field name=a offset=0
+//CHECK-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+//CHECK-NEXT:                   (field name=_value offset=0
+//CHECK-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
+//CHECK-NEXT:           (case name=a index=1)
+//CHECK-NEXT:           (case name=b index=2)))
+//CHECK-NEXT:       (case name=none index=1)))
+//CHECK-NEXT:   (case name=none index=1))
+
+//CHECK: Mangled name: $s22reflect_nested_generic6Outer2V1EO1FOy_AA2S2V_AA2S3VGSgSg
+//CHECK: Demangled name: Swift.Optional<Swift.Optional<reflect_nested_generic.Outer2.E<reflect_nested_generic.S2>.F<reflect_nested_generic.S3>>>
+
+//CHECK: Enum value:
+//CHECK-NEXT: (enum_value name=none index=1)
 
 reflect(enum: Outer2.E<S1>.Inner.F<S2>.Innerer?.none)
 


### PR DESCRIPTION
**Explanation**: Implements support for enums that have a mix of zero-sized and generic payloads.  I believe this implements all of the outstanding cases for enum layouts in RemoteMirror.
**Risk**: Only affects RemoteMirror.  Replaces a core piece of the layout calculation for all enum types in RemoteMirror
**Reviewed**: @mikeash 
**Resolves**: rdar://106655244
**Original PR**: #64852 
**Tests**: Several new unit tests were added