### PR TITLE
[5.9] IRGen: Only use clang protocol emission on newer deployment targets

### DIFF
--- a/test/Concurrency/objc_async_protocol_irgen.swift
+++ b/test/Concurrency/objc_async_protocol_irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -import-objc-header %S/Inputs/Delegate.h %s -emit-ir -o - | %FileCheck %s -DALIGNMENT=%target-alignment --check-prefix=CHECK-%is-darwin
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -target %target-swift-abi-5.8-triple -import-objc-header %S/Inputs/Delegate.h %s -emit-ir -o - | %FileCheck %s -DALIGNMENT=%target-alignment --check-prefix=CHECK-%is-darwin
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-os
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module -target %target-swift-abi-5.8-triple | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-os
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module > %t/out.ir
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -target %target-swift-abi-5.8-triple > %t/out.ir
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -target %target-swift-abi-5.7-triple > %t/out.old.ir
 // RUN: %FileCheck --input-file=%t/out.ir %s --check-prefix=CHECK --check-prefix=CHECK-%target-os
+// RUN: %FileCheck --input-file=%t/out.old.ir %s --check-prefix=CHECK-OLD --check-prefix=CHECK-%target-os-OLD
 
 // REQUIRES: PTRSIZE=64
 // REQUIRES: objc_interop
@@ -123,6 +125,8 @@ class ImplementingClass : InheritingProtocol { }
 
 // CHECK-linux: @_PROTOCOL_PROTOCOLS_NSDoubleInheritedFunging = weak hidden constant{{.*}}i64 2{{.*}} @_PROTOCOL_NSFungingAndRuncing {{.*}}@_PROTOCOL_NSFunging
 // CHECK-macosx: @"_OBJC_$_PROTOCOL_REFS_NSDoubleInheritedFunging" = internal global{{.*}}i64 2{{.*}} @"_OBJC_PROTOCOL_$_NSFungingAndRuncing"{{.*}} @"_OBJC_PROTOCOL_$_NSFunging"
+// CHECK-linux-OLD: @_PROTOCOL_PROTOCOLS_NSDoubleInheritedFunging = weak hidden constant{{.*}}i64 2{{.*}} @_PROTOCOL_NSFungingAndRuncing {{.*}}@_PROTOCOL_NSFunging
+// CHECK-macosx-OLD: @_PROTOCOL_PROTOCOLS_NSDoubleInheritedFunging = weak hidden constant{{.*}} @_PROTOCOL_NSFungingAndRuncing
 
 // -- Force generation of witness for Zim.
 // CHECK: define hidden swiftcc { %objc_object*, i8** } @"$s14objc_protocols22mixed_heritage_erasure{{[_0-9a-zA-Z]*}}F"
@@ -132,6 +136,7 @@ func mixed_heritage_erasure(_ x: Zim) -> Frungible {
   // CHECK: insertvalue { %objc_object*, i8** } [[T0]], i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* [[ZIM_FRUNGIBLE_WITNESS]], i32 0, i32 0), 1
 }
 
+// CHECK-OLD-LABEL: define hidden swiftcc void @"$s14objc_protocols0A8_generic{{[_0-9a-zA-Z]*}}F"(%objc_object* %0, %swift.type* %T) {{.*}} {
 // CHECK-LABEL: define hidden swiftcc void @"$s14objc_protocols0A8_generic{{[_0-9a-zA-Z]*}}F"(%objc_object* %0, %swift.type* %T) {{.*}} {
 func objc_generic<T : NSRuncing>(_ x: T) {
   x.runce()

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s -check-prefix=CHECK-%target-os
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module -target %target-swift-abi-5.8-triple | %FileCheck %s -check-prefix=CHECK-%target-os
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/validation-test/IRGen/issue-49393.swift
+++ b/validation-test/IRGen/issue-49393.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -module-name M -import-objc-header %S/Inputs/issue-49393.h | %FileCheck %s --check-prefix=CHECK-%is-darwin --check-prefix=CHECK
+// RUN: %target-swift-frontend -target %target-swift-abi-5.8-triple -emit-ir %s -module-name M -import-objc-header %S/Inputs/issue-49393.h | %FileCheck %s --check-prefix=CHECK-%is-darwin --check-prefix=CHECK
 // REQUIRES: objc_interop
 
 // https://github.com/apple/swift/issues/49393


### PR DESCRIPTION
We started using clang to emit the _OBJC_PROTOCOL_ definition.

But we would use a different name for the proto_list definition than clang.

"OBJC_LABEL_PROTOCOL$" (objc)
|--> OBJC_PROTOCOL
"\01l_OBJC_LABEL_PROTOCOL$_" (swift)
|--> OBJC_PROTOCOL

If an Objective C object also emitted the same protocol definition you could end up in a situation where both clang's and swift's proto_list definitions point to the same protocol definition.

Older linkers don't like that.

main PR: #65549

Risk: Should be quite low, were are restoring behavior that the compiler had pre 5.8 dependent on the deployment target

rdar://108505376