### PR TITLE
[IRGen] Respect optionality of unowned(unsafe) reference properties

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -798,6 +798,7 @@ namespace {
   class Name##ClassExistentialTypeInfo final \
     : public ScalarExistentialTypeInfoBase<Name##ClassExistentialTypeInfo, \
                                            LoadableTypeInfo> { \
+  bool IsOptional; \
   public: \
     Name##ClassExistentialTypeInfo( \
         ArrayRef<const ProtocolDecl *> storedProtocols, \
@@ -807,7 +808,8 @@ namespace {
         bool isOptional) \
       : ScalarExistentialTypeInfoBase(storedProtocols, ty, size, \
                                       spareBits, align, IsTriviallyDestroyable,\
-                                      IsCopyable, IsFixedSize) {} \
+                                      IsCopyable, IsFixedSize), \
+        IsOptional(isOptional) {} \
     TypeLayoutEntry \
     *buildTypeLayoutEntry(IRGenModule &IGM, \
                           SILType T, \
@@ -823,6 +825,18 @@ namespace {
         return IGM.getNativeObjectTypeInfo(); \
       else \
         return IGM.getUnknownObjectTypeInfo(); \
+    } \
+    unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override { \
+      return getValueTypeInfoForExtraInhabitants(IGM) \
+                  .getFixedExtraInhabitantCount(IGM) - IsOptional; \
+    } \
+    APInt getFixedExtraInhabitantValue(IRGenModule &IGM, \
+                                       unsigned bits, \
+                                       unsigned index) const override { \
+      /* Note that we pass down the original bit-width. */ \
+      return getValueTypeInfoForExtraInhabitants(IGM) \
+                  .getFixedExtraInhabitantValue(IGM, bits, \
+                                                index + IsOptional); \
     } \
     /* FIXME -- Use REF_STORAGE_HELPER and make */ \
     /* getValueTypeInfoForExtraInhabitants call llvm_unreachable() */ \

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -838,6 +838,13 @@ namespace {
                   .getFixedExtraInhabitantValue(IGM, bits, \
                                                 index + IsOptional); \
     } \
+    llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, \
+                                         Address src, SILType T, \
+                                         bool isOutlined) const override { \
+      return PointerInfo::forHeapObject(IGF.IGM) \
+        .withNullable(IsNullable_t(IsOptional)) \
+        .getExtraInhabitantIndex(IGF, src); \
+    } \
     /* FIXME -- Use REF_STORAGE_HELPER and make */ \
     /* getValueTypeInfoForExtraInhabitants call llvm_unreachable() */ \
     void emitValueRetain(IRGenFunction &IGF, llvm::Value *value, \

--- a/test/Interpreter/rdar108705703.swift
+++ b/test/Interpreter/rdar108705703.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+struct Context {
+    unowned(unsafe) var x: AnyObject? = nil
+}
+
+@inline(never)
+func test2(x: Context) -> Context? {
+  return .some(x)
+}
+
+// CHECK: works
+if (test2(x: Context()) == nil) {
+    print("bug")
+} else {
+    print("works")
+}

--- a/test/Interpreter/rdar108705703.swift
+++ b/test/Interpreter/rdar108705703.swift
@@ -6,13 +6,23 @@ struct Context {
 }
 
 @inline(never)
-func test2(x: Context) -> Context? {
-  return .some(x)
+func test(x: Context) -> Context? {
+  return x
 }
 
 // CHECK: works
-if (test2(x: Context()) == nil) {
+if (test(x: Context()) == nil) {
     print("bug")
 } else {
     print("works")
 }
+
+@inline(never)
+func test2() -> Context {
+  var g: [Context]  = [Context()]
+  print(g.endIndex)
+  return g.removeLast()
+}
+
+// CHECK: Context(x: nil)
+print(test2())


### PR DESCRIPTION
rdar://108705703

When generating the type info for fields marked unowned(unsafe) of an optional reference (e.g. AnyObject?), we dropped the fact that it was optional along the way. This caused incorrect tags to be returned when on object of the type was stored in an optional itself and the unowned property contained `nil`. In those cases the outer optional appeared to be `nil` as well, even if it in fact contained a value.
