### PR TITLE
Disable two failing tests

### DIFF
--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
+// REQUIRES: rdar_108947854
+
 protocol P {}
 struct X: P {}
 struct Y {}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
+// REQUIRES: rdar_108947721
+
 protocol P {
   associatedtype SomeType
 }


### PR DESCRIPTION
Disable two test that block package bots.

```
test/Constraints/conditionally_defined_types.swift
test/Constraints/diagnostics.swift
```

Failed on https://ci.swift.org/job/oss-swift-package-macos/1841, and on https://ci.swift.org/job/oss-swift-package-centos-7/1876.

rdar://108947854
rdar://108947721