### PR TITLE
[SemanticARCOpts] Check uses in moved load range.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.h
@@ -109,6 +109,10 @@ public:
 
   ArrayRef<Operand *> getDestroyingUses() const { return destroyingUses; }
 
+  ArrayRef<Operand *> getUnknownConsumingUses() const {
+    return unknownConsumingUses;
+  }
+
 private:
   struct OperandToUser;
 

--- a/test/SILOptimizer/semantic-arc-opts-loadcopy-to-loadborrow.sil
+++ b/test/SILOptimizer/semantic-arc-opts-loadcopy-to-loadborrow.sil
@@ -1601,3 +1601,39 @@ bb0:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil [ossa] @load_take_between_load_copy_and_move_inout : {{.*}} {
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'load_take_between_load_copy_and_move_inout'
+sil [ossa] @load_take_between_load_copy_and_move_inout : $@convention(thin) (@inout C) -> () {
+entry(%addr : $*C):
+    %v1 = load [copy] %addr : $*C
+    %v2 = load [take] %addr : $*C
+    %m1 = move_value [lexical] %v1 : $C
+    destroy_value %m1 : $C
+    store %v2 to [init] %addr : $*C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @load_take_between_load_copy_and_move_stack : {{.*}} {
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'load_take_between_load_copy_and_move_stack'
+sil [ossa] @load_take_between_load_copy_and_move_stack : $@convention(thin) () -> () {
+entry:
+    %addr = alloc_stack $C
+    %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+    %stored = apply %getC() : $@convention(thin) () -> (@owned C)
+    store %stored to [init] %addr : $*C
+
+    %v1 = load [copy] %addr : $*C
+    %v2 = load [take] %addr : $*C
+    %m1 = move_value [lexical] %v1 : $C
+    destroy_value %m1 : $C
+    store %v2 to [init] %addr : $*C
+
+    destroy_addr %addr : $*C
+    dealloc_stack %addr : $*C
+    %retval = tuple ()
+    return %retval : $()
+}


### PR DESCRIPTION
In https://github.com/apple/swift/pull/65417 , support for promoting moved-from `load [copy]`s was added.  At that time, the existing logic was generalized so that the check for whether writes the loaded-from address occurred: rather than checking whether the writes occurred in the live-range of the `load [copy]`, it was generalized to check whether writes occurred in the live range of the "original" value which was either the `load [copy]` or the `move_value`.  That opened a hole for writes that occurred between the `load [copy]` and the `move_value`:

```
%v = load [copy] %a
%u = load [take] %a
%m = move_value %v
```

Here, this is fixed by checking both the live-range of the "original" and also (supposing the original is different from the `load [copy]`) also the live range of the `load [copy]`.

This required changing the list of consuming uses passed to the `LinearLifetimeChecker::usesNotContainedWithinLifetime` to include not just the `destroy_value`s but also the "unknown" consuming uses (i.e. those that are not forwarding).

This change only affects arguments (and specifically only `@inout` arguments since promotion for `@in` arguments isn't supported) because a totally different code path is followed for `alloc_stack`s which regards `load [take]`s as an "init" of the address (concretely, `getSingleInitAllocStackUse` returns `truea for the above example if `%a` is an `alloc_stack`).

rdar://108745323
