### PR TITLE
[5.9][RemoteMirror] Test cleanup

### DIFF
--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
@@ -42,7 +42,8 @@ reflect(object: ClassWithEnumDepth0<S>())
 // CHECK-NEXT: (bound_generic_class reflect_Enum_MultiPayload_generic.ClassWithEnumDepth0
 // CHECK-NEXT:   (struct reflect_Enum_MultiPayload_generic.S))
 
-// X64: Type info:
+// CHECK: Type info:
+
 // X64-NEXT: (class_instance size=41 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // X64-NEXT:   (field name=e offset=16
 // X64-NEXT:     (single_payload_enum size=25 alignment=8 stride=32 num_extra_inhabitants=253 bitwise_takable=1
@@ -68,7 +69,6 @@ reflect(object: ClassWithEnumDepth0<S>())
 // X64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // X64-NEXT:       (case name=none index=1))))
 
-// X32: Type info:
 // X32-NEXT: (class_instance size=21 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // X32-NEXT:   (field name=e offset=8
 // X32-NEXT:     (single_payload_enum size=13 alignment=4 stride=16 num_extra_inhabitants=253 bitwise_takable=1
@@ -110,7 +110,8 @@ reflect(object: ClassWithEnumDepth1<S>())
 // CHECK-NEXT: (bound_generic_class reflect_Enum_MultiPayload_generic.ClassWithEnumDepth1
 // CHECK-NEXT:   (struct reflect_Enum_MultiPayload_generic.S))
 
-// X64: Type info:
+// CHECK: Type info:
+
 // X64-NEXT: (class_instance size=41 alignment=8 stride=48 num_extra_inhabitants=0 bitwise_takable=1
 // X64-NEXT:   (field name=e offset=16
 // X64-NEXT:     (single_payload_enum size=25 alignment=8 stride=32 num_extra_inhabitants=253 bitwise_takable=1
@@ -136,7 +137,6 @@ reflect(object: ClassWithEnumDepth1<S>())
 // X64-NEXT:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
 // X64-NEXT:       (case name=none index=1))))
 
-// X32: Type info:
 // X32-NEXT: (class_instance size=21 alignment=4 stride=24 num_extra_inhabitants=0 bitwise_takable=1
 // X32-NEXT:   (field name=e offset=8
 // X32-NEXT:     (single_payload_enum size=13 alignment=4 stride=16 num_extra_inhabitants=253 bitwise_takable=1
@@ -161,7 +161,6 @@ reflect(object: ClassWithEnumDepth1<S>())
 // X32-NEXT:               (field name=_value offset=0
 // X32-NEXT:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
 // X32-NEXT:       (case name=none index=1))))
-
 
 doneReflecting()
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
@@ -28,9 +28,6 @@ reflect(enum: SimplePayload1<ClassTypeA, Void>.a(ClassTypeA()))
 // CHECK-NEXT:   (tuple))
 
 // MemoryLayout<SimplePayload1<ClassTypeA, Void>> gives 9,8,16
-// SimplePayload1 is a BoundGenericTypeRef
-// It's getting laid out as a tagged MPE, not as an SPE
-// (an SPE would use the XIs of the ptr) XXXXXX OR WOULD IT???  Hmmmmm....
 
 // CHECK: Type info:
 // X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=254 bitwise_takable=1
@@ -62,8 +59,9 @@ reflect(enum: SimplePayload1<ClassTypeA, Void>.b(()))
 // X64-NEXT:     (reference kind=strong refcounting=native))
 // X64-NEXT:   (case name=b index=1 offset=0
 // X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))
-// X64-NEXT: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
-// X64-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
+
+// CHECK: Mangled name: $s34reflect_Enum_MultiPayload_generic214SimplePayload1OyAA10ClassTypeACytG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic2.SimplePayload1<reflect_Enum_MultiPayload_generic2.ClassTypeA, ()>
 
 // CHECK: Enum value:
 // CHECK-NEXT: (enum_value name=b index=1

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
@@ -148,6 +148,7 @@ reflect(enum: B<Int>.c(()))
 reflect(enum: B<Void>.a(8))
 
 // CHECK: Reflecting an enum.
+
 // CHECK: Type info:
 // X64-NEXT: (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=253 bitwise_takable=1
 // X64-NEXT:   (case name=a index=0 offset=0

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic8.swift
@@ -94,7 +94,7 @@ reflect(enum: B<Int>.a(S<Void>(t: ())) as B<Int>?)
 // CHECK-NEXT:   (bound_generic_enum reflect_Enum_MultiPayload_generic8.B
 // CHECK-NEXT:     (struct Swift.Int)))
 
-// X64: Type info:
+// CHECK: Type info:
 // X64-NEXT: (single_payload_enum size=10 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
 // X64-NEXT:   (case name=some index=0 offset=0
 // X64-NEXT:     (multi_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1

--- a/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
+++ b/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
@@ -33,7 +33,7 @@ reflect(enum: SimplePayload1<ClassTypeA>.b(ClassTypeA()))
 
 // CHECK: Type info:
 // X64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
-// X32-NEXT: FAIL XXX TODO XXX
+// X32-NEXT: (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants={{[0-9]+}} bitwise_takable=1
 // CHECK-NEXT:   (case name=b index=0 offset=0
 // CHECK-NEXT:     (reference kind=strong refcounting=native))
 // CHECK-NEXT:   (case name=a index=1)


### PR DESCRIPTION

**Explanation**: This fixes a handful of new RemoteMirror tests to work correctly on 32-bit hosts
**Risk**: Only affects tests that were incorrect when run on 32 bit hosts
**Original PR**: #64852 (somehow, these commits got dropped from #65525)
**Reviewed by**: @mikeash @al45tair 
**Resolves**: rdar://108850445
**Tests**: Yes, these are tests :grin: