### PR TITLE
[move-only] Address Only Patches

### DIFF
--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -30,6 +30,12 @@ public:
   void operator delete(void *, size_t) = delete;
 
   static SILUndef *get(SILType ty, SILModule &m);
+
+  /// Return a SILUndef with the same type as the passed in value.
+  static SILUndef *get(SILValue value) {
+    return SILUndef::get(value->getType(), *value->getModule());
+  }
+
   static SILUndef *get(SILType ty, const SILFunction &f);
 
   template <class OwnerTy>

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3183,7 +3183,8 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
     SILValue accessAddr = UnenforcedFormalAccess::enter(*this, loc, destAddr,
                                                         SILAccessKind::Read);
 
-    if (accessAddr->getType().isMoveOnly()) {
+    if (accessAddr->getType().isMoveOnly() &&
+        !isa<MarkMustCheckInst>(accessAddr)) {
       // When loading an rvalue, we should never need to modify the place
       // we're loading from.
       accessAddr = B.createMarkMustCheckInst(

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -748,7 +748,6 @@ private:
   /// if not null.
   void makeArgumentIntoBinding(SILLocation loc, ParamDecl *pd) {
     ManagedValue argrv = makeArgument(loc, pd);
-
     SILValue value = argrv.getValue();
     if (pd->isInOut()) {
       assert(argrv.getType().isAddress() && "expected inout to be address");
@@ -768,18 +767,52 @@ private:
     if (!argrv.getType().isAddress()) {
       // NOTE: We setup SGF.VarLocs[pd] in updateArgumentValueForBinding.
       updateArgumentValueForBinding(argrv, loc, pd, value, varinfo);
-    } else {
-      if (auto *allocStack = dyn_cast<AllocStackInst>(value)) {
-        allocStack->setArgNo(ArgNo);
-        if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(
-                SGF.getModule()) &&
-            SGF.F.getLifetime(pd, value->getType()).isLexical())
-          allocStack->setIsLexical();
-      } else {
-        SGF.B.createDebugValueAddr(loc, value, varinfo);
-      }
-      SGF.VarLocs[pd] = SILGenFunction::VarLoc::get(value);
+      return;
     }
+
+    if (auto *allocStack = dyn_cast<AllocStackInst>(value)) {
+      allocStack->setArgNo(ArgNo);
+      if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(
+              SGF.getModule()) &&
+          SGF.F.getLifetime(pd, value->getType()).isLexical())
+        allocStack->setIsLexical();
+      SGF.VarLocs[pd] = SILGenFunction::VarLoc::get(value);
+      return;
+    }
+
+    if (value->getType().isMoveOnly()) {
+      switch (pd->getValueOwnership()) {
+      case ValueOwnership::Default:
+        if (pd->isSelfParameter()) {
+          assert(!isa<MarkMustCheckInst>(value) &&
+                 "Should not have inserted mark must check inst in EmitBBArgs");
+          if (!pd->isInOut()) {
+            value = SGF.B.createMarkMustCheckInst(
+                loc, value, MarkMustCheckInst::CheckKind::NoConsumeOrAssign);
+          }
+        } else {
+          assert(isa<MarkMustCheckInst>(value) &&
+                 "Should have inserted mark must check inst in EmitBBArgs");
+        }
+        break;
+      case ValueOwnership::InOut:
+        assert(isa<MarkMustCheckInst>(value) &&
+               "Expected mark must check inst with inout to be handled in "
+               "emitBBArgs earlier");
+        break;
+      case ValueOwnership::Owned:
+        value = SGF.B.createMarkMustCheckInst(
+            loc, value, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
+        break;
+      case ValueOwnership::Shared:
+        value = SGF.B.createMarkMustCheckInst(
+            loc, value, MarkMustCheckInst::CheckKind::NoConsumeOrAssign);
+        break;
+      }
+    }
+
+    SGF.B.createDebugValueAddr(loc, value, varinfo);
+    SGF.VarLocs[pd] = SILGenFunction::VarLoc::get(value);
   }
 
   void emitParam(ParamDecl *PD) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1728,9 +1728,30 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
   // Now that we have handled or loadTakeOrCopy, we need to now track our
   // additional pure takes.
   if (::memInstMustConsume(op)) {
+    // If we don't have a consumeable and assignable check kind, then we can't
+    // consume. Emit an error.
+    //
+    // NOTE: Since SILGen eagerly loads loadable types from memory, this
+    // generally will only handle address only types.
+    if (markedValue->getCheckKind() !=
+        MarkMustCheckInst::CheckKind::ConsumableAndAssignable) {
+      auto *fArg = dyn_cast<SILFunctionArgument>(
+          stripAccessMarkers(markedValue->getOperand()));
+      if (fArg && fArg->isClosureCapture() && fArg->getType().isAddress()) {
+        moveChecker.diagnosticEmitter.emitPromotedBoxArgumentError(markedValue,
+                                                                   fArg);
+      } else {
+        moveChecker.diagnosticEmitter
+            .emitAddressEscapingClosureCaptureLoadedAndConsumed(markedValue);
+      }
+      emittedEarlyDiagnostic = true;
+      return true;
+    }
+
     auto leafRange = TypeTreeLeafTypeRange::get(op->get(), getRootAddress());
     if (!leafRange)
       return false;
+
     LLVM_DEBUG(llvm::dbgs() << "Pure consuming use: " << *user);
     useState.takeInsts.insert({user, *leafRange});
     return true;
@@ -2430,7 +2451,6 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
     LLVM_DEBUG(llvm::dbgs() << "Failed access path visit: " << *markedAddress);
     return false;
   }
-  addressUseState.initializeInOutTermUsers();
 
   // If we found a load [copy] or copy_addr that requires multiple copies or an
   // exclusivity error, then we emitted an early error. Bail now and allow the
@@ -2445,9 +2465,14 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
   if (diagCount != diagnosticEmitter.getDiagnosticCount())
     return true;
 
-  // Then check if we emitted an error. If we did not, return true.
-  if (diagCount != diagnosticEmitter.getDiagnosticCount())
-    return true;
+  // Now that we know that we have run our visitor and did not emit any errors
+  // and successfully visited everything, see if have any
+  // assignable_but_not_consumable of address only types that are consumed.
+  //
+  // DISCUSSION: For non address only types, this is not an issue since we
+  // eagerly load
+
+  addressUseState.initializeInOutTermUsers();
 
   //===---
   // Liveness Checking

--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -45,7 +45,7 @@ Tests.test("global destroyed once") {
   do {
     global = FD()
   }
-  expectEqual(0, LifetimeTracked.instances)    
+  expectEqual(0, LifetimeTracked.instances)
 }
 
 @_moveOnly
@@ -104,3 +104,31 @@ Tests.test("empty struct") {
     let _ = consume e
   }
 }
+
+protocol P {
+   var name: String { get }
+}
+
+Tests.test("AddressOnly") {
+    class Klass : P {
+        var name: String { "myName" }
+    }
+
+    @_moveOnly
+    struct S<T : P> {
+        var t: T
+    }
+
+    let e = S(t: Klass())
+    expectEqual(e.t.name, "myName")
+
+    func testGeneric<T : P>(_ x: borrowing S<T>) {
+        expectEqual(x.t.name, "myName")
+    }
+    testGeneric(e)
+
+    if e.t.name.count == 5 {
+        let _ = consume e
+    }
+}
+

--- a/test/SILOptimizer/move_only_checker_addressonly_fail.swift
+++ b/test/SILOptimizer/move_only_checker_addressonly_fail.swift
@@ -10,8 +10,12 @@ struct GenericAggregate<T> {
 func test1<T>(_ x: T) {
     @_noImplicitCopy let x2 = x // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
 
-    consumeValue(x2) // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    // expected-note @-1 {{consuming use here}}
-    consumeValue(x2) // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    // expected-note @-1 {{consuming use here}}
+    // These fail b/c we use an unchecked_addr_cast to convert addresses from
+    // @moveOnly to non-@moveOnly. We should change moveonly_to_copyable to
+    // handle addresses as well.
+    //
+    // An earlier change, I believe made it so that SILGen did not emit these
+    // unchecked_addr_cast.
+    consumeValue(x2) // expected-error {{Usage of @noImplicitCopy that the move checker does not know how to check!}}
+    consumeValue(x2) // expected-error {{Usage of @noImplicitCopy that the move checker does not know how to check!}}
 }

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -526,7 +526,7 @@ sil [ossa] @test_in_use : $@convention(thin) () -> () {
   %9 = function_ref @getNonTrivialStruct : $@convention(thin) () -> @owned NonTrivialStruct
   %10 = apply %9() : $@convention(thin) () -> @owned NonTrivialStruct
   %0 = alloc_stack [moveable_value_debuginfo] $NonTrivialStruct
-  %2 = mark_must_check [assignable_but_not_consumable] %0 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %0 : $*NonTrivialStruct
   store %10 to [init] %2 : $*NonTrivialStruct
   %f2 = function_ref @consumeNonTrivialStructAddr : $@convention(thin) (@in NonTrivialStruct) -> ()
   apply %f2(%2) : $@convention(thin) (@in NonTrivialStruct) -> ()

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -59,12 +59,30 @@ public struct AggStruct {
     var pair: KlassPair
 }
 
+protocol P {
+    static var value: Self { get }
+    static var value2: any P { get }
+}
+
+@_moveOnly
+public struct AddressOnlyGeneric<T : P> {
+    var copyable: T
+    var moveOnly: NonTrivialStruct
+
+    init()
+    init(_ input1: T)
+}
+
 sil @get_aggstruct : $@convention(thin) () -> @owned AggStruct
 sil @nonConsumingUseKlass : $@convention(thin) (@guaranteed Klass) -> ()
 sil @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
 sil @classConsume : $@convention(thin) (@owned Klass) -> () // user: %18
 sil @copyableClassConsume : $@convention(thin) (@owned CopyableKlass) -> () // user: %24
 sil @copyableClassUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed CopyableKlass) -> () // user: %16
+sil @getAddressOnlyGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out AddressOnlyGeneric<τ_0_0>
+sil @addressOnlyGenericInOutUse : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout AddressOnlyGeneric<τ_0_0>) -> ()
+sil @addressOnlyGenericConsume : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
+sil @addressOnlyGenericUse : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed AddressOnlyGeneric<τ_0_0>) -> ()
 
 ///////////
 // Tests //
@@ -315,4 +333,35 @@ bb0(%0 : $*Klass):
   dealloc_stack %3 : $*Klass
   %27 = tuple ()
   return %27 : $()
+}
+
+////////////////////////
+// Address Only Tests //
+////////////////////////
+
+sil [ossa] @inoutCaptureTestAddressOnlyGenericClosure2 : $@convention(thin) <T where T : P> (@guaranteed <τ_0_0 where τ_0_0 : P> { var AddressOnlyGeneric<τ_0_0> } <T>) -> () {
+bb0(%0 : @closureCapture @guaranteed $<τ_0_0 where τ_0_0 : P> { var AddressOnlyGeneric<τ_0_0> } <T>):
+  %1 = project_box %0 : $<τ_0_0 where τ_0_0 : P> { var AddressOnlyGeneric<τ_0_0> } <T>, 0
+  debug_value %1 : $*AddressOnlyGeneric<T>, var, name "x", argno 1, expr op_deref
+  %3 = alloc_stack $AddressOnlyGeneric<T>
+  %5 = function_ref @getAddressOnlyGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out AddressOnlyGeneric<τ_0_0>
+  %6 = apply %5<T>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out AddressOnlyGeneric<τ_0_0>
+  %7 = begin_access [modify] [dynamic] %1 : $*AddressOnlyGeneric<T>
+  %8 = mark_must_check [assignable_but_not_consumable] %7 : $*AddressOnlyGeneric<T>
+  copy_addr [take] %3 to %8 : $*AddressOnlyGeneric<T>
+  end_access %7 : $*AddressOnlyGeneric<T>
+  dealloc_stack %3 : $*AddressOnlyGeneric<T>
+  %12 = begin_access [modify] [dynamic] %1 : $*AddressOnlyGeneric<T>
+  %13 = mark_must_check [assignable_but_not_consumable] %12 : $*AddressOnlyGeneric<T>
+  %14 = function_ref @addressOnlyGenericInOutUse : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout AddressOnlyGeneric<τ_0_0>) -> ()
+  %15 = apply %14<T>(%13) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout AddressOnlyGeneric<τ_0_0>) -> ()
+  end_access %12 : $*AddressOnlyGeneric<T>
+  %17 = begin_access [deinit] [dynamic] %1 : $*AddressOnlyGeneric<T>
+  %18 = mark_must_check [assignable_but_not_consumable] %17 : $*AddressOnlyGeneric<T>
+  // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+  %19 = function_ref @addressOnlyGenericConsume : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
+  %20 = apply %19<T>(%18) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
+  end_access %17 : $*AddressOnlyGeneric<T>
+  %22 = tuple ()
+  return %22 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -53,6 +53,8 @@ public struct NonTrivialStruct {
     var copyableK = CopyableKlass()
     var nonTrivialStruct2 = NonTrivialStruct2()
     var nonTrivialCopyableStruct = NonTrivialCopyableStruct()
+
+    var computedCopyableK: CopyableKlass { CopyableKlass() }
 }
 
 @_moveOnly
@@ -67,6 +69,7 @@ public struct NonTrivialCopyableStruct {
 
 public struct NonTrivialCopyableStruct2 {
     var copyableKlass = CopyableKlass()
+    var computedCopyableKlass: CopyableKlass { CopyableKlass() }
 }
 
 @_moveOnly
@@ -3473,6 +3476,49 @@ func copyableStructsInMoveOnlyStructNonConsuming() {
     borrowVal(a.nonTrivialCopyableStruct)
     borrowVal(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2)
     borrowVal(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass)
+}
+
+func computedCopyableKlassInAMoveOnlyStruct() {
+    var a = NonTrivialStruct()
+    a = NonTrivialStruct()
+    borrowVal(a.computedCopyableK)
+    consumeVal(a.computedCopyableK)
+}
+
+// This shouldn't error since we are consuming a copyable type.
+func computedCopyableKlassInAMoveOnlyStruct2() {
+    var a = NonTrivialStruct()
+    a = NonTrivialStruct()
+    borrowVal(a.computedCopyableK)
+    consumeVal(a.computedCopyableK)
+    consumeVal(a.computedCopyableK)
+}
+
+// This shouldn't error since we are working with a copyable type.
+func computedCopyableKlassInAMoveOnlyStruct3() {
+    var a = NonTrivialStruct()
+    a = NonTrivialStruct()
+    borrowVal(a.computedCopyableK)
+    consumeVal(a.computedCopyableK)
+    borrowVal(a.computedCopyableK)
+}
+
+// This used to error, but no longer errors since we are using a true field
+// sensitive model.
+func computedCopyableKlassInAMoveOnlyStruct4() {
+    var a = NonTrivialStruct()
+    a = NonTrivialStruct()
+    borrowVal(a.computedCopyableK)
+    consumeVal(a.computedCopyableK)
+    borrowVal(a.nonTrivialStruct2)
+}
+
+func computedCopyableStructsInMoveOnlyStructNonConsuming() {
+    var a = NonTrivialStruct()
+    a = NonTrivialStruct()
+    borrowVal(a)
+    borrowVal(a.computedCopyableK)
+    borrowVal(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.computedCopyableKlass)
 }
 
 ///////////////////////////

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3609,6 +3609,29 @@ func inoutCaptureTest() -> (() -> ()) {
     return f
 }
 
+func inoutCaptureTestAddressOnlyGeneric<T : P>(_ t: T.Type) -> (() -> ()) {
+    var x = AddressOnlyGeneric<T>()
+    x = AddressOnlyGeneric<T>()
+
+    func useInOut(_ x: inout AddressOnlyGeneric<T>) {}
+    let f = {
+        useInOut(&x)
+    }
+
+    borrowVal(x)
+    consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    x = AddressOnlyGeneric<T>()
+
+    let g = {
+        x = AddressOnlyGeneric<T>()
+        useInOut(&x)
+        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    }
+    g()
+
+    return f
+}
+
 ////////////////
 // Misc Tests //
 ////////////////

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -2278,13 +2278,10 @@ public func addressOnlyGenericAssignToVar5Arg2<T>(_ x: borrowing AddressOnlyGene
 // remove them when I fix it in the next commit.
 public func addressOnlyGenericAccessAccessField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
-    // expected-error @-2 {{'x2' consumed more than once}}
     x2 = AddressOnlyGeneric<T>()
-    borrowVal(x2.copyable) // expected-note {{consuming use here}}
+    borrowVal(x2.copyable)
     for _ in 0..<1024 {
-        borrowVal(x2.copyable) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        borrowVal(x2.copyable)
     }
 }
 
@@ -2298,11 +2295,9 @@ public func addressOnlyGenericAccessAccessField2<T>(_ x: borrowing AddressOnlyGe
 }
 
 public func addressOnlyGenericAccessAccessFieldArg<T>(_ x2: inout AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    borrowVal(x2.copyable) // expected-note {{consuming use here}}
+    borrowVal(x2.copyable)
     for _ in 0..<1024 {
-        borrowVal(x2.copyable) // expected-note {{consuming use here}}
+        borrowVal(x2.copyable)
     }
 }
 
@@ -2314,12 +2309,9 @@ public func addressOnlyGenericAccessAccessFieldArg2<T>(_ x2: inout AddressOnlyGe
 }
 
 public func addressOnlyGenericAccessAccessFieldArg3<T>(_ x2: consuming AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    borrowVal(x2.copyable) // expected-note {{consuming use here}}
+    borrowVal(x2.copyable)
     for _ in 0..<1024 {
-        borrowVal(x2.copyable) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        borrowVal(x2.copyable)
     }
 }
 
@@ -2332,14 +2324,11 @@ public func addressOnlyGenericAccessAccessFieldArg4<T>(_ x2: consuming AddressOn
 
 public func addressOnlyGenericAccessConsumeField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
-    // expected-error @-2 {{'x2' consumed more than once}}
     x2 = AddressOnlyGeneric<T>()
 
-    consumeVal(x2.copyable) // expected-note {{consuming use here}}
+    consumeVal(x2.copyable)
     for _ in 0..<1024 {
-        consumeVal(x2.copyable) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.copyable)
     }
 }
 
@@ -2357,13 +2346,9 @@ public func addressOnlyGenericAccessConsumeField2<T>(_ x: borrowing AddressOnlyG
 }
 
 public func addressOnlyGenericAccessConsumeFieldArg<T>(_ x2: inout AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-
-    consumeVal(x2.copyable) // expected-note {{consuming use here}}
-
+    consumeVal(x2.copyable)
     for _ in 0..<1024 {
-        consumeVal(x2.copyable) // expected-note {{consuming use here}}
+        consumeVal(x2.copyable)
     }
 }
 
@@ -2378,14 +2363,10 @@ public func addressOnlyGenericAccessConsumeFieldArg2<T>(_ x2: inout AddressOnlyG
 }
 
 public func addressOnlyGenericAccessConsumeFieldArg3<T>(_ x2: consuming AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-
-    consumeVal(x2.copyable) // expected-note {{consuming use here}}
+    consumeVal(x2.copyable)
 
     for _ in 0..<1024 {
-        consumeVal(x2.copyable) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.copyable)
     }
 }
 


### PR DESCRIPTION
NOTE: In the following when I refer to an address only move only type, I am not referring to a generic type that is move only, instead I am referring to a concrete move only type that is generic over a copyable type T and contains that copyable type T as a field.

This PR contains a few changes needed for address only move only types.

Specifically:

1. This fixes SILGenProlog so arguments are handled correctly.
2. This changes the move checker so that if one uses an address only copyable type that is stored within a move only type, it is not considered to be a consume of the move only type.
3. It changes SILGenLValue so that we do not emit redundant mark_must_check if we are emitting an rvalue access to an address only. move only function argument.
4. It teaches the compiler how to properly check address only move only types.
5. It adds a bunch of tests both for address only move only types and also for some other cases that I noticed we did not have enough tests for.

rdar://105106470