### PR TITLE
Fix DiscardingTaskGroup availability

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -67,7 +67,7 @@ import Swift
 /// use the `withThrowingDiscardingTaskGroup(returning:body:)` method instead.
 ///
 /// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @inlinable
 @_unsafeInheritExecutor
 public func withDiscardingTaskGroup<GroupResult>(
@@ -139,7 +139,7 @@ public func withDiscardingTaskGroup<GroupResult>(
 /// - SeeAlso: ``TaskGroup``
 /// - SeeAlso: ``ThrowingTaskGroup``
 /// - SeeAlso: ``ThrowingDiscardingTaskGroup``
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct DiscardingTaskGroup {
 
@@ -331,7 +331,7 @@ public struct DiscardingTaskGroup {
   }
 }
 
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @available(*, unavailable)
 extension DiscardingTaskGroup: Sendable { }
 
@@ -428,7 +428,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// However,
 /// throwing out of the `body` of the `withThrowingTaskGroup` method does cancel
 /// the group, and all of its child tasks.
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @inlinable
 @_unsafeInheritExecutor
 public func withThrowingDiscardingTaskGroup<GroupResult>(
@@ -524,7 +524,7 @@ public func withThrowingDiscardingTaskGroup<GroupResult>(
 /// - SeeAlso: ``TaskGroup``
 /// - SeeAlso: ``ThrowingTaskGroup``
 /// - SeeAlso: ``DiscardingTaskGroup``
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ThrowingDiscardingTaskGroup<Failure: Error> {
 
@@ -641,7 +641,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   }
 }
 
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @available(*, unavailable)
 extension ThrowingDiscardingTaskGroup: Sendable { }
 
@@ -649,7 +649,7 @@ extension ThrowingDiscardingTaskGroup: Sendable { }
 // MARK: Runtime functions
 
 /// Always returns `nil`.
-@available(SwiftStdlib 5.8, *)
+@available(SwiftStdlib 5.9, *)
 @usableFromInline
 @discardableResult
 @_silgen_name("swift_taskGroup_waitAll")


### PR DESCRIPTION
Discarding task groups aren't available in the 5.8-aligned OS's, resulting in a loader error at launch if you try to use them.

Bumping the availability attributes to 5.9 on everything in DiscardingTaskGroup.swift

Initial build said to make the minimum deployment target 13.3;
```
$ swiftc -g main.swift                                                                                                                                                                
error: emit-module command failed with exit code 1 (use -v to see invocation)                                                                                                                                                      
main.swift:44:7: error: 'withDiscardingTaskGroup(returning:body:)' is only available in macOS 13.3 or newer                                                                                                                        
await withDiscardingTaskGroup { group in                                                                                                                                                                                           
      ^                                                                                                                                                                                                                            
main.swift:44:7: note: add 'if #available' version check                                                                                                                                                                           
await withDiscardingTaskGroup { group in                                                                                                                                                                                           
      ^                                                                                                                                                                                                                            
error: fatalError   
```

After setting it to 13.3 and running it on macOS 13.3, the program builds, but fails to launch since the symbols aren't actually in the OS runtime;

```
dyld[26579]: Symbol not found: _$ss23withDiscardingTaskGroup9returning4bodyxxm_xs0bcD0VzYaXEtYalF                                                                                                                                  
  Referenced from: <71830439-D729-380C-B9CF-B3233557D147> /private/tmp/SwiftTest/Test2/main                      
  Expected in:     <2D262AB4-BBFC-3917-8A4D-7C04E5AB4FE9> /usr/lib/swift/libswift_Concurrency.dylib              
zsh: abort      ./main 
```

rdar://108975888