### PR TITLE
[DiscardingTG] Undo pointer auth workaround; fix memory leaks

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2334,6 +2334,7 @@ public:
     Task_InheritContext                           = 11,
     Task_EnqueueJob                               = 12,
     Task_AddPendingGroupTaskUnconditionally       = 13,
+    Task_IsDiscardingTask                         = 14,
   };
 
   explicit constexpr TaskCreateFlags(size_t bits) : FlagSet(bits) {}
@@ -2360,6 +2361,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Task_AddPendingGroupTaskUnconditionally,
                                 addPendingGroupTaskUnconditionally,
                                 setAddPendingGroupTaskUnconditionally)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsDiscardingTask,
+                                isDiscardingTask,
+                                setIsDiscardingTask)
 };
 
 /// Flags for schedulable jobs.

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -171,21 +171,21 @@ public struct DiscardingTaskGroup {
   #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
   #endif
-  public mutating func addTask<DiscardedResult>(
+  public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> DiscardedResult
+    operation: __owned @Sendable @escaping () async -> Void
   ) {
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: false,
-      addPendingGroupTaskUnconditionally: true
+      addPendingGroupTaskUnconditionally: true, isDiscardingTask: true
     )
 #else
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
+      addPendingGroupTaskUnconditionally: true, isDiscardingTask: true
     )
 #endif
 
@@ -206,9 +206,9 @@ public struct DiscardingTaskGroup {
   #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
   #endif
-  public mutating func addTaskUnlessCancelled<DiscardedResult>(
+  public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async -> DiscardedResult
+    operation: __owned @Sendable @escaping () async -> Void
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
@@ -220,13 +220,13 @@ public struct DiscardingTaskGroup {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: false,
-      addPendingGroupTaskUnconditionally: false
+      addPendingGroupTaskUnconditionally: false, isDiscardingTask: true
     )
 #else
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
+      addPendingGroupTaskUnconditionally: false, isDiscardingTask: true
     )
 #endif
 
@@ -237,13 +237,13 @@ public struct DiscardingTaskGroup {
   }
 
   @_alwaysEmitIntoClient
-  public mutating func addTask<DiscardedResult>(
-    operation: __owned @Sendable @escaping () async -> DiscardedResult
+  public mutating func addTask(
+    operation: __owned @Sendable @escaping () async -> Void
   ) {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
+      addPendingGroupTaskUnconditionally: true, isDiscardingTask: true
     )
 
     // Create the task in this group.
@@ -260,8 +260,8 @@ public struct DiscardingTaskGroup {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
 #endif
   @_alwaysEmitIntoClient
-  public mutating func addTaskUnlessCancelled<DiscardedResult>(
-    operation: __owned @Sendable @escaping () async -> DiscardedResult
+  public mutating func addTaskUnlessCancelled(
+    operation: __owned @Sendable @escaping () async -> Void
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -274,7 +274,7 @@ public struct DiscardingTaskGroup {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
+      addPendingGroupTaskUnconditionally: false, isDiscardingTask: true
     )
 
     // Create the task in this group.
@@ -547,15 +547,15 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
 #endif
   @_alwaysEmitIntoClient
-  public mutating func addTask<DiscardedResult>(
+  public mutating func addTask(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> DiscardedResult
+    operation: __owned @Sendable @escaping () async throws -> Void
   ) {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
+      addPendingGroupTaskUnconditionally: true, isDiscardingTask: true
     )
 
     // Create the task in this group.
@@ -569,9 +569,9 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
 #endif
   @_alwaysEmitIntoClient
-  public mutating func addTaskUnlessCancelled<DiscardedResult>(
+  public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> DiscardedResult
+    operation: __owned @Sendable @escaping () async throws -> Void
   ) -> Bool {
 #if compiler(>=5.5) && $BuiltinCreateAsyncTaskInGroup
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -584,7 +584,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
+      addPendingGroupTaskUnconditionally: false, isDiscardingTask: true
     )
 
     // Create the task in this group.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -200,7 +200,8 @@ extension Task where Failure == Error {
         let flags = taskCreateFlags(priority: priority, isChildTask: false,
                                     copyTaskLocals: true, inheritContext: true,
                                     enqueueJob: false,
-                                    addPendingGroupTaskUnconditionally: false)
+                                    addPendingGroupTaskUnconditionally: false,
+                                    isDiscardingTask: false)
         let (task, _) = Builtin.createAsyncTask(flags, work)
         _startTaskOnMainActor(task)
         return Task<Success, Error>(task)
@@ -222,7 +223,8 @@ extension Task where Failure == Never {
         let flags = taskCreateFlags(priority: priority, isChildTask: false,
                                     copyTaskLocals: true, inheritContext: true,
                                     enqueueJob: false,
-                                    addPendingGroupTaskUnconditionally: false)
+                                    addPendingGroupTaskUnconditionally: false,
+                                    isDiscardingTask: false)
         let (task, _) = Builtin.createAsyncTask(flags, work)
         _startTaskOnMainActor(task)
         return Task(task)
@@ -503,36 +505,8 @@ struct JobFlags {
 func taskCreateFlags(
   priority: TaskPriority?, isChildTask: Bool, copyTaskLocals: Bool,
   inheritContext: Bool, enqueueJob: Bool,
-  addPendingGroupTaskUnconditionally: Bool
-) -> Int {
-  var bits = 0
-  bits |= (bits & ~0xFF) | Int(priority?.rawValue ?? 0)
-  if isChildTask {
-    bits |= 1 << 8
-  }
-  if copyTaskLocals {
-    bits |= 1 << 10
-  }
-  if inheritContext {
-    bits |= 1 << 11
-  }
-  if enqueueJob {
-    bits |= 1 << 12
-  }
-  if addPendingGroupTaskUnconditionally {
-    bits |= 1 << 13
-  }
-  return bits
-}
-
-/// Form task creation flags for use with the createAsyncTask builtins.
-@available(SwiftStdlib 5.9, *)
-@_alwaysEmitIntoClient
-func taskCreateFlags(
-    priority: TaskPriority?, isChildTask: Bool, copyTaskLocals: Bool,
-    inheritContext: Bool, enqueueJob: Bool,
-    addPendingGroupTaskUnconditionally: Bool,
-    isDiscardingTask: Bool
+  addPendingGroupTaskUnconditionally: Bool,
+  isDiscardingTask: Bool
 ) -> Int {
   var bits = 0
   bits |= (bits & ~0xFF) | Int(priority?.rawValue ?? 0)
@@ -605,7 +579,8 @@ extension Task where Failure == Never {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: false, copyTaskLocals: true,
       inheritContext: true, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false)
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the asynchronous task.
     let (task, _) = Builtin.createAsyncTask(flags, operation)
@@ -665,8 +640,8 @@ extension Task where Failure == Error {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: false, copyTaskLocals: true,
       inheritContext: true, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the asynchronous task future.
     let (task, _) = Builtin.createAsyncTask(flags, operation)
@@ -724,7 +699,8 @@ extension Task where Failure == Never {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: false, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false)
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the asynchronous task future.
     let (task, _) = Builtin.createAsyncTask(flags, operation)
@@ -783,8 +759,8 @@ extension Task where Failure == Error {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: false, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the asynchronous task future.
     let (task, _) = Builtin.createAsyncTask(flags, operation)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -525,6 +525,38 @@ func taskCreateFlags(
   return bits
 }
 
+/// Form task creation flags for use with the createAsyncTask builtins.
+@available(SwiftStdlib 5.9, *)
+@_alwaysEmitIntoClient
+func taskCreateFlags(
+    priority: TaskPriority?, isChildTask: Bool, copyTaskLocals: Bool,
+    inheritContext: Bool, enqueueJob: Bool,
+    addPendingGroupTaskUnconditionally: Bool,
+    isDiscardingTask: Bool
+) -> Int {
+  var bits = 0
+  bits |= (bits & ~0xFF) | Int(priority?.rawValue ?? 0)
+  if isChildTask {
+    bits |= 1 << 8
+  }
+  if copyTaskLocals {
+    bits |= 1 << 10
+  }
+  if inheritContext {
+    bits |= 1 << 11
+  }
+  if enqueueJob {
+    bits |= 1 << 12
+  }
+  if addPendingGroupTaskUnconditionally {
+    bits |= 1 << 13
+  }
+  if isDiscardingTask {
+    bits |= 1 << 14
+  }
+  return bits
+}
+
 // ==== Task Creation ----------------------------------------------------------
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -272,14 +272,15 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: false,
-      addPendingGroupTaskUnconditionally: true
+      addPendingGroupTaskUnconditionally: true,
+      isDiscardingTask: false
     )
 #else
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
-    )
+      addPendingGroupTaskUnconditionally: true,
+      isDiscardingTask: false)
 #endif
 
     // Create the task in this group.
@@ -314,14 +315,14 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: false,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 #else
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 #endif
 
     // Create the task in this group.
@@ -354,8 +355,8 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
-    )
+      addPendingGroupTaskUnconditionally: true,
+      isDiscardingTask: false)
 
     // Create the task in this group.
     _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
@@ -394,8 +395,8 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the task in this group.
     _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
@@ -682,7 +683,8 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
+      addPendingGroupTaskUnconditionally: true,
+      isDiscardingTask: false
     )
 
     // Create the task in this group.
@@ -720,8 +722,8 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the task in this group.
     _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
@@ -756,8 +758,8 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: true
-    )
+      addPendingGroupTaskUnconditionally: true,
+      isDiscardingTask: false)
 
     // Create the task in this group.
     _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
@@ -799,8 +801,8 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     let flags = taskCreateFlags(
       priority: nil, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
-      addPendingGroupTaskUnconditionally: false
-    )
+      addPendingGroupTaskUnconditionally: false,
+      isDiscardingTask: false)
 
     // Create the task in this group.
     _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -240,7 +240,8 @@ extension Task where Success == Never, Failure == Never {
               let sleepTaskFlags = taskCreateFlags(
                 priority: nil, isChildTask: false, copyTaskLocals: false,
                 inheritContext: false, enqueueJob: false,
-                addPendingGroupTaskUnconditionally: false)
+                addPendingGroupTaskUnconditionally: false,
+                isDiscardingTask: false)
               let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
                 onSleepWake(wordPtr)
               }

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -58,7 +58,8 @@ extension Task where Success == Never, Failure == Never {
               let sleepTaskFlags = taskCreateFlags(
                 priority: nil, isChildTask: false, copyTaskLocals: false,
                 inheritContext: false, enqueueJob: false,
-                addPendingGroupTaskUnconditionally: false)
+                addPendingGroupTaskUnconditionally: false,
+                isDiscardingTask: false)
               let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
                 onSleepWake(wordPtr)
               }

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -525,6 +525,7 @@ void (*SWIFT_RT_DECLARE_ENTRY _swift_release)(HeapObject *object) =
     _swift_release_;
 
 void swift::swift_nonatomic_release(HeapObject *object) {
+  fprintf(stderr, "[%s:%d](%s) swift_nonatomic_release %p\n", __FILE_NAME__, __LINE__, __FUNCTION__, object);
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_release);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinitNonAtomic(1);
@@ -532,6 +533,7 @@ void swift::swift_nonatomic_release(HeapObject *object) {
 
 SWIFT_ALWAYS_INLINE
 static void _swift_release_n_(HeapObject *object, uint32_t n) {
+fprintf(stderr, "[%s:%d](%s) _swift_release_n_ %p (n=%d)\n", __FILE_NAME__, __LINE__, __FUNCTION__, object, n);
   SWIFT_RT_TRACK_INVOCATION(object, swift_release_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinit(n);
@@ -795,6 +797,8 @@ void swift::swift_unownedCheck(HeapObject *object) {
 }
 
 void _swift_release_dealloc(HeapObject *object) {
+  fprintf(stderr, "[%s:%d](%s) _swift_release_dealloc %p (count before: %d)\n", __FILE_NAME__, __LINE__, __FUNCTION__, object,
+          swift_retainCount(object));
   asFullMetadata(object->metadata)->destroy(object);
 }
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -525,7 +525,6 @@ void (*SWIFT_RT_DECLARE_ENTRY _swift_release)(HeapObject *object) =
     _swift_release_;
 
 void swift::swift_nonatomic_release(HeapObject *object) {
-  fprintf(stderr, "[%s:%d](%s) swift_nonatomic_release %p\n", __FILE_NAME__, __LINE__, __FUNCTION__, object);
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_release);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinitNonAtomic(1);
@@ -533,7 +532,6 @@ void swift::swift_nonatomic_release(HeapObject *object) {
 
 SWIFT_ALWAYS_INLINE
 static void _swift_release_n_(HeapObject *object, uint32_t n) {
-fprintf(stderr, "[%s:%d](%s) _swift_release_n_ %p (n=%d)\n", __FILE_NAME__, __LINE__, __FUNCTION__, object, n);
   SWIFT_RT_TRACK_INVOCATION(object, swift_release_n);
   if (isValidPointerForNativeRetain(object))
     object->refCounts.decrementAndMaybeDeinit(n);
@@ -797,8 +795,6 @@ void swift::swift_unownedCheck(HeapObject *object) {
 }
 
 void _swift_release_dealloc(HeapObject *object) {
-  fprintf(stderr, "[%s:%d](%s) _swift_release_dealloc %p (count before: %d)\n", __FILE_NAME__, __LINE__, __FUNCTION__, object,
-          swift_retainCount(object));
   asFullMetadata(object->metadata)->destroy(object);
 }
 

--- a/stdlib/toolchain/Compatibility56/include/Runtime/Concurrency.h
+++ b/stdlib/toolchain/Compatibility56/include/Runtime/Concurrency.h
@@ -51,7 +51,6 @@ struct AsyncTaskAndContext {
   AsyncContext *InitialContext;
 };
 
-
 /// Caution: not all future-initializing functions actually throw, so
 /// this signature may be incorrect.
 using FutureAsyncSignature =

--- a/test/Concurrency/Runtime/async_taskgroup_discarding.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-leaks-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
+// TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test
@@ -11,31 +12,30 @@
 // UNSUPPORTED: OS=windows-msvc
 
 import _Concurrency
-import Darwin
 
-final class FIRST_PAYLOAD {}
-final class SECOND_PAYLOAD {}
+final class PayloadFirst {}
+final class PayloadSecond {}
 
-final class FIRST_ERROR: Error {
-  let first: FIRST_PAYLOAD
+final class ErrorFirst: Error {
+  let first: PayloadFirst
 
   init(file: String = #fileID, line: UInt = #line) {
     first = .init()
   }
   deinit {
-    fputs("\(Self.self) deinit\n", stderr)
+    print("deinit \(self)")
   }
 }
 
-final class SECOND_ERROR: Error {
-  let second: SECOND_PAYLOAD
+final class ErrorSecond: Error {
+  let second: PayloadSecond
 
   init(file: String = #fileID, line: UInt = #line) {
     second = .init()
   }
 
   deinit {
-    fputs("\(Self.self) deinit\n", stderr)
+    print("deinit \(self)")
   }
 }
 
@@ -55,20 +55,20 @@ func shouldStartWith(_ lhs: Any, _ rhs: Any) {
           1
         }
         group.addTask {
-          throw FIRST_ERROR()
+          throw ErrorFirst()
         }
 
-//        try? await Task.sleep(for: .seconds(1))
-
         group.addTask {
-          throw SECOND_ERROR()
+          throw ErrorSecond()
         }
 
         return 12
       }
       fatalError("expected error to be re-thrown, got: \(got)")
     } catch {
-      // shouldStartWith(error, "main.Boom")
+       shouldStartWith(error, "main.Error")
     }
+    // CHECK: deinit main.Error
+    // CHECK: deinit main.Error
   }
 }

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
@@ -1,0 +1,122 @@
+// RUN: %target-run-simple-leaks-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// This test uses `leaks` which is only available on apple platforms; limit it to macOS:
+// REQUIRES: OS=macosx
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+// FIXME: enable discarding taskgroup on windows; rdar://104762037
+// UNSUPPORTED: OS=windows-msvc
+
+import _Concurrency
+
+struct Boom: Error {
+  let id: String
+
+  init(file: String = #fileID, line: UInt = #line) {
+    self.id = "\(file):\(line)"
+  }
+
+  init(id: String) {
+    self.id = id
+  }
+}
+
+final class BoomClass: Error {
+  let id: String
+
+  init(file: String = #fileID, line: UInt = #line) {
+    self.id = "\(file):\(line)"
+  }
+
+  init(id: String) {
+    self.id = id
+  }
+}
+
+final class SomeClass: @unchecked Sendable {
+//struct SomeClass: @unchecked Sendable {
+  let number: Int
+  init() {
+    self.number = 0
+  }
+  init(number: Int) {
+    self.number = number
+  }
+}
+
+// NOTE: Not as StdlibUnittest/TestSuite since these types of tests are unreasonably slow to load/debug.
+
+@main struct Main {
+  static func main() async {
+    _ = try? await withThrowingDiscardingTaskGroup() { group in
+      group.addTask {
+        throw Boom()
+      }
+      group.addTask {
+        SomeClass() // will be discarded
+      }
+
+      return 12
+    }
+
+    // many ok
+    _ = try? await withThrowingDiscardingTaskGroup() { group in
+      for i in 0..<10 {
+        group.addTask {
+          SomeClass(number: i) // will be discarded
+        }
+      }
+
+      return 12
+    }
+
+    // many throws
+    do {
+      let value = try await withThrowingDiscardingTaskGroup() { group in
+        for i in 0..<10 {
+          group.addTask {
+            throw BoomClass() // will be rethrown
+          }
+        }
+
+        12 // must be ignored
+      }
+      preconditionFailure("Should throw")
+    } catch {
+      precondition("\(error)" == "main.BoomClass", "error was: \(error)")
+    }
+
+    // many errors, many values
+    _ = try? await withThrowingDiscardingTaskGroup() { group in
+      group.addTask {
+        SomeClass() // will be discarded
+      }
+      group.addTask {
+        SomeClass() // will be discarded
+      }
+      group.addTask {
+        SomeClass() // will be discarded
+      }
+      group.addTask {
+        throw Boom()
+      }
+      group.addTask {
+        throw Boom()
+      }
+      group.addTask {
+        throw Boom()
+      }
+      group.addTask {
+        throw Boom()
+      }
+
+      return 12
+    }
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak_class_error.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak_class_error.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-leaks-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// This test uses `leaks` which is only available on apple platforms; limit it to macOS:
+// REQUIRES: OS=macosx
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+// FIXME: enable discarding taskgroup on windows; rdar://104762037
+// UNSUPPORTED: OS=windows-msvc
+
+import _Concurrency
+
+final class ClassBoom: Error {
+  let id: String
+
+  init(file: String = #fileID, line: UInt = #line) {
+    self.id = "\(file):\(line)"
+  }
+
+  init(id: String) {
+    self.id = id
+  }
+}
+
+@main struct Main {
+  static func main() async {
+
+    // many errors
+    _ = try? await withThrowingDiscardingTaskGroup() { group in
+      group.addTask {
+        throw ClassBoom()
+      }
+      group.addTask {
+        throw ClassBoom()
+      }
+      group.addTask {
+        throw ClassBoom()
+      }
+      group.addTask {
+        throw ClassBoom()
+      }
+      group.addTask {
+        12
+      }
+
+      return 12
+    }
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-leaks-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
+// TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
 
 // This test uses `leaks` which is only available on apple platforms; limit it to macOS:
 // REQUIRES: OS=macosx
@@ -16,6 +17,10 @@ final class Something {
   init(int: Int) {
     self.int = int
   }
+
+  deinit {
+    print("deinit, Something, int: \(int)")
+  }
 }
 
 func test_taskGroup_next() async {
@@ -31,6 +36,13 @@ func test_taskGroup_next() async {
     for await value in group {
       sum += value.int
     }
+
+
+    // CHECK-DAG: deinit, Something, int: 0
+    // CHECK-DAG: deinit, Something, int: 1
+    // CHECK-DAG: deinit, Something, int: 2
+    // CHECK-DAG: deinit, Something, int: 3
+    // CHECK-DAG: deinit, Something, int: 4
 
     return sum
   }

--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -1,52 +1,39 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-leaks-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// This test uses `leaks` which is only available on apple platforms; limit it to macOS:
+// REQUIRES: OS=macosx
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: swift_task_debug_log
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-#if os(Linux)
-import Glibc
-#elseif os(Windows)
-import MSVCRT
-#else
 import Darwin
-#endif
+
+final class Something {
+  let int: Int
+  init(int: Int) {
+    self.int = int
+  }
+}
 
 func test_taskGroup_next() async {
-  // CHECK: creating task [[MAIN_TASK:0x.*]] with parent 0x0
-  // CHECK: creating task [[GROUP_TASK_1:0x.*]] with parent [[MAIN_TASK]]
-  // CHECK: creating task [[GROUP_TASK_2:0x.*]] with parent [[MAIN_TASK]]
-  // CHECK: creating task [[GROUP_TASK_3:0x.*]] with parent [[MAIN_TASK]]
-  // CHECK: creating task [[GROUP_TASK_4:0x.*]] with parent [[MAIN_TASK]]
-  // CHECK: creating task [[GROUP_TASK_5:0x.*]] with parent [[MAIN_TASK]]
-
-  _ = await withTaskGroup(of: Int.self, returning: Int.self) { group in
-    for n in 0..<5 {
+  let tasks = 5
+  _ = await withTaskGroup(of: Something.self, returning: Int.self) { group in
+    for n in 0..<tasks {
       group.spawn {
-        return n
+        Something(int: n)
       }
     }
-    await Task.sleep(2_000_000)
 
     var sum = 0
     for await value in group {
-      sum += 1
+      sum += value.int
     }
 
     return sum
   }
-  // as we exit the group, it must be guaranteed that its child tasks were destroyed
-  //
-  // NOTE: there is no great way to express "any of GROUP_TASK_n",
-  //       so we just check that 5 tasks were destroyed
-  //
-  // CHECK: destroy task [[DESTROY_GROUP_TASK_1:0x.*]]
-  // CHECK: destroy task [[DESTROY_GROUP_TASK_2:0x.*]]
-  // CHECK: destroy task [[DESTROY_GROUP_TASK_3:0x.*]]
-  // CHECK: destroy task [[DESTROY_GROUP_TASK_4:0x.*]]
-  // CHECK: destroy task [[DESTROY_GROUP_TASK_5:0x.*]]
 }
 
 @main struct Main {

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2313,16 +2313,17 @@ if not getattr(config, 'target_run_simple_swift', None):
            escape_for_substitute_captures(config.target_codesign),
            escape_for_substitute_captures(config.target_run))
     )
-    config.target_run_simple_leaks_swift_parameterized = SubstituteCaptures(
-        r"%%empty-directory(%%t) && "
-        r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
-        r"%s %%t/a.out && "
-        r"%s %%t/a.out"
-        % (escape_for_substitute_captures(config.target_build_swift),
-           escape_for_substitute_captures(mcp_opt),
-           escape_for_substitute_captures(config.target_codesign),
-           escape_for_substitute_captures(config.target_run_with_leaks))
-    )
+    if not kIsWindows:
+        config.target_run_simple_leaks_swift_parameterized = SubstituteCaptures(
+            r"%%empty-directory(%%t) && "
+            r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
+            r"%s %%t/a.out && "
+            r"%s %%t/a.out"
+            % (escape_for_substitute_captures(config.target_build_swift),
+               escape_for_substitute_captures(mcp_opt),
+               escape_for_substitute_captures(config.target_codesign),
+               escape_for_substitute_captures(config.target_run_with_leaks))
+        )
     config.target_fail_simple_swift_parameterized = SubstituteCaptures(
         r"%%empty-directory(%%t) && "
         r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
@@ -2498,8 +2499,9 @@ config.substitutions.append(('%target-run-simple-swiftgyb\(([^)]+)\)',
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
 config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)',
                             config.target_run_simple_swift_parameterized))
-config.substitutions.append(('%target-run-simple-leaks-swift\(([^)]+)\)',
-                            config.target_run_simple_leaks_swift_parameterized))
+if not kIsWindows:
+    config.substitutions.append(('%target-run-simple-leaks-swift\(([^)]+)\)',
+                                config.target_run_simple_leaks_swift_parameterized))
 config.substitutions.append(('%target-fail-simple-swift\(([^)]+)\)',
                             config.target_fail_simple_swift_parameterized))
 config.substitutions.append(('%target-run-stdlib-swift\(([^)]+)\)',

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1006,7 +1006,7 @@ else:
 swift_reflection_test_name = 'swift-reflection-test' + variant_suffix
 
 def use_interpreter_for_simple_runs():
-    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False):
+    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False, leaks=False):
         result = ''
         if gyb:
             result += ('%empty-directory(%t) && '
@@ -1034,6 +1034,7 @@ def use_interpreter_for_simple_runs():
     config.target_run_stdlib_swift = make_simple_target_run(stdlib=True)
     config.target_run_simple_swift = make_simple_target_run()
     config.target_run_simple_swift_parameterized = make_simple_target_run(parameterized=True)
+    config.target_run_simple_leaks_swift_parameterized = make_simple_leaks_target_run(parameterized=True)
     config.target_run_stdlib_swift_parameterized = make_simple_target_run(stdlib=True, parameterized=True)
     config.target_run_simple_swiftgyb_parameterized = make_simple_target_run(gyb=True, parameterized=True)
     config.available_features.add('interpret')
@@ -2272,6 +2273,11 @@ elif not kIsWindows:
         lit_config.note('Testing with the just-built libraries')
 
     lit_config.note('Library load path: {0}'.format(os.path.pathsep.join(target_stdlib_path)))
+    config.target_run_with_leaks = (
+        "/usr/bin/env " +
+        construct_library_path_env(target_stdlib_path) +
+        " xcrun leaks -atExit -- " +
+        config.target_run)
     config.target_run = (
         "/usr/bin/env " +
         construct_library_path_env(target_stdlib_path) +
@@ -2306,6 +2312,16 @@ if not getattr(config, 'target_run_simple_swift', None):
            escape_for_substitute_captures(mcp_opt),
            escape_for_substitute_captures(config.target_codesign),
            escape_for_substitute_captures(config.target_run))
+    )
+    config.target_run_simple_leaks_swift_parameterized = SubstituteCaptures(
+        r"%%empty-directory(%%t) && "
+        r"%s %s %%s \1 -o %%t/a.out -module-name main  && "
+        r"%s %%t/a.out && "
+        r"%s %%t/a.out"
+        % (escape_for_substitute_captures(config.target_build_swift),
+           escape_for_substitute_captures(mcp_opt),
+           escape_for_substitute_captures(config.target_codesign),
+           escape_for_substitute_captures(config.target_run_with_leaks))
     )
     config.target_fail_simple_swift_parameterized = SubstituteCaptures(
         r"%%empty-directory(%%t) && "
@@ -2482,6 +2498,8 @@ config.substitutions.append(('%target-run-simple-swiftgyb\(([^)]+)\)',
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
 config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)',
                             config.target_run_simple_swift_parameterized))
+config.substitutions.append(('%target-run-simple-leaks-swift\(([^)]+)\)',
+                            config.target_run_simple_leaks_swift_parameterized))
 config.substitutions.append(('%target-fail-simple-swift\(([^)]+)\)',
                             config.target_fail_simple_swift_parameterized))
 config.substitutions.append(('%target-run-stdlib-swift\(([^)]+)\)',


### PR DESCRIPTION
There are two leaks in the group.

"first error task leaks"
(a) the "the first error task that we RETAIN" and later on use to automatically re-throw the "first thrown by a child task error" task was not released;

"all values leak"
(b) due to the "hot fix" for pointer auth https://github.com/apple/swift/pull/65220 done for rdar://107574868 where we changed the signature of addTask from `()->()` (what it must be),  to `()->T` in order to work around pointer-auth issues we introduced a leak and ALL "discarded" values would be leaking since we would not release that T value. The correct way to solve this is to undo this workaround and use correct pointer auth, which this PR does.

We must fix the method signature and undo the hack which https://github.com/apple/swift/pull/65223 was.

Resolves: rdar://108829466