### PR TITLE
[5.9] Macros: Escape `init` when printing names for attached macros

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1384,7 +1384,9 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
             if (macroIntroducedNameRequiresArgument(name.getKind())) {
               SmallString<32> buffer;
               StringRef nameText = name.getName().getString(buffer);
-              bool shouldEscape = nameText == "$";
+              bool shouldEscape =
+                  escapeKeywordInContext(nameText, PrintNameContext::Normal) ||
+                  nameText == "$";
               Printer << "(";
               if (shouldEscape)
                 Printer << "`";

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -38,7 +38,7 @@
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 // CHECK-NEXT: #endif
 @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65602.

Older compilers can't parse `name(init)`. Restore the call to `escapeKeywordInContext()` to ensure special names get escaped.

Resolves rdar://108806697
