### PR TITLE
[5.9] Fix RelBase indexing with composite types

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -878,6 +878,10 @@ private:
         auto AfterDollar = Loc.getAdvancedLoc(1);
         reportRef(Wrapped, AfterDollar, Info, None);
       }
+    } else if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
+      TypeLoc TL(TAD->getUnderlyingTypeRepr(), TAD->getUnderlyingType());
+      if (!reportRelatedTypeRef(TL, (SymbolRoleSet)SymbolRole::Reference, D, /*isImplicit=*/true, Loc))
+        return false;
     }
 
     return true;
@@ -962,7 +966,18 @@ private:
   bool startEntityDecl(ValueDecl *D);
 
   bool reportRelatedRef(ValueDecl *D, SourceLoc Loc, bool isImplicit, SymbolRoleSet Relations, Decl *Related);
-  bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related);
+
+  /// Report references for dependent types
+  ///
+  /// NOTE: If the dependent type is a typealias, report the underlying types as well.
+  ///
+  /// \param Ty The type being referenced.
+  /// \param Relations The relationship between the referenced type and the passed Decl.
+  /// \param Related The Decl that is referencing the type.
+  /// \param isImplicit Whether the reference is implicit, such as for a typealias' underlying type.
+  /// \param Loc The location of the reference, otherwise the location of the TypeLoc is used.
+  bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related,
+                            bool isImplicit=false, SourceLoc Loc={});
   bool reportInheritedTypeRefs(
       ArrayRef<InheritedEntry> Inherited, Decl *Inheritee);
   NominalTypeDecl *getTypeLocAsNominalTypeDecl(const TypeLoc &Ty);
@@ -1378,19 +1393,36 @@ bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<InheritedEntry> Inher
   return true;
 }
 
-bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related) {
-  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
-    SourceLoc IdLoc = declRefTR->getLoc();
+bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations,
+                                               Decl *Related, bool Implicit, SourceLoc Loc) {
+  if (auto *composite = llvm::dyn_cast_or_null<CompositionTypeRepr>(Ty.getTypeRepr())) {
+    SourceLoc IdLoc = Loc.isValid() ? Loc : composite->getSourceLoc();
+    for (auto *Type : composite->getTypes()) {
+      if (!reportRelatedTypeRef(Type, Relations, Related, /*isImplicit=*/Implicit, IdLoc))
+        return false;
+    }
+
+    return true;
+  } else if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
+    SourceLoc IdLoc = Loc.isValid() ? Loc : declRefTR->getLoc();
     NominalTypeDecl *NTD = nullptr;
-    bool isImplicit = false;
+    bool isImplicit = Implicit;
     if (auto *VD = declRefTR->getBoundDecl()) {
       if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
         IndexSymbol Info;
+        if (isImplicit)
+          Info.roles |= (unsigned)SymbolRole::Implicit;
         if (!reportRef(TAD, IdLoc, Info, None))
           return false;
         if (auto Ty = TAD->getUnderlyingType()) {
           NTD = Ty->getAnyNominal();
           isImplicit = true;
+        }
+
+        if (isa_and_nonnull<CompositionTypeRepr>(TAD->getUnderlyingTypeRepr())) {
+          TypeLoc TL(TAD->getUnderlyingTypeRepr(), TAD->getUnderlyingType());
+          if (!reportRelatedTypeRef(TL, Relations, Related, /*isImplicit=*/true, IdLoc))
+            return false;
         }
       } else {
         NTD = dyn_cast<NominalTypeDecl>(VD);

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -455,6 +455,13 @@
               key.usr: <usr>,
               key.line: 50,
               key.column: 19
+            },
+            {
+              key.kind: source.lang.swift.ref.class,
+              key.usr: <usr>,
+              key.line: 50,
+              key.column: 19,
+              key.is_implicit: 1
             }
           ],
           key.effective_access: source.decl.effective_access.internal


### PR DESCRIPTION
Previously the index data differed when using `Foo, Bar` vs `Foo & Bar`.

Fixes https://github.com/apple/swift/issues/56255

(cherry picked from commit 7a5e9dcf194df9c1c2c655cf29842408f5a7e4b2 / https://github.com/apple/swift/pull/64997)