### PR TITLE
stdlib: force inlining of `ContiguousArray.endIndex` and `ContiguousArray._getCount`

### DIFF
--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -53,6 +53,7 @@ public struct ContiguousArray<Element>: _DestructorSafeContainer {
 //===--- private helpers---------------------------------------------------===//
 extension ContiguousArray {
   @inlinable
+  @inline(__always)
   @_semantics("array.get_count")
   internal func _getCount() -> Int {
     return _buffer.immutableCount
@@ -204,6 +205,7 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
   /// If the array is empty, `endIndex` is equal to `startIndex`.
   public var endIndex: Int {
     @inlinable
+    @inline(__always)
     get {
       return _getCount()
     }

--- a/test/SILOptimizer/array_loop.swift
+++ b/test/SILOptimizer/array_loop.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -O -module-name=test -emit-sil -primary-file %s | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: swift_in_compiler
+
+
+// Test that even with a generic array the iteration is done efficiently.
+
+// CHECK-LABEL: sil @$s4test0A15ContiguousArrayySis0bC0VyxG_SixXEtlF : $@convention(thin) <Element> (@guaranteed ContiguousArray<Element>, @guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> Int for <Element>) -> Int {
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     method
+// CHECK:       } // end sil function '$s4test0A15ContiguousArrayySis0bC0VyxG_SixXEtlF'
+public func testContiguousArray<Element>(_ a: ContiguousArray<Element>, _ c: (Element) -> Int) -> Int {
+  var s = 0
+  for x in a {
+    s += c(x)
+  }
+  return s
+}
+


### PR DESCRIPTION
This lets the optimizer generate efficient code for generic array loops (note that generic functions are not inlined by default). Note that the same change is not done for `Array` because this might increase code size due to Array's bridging code.

rdar://108746069
