### PR TITLE
Support `std::unique_ptr`.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3712,6 +3712,17 @@ namespace {
       auto dc = Impl.importDeclContextOf(
           decl, importedName.getEffectiveContext());
 
+#ifndef NDEBUG
+      if (dc == nullptr) {
+        llvm::dbgs() << "No decl context!\n";
+        llvm::dbgs() << "Decl: " << importedName.getDeclName().getBaseIdentifier().str() << "\n";
+        llvm::dbgs() << "Decl: "; decl->dump();
+        llvm::dbgs() << "Efective ctx: "; importedName.getEffectiveContext().DC->dumpAsDecl();
+        llvm::dbgs() << "Decl ctx: "; decl->getDeclContext()->dumpAsDecl();
+        llvm_unreachable("");
+      }
+#endif
+      
       SmallVector<GenericTypeParamDecl *, 4> genericParams;
       for (auto &param : *decl->getTemplateParameters()) {
         auto genericParamDecl =

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2135,15 +2135,6 @@ namespace {
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
       if (recordHasMoveOnlySemantics(decl)) {
-        if (!Impl.SwiftContext.LangOpts.hasFeature(Feature::MoveOnly)) {
-          Impl.addImportDiagnostic(
-              decl, Diagnostic(
-                        diag::move_only_requires_move_only,
-                        Impl.SwiftContext.AllocateCopy(decl->getNameAsString())),
-              decl->getLocation());
-          return nullptr;
-        }
-
         result->getAttrs().add(new (Impl.SwiftContext)
                                    MoveOnlyAttr(/*Implicit=*/true));
       }

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -5,11 +5,7 @@
 // CHECK-NOT: StructWithPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructWithInheritedPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedCopyConstructor
-// CHECK-NOT: StructNonCopyableTriviallyMovable
 // CHECK-NOT: StructNonCopyableNonMovable
-// CHECK-NOT: StructWithMoveConstructor
-// CHECK-NOT: StructWithInheritedMoveConstructor
-// CHECK-NOT: StructWithSubobjectMoveConstructor
 // CHECK-NOT: StructWithMoveAssignment
 // CHECK-NOT: StructWithInheritedMoveAssignment
 // CHECK-NOT: StructWithSubobjectMoveAssignment
@@ -19,6 +15,14 @@
 // CHECK-NOT: StructWithDeletedDestructor
 // CHECK-NOT: StructWithInheritedDeletedDestructor
 // CHECK-NOT: StructWithSubobjectDeletedDestructor
+
+// CHECK: struct StructWithMoveConstructor
+
+// CHECK: struct StructWithInheritedMoveConstructor
+
+// CHECK: struct StructWithSubobjectMoveConstructor
+
+// CHECK: struct StructNonCopyableTriviallyMovable
 
 // CHECK: struct Iterator {
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -27,3 +27,8 @@ module StdPair {
   header "std-pair.h"
   requires cplusplus
 }
+
+module StdUniquePtr {
+  header "std-unique-ptr.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -1,0 +1,29 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+
+#include <memory>
+
+std::unique_ptr<int> makeInt() {
+  return std::make_unique<int>(42);
+}
+
+std::unique_ptr<int[]> makeArray() {
+  int *array = new int[3];
+  array[0] = 1;
+  array[1] = 2;
+  array[2] = 3;
+  return std::unique_ptr<int[]>(array);
+}
+
+static bool dtorCalled = false;
+struct HasDtor {
+  ~HasDtor() {
+    dtorCalled = true;
+  }
+};
+
+std::unique_ptr<HasDtor> makeDtor() {
+  return std::make_unique<HasDtor>();
+}
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdUniquePtr
+#if os(Linux)
+import CxxStdlib
+// FIXME: import CxxStdlib.string once libstdc++ is split into submodules.
+#else
+import CxxStdlib.memory
+#endif
+
+var StdUniquePtrTestSuite = TestSuite("StdUniquePtr")
+
+StdUniquePtrTestSuite.test("int") {
+  let u = makeInt()
+  expectEqual(u.pointee, 42)
+}
+
+StdUniquePtrTestSuite.test("array") {
+  var u = makeArray()
+  expectEqual(u[0], 1)
+// Over consume:
+//  expectEqual(u[1], 2)
+//  expectEqual(u[2], 3)
+// Crash:
+//  u[0] = 10
+//  expectEqual(u[0], 10)
+}
+
+StdUniquePtrTestSuite.test("custom dtor") {
+  expectEqual(dtorCalled, false)
+  let c = {
+    _ = makeDtor()
+  }
+  c()
+  expectEqual(dtorCalled, true)
+}
+
+runAllTests()
+


### PR DESCRIPTION
Currently the synthesized members consume but that's OK for now. At least it's correct. 