### PR TITLE
[CodeCompletion] Fix a crash when completing an argument to a function taking a parameter pack

### DIFF
--- a/include/swift/IDE/ArgumentCompletion.h
+++ b/include/swift/IDE/ArgumentCompletion.h
@@ -29,8 +29,8 @@ class ArgumentTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
     Type ExpectedCallType;
     /// True if this is a subscript rather than a function call.
     bool IsSubscript;
-    /// The FuncDecl or SubscriptDecl associated with the call.
-    ValueDecl *FuncD;
+    /// The reference to the FuncDecl or SubscriptDecl associated with the call.
+    ConcreteDeclRef FuncDeclRef;
     /// The type of the function being called.
     AnyFunctionType *FuncTy;
     /// The index of the argument containing the completion location
@@ -55,6 +55,9 @@ class ArgumentTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
     /// this result. This in particular includes parameters of closures that
     /// were type-checked with the code completion expression.
     llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+
+    /// Return the \c FuncDecl or \c SubscriptDecl associated with this call.
+    ValueDecl *getFuncD() const { return FuncDeclRef.getDecl(); }
   };
 
   CodeCompletionExpr *CompletionExpr;

--- a/include/swift/IDE/SelectedOverloadInfo.h
+++ b/include/swift/IDE/SelectedOverloadInfo.h
@@ -25,13 +25,15 @@ using namespace swift::constraints;
 /// \c SelectedOverload.
 struct SelectedOverloadInfo {
   /// The function that is being called or the value that is being accessed.
-  ValueDecl *Value = nullptr;
+  ConcreteDeclRef ValueRef;
   /// For a function, type of the called function itself (not its result type),
   /// for an arbitrary value the type of that value.
   Type ValueTy;
   /// The type on which the overload is being accessed. \c null if it does not
   /// have a base type, e.g. for a free function.
   Type BaseTy;
+
+  ValueDecl *getValue() const { return ValueRef.getDecl(); }
 };
 
 /// Extract additional information about the overload that is being called by

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -311,7 +311,7 @@ private:
     auto Locator = CS.getConstraintLocator(ResolveExpr);
     auto CalleeLocator = S.getCalleeLocator(Locator);
     auto OverloadInfo = getSelectedOverloadInfo(S, CalleeLocator);
-    if (!OverloadInfo.Value) {
+    if (!OverloadInfo.ValueRef) {
       // We could not resolve the referenced declaration. Skip the solution.
       return;
     }
@@ -322,11 +322,12 @@ private:
     if (auto BaseExpr =
             simplifyLocatorToAnchor(BaseLocator).dyn_cast<Expr *>()) {
       IsDynamicRef =
-          ide::isDynamicRef(BaseExpr, OverloadInfo.Value,
+          ide::isDynamicRef(BaseExpr, OverloadInfo.getValue(),
                             [&S](Expr *E) { return S.getResolvedType(E); });
     }
 
-    Results.push_back({OverloadInfo.BaseTy, IsDynamicRef, OverloadInfo.Value});
+    Results.push_back(
+        {OverloadInfo.BaseTy, IsDynamicRef, OverloadInfo.getValue()});
   }
 
 public:

--- a/lib/IDE/SelectedOverloadInfo.cpp
+++ b/lib/IDE/SelectedOverloadInfo.cpp
@@ -40,7 +40,9 @@ swift::ide::getSelectedOverloadInfo(const Solution &S,
       Result.BaseTy = nullptr;
     }
 
-    Result.Value = SelectedOverload->choice.getDeclOrNull();
+    if (auto ReferencedDecl = SelectedOverload->choice.getDeclOrNull()) {
+      Result.ValueRef = S.resolveConcreteDeclRef(ReferencedDecl, CalleeLocator);
+    }
     Result.ValueTy =
         S.simplifyTypeForCodeCompletion(SelectedOverload->adjustedOpenedType);
 

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1303,3 +1303,10 @@ func testMacroArg() {
 // MACRO_CALL_ARG-DAG: Literal[Boolean]/None:              true[#Bool#]; name=true
 // MACRO_CALL_ARG: End completions
 }
+
+func testParameterPack(intArray: [Int]) {
+  func myZip<each S>(_ sequence: repeat each S, otherParam: Int) where repeat each S: Sequence {}
+  myZip([1], #^PARAMETER_PACK_ARG^#)
+  // PARAMETER_PACK_ARG: Pattern/Local/Flair[ArgLabels]:     {#otherParam: Int#}[#Int#]; name=otherParam:
+  // PARAMETER_PACK_ARG: Decl[LocalVar]/Local/TypeRelation[Convertible]: intArray[#[Int]#]; name=intArray
+}


### PR DESCRIPTION
We previously asserted that for a call the function type had the same number of parameters as the declaration. But that’s not true for parameter packs anymore because the parameter pack will be exploded in the function type to account for passing multiple arguments to the pack.

To fix this, use `ConcreteDeclRef` instead of a `ValueDecl`, which has a substitution map and is able to account for the exploded parameter packs when accessed using `getParameterAt`.

rdar://100066716
