### PR TITLE
[5.9][cxx-interop] do not import functions with rvalue ref parameters and fix ref parameter type conversion for typealiased refs

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -156,6 +156,7 @@ NOTE(macro_not_imported, none, "macro '%0' unavailable (cannot import)", (String
 
 NOTE(return_type_not_imported, none, "return type unavailable (cannot import)", ())
 NOTE(parameter_type_not_imported, none, "parameter %0 unavailable (cannot import)", (const clang::NamedDecl*))
+NOTE(rvalue_ref_params_not_imported, none, "C++ functions with rvalue reference parameters are unavailable in Swift", ())
 NOTE(incomplete_interface, none, "interface %0 is incomplete", (const clang::NamedDecl*))
 NOTE(incomplete_protocol, none, "protocol %0 is incomplete", (const clang::NamedDecl*))
 NOTE(incomplete_record, none, "record '%0' is not defined (incomplete)", (StringRef))

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -588,6 +588,14 @@ namespace importer {
 /// Returns true if the given module has a 'cplusplus' requirement.
 bool requiresCPlusPlus(const clang::Module *module);
 
+/// Returns the pointee type if the given type is a C++ `const`
+/// reference type, `None` otherwise.
+llvm::Optional<clang::QualType>
+getCxxReferencePointeeTypeOrNone(const clang::Type *type);
+
+/// Returns true if the given type is a C++ `const` reference type.
+bool isCxxConstReferenceType(const clang::Type *type);
+
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6840,3 +6840,15 @@ bool importer::requiresCPlusPlus(const clang::Module *module) {
     return req.first == "cplusplus";
   });
 }
+
+llvm::Optional<clang::QualType>
+importer::getCxxReferencePointeeTypeOrNone(const clang::Type *type) {
+  if (type->isReferenceType())
+    return type->getPointeeType();
+  return {};
+}
+
+bool importer::isCxxConstReferenceType(const clang::Type *type) {
+  auto pointeeType = getCxxReferencePointeeTypeOrNone(type);
+  return pointeeType && pointeeType->isConstQualified();
+}

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2362,7 +2362,7 @@ ClangImporter::Implementation::importParameterType(
 
       // We don't support rvalue reference types, just bail.
       if (paramTy->isRValueReferenceType()) {
-        // FIXME: add import diagnostic.
+        addImportDiagnosticFn(Diagnostic(diag::rvalue_ref_params_not_imported));
         return None;
       }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2347,9 +2347,14 @@ ClangImporter::Implementation::importParameterType(
                  dyn_cast<clang::TemplateTypeParmType>(paramTy)) {
     swiftParamTy = findGenericTypeInGenericDecls(
         *this, templateParamType, genericParams, attrs, addImportDiagnosticFn);
-  } else if (auto refType = dyn_cast<clang::ReferenceType>(paramTy)) {
+  } else if (auto refType = dyn_cast<clang::ReferenceType>(paramTy)) {    
     // We don't support reference type to a dependent type, just bail.
     if (refType->getPointeeType()->isDependentType()) {
+      return None;
+    }
+
+    // We don't support rvalue reference types, just bail.
+    if (refType->isRValueReferenceType()) {
       return None;
     }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2347,20 +2347,32 @@ ClangImporter::Implementation::importParameterType(
                  dyn_cast<clang::TemplateTypeParmType>(paramTy)) {
     swiftParamTy = findGenericTypeInGenericDecls(
         *this, templateParamType, genericParams, attrs, addImportDiagnosticFn);
-  } else if (auto refType = dyn_cast<clang::ReferenceType>(paramTy)) {    
-    // We don't support reference type to a dependent type, just bail.
-    if (refType->getPointeeType()->isDependentType()) {
-      return None;
-    }
+  }
 
-    // We don't support rvalue reference types, just bail.
-    if (refType->isRValueReferenceType()) {
-      return None;
-    }
+  if (!swiftParamTy) {
+    // C++ reference types are brought in as direct
+    // types most commonly.
+    auto refPointeeType =
+        importer::getCxxReferencePointeeTypeOrNone(paramTy.getTypePtr());
+    if (refPointeeType) {
+      // We don't support reference type to a dependent type, just bail.
+      if ((*refPointeeType)->isDependentType()) {
+        return None;
+      }
 
-    paramTy = refType->getPointeeType();
-    if (!paramTy.isConstQualified())
-      isInOut = true;
+      // We don't support rvalue reference types, just bail.
+      if (paramTy->isRValueReferenceType()) {
+        // FIXME: add import diagnostic.
+        return None;
+      }
+
+      // A C++ parameter of type `const <type> &` or `<type> &` becomes `<type>`
+      // or `inout <type>` in Swift. Note that SILGen will use the indirect
+      // parameter convention for such a type.
+      paramTy = *refPointeeType;
+      if (!paramTy.isConstQualified())
+        isInOut = true;
+    }
   }
 
   // Special case for NSDictionary's subscript.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1420,8 +1420,7 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
   // Pass C++ const reference types indirectly. Right now there's no way to
   // express immutable borrowed params, so we have to have this hack.
   // Eventually, we should just express these correctly: rdar://89647503
-  if (clangTy->isReferenceType() &&
-      clangTy->getPointeeType().isConstQualified())
+  if (importer::isCxxConstReferenceType(clangTy))
     return true;
 
   return false;
@@ -3109,7 +3108,7 @@ static bool isCFTypedef(const TypeLowering &tl, clang::QualType type) {
 static ParameterConvention getIndirectCParameterConvention(clang::QualType type) {
   // Non-trivial C++ types would be Indirect_Inout (at least in Itanium).
   // A trivial const * parameter in C should be considered @in.
-  if (type->isReferenceType() && type->getPointeeType().isConstQualified())
+  if (importer::isCxxConstReferenceType(type.getTypePtr()))
     return ParameterConvention::Indirect_In_Guaranteed;
   return ParameterConvention::Indirect_In;
 }

--- a/test/Interop/Cxx/reference/Inputs/reference.cpp
+++ b/test/Interop/Cxx/reference/Inputs/reference.cpp
@@ -20,3 +20,11 @@ auto getFuncRvalueRef() -> int (&&)() { return getStaticInt; }
 void takeConstRef(const int &value) {
   staticInt = value;
 }
+
+void setConstStaticIntRefTypealias(ConstIntRefTypealias ref) {
+  staticInt = ref;
+}
+
+void setStaticIntRefTypealias(IntRefTypealias ref) {
+  staticInt = ref;
+}

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -16,6 +16,14 @@ void setConstStaticIntRvalueRef(const int &&);
 auto getFuncRef() -> int (&)();
 auto getFuncRvalueRef() -> int (&&)();
 
+using ConstIntRefTypealias = const int &;
+
+void setConstStaticIntRefTypealias(ConstIntRefTypealias ref);
+
+using IntRefTypealias = int &;
+
+void setStaticIntRefTypealias(IntRefTypealias ref);
+
 template<class T>
 struct ClassTemplate {};
 

--- a/test/Interop/Cxx/reference/reference-cannot-import-diagnostic.swift
+++ b/test/Interop/Cxx/reference/reference-cannot-import-diagnostic.swift
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: not %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+
+void acceptRValueRef(int &&);
+
+//--- test.swift
+
+import Test
+
+public func test() {
+  var x: CInt = 2
+  acceptRValueRef(x)
+  // CHECK: note: function 'acceptRValueRef' unavailable (cannot import)
+  // CHECK: note: C++ functions with rvalue reference parameters are unavailable in Swift
+}

--- a/test/Interop/Cxx/reference/reference-irgen.swift
+++ b/test/Interop/Cxx/reference/reference-irgen.swift
@@ -45,19 +45,3 @@ public func setCxxConstRef() {
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main14setCxxConstRefyyF"()
 // CHECK: call void @{{_Z20setConstStaticIntRefRKi|"\?setConstStaticIntRef@@YAXAEBH@Z"}}(i32* %{{.*}})
-
-public func setCxxRvalueRef() {
-  var val: CInt = 21
-  setStaticIntRvalueRef(&val)
-}
-
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main15setCxxRvalueRefyyF"()
-// CHECK: call void @{{_Z21setStaticIntRvalueRefOi|"\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z"}}(i32* %{{.*}})
-
-public func setCxxConstRvalueRef() {
-  let val: CInt = 21
-  setConstStaticIntRvalueRef(val)
-}
-
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20setCxxConstRvalueRefyyF"()
-// CHECK: call void @{{_Z26setConstStaticIntRvalueRefOKi|"\?setConstStaticIntRvalueRef@@YAX\$\$QEBH@Z"}}(i32* %{{.*}})

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -7,9 +7,7 @@
 // CHECK: func getConstStaticIntRvalueRef() -> UnsafePointer<Int32>
 // CHECK: func setStaticInt(_: Int32)
 // CHECK: func setStaticIntRef(_: inout Int32)
-// CHECK: func setStaticIntRvalueRef(_: inout Int32)
 // CHECK: func setConstStaticIntRef(_: Int32)
-// CHECK: func setConstStaticIntRvalueRef(_: Int32)
 // CHECK: func getFuncRef() -> @convention(c) () -> Int32
 // CHECK: func getFuncRvalueRef() -> @convention(c) () -> Int32
 // CHECK: func refToTemplate<T>(_ t: inout T) -> UnsafeMutablePointer<T>
@@ -18,3 +16,5 @@
 // CHECK-NOT: refToDependent
 // CHECK-NOT: refToDependentParam
 // CHECK-NOT: dontImportAtomicRef
+// CHECK-NOT: setStaticIntRvalueRef
+// CHECK-NOT: setConstStaticIntRvalueRef

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -10,6 +10,8 @@
 // CHECK: func setConstStaticIntRef(_: Int32)
 // CHECK: func getFuncRef() -> @convention(c) () -> Int32
 // CHECK: func getFuncRvalueRef() -> @convention(c) () -> Int32
+// CHECK: func setConstStaticIntRefTypealias(_ ref: Int32)
+// CHECK: func setStaticIntRefTypealias(_ ref: inout Int32)
 // CHECK: func refToTemplate<T>(_ t: inout T) -> UnsafeMutablePointer<T>
 // CHECK: func constRefToTemplate<T>(_ t: T) -> UnsafePointer<T>
 

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -51,21 +51,3 @@ func setCxxConstRef() {
 // CHECK: sil hidden @$s4main14setCxxConstRefyyF : $@convention(thin) () -> ()
 // CHECK: [[REF:%.*]] = function_ref @{{_Z20setConstStaticIntRefRKi|\?setConstStaticIntRef@@YAXAEBH@Z}} : $@convention(c) (@in_guaranteed Int32) -> ()
 // CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> ()
-
-func setCxxRvalueRef() {
-  var val: CInt = 21
-  setStaticIntRvalueRef(&val)
-}
-
-// CHECK: sil hidden @$s4main15setCxxRvalueRefyyF : $@convention(thin) () -> ()
-// CHECK: [[REF:%.*]] = function_ref @{{_Z21setStaticIntRvalueRefOi|\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z}} : $@convention(c) (@inout Int32) -> ()
-// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
-
-func setCxxConstRvalueRef() {
-  let val: CInt = 21
-  setConstStaticIntRvalueRef(val)
-}
-
-// CHECK: sil hidden @$s4main20setCxxConstRvalueRefyyF : $@convention(thin) () -> ()
-// CHECK: [[REF:%.*]] = function_ref @{{_Z26setConstStaticIntRvalueRefOKi|\?setConstStaticIntRvalueRef@@YAX\$\$QEBH@Z}} : $@convention(c) (@in_guaranteed Int32) -> ()
-// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> ()

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -51,3 +51,21 @@ func setCxxConstRef() {
 // CHECK: sil hidden @$s4main14setCxxConstRefyyF : $@convention(thin) () -> ()
 // CHECK: [[REF:%.*]] = function_ref @{{_Z20setConstStaticIntRefRKi|\?setConstStaticIntRef@@YAXAEBH@Z}} : $@convention(c) (@in_guaranteed Int32) -> ()
 // CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> ()
+
+func setCxxConstRefTypealias() {
+  let val: CInt = 21
+  setConstStaticIntRefTypealias(val)
+}
+
+// CHECK: sil hidden @$s4main23setCxxConstRefTypealiasyyF : $@convention(thin) () -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z29setConstStaticIntRefTypealiasRKi|\?setConstStaticIntRefTypealias@@YAXAEBH@Z}} : $@convention(c) (@in_guaranteed Int32) -> ()
+// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> ()
+
+func setStaticIntRefTypealias() {
+  var val: CInt = 21
+  setStaticIntRefTypealias(&val)
+}
+
+// CHECK: sil hidden @$s4main24setStaticIntRefTypealiasyyF : $@convention(thin) () -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z24setStaticIntRefTypealiasRi|\?setStaticIntRefTypealias@@YAXAEAH@Z}} : $@convention(c) (@inout Int32) -> ()
+// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -42,6 +42,9 @@ ReferenceTestSuite.test("pass-lvalue-reference") {
   var val: CInt = 21
   setStaticIntRef(&val)
   expectEqual(21, getStaticInt())
+  val = 111
+  setStaticIntRefTypealias(&val)
+  expectEqual(getStaticInt(), 111)
 }
 
 ReferenceTestSuite.test("pass-const-lvalue-reference") {
@@ -49,6 +52,8 @@ ReferenceTestSuite.test("pass-const-lvalue-reference") {
   let val: CInt = 22
   setConstStaticIntRef(val)
   expectEqual(22, getStaticInt())
+  setConstStaticIntRefTypealias(112)
+  expectEqual(getStaticInt(), 112)
 }
 
 ReferenceTestSuite.test("func-reference") {

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -51,20 +51,6 @@ ReferenceTestSuite.test("pass-const-lvalue-reference") {
   expectEqual(22, getStaticInt())
 }
 
-ReferenceTestSuite.test("pass-rvalue-reference") {
-  expectNotEqual(52, getStaticInt())
-  var val: CInt = 52
-  setStaticIntRvalueRef(&val)
-  expectEqual(52, getStaticInt())
-}
-
-ReferenceTestSuite.test("pass-const-rvalue-reference") {
-  expectNotEqual(53, getStaticInt())
-  let val: CInt = 53
-  setConstStaticIntRvalueRef(val)
-  expectEqual(53, getStaticInt())
-}
-
 ReferenceTestSuite.test("func-reference") {
   let cxxF: @convention(c) () -> Int32 = getFuncRef()
 

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -20,18 +20,17 @@ StdVectorTestSuite.test("init") {
 
 StdVectorTestSuite.test("push back") {
     var v = Vector()
-    var _42: CInt = 42
-    v.push_back(&_42)
+    let _42: CInt = 42
+    v.push_back(_42)
     expectEqual(v.size(), 1)
     expectFalse(v.empty())
     expectEqual(v[0], 42)
 }
 
 func fill(vector v: inout Vector) {
-    var _1: CInt = 1, _2: CInt = 2, _3: CInt = 3
-    v.push_back(&_1)
-    v.push_back(&_2)
-    v.push_back(&_3)
+    v.push_back(1)
+    v.push_back(2)
+    v.push_back(CInt(3))
 }
 
 StdVectorTestSuite.test("for loop") {


### PR DESCRIPTION

- Explanation: C++ rvalue refs has been converted to `inout` parameters in Swift. This is wrong, as they should be `consuming` instead. We aren't ready to support them in `consuming` mode though. Also, methods with such parameters can hide other overloads, like the ones taking a const ref (e.g. `push_back(const T &)` vs `push_back(T &&)`). That's why we should not import functions that take in rvalue ref parameters yet. While making this change we also found that the logic for handling lvalue reference parameters (to convert them to `T` or `inout T`) didn't work when the parameter's type was a type alias. This is now fixed, so finally libc++'s vector's `push_back` can be called directly with a value passed into it.
- Scope: Swift's and C++ interoperability, clang importer, type importer
- Risk: Medium. This is a source breaking change but our main adopter will be able to handle it. It only affects C++ interoperability enabled code only as it works with C++ refs.
- Testing: Swift unit tests, manual testing.
- Reviewer: @ravikandhadai , @zoecarver 