### PR TITLE
Revert "[SwiftSyntax] Verify swift-syntax code gen"

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -80,16 +80,6 @@ class SwiftSyntax(product.Product):
         return True
 
     def build(self, host_target):
-        if self.args.swiftsyntax_verify_generated_files:
-            build_cmd = [
-                os.path.join(self.source_dir, 'build-script.py'),
-                'verify-source-code',
-                '--toolchain', self.install_toolchain_path(host_target)
-            ]
-            if self.args.verbose_build:
-                build_cmd.append('--verbose')
-            shell.call(build_cmd)
-
         self.run_swiftsyntax_build_script(target=host_target,
                                           command='build')
 


### PR DESCRIPTION
This is causing failures on Linux nodes, e.g. https://ci.swift.org/job/oss-swift-RA-linux-ubuntu-18_04-long-test/3820/console

Reverts apple/swift#65439