### PR TITLE
[5.9][CursorInfo] Prefer AST based results over solver based

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_reuses_astcontext.swift
+++ b/test/SourceKit/CursorInfo/cursor_reuses_astcontext.swift
@@ -1,27 +1,31 @@
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
+
 // RUN: %sourcekitd-test -req=cursor -pos=%(line + 2):7 %s -- %s == -req=cursor -pos=%(line + 3):7 %s -- %s | %FileCheck %s --check-prefix IN-FUNCTION
 func foo() {
-  let inFunctionA = 1
-  let inFunctionB = "hi"
+  _ = bar()
+  _ = bar()
 }
 
-// IN-FUNCTION: source.lang.swift.decl.var.local
-// IN-FUNCTION-NEXT: inFunctionA
+// IN-FUNCTION: source.lang.swift.ref.function.free
+// IN-FUNCTION-NEXT: bar
 // IN-FUNCTION: DID REUSE AST CONTEXT: 0
-// IN-FUNCTION: source.lang.swift.decl.var.local
-// IN-FUNCTION-NEXT: inFunctionB
+// IN-FUNCTION: source.lang.swift.ref.function.free
+// IN-FUNCTION-NEXT: bar
+// IN-FUNCTION-NEXT: bar
 // IN-FUNCTION: DID REUSE AST CONTEXT: 1
 
 // RUN: %sourcekitd-test -req=cursor -pos=%(line + 3):9 %s -- %s == -req=cursor -pos=%(line + 4):9 %s -- %s | %FileCheck %s --check-prefix IN-INSTANCE-METHOD
 struct MyStruct {
   func test() {
-    let inInstanceMethod1 = 2
-    let inInstanceMethod2 = "hello"
+    _ = bar()
+    _ = bar()
   }
 }
 
-// IN-INSTANCE-METHOD: source.lang.swift.decl.var.local
-// IN-INSTANCE-METHOD-NEXT: inInstanceMethod1
+// IN-INSTANCE-METHOD: source.lang.swift.ref.function.free
+// IN-INSTANCE-METHOD-NEXT: bar
 // IN-INSTANCE-METHOD: DID REUSE AST CONTEXT: 0
-// IN-INSTANCE-METHOD: source.lang.swift.decl.var.local
-// IN-INSTANCE-METHOD-NEXT: inInstanceMethod2
+// IN-INSTANCE-METHOD: source.lang.swift.ref.function.free
+// IN-INSTANCE-METHOD-NEXT: bar
 // IN-INSTANCE-METHOD: DID REUSE AST CONTEXT: 1

--- a/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
+++ b/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
@@ -3,90 +3,90 @@
 
 // RUN: %sourcekitd-test \
 // RUN:   -shell -- echo '## State 1' == \
-// RUN:   -req=cursor -pos=5:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=6:21 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 2' == \
 // RUN:   -shell -- cp %t/State2.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=6:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=7:21 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 3' == \
 // RUN:   -shell -- cp %t/State3.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=5:21 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 4' == \
 // RUN:   -shell -- cp %t/State4.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=5:19 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 5' == \
 // RUN:   -shell -- cp %t/State5.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -req=cursor -pos=5:19 %t/file.swift -- %t/file.swift == \
 // RUN:   -shell -- echo '## State 6' == \
 // RUN:   -shell -- cp %t/State6.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift > %t/response.txt
+// RUN:   -req=cursor -pos=5:19 %t/file.swift -- %t/file.swift > %t/response.txt
 // RUN: %FileCheck %s < %t/response.txt
 
 // CHECK-LABEL: ## State 1
-// CHECK: source.lang.swift.decl.var.local (5:7-5:18)
-// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: source.lang.swift.ref.function.free
 // CHECK: DID REUSE AST CONTEXT: 0
 // CHECK-LABEL: ## State 2
-// CHECK: source.lang.swift.decl.var.local (6:7-6:18)
-// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: source.lang.swift.ref.function.free
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 3
-// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
-// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: source.lang.swift.ref.function.free
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 4
-// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
-// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: source.lang.swift.ref.function.free
 // CHECK: DID REUSE AST CONTEXT: 1
 // CHECK-LABEL: ## State 5
-// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
-// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: source.lang.swift.ref.function.free
 // CHECK: DID REUSE AST CONTEXT: 0
 // CHECK-LABEL: ## State 6
-// CHECK: source.lang.swift.decl.var.local (4:7-4:16)
-// CHECK: <Declaration>let myNewName: <Type usr="s:Si">Int</Type></Declaration>
+// CHECK: source.lang.swift.ref.function.free
 // CHECK: DID REUSE AST CONTEXT: 1
 
 //--- file.swift
-func unrelated() {}
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
 
 func foo() {
-  let inFunctionA = 1
-  let inFunctionB = "hi"
+  let inFunctionA = bar()
+  let inFunctionB = bar()
 }
 
 //--- State2.swift
-func unrelated() {}
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
 
 func foo() {
-  let newlyAddedMember = 3
-  let inFunctionA = 1
-  let inFunctionB = "hi"
+  let newlyAddedMember: Int = bar()
+  let inFunctionA = bar()
+  let inFunctionB = bar()
 }
 
 //--- State3.swift
-func unrelated() {}
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
 
 func foo() {
-  let inFunctionB = "hi"
+  let inFunctionB = bar()
 }
 
 //--- State4.swift
-func unrelated() {}
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
 
 func foo() {
-  let myNewName = "hi"
+  let myNewName = bar()
 }
 
 //--- State5.swift
-func unrelated() {}
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
 
 func foo(param: Int) {
-  let myNewName = "hi"
+  let myNewName = bar()
 }
 
 //--- State6.swift
-func unrelated() {}
+func bar() -> Int { return 1 }
+func bar() -> String { return "" }
 
 func foo(param: Int) {
-  let myNewName = 7
+  let myNewName = bar() + bar()
 }

--- a/test/SourceKit/CursorInfo/static_vs_class_spelling.swift
+++ b/test/SourceKit/CursorInfo/static_vs_class_spelling.swift
@@ -21,8 +21,8 @@ func application() {
   // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):18 %t/test.swift -- %t/test.swift -I %t/Modules -target %target-triple | %FileCheck %s --check-prefix=SHARED_STATIC
   UserCollection.sharedStatic
   // FIXME: This should be reported as 'static var' rdar://105239467
-  // SHARED_STATIC: <Declaration>class let sharedStatic: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type></Declaration>
-  // SHARED_STATIC: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>sharedStatic</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type></decl.var.class>
+  // SHARED_STATIC: <Declaration>static let sharedStatic: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type></Declaration>
+  // SHARED_STATIC: <decl.var.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>sharedStatic</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type></decl.var.static>
 
   // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):18 %t/test.swift -- %t/test.swift -I %t/Modules -target %target-triple | %FileCheck %s --check-prefix=SHARED_COMPUTED_CLASS
   UserCollection.sharedComputedClass

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -109,6 +109,10 @@ SwiftInvocation::~SwiftInvocation() {
   delete &Impl;
 }
 
+ArrayRef<std::string> SwiftInvocation::getArgs() const {
+  return ArrayRef(Impl.Opts.Args);
+}
+
 void SwiftInvocation::applyTo(swift::CompilerInvocation &CompInvok) const {
   return Impl.Opts.applyTo(CompInvok);
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftInvocation.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInvocation.h
@@ -33,6 +33,7 @@ public:
   struct Implementation;
   Implementation &Impl;
 
+  ArrayRef<std::string> getArgs() const;
   void applyTo(swift::CompilerInvocation &CompInvok) const;
   void raw(std::vector<std::string> &Args, std::string &PrimaryFile) const;
 


### PR DESCRIPTION
* Explanation: Solver based results are fast within a function, where the `ASTContext` can be re-used. But it is significantly slower than the AST based results when outside of a function. Instead of using solver based as the primary results, only use them as a fallback for when AST based fails.
* Scope: Cursor info
* Risk: Doesn't touch any compiler code. Low for the cursor info request itself as theAST based was previously always used. The main risk is the async and callback heavy nature of this code.
* Testing: Current tests still pass (with slight modifications to actually trigger solver based to be used). Have also run ASAN and the stress tester.
* Original PR: https://github.com/apple/swift/pull/65688