### PR TITLE
[interop] lookup FRT retain/release functions in top level module

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6761,8 +6761,10 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
     return {CustomRefCountingOperationResult::immortal, nullptr, name};
 
   llvm::SmallVector<ValueDecl *, 1> results;
-  auto parentModule = ctx.getClangModuleLoader()->getWrapperForModule(
-      swiftDecl->getClangDecl()->getOwningModule());
+  auto *clangMod = swiftDecl->getClangDecl()->getOwningModule();
+  if (clangMod && clangMod->isSubModule())
+    clangMod = clangMod->getTopLevelModule();
+  auto parentModule = ctx.getClangModuleLoader()->getWrapperForModule(clangMod);
   ctx.lookupInModule(parentModule, name, results);
 
   if (results.size() == 1)

--- a/test/Interop/Cxx/foreign-reference/submodule-lookup-retain-release.swift
+++ b/test/Interop/Cxx/foreign-reference/submodule-lookup-retain-release.swift
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop -disable-availability-checking 2>&1
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+    
+    module sub {
+        header "subtest.h"
+
+        export *
+    }
+    
+    export *
+}
+
+//--- Inputs/test.h
+// empty file
+
+//--- Inputs/subtest.h
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:retainFn")))
+    __attribute__((swift_attr("release:releaseFn")))
+RefCounted {
+    static RefCounted *create();
+};
+
+void retainFn(RefCounted *);
+void releaseFn(RefCounted *);
+
+//--- test.swift
+
+import Test
+
+let x = RefCounted.create()


### PR DESCRIPTION
Lookups in submodules do not work and are explicitly ignored in the clang importer
