### PR TITLE
[5.9🍒] Prevent noncopyable metatypes from being converted to `Any`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3831,8 +3831,8 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
     return getTypeMatchAmbiguous();
   }
 
-  // move-only types cannot match with any existential types.
-  if (type1->isPureMoveOnly()) {
+  // move-only types (and their metatypes) cannot match with existential types.
+  if (type1->getMetatypeInstanceType()->isPureMoveOnly()) {
     // tailor error message
     if (shouldAttemptFixes()) {
       auto *fix = MustBeCopyable::create(*this, type1,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1652,12 +1652,12 @@ TypeChecker::typeCheckCheckedCast(Type fromType, Type toType,
   }
 
   // Since move-only types currently cannot conform to protocols, nor be a class
-  // type, the subtyping hierarchy is a bit bizarre as of now:
+  // type, the subtyping hierarchy looks a bit like this:
   //
-  //              noncopyable
-  //           structs and enums
-  //                   |
-  //       +--------- Any
+  //                  ~Copyable
+  //                    /  \
+  //                   /    \
+  //       +--------- Any    noncopyable structs/enums
   //       |           |
   //   AnyObject    protocol
   //       |       existentials
@@ -1669,7 +1669,9 @@ TypeChecker::typeCheckCheckedCast(Type fromType, Type toType,
   //
   //
   // Thus, right now, a move-only type is only a subtype of itself.
-  if (fromType->isPureMoveOnly() || toType->isPureMoveOnly())
+  // We also want to prevent conversions of a move-only type's metatype.
+  if (fromType->getMetatypeInstanceType()->isPureMoveOnly()
+      || toType->getMetatypeInstanceType()->isPureMoveOnly())
     return CheckedCastKind::Unresolved;
   
   // Check for a bridging conversion.

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -142,9 +142,9 @@ public struct ExecutorJob: Sendable {
     /// and it appearing as 0 for _different_ jobs may lead to misunderstanding it as
     /// being "the same 0 id job", we specifically print 0 (id not set) as nil.
     if (id > 0) {
-      return "\(Self.self)(id: \(id))"
+      return "ExecutorJob(id: \(id))"
     } else {
-      return "\(Self.self)(id: nil)"
+      return "ExecutorJob(id: nil)"
     }
   }
 }

--- a/stdlib/public/Distributed/DistributedDefaultExecutor.swift
+++ b/stdlib/public/Distributed/DistributedDefaultExecutor.swift
@@ -26,7 +26,7 @@ internal final class DistributedRemoteActorReferenceExecutor: SerialExecutor {
   @inlinable
   public func enqueue(_ job: __owned ExecutorJob) {
     let jobDescription = job.description
-    fatalError("Attempted to enqueue \(Job.self) (\(jobDescription)) on executor of remote distributed actor reference!")
+    fatalError("Attempted to enqueue ExecutorJob (\(jobDescription)) on executor of remote distributed actor reference!")
   }
 
   public func asUnownedSerialExecutor() -> UnownedSerialExecutor {


### PR DESCRIPTION
• Description: Through a convoluted series of casts, one could possibly cast a noncopyable type's metatype to some existential's metatype and then construct instances of the underlying noncopyable type behind the existential's facade. Those existentials would then be permitted to be copied, which is a Bad Thing.
• Risk: There's not a whole lot the metatype can have done for you given there are very limited existentials or protocols in general that a noncopyable can conform to anyway. So far the only uses I ran into in the compiler were implicit casts to `Any` while turning `NoncopyableType.self` into a String to get its name. Simple enough for users to workaround, but _does_ introduce a source break for them.
• Original PR: https://github.com/apple/swift/pull/65606
• Reviewed By: @jckarter @ktoso 
• Testing: regression tests included
• Resolves: rdar://106452518

