### PR TITLE
[AST] Preserve `RecursiveTypeProperties::HasTypeVariable` for PlaceholderType

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3135,16 +3135,17 @@ Type PlaceholderType::get(ASTContext &ctx, Originator originator) {
 
     return false;
   }();
-  auto arena = hasTypeVariables ? AllocationArena::ConstraintSolver
-                                : AllocationArena::Permanent;
+  RecursiveTypeProperties properties = RecursiveTypeProperties::HasPlaceholder;
+  if (hasTypeVariables)
+    properties |= RecursiveTypeProperties::HasTypeVariable;
 
+  auto arena = getArena(properties);
   auto &cache = ctx.getImpl().getArena(arena).PlaceholderTypes;
   auto &entry = cache[originator.getOpaqueValue()];
   if (entry)
     return entry;
 
-  entry = new (ctx, arena)
-      PlaceholderType(ctx, originator, RecursiveTypeProperties::HasPlaceholder);
+  entry = new (ctx, arena) PlaceholderType(ctx, originator, properties);
   return entry;
 }
 


### PR DESCRIPTION
This is a tentative fix for rdar://108947721 (and hopefully rdar://108947854), I haven't yet been able to reproduce the issue.

Make sure we preserve the "has type variables" recursive property for placeholder types to ensure we don't do permanent allocation for any type wrapping a placeholder type that has a type variable. Otherwise, we could end up deallocating the placeholder, and having another type allocated in its place.