### PR TITLE
[test] Allow customizing swift-ide-test invocations during tests.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -511,6 +511,7 @@ if test_options:
 
 config.swift_frontend_test_options += os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
 config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
+config.swift_ide_test_test_options += os.environ.get('SWIFT_IDE_TEST_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
 config.clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")
@@ -772,6 +773,7 @@ elif swift_test_mode == 'with_cxx_interop':
     config.available_features.add("with_cxx_interop")
     config.swift_frontend_test_options += ' -cxx-interoperability-mode=default'
     config.swift_driver_test_options += ' -cxx-interoperability-mode=default'
+    config.swift_ide_test_test_options += ' -cxx-interoperability-mode=default'
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_mode)
 
@@ -1357,11 +1359,13 @@ if run_vendor == 'apple':
         "%s %s -sdk %r" %
         (config.swift_api_extract, target_options, config.variant_sdk))
     config.target_swift_ide_test = (
-        "%s %s %s %s" %
-        (xcrun_prefix, config.swift_ide_test, target_options, ccp_opt))
+        "%s %s %s %s %s" %
+        (xcrun_prefix, config.swift_ide_test, target_options, ccp_opt,
+         config.swift_ide_test_test_options))
     subst_target_swift_ide_test_mock_sdk = (
-        "%s %s %s %s" %
-        (xcrun_prefix, config.swift_ide_test, target_options_for_mock_sdk, ccp_opt))
+        "%s %s %s %s %s" %
+        (xcrun_prefix, config.swift_ide_test, target_options_for_mock_sdk, ccp_opt,
+         config.swift_ide_test_test_options))
     subst_target_swift_ide_test_mock_sdk_after = \
         target_options_for_mock_sdk_after
     config.target_swiftc_driver = (
@@ -1497,9 +1501,11 @@ elif run_os in ['windows-msvc']:
                                          config.variant_sdk,                     \
                                          config.variant_triple))
     config.target_swift_ide_test =                                               \
-            ('%r -target %s %s %s %s' % (config.swift_ide_test,                  \
-                                         config.variant_triple,                  \
-                                         config.resource_dir_opt, mcp_opt, ccp_opt))
+            ('%r -target %s %s %s %s %s' % (config.swift_ide_test,               \
+                                            config.variant_triple,               \
+                                            config.resource_dir_opt, mcp_opt,    \
+                                            ccp_opt,                             \
+                                            config.swift_ide_test_test_options))
 
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ''
@@ -1632,9 +1638,9 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
         '%s -target %s -sdk %r' %
         (config.swift_api_extract, config.variant_triple, config.variant_sdk))
     config.target_swift_ide_test = (
-        '%s -target %s %s %s %s' %
+        '%s -target %s %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,
-         mcp_opt, ccp_opt))
+         mcp_opt, ccp_opt, config.swift_ide_test_test_options))
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
@@ -1747,7 +1753,8 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         'env', 'SDKROOT={}'.format(shell_quote(config.variant_sdk)),
         config.swift_ide_test,
         '-target', config.variant_triple,
-        config.resource_dir_opt, mcp_opt, ccp_opt])
+        config.resource_dir_opt, mcp_opt, ccp_opt,
+        config.swift_ide_test_test_options])
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = ' '.join([
@@ -1819,9 +1826,9 @@ elif run_os == 'wasi':
         '-target', config.variant_triple,
         mcp_opt])
     config.target_swift_ide_test = (
-        '%s -target %s %s %s %s' %
+        '%s -target %s %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,
-         mcp_opt, ccp_opt))
+         mcp_opt, ccp_opt, config.swift_ide_test_test_options))
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -40,6 +40,7 @@ config.libdispatch_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_BUILD@"
 config.libdispatch_static_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_STATIC_BUILD@"
 config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
 config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
+config.swift_ide_test_test_options = "@SWIFT_IDE_TEST_TEST_OPTIONS@"
 
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -34,6 +34,7 @@ config.host_sdkroot = "@SWIFT_HOST_SDKROOT@"
 
 config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
 config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
+config.swift_ide_test_test_options = "@SWIFT_IDE_TEST_TEST_OPTIONS@"
 
 # --- Darwin Configuration ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"


### PR DESCRIPTION
In some Linux setups, one might need to provide extra arguments to setup the environment for invocations done during the tests. The Swift frontend and driver already had a mechanism to provide those arguments in the shape of `SWIFT_FRONTEND_TEST_OPTIONS` and
`SWIFT_DRIVER_TEST_OPTIONS`. `swift-ide-test` was sadly missing the same feature, which meant that many tests might fail or tests against the incorrect environment.

The changes implement the `SWIFT_IDE_TEST_TEST_OPTIONS` mechanism to cover that gap.
