### PR TITLE
[stdlib] Add a conditional identity cast

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -109,14 +109,13 @@ public func _identityCast<T, U>(_ x: T, to expectedType: U.Type) -> U {
   return Builtin.reinterpretCast(x)
 }
 
-/// Returns `x` as its concrete type `U`.
+/// Returns `x` as its concrete type `U`, or `nil` if `x` has a different
+/// concrete type.
 ///
 /// This cast can be useful for dispatching to specializations of generic
 /// functions.
-///
-/// - Requires: `x` has type `U`.
 @_alwaysEmitIntoClient
-public func _conditionalIdentityCast<T, U>(_ x: T, to: U.Type) -> U? {
+public func _specialize<T, U>(_ x: T, for: U.Type) -> U? {
   guard T.self == U.self else {
     return nil
   }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -109,6 +109,21 @@ public func _identityCast<T, U>(_ x: T, to expectedType: U.Type) -> U {
   return Builtin.reinterpretCast(x)
 }
 
+/// Returns `x` as its concrete type `U`.
+///
+/// This cast can be useful for dispatching to specializations of generic
+/// functions.
+///
+/// - Requires: `x` has type `U`.
+@_alwaysEmitIntoClient
+public func _conditionalIdentityCast<T, U>(_ x: T, to: U.Type) -> U? {
+  guard T.self == U.self else {
+    return nil
+  }
+
+  return Builtin.reinterpretCast(x)
+}
+
 /// `unsafeBitCast` something to `AnyObject`.
 @usableFromInline @_transparent
 internal func _reinterpretCastToAnyObject<T>(_ x: T) -> AnyObject {

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -307,4 +307,23 @@ tests.test("_isConcrete") {
   expectFalse(isConcrete_false(Int.self))
 }
 
+tests.test("_conditionalIdentityCast") {
+  func something<T>(with x: some Collection<T>) -> Int {
+    if let y = _conditionalIdentityCast(x, to: [Int].self) {
+      return y[0]
+    } else {
+      return 1234567890
+    }
+  }
+
+  let x = [0987654321, 1, 2]
+  expectEqual(something(with: x), 0987654321)
+
+  let y = CollectionOfOne<String>("hello world")
+  expectEqual(something(with: y), 1234567890)
+
+  let z: Any = [0, 1, 2, 3]
+  expectNil(_conditionalIdentityCast(z, to: [Int].self))
+}
+
 runAllTests()

--- a/test/stdlib/Builtins.swift
+++ b/test/stdlib/Builtins.swift
@@ -307,9 +307,9 @@ tests.test("_isConcrete") {
   expectFalse(isConcrete_false(Int.self))
 }
 
-tests.test("_conditionalIdentityCast") {
+tests.test("_specialize") {
   func something<T>(with x: some Collection<T>) -> Int {
-    if let y = _conditionalIdentityCast(x, to: [Int].self) {
+    if let y = _specialize(x, for: [Int].self) {
       return y[0]
     } else {
       return 1234567890
@@ -323,7 +323,7 @@ tests.test("_conditionalIdentityCast") {
   expectEqual(something(with: y), 1234567890)
 
   let z: Any = [0, 1, 2, 3]
-  expectNil(_conditionalIdentityCast(z, to: [Int].self))
+  expectNil(_specialize(z, for: [Int].self))
 }
 
 runAllTests()


### PR DESCRIPTION
This is a conditional variant of `_identityCast` that returns nil if the types do not compare equal.