### PR TITLE
[SILVerifier] Turn up load_borrow tracing.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2293,7 +2293,13 @@ public:
     requireSameType(LBI->getOperand()->getType().getObjectType(),
                     LBI->getType(),
                     "Load operand type and result type mismatch");
-    require(loadBorrowImmutabilityAnalysis.isImmutable(LBI),
+    auto immutable = loadBorrowImmutabilityAnalysis.isImmutable(LBI);
+    if (!immutable) {
+      llvm::errs()
+          << "Found load_borrow invalidated by local write in function:\n";
+      F.dump();
+    }
+    require(immutable,
             "Found load borrow that is invalidated by a local write?!");
   }
 

--- a/test/SIL/OwnershipVerifier/load_borrow_verify_errors.sil
+++ b/test/SIL/OwnershipVerifier/load_borrow_verify_errors.sil
@@ -100,3 +100,15 @@ bb0(%0 : $*MyArray<MyStruct>):
   return %t : $()
 }
 
+// CHECK: Found load_borrow invalidated by local write in function:
+// CHECK: sil [ossa] @test_verbose_error : $@convention(thin) (Builtin.Int32, @in Klass) -> () {
+sil [ossa] @test_verbose_error : $@convention(thin) (Builtin.Int32, @in Klass) -> () {
+entry(%int : $Builtin.Int32, %addr : $*Klass):
+  %val = load_borrow %addr : $*Klass
+  %val2 = load [take] %addr : $*Klass
+  store %val2 to [init] %addr : $*Klass
+  end_borrow %val : $Klass
+  destroy_addr %addr : $*Klass
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
There are a couple of reports of encountering this particular verification error (write to an address within the scope of a load_borrow).  Until it can be consistently encountered, print out a bit more info about this particular failure to aid with triggering the issue.
