### PR TITLE
[5.9][interop] NFC, test, re-enable unit test for the for loop iteration o…

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// FIXME: also test this in C++20 mode once rdar://108810356 is fixed.
 //
 // REQUIRES: executable_test
 //
@@ -33,19 +34,17 @@ func fill(vector v: inout Vector) {
     v.push_back(&_3)
 }
 
-// TODO: in some configurations the stdlib emits a "initializeWithCopy" where the arguments
-// have incorrect indirection: rdar://87728422 and rdar://87805795
-// StdVectorTestSuite.test("for loop") {
-//     var v = Vector()
-//     fill(vector: &v)
-//
-//     var count: CInt = 1
-//     for e in v {
-//         expectEqual(e, count)
-//         count += 1
-//     }
-//     expectEqual(count, 4)
-// }
+StdVectorTestSuite.test("for loop") {
+    var v = Vector()
+    fill(vector: &v)
+
+    var count: CInt = 1
+    for e in v {
+        expectEqual(e, count)
+        count += 1
+    }
+    expectEqual(count, 4)
+}
 
 StdVectorTestSuite.test("map") {
     var v = Vector()


### PR DESCRIPTION
…ver std::vector

Explanation: We had disabled test for `for` loop iteration over std::vector. Reenable it as blockers are fixed.
Scope: Swift's and C++ interoperability, tests.
Risk: Low, NFC.
Testing: Swift unit tests.
Reviewer: @egorzhdan 