### PR TITLE
ASTMangler: Fix mangling of SILFunctionType with @pack conventions [5.9]

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1097,9 +1097,9 @@ static char getParamConvention(ParameterConvention conv) {
     case ParameterConvention::Direct_Owned: return 'x';
     case ParameterConvention::Direct_Unowned: return 'y';
     case ParameterConvention::Direct_Guaranteed: return 'g';
-    case ParameterConvention::Pack_Owned: return 'x';
-    case ParameterConvention::Pack_Inout: return 'y';
-    case ParameterConvention::Pack_Guaranteed: return 'g';
+    case ParameterConvention::Pack_Owned: return 'v';
+    case ParameterConvention::Pack_Inout: return 'm';
+    case ParameterConvention::Pack_Guaranteed: return 'p';
   }
   llvm_unreachable("bad parameter convention");
 }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2068,7 +2068,7 @@ NodePointer Demangler::demangleImplParamConvention(Node::Kind ConvKind) {
     case 'y': attr = "@unowned"; break;
     case 'v': attr = "@pack_owned"; break;
     case 'p': attr = "@pack_guaranteed"; break;
-    case 'm': attr = "@pack_guaranteed"; break;
+    case 'm': attr = "@pack_inout"; break;
     default:
       pushBack();
       return nullptr;

--- a/test/DebugInfo/variadic-generics-closure.swift
+++ b/test/DebugInfo/variadic-generics-closure.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -emit-ir %s -g | %FileCheck %s
+
+// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_QSiIgp_D", {{.*}})
+public func f<each Input>(builder: (repeat each Input) -> ()) {}

--- a/test/SILGen/variadic-generic-reabstraction.swift
+++ b/test/SILGen/variadic-generic-reabstraction.swift
@@ -53,13 +53,13 @@ func forwardAndReabstractFunctionPack<each T>(functions: repeat (each T) -> Bool
 
 // CHECK-LABEL: sil{{.*}} @$s4main22passConcreteToVariadic2fnyS2i_SStXE_tF :
 // CHECK:         [[COPY:%.*]] = copy_value %0 : $@noescape @callee_guaranteed (Int, @guaranteed String) -> Int
-// CHECK:         [[THUNK:%.*]] = function_ref @$sSiSSSiIgygd_Si_SSQSiSiIeggd_TR
+// CHECK:         [[THUNK:%.*]] = function_ref @$sSiSSSiIgygd_Si_SSQSiSiIegpd_TR
 // CHECK:         partial_apply [callee_guaranteed] [[THUNK]]([[COPY]])
 func passConcreteToVariadic(fn: (Int, String) -> Int) {
   takesVariadicFunction(function: fn)
 }
 
-// CHECK-LABEL: sil{{.*}} @$sSiSSSiIgygd_Si_SSQSiSiIeggd_TR :
+// CHECK-LABEL: sil{{.*}} @$sSiSSSiIgygd_Si_SSQSiSiIegpd_TR :
 // CHECK:       bb0(%0 : $*Pack{Int, String}, %1 : @guaranteed $@noescape @callee_guaranteed (Int, @guaranteed String) -> Int):
 // CHECK-NEXT:    [[INT_INDEX:%.*]] = scalar_pack_index 0 of $Pack{Int, String}
 // CHECK-NEXT:    [[INT_ADDR:%.*]] = pack_element_get [[INT_INDEX]] of %0 : $*Pack{Int, String}
@@ -74,7 +74,7 @@ func passConcreteToVariadic(fn: (Int, String) -> Int) {
 //   FIXME: we aren't preserving that the argument is owned
 // CHECK-LABEL: sil{{.*}} @$s4main27passConcreteToOwnedVariadic2fnyS2i_SStXE_tF :
 // CHECK:         [[COPY:%.*]] = copy_value %0 : $@noescape @callee_guaranteed (Int, @guaranteed String) -> Int
-// CHECK:         [[THUNK:%.*]] = function_ref @$sSiSSSiIgygd_Si_SSQSiSiIeggd_TR
+// CHECK:         [[THUNK:%.*]] = function_ref @$sSiSSSiIgygd_Si_SSQSiSiIegpd_TR
 // CHECK:         partial_apply [callee_guaranteed] [[THUNK]]([[COPY]])
 func passConcreteToOwnedVariadic(fn: (Int, String) -> Int) {
   takesVariadicOwnedFunction(function: fn)


### PR DESCRIPTION
* Description: We incorrectly mangled SILFunctionTypes, which only appear in debug info. The symptom was an assertion failure in demangling.
* Risk: Low, changes the mangling for variadic generics only
* Reviewed by: @hborla 
* Radar: rdar://problem/107151125.
* Tested: Added a test case.
