### PR TITLE
Remove a stateful workaround for Property Wrappers.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6283,6 +6283,15 @@ public:
       // inherit the sourrounding scope in IRGenSIL.
       if (SI.getLoc().getKind() == SILLocation::MandatoryInlinedKind)
         continue;
+      // FIXME: There are situations where the execution legitimately goes
+      //        backwards, such as
+      //
+      //            while case let w: String? = Optional.some("b") {}
+      //
+      //        where the RHS of the assignment gets run first and then the
+      //        result is copied into the LHS.
+      if (!llvm::isa<BeginBorrowInst>(&SI) || !llvm::isa<CopyValueInst>(&SI))
+        continue;
 
       // If we haven't seen this debug scope yet, update the
       // map and go on.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -370,20 +370,9 @@ SILGenFunction::getOrCreateScope(const ast_scope::ASTScopeImpl *ASTScope,
   // Decide whether to pick a parent scope instead.
   if (ASTScope->ignoreInDebugInfo()) {
     LLVM_DEBUG(llvm::dbgs() << "ignored\n");
-    // FIXME: it would be more deterministic to use
-    //        getOrCreateScope(ASTScope->getParent().getPtrOrNull());
-    //        here. Unfortunately property wrappers rearrange AST
-    //        nodes without marking them as implicit, e.g.:
-    //
-    //           @Wrapper(a) var v = b
-    //        ->
-    //           let _tmp = Constructor(a, b); var v = _tmp
-    //
-    //        Since the arguments to Constructor aren't marked as implicit,
-    //        argument b is in the scope of v, but the call to Constructor
-    //        isn't, which correctly triggers the scope hole verifier.
-    auto *CurScope = B.getCurrentDebugScope();
-    return CurScope->InlinedCallSite != InlinedAt ? FnScope : CurScope;
+    auto *ParentScope = getOrCreateScope(ASTScope->getParent().getPtrOrNull(),
+                                         FnScope, InlinedAt);
+    return ParentScope->InlinedCallSite != InlinedAt ? FnScope : ParentScope;
   }
 
   // Collapse BraceStmtScopes whose parent is a .*BodyScope.

--- a/test/DebugInfo/guard-let-scope3.swift
+++ b/test/DebugInfo/guard-let-scope3.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -g -emit-sil %s -parse-as-library -module-name a | %FileCheck %s
+public class C {}
+public enum MyError : Error {
+  init() { self.init() }
+}
+public class S {
+  private var c = [Int : C?]()
+  public func f(_ i: Int) throws  -> C {
+    guard let x = c[i], let x else {
+    // CHECK: sil_scope [[X1:[0-9]+]] { loc "{{.*}}":[[@LINE-1]]:5
+    // CHECK: sil_scope [[X2:[0-9]+]] { loc "{{.*}}":[[@LINE-2]]:29
+    // CHECK: debug_value {{.*}} : $Optional<C>, let, name "x", {{.*}}, scope [[X1]]
+    // CHECK: debug_value %29 : $C, let, name "x", {{.*}}, scope [[X2]]
+    // CHECK-NEXT:  scope [[X2]]
+      throw MyError()
+    }
+    return x
+  }
+}


### PR DESCRIPTION
In an earlier version of the ASTScope -> SILdebugScope translation a wrokaround was put into place that would select the current debug scope if an ASTScope was marked as ignoreInDebugInfo. Removing this workaround makes the translation more predictable as it eliminated the dependency on the current SILBuilder state. The result builder tests still pass without this.

rdar://108736443
