### PR TITLE
5.9: [IRGen] Check for nil in final class cast opt.

### DIFF
--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -885,6 +885,8 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
     }
   };
 
+  bool sourceWrappedInOptional = false;
+
   if (auto sourceOptObjectType = sourceLoweredType.getOptionalObjectType()) {
     // Translate the value from an enum representation to a possibly-null
     // representation.  Note that we assume that this projection is safe
@@ -898,6 +900,7 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
     value = std::move(optValue);
     sourceLoweredType = sourceOptObjectType;
     sourceFormalType = sourceFormalType.getOptionalObjectType();
+    sourceWrappedInOptional = true;
 
     // We need a null-check because the runtime function can't handle null in
     // some of the cases.
@@ -1021,9 +1024,12 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
     return;
   }
 
-  if (llvm::Value *fastResult = emitFastClassCastIfPossible(IGF, instance,
-                                        sourceFormalType, targetFormalType)) {
-    out.add(fastResult);
+  if (llvm::Value *fastResult = emitFastClassCastIfPossible(
+          IGF, instance, sourceFormalType, targetFormalType,
+          sourceWrappedInOptional, nilCheckBB, nilMergeBB)) {
+    Explosion fastExplosion;
+    fastExplosion.add(fastResult);
+    returnNilCheckedResult(IGF.Builder, fastExplosion);
     return;
   }
 
@@ -1039,10 +1045,10 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
 /// It also avoids a call to the metadata accessor of the class (which calls
 /// `swift_getInitializedObjCClass`). For comparing the metadata pointers it's
 /// not required that the metadata is fully initialized.
-llvm::Value *irgen::emitFastClassCastIfPossible(IRGenFunction &IGF,
-                                                llvm::Value *instance,
-                                                CanType sourceFormalType,
-                                                CanType targetFormalType) {
+llvm::Value *irgen::emitFastClassCastIfPossible(
+    IRGenFunction &IGF, llvm::Value *instance, CanType sourceFormalType,
+    CanType targetFormalType, bool sourceWrappedInOptional,
+    llvm::BasicBlock *&nilCheckBB, llvm::BasicBlock *&nilMergeBB) {
   if (!doesCastPreserveOwnershipForTypes(IGF.IGM.getSILModule(),
                                          sourceFormalType, targetFormalType)) {
     return nullptr;
@@ -1073,6 +1079,19 @@ llvm::Value *irgen::emitFastClassCastIfPossible(IRGenFunction &IGF,
                               AncestryFlags::ObjCObjectModel;
   if (toClass->checkAncestry() & forbidden)
     return nullptr;
+
+  // If the source was originally wrapped in an Optional, check it for nil now.
+  if (sourceWrappedInOptional) {
+    auto isNotNil = IGF.Builder.CreateICmpNE(
+        instance, llvm::ConstantPointerNull::get(
+                      cast<llvm::PointerType>(instance->getType())));
+    auto *isNotNilContBB = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
+    nilMergeBB = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
+    nilCheckBB = IGF.Builder.GetInsertBlock();
+    IGF.Builder.CreateCondBr(isNotNil, isNotNilContBB, nilMergeBB);
+
+    IGF.Builder.emitBlock(isNotNilContBB);
+  }
 
   // Get the metadata pointer of the destination class type.
   llvm::Value *destMetadata = IGF.IGM.getAddrOfTypeMetadata(targetFormalType);

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -21,6 +21,7 @@
 
 namespace llvm {
   class Value;
+  class BasicBlock;
 }
 
 namespace swift {
@@ -56,10 +57,10 @@ namespace irgen {
                              GenericSignature fnSig,
                              Explosion &out);
 
-  llvm::Value *emitFastClassCastIfPossible(IRGenFunction &IGF,
-                                           llvm::Value *instance,
-                                           CanType sourceFormalType,
-                                           CanType targetFormalType);
+  llvm::Value *emitFastClassCastIfPossible(
+      IRGenFunction &IGF, llvm::Value *instance, CanType sourceFormalType,
+      CanType targetFormalType, bool sourceWrappedInOptional,
+      llvm::BasicBlock *&nilCheckBB, llvm::BasicBlock *&nilMergeBB);
 
   /// Convert a class object to the given destination type,
   /// using a runtime-checked cast.

--- a/validation-test/IRGen/rdar108614878.swift
+++ b/validation-test/IRGen/rdar108614878.swift
@@ -1,0 +1,24 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+final class C {}
+
+struct S {
+    @inline(never)
+    func g1<T>(_ componentType: T.Type) -> T? {
+        return nil
+    }
+    @inline(never)
+    func g2<T>(_ type: T.Type) -> T? {
+        g1(T.self) as? T
+    }
+}
+
+func run() -> C? {
+    var e = S()
+    let r = e.g2(C.self)
+    return r
+}
+
+// CHECK: nil
+print(run())


### PR DESCRIPTION
• Description: As an optimization, there is a fast-cast to final classes that compares isa pointers to avoid calling `swift_dynamicCast`.  If the source of the cast is an `Optional<final class>`, though, it's not legal to compare isa-pointers: to do so, the source of the cast must be loaded (to get its isa pointer), but it might be `Optional.none` which for such an instance is represented with `null`.  This patch adds a `null` check if the source of the cast is wrapped in an `Optional`.
• Risk: Low.  The patch makes use mostly of existing code to check for `null` when the source is `Optional`.
• Original PR: https://github.com/apple/swift/pull/65636/
• Reviewed By: Erik Eckstein ( @eeckstein )
• Testing: Added an execution test that previously crashed.
• Resolves: rdar://108893429
