### PR TITLE
[test] Take care of change out of deleted directories

### DIFF
--- a/test/Frontend/emit-module-path-wmo.swift
+++ b/test/Frontend/emit-module-path-wmo.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // Default output:
-// RUN: cd %t; %target-swift-frontend -emit-module -module-name foo -whole-module-optimization %s
+// RUN: pushd %t
+// RUN: %target-swift-frontend -emit-module -module-name foo -whole-module-optimization %s
 // RUN: test -f %t/foo.swiftmodule
+// RUN: popd
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name foo -emit-module-path %t/bar.swiftmodule -whole-module-optimization %s

--- a/test/SymbolGraph/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/EmitWhileBuilding.swift
@@ -23,10 +23,12 @@
 
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t
-// RUN: cd %t && %target-build-swift %t/EmitWhileBuilding.swift -module-name EmitWhileBuilding -c -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-dependencies -incremental -output-file-map=%S/Inputs/EmitWhileBuilding.output.json -working-directory %t -v -driver-show-incremental
-// RUN: cd %t && %target-build-swift %t/EmitWhileBuilding.swift -module-name EmitWhileBuilding -c -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-dependencies -incremental -output-file-map=%S/Inputs/EmitWhileBuilding.output.json -working-directory %t -v -driver-show-incremental -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: pushd %t
+// RUN: %target-build-swift %t/EmitWhileBuilding.swift -module-name EmitWhileBuilding -c -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-dependencies -incremental -output-file-map=%S/Inputs/EmitWhileBuilding.output.json -working-directory %t -v -driver-show-incremental
+// RUN: %target-build-swift %t/EmitWhileBuilding.swift -module-name EmitWhileBuilding -c -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-dependencies -incremental -output-file-map=%S/Inputs/EmitWhileBuilding.output.json -working-directory %t -v -driver-show-incremental -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix PUB
+// RUN: popd
 
 // now run with -symbol-graph-minimum-access-level to change the available symbols
 


### PR DESCRIPTION
These two tests were changing directories into the temporary, never changing out of there, and then recreating the temporary, which left the rest of the test executing in a non-existing directory.

Modify those tests to change out to the previous directory and avoid executing any command in a non-existing directory.
