### PR TITLE
[5.9🍒] Fix a performance issue when answering "is this tuple Copyable"?

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8200,6 +8200,21 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     return SolutionKind::Solved;
   }
 
+  // Copyable is checked structurally, so for better performance, split apart
+  // this constraint into individual Copyable constraints on each tuple element.
+  if (auto *tupleType = type->getAs<TupleType>()) {
+    if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
+      for (unsigned i = 0, e = tupleType->getNumElements(); i < e; ++i) {
+        addConstraint(ConstraintKind::ConformsTo,
+                      tupleType->getElementType(i),
+                      protocol->getDeclaredInterfaceType(),
+                      locator.withPathElement(LocatorPathElt::TupleElement(i)));
+      }
+
+      return SolutionKind::Solved;
+    }
+  }
+
   auto *loc = getConstraintLocator(locator);
 
   /// Record the given conformance as the result, adding any conditional

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -88,8 +88,8 @@ func testBasic(_ mo: borrowing MO) {
   genericVarArg(5)
   genericVarArg(mo) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
 
-  takeGeneric( (mo, 5) ) // expected-error {{global function 'takeGeneric' requires that 'MO' conform to '_Copyable'}}
-  takeGenericSendable((mo, mo)) // expected-error 2{{global function 'takeGenericSendable' requires that 'MO' conform to '_Copyable'}}
+  takeGeneric( (mo, 5) ) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeGenericSendable((mo, mo)) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
 
   let singleton : (MO) = (mo)
   takeGeneric(singleton) // expected-error {{move-only type 'MO' cannot be used with generics yet}}


### PR DESCRIPTION
• Description: This PR fixes a performance regression in a RegexBuilder test that triggered [this workaround](https://github.com/apple/swift-experimental-string-processing/pull/643). The regression was caused by the addition of the `Copyable` constraint on generic type parameters, manifesting as a "expression too complex" error message.
• Risk: Low. It's very unlikely for this change to cause regressions in typechecking other programs, based on how the solver operates.
• Original PR: https://github.com/apple/swift/pull/65673
• Reviewed By: @xedin 
• Testing: [compiler performance testing](https://github.com/apple/swift/pull/65673#issuecomment-1536607960) showed no regression in performance. Also manually tested different builds of the compiler to see that this patch makes the error go away. See original PR for rationale about why this is sufficient.
• Resolves: rdar://107536402