### PR TITLE
[cxx-interop] Do not emit IR for C++20 requires expr

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -119,6 +119,8 @@ public:
     return true;
   }
 
+  bool TraverseRequiresExpr(clang::RequiresExpr *RE) { return true; }
+
   // Do not traverse type locs, as they might contain expressions that reference
   // code that should not be instantiated and/or emitted.
   bool TraverseTypeLoc(clang::TypeLoc TL) { return true; }

--- a/test/Interop/Cxx/concepts/Inputs/method-requires.h
+++ b/test/Interop/Cxx/concepts/Inputs/method-requires.h
@@ -1,0 +1,11 @@
+inline void calledFromConceptBody(int x) {}
+inline void calledFromMethodBody(int x) {}
+
+struct MyStruct {
+  template <typename T>
+  void foo(T x)
+    requires requires(const T x) { calledFromConceptBody(x); }
+  {
+    calledFromMethodBody(x);
+  }
+};

--- a/test/Interop/Cxx/concepts/Inputs/module.modulemap
+++ b/test/Interop/Cxx/concepts/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module MethodRequires {
+  header "method-requires.h"
+  export *
+}

--- a/test/Interop/Cxx/concepts/method-requires.swift
+++ b/test/Interop/Cxx/concepts/method-requires.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swiftxx-frontend -emit-ir -Xcc -std=gnu++20 -I %S/Inputs %s | %FileCheck %s
+//
+// REQUIRES: OS=macosx
+
+import MethodRequires
+
+var s = MyStruct()
+s.foo(123)
+// CHECK-NOT: calledFromConceptBody
+// CHECK: calledFromMethodBody


### PR DESCRIPTION
This fixes a compiler crash when emitting IR for a for-in loop over a C++ `std::vector` in C++20 mode.

rdar://108810356