### PR TITLE
[5.9🍒] temporarily prevent Copyable types from using consuming and borrowing

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7111,6 +7111,11 @@ ERROR(moveonly_parameter_missing_ownership, none,
       "noncopyable parameter must specify its ownership", ())
 NOTE(moveonly_parameter_ownership_suggestion, none,
       "add '%0' %1", (StringRef, StringRef))
+ERROR(ownership_specifier_copyable,none,
+      "Copyable types cannot be 'consuming' or 'borrowing' yet", ())
+ERROR(self_ownership_specifier_copyable,none,
+      "%0 is not yet valid on %1s in a Copyable type",
+      (SelfAccessKind, DescriptiveDeclKind))
 
 //------------------------------------------------------------------------------
 // MARK: Runtime discoverable attributes (@runtimeMetadata)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4279,7 +4279,33 @@ TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
   // Remember that we've seen an ownership specifier for this base type.
   options |= TypeResolutionFlags::HasOwnership;
 
-  return resolveType(repr->getBase(), options);
+  auto result = resolveType(repr->getBase(), options);
+  if (result->hasError())
+    return result;
+
+  // Unless we have the experimental no-implicit-copy feature enabled, Copyable
+  // types can't use 'consuming' or 'borrowing' ownership specifiers.
+  if (!getASTContext().LangOpts.hasFeature(Feature::NoImplicitCopy)) {
+    if (!result->isPureMoveOnly()) {
+      // Prevent copyable types from using the non-underscored ownership parameter
+      // specifiers, other than 'inout'.
+      switch (ownershipRepr->getSpecifier()) {
+      case ParamSpecifier::Default:
+      case ParamSpecifier::InOut:
+      case ParamSpecifier::LegacyShared:
+      case ParamSpecifier::LegacyOwned:break;
+
+      case ParamSpecifier::Borrowing:
+      case ParamSpecifier::Consuming:
+        diagnoseInvalid(ownershipRepr,
+                        ownershipRepr->getLoc(),
+                        diag::ownership_specifier_copyable);
+        return ErrorType::get(getASTContext());
+      }
+    }
+  }
+
+  return result;
 }
 
 NeverNullType

--- a/test/Parse/ownership_modifiers.swift
+++ b/test/Parse/ownership_modifiers.swift
@@ -3,7 +3,7 @@
 struct borrowing {}
 struct consuming {}
 
-struct Foo {}
+struct Foo: ~Copyable {}
 
 func foo(x: borrowing Foo) {}
 func bar(x: consuming Foo) {}
@@ -18,13 +18,13 @@ func worst(x: (borrowing consuming Foo) -> ()) {} // expected-error{{at most one
 
 func zim(x: borrowing) {}
 func zang(x: consuming) {}
-func zung(x: borrowing consuming) {}
-func zip(x: consuming borrowing) {}
+func zung(x: borrowing consuming) {} // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func zip(x: consuming borrowing) {}  // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
 func zap(x: (borrowing, consuming) -> ()) {}
-func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {}
+func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {} // expected-error 2{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
 
-func worster(x: borrowing borrowing borrowing) {} // expected-error{{at most one}}
-func worstest(x: (borrowing borrowing borrowing) -> ()) {} // expected-error{{at most one}}
+func worster(x: borrowing borrowing borrowing) {} // expected-error{{at most one}} // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func worstest(x: (borrowing borrowing borrowing) -> ()) {} // expected-error{{at most one}} // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
 
 // Parameter specifier names are regular identifiers in other positions,
 // including argument labels.
@@ -47,7 +47,7 @@ func argumentLabel(anonConsumingInClosure: (_ consuming: Int) -> ()) {}
 func argumentLabel(anonSharedInClosure: (_ __shared: Int) -> ()) {}
 func argumentLabel(anonOwnedInClosure: (_ __owned: Int) -> ()) {}
 
-struct MethodModifiers {
+struct MethodModifiers: ~Copyable {
     mutating func mutating() {}
     borrowing func borrowing() {}
     consuming func consuming() {}
@@ -58,4 +58,46 @@ struct MethodModifiers {
     nonmutating borrowing func tooManyB() {} // expected-error{{method must not be declared both 'nonmutating' and 'borrowing'}}
     borrowing consuming func tooManyC() {} // expected-error{{method must not be declared both 'borrowing' and 'consuming'}}
     borrowing mutating consuming func tooManyD() {} // expected-error 2 {{method must not be declared both }}
+}
+
+
+func chalk(_ a: consuming String, // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+           _ b: borrowing [Int], // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+           _ c: __shared [String],
+           _ d: __owned Int?)
+           {}
+
+struct Stepping {
+    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
+    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+  mutating func change() {}
+  var ex: Int {
+    __consuming get { 0 }
+  }
+}
+
+class Clapping {
+    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
+    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+  var ex: Int {
+    __consuming get { 0 }
+  }
+}
+
+protocol Popping {
+    consuming func perform() // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
+    borrowing func doIt() // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+  mutating func change()
+  var ex: Int {
+    __consuming get
+  }
+}
+
+enum Exercising {
+    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
+    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+  mutating func change() {}
+  var ex: Int {
+    __consuming get { 0 }
+  }
 }

--- a/test/Parse/ownership_modifiers_no_errors.swift
+++ b/test/Parse/ownership_modifiers_no_errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoImplicitCopy
 
 // This is a variation of `ownership_modifiers.swift` with the expected error
 // lines removed, so that the file is parsed by the SwiftSyntax parser

--- a/test/SILGen/consuming_parameter.swift
+++ b/test/SILGen/consuming_parameter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy %s | %FileCheck %s
 
 func bar(_: String) {}
 

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy %s | %FileCheck %s
 
 //////////////////
 // Declarations //

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name moveonly_closure %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name moveonly_closure -verify %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -module-name moveonly_closure %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -module-name moveonly_closure -verify %s
 
 @_moveOnly
 struct Empty {}

--- a/test/SILGen/ownership_specifier_mangling.swift
+++ b/test/SILGen/ownership_specifier_mangling.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy %s | %FileCheck %s
 
 // The internal `__shared` and `__owned` modifiers would always affect
 // symbol mangling, even if they don't have a concrete impact on ABI. The

--- a/test/SILOptimizer/consuming_parameter.swift
+++ b/test/SILOptimizer/consuming_parameter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -c -disable-availability-checking -Xllvm --sil-print-final-ossa-module -O -module-name=main -o /dev/null %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -c -enable-experimental-feature NoImplicitCopy -disable-availability-checking -Xllvm --sil-print-final-ossa-module -O -module-name=main -o /dev/null %s 2>&1 | %FileCheck %s
  
 // REQUIRES: concurrency
 

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
 
 // This test validates that we properly emit errors if we partially invalidate
 // through a type with a deinit.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/attr/lexical.swift
+++ b/test/attr/lexical.swift
@@ -44,13 +44,14 @@ func foo() {
   _ = s3
 }
 
-@_moveOnly struct MoveOnly {}
+struct MoveOnly: ~Copyable {}
 
-@_eagerMove @_moveOnly struct MoveOnlyEagerly {} // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}
+@_eagerMove struct MoveOnlyEagerly: ~Copyable {} // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}
 
 func zoo(@_eagerMove _ : consuming MoveOnly) {} // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}
 
-func zooo(@_noEagerMove  _ : consuming C) {} // ok, only way to spell this behavior
+// TODO: Copyable types can't be consuming right now (rdar://108383660)
+//func zooo(@_noEagerMove  _ : consuming C) {} // ok, only way to spell this behavior
 
 extension MoveOnly {
   @_eagerMove // expected-error {{@_eagerMove cannot be applied to NonCopyable types}}


### PR DESCRIPTION
• Description: Copyable types with `borrowing` and `consuming` ownership specifiers are expected to have implicit copying behaviors disabled in the future, but today they permit implicit copies. This PR makes it an error to use those ownership specifiers for now, until we have the intended behavior in-place. The goal is to prevent future source breaks.
• Risk: Early adopters will not be able to compile and receive errors. They will need to know to use the unofficial `__owned` and `__shared` as alternatives to not break ABI, as simply removing the ownership annotation can lead to ABI breaks.
• Original PR: https://github.com/apple/swift/pull/65570
• Reviewed By: @gottesmm
• Testing: regression tests included.
• Resolves: rdar://108538971