### PR TITLE
[5.9][CodeComplete] Offer code completion for attached macro attributes

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3258,7 +3258,7 @@ void simple_display(llvm::raw_ostream &out,
 class ResolveMacroRequest
     : public SimpleRequest<ResolveMacroRequest,
                            ConcreteDeclRef(UnresolvedMacroReference,
-                                           const Decl *),
+                                           DeclContext *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3266,9 +3266,9 @@ public:
 private:
   friend SimpleRequest;
 
-  ConcreteDeclRef
-  evaluate(Evaluator &evaluator, UnresolvedMacroReference macroRef,
-           const Decl *decl) const;
+  ConcreteDeclRef evaluate(Evaluator &evaluator,
+                           UnresolvedMacroReference macroRef,
+                           DeclContext *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -445,8 +445,7 @@ void Decl::forEachAttachedMacro(MacroRole role,
 MacroDecl *Decl::getResolvedMacro(CustomAttr *customAttr) const {
   auto declRef = evaluateOrDefault(
       getASTContext().evaluator,
-      ResolveMacroRequest{customAttr, this},
-      ConcreteDeclRef());
+      ResolveMacroRequest{customAttr, getDeclContext()}, ConcreteDeclRef());
 
   return dyn_cast_or_null<MacroDecl>(declRef.getDecl());
 }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1416,14 +1416,25 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     llvm::SaveAndRestore<TypeCheckCompletionCallback*>
       CompletionCollector(Context.CompletionCallback, &Lookup);
     if (AttrWithCompletion) {
-      /// The attribute might not be attached to the AST if there is no var decl
-      /// it could be attached to. Type check it standalone.
-      ASTNode Call = CallExpr::create(
-          CurDeclContext->getASTContext(), AttrWithCompletion->getTypeExpr(),
-          AttrWithCompletion->getArgs(), /*implicit=*/true);
-      typeCheckContextAt(
-          TypeCheckASTNodeAtLocContext::node(CurDeclContext, Call),
-          CompletionLoc);
+      /// The attribute might not be attached to the AST if there is no var
+      /// decl it could be attached to. Type check it standalone.
+
+      // First try to check it as an attached macro.
+      auto resolvedMacro = evaluateOrDefault(
+          CurDeclContext->getASTContext().evaluator,
+          ResolveMacroRequest{AttrWithCompletion, CurDeclContext},
+          ConcreteDeclRef());
+
+      // If that fails, type check as a call to the attribute's type. This is
+      // how, e.g., property wrappers are modelled.
+      if (!resolvedMacro) {
+        ASTNode Call = CallExpr::create(
+            CurDeclContext->getASTContext(), AttrWithCompletion->getTypeExpr(),
+            AttrWithCompletion->getArgs(), /*implicit=*/true);
+        typeCheckContextAt(
+            TypeCheckASTNodeAtLocContext::node(CurDeclContext, Call),
+            CompletionLoc);
+      }
     } else {
       typeCheckContextAt(
           TypeCheckASTNodeAtLocContext::declContext(CurDeclContext),

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3794,9 +3794,8 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
   auto *dc = MED->getDeclContext();
 
   // Resolve macro candidates.
-  auto macro = evaluateOrDefault(
-      ctx.evaluator, ResolveMacroRequest{MED, MED},
-      ConcreteDeclRef());
+  auto macro = evaluateOrDefault(ctx.evaluator, ResolveMacroRequest{MED, dc},
+                                 ConcreteDeclRef());
   if (!macro)
     return None;
   MED->setMacroRef(macro);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1496,12 +1496,9 @@ swift::expandConformances(CustomAttr *attr, MacroDecl *macro,
   return macroSourceFile->getBufferID();
 }
 
-ConcreteDeclRef
-ResolveMacroRequest::evaluate(Evaluator &evaluator,
-                              UnresolvedMacroReference macroRef,
-                              const Decl *decl) const {
-  auto dc = decl->getDeclContext();
-
+ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
+                                              UnresolvedMacroReference macroRef,
+                                              DeclContext *dc) const {
   // Macro expressions and declarations have their own stored macro
   // reference. Use it if it's there.
   if (auto *expr = macroRef.getExpr()) {

--- a/test/IDE/complete_macros.swift
+++ b/test/IDE/complete_macros.swift
@@ -36,6 +36,16 @@ public macro AttachedMemberMacro()
 @attached(member)
 public macro AttachedMemberMacroWithArgs(arg1: Int)
 
+public enum Direction {
+  case up, down
+}
+
+@attached(member)
+public macro AttachedMemberMacroWithEnumArgs(_ direction: Direction)
+
+@attached(member)
+public macro AttachedMemberMacroWithMultipleArgs(first: Int, second: Int)
+
 @attached(memberAttribute)
 public macro AttachedMemberAttributeMacro()
 
@@ -156,6 +166,19 @@ struct NestedFreestanding {
 // ITEM_FREESTANDING-NOT: freestandingCodeItemMacro
 // ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclMacro[#Void#]; name=freestandingDeclMacro
 // ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Void#]; name=EverythingMacro
+
+
+@AttachedMemberMacroWithEnumArgs(.#^ATTACHED_MACRO_ARG^#)
+struct AttachedMacroArg {}
+
+// ATTACHED_MACRO_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: up[#Direction#]; name=up
+// ATTACHED_MACRO_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: down[#Direction#]; name=down
+
+@AttachedMemberMacroWithMultipleArgs(first: 1, #^ATTACHED_MACRO_SECOND_ARG_LABEL^#)
+struct AttachedMacroSecondArgLabel {}
+
+// ATTACHED_MACRO_SECOND_ARG_LABEL: Pattern/Local/Flair[ArgLabels]:     {#second: Int#}[#Int#]; name=second:
+
 
 struct LastMember {
   @#^LAST_MEMBER_ATTR?check=INDEPENDENT_ATTR^#


### PR DESCRIPTION
* **Explanation**: To complete inside attached macro attributes, we need to teach code completion how to invoke the type checker for attached macro attributes. After that, everything started working.
* **Scope**: Type checking of macros 
* **Risk**: The biggest risk is changing the parameter of `ResolveMacroRequest` from `DeclContext *` to `Decl *`. Doug thought that he had made the change to avoid a cycle in the request evaluator but no test are failing and he can’t remember why it’s needed. So we should be fine
* **Testing**: Added test case
* **Issue**: rdar://105232015
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/65572
