### PR TITLE
[stdlib] Adopt func _specialize for generic specializations

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -115,6 +115,7 @@ public func _identityCast<T, U>(_ x: T, to expectedType: U.Type) -> U {
 /// This cast can be useful for dispatching to specializations of generic
 /// functions.
 @_alwaysEmitIntoClient
+@_transparent
 public func _specialize<T, U>(_ x: T, for: U.Type) -> U? {
   guard T.self == U.self else {
     return nil

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -5617,14 +5617,16 @@ extension Dictionary: Encodable where Key: Encodable, Value: Encodable {
       // Since the keys are already Strings, we can use them as keys directly.
       var container = encoder.container(keyedBy: _DictionaryCodingKey.self)
       for (key, value) in self {
-        let codingKey = _DictionaryCodingKey(stringValue: key as! String)
+        let codingKey = _DictionaryCodingKey(
+          stringValue: _identityCast(key, to: String.self))
         try container.encode(value, forKey: codingKey)
       }
     } else if Key.self == Int.self {
       // Since the keys are already Ints, we can use them as keys directly.
       var container = encoder.container(keyedBy: _DictionaryCodingKey.self)
       for (key, value) in self {
-        let codingKey = _DictionaryCodingKey(intValue: key as! Int)
+        let codingKey = _DictionaryCodingKey(
+          intValue: _identityCast(key, to: Int.self))
         try container.encode(value, forKey: codingKey)
       }
     } else if #available(SwiftStdlib 5.6, *),

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -475,7 +475,7 @@ public struct Dictionary<Key: Hashable, Value> {
   public init<S: Sequence>(
     uniqueKeysWithValues keysAndValues: __owned S
   ) where S.Element == (Key, Value) {
-    if let d = keysAndValues as? Dictionary<Key, Value> {
+    if let d = _specialize(keysAndValues, for: Dictionary<Key, Value>.self) {
       self = d
       return
     }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -678,7 +678,7 @@ extension Set: SetAlgebra {
   @inlinable
   public init<Source: Sequence>(_ sequence: __owned Source)
   where Source.Element == Element {
-    if let s = sequence as? Set<Element> {
+    if let s = _specialize(sequence, for: Set<Element>.self) {
       // If this sequence is actually a `Set`, then we can quickly
       // adopt its storage and let COW handle uniquing only if necessary.
       self = s
@@ -710,7 +710,7 @@ extension Set: SetAlgebra {
   where S.Element == Element {
     guard !isEmpty else { return true }
     if self.count == 1 { return possibleSuperset.contains(self.first!) }
-    if let s = possibleSuperset as? Set<Element> {
+    if let s = _specialize(possibleSuperset, for: Set<Element>.self) {
       return isSubset(of: s)
     }
     return _variant.convertedToNative.isSubset(of: possibleSuperset)
@@ -739,7 +739,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSubset<S: Sequence>(of possibleStrictSuperset: S) -> Bool
   where S.Element == Element {
-    if let s = possibleStrictSuperset as? Set<Element> {
+    if let s = _specialize(possibleStrictSuperset, for: Set<Element>.self) {
       return isStrictSubset(of: s)
     }
     return _variant.convertedToNative.isStrictSubset(of: possibleStrictSuperset)
@@ -763,7 +763,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isSuperset<S: Sequence>(of possibleSubset: __owned S) -> Bool
   where S.Element == Element {
-    if let s = possibleSubset as? Set<Element> {
+    if let s = _specialize(possibleSubset, for: Set<Element>.self) {
       return isSuperset(of: s)
     }
     for member in possibleSubset {
@@ -796,7 +796,7 @@ extension Set: SetAlgebra {
   public func isStrictSuperset<S: Sequence>(of possibleStrictSubset: S) -> Bool
   where S.Element == Element {
     if isEmpty { return false }
-    if let s = possibleStrictSubset as? Set<Element> {
+    if let s = _specialize(possibleStrictSubset, for: Set<Element>.self) {
       return isStrictSuperset(of: s)
     }
     return _variant.convertedToNative.isStrictSuperset(of: possibleStrictSubset)
@@ -819,7 +819,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isDisjoint<S: Sequence>(with other: S) -> Bool
   where S.Element == Element {
-    if let s = other as? Set<Element> {
+    if let s = _specialize(other, for: Set<Element>.self) {
       return isDisjoint(with: s)
     }
     return _isDisjoint(with: other)
@@ -955,7 +955,7 @@ extension Set: SetAlgebra {
   @inlinable
   public __consuming func intersection<S: Sequence>(_ other: S) -> Set<Element>
   where S.Element == Element {
-    if let other = other as? Set<Element> {
+    if let s = _specialize(other, for: Set<Element>.self) {
       return self.intersection(other)
     }
     return Set(_native: _variant.convertedToNative.genericIntersection(other))

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -956,7 +956,7 @@ extension Set: SetAlgebra {
   public __consuming func intersection<S: Sequence>(_ other: S) -> Set<Element>
   where S.Element == Element {
     if let s = _specialize(other, for: Set<Element>.self) {
-      return self.intersection(other)
+      return self.intersection(s)
     }
     return Set(_native: _variant.convertedToNative.genericIntersection(other))
   }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -965,7 +965,7 @@ extension String: CustomStringConvertible {
   ///
   /// Using this property directly is discouraged. Instead, use simple
   /// assignment to create a new constant or variable equal to this string.
-  @inlinable
+  @inlinable @inline(__always)
   public var description: String { return self }
 }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -792,17 +792,17 @@ extension Sequence where Element: StringProtocol {
     result.reserveCapacity(underestimatedCap)
     if separator.isEmpty {
       for x in self {
-        result.append(x._ephemeralString)
+        result.append(contentsOf: x)
       }
       return result
     }
 
     var iter = makeIterator()
     if let first = iter.next() {
-      result.append(first._ephemeralString)
+      result.append(contentsOf: first)
       while let next = iter.next() {
         result.append(separator)
-        result.append(next._ephemeralString)
+        result.append(contentsOf: next)
       }
     }
     return result

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -792,12 +792,10 @@ extension StringProtocol {
 
   public // SPI(Foundation)
   func _toUTF16Offsets(_ indices: Range<Index>) -> Range<Int> {
-    if Self.self == String.self {
-      let s = unsafeBitCast(self, to: String.self)
+    if let s = _specialize(self, for: String.self) {
       return s.utf16._offsetRange(for: indices, from: s.startIndex)
     }
-    if Self.self == Substring.self {
-      let s = unsafeBitCast(self, to: Substring.self)
+    if let s = _specialize(self, for: Substring.self) {
       return s._slice._base.utf16._offsetRange(for: indices, from: s.startIndex)
     }
     let startOffset = _toUTF16Offset(indices.lowerBound)
@@ -807,12 +805,10 @@ extension StringProtocol {
 
   public // SPI(Foundation)
   func _toUTF16Indices(_ range: Range<Int>) -> Range<Index> {
-    if Self.self == String.self {
-      let s = unsafeBitCast(self, to: String.self)
+    if let s = _specialize(self, for: String.self) {
       return s.utf16._indexRange(for: range, from: s.startIndex)
     }
-    if Self.self == Substring.self {
-      let s = unsafeBitCast(self, to: Substring.self)
+    if let s = _specialize(self, for: Substring.self) {
       return s._slice._base.utf16._indexRange(for: range, from: s.startIndex)
     }
     let lowerbound = _toUTF16Index(range.lowerBound)

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -294,6 +294,8 @@ extension String {
         String._uncheckedFromUTF8($0)
       }
     }
+    // TODO(String performance): Skip intermediary array, transcode directly
+    // into StringStorage.
     return Array(str.utf8).withUnsafeBufferPointer {
       String._uncheckedFromUTF8($0)
     }

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -321,14 +321,14 @@ extension _StringGuts {
   ) -> Range<Int>
   where C: Collection, C.Iterator.Element == Character {
     if isUniqueNative {
-      if let repl = newElements as? String {
+      if let repl = _specialize(newElements, for: String.self) {
         if repl._guts.isFastUTF8 {
           return repl._guts.withFastUTF8 {
             uniqueNativeReplaceSubrange(
               bounds, with: $0, isASCII: repl._guts.isASCII)
           }
         }
-      } else if let repl = newElements as? Substring {
+      } else if let repl = _specialize(newElements, for: Substring.self) {
         if repl._wholeGuts.isFastUTF8 {
           return repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
             uniqueNativeReplaceSubrange(
@@ -364,14 +364,19 @@ extension _StringGuts {
   ) -> Range<Int>
   where C: Collection, C.Iterator.Element == UnicodeScalar {
     if isUniqueNative {
-      if let repl = newElements as? String.UnicodeScalarView {
+      if let repl = _specialize(
+        newElements, for: String.UnicodeScalarView.self
+      ) {
         if repl._guts.isFastUTF8 {
           return repl._guts.withFastUTF8 {
             uniqueNativeReplaceSubrange(
               bounds, with: $0, isASCII: repl._guts.isASCII)
           }
         }
-      } else if let repl = newElements as? Substring.UnicodeScalarView {
+      }
+      else if let repl = _specialize(
+        newElements, for: Substring.UnicodeScalarView.self
+      ) {
         if repl._wholeGuts.isFastUTF8 {
           return repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
             uniqueNativeReplaceSubrange(

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -314,6 +314,9 @@ extension _StringGuts {
   }
 
   // - Returns: The encoded offset range of the replaced contents in the result.
+  @_specialize(where C == String)
+  @_specialize(where C == Substring)
+  @_specialize(where C == Array<Character>)
   @discardableResult
   internal mutating func replaceSubrange<C>(
     _ bounds: Range<Index>,

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -314,9 +314,6 @@ extension _StringGuts {
   }
 
   // - Returns: The encoded offset range of the replaced contents in the result.
-  @_specialize(where C == String)
-  @_specialize(where C == Substring)
-  @_specialize(where C == Array<Character>)
   @discardableResult
   internal mutating func replaceSubrange<C>(
     _ bounds: Range<Index>,

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -30,6 +30,8 @@ extension String: Hashable {
   }
 }
 
+// FIXME: Add an explicit definition for `Substring.hash(into:)`.
+
 extension StringProtocol {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -103,11 +103,11 @@ extension String.Index {
   public init?<S: StringProtocol>(
     _ sourcePosition: String.Index, within target: S
   ) {
-    if let str = target as? String {
+    if let str = _specialize(target, for: String.self) {
       self.init(sourcePosition, within: str)
       return
     }
-    if let str = target as? Substring {
+    if let str = _specialize(target, for: Substring.self) {
       // As a special exception, we allow `sourcePosition` to be an UTF-16 index
       // when `self` is a UTF-8 string (or vice versa), to preserve
       // compatibility with (broken) code that keeps using indices from a

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -127,19 +127,15 @@ extension StringProtocol {
   //
   public // @SPI(NSStringAPI.swift)
   var _ephemeralString: String {
-    @_specialize(where Self == String)
-    @_specialize(where Self == Substring)
-    get { return String(self) }
+    String(self)
   }
 
   internal var _gutsSlice: _StringGutsSlice {
-    @_specialize(where Self == String)
-    @_specialize(where Self == Substring)
     @inline(__always) get {
-      if let str = self as? String {
+      if let str = _specialize(self, for: String.self) {
         return _StringGutsSlice(str._guts)
       }
-      if let subStr = self as? Substring {
+      if let subStr = _specialize(self, for: Substring.self) {
         return _StringGutsSlice(subStr._wholeGuts, subStr._offsetRange)
       }
       return _StringGutsSlice(String(self)._guts)
@@ -159,13 +155,11 @@ extension StringProtocol {
 
   @inlinable
   internal var _wholeGuts: _StringGuts {
-    @_specialize(where Self == String)
-    @_specialize(where Self == Substring)
     @inline(__always) get {
-      if let str = self as? String {
+      if let str = _specialize(self, for: String.self) {
         return str._guts
       }
-      if let subStr = self as? Substring {
+      if let subStr = _specialize(self, for: Substring.self) {
         return subStr._wholeGuts
       }
       return String(self)._guts

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -125,13 +125,15 @@ extension StringProtocol {
   // TODO(String performance): Provide a closure-based call with stack-allocated
   // _SharedString for non-smol Substrings
   //
-  @inlinable @inline(__always)
+  @inlinable
   public // @SPI(NSStringAPI.swift)
   var _ephemeralString: String {
-    String(self)
+    @inline(__always) get { return String(self) }
   }
 
   internal var _gutsSlice: _StringGutsSlice {
+    @_specialize(where Self == String)
+    @_specialize(where Self == Substring)
     @inline(__always) get {
       if let str = _specialize(self, for: String.self) {
         return _StringGutsSlice(str._guts)
@@ -156,6 +158,8 @@ extension StringProtocol {
 
   @inlinable
   internal var _wholeGuts: _StringGuts {
+    @_specialize(where Self == String)
+    @_specialize(where Self == Substring)
     @inline(__always) get {
       if let str = _specialize(self, for: String.self) {
         return str._guts

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -125,6 +125,7 @@ extension StringProtocol {
   // TODO(String performance): Provide a closure-based call with stack-allocated
   // _SharedString for non-smol Substrings
   //
+  @inlinable @inline(__always)
   public // @SPI(NSStringAPI.swift)
   var _ephemeralString: String {
     String(self)

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -169,7 +169,6 @@ extension String: RangeReplaceableCollection {
       return
     }
     if let substr = _specialize(newElements, for: Array<Character>.self) {
-      // FIXME: Does this really pull its weight?
       for c in newElements {
         self.append(c._str)
       }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -51,16 +51,11 @@ extension String: RangeReplaceableCollection {
   ///
   /// - Parameter other: A string instance or another sequence of
   ///   characters.
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
   public init<S: Sequence & LosslessStringConvertible>(_ other: S)
   where S.Element == Character {
-    if let str = _specialize(other, for: String.self) {
-      self = str
-      return
-    }
-    if let str = _specialize(other, for: Substring.self) {
-      self = str.description
-      return
-    }
+    // FIXME: Consider making this inlinable.
     self = other.description
   }
 
@@ -79,13 +74,18 @@ extension String: RangeReplaceableCollection {
   ///
   /// - Parameter characters: A string instance or another sequence of
   ///   characters.
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
+  @_specialize(where S == Array<Character>)
   public init<S: Sequence>(_ characters: S)
   where S.Iterator.Element == Character {
+    // FIXME: Consider making this inlinable.
     if let str = _specialize(characters, for: String.self) {
       self = str
       return
     }
     if let subStr = _specialize(characters, for: Substring.self) {
+      // Note: this is a standalone overload in Substring.swift.
       self.init(subStr)
       return
     }
@@ -158,20 +158,18 @@ extension String: RangeReplaceableCollection {
   /// Appends the characters in the given sequence to the string.
   ///
   /// - Parameter newElements: A sequence of characters.
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
+  @_specialize(where S == Array<Character>)
   public mutating func append<S: Sequence>(contentsOf newElements: S)
   where S.Iterator.Element == Character {
+    // FIXME: consider making this inlinable.
     if let str = _specialize(newElements, for: String.self) {
       self.append(str)
       return
     }
     if let substr = _specialize(newElements, for: Substring.self) {
       self.append(contentsOf: substr)
-      return
-    }
-    if let substr = _specialize(newElements, for: Array<Character>.self) {
-      for c in newElements {
-        self.append(c._str)
-      }
       return
     }
     for c in newElements {
@@ -193,6 +191,9 @@ extension String: RangeReplaceableCollection {
   ///   `newElements`. If the call to `replaceSubrange(_:with:)` simply
   ///   removes text at the end of the string, the complexity is O(*n*), where
   ///   *n* is equal to `bounds.count`.
+  @_specialize(where C == String)
+  @_specialize(where C == Substring)
+  @_specialize(where C == Array<Character>)
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Index>,
     with newElements: C
@@ -235,6 +236,9 @@ extension String: RangeReplaceableCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the combined length of the string and
   ///   `newElements`.
+  @_specialize(where S == String)
+  @_specialize(where S == Substring)
+  @_specialize(where S == Array<Character>)
   public mutating func insert<S: Collection>(
     contentsOf newElements: S, at i: Index
   ) where S.Element == Character {

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -386,7 +386,7 @@ extension String.UnicodeScalarView: RangeReplaceableCollection {
   ///   `newElements`. If the call to `replaceSubrange(_:with:)` simply
   ///   removes elements at the end of the string, the complexity is O(*n*),
   ///   where *n* is equal to `bounds.count`.
-  public mutating func replaceSubrange<C>(
+  public mutating func replaceSubrange<C>(  // FIXME: Add @_specialize
     _ subrange: Range<Index>,
     with newElements: C
   ) where C: Collection, C.Element == Unicode.Scalar {

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -1145,16 +1145,13 @@ extension Substring.UnicodeScalarView: RangeReplaceableCollection {
 }
 
 extension Substring: RangeReplaceableCollection {
-  @_specialize(where S == String)
-  @_specialize(where S == Substring)
-  @_specialize(where S == Array<Character>)
   public init<S: Sequence>(_ elements: S)
   where S.Element == Character {
-    if let str = elements as? String {
+    if let str = _specialize(elements, for: String.self) {
       self.init(str)
       return
     }
-    if let subStr = elements as? Substring {
+    if let subStr = _specialize(elements, for: Substring.self) {
       self = subStr
       return
     }

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -415,8 +415,7 @@ extension Substring: StringProtocol {
       startingAt: i._encodedOffset, endingAt: endOffset)
   }
 
-  @_specialize(where C == String)
-  @_specialize(where C == Substring)
+  // FIXME: Add @_specialize
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Index>,
     with newElements: C
@@ -1124,8 +1123,7 @@ extension Substring.UnicodeScalarView: RangeReplaceableCollection {
   @inlinable
   public init() { _slice = Slice.init() }
 
-  @_specialize(where C == String)
-  @_specialize(where C == Substring)
+  // FIXME: Add @_specialize
   public mutating func replaceSubrange<C: Collection>(
     _ subrange: Range<Index>, with replacement: C
   ) where C.Element == Element {

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -1156,6 +1156,7 @@ extension Substring.UnicodeScalarView: RangeReplaceableCollection {
 }
 
 extension Substring: RangeReplaceableCollection {
+  @inlinable // specialize
   public init<S: Sequence>(_ elements: S)
   where S.Element == Character {
     if let str = _specialize(elements, for: String.self) {

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -415,6 +415,8 @@ extension Substring: StringProtocol {
       startingAt: i._encodedOffset, endingAt: endOffset)
   }
 
+  @_specialize(where C == String)
+  @_specialize(where C == Substring)
   public mutating func replaceSubrange<C>(
     _ subrange: Range<Index>,
     with newElements: C
@@ -1122,6 +1124,8 @@ extension Substring.UnicodeScalarView: RangeReplaceableCollection {
   @inlinable
   public init() { _slice = Slice.init() }
 
+  @_specialize(where C == String)
+  @_specialize(where C == Substring)
   public mutating func replaceSubrange<C: Collection>(
     _ subrange: Range<Index>, with replacement: C
   ) where C.Element == Element {


### PR DESCRIPTION
https://github.com/apple/swift/pull/65594 introduced the `_specialize(_:for:)` function as a convenience shortcut for checking for type equality followed by `_identityCast`.

Adopt this new function in the stdlib, in all places (that I could find) where we're manually specializing generic functions for specific type arguments.