### PR TITLE
[5.9][Macros] Improve error handling of executable plugins

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -313,6 +313,9 @@ void Plugin_setCapability(PluginHandle handle, PluginCapabilityPtr data);
 /// Get a capability data set by \c Plugin_setCapability .
 PluginCapabilityPtr _Nullable Plugin_getCapability(PluginHandle handle);
 
+/// Get the executable file path of the plugin.
+const char *Plugin_getExecutableFilePath(PluginHandle handle);
+
 /// Lock the plugin. Clients should lock it during sending and recving the
 /// response.
 void Plugin_lock(PluginHandle handle);

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -12,6 +12,7 @@
 #ifndef SWIFT_PLUGIN_REGISTRY_H
 #define SWIFT_PLUGIN_REGISTRY_H
 
+#include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -138,6 +139,10 @@ public:
   }
 
   llvm::sys::procid_t getPid() { return Process->pid; }
+
+  NullTerminatedStringRef getExecutablePath() {
+    return {ExecutablePath.c_str(), ExecutablePath.size()};
+  }
 
   const void *getCapability() { return capability; };
   void setCapability(const void *newValue) { capability = newValue; };

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -642,6 +642,11 @@ void Plugin_setCapability(PluginHandle handle, PluginCapabilityPtr data) {
   plugin->setCapability(data);
 }
 
+const char *Plugin_getExecutableFilePath(PluginHandle handle) {
+  auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
+  return plugin->getExecutablePath().data();
+}
+
 void Plugin_lock(PluginHandle handle) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   plugin->lock();

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -178,7 +178,8 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
 
 LoadedExecutablePlugin::~LoadedExecutablePlugin() {
   // Let ASTGen to cleanup things.
-  this->cleanup();
+  if (this->cleanup)
+    this->cleanup();
 }
 
 ssize_t LoadedExecutablePlugin::PluginProcess::read(void *buf,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -310,8 +310,6 @@ loadExecutablePluginByName(ASTContext &ctx, Identifier moduleName) {
   if (!executablePlugin->isInitialized()) {
 #if SWIFT_SWIFT_PARSER
     if (!swift_ASTGen_initializePlugin(executablePlugin, &ctx.Diags)) {
-      ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded,
-                         executablePluginPath, "failed to initialize plugin");
       return nullptr;
     }
     executablePlugin->setCleanup([executablePlugin] {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/CASTBridging.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Expr.h"
 #include "../AST/InlinableText.h"
 #include "swift/AST/MacroDefinition.h"
@@ -74,7 +75,7 @@ extern "C" ptrdiff_t swift_ASTGen_expandAttachedMacro(
     void *parentDeclSourceFile, const void *parentDeclSourceLocation,
     const char **evaluatedSource, ptrdiff_t *evaluatedSourceLength);
 
-extern "C" void swift_ASTGen_initializePlugin(void *handle);
+extern "C" bool swift_ASTGen_initializePlugin(void *handle, void *diagEngine);
 extern "C" void swift_ASTGen_deinitializePlugin(void *handle);
 extern "C" bool swift_ASTGen_pluginServerLoadLibraryPlugin(
     void *handle, const char *libraryPath, const char *moduleName,
@@ -308,7 +309,11 @@ loadExecutablePluginByName(ASTContext &ctx, Identifier moduleName) {
   // But plugin loading is in libAST and it can't link ASTGen symbols.
   if (!executablePlugin->isInitialized()) {
 #if SWIFT_SWIFT_PARSER
-    swift_ASTGen_initializePlugin(executablePlugin);
+    if (!swift_ASTGen_initializePlugin(executablePlugin, &ctx.Diags)) {
+      ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded,
+                         executablePluginPath, "failed to initialize plugin");
+      return nullptr;
+    }
     executablePlugin->setCleanup([executablePlugin] {
       swift_ASTGen_deinitializePlugin(executablePlugin);
     });
@@ -320,7 +325,9 @@ loadExecutablePluginByName(ASTContext &ctx, Identifier moduleName) {
 #if SWIFT_SWIFT_PARSER
     llvm::SmallString<128> resolvedLibraryPath;
     auto fs = ctx.SourceMgr.getFileSystem();
-    if (fs->getRealPath(libraryPath, resolvedLibraryPath)) {
+    if (auto err = fs->getRealPath(libraryPath, resolvedLibraryPath)) {
+      ctx.Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded,
+                         executablePluginPath, err.message());
       return nullptr;
     }
     std::string resolvedLibraryPathStr(resolvedLibraryPath);

--- a/test/Macros/macro_plugin_broken.swift
+++ b/test/Macros/macro_plugin_broken.swift
@@ -19,7 +19,7 @@
 
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK %s
 
-// CHECK: (null):0:0: warning: compiler plugin not loaded: {{.+}}broken-plugin; loader error: failed to initialize plugin
+// CHECK: (null):0:0: warning: compiler plugin not loaded: {{.+}}broken-plugin; failed to initialize
 // CHECK: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro';
 // CHECK: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro';
 // CHECK: +-{{.+}}test.swift:1:33: note: 'fooMacro' declared here

--- a/test/Macros/macro_plugin_broken.swift
+++ b/test/Macros/macro_plugin_broken.swift
@@ -1,0 +1,40 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift \
+// RUN:   -swift-version 5 -o %t/broken-plugin \
+// RUN:   -module-name=TestPlugin \
+// RUN:   %t/broken_plugin.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath -swift-version 5
+
+// RUN: not %swift-target-frontend \
+// RUN:   -typecheck \
+// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -load-plugin-executable %t/broken-plugin#TestPlugin \
+// RUN:   -module-name MyApp \
+// RUN:   -serialize-diagnostics-path %t/macro_expand.dia \
+// RUN:   %t/test.swift
+
+// RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK %s
+
+// CHECK: (null):0:0: warning: compiler plugin not loaded: {{.+}}broken-plugin; loader error: failed to initialize plugin
+// CHECK: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro';
+// CHECK: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro';
+// CHECK: +-{{.+}}test.swift:1:33: note: 'fooMacro' declared here
+
+//--- test.swift
+@freestanding(expression) macro fooMacro(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "FooMacro")
+
+func test() {
+  _ = #fooMacro(1)
+}
+
+//--- broken_plugin.swift
+func minusTen(value: UInt) -> UInt {
+  // Causes crash.
+  return value - 10
+}
+
+_ = minusTen(value: 5)

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -23,12 +23,12 @@
 
 // CHECK: ->(plugin:[[#PID1:]]) {"getCapability":{}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":200},"source":"#fooMacro(1)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":[[#]]},"source":"#fooMacro(1)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"invalidResponse":{}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":8,"offset":304},"source":"#fooMacro(2)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":8,"offset":[[#]]},"source":"#fooMacro(2)"}}}
 // ^ This messages causes the mock plugin exit because there's no matching expected message.
 
-// CHECK: ->(plugin:[[#PID2:]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":10,"offset":386},"source":"#fooMacro(3)"}}}
+// CHECK: ->(plugin:[[#PID2:]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":10,"offset":[[#]]},"source":"#fooMacro(3)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2:]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"3.description"}}
 
 //--- test.swift
@@ -40,7 +40,7 @@ func test() {
   let _: String = #fooMacro(1)
   // expected-error @-1 {{typeMismatch(swiftASTGen.PluginToHostMessage}}
   let _: String = #fooMacro(2)
-  // expected-error @-1 {{failedToReceiveMessage}}
+  // expected-error @-1 {{failed to receive result from plugin (from macro 'fooMacro')}}
   let _: String = #fooMacro(3)
   // ^ This should succeed.
 }

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -56,7 +56,7 @@ func testStringify(a: Int, b: Int) {
   let s1: String = #stringify(a + b).1
   print(s1)
 
-  // expected-error @+1 {{failedToReceiveMessage (from macro 'evil')}}
+  // expected-error @+1 {{failed to receive result from plugin (from macro 'evil')}}
   let s2: String = #evil(42)
   print(s2)
 


### PR DESCRIPTION
Cherry-pick #65630 into `release/5.9`

**Explanation**: Previously, when the compiler fails to read the result from `getCapability` IPC message, it used to just crashed with `assertionFailure`. Instead, it now emits appropriate diagnostics and gracefully fails to load the plugin.
**Scope**: Macro expansion with erroneous executable plugins
**Risk**: Low
**Testing**: Added regression test cases
**Issue**: rdar://108022847
**Reviewer**: Ben Barham (@bnbarham)