### PR TITLE
[5.9] [Macros] Fix lazy expansion of freestanding macros within types/extensions

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1620,7 +1620,6 @@ populateLookupTableEntryFromMacroExpansions(ASTContext &ctx,
                                             MemberLookupTable &table,
                                             DeclName name,
                                             TypeOrExtensionDecl container) {
-
   // Trigger the expansion of member macros on the container, if any of the
   // names match.
   {
@@ -1645,7 +1644,7 @@ populateLookupTableEntryFromMacroExpansions(ASTContext &ctx,
     MacroIntroducedNameTracker nameTracker;
     if (auto *med = dyn_cast<MacroExpansionDecl>(member)) {
       forEachPotentialResolvedMacro(
-          member->getModuleContext(), med->getMacroName(),
+          dc->getModuleScopeContext(), med->getMacroName(),
           MacroRole::Declaration, nameTracker);
     } else if (auto *vd = dyn_cast<ValueDecl>(member)) {
       nameTracker.attachedTo = dyn_cast<ValueDecl>(member);

--- a/test/Macros/Inputs/freestanding_macro_library.swift
+++ b/test/Macros/Inputs/freestanding_macro_library.swift
@@ -1,0 +1,14 @@
+@freestanding(declaration, names: named(StructWithUnqualifiedLookup))
+public macro structWithUnqualifiedLookup() = #externalMacro(module: "MacroDefinition", type: "DefineStructWithUnqualifiedLookupMacro")
+
+@freestanding(declaration)
+public macro anonymousTypes(public: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+
+@freestanding(declaration)
+public macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
+
+@freestanding(declaration, names: arbitrary)
+public macro bitwidthNumberedStructs(_ baseName: String) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
+
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")

--- a/test/Macros/Inputs/freestanding_macro_library_2.swift
+++ b/test/Macros/Inputs/freestanding_macro_library_2.swift
@@ -1,0 +1,4 @@
+import freestanding_macro_library
+
+@freestanding(declaration, names: arbitrary)
+public macro bitwidthNumberedStructs(_ baseName: String, blah: Bool) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")

--- a/test/Macros/Inputs/top_level_freestanding_other.swift
+++ b/test/Macros/Inputs/top_level_freestanding_other.swift
@@ -1,3 +1,7 @@
+#if IMPORT_MACRO_LIBRARY
+import freestanding_macro_library
+#endif
+
 #anonymousTypes { "hello2" }
 
 var globalVar = #stringify(1 + 1)


### PR DESCRIPTION
* Explanation: An incorrectly-specified starting context for name lookup meant that macro lookup itself was failing, and therefore did not trigger expansion of the freestanding macro or introduction of the macro-expanded declarations into the context.
* Scope: Narrow; affects code using freestanding declaration macros within types or extensions.
* Risk: Low, no effect in code that doesn't use macros.
* Review: @rxwei 
* Issue: rdar://108824784
* Original pull request: https://github.com/apple/swift/pull/65670