### PR TITLE
Configure `ModuleInterface/arm64e-fallback` to not run in simulators

### DIFF
--- a/test/ModuleInterface/arm64e-fallback.swift
+++ b/test/ModuleInterface/arm64e-fallback.swift
@@ -4,6 +4,7 @@
 // PtrAuthFramework only supports these OSes.
 //
 // REQUIRES: OS=tvos || OS=macosx || OS=ios
+// UNSUPPORTED: DARWIN_SIMULATOR={{.*}}
 
 // When run on arm64, this tests that we fall back to the arm64e interface, but
 // build it with `#if _ptrauth(_arm64e)` off.


### PR DESCRIPTION
This would be needed to avoid test failures when running the test suite on an Apple Silicon machine.

Addresses rdar://108788721