### PR TITLE
[5.9][ConstraintSystem] Reverse direction of `ShapeOf` constraint

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -224,7 +224,8 @@ enum class ConstraintKind : char {
   /// Binds the RHS type to a tuple of the params of a function typed LHS. Note
   /// this discards function parameter flags.
   BindTupleOfFunctionParams,
-  /// The first type is a type pack, and the second type is its reduced shape.
+  /// The first type is a reduced shape of the second type (represented as a
+  /// pack type).
   ShapeOf,
   /// Represents explicit generic arguments provided for a reference to
   /// a declaration.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4858,10 +4858,10 @@ private:
       ASTNode element, ContextualTypeInfo context, bool isDiscarded,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
-  /// Simplify a shape constraint by binding the reduced shape of the
-  /// left hand side to the right hand side.
+  /// Simplify a shape constraint by binding the left-hand side to the
+  /// reduced shape of the right-hand side.
   SolutionKind simplifyShapeOfConstraint(
-      Type type1, Type type2, TypeMatchOptions flags,
+      Type shapeTy, Type packTy, TypeMatchOptions flags,
       ConstraintLocatorBuilder locator);
 
   /// Simplify an explicit generic argument constraint by equating the

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3103,7 +3103,8 @@ namespace {
           llvm_unreachable("unsupported pack reference ASTNode");
         }
 
-        CS.addConstraint(ConstraintKind::ShapeOf, packType, shapeTypeVar,
+        CS.addConstraint(
+            ConstraintKind::ShapeOf, shapeTypeVar, packType,
             CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13420,11 +13420,11 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
   auto formUnsolved = [&]() {
     // If we're supposed to generate constraints, do so.
     if (flags.contains(TMF_GenerateConstraints)) {
-      auto *shapeOf = Constraint::create(
-          *this, ConstraintKind::ShapeOf, type1, type2,
-          getConstraintLocator(locator));
+      auto *explictGenericArgs =
+          Constraint::create(*this, ConstraintKind::ExplicitGenericArguments,
+                             type1, type2, getConstraintLocator(locator));
 
-      addUnsolvedConstraint(shapeOf);
+      addUnsolvedConstraint(explictGenericArgs);
       return SolutionKind::Solved;
     }
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -90,9 +90,9 @@ func typeReprPacks<each T: ExpressibleByIntegerLiteral>(_ t: repeat each T) {
 }
 
 func sameShapeDiagnostics<each T, each U>(t: repeat each T, u: repeat each U) {
-  _ = (repeat (each t, each u)) // expected-error {{pack expansion requires that 'each U' and 'each T' have the same shape}}
-  _ = (repeat Array<(each T, each U)>()) // expected-error {{pack expansion requires that 'each U' and 'each T' have the same shape}}
-  _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each U' and 'each T' have the same shape}}
+  _ = (repeat (each t, each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
+  _ = (repeat Array<(each T, each U)>()) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
+  _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
 }
 
 func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65625

---

- Explanation:
 
  Changes directionality of the `ShapeOf` constraint to better fit and fixes one place in simplification logic where `ShapeOf` was used incorrectly:

  - (NFC change)`ShapeOf` - First type is the reduced shape of the second type (the pack type).
  - Fix incorrect use of `ShapeOf` instead of `ExplicitGenericArguments`.

- Scope: Expressions that use variadic generics feature.

- Main Branch PR: https://github.com/apple/swift/pull/65625

- Resolves:  (There are no issues for this discovered via code review).

- Risk: Extra Low.

- Reviewed By: @hborla

- Testing:  Added regression test-cases to the suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
