### PR TITLE
[CodeComplete] Offer completion suggestions for default argument values inside the macro declaration + argument label inside `#externalMacro`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8871,6 +8871,10 @@ const ParamDecl *getParameterAt(ConcreteDeclRef declRef, unsigned index);
 /// nullptr if the source does not have a parameter list.
 const ParamDecl *getParameterAt(const ValueDecl *source, unsigned index);
 
+/// Retrieve parameter declaration from the given source at given index, or
+/// nullptr if the source does not have a parameter list.
+const ParamDecl *getParameterAt(const DeclContext *source, unsigned index);
+
 void simple_display(llvm::raw_ostream &out,
                     OptionSet<NominalTypeDecl::LookupDirectFlags> options);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8281,6 +8281,14 @@ const ParamDecl *swift::getParameterAt(const ValueDecl *source,
   return nullptr;
 }
 
+const ParamDecl *swift::getParameterAt(const DeclContext *source,
+                                       unsigned index) {
+  if (auto *params = getParameterList(const_cast<DeclContext *>(source))) {
+    return index < params->size() ? params->get(index) : nullptr;
+  }
+  return nullptr;
+}
+
 Type AbstractFunctionDecl::getMethodInterfaceType() const {
   assert(getDeclContext()->isTypeContext());
   auto Ty = getInterfaceType();

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3959,7 +3959,8 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
                                         fn.getAsRegularLocation(), Context);
       
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(curFn.getDecl())) {
-        auto *param = getParameterAt(afd, curFn.defaultArgIndex);
+        auto *param = getParameterAt(static_cast<ValueDecl *>(afd),
+                                     curFn.defaultArgIndex);
         if (param->hasDefaultExpr()) {
           auto dc = afd->getInnermostDeclContext();
           collectCaptures(param->getDefaultArgumentCaptureInfo(), dc);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -193,6 +193,13 @@ MacroDefinition MacroDefinitionRequest::evaluate(
     free(replacements);
   };
 
+  if (checkResult < 0 && ctx.CompletionCallback) {
+    // If the macro failed to check and we are in code completion mode, pretend
+    // it's an arbitrary macro. This allows us to get call argument completions
+    // inside `#externalMacro`.
+    checkResult = BridgedMacroDefinitionKind::BridgedExpandedMacro;
+  }
+
   if (checkResult < 0)
     return MacroDefinition::forInvalid();
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2366,13 +2366,8 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
         }
       }
     } else if (auto *defaultArg = dyn_cast<DefaultArgumentInitializer>(DC)) {
-      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(defaultArg->getParent())) {
-        auto *Param = AFD->getParameters()->get(defaultArg->getIndex());
-        (void)Param->getTypeCheckedDefaultExpr();
-        return false;
-      }
-      if (auto *SD = dyn_cast<SubscriptDecl>(defaultArg->getParent())) {
-        auto *Param = SD->getIndices()->get(defaultArg->getIndex());
+      if (const ParamDecl *Param =
+              getParameterAt(defaultArg->getParent(), defaultArg->getIndex())) {
         (void)Param->getTypeCheckedDefaultExpr();
         return false;
       }

--- a/test/IDE/complete_macro_declaration.swift
+++ b/test/IDE/complete_macro_declaration.swift
@@ -1,7 +1,22 @@
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 let globalVar = 1
 macro expect(file: Int = #^DEFAULT_ARG^#) = #externalMacro(module: "MyModule", type: "MyMacro")
-
 // DEFAULT_ARG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: globalVar[#Int#]; name=globalVar
+
+@freestanding(expression)
+macro externalMacro() = ##^EXTERNAL_MACRO^#
+// EXTERNAL_MACRO: Decl[Macro]/OtherModule[Swift]/IsSystem: externalMacro({#module: String#}, {#type: String#})[#T#]; name=externalMacro(module:type:)
+
+@freestanding(expression)
+macro externalMacroWithTrailing() = ##^EXTERNAL_MACRO_WITH_TRAILING?check=EXTERNAL_MACRO^#externalMacro
+
+@freestanding(expression)
+macro externalMacroCallPattern() = #externalMacro(#^EXTERNAL_MACRO_CALL_PATTERN^#)
+// EXTERNAL_MACRO_CALL_PATTERN: Pattern/None/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#module: String#}, {#type: String#}[')'][#Void#]; name=module:type:
+
+@freestanding(expression)
+macro externalMacroCallPattern() = #externalMacro(module: "MyModule", #^EXTERNAL_MACRO_TYPE_ARG_LABEL^#)
+// EXTERNAL_MACRO_TYPE_ARG_LABEL: Pattern/Local/Flair[ArgLabels]:     {#type: String#}[#String#]; name=type:

--- a/test/IDE/complete_macro_declaration.swift
+++ b/test/IDE/complete_macro_declaration.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+let globalVar = 1
+macro expect(file: Int = #^DEFAULT_ARG^#) = #externalMacro(module: "MyModule", type: "MyMacro")
+
+// DEFAULT_ARG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: globalVar[#Int#]; name=globalVar


### PR DESCRIPTION
We were not type checking the default argument initializer because `MacroDecl` is not an `AbstractFucntionDecl`. Add `MacroDecl` to the list of nodes we know how to get parameters from. 

Pretty much unrelated, but also a small change in the same test file: Continue checking a `#externalMacro` declaration in code completion mode even if the argument labels don’t match. This way we get completion results for `#externalMacro` argument labels and when competing after `#` when `externalMacro` is already specified.

rdar://108163564
rdar://108163809
rdar://108681394