### PR TITLE
Revert "[build] Reenable lldb tests for macOS toolchain package"

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1391,6 +1391,8 @@ mixin-preset=
     mixin_osx_package_test
     mixin_lightweight_assertions,no-stdlib-asserts
 
+# SKIP LLDB TESTS (67923799)
+skip-test-lldb
 skip-test-playgroundsupport
 
 [preset: buildbot_osx_package,use_os_runtime]


### PR DESCRIPTION
Reverts apple/swift#35357

This is causing failures on the macOS package trigger bot. 