### PR TITLE
[WebAssembly][Test] Disable some tests to make the CI green.

### DIFF
--- a/test/AutoDiff/e2e_optimizations.swift
+++ b/test/AutoDiff/e2e_optimizations.swift
@@ -1,5 +1,10 @@
 // RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
 // REQUIRES: swift_in_compiler
+
+// Checks for inlining depends on code-size but cow check adds some
+// amount of extra code
+// UNSUPPORTED: array_cow_checks
+
 import _Differentiation
 
 @_silgen_name("blackHole")

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
@@ -14,6 +14,8 @@
 
 // FIXME(distributed): Distributed actors currently have some issues on windows rdar://82593574
 // UNSUPPORTED: OS=windows-msvc
+// https://github.com/apple/swift/issues/65529
+// UNSUPPORTED: single_threaded_concurrency
 
 
 import Distributed

--- a/test/Runtime/concurrentTypeByName.swift
+++ b/test/Runtime/concurrentTypeByName.swift
@@ -3,6 +3,7 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: single_threaded_concurrency
 
 import StdlibUnittest
 import SwiftPrivateThreadExtras


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR disables two tests to make [the WebAssembly CI](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-20.04-webassembly/) green again.

1. [test/AutoDiff/e2e_optimizations.swift](https://github.com/apple/swift/commit/f224dbdc1bde1cb2f51bb4d7987aa8454c39ef06) assumes the most performant scenario but the CI now uses `array_cow_checks` conservatively, so just disabled it.
2. [test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift](https://github.com/apple/swift/commit/5f94468416e9ef76a088c9f6593395b0a8e76916) failed on cooperative global executor mode due to https://github.com/apple/swift/issues/65529. The test itself can be fixed by just removing `?` from `executorPreference` but let me keep it as is until the root issue will be fixed as a good signal.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
