### PR TITLE
[SIL Serialization] Print mismatching SILFunction types on crash

### DIFF
--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1148,7 +1148,6 @@ std::string SILType::getDebugDescription() const {
     std::string str;
     llvm::raw_string_ostream os(str);
     print(os);
-    str.pop_back(); // Remove trailing newline.
     return str;
   }
 

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -442,6 +442,28 @@ public:
   }
 };
 
+class SILFunctionTypeMismatch : public llvm::ErrorInfo<SILFunctionTypeMismatch> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  StringRef name;
+  std::string descLHS, descRHS;
+public:
+  SILFunctionTypeMismatch(StringRef name, std::string descLHS,
+                          std::string descRHS)
+      : name(name), descLHS(descLHS), descRHS(descRHS) {}
+
+  void log(raw_ostream &OS) const override {
+    OS << "SILFunction type mismatch for '" << name << "': '";
+    OS << descLHS << "' != '" <<  descRHS << "'\n";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 // Decl was not deserialized because its attributes did not match the filter.
 //
 // \sa getDeclChecked

--- a/test/Serialization/Recovery/error-sil-function.swift
+++ b/test/Serialization/Recovery/error-sil-function.swift
@@ -1,0 +1,13 @@
+// RUN: not --crash %target-swift-frontend -c %s 2>&1 | %FileCheck %s
+// CHECK: *** DESERIALIZATION FAILURE ***
+// CHECK: SILFunction type mismatch for 'asinf': '$@convention(thin) (Float) -> Float' != '$@convention(c) (Float) -> Float'
+
+// REQUIRES: VENDOR=apple
+
+import Darwin
+
+@_silgen_name("asinf") internal func quux(_ x: Float) -> Float
+
+public func bar(_ x: Float) -> Float {
+  return quux(x)
+}


### PR DESCRIPTION
Crashes on `SILFunction type mismatch` provided little information and tend to be difficult to reproduce. Let's print some of the available information and distinguish the two failure sites.

I'm not confident all required information is printed so we may need to improve this further in the future. This version also still crashes the compiler, we may want a proper type-check to prevent this failure with a clean diagnostic for the reproducer used in the test here.

rdar://53821031