### PR TITLE
[CSBindings] NFC: Diagnose leading-dot inference failure when base type is…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2257,6 +2257,13 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     }
   }
 
+  if (srcLocator->isLastElement<LocatorPathElt::MemberRefBase>()) {
+    auto *baseExpr = castToExpr<UnresolvedMemberExpr>(srcLocator->getAnchor());
+    ConstraintFix *fix = SpecifyBaseTypeForContextualMember::create(
+        cs, baseExpr->getName(), srcLocator);
+    return std::make_pair(fix, defaultImpact);
+  }
+
   return None;
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6185,20 +6185,9 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::UnresolvedMemberChainResult: {
-    // Ignore this mismatch if result is already a hole.
-    if (rhs->isPlaceholder())
+    // Ignore this mismatch if base or result is already a hole.
+    if (lhs->isPlaceholder() || rhs->isPlaceholder())
       return true;
-
-    // The base is a placeholder, let's report an unknown base issue.
-    if (lhs->isPlaceholder()) {
-      auto *baseExpr =
-          castToExpr<UnresolvedMemberChainResultExpr>(anchor)->getChainBase();
-
-      auto *fix = SpecifyBaseTypeForContextualMember::create(
-          *this, baseExpr->getName(), getConstraintLocator(locator));
-      conversionsOrFixes.push_back(fix);
-      break;
-    }
 
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))


### PR DESCRIPTION
… attempted as placeholder

Diagnose base inference failure only if base gets inferred to be a placeholder, 
any transitive placeholder inference points to the problem being elsewhere.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
