### PR TITLE
[5.9] [Macros] Mangle attached macros for accessors

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4062,7 +4062,42 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
   // dependencies.
   const Decl *attachedTo = decl;
   DeclBaseName attachedToName;
-  if (auto valueDecl = dyn_cast<ValueDecl>(decl)) {
+  if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
+    auto storage = accessor->getStorage();
+    appendContextOf(storage);
+
+    // Introduce an identifier mangling that includes var/subscript, accessor
+    // kind, and static.
+    // FIXME: THIS IS A HACK. We need something different.
+    {
+      llvm::SmallString<16> name;
+      {
+        llvm::raw_svector_ostream out(name);
+        out << storage->getName().getBaseName().userFacingName()
+            << "__";
+        if (isa<VarDecl>(storage)) {
+          out << "v";
+        } else {
+          assert(isa<SubscriptDecl>(storage));
+          out << "i";
+        }
+
+        out << getCodeForAccessorKind(accessor->getAccessorKind());
+        if (storage->isStatic())
+          out << "Z";
+      }
+
+      attachedToName = decl->getASTContext().getIdentifier(name);
+    }
+
+    appendDeclName(storage, attachedToName);
+
+    // For member attribute macros, the attribute is attached to the enclosing
+    // declaration.
+    if (role == MacroRole::MemberAttribute) {
+      attachedTo = storage->getDeclContext()->getAsDecl();
+    }
+  } else if (auto valueDecl = dyn_cast<ValueDecl>(decl)) {
     appendContextOf(valueDecl);
 
     // Mangle the name, replacing special names with their user-facing names.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10529,6 +10529,9 @@ DeclContext *
 MacroDiscriminatorContext::getInnermostMacroContext(DeclContext *dc) {
   switch (dc->getContextKind()) {
   case DeclContextKind::SubscriptDecl:
+    // For a subscript, return its parent context.
+    return getInnermostMacroContext(dc->getParent());
+
   case DeclContextKind::EnumElementDecl:
   case DeclContextKind::AbstractFunctionDecl:
   case DeclContextKind::SerializedLocal:

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -111,3 +111,15 @@ struct OldStorage {
 // The deprecation warning below comes from the deprecation attribute
 // introduced by @wrapStoredProperties on OldStorage.
 _ = OldStorage(x: 5).x   // expected-warning{{'x' is deprecated: hands off my data}}
+
+@wrapStoredProperties(#"available(*, deprecated, message: "hands off my data")"#)
+class C2: P {
+  var x: Int = 0
+  var y: Int = 0
+
+  var squareOfLength: Int {
+    return x*x + y*y // expected-warning 4{{hands off my data}}
+  }
+
+  var blah: Int { squareOfLength }
+}


### PR DESCRIPTION
* Explanation: Attached macro mangles for accessors were using a fallback case that triggers an assertion in +Asserts builds, and conflicting manglings is non-Asserts builds. Provide a custom mangling for these cases that's embedded in the identifier.
* Scope: Narrow; affects code using macros on accessors.
* Risk: Low, no effect in code that doesn't use macros.
* Reviewed by: @jckarter 
* Issue: rdar://108766291
* Original pull request: https://github.com/apple/swift/pull/65559