### PR TITLE
clang importer: don't trigger stack protection when accessing an imported enum

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -877,7 +877,7 @@ synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
   newValueRef->setType(newValueDecl->getInterfaceType());
 
   auto addressofFn =
-      cast<FuncDecl>(getBuiltinValueDecl(ctx, ctx.getIdentifier("addressof")));
+      cast<FuncDecl>(getBuiltinValueDecl(ctx, ctx.getIdentifier("unprotectedAddressOf")));
   ConcreteDeclRef addressofFnRef(
       addressofFn, SubstitutionMap::get(addressofFn->getGenericSignature(),
                                         {inoutSelfDecl->getInterfaceType()},

--- a/test/ClangImporter/Inputs/enum-stack-protection.h
+++ b/test/ClangImporter/Inputs/enum-stack-protection.h
@@ -1,0 +1,10 @@
+
+struct S {
+  int a;
+  union {
+    int b;
+    int c;
+  };
+};
+
+

--- a/test/ClangImporter/enum-stack-protection.swift
+++ b/test/ClangImporter/enum-stack-protection.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/enum-stack-protection.h %s -Onone -module-name=test -emit-sil | %FileCheck %s
+
+// Check that accessing an imported enum doesn't trigger stack protection.
+
+// CHECK-LABEL: sil @$s4test6testityyF : $@convention(thin) () -> () {
+// CHECK:        address_to_pointer %{{[0-9]+}}
+// CHECK:        address_to_pointer %{{[0-9]+}}
+// CHECK:      } // end sil function '$s4test6testityyF'
+public func testit() {
+  var s = S()
+  s.a = 1
+  s.b = 2
+  s.c = 3
+  useit(s)
+}
+
+@inline(never)
+public func useit(_ s: S) {
+}
+


### PR DESCRIPTION
rdar://108867547
