### PR TITLE
[5.9] Pick new diagnostic for unsafe 'begin' methods: suggest using for loop.

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -195,7 +195,7 @@ NOTE(mark_safe_to_import, none, "annotate method '%0' with 'SWIFT_RETURNS_INDEPE
 NOTE(at_to_subscript, none, "do you want to replace it with a call "
                             "to the subscript operator?",
      ())
-NOTE(get_swift_iterator, none, "do you want to make a Swift iterator instead?",
+NOTE(use_collection_apis, none, "do you want to use a for-loop instead?",
      ())
 NOTE(replace_with_nil, none, "do you want to compare against 'nil' instead?",
      ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3877,7 +3877,7 @@ void MissingMemberFailure::diagnoseUnsafeCxxMethod(SourceLoc loc,
       if (conformsToRACollection(baseType)) {
         ctx.Diags.diagnose(loc, diag::iterator_method_unavailable,
                            name.getBaseIdentifier().str());
-        ctx.Diags.diagnose(loc, diag::get_swift_iterator)
+        ctx.Diags.diagnose(loc, diag::use_collection_apis)
             .fixItReplaceChars(
                 loc, loc.getAdvancedLoc(name.getBaseIdentifier().str().size()),
                 "makeIterator");

--- a/test/Interop/Cxx/class/fixits-for-std-vector.swift
+++ b/test/Interop/Cxx/class/fixits-for-std-vector.swift
@@ -22,7 +22,7 @@ import CxxStdlib
 
 public func test(v: V) {
   // CHECK: note: C++ method 'begin' that returns an iterator is unavailable
-  // CHECK: note: do you want to make a Swift iterator instead?
+  // CHECK: note: do you want to use a for-loop instead?
   // CHECK: ^~~~~
   // CHECK: makeIterator
   _ = v.begin()


### PR DESCRIPTION
Explanation: 'begin' is one of the most commonly used methods that returns an iterator. We should lead Swift users towards using the collection/sequence API interface, not the Swift iterator interface. This is a UX improvement that we want in 5.9.
Testing: Swift unit tests, manual testing.
Scope: Swift's and C++ interoperability, diagnostics
Risk: extra-low. This only changes the text of a diagnostic; this is a non-functional change.
Reviewers: @hyp @xedin 