### PR TITLE
reland: Fix RelBase indexing with composite types

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -962,7 +962,18 @@ private:
   bool startEntityDecl(ValueDecl *D);
 
   bool reportRelatedRef(ValueDecl *D, SourceLoc Loc, bool isImplicit, SymbolRoleSet Relations, Decl *Related);
-  bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related);
+
+  /// Report references for dependent types
+  ///
+  /// NOTE: If the dependent type is a typealias, report the underlying types as well.
+  ///
+  /// \param Ty The type being referenced.
+  /// \param Relations The relationship between the referenced type and the passed Decl.
+  /// \param Related The Decl that is referencing the type.
+  /// \param isImplicit Whether the reference is implicit, such as for a typealias' underlying type.
+  /// \param Loc The location of the reference, otherwise the location of the TypeLoc is used.
+  bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related,
+                            bool isImplicit=false, SourceLoc Loc={});
   bool reportInheritedTypeRefs(
       ArrayRef<InheritedEntry> Inherited, Decl *Inheritee);
   NominalTypeDecl *getTypeLocAsNominalTypeDecl(const TypeLoc &Ty);
@@ -1378,19 +1389,36 @@ bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<InheritedEntry> Inher
   return true;
 }
 
-bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related) {
-  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
-    SourceLoc IdLoc = declRefTR->getLoc();
+bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations,
+                                               Decl *Related, bool Implicit, SourceLoc Loc) {
+  if (auto *composite = llvm::dyn_cast_or_null<CompositionTypeRepr>(Ty.getTypeRepr())) {
+    SourceLoc IdLoc = Loc.isValid() ? Loc : composite->getSourceLoc();
+    for (auto *Type : composite->getTypes()) {
+      if (!reportRelatedTypeRef(Type, Relations, Related, /*isImplicit=*/Implicit, IdLoc))
+        return false;
+    }
+
+    return true;
+  } else if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
+    SourceLoc IdLoc = Loc.isValid() ? Loc : declRefTR->getLoc();
     NominalTypeDecl *NTD = nullptr;
-    bool isImplicit = false;
+    bool isImplicit = Implicit;
     if (auto *VD = declRefTR->getBoundDecl()) {
       if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
         IndexSymbol Info;
+        if (isImplicit)
+          Info.roles |= (unsigned)SymbolRole::Implicit;
         if (!reportRef(TAD, IdLoc, Info, None))
           return false;
         if (auto Ty = TAD->getUnderlyingType()) {
           NTD = Ty->getAnyNominal();
           isImplicit = true;
+        }
+
+        if (isa_and_nonnull<CompositionTypeRepr>(TAD->getUnderlyingTypeRepr())) {
+          TypeLoc TL(TAD->getUnderlyingTypeRepr(), TAD->getUnderlyingType());
+          if (!reportRelatedTypeRef(TL, Relations, Related, /*isImplicit=*/true, IdLoc))
+            return false;
         }
       } else {
         NTD = dyn_cast<NominalTypeDecl>(VD);

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -57,7 +57,7 @@ protocol P3 {
   func meth2() // CHECK: [[@LINE]]:8 | instance-method/Swift | meth2() | [[P3_meth2_USR:.*]] | Def
 }
 
-class BaseMultiConf {
+class BaseMultiConf { // CHECK: [[@LINE]]:7 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR:.*]] | Def
   func meth2() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | meth2() | [[BaseMultiConf_meth2_USR:.*]] | Def
 }
 extension SubMultiConf {
@@ -78,6 +78,49 @@ class SubMultiConf: BaseMultiConf,P2,P1,P3 { // CHECK: [[@LINE]]:7 | class/Swift
     // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
   // CHECK-NOT: [[@LINE-13]]:7 | instance-method
 }
+
+class CompositionType: BaseMultiConf & P1 { // CHECK: [[@LINE]]:7 | class/Swift | CompositionType | [[CompositionType_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:24 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,RelBase | rel: 1
+  // CHECK: [[@LINE-2]]:24 | protocol/Swift | P1 | [[P1_USR]] | Ref,RelBase | rel: 1
+  func foo() {}
+}
+
+typealias CompositionTypeAlias = BaseMultiConf & P1 // CHECK: [[@LINE]]:11 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:34 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:50 | protocol/Swift | P1 | [[P1_USR]] | Ref | rel: 0
+
+class CompositionTypeViaAlias: CompositionTypeAlias { // CHECK: [[@LINE]]:7 | class/Swift | CompositionTypeViaAlias | [[CompositionTypeViaAlias_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:32 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:32 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,Impl,RelBase | rel: 1
+  // CHECK: [[@LINE-3]]:32 | protocol/Swift | P1 | [[P1_USR]] | Ref,Impl,RelBase | rel: 1
+  func foo() {}
+}
+
+typealias NestedCompositionTypeAlias = CompositionTypeAlias & P2 // CHECK: [[@LINE]]:11 | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:40 | type-alias/Swift | CompositionTypeAlias | [[CompositionTypeAlias_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:63 | protocol/Swift | P2 | [[P2_USR]] | Ref | rel: 0
+
+class CompositionViaNestedAlias: NestedCompositionTypeAlias { // CHECK: [[@LINE]]:7 | class/Swift | CompositionViaNestedAlias | [[CompositionViaNestedAlias_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:34 | type-alias/Swift | NestedCompositionTypeAlias | [[NestedCompositionTypeAlias_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:34 | class/Swift | BaseMultiConf | [[BaseMultiConf_USR]] | Ref,Impl,RelBase | rel: 1
+  // CHECK: [[@LINE-3]]:34 | protocol/Swift | P1 | [[P1_USR]] | Ref,Impl,RelBase | rel: 1
+  // CHECK: [[@LINE-4]]:34 | protocol/Swift | P2 | [[P2_USR]] | Ref,Impl,RelBase | rel: 1
+  func foo() {}
+}
+
+typealias ProtocolsOnly = P1 & P2 // CHECK: [[@LINE]]:11 | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR:.*]] | Def
+  // CHECK: [[@LINE-1]]:27 | protocol/Swift | P1 | [[P1_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:32 | protocol/Swift | P2 | [[P2_USR]] | Ref | rel: 0
+
+class NoInherited {} // CHECK: [[@LINE]]:7 | class/Swift | NoInherited | [[NoInherited_USR:.*]] | Def
+extension NoInherited: ProtocolsOnly { // CHECK: [[@LINE]]:11 | class/Swift | NoInherited | [[NoInherited_USR:.*]] | Ref
+  // CHECK: [[@LINE-1]]:24 | type-alias/Swift | ProtocolsOnly | [[ProtocolsOnly_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:24 | protocol/Swift | P1 | [[P1_USR]] | Ref,Impl,RelBase | rel: 1
+  // CHECK: [[@LINE-3]]:24 | protocol/Swift | P2 | [[P2_USR]] | Ref,Impl,RelBase | rel: 1
+  func foo() {}
+}
+
+struct WithCodable: Codable {} // CHECK: [[@LINE]]:21 | type-alias/Swift | Codable | [[Codable_USR:.*]] | Ref | rel: 0
 
 protocol InheritingP: P1 { // CHECK: [[@LINE]]:10 | protocol/Swift | InheritingP | [[InheritingP_USR:.*]] | Def
   func foo() // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2

--- a/test/Index/multifile.swift
+++ b/test/Index/multifile.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Validate that we're not looking into typealises across files / modules which leads to an assertion
+
+// RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %t/file2.swift %t/file1.swift -verify
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/file2.swift %t/file1.swift > %t/output.txt
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/file1.swift %t/file2.swift >> %t/output.txt
+// RUN: %FileCheck %s < %t/output.txt
+
+//--- file1.swift
+
+typealias Bar = [Int] // CHECK: 2:11 | type-alias/Swift | Bar | [[Bar_USR:.*]] | Def | rel: 0
+
+//--- file2.swift
+
+func foo() -> Bar { [] } // CHECK: 2:15 | type-alias/Swift | Bar | [[Bar_USR]] | Ref,RelCont | rel: 1
+extension Optional where Wrapped == Bar {} // CHECK: 3:37 | type-alias/Swift | Bar | [[Bar_USR]] | Ref | rel: 0


### PR DESCRIPTION
This removes the `visitDeclReference` changes from the first change. This means that nested typealiases are no longer expanded in the index as references, except in the case they are inherited from a type. This also adds a test covering the crash that snuck through

This reverts commit 5e2c7a9d476c625ba18970212981a13c9d298c63.