### PR TITLE
[stdlib] _Int128: fix invalid overflow crash

### DIFF
--- a/stdlib/public/core/Int128.swift.gyb
+++ b/stdlib/public/core/Int128.swift.gyb
@@ -257,7 +257,7 @@ extension _${U}Int128: FixedWidthInteger {
     by rhs: Self
   ) -> (partialValue: Self, overflow: Bool) {
     % if signed:
-    let isNegative = (self._isNegative != rhs._isNegative)
+    let isNegative = (self._isNegative != rhs._isNegative && self != .zero && rhs != .zero)
     let (p, overflow) = self.magnitude.multipliedReportingOverflow(
       by: rhs.magnitude)
     let r = _Int128(bitPattern: isNegative ? p._twosComplement : p)
@@ -281,7 +281,7 @@ extension _${U}Int128: FixedWidthInteger {
     by other: UInt64
   ) -> (partialValue: Self, overflow: Bool) {
     % if signed:
-    let isNegative = self._isNegative
+    let isNegative = self._isNegative && self != .zero && other != .zero
     let (p, overflow) = self.magnitude.multipliedReportingOverflow(by: other)
     let r = _Int128(bitPattern: isNegative ? p._twosComplement : p)
     return (r, overflow || (isNegative != r._isNegative))


### PR DESCRIPTION
<!-- What's in this pull request? -->
<!--
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.
-->

This PR fixes a bug where multiplication of any negative value with zero would result in the overflow precondition being triggered when using `_Int128`. `Duration` exposed this bug publicly:

before:
```swift
print(Duration.seconds(-1) * 0) //  Swift/Int128.swift:662: Fatal error: Overflow in *
```
after:
```swift
print(Duration.seconds(-1) * 0) // 0.0 seconds
```

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
<!--
Resolves #NNNNN, fix apple/llvm-project#MMMMM.
-->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->