### PR TITLE
[Serialization] Teach ASTSectionImporter to filter by triple.

### DIFF
--- a/include/swift/ASTSectionImporter/ASTSectionImporter.h
+++ b/include/swift/ASTSectionImporter/ASTSectionImporter.h
@@ -20,6 +20,9 @@
 #include "swift/Basic/LLVM.h"
 #include <string>
 
+namespace llvm {
+class Triple;
+}
 namespace swift {
   class MemoryBufferSerializedModuleLoader;
 
@@ -28,9 +31,10 @@ namespace swift {
   /// registers them using registerMemoryBuffer() so they can be found by
   /// loadModule(). The access path of all modules found in the section is
   /// appended to the vector foundModules.
+  /// \param filter  If fully specified, only matching modules are registered.
   /// \return true if successful.
   bool parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
-                       StringRef Data,
+                       StringRef Data, const llvm::Triple &filter,
                        SmallVectorImpl<std::string> &foundModules);
 }
 #endif

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -19,6 +19,10 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
+namespace llvm {
+class Triple;
+}
+
 namespace swift {
 
 class ModuleFile;
@@ -301,6 +305,11 @@ void diagnoseSerializedASTLoadFailure(
 void diagnoseSerializedASTLoadFailureTransitive(
     ASTContext &Ctx, SourceLoc diagLoc, const serialization::Status status,
     ModuleFile *loadedModuleFile, Identifier ModuleName, bool forTestable);
+
+/// Determine whether two triples are considered to be compatible for module
+/// serialization purposes.
+bool areCompatible(const llvm::Triple &moduleTarget,
+                   const llvm::Triple &ctxTarget);
 
 } // end namespace serialization
 } // end namespace swift

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -91,6 +91,16 @@ static bool isTargetTooNew(const llvm::Triple &moduleTarget,
   return ctxTarget.isOSVersionLT(moduleTarget);
 }
 
+namespace swift {
+namespace serialization {
+bool areCompatible(const llvm::Triple &moduleTarget,
+                   const llvm::Triple &ctxTarget) {
+  return areCompatibleArchitectures(moduleTarget, ctxTarget) &&
+         areCompatibleOSs(moduleTarget, ctxTarget);
+}
+} // namespace serialization
+} // namespace swift
+
 ModuleFile::ModuleFile(std::shared_ptr<const ModuleFileSharedCore> core)
     : Core(core) {
   assert(!core->hasError());
@@ -249,8 +259,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
   ASTContext &ctx = getContext();
 
   llvm::Triple moduleTarget(llvm::Triple::normalize(Core->TargetTriple));
-  if (!areCompatibleArchitectures(moduleTarget, ctx.LangOpts.Target) ||
-      !areCompatibleOSs(moduleTarget, ctx.LangOpts.Target)) {
+  if (!areCompatible(moduleTarget, ctx.LangOpts.Target)) {
     status = Status::TargetIncompatible;
     if (!recoverFromIncompatibility)
       return error(status);

--- a/test/DebugInfo/ASTSection.swift
+++ b/test/DebugInfo/ASTSection.swift
@@ -2,6 +2,7 @@
 
 // RUN: %target-build-swift -emit-executable %s -g -o %t/ASTSection -emit-module
 // RUN: %lldb-moduleimport-test -verbose %t/ASTSection | %FileCheck %s
+// RUN: %lldb-moduleimport-test -filter mips64-unknown-hurd -verbose %t/ASTSection | %FileCheck %s --check-prefix=LINETABLE-CHECK
 
 // REQUIRES: executable_test
 // REQUIRES: swift_tools_extra

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -239,6 +239,9 @@ int main(int argc, char **argv) {
   opt<bool> Verbose("verbose", desc("Dump informations on the loaded module"),
                     cat(Visible));
 
+  opt<std::string> Filter("filter", desc("triple for filtering modules"),
+                          cat(Visible));
+
   opt<std::string> ModuleCachePath(
       "module-cache-path", desc("Clang module cache path"), cat(Visible));
 
@@ -351,9 +354,11 @@ int main(int argc, char **argv) {
     ClangImporter->setDWARFImporterDelegate(dummyDWARFImporter);
   }
 
+  llvm::Triple filter(Filter);
   for (auto &Module : Modules)
     if (!parseASTSection(*CI.getMemoryBufferSerializedModuleLoader(),
-                         StringRef(Module.first, Module.second), modules)) {
+                         StringRef(Module.first, Module.second), filter,
+                         modules)) {
       llvm::errs() << "error: Failed to parse AST section!\n";
       return 1;
     }


### PR DESCRIPTION
On macOS it is possible for one application to contain Swift modules compiled for different triples that are incompatible as far as the Swift compiler is concerned. Examples include an iOS simulator application hunning on a macOS host, or a macCatalyst application running on macOS. A debugger might see .swift_ast sections for all triples at the same time. This patch adds an interface to let the client provide a triple to filter Swift modules in an ASTSection.

rdar://107869141
