### PR TITLE
[5.9][IRGen] Respect optionality of unowned(unsafe) reference properties

### DIFF
--- a/test/Interpreter/rdar108705703.swift
+++ b/test/Interpreter/rdar108705703.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+struct Context {
+    unowned(unsafe) var x: AnyObject? = nil
+}
+
+@inline(never)
+func test(x: Context) -> Context? {
+  return x
+}
+
+// CHECK: works
+if (test(x: Context()) == nil) {
+    print("bug")
+} else {
+    print("works")
+}
+
+@inline(never)
+func test2() -> Context {
+  var g: [Context]  = [Context()]
+  print(g.endIndex)
+  return g.removeLast()
+}
+
+// CHECK: Context(x: nil)
+print(test2())


### PR DESCRIPTION
Cherry-picked from: https://github.com/apple/swift/pull/65663

rdar://108705703

When generating the type info for fields marked unowned(unsafe) of an optional reference (e.g. AnyObject?), we dropped the fact that it was optional along the way. This caused incorrect tags to be returned when on object of the type was stored in an optional itself and the unowned property contained `nil`. In those cases the outer optional appeared to be `nil` as well, even if it in fact contained a value.
