### PR TITLE
[5.9][ConstraintSystem] Anthology of changes to variadic generics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5422,7 +5422,8 @@ ERROR(cannot_convert_tuple_into_pack_expansion_parameter,none,
 NOTE(cannot_convert_tuple_into_pack_expansion_parameter_note,none,
      "value pack expansion at parameter #%0 expects %1 separate arguments",
      (unsigned, unsigned))
-
+ERROR(value_expansion_not_variadic,none,
+      "value pack expansion must contain at least one pack reference", ())
 
 ERROR(expansion_not_same_shape,none,
       "pack expansion %0 requires that %1 and %2 have the same shape",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5415,6 +5415,14 @@ ERROR(tuple_duplicate_label,none,
       "cannot create a tuple with a duplicate element label", ())
 ERROR(multiple_ellipsis_in_tuple,none,
       "only a single element can be variadic", ())
+ERROR(cannot_convert_tuple_into_pack_expansion_parameter,none,
+      "value pack expansion at parameter #%0 expects %1 separate arguments"
+      "%select{|; remove extra parentheses to change tuple into separate arguments}2",
+      (unsigned, unsigned, bool))
+NOTE(cannot_convert_tuple_into_pack_expansion_parameter_note,none,
+     "value pack expansion at parameter #%0 expects %1 separate arguments",
+     (unsigned, unsigned))
+
 
 ERROR(expansion_not_same_shape,none,
       "pack expansion %0 requires that %1 and %2 have the same shape",

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -400,12 +400,12 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 6+32,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+31,
     /// Type variable options.
-    Options : 6,
+    Options : 7,
     : NumPadBits,
     /// The unique number assigned to this type variable.
-    ID : 32
+    ID : 31
   );
 
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+4+1+2+1+1,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2459,6 +2459,10 @@ public:
   
   bool containsPackExpansionType() const;
 
+  /// Check whether this tuple consists of a single unlabeled element
+  /// of \c PackExpansionType.
+  bool isSingleUnlabeledPackExpansion() const;
+
 private:
   TupleType(ArrayRef<TupleTypeElt> elements, const ASTContext *CanCtx,
             RecursiveTypeProperties properties)

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -438,6 +438,9 @@ enum class FixKind : uint8_t {
   /// Allow a pack expansion parameter of N elements to be matched
   /// with a single tuple literal argument of the same arity.
   DestructureTupleToMatchPackExpansionParameter,
+
+  /// Allow value pack expansion without pack references.
+  AllowValueExpansionWithoutPackReferences,
 };
 
 class ConstraintFix {
@@ -3450,6 +3453,31 @@ public:
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() ==
            FixKind::DestructureTupleToMatchPackExpansionParameter;
+  }
+};
+
+class AllowValueExpansionWithoutPackReferences final : public ConstraintFix {
+  AllowValueExpansionWithoutPackReferences(ConstraintSystem &cs,
+                                           ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowValueExpansionWithoutPackReferences,
+                      locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow value pack expansion without pack references";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static AllowValueExpansionWithoutPackReferences *
+  create(ConstraintSystem &cs, ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowValueExpansionWithoutPackReferences;
   }
 };
 

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -233,6 +233,8 @@ enum class ConstraintKind : char {
   /// an overload. The second type is a PackType containing the explicit
   /// generic arguments.
   ExplicitGenericArguments,
+  /// Both (first and second) pack types should have the same reduced shape.
+  SameShape,
 };
 
 /// Classification of the different kinds of constraints.
@@ -701,6 +703,7 @@ public:
     case ConstraintKind::DefaultClosureType:
     case ConstraintKind::UnresolvedMemberChainBase:
     case ConstraintKind::PackElementOf:
+    case ConstraintKind::SameShape:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1177,6 +1177,22 @@ public:
   }
 };
 
+class LocatorPathElt::PackExpansionType final
+    : public StoredPointerElement<swift::PackExpansionType> {
+public:
+  PackExpansionType(swift::PackExpansionType *openedPackExpansionTy)
+      : StoredPointerElement(PathElementKind::PackExpansionType,
+                             openedPackExpansionTy) {
+    assert(openedPackExpansionTy);
+  }
+
+  swift::PackExpansionType *getOpenedType() const { return getStoredPointer(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == PathElementKind::PackExpansionType;
+  }
+};
+
 namespace details {
   template <typename CustomPathElement>
   class PathElement {

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -202,8 +202,8 @@ CUSTOM_LOCATOR_PATH_ELT(PackElement)
 /// The shape of a parameter pack.
 SIMPLE_LOCATOR_PATH_ELT(PackShape)
 
-/// The type of pack expansion
-SIMPLE_LOCATOR_PATH_ELT(PackExpansionType)
+/// The type of an "opened" pack expansion
+CUSTOM_LOCATOR_PATH_ELT(PackExpansionType)
 
 /// The pattern  of a pack expansion.
 SIMPLE_LOCATOR_PATH_ELT(PackExpansionPattern)

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -202,6 +202,9 @@ CUSTOM_LOCATOR_PATH_ELT(PackElement)
 /// The shape of a parameter pack.
 SIMPLE_LOCATOR_PATH_ELT(PackShape)
 
+/// The type of pack expansion
+SIMPLE_LOCATOR_PATH_ELT(PackExpansionType)
+
 /// The pattern  of a pack expansion.
 SIMPLE_LOCATOR_PATH_ELT(PackExpansionPattern)
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3885,11 +3885,11 @@ public:
   /// variable representing a pack expansion type, let's resolve the expansion.
   ///
   /// \param typeVar The type variable representing pack expansion type.
-  /// \param locator The locator associated with contextual type.
+  /// \param contextualType The contextual type this pack expansion variable
+  /// would be bound/equated to.
   ///
   /// \returns `true` if pack expansion has been resolved, `false` otherwise.
-  bool resolvePackExpansion(TypeVariableType *typeVar,
-                            ConstraintLocatorBuilder locator);
+  bool resolvePackExpansion(TypeVariableType *typeVar, Type contextualType);
 
   /// Assign a fixed type to the given type variable.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -335,6 +335,9 @@ enum TypeVariableOptions {
 
   /// Whether the type variable can be bound to a pack type or not.
   TVO_CanBindToPack = 0x20,
+
+  /// Whether the type variable can be bound only to a pack expansion type.
+  TVO_PackExpansion = 0x40,
 };
 
 /// The implementation object for a type variable used within the
@@ -406,6 +409,9 @@ public:
 
   /// Whether this type variable can bind to a PackType.
   bool canBindToPack() const { return getRawOptions() & TVO_CanBindToPack; }
+
+  /// Whether this type variable can bind only to PackExpansionType.
+  bool isPackExpansion() const { return getRawOptions() & TVO_PackExpansion; }
 
   /// Whether this type variable prefers a subtype binding over a supertype
   /// binding.
@@ -650,6 +656,7 @@ private:
     ENTRY(TVO_CanBindToHole, "hole");
     ENTRY(TVO_PrefersSubtypeBinding, "");
     ENTRY(TVO_CanBindToPack, "pack");
+    ENTRY(TVO_PackExpansion, "pack expansion");
     }
   #undef ENTRY
   }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3978,7 +3978,8 @@ public:
   ///                     corresponding opened type variables.
   ///
   /// \returns The opened type, or \c type if there are no archetypes in it.
-  Type openType(Type type, OpenedTypeMap &replacements);
+  Type openType(Type type, OpenedTypeMap &replacements,
+                ConstraintLocatorBuilder locator);
 
 private:
   /// "Open" an opaque archetype type, similar to \c openType.
@@ -3989,7 +3990,8 @@ private:
   /// opening its pattern and shape types and connecting them to the
   /// aforementioned variable via special constraints.
   Type openPackExpansionType(PackExpansionType *expansion,
-                             OpenedTypeMap &replacements);
+                             OpenedTypeMap &replacements,
+                             ConstraintLocatorBuilder locator);
 
 public:
   /// Recurse over the given type and open any opaque archetype types.
@@ -4061,9 +4063,9 @@ public:
   /// Wrapper over swift::adjustFunctionTypeForConcurrency that passes along
   /// the appropriate closure-type and opening extraction functions.
   AnyFunctionType *adjustFunctionTypeForConcurrency(
-    AnyFunctionType *fnType, ValueDecl *decl, DeclContext *dc,
-    unsigned numApplies, bool isMainDispatchQueue,
-    OpenedTypeMap &replacements);
+      AnyFunctionType *fnType, ValueDecl *decl, DeclContext *dc,
+      unsigned numApplies, bool isMainDispatchQueue,
+      OpenedTypeMap &replacements, ConstraintLocatorBuilder locator);
 
   /// Retrieve the type of a reference to the given value declaration.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1467,6 +1467,9 @@ public:
   llvm::DenseMap<ConstraintLocator *, OpenedArchetypeType *>
     OpenedExistentialTypes;
 
+  llvm::DenseMap<PackExpansionType *, TypeVariableType *>
+      OpenedPackExpansionTypes;
+
   /// The pack expansion environment that can open pack elements for
   /// a given locator.
   llvm::DenseMap<ConstraintLocator *, std::pair<UUID, Type>>
@@ -2219,6 +2222,9 @@ private:
   llvm::SmallMapVector<ConstraintLocator *, OpenedArchetypeType *, 4>
       OpenedExistentialTypes;
 
+  llvm::SmallMapVector<PackExpansionType *, TypeVariableType *, 4>
+      OpenedPackExpansionTypes;
+
   llvm::SmallMapVector<ConstraintLocator *, std::pair<UUID, Type>, 4>
       PackExpansionEnvironments;
 
@@ -2701,6 +2707,9 @@ public:
 
     /// The length of \c OpenedExistentialTypes.
     unsigned numOpenedExistentialTypes;
+
+    /// The length of \c OpenedPackExpansionsTypes.
+    unsigned numOpenedPackExpansionTypes;
 
     /// The length of \c PackExpansionEnvironments.
     unsigned numPackExpansionEnvironments;
@@ -3965,6 +3974,12 @@ private:
   /// "Open" an opaque archetype type, similar to \c openType.
   Type openOpaqueType(OpaqueTypeArchetypeType *type,
                       ConstraintLocatorBuilder locator);
+
+  /// "Open" a pack expansion type by replacing it with a type variable,
+  /// opening its pattern and shape types and connecting them to the
+  /// aforementioned variable via special constraints.
+  Type openPackExpansionType(PackExpansionType *expansion,
+                             OpenedTypeMap &replacements);
 
 public:
   /// Recurse over the given type and open any opaque archetype types.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3881,6 +3881,16 @@ public:
   bool resolveClosure(TypeVariableType *typeVar, Type contextualType,
                       ConstraintLocatorBuilder locator);
 
+  /// Given the fact that contextual type is now available for the type
+  /// variable representing a pack expansion type, let's resolve the expansion.
+  ///
+  /// \param typeVar The type variable representing pack expansion type.
+  /// \param locator The locator associated with contextual type.
+  ///
+  /// \returns `true` if pack expansion has been resolved, `false` otherwise.
+  bool resolvePackExpansion(TypeVariableType *typeVar,
+                            ConstraintLocatorBuilder locator);
+
   /// Assign a fixed type to the given type variable.
   ///
   /// \param typeVar The type variable to bind.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4864,6 +4864,12 @@ private:
       Type type1, Type type2, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);
 
+  /// Simplify a same-shape constraint by comparing the reduced shape of the
+  /// left hand side to the right hand side.
+  SolutionKind simplifySameShapeConstraint(Type type1, Type type2,
+                                           TypeMatchOptions flags,
+                                           ConstraintLocatorBuilder locator);
+
 public: // FIXME: Public for use by static functions.
   /// Simplify a conversion constraint with a fix applied to it.
   SolutionKind simplifyFixConstraint(ConstraintFix *fix, Type type1, Type type2,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3353,6 +3353,13 @@ public:
   void recordPotentialHole(TypeVariableType *typeVar);
   void recordAnyTypeVarAsPotentialHole(Type type);
 
+  /// Record all unbound type variables that occur in the given type
+  /// as being bound to "hole" type represented by \c PlaceholderType
+  /// in this constraint system.
+  ///
+  /// \param type The type on which to holeify.
+  void recordTypeVariablesAsHoles(Type type);
+
   void recordMatchCallArgumentResult(ConstraintLocator *locator,
                                      MatchCallArgumentResult result);
 

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -117,8 +117,11 @@ unsigned TupleType::getNumScalarElements() const {
 }
 
 bool TupleType::containsPackExpansionType() const {
+  assert(!hasTypeVariable());
   for (auto elt : getElements()) {
-    if (elt.getType()->is<PackExpansionType>())
+    auto eltTy = elt.getType();
+    assert(!eltTy->hasTypeVariable());
+    if (eltTy->is<PackExpansionType>())
       return true;
   }
 
@@ -144,7 +147,9 @@ bool TupleType::isSingleUnlabeledPackExpansion() const {
 
 bool AnyFunctionType::containsPackExpansionType(ArrayRef<Param> params) {
   for (auto param : params) {
-    if (param.getPlainType()->is<PackExpansionType>())
+    auto paramTy = param.getPlainType();
+    assert(!paramTy->hasTypeVariable());
+    if (paramTy->is<PackExpansionType>())
       return true;
   }
 

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -134,6 +134,14 @@ bool CanTupleType::containsPackExpansionTypeImpl(CanTupleType tuple) {
   return false;
 }
 
+bool TupleType::isSingleUnlabeledPackExpansion() const {
+  if (getNumElements() != 1)
+    return false;
+
+  const auto &elt = getElement(0);
+  return !elt.hasName() && elt.getType()->is<PackExpansionType>();
+}
+
 bool AnyFunctionType::containsPackExpansionType(ArrayRef<Param> params) {
   for (auto param : params) {
     if (param.getPlainType()->is<PackExpansionType>())

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1174,13 +1174,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
 
       if (auto *closure =
               getAsExpr<ClosureExpr>(fn.getAbstractClosureExpr())) {
-        auto closureTy = getClosureType(closure);
-        simplifyType(closureTy).visit([&](Type componentTy) {
-          if (auto *typeVar = componentTy->getAs<TypeVariableType>()) {
-            assignFixedType(typeVar,
-                            PlaceholderType::get(getASTContext(), typeVar));
-          }
-        });
+        recordTypeVariablesAsHoles(getClosureType(closure));
       }
 
       return getTypeMatchSuccess();

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -148,6 +148,11 @@ bool BindingSet::isDelayed() const {
 }
 
 bool BindingSet::involvesTypeVariables() const {
+  // This type variable always depends on a pack expansion variable
+  // which should be inferred first if possible.
+  if (TypeVar->getImpl().canBindToPack())
+    return true;
+
   // This is effectively O(1) right now since bindings are re-computed
   // on each step of the solver, but once bindings are computed
   // incrementally it becomes more important to double-check that

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1480,6 +1480,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::SameShape:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5232,9 +5232,6 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   if (!locator->isLastElement<LocatorPathElt::ApplyArgument>())
     return false;
 
-  if (SynthesizedArgs.size() < 2)
-    return false;
-
   auto *args = getArgumentListFor(locator);
   if (!args)
     return false;
@@ -5251,11 +5248,16 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   if (!decl)
     return false;
 
+  auto *funcType =
+      resolveType(selectedOverload->openedType)->getAs<FunctionType>();
+  if (!funcType)
+    return false;
+
   auto name = decl->getBaseName();
   auto diagnostic =
       emitDiagnostic(diag::cannot_convert_single_tuple_into_multiple_arguments,
                      decl->getDescriptiveKind(), name, name.isSpecial(),
-                     SynthesizedArgs.size(), isa<TupleExpr>(argExpr));
+                     funcType->getNumParams(), isa<TupleExpr>(argExpr));
 
   // If argument is a literal tuple, let's suggest removal of parentheses.
   if (auto *TE = dyn_cast<TupleExpr>(argExpr)) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8899,3 +8899,8 @@ bool DestructureTupleToUseWithPackExpansionParameter::diagnoseAsNote() {
       argLoc.getParamIdx(), ParamShape->getNumElements());
   return true;
 }
+
+bool ValuePackExpansionWithoutPackReferences::diagnoseAsError() {
+  emitDiagnostic(diag::value_expansion_not_variadic);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -99,37 +99,42 @@ public:
   /// Resolve type variables present in the raw type, if any.
   Type resolveType(Type rawType, bool reconstituteSugar = false,
                    bool wantRValue = true) const {
-    if (rawType->hasTypeVariable() || rawType->hasPlaceholder()) {
-      rawType = rawType.transform([&](Type type) -> Type {
-        if (auto *typeVar = type->getAs<TypeVariableType>()) {
-          auto resolvedType = S.simplifyType(typeVar);
+    rawType = rawType.transform([&](Type type) -> Type {
+      if (auto *typeVar = type->getAs<TypeVariableType>()) {
+        auto resolvedType = S.simplifyType(typeVar);
 
-          if (!resolvedType->hasUnresolvedType())
-            return resolvedType;
+        if (!resolvedType->hasUnresolvedType())
+          return resolvedType;
 
-          // If type variable was simplified to an unresolved pack expansion
-          // type, let's examine its original pattern type because it could
-          // contain type variables replaceable with their generic parameter
-          // types.
-          if (auto *expansion = resolvedType->getAs<PackExpansionType>()) {
-            auto *locator = typeVar->getImpl().getLocator();
-            auto *openedExpansionTy =
-                locator->castLastElementTo<LocatorPathElt::PackExpansionType>()
-                    .getOpenedType();
-            auto patternType = resolveType(openedExpansionTy->getPatternType());
-            return PackExpansionType::get(patternType,
-                                          expansion->getCountType());
-          }
-
-          Type GP = typeVar->getImpl().getGenericParameter();
-          return resolvedType->is<UnresolvedType>() && GP ? GP : resolvedType;
+        // If type variable was simplified to an unresolved pack expansion
+        // type, let's examine its original pattern type because it could
+        // contain type variables replaceable with their generic parameter
+        // types.
+        if (auto *expansion = resolvedType->getAs<PackExpansionType>()) {
+          auto *locator = typeVar->getImpl().getLocator();
+          auto *openedExpansionTy =
+              locator->castLastElementTo<LocatorPathElt::PackExpansionType>()
+                  .getOpenedType();
+          auto patternType = resolveType(openedExpansionTy->getPatternType());
+          return PackExpansionType::get(patternType, expansion->getCountType());
         }
 
-        return type->isPlaceholder()
-                   ? Type(type->getASTContext().TheUnresolvedType)
-                   : type;
-      });
-    }
+        Type GP = typeVar->getImpl().getGenericParameter();
+        return resolvedType->is<UnresolvedType>() && GP ? GP : resolvedType;
+      }
+
+      if (auto *packType = type->getAs<PackType>()) {
+        if (packType->getNumElements() == 1) {
+          auto eltType = resolveType(packType->getElementType(0));
+          if (auto expansion = eltType->getAs<PackExpansionType>())
+            return expansion->getPatternType();
+        }
+      }
+
+      return type->isPlaceholder()
+                 ? Type(type->getASTContext().TheUnresolvedType)
+                 : type;
+    });
 
     if (reconstituteSugar)
       rawType = rawType->reconstituteSugar(/*recursive*/ true);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2976,6 +2976,30 @@ private:
   bool diagnoseTupleElement();
 };
 
+/// Diagnose situation when a single argument to tuple type is passed to
+/// a value pack expansion parameter that expects distinct N elements:
+///
+/// ```swift
+/// struct S<each T> {
+///   func test(x: Int, _: repeat each T) {}
+/// }
+///
+/// S<Int, String>().test(x: 42, (2, "b"))
+/// ```
+class DestructureTupleToUseWithPackExpansionParameter final
+    : public FailureDiagnostic {
+  PackType *ParamShape;
+
+public:
+  DestructureTupleToUseWithPackExpansionParameter(const Solution &solution,
+                                                  PackType *paramShape,
+                                                  ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), ParamShape(paramShape) {}
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3000,6 +3000,23 @@ public:
   bool diagnoseAsNote() override;
 };
 
+/// Diagnose situations when value pack expansion doesn't have any pack
+/// references i.e.:
+///
+/// ```swift
+/// func test(x: Int) {
+///   repeat x
+/// }
+/// ```
+class ValuePackExpansionWithoutPackReferences final : public FailureDiagnostic {
+public:
+  ValuePackExpansionWithoutPackReferences(const Solution &solution,
+                                          ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2742,3 +2742,15 @@ AllowGlobalActorMismatch::create(ConstraintSystem &cs, Type fromType,
   return new (cs.getAllocator())
       AllowGlobalActorMismatch(cs, fromType, toType, locator);
 }
+
+bool DestructureTupleToMatchPackExpansionParameter::diagnose(
+    const Solution &solution, bool asNote) const {
+  return false;
+}
+
+DestructureTupleToMatchPackExpansionParameter *
+DestructureTupleToMatchPackExpansionParameter::create(
+    ConstraintSystem &cs, PackType *paramShapeTy, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      DestructureTupleToMatchPackExpansionParameter(cs, paramShapeTy, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2756,3 +2756,15 @@ DestructureTupleToMatchPackExpansionParameter::create(
   return new (cs.getAllocator())
       DestructureTupleToMatchPackExpansionParameter(cs, paramShapeTy, locator);
 }
+
+bool AllowValueExpansionWithoutPackReferences::diagnose(
+    const Solution &solution, bool asNote) const {
+  return false;
+}
+
+AllowValueExpansionWithoutPackReferences *
+AllowValueExpansionWithoutPackReferences::create(ConstraintSystem &cs,
+                                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowValueExpansionWithoutPackReferences(cs, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2759,7 +2759,8 @@ DestructureTupleToMatchPackExpansionParameter::create(
 
 bool AllowValueExpansionWithoutPackReferences::diagnose(
     const Solution &solution, bool asNote) const {
-  return false;
+  ValuePackExpansionWithoutPackReferences failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowValueExpansionWithoutPackReferences *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2745,7 +2745,9 @@ AllowGlobalActorMismatch::create(ConstraintSystem &cs, Type fromType,
 
 bool DestructureTupleToMatchPackExpansionParameter::diagnose(
     const Solution &solution, bool asNote) const {
-  return false;
+  DestructureTupleToUseWithPackExpansionParameter failure(solution, ParamShape,
+                                                          getLocator());
+  return failure.diagnose(asNote);
 }
 
 DestructureTupleToMatchPackExpansionParameter *

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2920,8 +2920,8 @@ namespace {
         // TODO: we could try harder here, e.g. for enum elements to provide the
         // enum type.
         return setType(
-            CS.createTypeVariable(
-              CS.getConstraintLocator(locator), TVO_CanBindToNoEscape));
+            CS.createTypeVariable(CS.getConstraintLocator(locator),
+                                  TVO_CanBindToNoEscape | TVO_CanBindToHole));
       }
 
       llvm_unreachable("Unhandled pattern kind");

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3080,6 +3080,12 @@ namespace {
       // pack expansion expression through the shape type variable.
       SmallVector<ASTNode, 2> expandedPacks;
       expr->getExpandedPacks(expandedPacks);
+
+      if (expandedPacks.empty()) {
+        (void)CS.recordFix(AllowValueExpansionWithoutPackReferences::create(
+            CS, CS.getConstraintLocator(expr)));
+      }
+
       for (auto pack : expandedPacks) {
         Type packType;
         if (auto *elementExpr = getAsExpr<PackElementExpr>(pack)) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2768,8 +2768,9 @@ namespace {
         // correct handling of patterns like `_ as Foo` where `_` would
         // get a type of `Foo` but `is` pattern enclosing it could still be
         // inferred from enclosing context.
-        auto isType = CS.createTypeVariable(CS.getConstraintLocator(pattern),
-                                            TVO_CanBindToNoEscape);
+        auto isType =
+            CS.createTypeVariable(CS.getConstraintLocator(pattern),
+                                  TVO_CanBindToNoEscape | TVO_CanBindToHole);
         CS.addConstraint(
             ConstraintKind::Conversion, subPatternType, isType,
             locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -473,7 +473,7 @@ bool CompareDeclSpecializationRequest::evaluate(
     cs.openGeneric(outerDC, innerDC->getGenericSignatureOfContext(), locator,
                    replacements);
 
-    return cs.openType(type, replacements);
+    return cs.openType(type, replacements, locator);
   };
 
   bool knownNonSubtype = false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11036,7 +11036,7 @@ static Type getOpenedResultBuilderTypeFor(ConstraintSystem &cs,
     auto substitutions = cs.getOpenedTypes(calleeLocator);
     if (!substitutions.empty()) {
       OpenedTypeMap replacements(substitutions.begin(), substitutions.end());
-      builderType = cs.openType(builderType, replacements);
+      builderType = cs.openType(builderType, replacements, locator);
     }
     assert(!builderType->hasTypeParameter());
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6230,14 +6230,7 @@ bool ConstraintSystem::repairFailures(
     // unrelated fixes, let's proactively bind all of the pattern
     // elemnts to holes here.
     if (lhs->isAny()) {
-      rhs.visit([&](Type type) {
-        if (auto *typeVar = type->getAs<TypeVariableType>()) {
-          if (!getFixedType(typeVar)) {
-            assignFixedType(typeVar,
-                            PlaceholderType::get(getASTContext(), typeVar));
-          }
-        }
-      });
+      recordTypeVariablesAsHoles(rhs);
     }
 
     conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
@@ -10560,8 +10553,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
             // equality instead of argument application constraint, so allowing
             // them to bind member could mean missing valid hole positions in
             // the pattern.
-            assignFixedType(memberTypeVar, PlaceholderType::get(getASTContext(),
-                                                                memberTypeVar));
+            recordTypeVariablesAsHoles(memberTypeVar);
           } else {
             recordPotentialHole(memberTypeVar);
           }
@@ -14348,8 +14340,24 @@ void ConstraintSystem::recordAnyTypeVarAsPotentialHole(Type type) {
     return;
 
   type.visit([&](Type type) {
-    if (auto *typeVar = type->getAs<TypeVariableType>())
+    if (auto *typeVar = type->getAs<TypeVariableType>()) {
       typeVar->getImpl().enableCanBindToHole(getSavedBindings());
+    }
+  });
+}
+
+void ConstraintSystem::recordTypeVariablesAsHoles(Type type) {
+  type.visit([&](Type componentTy) {
+    if (auto *typeVar = componentTy->getAs<TypeVariableType>()) {
+      // Ignore bound type variables. This can happen if a type variable
+      // occurs in multiple positions and/or  if type hasn't been fully
+      // simplified before this call.
+      if (typeVar->getImpl().hasRepresentativeOrFixed())
+        return;
+
+      assignFixedType(typeVar,
+                      PlaceholderType::get(getASTContext(), typeVar));
+    }
   });
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9181,12 +9181,18 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   if (auto baseTuple = baseObjTy->getAs<TupleType>()) {
     if (!memberName.isSpecial()) {
       StringRef nameStr = memberName.getBaseIdentifier().str();
-
       // Accessing `.element` on an abstract tuple materializes a pack.
       if (nameStr == "element" && baseTuple->getNumElements() == 1 &&
-          baseTuple->getElementType(0)->is<PackExpansionType>()) {
-        result.ViableCandidates.push_back(
+          isPackExpansionType(baseTuple->getElementType(0))) {
+        auto elementType = baseTuple->getElementType(0);
+
+        if (elementType->is<PackExpansionType>()) {
+          result.ViableCandidates.push_back(
             OverloadChoice(baseTy, OverloadChoiceKind::MaterializePack));
+        } else {
+          assert(elementType->is<TypeVariableType>());
+          result.OverallResult = MemberLookupResult::Unsolved;
+        }
         return result;
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -127,6 +127,18 @@ static bool isPackExpansionType(Type type) {
   return false;
 }
 
+static bool containsPackExpansionType(ArrayRef<AnyFunctionType::Param> params) {
+  return llvm::any_of(params, [&](const auto &param) {
+    return isPackExpansionType(param.getPlainType());
+  });
+}
+
+static bool containsPackExpansionType(TupleType *tuple) {
+  return llvm::any_of(tuple->getElements(), [&](const auto &elt) {
+    return isPackExpansionType(elt.getType());
+  });
+}
+
 bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
                                                 const ValueDecl *decl) {
   assert(decl->getDeclContext()->isTypeContext() &&
@@ -2104,8 +2116,8 @@ public:
   bool match(MatchKind kind, ConstraintLocatorBuilder locator) {
     // FIXME: TuplePackMatcher should completely replace the non-variadic
     // case too eventually.
-    if (tuple1->containsPackExpansionType() ||
-        tuple2->containsPackExpansionType()) {
+    if (containsPackExpansionType(tuple1) ||
+        containsPackExpansionType(tuple2)) {
       TuplePackMatcher matcher(tuple1, tuple2, isPackExpansionType);
       if (matcher.match())
         return true;
@@ -3349,8 +3361,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
   // FIXME: ParamPackMatcher should completely replace the non-variadic
   // case too eventually.
-  if (AnyFunctionType::containsPackExpansionType(func1Params) ||
-      AnyFunctionType::containsPackExpansionType(func2Params)) {
+  if (containsPackExpansionType(func1Params) ||
+      containsPackExpansionType(func2Params)) {
     ParamPackMatcher matcher(func1Params, func2Params, getASTContext(),
                              isPackExpansionType);
     if (matcher.match())
@@ -14173,8 +14185,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     // the fix constraint solved without trying to figure out which tuple
     // elements were part of the pack.
     {
-      if (lhs->containsPackExpansionType() ||
-          rhs->containsPackExpansionType()) {
+      if (containsPackExpansionType(lhs) ||
+          containsPackExpansionType(rhs)) {
         if (recordFix(fix))
           return SolutionKind::Error;
         return SolutionKind::Solved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14762,6 +14762,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowSwiftToCPointerConversion:
   case FixKind::AllowTupleLabelMismatch:
   case FixKind::AddExplicitExistentialCoercion:
+  case FixKind::DestructureTupleToMatchPackExpansionParameter:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6232,8 +6232,10 @@ bool ConstraintSystem::repairFailures(
     if (lhs->isAny()) {
       rhs.visit([&](Type type) {
         if (auto *typeVar = type->getAs<TypeVariableType>()) {
-          assignFixedType(typeVar,
-                          PlaceholderType::get(getASTContext(), typeVar));
+          if (!getFixedType(typeVar)) {
+            assignFixedType(typeVar,
+                            PlaceholderType::get(getASTContext(), typeVar));
+          }
         }
       });
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13274,6 +13274,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
       return formUnsolved();
   }
 
+  if (type1->hasPlaceholder()) {
+    if (!shouldAttemptFixes())
+      return SolutionKind::Error;
+
+    recordTypeVariablesAsHoles(type2);
+    return SolutionKind::Solved;
+  }
+
   auto shape = type1->getReducedShape();
   addConstraint(ConstraintKind::Bind, shape, type2, locator);
   return SolutionKind::Solved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2409,13 +2409,16 @@ static PackType *replaceTypeVariablesWithFreshPacks(ConstraintSystem &cs,
       auto elementLoc = cs.getConstraintLocator(loc,
           LocatorPathElt::PackElement(freshTypeVars.size()));
       if (packExpansionElt != nullptr) {
-        auto *freshTypeVar =
-            cs.createTypeVariable(elementLoc, TVO_CanBindToPack);
+        auto *freshTypeVar = cs.createTypeVariable(
+            elementLoc,
+            TVO_CanBindToPack |
+                (typeVar->getImpl().canBindToHole() ? TVO_CanBindToHole : 0));
         freshTypeVars.push_back(PackExpansionType::get(
             freshTypeVar, packExpansionElt->getCountType()));
       } else {
-        freshTypeVars.push_back(
-            cs.createTypeVariable(elementLoc, /*options=*/0));
+        freshTypeVars.push_back(cs.createTypeVariable(
+            elementLoc,
+            typeVar->getImpl().canBindToHole() ? TVO_CanBindToHole : 0));
       }
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14792,6 +14792,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowTupleLabelMismatch:
   case FixKind::AddExplicitExistentialCoercion:
   case FixKind::DestructureTupleToMatchPackExpansionParameter:
+  case FixKind::AllowValueExpansionWithoutPackReferences:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2273,6 +2273,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     llvm_unreachable("Bad constraint kind in matchTupleTypes()");
   }
 
@@ -2486,13 +2487,9 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
                                           ConstraintKind kind, TypeMatchOptions flags,
                                           ConstraintLocatorBuilder locator) {
   // The count types of two pack expansion types must have the same shape.
-  auto *shapeLoc = getConstraintLocator(
-      locator.withPathElement(ConstraintLocator::PackShape));
-  auto *shapeTypeVar = createTypeVariable(shapeLoc, TVO_CanBindToPack);
-  addConstraint(ConstraintKind::ShapeOf,
-                expansion1->getCountType(), shapeTypeVar, shapeLoc);
-  addConstraint(ConstraintKind::ShapeOf,
-                expansion2->getCountType(), shapeTypeVar, shapeLoc);
+  addConstraint(ConstraintKind::SameShape, expansion1->getCountType(),
+                expansion2->getCountType(),
+                locator.withPathElement(ConstraintLocator::PackShape));
 
   auto pattern1 = expansion1->getPatternType();
   auto pattern2 = expansion2->getPatternType();
@@ -2652,6 +2649,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     return true;
   }
 
@@ -3159,6 +3157,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     llvm_unreachable("Not a relational constraint");
   }
 
@@ -6819,6 +6818,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::PackElementOf:
     case ConstraintKind::ShapeOf:
     case ConstraintKind::ExplicitGenericArguments:
+    case ConstraintKind::SameShape:
       llvm_unreachable("Not a relational constraint");
     }
   }
@@ -13195,6 +13195,18 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
   return SolutionKind::Solved;
 }
 
+static bool hasUnresolvedPackVars(Type type) {
+  // We can't compute a reduced shape if the input type still
+  // contains type variables that might bind to pack archetypes
+  // or pack expansions.
+  SmallPtrSet<TypeVariableType *, 2> typeVars;
+  type->getTypeVariables(typeVars);
+  return llvm::any_of(typeVars, [](const TypeVariableType *typeVar) {
+    return typeVar->getImpl().canBindToPack() ||
+           typeVar->getImpl().isPackExpansion();
+  });
+}
+
 ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
     Type type1, Type type2, TypeMatchOptions flags,
     ConstraintLocatorBuilder locator) {
@@ -13234,6 +13246,51 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
   auto shape = type1->getReducedShape();
   addConstraint(ConstraintKind::Bind, shape, type2, locator);
   return SolutionKind::Solved;
+}
+
+ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
+    Type type1, Type type2, TypeMatchOptions flags,
+    ConstraintLocatorBuilder locator) {
+  type1 = simplifyType(type1);
+  type2 = simplifyType(type2);
+
+  auto formUnsolved = [&]() {
+    // If we're supposed to generate constraints, do so.
+    if (flags.contains(TMF_GenerateConstraints)) {
+      auto *sameShape =
+          Constraint::create(*this, ConstraintKind::SameShape, type1, type2,
+                             getConstraintLocator(locator));
+
+      addUnsolvedConstraint(sameShape);
+      return SolutionKind::Solved;
+    }
+
+    return SolutionKind::Unsolved;
+  };
+
+  if (hasUnresolvedPackVars(type1) || hasUnresolvedPackVars(type2))
+    return formUnsolved();
+
+  auto shape1 = type1->getReducedShape();
+  auto shape2 = type2->getReducedShape();
+
+  if (shape1->isEqual(shape2))
+    return SolutionKind::Solved;
+
+  if (shouldAttemptFixes()) {
+    if (type1->hasPlaceholder() || type2->hasPlaceholder())
+      return SolutionKind::Solved;
+
+    unsigned impact = 1;
+    if (locator.endsWith<LocatorPathElt::AnyRequirement>())
+      impact = assessRequirementFailureImpact(*this, shape1, locator);
+
+    auto *fix = SkipSameShapeRequirement::create(*this, type1, type2,
+                                                 getConstraintLocator(locator));
+    return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
+  }
+
+  return SolutionKind::Error;
 }
 
 ConstraintSystem::SolutionKind
@@ -14707,6 +14764,9 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
   case ConstraintKind::ShapeOf:
     return simplifyShapeOfConstraint(first, second, subflags, locator);
 
+  case ConstraintKind::SameShape:
+    return simplifySameShapeConstraint(first, second, subflags, locator);
+
   case ConstraintKind::ExplicitGenericArguments:
     return simplifyExplicitGenericArgumentsConstraint(
         first, second, subflags, locator);
@@ -14878,13 +14938,7 @@ void ConstraintSystem::addConstraint(Requirement req,
     auto type1 = req.getFirstType();
     auto type2 = req.getSecondType();
 
-    auto *shapeLoc = getConstraintLocator(
-        locator.withPathElement(ConstraintLocator::PackShape));
-    auto typeVar = createTypeVariable(shapeLoc,
-                                      TVO_CanBindToPack);
-
-    addConstraint(ConstraintKind::ShapeOf, type1, typeVar, locator);
-    addConstraint(ConstraintKind::ShapeOf, type2, typeVar, locator);
+    addConstraint(ConstraintKind::SameShape, type1, type2, locator);
     return;
   }
 
@@ -15307,6 +15361,11 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
     return simplifyShapeOfConstraint(
         constraint.getFirstType(), constraint.getSecondType(), /*flags*/ None,
         constraint.getLocator());
+
+  case ConstraintKind::SameShape:
+    return simplifySameShapeConstraint(constraint.getFirstType(),
+                                       constraint.getSecondType(),
+                                       /*flags*/ None, constraint.getLocator());
 
   case ConstraintKind::ExplicitGenericArguments:
     return simplifyExplicitGenericArgumentsConstraint(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6581,6 +6581,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         auto rep1 = getRepresentative(typeVar1);
         auto rep2 = getRepresentative(typeVar2);
 
+        // Pack expansion variables cannot be merged because
+        // they involve other type variables.
+        if (rep1->getImpl().isPackExpansion() ||
+            rep2->getImpl().isPackExpansion())
+          return formUnsolvedResult();
+
         // If exactly one of the type variables can bind to an lvalue, we
         // can't merge these two type variables.
         if (kind == ConstraintKind::Equal &&
@@ -6637,6 +6643,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       } if (typeVar1 && typeVar2) {
         auto rep1 = getRepresentative(typeVar1);
         auto rep2 = getRepresentative(typeVar2);
+
+        // Pack expansion variables cannot be merged because
+        // they involve other type variables.
+        if (rep1->getImpl().isPackExpansion() ||
+            rep2->getImpl().isPackExpansion())
+          return formUnsolvedResult();
 
         if (!rep1->getImpl().canBindToInOut() ||
             !rep2->getImpl().canBindToLValue()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11318,24 +11318,16 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 
 bool ConstraintSystem::resolvePackExpansion(TypeVariableType *typeVar,
                                             ConstraintLocatorBuilder locator) {
-  // TODO: Pack expansion type variable can carry opened type.
-  auto expansion =
-      llvm::find_if(OpenedPackExpansionTypes, [&](const auto &expansion) {
-        return expansion.second->isEqual(typeVar);
-      });
-
-  assert(expansion != OpenedPackExpansionTypes.end());
-
-  assignFixedType(typeVar, expansion->first, getConstraintLocator(locator));
-
-  if (isDebugMode()) {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-    llvm::errs().indent(solverState->getCurrentIndent())
-        << "(pack expansion variable " << typeVar->getString(PO)
-        << " is bound to '" << expansion->first->getString(PO) << "')\n";
+  Type openedExpansionType;
+  if (auto last = locator.last()) {
+    auto expansionElt = last->castTo<LocatorPathElt::PackExpansionType>();
+    openedExpansionType = expansionElt.getOpenedType();
   }
 
+  if (!openedExpansionType)
+    return false;
+
+  assignFixedType(typeVar, openedExpansionType, getConstraintLocator(locator));
   return true;
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4318,16 +4318,17 @@ ConstraintSystem::matchTypesBindTypeVar(
   // pack expansion expression.
   if (!typeVar->getImpl().canBindToPack() &&
       (type->is<PackArchetypeType>() || type->is<PackType>())) {
-    if (shouldAttemptFixes()) {
-      auto *fix = AllowInvalidPackReference::create(*this, type,
-                                                    getConstraintLocator(locator));
-      if (!recordFix(fix)) {
-        recordPotentialHole(typeVar);
-        return getTypeMatchSuccess();
-      }
-    }
+    if (!shouldAttemptFixes())
+      return getTypeMatchFailure(locator);
 
-    return getTypeMatchFailure(locator);
+    auto *fix = AllowInvalidPackReference::create(
+        *this, type, getConstraintLocator(locator));
+    if (recordFix(fix))
+      return getTypeMatchFailure(locator);
+
+    // Don't allow the invalid pack reference to propagate to other
+    // bindings.
+    type = PlaceholderType::get(typeVar->getASTContext(), typeVar);
   }
 
   // Binding to a pack expansion type is always an error in Swift 6 mode.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5110,6 +5110,19 @@ bool ConstraintSystem::repairFailures(
                         });
   };
 
+  // Check whether this is a tuple with a single unlabeled element
+  // i.e. `(_: Int)` and return type of that element if so. Note that
+  // if the element is pack expansion type the tuple is significant.
+  auto isSingleUnlabeledElementTuple = [](Type type) -> Type {
+    if (auto *tuple = type->getAs<TupleType>()) {
+      if (tuple->getNumElements() == 1 && !tuple->getElement(0).hasName()) {
+        auto eltType = tuple->getElement(0).getType();
+        return isPackExpansionType(eltType) ? Type() : eltType;
+      }
+    }
+    return Type();
+  };
+
   if (repairArrayLiteralUsedAsDictionary(*this, lhs, rhs, matchKind,
                                          conversionsOrFixes,
                                          getConstraintLocator(locator)))
@@ -5916,6 +5929,14 @@ bool ConstraintSystem::repairFailures(
       conversionsOrFixes.push_back(fix);
     }
 
+    // Solver can unwrap contextual type in an unlabeled one-element tuple
+    // while matching type to a tuple that contains one or more pack expansion
+    // types (because such tuples can loose their elements under substitution),
+    // if that's the case, let's just produce a regular contextual mismatch fix.
+    if (auto contextualType = isSingleUnlabeledElementTuple(rhs)) {
+      rhs = contextualType;
+    }
+
     if (purpose == CTP_Initialization && lhs->is<TupleType>() &&
         rhs->is<TupleType>()) {
       auto *fix = AllowTupleTypeMismatch::create(*this, lhs, rhs,
@@ -6110,6 +6131,13 @@ bool ConstraintSystem::repairFailures(
     // top level type and not just a part of it.
     if (tupleLocator->findLast<LocatorPathElt::OptionalPayload>())
       break;
+
+    if (tupleLocator->isForContextualType()) {
+      if (auto contextualTy = isSingleUnlabeledElementTuple(rhs)) {
+        return repairFailures(lhs, contextualTy, matchKind, flags,
+                              conversionsOrFixes, tupleLocator);
+      }
+    }
 
     ConstraintFix *fix;
     if (tupleLocator->isLastElement<LocatorPathElt::FunctionArgument>()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4284,6 +4284,15 @@ ConstraintSystem::matchTypesBindTypeVar(
     }
   }
 
+  if (typeVar->getImpl().isPackExpansion()) {
+    if (!flags.contains(TMF_BindingTypeVariable))
+      return formUnsolvedResult();
+
+    return resolvePackExpansion(typeVar, locator)
+               ? getTypeMatchSuccess()
+               : getTypeMatchFailure(locator);
+  }
+
   // If we're attempting to bind a PackType or PackArchetypeType to a type
   // variable that doesn't support it, we have a pack reference outside of a
   // pack expansion expression.
@@ -4298,11 +4307,6 @@ ConstraintSystem::matchTypesBindTypeVar(
       }
     }
 
-    return getTypeMatchFailure(locator);
-  }
-
-  // FIXME: Add a fix for this.
-  if (typeVar->getImpl().isPackExpansion() && !type->is<PackExpansionType>()) {
     return getTypeMatchFailure(locator);
   }
 
@@ -11232,6 +11236,29 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 
   // Generate constraints from the body of this closure.
   return !generateConstraints(AnyFunctionRef{closure}, closure->getBody());
+}
+
+bool ConstraintSystem::resolvePackExpansion(TypeVariableType *typeVar,
+                                            ConstraintLocatorBuilder locator) {
+  // TODO: Pack expansion type variable can carry opened type.
+  auto expansion =
+      llvm::find_if(OpenedPackExpansionTypes, [&](const auto &expansion) {
+        return expansion.second->isEqual(typeVar);
+      });
+
+  assert(expansion != OpenedPackExpansionTypes.end());
+
+  assignFixedType(typeVar, expansion->first, getConstraintLocator(locator));
+
+  if (isDebugMode()) {
+    PrintOptions PO;
+    PO.PrintTypesForDebugging = true;
+    llvm::errs().indent(solverState->getCurrentIndent())
+        << "(pack expansion variable " << typeVar->getString(PO)
+        << " is bound to '" << expansion->first->getString(PO) << "')\n";
+  }
+
+  return true;
 }
 
 ConstraintSystem::SolutionKind

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6518,6 +6518,17 @@ bool ConstraintSystem::repairFailures(
   return !conversionsOrFixes.empty();
 }
 
+static bool isTupleWithUnresolvedPackExpansion(Type type) {
+  if (auto *tuple = type->getAs<TupleType>()) {
+    return llvm::any_of(tuple->getElements(), [&](const TupleTypeElt &elt) {
+      if (auto typeVar = elt.getType()->getAs<TypeVariableType>())
+        return typeVar->getImpl().isPackExpansion();
+      return false;
+    });
+  }
+  return false;
+}
+
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                              TypeMatchOptions flags,
@@ -6784,6 +6795,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       desugar2->isTypeVariableOrMember()) {
     return formUnsolvedResult();
   }
+
+  // If either side is a tuple that has unresolved pack expansions,
+  // delay matching until more is inferred about type structure.
+  if (isTupleWithUnresolvedPackExpansion(desugar1) ||
+      isTupleWithUnresolvedPackExpansion(desugar2))
+    return formUnsolvedResult();
 
   llvm::SmallVector<RestrictionOrFix, 4> conversionsOrFixes;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4193,15 +4193,15 @@ static bool isBindable(TypeVariableType *typeVar, Type type) {
 
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchTypesBindTypeVar(
-    TypeVariableType *typeVar, Type type, ConstraintKind kind,
+    TypeVariableType *typeVar, Type origType, ConstraintKind kind,
     TypeMatchOptions flags, ConstraintLocatorBuilder locator,
     llvm::function_ref<TypeMatchResult()> formUnsolvedResult) {
   assert(typeVar->is<TypeVariableType>() && "Expected a type variable!");
-  assert(!type->is<TypeVariableType>() && "Expected a non-type variable!");
+  assert(!origType->is<TypeVariableType>() && "Expected a non-type variable!");
 
   // Simplify the right-hand type and perform the "occurs" check.
   typeVar = getRepresentative(typeVar);
-  type = simplifyType(type, flags);
+  auto type = simplifyType(origType, flags);
   if (!isBindable(typeVar, type)) {
     if (shouldAttemptFixes()) {
       // If type variable is allowed to be a hole and it can't be bound to
@@ -4303,7 +4303,7 @@ ConstraintSystem::matchTypesBindTypeVar(
     if (!flags.contains(TMF_BindingTypeVariable))
       return formUnsolvedResult();
 
-    return resolvePackExpansion(typeVar, locator)
+    return resolvePackExpansion(typeVar, origType)
                ? getTypeMatchSuccess()
                : getTypeMatchFailure(locator);
   }
@@ -11359,17 +11359,30 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 }
 
 bool ConstraintSystem::resolvePackExpansion(TypeVariableType *typeVar,
-                                            ConstraintLocatorBuilder locator) {
+                                            Type contextualType) {
+  auto *locator = typeVar->getImpl().getLocator();
+
   Type openedExpansionType;
-  if (auto last = locator.last()) {
-    auto expansionElt = last->castTo<LocatorPathElt::PackExpansionType>();
-    openedExpansionType = expansionElt.getOpenedType();
+  if (auto expansionElt =
+          locator->getLastElementAs<LocatorPathElt::PackExpansionType>()) {
+    openedExpansionType = expansionElt->getOpenedType();
   }
 
   if (!openedExpansionType)
     return false;
 
-  assignFixedType(typeVar, openedExpansionType, getConstraintLocator(locator));
+  assignFixedType(typeVar, openedExpansionType, locator);
+
+  // We have a fully resolved contextual pack expansion type, let's
+  // apply it right away.
+  if (!contextualType->isEqual(openedExpansionType)) {
+    assert(contextualType->is<PackExpansionType>() &&
+           !contextualType->hasTypeVariable());
+    auto result = matchTypes(openedExpansionType, contextualType,
+                             ConstraintKind::Equal, {}, locator);
+    return !result.isFailure();
+  }
+
   return true;
 }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -169,6 +169,14 @@ Solution ConstraintSystem::finalize() {
     solution.OpenedExistentialTypes.insert(openedExistential);
   }
 
+  for (const auto &expansion : OpenedPackExpansionTypes) {
+    assert(solution.OpenedPackExpansionTypes.count(expansion.first) == 0 ||
+           solution.OpenedPackExpansionTypes[expansion.first] ==
+                   expansion.second &&
+               "Already recorded");
+    solution.OpenedPackExpansionTypes.insert(expansion);
+  }
+
   // Remember the defaulted type variables.
   solution.DefaultedConstraints.insert(DefaultedConstraints.begin(),
                                        DefaultedConstraints.end());
@@ -269,6 +277,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the solution's opened existential types.
   for (const auto &openedExistential : solution.OpenedExistentialTypes) {
     OpenedExistentialTypes.insert(openedExistential);
+  }
+
+  // Register the solution's opened pack expansion types.
+  for (const auto &expansion : solution.OpenedPackExpansionTypes) {
+    OpenedPackExpansionTypes.insert(expansion);
   }
 
   // Register the solutions's pack expansion environments.
@@ -594,6 +607,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numArgumentMatchingChoices = cs.argumentMatchingChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
+  numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
@@ -671,6 +685,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any opened existential types.
   truncate(cs.OpenedExistentialTypes, numOpenedExistentialTypes);
+
+  // Remove any opened pack expansion types.
+  truncate(cs.OpenedPackExpansionTypes, numOpenedPackExpansionTypes);
 
   // Remove any pack expansion environments.
   truncate(cs.PackExpansionEnvironments, numPackExpansionEnvironments);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -213,6 +213,10 @@ Solution ConstraintSystem::finalize() {
     solution.ImplicitCallAsFunctionRoots.insert(implicitRoot);
   }
 
+  for (const auto &env : PackExpansionEnvironments) {
+    solution.PackExpansionEnvironments.insert(env);
+  }
+
   return solution;
 }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -82,6 +82,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -171,6 +172,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -319,6 +321,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -569,6 +572,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
     Out << " shape of ";
     break;
 
+  case ConstraintKind::SameShape:
+    Out << " same-shape ";
+    break;
+
   case ConstraintKind::ExplicitGenericArguments:
     Out << " explicit generic argument binding ";
     break;
@@ -742,6 +749,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::PackElementOf:
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
+  case ConstraintKind::SameShape:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -106,6 +106,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::AnyPatternDecl:
   case ConstraintLocator::GlobalActorType:
   case ConstraintLocator::CoercionOperand:
+  case ConstraintLocator::PackExpansionType:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -500,6 +501,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
 
   case ConstraintLocator::CoercionOperand: {
     out << "coercion operand";
+    break;
+
+  case ConstraintLocator::PackExpansionType:
+    out << "pack expansion type";
     break;
   }
   }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -504,7 +504,9 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     break;
 
   case ConstraintLocator::PackExpansionType:
-    out << "pack expansion type";
+    auto expansionElt = elt.castTo<LocatorPathElt::PackExpansionType>();
+    out << "pack expansion type ("
+        << expansionElt.getOpenedType()->getString(PO) << ")";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5745,6 +5745,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
 
     case ConstraintLocator::PackElement:
     case ConstraintLocator::PackShape:
+    case ConstraintLocator::PackExpansionType:
       break;
 
     case ConstraintLocator::PackExpansionPattern: {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7201,6 +7201,21 @@ TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
     return;
   }
 
+  // Pack expansion type variable can only ever have one binding
+  // which is handled by \c resolvePackExpansion.
+  //
+  // There is no need to iterate over other bindings here because
+  // there is no use for contextual types (unlike closures that can
+  // propagate contextual information into the body).
+  if (TypeVar->getImpl().isPackExpansion()) {
+    for (const auto &entry : bindings.Defaults) {
+      auto *constraint = entry.second;
+      Bindings.push_back(getDefaultBinding(constraint));
+    }
+
+    return;
+  }
+
   // A binding to `Any` which should always be considered as a last resort.
   Optional<Binding> Any;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1018,7 +1018,8 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
     return known->second;
 
   auto *expansionVar = createTypeVariable(
-      getConstraintLocator({}, ConstraintLocator::PackExpansionType),
+      getConstraintLocator(
+          {}, LocatorPathElt::PackExpansionType(openedPackExpansion)),
       TVO_PackExpansion);
 
   // This constraint is important to make sure that pack expansion always
@@ -1026,7 +1027,8 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
   // that appear in pattern and shape types.
   addUnsolvedConstraint(Constraint::create(
       *this, ConstraintKind::Defaultable, expansionVar, openedPackExpansion,
-      getConstraintLocator({}, ConstraintLocator::PackExpansionType)));
+      getConstraintLocator(
+          {}, LocatorPathElt::PackExpansionType(openedPackExpansion))));
 
   OpenedPackExpansionTypes[openedPackExpansion] = expansionVar;
   return expansionVar;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3784,7 +3784,9 @@ struct TypeSimplifier {
         // Flatten single-element tuples containing type variables that cannot
         // bind to packs.
         auto typeVar = elementType->getAs<TypeVariableType>();
-        if (!element.hasName() && typeVar && !typeVar->getImpl().canBindToPack()) {
+        if (!element.hasName() && typeVar &&
+            !typeVar->getImpl().canBindToPack() &&
+            !typeVar->getImpl().isPackExpansion()) {
           return typeVar;
         }
       }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1586,6 +1586,16 @@ void ConstraintSystem::print(raw_ostream &out) const {
     }
   }
 
+  if (!PackExpansionEnvironments.empty()) {
+    out.indent(indent) << "Pack Expansion Environments:\n";
+    for (const auto &env : PackExpansionEnvironments) {
+      out.indent(indent + 2);
+      env.first->dump(&getASTContext().SourceMgr, out);
+      out << " = (" << env.second.first << ", "
+          << env.second.second->getString(PO) << ")" << '\n';
+    }
+  }
+
   if (!DefaultedConstraints.empty()) {
     out.indent(indent) << "Defaulted constraints:\n";
     interleave(DefaultedConstraints, [&](ConstraintLocator *locator) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -658,7 +658,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       cs.openGenericRequirement(DC->getParent(), index, requirement,
                                 /*skipSelfProtocolConstraint=*/false, locator,
                                 [&](Type type) -> Type {
-                                  return cs.openType(type, genericParameters);
+                                  return cs.openType(type, genericParameters,
+                                                     locator);
                                 });
     };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -67,6 +67,10 @@ void TypeVariableType::Implementation::print(llvm::raw_ostream &OS) {
     bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToNoEscape);
   if (canBindToHole())
     bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToHole);
+  if (canBindToPack())
+    bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToPack);
+  if (isPackExpansion())
+    bindingOptions.push_back(TypeVariableOptions::TVO_PackExpansion);
   if (!bindingOptions.empty()) {
     OS << " [allows bindings to: ";
     interleave(bindingOptions, OS,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1600,6 +1600,16 @@ void ConstraintSystem::print(raw_ostream &out) const {
     }
   }
 
+  if (!OpenedPackExpansionTypes.empty()) {
+    out.indent(indent) << "Opened pack expansion types:\n";
+    for (const auto &expansion : OpenedPackExpansionTypes) {
+      out.indent(indent + 2);
+      out << expansion.first->getString(PO);
+      out << " opens to " << expansion.second->getString(PO);
+      out << "\n";
+    }
+  }
+
   if (!DefaultedConstraints.empty()) {
     out.indent(indent) << "Defaulted constraints:\n";
     interleave(DefaultedConstraints, [&](ConstraintLocator *locator) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1749,6 +1749,16 @@ Stmt *PreCheckReturnStmtRequest::evaluate(Evaluator &evaluator, ReturnStmt *RS,
 }
 
 static bool isDiscardableType(Type type) {
+  // If type is `(_: repeat ...)`, it can be discardable.
+  if (auto *tuple = type->getAs<TupleType>()) {
+    if (tuple->isSingleUnlabeledPackExpansion()) {
+      type = tuple->getElementType(0);
+    }
+  }
+
+  if (auto *expansion = type->getAs<PackExpansionType>())
+    return isDiscardableType(expansion->getPatternType());
+
   return (type->hasError() ||
           type->isUninhabited() ||
           type->lookThroughAllOptionalTypes()->isVoid());

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -329,10 +329,11 @@ func test_pack_expansions_with_closures() {
 }
 
 // rdar://107151854 - crash on invalid due to specialized pack expansion
-func test_pack_expansion_specialization() {
+func test_pack_expansion_specialization(tuple: (Int, String, Float)) {
   struct Data<each T> {
-    init(_: repeat each T) {} // expected-note 3 {{'init(_:)' declared here}}
+    init(_: repeat each T) {} // expected-note 4 {{'init(_:)' declared here}}
     init(vals: repeat each T) {} // expected-note {{'init(vals:)' declared here}}
+    init<each U>(x: Int, _: repeat each T, y: repeat each U) {} // expected-note 3 {{'init(x:_:y:)' declared here}}
   }
 
   _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}
@@ -340,11 +341,28 @@ func test_pack_expansion_specialization() {
   _ = Data<Int, String>(42, "") // Ok
   _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
   _ = Data<Int, String>((42, ""))
-  // expected-error@-1 {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{32-33=}}
   _ = Data<Int, String, Float>(vals: (42, "", 0))
-  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{38-39=}} {{48-49=}}
   _ = Data<Int, String, Float>((vals: 42, "", 0))
-  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{32-33=}} {{48-49=}}
+  _ = Data<Int, String, Float>(tuple)
+  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+  _ = Data<Int, String, Float>(x: 42, tuple)
+  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}}
+  _ = Data<Int, String, Float>(x: 42, tuple, y: 1, 2, 3)
+  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}}
+  _ = Data<Int, String, Float>(x: 42, (42, "", 0), y: 1, 2, 3)
+  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}} {{39-40=}} {{49-50=}}
+
+  struct Ambiguity<each T> {
+    func test(_: repeat each T) -> Int { 42 }
+    // expected-note@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+    func test(_: repeat each T) -> String { "" }
+    // expected-note@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+  }
+
+  _ = Ambiguity<Int, String, Float>().test(tuple) // expected-error {{no exact matches in call to instance method 'test'}}
 }
 
 // Make sure that in-exact matches (that require any sort of conversion or load) on arguments are handled correctly.

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -407,3 +407,16 @@ func test_no_unused_result_warning(arr: inout [Any]) {
     ((repeat arr.append(each value))) // no warning
   }
 }
+
+func test_partually_flattened_expansions() {
+  struct S<each T> {
+    init() {}
+
+    func fn<each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {
+      return (repeat (each t, each u))
+    }
+  }
+
+  _ = S().fn(t: 1, "hi", u: false, 1.0) // Ok
+  _ = S<Int, String>().fn(t: 1, "hi", u: false, 1.0) // Ok
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -133,7 +133,7 @@ func tupleExpansion<each T, each U>(
   _ = zip(repeat each tuple1.element, with: repeat each tuple1.element)
 
   _ = zip(repeat each tuple1.element, with: repeat each tuple2.element)
-  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each U' and 'each T' have the same shape}}
+  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each T' and 'each U' have the same shape}}
 }
 
 protocol Generatable {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -457,3 +457,26 @@ do {
     // expected-error@-1 {{pack reference 'each T' can only appear in pack expansion}}
   }
 }
+
+// rdar://107835215 - failed to produce a diagnostic for invalid pack expansion expression
+do {
+  func test1(x: Int) {
+    repeat x
+    // expected-error@-1:5 {{value pack expansion must contain at least one pack reference}}
+  }
+
+  func test2<T: Numeric>(_ x: T) {
+    repeat print(x * 2)
+    // expected-error@-1:5 {{value pack expansion must contain at least one pack reference}}
+  }
+
+  struct S<T> {
+    init(_: T) {}
+  }
+
+  func test<each T>(x: repeat each T, y: Int) {
+    func f<each A, each B>(_: repeat each A, y: repeat each B) {}
+    f(repeat each x, y: repeat [S(y)])
+    // expected-error@-1:25 {{value pack expansion must contain at least one pack reference}}
+  }
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -396,3 +396,14 @@ do {
     return G<repeat each T>() // Ok
   }
 }
+
+// rdar://108064941 - unused result diagnostic is unaware of Void packs
+func test_no_unused_result_warning(arr: inout [Any]) {
+  func test1<each T>(_ value: (repeat each T)) {
+    repeat arr.append(each value.element) // no warning
+  }
+
+  func test2<each T>(_ value: repeat each T) {
+    ((repeat arr.append(each value))) // no warning
+  }
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -331,8 +331,8 @@ func test_pack_expansions_with_closures() {
 // rdar://107151854 - crash on invalid due to specialized pack expansion
 func test_pack_expansion_specialization() {
   struct Data<each T> {
-    init(_: repeat each T) {} // expected-note 2 {{'init(_:)' declared here}}
-    init(vals: repeat each T) {} // expected-note 2 {{'init(vals:)' declared here}}
+    init(_: repeat each T) {} // expected-note 3 {{'init(_:)' declared here}}
+    init(vals: repeat each T) {} // expected-note {{'init(vals:)' declared here}}
   }
 
   _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -210,7 +210,7 @@ func concreteReturnFunctionInvalid() {
 }
 
 func patternInstantiationTupleTest1<each T>() -> (repeat Array<each T>) {}
-// expected-note@-1 2 {{in call to function 'patternInstantiationTupleTest1()'}}
+// expected-note@-1 {{in call to function 'patternInstantiationTupleTest1()'}}
 func patternInstantiationTupleTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) {}
 
 func patternInstantiationFunctionTest1<each T>() -> (repeat Array<each T>) -> () {}
@@ -240,10 +240,9 @@ func patternInstantiationConcreteValid() {
 
 func patternInstantiationConcreteInvalid() {
   let _: Set<Int> = patternInstantiationTupleTest1()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(repeat Array<each T>)' to specified type 'Set<Int>'}}
+  // expected-error@-1 {{cannot convert value of type '(repeat Array<Pack{_}>)' to specified type 'Set<Int>'}}
 
-  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Pack{Int, _}>)' is not convertible to '(Array<Int>, Set<String>)', tuples have a different number of elements}}
 }
 
 func patternInstantiationGenericValid<each T, each U>(t: repeat each T, u: repeat each U)
@@ -273,7 +272,7 @@ func patternInstantiationGenericInvalid<each T: Hashable>(t: repeat each T) {
   let _: (repeat Set<each T>) = patternInstantiationTupleTest1() // expected-error {{cannot convert value of type '(repeat Array<each T>)' to specified type '(repeat Set<each T>)}}
   // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
 
-  let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+  let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Pack{repeat each T, _}>)' is not convertible to '(repeat Array<each T>, Set<String>)', tuples have a different number of elements}}
 }
 
 // rdar://107996926 - Vanishing metatype of tuple not supported

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -1,10 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
 func returnTuple1<each T>() -> (repeat each T) { fatalError() }
-// expected-note@-1 3 {{in call to function 'returnTuple1()'}}
+// expected-note@-1 {{in call to function 'returnTuple1()'}}
 
 func returnTuple2<each T>() -> (Int, repeat each T) { fatalError() }
-// expected-note@-1 3 {{in call to function 'returnTuple2()'}}
+// expected-note@-1 2 {{in call to function 'returnTuple2()'}}
 
 func returnTupleLabel1<each T>() -> (x: repeat each T) { fatalError() }
 // expected-error@-1 {{cannot use label with pack expansion tuple element}}
@@ -26,16 +26,10 @@ func returnTupleLabel6<each T, each U>() -> (Int, x: repeat each T, y: repeat ea
 
 func concreteReturnTupleValid() {
   let _: () = returnTuple1()
-  // FIXME: consider propagating 'Int' through the conversion constraint
-  // as a binding for the parameter pack expanded in the tuple return type.
   let _: Int = returnTuple1()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(repeat each T)' to specified type 'Int'}}
   let _: (Int, String) = returnTuple1()
 
   let _: Int = returnTuple2()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(Int, repeat each T)' to specified type 'Int'}}
   let _: (Int, String) = returnTuple2()
   let _: (Int, String, Float) = returnTuple2()
 
@@ -72,8 +66,6 @@ func concreteReturnTupleValid() {
 
 func concreteReturnTypeInvalid() {
   let _: Int = returnTuple1()
-  // expected-error@-1 {{cannot convert value of type '(repeat each T)' to specified type 'Int'}}
-  // expected-error@-2 {{generic parameter 'each T' could not be inferred}}
 
   let _: () = returnTuple2()
   // expected-error@-1 {{'(Int, repeat each T)' is not convertible to '()', tuples have a different number of elements}}
@@ -218,28 +210,20 @@ func concreteReturnFunctionInvalid() {
 }
 
 func patternInstantiationTupleTest1<each T>() -> (repeat Array<each T>) {}
-// expected-note@-1 3 {{in call to function 'patternInstantiationTupleTest1()'}}
+// expected-note@-1 2 {{in call to function 'patternInstantiationTupleTest1()'}}
 func patternInstantiationTupleTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) {}
-// expected-note@-1 {{in call to function 'patternInstantiationTupleTest2()'}}
 
 func patternInstantiationFunctionTest1<each T>() -> (repeat Array<each T>) -> () {}
 func patternInstantiationFunctionTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) -> () {}
 
 func patternInstantiationConcreteValid() {
   let _: () = patternInstantiationTupleTest1()
-  // FIXME
   let _: Array<Int> = patternInstantiationTupleTest1()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{cannot convert value of type '(repeat Array<each T>)' to specified type 'Array<Int>'}}
   let _: (Array<Int>, Array<String>) = patternInstantiationTupleTest1()
   let _: (Array<Int>, Array<String>, Array<Float>) = patternInstantiationTupleTest1()
 
   let _: () = patternInstantiationTupleTest2()
-  // FIXME
   let _: Dictionary<Int, String> = patternInstantiationTupleTest2()
-  // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
-  // expected-error@-2 {{generic parameter 'each U' could not be inferred}}
-  // expected-error@-3 {{cannot convert value of type '(repeat Dictionary<each T, each U>)' to specified type 'Dictionary<Int, String>'}}
   let _: (Dictionary<Int, String>, Dictionary<Float, Bool>) = patternInstantiationTupleTest2()
   let _: (Dictionary<Int, String>, Dictionary<Float, Bool>, Dictionary<Double, Character>) = patternInstantiationTupleTest2()
 
@@ -290,4 +274,27 @@ func patternInstantiationGenericInvalid<each T: Hashable>(t: repeat each T) {
   // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
 
   let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+}
+
+// rdar://107996926 - Vanishing metatype of tuple not supported
+func test_one_element_tuple_vs_non_tuple_matching() {
+  struct S {
+    func test<each T>(_: (repeat each T).Type) -> (repeat each T) { fatalError() }
+    func testVanishing<each T>(_: (Int, repeat each T)) {}
+  }
+
+  let _ = S().test(Int.self) // Ok
+  let _: Int = S().test(Int.self) // Ok
+  let _ = S().test((Int, String).self) // Ok
+  let _ = S().testVanishing(42) // Ok
+
+  do {
+    struct V<T> {}
+
+    func test<each T>(_: V<(repeat each T)>?) {}
+    func test<each T>(_: V<(repeat each T)>.Type) {}
+
+    test(V<Int>()) // Ok
+    test(V<Int>.self) // Ok
+  }
 }

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -73,5 +73,5 @@ func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (re
 
 func badCallToZip<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = zip(t: repeat each t, u: repeat each u)
-  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each U' and 'each T' have the same shape}}
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each T' and 'each U' have the same shape}}
 }

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -58,14 +58,14 @@ takesParallelSequences(t: Array<String>(), Set<Int>(), u: Array<Int>(), Set<Stri
 // Same-shape requirements
 
 func zip<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {}
+// expected-note@-1 {{'zip(t:u:)' declared here}}
 
 let _ = zip()  // ok
 let _ = zip(t: 1, u: "hi")  // ok
 let _ = zip(t: 1, 2, u: "hi", "hello")  // ok
 let _ = zip(t: 1, 2, 3, u: "hi", "hello", "greetings")  // ok
-
-// FIXME: Bad diagnostic
-let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{type of expression is ambiguous without more context}}
+let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{extra arguments at positions #3, #4 in call}}
+// expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'Pack{Int}' and 'Pack{String, String, String}' have the same shape}}
 
 func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any {
   _ = zip(t: repeat each t, u: repeat each u)

--- a/test/Constraints/variadic_generic_functions.swift
+++ b/test/Constraints/variadic_generic_functions.swift
@@ -32,9 +32,15 @@ func call() {
 
   let x: String = multipleParameters(xs: "", ys: "")
   let (one, two) = multipleParameters(xs: "", 5.0, ys: "", 5.0)
-  multipleParameters(xs: "", 5.0, ys: 5.0, "") // expected-error {{type of expression is ambiguous without more context}}
+  multipleParameters(xs: "", 5.0, ys: 5.0, "") // expected-error {{conflicting arguments to generic parameter 'each T' ('Pack{Double, String}' vs. 'Pack{String, String}' vs. 'Pack{String, Double}' vs. 'Pack{Double, Double}')}}
 
   func multipleSequences<each T, each U>(xs: repeat each T, ys: repeat each U) -> (repeat each T) {
+    return (repeat each ys)
+    // expected-error@-1 {{pack expansion requires that 'each U' and 'each T' have the same shape}}
+    // expected-error@-2 {{cannot convert return expression of type '(repeat each U)' to return type '(repeat each T)'}}
+  }
+
+  func multipleSequencesWithSameShape<each T, each U>(xs: repeat each T, ys: repeat each U) -> (repeat each T) where (repeat (each T, each U)): Any {
     return (repeat each ys)
     // expected-error@-1 {{cannot convert return expression of type '(repeat each U)' to return type '(repeat each T)'}}
   }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -336,9 +336,10 @@ func test_unknown_refs_in_tilde_operator() {
   enum E {
   }
 
-  let _: (E) -> Void = { // expected-error {{unable to infer closure type in the current context}}
+  let _: (E) -> Void = {
     if case .test(unknown) = $0 {
       // expected-error@-1 2 {{cannot find 'unknown' in scope}}
+      // expected-error@-2 {{type 'E' has no member 'test'}}
     }
   }
 }

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-65360.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-65360.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+
+var a: Any?
+
+let _: () -> Void = {
+  for case (is Int)? in [a] {}
+  if case (is Int, is Int) = a {} // expected-error {{cannot convert value of type 'Any?' to specified type '(_, _)'}}
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-65360.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-65360.swift
@@ -6,3 +6,17 @@ let _: () -> Void = {
   for case (is Int)? in [a] {}
   if case (is Int, is Int) = a {} // expected-error {{cannot convert value of type 'Any?' to specified type '(_, _)'}}
 }
+
+let _: () -> Void = {
+  for case (0)? in [a] {}
+  if case (0, 0) = a {}
+  // expected-error@-1 {{cannot convert value of type 'Any?' to specified type '(_, _)}}
+}
+
+let _: () -> Void = {
+  for case (0)? in [a] {}
+  for case (0, 0) in [a] {}
+  // expected-error@-1 {{conflicting arguments to generic parameter 'Elements' ('[Any]' vs. '[Any?]')}}
+  // expected-error@-2 {{conflicting arguments to generic parameter 'Element' ('Any' vs. 'Any?')}}
+  // expected-error@-3 {{conflicting arguments to generic parameter 'Self' ('[Any]' vs. '[Any?]')}}
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
@@ -10,7 +10,7 @@ func test(result: MyEnum, optResult: MyEnum?) {
   }
 
   if let .co(42) = result { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
-    // expected-error@-1 {{type of expression is ambiguous without more context}}
+    // expected-error@-1 {{type 'MyEnum' has no member 'co'}}
   }
 
   if let .co = optResult { // expected-error {{pattern matching in a condition requires the 'case' keyword}}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65165, https://github.com/apple/swift/pull/65445, https://github.com/apple/swift/pull/65125, https://github.com/apple/swift/pull/64907, https://github.com/apple/swift/pull/65366

---

- Explanation:
 
  - Represent pack expansion type as a type variable. Description of https://github.com/apple/swift/pull/65125 provides a good overview of the new representation;
  - Introduce `same-shape` constraint to match shape types of packs and aid with diagnostics;
  - Prevent invalid pack references from causing infinite loops;
  - Add a few tailed diagnostics to invalid pack expansion expressions;
  - Suppress unused expression warning if result is discardable pack expansion;
  - Add recorded pack expansion environments to solutions.

- Scope: Expressions that use variadic generics feature.

- Main Branch PR: https://github.com/apple/swift/pull/65165, https://github.com/apple/swift/pull/65445, https://github.com/apple/swift/pull/65125, #64907, #65366

- Resolves:  rdar://107996926, rdar://107835125, rdar://107675464, rdar://107429079, rdar://107835215, rdar://107835086, rdar://108064941

- Risk: Medium

- Reviewed By: @hborla

- Testing:  Added regression test-cases to the suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
