### PR TITLE
[5.9 🍒] Re-enable now-passing 'Reflection/typeref_decoding.swift'

### DIFF
--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -2,7 +2,6 @@
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
-// XFAIL: OS=linux-gnu && CPU=aarch64
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65482
-----------------------