### PR TITLE
[5.8][build] Remove runpath from build host from shared ICU libraries on linux

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2674,12 +2674,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     fi
 
                     with_pushd "${LIBICU_BUILD_DIR}" \
-                        call env CXXFLAGS=-fPIC "${LIBICU_SOURCE_DIR}"/icu4c/source/runConfigureICU Linux \
+                        call env CXXFLAGS=-fPIC LDFLAGS='-Wl,-rpath=\$$ORIGIN' \
+                        "${LIBICU_SOURCE_DIR}"/icu4c/source/runConfigureICU Linux \
                         ${icu_build_variant_arg} --prefix=${ICU_TMPINSTALL} \
                         ${libicu_enable_debug} \
                         --enable-renaming --with-library-suffix=swift \
                         --libdir=${ICU_TMPLIBDIR} \
-                        --enable-shared --enable-static --enable-rpath \
+                        --enable-shared --enable-static \
                         --enable-strict --disable-icuio \
                         --disable-plugins --disable-dyload --disable-extras \
                         --disable-samples --disable-layoutex --with-data-packaging=auto


### PR DESCRIPTION
Cherrypick of #64365

__Explanation:__ I found this `--enable-rpath` flag in a hurry more than a year ago and suggested it before the branch in #40340, but was unaware it also adds an absolute runpath to the CI install directory:
```
> readelf -d swift-5.8-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicu*so | ag "File:|runpath"
File: swift-5.8-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicudataswift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-5.8-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicui18nswift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-5.8-RELEASE-ubuntu20.04/usr/lib/swift/linux/libicuucswift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
```
This is a deployment security risk, as these libraries are linked by Foundation, and thus is worth fixing in the current 5.8 release branch.

__Scope:__ Only affects these libicu runpaths on ELF platforms like linux

__Issue:__ None

__Risk:__ low, as it only affects libicu runpaths for ELF platforms

__Testing:__ Passed all CI, and we've had no problems since it was merged into trunk/5.9 a couple months ago.

__Reviewer:__ @bnbarham

@tomerd, would be good to get this in before the next patch release.