### PR TITLE
[5.9] Concurrency: Make _Concurrency module interface parsable by older compilers

### DIFF
--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -172,7 +172,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    _taskLocalValuePush(key: key, value: valueDuringOperation)
     do {
       let result = try await operation()
       _taskLocalValuePop()

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -172,7 +172,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    _taskLocalValuePush(key: key, value: valueDuringOperation)
     do {
       let result = try await operation()
       _taskLocalValuePop()


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/65599.

Revert a few unnecessary changes have been made to the _Concurrency module recently that make its swiftinterface un-parseable by older compilers that we need to support.

- The `consume` keyword is not understood by older compilers, so including it in inlinable code is a problem. It has no actual effect on lifetimes where it was used, so just omit it.

 Resolves rdar://108793606
