### PR TITLE
Concurrency: Make _Concurrency module interface parseable by older compilers

### DIFF
--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -172,7 +172,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    _taskLocalValuePush(key: key, value: valueDuringOperation)
     defer { _taskLocalValuePop() }
 
     return try await operation()

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -149,7 +149,6 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-concurrency
-    -enable-experimental-feature MoveOnly
     -diagnostic-style swift
     ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
   ${swift_concurrency_options}

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -172,7 +172,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    _taskLocalValuePush(key: key, value: valueDuringOperation)
     defer { _taskLocalValuePop() }
 
     return try await operation()


### PR DESCRIPTION
Revert a few unnecessary changes have been made to the _Concurrency module recently that make its swiftinterface un-parseable by older compilers that we need to support.

- The `consume` keyword is not understood by older compilers, so including it in inlinable code is a problem. It has no actual effect on lifetimes where it was used, so just omit it.
- Don't build the _Concurrency module with `-enable-experimental-feature MoveOnly`. The MoveOnly feature is now enabled by default in recent compilers, so the flag is superfluous when building the dylib. When emitting the interface, having the feature enabled explicitly exposes code guarded by `$MoveOnly` to older compilers that do not accept all of the code.

Resolves rdar://108793606
