### PR TITLE
Revert #64269

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -320,9 +320,6 @@ struct PrintOptions {
   /// for class layout
   bool PrintClassLayoutName = false;
 
-  /// Replace @freestanding(expression) with @expression.
-  bool SuppressingFreestandingExpression = false;
-
   /// Suppress emitting @available(*, noasync)
   bool SuppressNoAsyncAvailabilityAttr = false;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -95,7 +95,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync",
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
 LANGUAGE_FEATURE(BuiltinIntLiteralAccessors, 368, "Builtin.IntLiteral accessors", true)
 LANGUAGE_FEATURE(Macros, 0, "Macros", hasSwiftSwiftParser)
-SUPPRESSIBLE_LANGUAGE_FEATURE(
+LANGUAGE_FEATURE(
     FreestandingExpressionMacros, 382, "Expression macros",
         hasSwiftSwiftParser)
 LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", hasSwiftSwiftParser)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3341,14 +3341,6 @@ static bool usesFeatureFreestandingExpressionMacros(Decl *decl) {
 }
 
 static void
-suppressingFeatureFreestandingExpressionMacros(PrintOptions &options,
-                                        llvm::function_ref<void()> action) {
-  llvm::SaveAndRestore<PrintOptions> originalOptions(options);
-  options.SuppressingFreestandingExpression = true;
-  action();
-}
-
-static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {
   llvm::SaveAndRestore<PrintOptions> originalOptions(options);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1356,14 +1356,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DAK_MacroRole: {
     auto Attr = cast<MacroRoleAttr>(this);
-
-    if (Options.SuppressingFreestandingExpression &&
-        Attr->getMacroSyntax() == MacroSyntax::Freestanding &&
-        Attr->getMacroRole() == MacroRole::Expression) {
-      Printer.printAttrName("@expression");
-      break;
-    }
-
     switch (Attr->getMacroSyntax()) {
     case MacroSyntax::Freestanding:
       Printer.printAttrName("@freestanding");

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -5,7 +5,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -module-name Macros -emit-module-interface-path %t/Macros.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t/Macros.swiftinterface) -module-name Macros %s
 // RUN: %FileCheck %s < %t/Macros.swiftinterface --check-prefix CHECK
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Macros.swiftinterface -o %t/Macros.swiftmodule
 
@@ -14,6 +14,9 @@
 // CHECK-NEXT: #endif
 @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
 
+// CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
+// CHECK: @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+// CHECK-NEXT: #endif
 @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: String) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -9,26 +9,20 @@
 // RUN: %FileCheck %s < %t/Macros.swiftinterface --check-prefix CHECK
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Macros.swiftinterface -o %t/Macros.swiftmodule
 
-// CHECK: #if compiler(>=5.3) && $Macros
-// CHECK-NEXT: #if $FreestandingExpressionMacros
+// CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
 // CHECK-NEXT: @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
-// CHECK-NEXT: #else
-// CHECK-NEXT: @expression public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
-// CHECK-NEXT: #endif
 // CHECK-NEXT: #endif
 @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
 
 @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: String) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
 
+// CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
 // CHECK: @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #labeledStringify(value, label: "default label")
+// CHECK-NEXT: #endif
 @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: String) -> (T, String) = #labeledStringify(value, label: "default label")
 
-// CHECK: #if compiler(>=5.3) && $Macros
-// CHECK-NEXT: #if $FreestandingExpressionMacros
+// CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
 // CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "SomeModule", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
-// CHECK-NEXT: #else
-// CHECK: @expression public macro publicLine<T>() -> T = #externalMacro(module: "SomeModule", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
-// CHECK-NEXT: #endif
 // CHECK-NEXT: #endif
 @freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "SomeModule", type: "Line")
 


### PR DESCRIPTION
Older compilers that we aim to support with textual interfaces don't understand `@expression` but do understand `$Macros` so falling back to `@expression` when `$FreestandingExpressionMacros` is not available causes a condfail. Revert https://github.com/apple/swift/pull/64269/ and just require users to have a relatively recent compiler if they want to work with the expression macros in the standard library.

Resolves rdar://108591384