### PR TITLE
[5.9][Macros] Serialize plugin search paths for LLDB use

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -43,6 +43,10 @@ namespace swift {
     StringRef ModuleLinkName;
     StringRef ModuleInterface;
     std::vector<std::string> ExtraClangOptions;
+    std::vector<std::string> PluginSearchPaths;
+    std::vector<std::string> ExternalPluginSearchPaths;
+    std::vector<std::string> CompilerPluginLibraryPaths;
+    std::vector<std::string> CompilerPluginExecutablePaths;
 
     /// Path prefixes that should be rewritten in debug info.
     PathRemapper DebuggingOptionsPrefixMap;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -106,6 +106,12 @@ struct ValidationInfo {
 /// \sa validateSerializedAST()
 class ExtendedValidationInfo {
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
+
+  SmallVector<StringRef, 1> PluginSearchPaths;
+  SmallVector<StringRef, 1> ExternalPluginSearchPaths;
+  SmallVector<StringRef, 1> CompilerPluginLibraryPaths;
+  SmallVector<StringRef, 1> CompilerPluginExecutablePaths;
+
   std::string SDKPath;
   StringRef ModuleABIName;
   StringRef ModulePackageName;
@@ -136,6 +142,34 @@ public:
   }
   void addExtraClangImporterOption(StringRef option) {
     ExtraClangImporterOpts.push_back(option);
+  }
+
+  ArrayRef<StringRef> getPluginSearchPaths() const {
+    return PluginSearchPaths;
+  }
+  void addPluginSearchPath(StringRef path) {
+    PluginSearchPaths.push_back(path);
+  }
+
+  ArrayRef<StringRef> getExternalPluginSearchPaths() const {
+    return ExternalPluginSearchPaths;
+  }
+  void addExternalPluginSearchPath(StringRef path) {
+    ExternalPluginSearchPaths.push_back(path);
+  }
+
+  ArrayRef<StringRef> getCompilerPluginLibraryPaths() const {
+    return CompilerPluginLibraryPaths;
+  }
+  void addCompilerPluginLibraryPath(StringRef path) {
+    CompilerPluginLibraryPaths.push_back(path);
+  }
+
+  ArrayRef<StringRef> getCompilerPluginExecutablePaths() const {
+    return CompilerPluginExecutablePaths;
+  }
+  void addCompilerPluginExecutablePath(StringRef path) {
+    CompilerPluginExecutablePaths.push_back(path);
   }
 
   bool isSIB() const { return Bits.IsSIB; }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -202,6 +202,32 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   }
 
+  // '-plugin-path' options.
+  for (const auto &path : getSearchPathOptions().PluginSearchPaths) {
+    serializationOpts.PluginSearchPaths.push_back(path);
+  }
+  // '-external-plugin-path' options.
+  for (const ExternalPluginSearchPathAndServerPath &pair :
+       getSearchPathOptions().ExternalPluginSearchPaths) {
+    serializationOpts.ExternalPluginSearchPaths.push_back(
+        pair.SearchPath + "#" +
+        pair.ServerPath);
+  }
+  // '-load-plugin-library' options.
+  for (const auto &path :
+       getSearchPathOptions().getCompilerPluginLibraryPaths()) {
+    serializationOpts.CompilerPluginLibraryPaths.push_back(path);
+  }
+  // '-load-plugin-executable' options.
+  for (const PluginExecutablePathAndModuleNames &pair :
+       getSearchPathOptions().getCompilerPluginExecutablePaths()) {
+    std::string optStr = pair.ExecutablePath + "#";
+    llvm::interleave(
+        pair.ModuleNames, [&](auto &name) { optStr += name; },
+        [&]() { optStr += ","; });
+    serializationOpts.CompilerPluginLibraryPaths.push_back(optStr);
+  }
+
   serializationOpts.DisableCrossModuleIncrementalInfo =
       opts.DisableCrossModuleIncrementalBuild;
 

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -126,6 +126,18 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::XCC:
       extendedInfo.addExtraClangImporterOption(blobData);
       break;
+    case options_block::PLUGIN_SEARCH_PATH:
+      extendedInfo.addPluginSearchPath(blobData);
+      break;
+    case options_block::EXTERNAL_SEARCH_PLUGIN_PATH:
+      extendedInfo.addExternalPluginSearchPath(blobData);
+      break;
+    case options_block::COMPILER_PLUGIN_LIBRARY_PATH:
+      extendedInfo.addCompilerPluginLibraryPath(blobData);
+      break;
+    case options_block::COMPILER_PLUGIN_EXECUTABLE_PATH:
+      extendedInfo.addCompilerPluginExecutablePath(blobData);
+      break;
     case options_block::IS_SIB:
       bool IsSIB;
       options_block::IsSIBLayout::readRecord(scratch, IsSIB);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -883,6 +883,10 @@ namespace options_block {
     IS_CONCURRENCY_CHECKED,
     MODULE_PACKAGE_NAME,
     MODULE_EXPORT_AS_NAME,
+    PLUGIN_SEARCH_PATH,
+    EXTERNAL_SEARCH_PLUGIN_PATH,
+    COMPILER_PLUGIN_LIBRARY_PATH,
+    COMPILER_PLUGIN_EXECUTABLE_PATH,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -893,6 +897,26 @@ namespace options_block {
   using XCCLayout = BCRecordLayout<
     XCC,
     BCBlob // -Xcc flag, as string
+  >;
+
+  using PluginSearchPathLayout = BCRecordLayout<
+    PLUGIN_SEARCH_PATH,
+    BCBlob // -plugin-path value
+  >;
+
+  using ExternalPluginSearchPathLayout = BCRecordLayout<
+    EXTERNAL_SEARCH_PLUGIN_PATH,
+    BCBlob // -external-plugin-path value
+  >;
+
+  using CompilerPluginLibraryPathLayout = BCRecordLayout<
+    COMPILER_PLUGIN_LIBRARY_PATH,
+    BCBlob // -load-plugin-library value
+  >;
+
+  using CompilerPluginExecutablePathLayout = BCRecordLayout<
+    COMPILER_PLUGIN_EXECUTABLE_PATH,
+    BCBlob // -load-plugin-executable value
   >;
 
   using IsSIBLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -844,6 +844,11 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, MODULE_ABI_NAME);
   BLOCK_RECORD(options_block, IS_CONCURRENCY_CHECKED);
   BLOCK_RECORD(options_block, MODULE_PACKAGE_NAME);
+  BLOCK_RECORD(options_block, MODULE_EXPORT_AS_NAME);
+  BLOCK_RECORD(options_block, PLUGIN_SEARCH_PATH);
+  BLOCK_RECORD(options_block, EXTERNAL_SEARCH_PLUGIN_PATH);
+  BLOCK_RECORD(options_block, COMPILER_PLUGIN_LIBRARY_PATH);
+  BLOCK_RECORD(options_block, COMPILER_PLUGIN_EXECUTABLE_PATH);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1123,6 +1128,30 @@ void Serializer::writeHeader(const SerializationOptions &options) {
             continue;
           }
           XCC.emit(ScratchRecord, arg);
+        }
+
+        // Macro plugins
+        options_block::PluginSearchPathLayout PluginSearchPath(Out);
+        for (auto Arg : options.PluginSearchPaths) {
+          PluginSearchPath.emit(ScratchRecord, Arg);
+        }
+
+        options_block::ExternalPluginSearchPathLayout
+          ExternalPluginSearchPath(Out);
+        for (auto Arg : options.ExternalPluginSearchPaths) {
+          ExternalPluginSearchPath.emit(ScratchRecord, Arg);
+        }
+
+        options_block::CompilerPluginLibraryPathLayout
+          CompilerPluginLibraryPath(Out);
+        for (auto Arg : options.CompilerPluginLibraryPaths) {
+          CompilerPluginLibraryPath.emit(ScratchRecord, Arg);
+        }
+
+        options_block::CompilerPluginExecutablePathLayout
+          CompilerPluginExecutablePath(Out);
+        for (auto Arg : options.CompilerPluginLibraryPaths) {
+          CompilerPluginExecutablePath.emit(ScratchRecord, Arg);
         }
       }
     }

--- a/test/Macros/serialize_plugin_search_paths.swift
+++ b/test/Macros/serialize_plugin_search_paths.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift %s -g -o %t/a.out \
+// RUN:   -emit-executable -emit-module \
+// RUN:   -Xfrontend -serialize-debugging-options \
+// RUN:   -module-name MyApp \
+// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -plugin-path %t/plugins \
+// RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
+// RUN:   -load-plugin-library %t/%target-library-name(MacroDefinition) \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin
+
+// RUN: %lldb-moduleimport-test -verbose -dump-module %t/a.out | %FileCheck %s
+// CHECK: - Macro Search Paths:
+// CHECK:     -plugin-path: {{.*}}plugins
+// CHECK:     -plugin-path: {{.*}}plugins
+// CHECK:     -plugin-path: {{.*}}plugins
+// CHECK:     -external-plugin-path: {{.*}}plugins#{{.*}}swift-plugin-server
+// CHECK:     -load-plugin-library: {{.*}}MacroDefinition.{{dylib|so|dll}}
+// CHECK:     -load-plugin-executable: {{.*}}MacroDefinition.{{dylib|so|dll}}
+// CHECK:     -load-plugin-executable: {{.*}}mock-plugin#TestPlugin

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -89,6 +89,15 @@ static bool validateModule(
       llvm::outs() << ", system=" << (searchPath.IsSystem ? "true" : "false")
                    << "\n";
     }
+    llvm::outs() << "- Macro Search Paths:\n";
+    for (auto path : extendedInfo.getPluginSearchPaths())
+      llvm::outs() << "    -plugin-path: " << path << "\n";
+    for (auto path : extendedInfo.getExternalPluginSearchPaths())
+      llvm::outs() << "    -external-plugin-path: " << path << "\n";
+    for (auto path : extendedInfo.getCompilerPluginLibraryPaths())
+      llvm::outs() << "    -load-plugin-library: " << path << "\n";
+    for (auto path : extendedInfo.getCompilerPluginExecutablePaths())
+      llvm::outs() << "    -load-plugin-executable: " << path << "\n";
   }
 
   return true;


### PR DESCRIPTION
Write down the plugin search paths in the binary swiftmodule files so LLDB can load them and understand the macros in the expression evaluator. This may list local search paths as expected for debugging locally built modules, however LLDB may want to ignore these paths when read from a distributed swiftmodule file.

Risk: Low, the information will only be read by LLDB. There's no need to bump the swiftmodule format version.
Scope: Macro support in LLDB.
Reviewer: @rintaro 

rdar://107030743

Cherry-pick of #65370.