### PR TITLE
`_forget` usage fixes to match SE-390

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -735,6 +735,18 @@ ERROR(noimplicitcopy_used_on_generic_or_existential, none,
       "@_noImplicitCopy can not be used on a generic or existential typed "
       "binding or a nominal type containing such typed things", ())
 
+// forget statement
+ERROR(forget_nontrivial_storage,none,
+      "can only 'forget' type %0 if it contains trivially-destroyed "
+      "stored properties at this time",
+      (Type))
+NOTE(forget_nontrivial_storage_note,none,
+      "type %0 cannot be trivially destroyed",
+      (Type))
+NOTE(forget_nontrivial_implicit_storage_note,none,
+     "type %0 implicitly contains %1 which cannot be trivially destroyed",
+     (Type, Type))
+
 // move only checker diagnostics
 ERROR(sil_moveonlychecker_owned_value_consumed_more_than_once, none,
       "'%0' consumed more than once", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4599,9 +4599,16 @@ ERROR(opaque_type_var_no_underlying_type,none,
       "property declares an opaque return type, but cannot infer the "
       "underlying type from its initializer expression", ())
 
+
+//------------------------------------------------------------------------------
+// MARK: Forget Statement
+//------------------------------------------------------------------------------
 ERROR(forget_wrong_context_decl,none,
       "'forget' statement cannot appear in %0",
       (DescriptiveDeclKind))
+ERROR(forget_no_deinit,none,
+      "'forget' has no effect for type %0 unless it has a deinitializer",
+      (Type))
 ERROR(forget_wrong_context_closure,none,
       "'forget' statement cannot appear in closure",
       ())

--- a/test/Interpreter/moveonly_forget.swift
+++ b/test/Interpreter/moveonly_forget.swift
@@ -14,6 +14,8 @@ struct FileDescriptor {
   var fd: Int
   static var nextFD: Int = 0
 
+  consuming func forget() { _forget self }
+
   init() {
     self.fd = FileDescriptor.nextFD
     FileDescriptor.nextFD += 1
@@ -22,7 +24,7 @@ struct FileDescriptor {
   init(doForget: Bool) throws {
     self.init()
     if doForget {
-      _forget self
+      forget()
       throw E.err
     }
   }
@@ -61,10 +63,12 @@ struct FileDescriptor {
   case some(FileDescriptor)
   case nothing
 
+  consuming func forget() { _forget self }
+
   init(reinit: Bool) {
     self = .some(FileDescriptor())
     if reinit {
-      _forget self
+      forget()
       self = .some(FileDescriptor())
     }
   }

--- a/test/SILGen/forget.swift
+++ b/test/SILGen/forget.swift
@@ -60,28 +60,22 @@ func invokedDeinit() {}
 }
 
 @_moveOnly struct PointerTree {
-  let left: Ptr
-  let file: File
-  let popularity: Int
-  var right: Ptr
+  let left: Ptr = Ptr()
+  let file: File = File()
+  let popularity: Int = 0
+  var right: Ptr = Ptr()
 
-  init(doForget: Bool, file: __owned File, ptr: Ptr) throws {
-    self.file = file
-    self.left = ptr
-    self.popularity = 0
-    self.right = ptr
-
+  consuming func tryDestroy(doForget: Bool) throws {
     if doForget {
       _forget self
     }
     throw E.err
   }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4test11PointerTreeV8doForget4file3ptrACSb_AA4FileVnAA3PtrCtKcfC
+// CHECK-LABEL: sil hidden [ossa] @$s4test11PointerTreeV10tryDestroy8doForgetySb_tKF : $@convention(method) (Bool, @owned PointerTree) -> @error any Error {
 // CHECK:   bb0{{.*}}:
 // CHECK:     [[SELF_BOX:%.*]] = alloc_box ${ var PointerTree }, var, name "self"
-// CHECK:     [[MUI:%.*]] = mark_uninitialized [rootself] [[SELF_BOX]] : ${ var PointerTree }
-// CHECK:     [[SELF:%.*]] = begin_borrow [lexical] [[MUI]] : ${ var PointerTree }
+// CHECK:     [[SELF:%.*]] = begin_borrow [lexical] [[SELF_BOX]] : ${ var PointerTree }
 // CHECK:     [[SELF_PTR:%.*]] = project_box [[SELF]] : ${ var PointerTree }, 0
 //            .. skip to the conditional test ..
 // CHECK:     [[SHOULD_THROW:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
@@ -104,13 +98,13 @@ func invokedDeinit() {}
 //
 // CHECK:   bb3:
 // CHECK:     end_borrow [[SELF]] : ${ var PointerTree }
-// CHECK:     destroy_value [[MUI]] : ${ var PointerTree }
+// CHECK:     destroy_value [[SELF_BOX]] : ${ var PointerTree }
 // CHECK:     throw
 // CHECK: } // end sil function
 
 // After the mandatory passes have run, check for correct deinitializations within the init.
 
-// CHECK-SIL-LABEL: sil hidden @$s4test11PointerTreeV8doForget4file3ptrACSb_AA4FileVnAA3PtrCtKcfC
+// CHECK-SIL-LABEL: sil hidden @$s4test11PointerTreeV10tryDestroy8doForgetySb_tKF
 // CHECK-SIL:     [[SHOULD_THROW:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
 // CHECK-SIL:     cond_br [[SHOULD_THROW]], bb1, bb2
 //
@@ -151,34 +145,32 @@ final class Wallet {
   case empty
   case within(Wallet)
 
-  init(inWallet wallet: Wallet? = nil) {
-    self = .within(Wallet())
+  consuming func changeTicket(inWallet wallet: Wallet? = nil) {
     if let existingWallet = wallet {
       _forget self
       self = .within(existingWallet)
     }
   }
   // As of now, we allow reinitialization after forget. Not sure if this is intended.
-  // CHECK-LABEL: sil hidden [ossa] @$s4test6TicketO8inWalletAcA0D0CSg_tcfC
+  // CHECK-LABEL: sil hidden [ossa] @$s4test6TicketO06changeB08inWalletyAA0E0CSg_tF : $@convention(method) (@guaranteed Optional<Wallet>, @owned Ticket) -> () {
   // CHECK:    [[SELF_REF:%.*]] = project_box [[SELF_BOX:%.*]] : ${ var Ticket }, 0
-  // CHECK:    switch_enum {{.*}} : $Optional<Wallet>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
-  // CHECK:  bb2({{%.*}} : @owned $Wallet):
-  // CHECK:    br bb3
+  // CHECK:    switch_enum {{.*}} : $Optional<Wallet>, case #Optional.some!enumelt: [[HAVE_WALLET_BB:bb.*]], case #Optional.none!enumelt: {{.*}}
+  //
   // >> now we begin the destruction sequence, which involves pattern matching on self to destroy its innards
-  // CHECK:  bb3:
+  // CHECK:  [[HAVE_WALLET_BB]]({{%.*}} : @owned $Wallet):
   // CHECK:    [[SELF_ACCESS:%.*]] = begin_access [read] [unknown] {{%.*}} : $*Ticket
   // CHECK:    [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_ACCESS]]
   // CHECK:    [[SELF_COPY:%.*]] = load [copy] [[SELF_MMC]] : $*Ticket
   // CHECK:    end_access [[SELF_ACCESS:%.*]] : $*Ticket
   // CHECK:    [[DD:%.*]] = drop_deinit [[SELF_COPY]] : $Ticket
-  // CHECK:    switch_enum [[DD]] : $Ticket, case #Ticket.empty!enumelt: bb4, case #Ticket.within!enumelt: bb5
-  // CHECK:  bb4:
-  // CHECK:    br bb6
-  // CHECK:  bb5([[PREV_SELF_WALLET:%.*]] : @owned $Wallet):
+  // CHECK:    switch_enum [[DD]] : $Ticket, case #Ticket.empty!enumelt: [[TICKET_EMPTY:bb[0-9]+]], case #Ticket.within!enumelt: [[TICKET_WITHIN:bb[0-9]+]]
+  // CHECK:  [[TICKET_EMPTY]]:
+  // CHECK:    br [[JOIN_POINT:bb[0-9]+]]
+  // CHECK:  [[TICKET_WITHIN]]([[PREV_SELF_WALLET:%.*]] : @owned $Wallet):
   // CHECK:    destroy_value [[PREV_SELF_WALLET]] : $Wallet
-  // CHECK:    br bb6
+  // CHECK:    br [[JOIN_POINT]]
   // >> from here on we are reinitializing self.
-  // CHECK:  bb6:
+  // CHECK:  [[JOIN_POINT]]:
   // CHECK:    [[NEW_SELF_VAL:%.*]] = enum $Ticket, #Ticket.within!enumelt, {{.*}} : $Wallet
   // CHECK:    [[SELF_ACCESS2:%.*]] = begin_access [modify] [unknown] [[SELF_REF]] : $*Ticket
   // CHECK:    [[SELF_MMC2:%.*]] = mark_must_check [assignable_but_not_consumable] [[SELF_ACCESS2]] : $*Ticket

--- a/test/SILGen/forget.swift
+++ b/test/SILGen/forget.swift
@@ -7,6 +7,8 @@ func invokedDeinit() {}
   case some(File)
   case none
 
+  deinit {}
+
   // NOTE: we can't pattern match on self since
   // that would consume it before we can forget self!
   var test: Int {

--- a/test/SILGen/forget.swift
+++ b/test/SILGen/forget.swift
@@ -62,10 +62,10 @@ func invokedDeinit() {}
 }
 
 @_moveOnly struct PointerTree {
-  let left: Ptr = Ptr()
-  let file: File = File()
-  let popularity: Int = 0
-  var right: Ptr = Ptr()
+  let left: UnsafePointer<UInt>?
+  let file: Int = 0
+  lazy var popularity: Int = 0
+  var right: Float = 0.0
 
   consuming func tryDestroy(doForget: Bool) throws {
     if doForget {
@@ -77,11 +77,10 @@ func invokedDeinit() {}
 // CHECK-LABEL: sil hidden [ossa] @$s4test11PointerTreeV10tryDestroy8doForgetySb_tKF : $@convention(method) (Bool, @owned PointerTree) -> @error any Error {
 // CHECK:   bb0{{.*}}:
 // CHECK:     [[SELF_BOX:%.*]] = alloc_box ${ var PointerTree }, var, name "self"
-// CHECK:     [[SELF:%.*]] = begin_borrow [lexical] [[SELF_BOX]] : ${ var PointerTree }
-// CHECK:     [[SELF_PTR:%.*]] = project_box [[SELF]] : ${ var PointerTree }, 0
+// CHECK:     [[SELF_PTR:%.*]] = project_box [[SELF_BOX]] : ${ var PointerTree }, 0
 //            .. skip to the conditional test ..
-// CHECK:     [[SHOULD_THROW:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
-// CHECK:     cond_br [[SHOULD_THROW]], bb1, bb2
+// CHECK:     [[SHOULD_FORGET:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
+// CHECK:     cond_br [[SHOULD_FORGET]], bb1, bb2
 //
 // CHECK:   bb1:
 // CHECK:     [[ACCESS:%.*]] = begin_access [read] [unknown] [[SELF_PTR]] : $*PointerTree
@@ -89,17 +88,13 @@ func invokedDeinit() {}
 // CHECK:     [[COPIED_SELF:%.*]] = load [copy] [[MMC]] : $*PointerTree
 // CHECK:     end_access [[ACCESS]] : $*PointerTree
 // CHECK:     [[DD:%.*]] = drop_deinit [[COPIED_SELF]]
-// CHECK:     ([[LEFT:%.*]], [[FILE:%.*]], {{%.*}}, [[RIGHT:%.*]]) = destructure_struct [[DD]] : $PointerTree
-// CHECK:     destroy_value [[LEFT]] : $Ptr
-// CHECK:     destroy_value [[FILE]] : $File
-// CHECK:     destroy_value [[RIGHT]] : $Ptr
+// CHECK:     end_lifetime [[DD]]
 // CHECK:     br bb3
 //
 // CHECK:   bb2:
 // CHECK:     br bb3
 //
 // CHECK:   bb3:
-// CHECK:     end_borrow [[SELF]] : ${ var PointerTree }
 // CHECK:     destroy_value [[SELF_BOX]] : ${ var PointerTree }
 // CHECK:     throw
 // CHECK: } // end sil function
@@ -107,20 +102,15 @@ func invokedDeinit() {}
 // After the mandatory passes have run, check for correct deinitializations within the init.
 
 // CHECK-SIL-LABEL: sil hidden @$s4test11PointerTreeV10tryDestroy8doForgetySb_tKF
-// CHECK-SIL:     [[SHOULD_THROW:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
-// CHECK-SIL:     cond_br [[SHOULD_THROW]], bb1, bb2
+// CHECK-SIL:     [[SHOULD_FORGET:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value
+// CHECK-SIL:     cond_br [[SHOULD_FORGET]], bb1, bb2
 //
 // CHECK-SIL:  bb1:
 // CHECK-SIL:     [[ACCESS:%.*]] = begin_access [modify] [static] {{.*}} : $*PointerTree
 // CHECK-SIL:     [[SELF_VAL:%.*]] = load [[ACCESS]] : $*PointerTree
 // CHECK-SIL:     end_access [[ACCESS]] : $*PointerTree
-// CHECK-SIL:     [[LEFT:%.*]] = struct_extract [[SELF_VAL]] : $PointerTree, #PointerTree.left
-// CHECK-SIL:     [[FILE:%.*]] = struct_extract [[SELF_VAL]] : $PointerTree, #PointerTree.file
-// CHECK-SIL:     [[RIGHT:%.*]] = struct_extract [[SELF_VAL]] : $PointerTree, #PointerTree.right
-// CHECK-SIL:     strong_release [[LEFT]] : $Ptr
-// CHECK-SIL:     [[FILE_DEINIT:%.*]] = function_ref @$s4test4FileVfD : $@convention(method) (@owned File) -> ()
-// CHECK-SIL:     apply [[FILE_DEINIT]]([[FILE]])
-// CHECK-SIL:     strong_release [[RIGHT]] : $Ptr
+// CHECK-SIL-NOT: struct_extract
+                  // no accesses to the fields are expected because the fields are no-op destroyed.
 // CHECK-SIL:     br bb3
 //
 // CHECK-SIL:  bb2:

--- a/test/SILOptimizer/moveonly_forget.swift
+++ b/test/SILOptimizer/moveonly_forget.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil %s
+// RUN: %target-swift-frontend -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s
 
 func posix_close(_ t: Int) {}
 
@@ -28,6 +28,8 @@ struct GoodFileDescriptor {
 @_moveOnly
 struct BadFileDescriptor {
   let _fd: Int = 0
+
+  deinit {}
 
   var rawFileDescriptor: Int {
     __consuming get { // expected-error {{'self' consumed more than once}}
@@ -89,5 +91,7 @@ final class Wallet {
       return
     }
   }
+
+  deinit {}
 
 }

--- a/test/SILOptimizer/moveonly_forget.swift
+++ b/test/SILOptimizer/moveonly_forget.swift
@@ -64,10 +64,12 @@ final class Wallet {
   case pagedOut(GoodFileDescriptor)
   case within(Wallet)
 
+  consuming func forget() { _forget self }
+
   init(inWallet wallet: Wallet? = nil) { // expected-error {{'self' consumed more than once}}
     self = .within(Wallet())
     if let existingWallet = wallet {
-      _forget self
+      forget()
       self = .within(existingWallet)
     }
     forget(forever: true) // expected-note {{consuming use here}}

--- a/test/Sema/Inputs/forget_module_adjacent.swift
+++ b/test/Sema/Inputs/forget_module_adjacent.swift
@@ -1,6 +1,7 @@
 public extension Regular {
   __consuming func shutdownParty() {
-    _forget self // ok; same module
+    // FIXME: rdar://108933330 (cannot define struct deinit with -enable-library-evolution)
+//    _forget self // ok; same module
   }
 }
 

--- a/test/Sema/Inputs/forget_module_defining.swift
+++ b/test/Sema/Inputs/forget_module_defining.swift
@@ -1,18 +1,21 @@
 @_moveOnly
 public struct Regular {
   private let sorry = 0
+  // FIXME: rdar://108933330 (cannot define struct deinit with -enable-library-evolution)
+//  deinit {}
+}
+
+public extension Regular {
+  __consuming func endParty() {
+    // FIXME: rdar://108933330 (cannot define struct deinit with -enable-library-evolution)
+//    _forget self
+  }
 }
 
 @_moveOnly
 @frozen public struct Frozen {
   private let lotfan = 0
-}
-
-
-public extension Regular {
-  __consuming func endParty() {
-    _forget self
-  }
+  deinit {}
 }
 
 public extension Frozen {

--- a/test/Sema/forget.swift
+++ b/test/Sema/forget.swift
@@ -45,7 +45,7 @@ enum E: Error { case err }
   init() throws {
     self.fd = 0
 
-    _forget self
+    _forget self // expected-error {{'forget' statement cannot appear in initializer}}
 
     throw E.err
   }
@@ -53,7 +53,7 @@ enum E: Error { case err }
   init(_ b: Bool) throws {
     try self.init()
 
-    _forget self
+    _forget self // expected-error {{'forget' statement cannot appear in initializer}}
 
     throw E.err
   }
@@ -122,7 +122,7 @@ enum E: Error { case err }
   case nothing
 
   init() throws {
-    _forget self
+    _forget self // expected-error {{'forget' statement cannot appear in initializer}}
     throw E.err
   }
 

--- a/test/Sema/forget.swift
+++ b/test/Sema/forget.swift
@@ -147,3 +147,17 @@ enum E: Error { case err }
     try? take().close()
   }
 }
+
+struct NoDeinitStruct: ~Copyable {
+  consuming func blah() {
+    _forget self // expected-error {{'forget' has no effect for type 'NoDeinitStruct' unless it has a deinitializer}}{{5-18=}}
+  }
+}
+
+enum NoDeinitEnum: ~Copyable {
+  case whatever
+
+  consuming func blah() {
+    _forget self // expected-error {{'forget' has no effect for type 'NoDeinitEnum' unless it has a deinitializer}}{{5-18=}}
+  }
+}

--- a/test/Sema/forget_module.swift
+++ b/test/Sema/forget_module.swift
@@ -13,7 +13,8 @@ import SorryModule
 
 extension Regular {
   __consuming func delete() {
-    _forget self // expected-error {{can only 'forget' from the same module defining type 'Regular'}}
+    // FIXME: rdar://108933330 (cannot define struct deinit with -enable-library-evolution)
+//    _forget self // DISABLED-error {{can only 'forget' from the same module defining type 'Regular'}}
   }
 }
 

--- a/test/Sema/forget_trivially_destroyed.swift
+++ b/test/Sema/forget_trivially_destroyed.swift
@@ -1,0 +1,100 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+// Yes, you read that right. This is being checked in SILGen! So we have to
+// separate these tests from ones emitting errors during Sema.
+
+class ClassyGal {}
+
+@propertyWrapper
+struct Appending<Val> {
+  let terminator: Val
+  var store: [Val] = []
+
+  var wrappedValue: [Val] {
+    get {
+      return store + [terminator]
+    }
+    set {
+      fatalError("mutation is the root of all bugs")
+    }
+  }
+}
+
+struct StructuredGuy: ~Copyable {
+  let x = ClassyGal()
+  // expected-note@-1 {{type 'ClassyGal' cannot be trivially destroyed}}
+
+  @Appending(terminator: ClassyGal())
+  var bestC: [ClassyGal]
+
+  consuming func doForget() { _forget self }
+  // expected-error@-1 {{can only 'forget' type 'StructuredGuy' if it contains trivially-destroyed stored properties at this time}}
+  deinit {}
+}
+
+struct AppendyEnby: ~Copyable {
+  @Appending(terminator: 0)
+  var string: [Int]
+  // expected-note@-1 {{type 'Appending<Int>' cannot be trivially destroyed}}
+
+
+  consuming func doForget() { _forget self }
+  // expected-error@-1 {{can only 'forget' type 'AppendyEnby' if it contains trivially-destroyed stored properties at this time}}
+  deinit {}
+}
+
+struct HasGeneric: ~Copyable {
+  var thing: Any // expected-note {{type 'Any' cannot be trivially destroyed}}
+
+  consuming func forget() { _forget self }
+  // expected-error@-1 {{can only 'forget' type 'HasGeneric' if it contains trivially-destroyed stored properties at this time}}
+
+  deinit{}
+}
+
+struct WrappingNoncopyable: ~Copyable {
+  var computed: String { "mine" }
+
+  var x: AppendyEnby // expected-note{{type 'AppendyEnby' cannot be trivially destroyed}}
+  consuming func doForget() { _forget self }
+  // expected-error@-1 {{can only 'forget' type 'WrappingNoncopyable' if it contains trivially-destroyed stored properties at this time}}
+  deinit {}
+}
+
+struct LazyGuy: ~Copyable {
+  lazy var thing: String = "asdf"
+  // expected-note@-1 {{type 'String?' cannot be trivially destroyed}}
+
+  consuming func doForget() { _forget self }
+  // expected-error@-1 {{can only 'forget' type 'LazyGuy' if it contains trivially-destroyed stored properties at this time}}
+  deinit {}
+}
+
+struct BoringNoncopyable: ~Copyable {
+  let x = 0
+  let y = 0
+}
+
+struct Boring {
+  var x = 0
+  var y = 1.9
+}
+
+// FIXME: Despite not having a deinit, the noncopyable struct isn't considered trivial?
+struct ContainsBoring: ~Copyable {
+  let z: BoringNoncopyable // expected-note {{type 'BoringNoncopyable' cannot be trivially destroyed}}
+  consuming func forget() { _forget self }
+  // expected-error@-1 {{can only 'forget' type 'ContainsBoring' if it contains trivially-destroyed stored properties at this time}}
+  deinit {}
+}
+
+struct AllOK: ~Copyable {
+  var maybeDigits: Int?
+  var maybeFloat: Float?
+  let dbl: Double
+  var location: Boring = Boring()
+  var unsafePtr: UnsafePointer<Int>
+
+  consuming func doForget() { _forget self }
+  deinit {}
+}

--- a/test/expr/print/forget.swift
+++ b/test/expr/print/forget.swift
@@ -5,6 +5,8 @@ struct S {
   __consuming func c() {
     _forget self
   }
+
+  deinit {}
 }
 
 // CHECK: @_moveOnly internal struct S {


### PR DESCRIPTION
Contains a bundle of fixes for the `_forget` statement in terms of its legal usages to match the conclusions of SE-390 review. The changes are detailed in each commit.

rdar://108877261