### PR TITLE
[cxx-interop] Update a test on Linux

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -4,12 +4,7 @@
 
 import StdlibUnittest
 import StdString
-#if os(Linux)
 import CxxStdlib
-// FIXME: import CxxStdlib.string once libstdc++ is split into submodules.
-#else
-import CxxStdlib.string
-#endif
 
 var StdStringTestSuite = TestSuite("StdString")
 


### PR DESCRIPTION
libstdc++ currently cannot be split into submodules due to the way some types are defined, e.g. there are multiple headers that define `size_t`, so those headers must be a single (sub-)module.