### PR TITLE
[interop][SwiftToCxx] avoid emitting ambiguous C++ overloads and emit unavailable type stubs for top level types that could not be emitted in the C++ section of the generated header

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1696,6 +1696,8 @@ ERROR(expose_enum_case_tuple_to_cxx,none,
       "enum %0 can not yet be represented in C++ as one of its cases has multiple associated values", (ValueDecl *))
 ERROR(expose_protocol_to_cxx_unsupported,none,
       "protocol %0 can not yet be represented in C++", (ValueDecl *))
+ERROR(expose_move_only_to_cxx,none,
+      "move-only %0 %1 can not yet be represented in C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(unexposed_other_decl_in_cxx,none,
       "%0 %1 is not yet exposed to C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(unsupported_other_decl_in_cxx,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1694,6 +1694,8 @@ ERROR(expose_enum_case_type_to_cxx,none,
       "enum %0 can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++", (ValueDecl *))
 ERROR(expose_enum_case_tuple_to_cxx,none,
       "enum %0 can not yet be represented in C++ as one of its cases has multiple associated values", (ValueDecl *))
+ERROR(expose_protocol_to_cxx_unsupported,none,
+      "protocol %0 can not yet be represented in C++", (ValueDecl *))
 ERROR(unexposed_other_decl_in_cxx,none,
       "%0 %1 is not yet exposed to C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(unsupported_other_decl_in_cxx,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1694,6 +1694,10 @@ ERROR(expose_enum_case_type_to_cxx,none,
       "enum %0 can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++", (ValueDecl *))
 ERROR(expose_enum_case_tuple_to_cxx,none,
       "enum %0 can not yet be represented in C++ as one of its cases has multiple associated values", (ValueDecl *))
+ERROR(unexposed_other_decl_in_cxx,none,
+      "%0 %1 is not yet exposed to C++", (DescriptiveDeclKind, ValueDecl *))
+ERROR(unsupported_other_decl_in_cxx,none,
+      "Swift %0 %1 cannot be represented in C++", (DescriptiveDeclKind, ValueDecl *))
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -13,8 +13,9 @@
 #ifndef SWIFT_NAME_TRANSLATION_H
 #define SWIFT_NAME_TRANSLATION_H
 
-#include "swift/AST/Identifier.h"
 #include "swift/AST/AttrKind.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Identifier.h"
 
 namespace swift {
   class ValueDecl;
@@ -77,6 +78,9 @@ enum RepresentationError {
   UnrepresentableEnumCaseType,
   UnrepresentableEnumCaseTuple,
 };
+
+/// Constructs a diagnostic that describes the given C++ representation error.
+Diagnostic diagnoseRepresenationError(RepresentationError error, ValueDecl *vd);
 
 struct DeclRepresentation {
   RepresentationKind kind;

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -77,6 +77,7 @@ enum RepresentationError {
   UnrepresentableIndirectEnum,
   UnrepresentableEnumCaseType,
   UnrepresentableEnumCaseTuple,
+  UnrepresentableProtocol,
 };
 
 /// Constructs a diagnostic that describes the given C++ representation error.

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -78,6 +78,7 @@ enum RepresentationError {
   UnrepresentableEnumCaseType,
   UnrepresentableEnumCaseTuple,
   UnrepresentableProtocol,
+  UnrepresentableMoveOnly,
 };
 
 /// Constructs a diagnostic that describes the given C++ representation error.

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
@@ -282,4 +283,38 @@ bool swift::cxx_translation::isVisibleToCxx(const ValueDecl *VD,
     }
   }
   return false;
+}
+
+Diagnostic
+swift::cxx_translation::diagnoseRepresenationError(RepresentationError error,
+                                                   ValueDecl *vd) {
+  switch (error) {
+  case UnrepresentableObjC:
+    return Diagnostic(diag::expose_unsupported_objc_decl_to_cxx,
+                      vd->getDescriptiveKind(), vd);
+  case UnrepresentableAsync:
+    return Diagnostic(diag::expose_unsupported_async_decl_to_cxx,
+                      vd->getDescriptiveKind(), vd);
+  case UnrepresentableIsolatedInActor:
+    return Diagnostic(diag::expose_unsupported_actor_isolated_to_cxx,
+                      vd->getDescriptiveKind(), vd);
+  case UnrepresentableRequiresClientEmission:
+    return Diagnostic(diag::expose_unsupported_client_emission_to_cxx,
+                      vd->getDescriptiveKind(), vd);
+  case UnrepresentableGeneric:
+    return Diagnostic(diag::expose_generic_decl_to_cxx,
+                      vd->getDescriptiveKind(), vd);
+  case UnrepresentableGenericRequirements:
+    return Diagnostic(diag::expose_generic_requirement_to_cxx,
+                      vd->getDescriptiveKind(), vd);
+  case UnrepresentableThrows:
+    return Diagnostic(diag::expose_throwing_to_cxx, vd->getDescriptiveKind(),
+                      vd);
+  case UnrepresentableIndirectEnum:
+    return Diagnostic(diag::expose_indirect_enum_cxx, vd);
+  case UnrepresentableEnumCaseType:
+    return Diagnostic(diag::expose_enum_case_type_to_cxx, vd);
+  case UnrepresentableEnumCaseTuple:
+    return Diagnostic(diag::expose_enum_case_tuple_to_cxx, vd);
+  }
 }

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -221,6 +221,8 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
       genericSignature = AFD->getGenericSignature().getCanonicalSignature();
   }
   if (const auto *typeDecl = dyn_cast<NominalTypeDecl>(VD)) {
+    if (isa<ProtocolDecl>(typeDecl))
+      return {Unsupported, UnrepresentableProtocol};
     if (typeDecl->isGeneric()) {
       if (isa<ClassDecl>(VD))
         return {Unsupported, UnrepresentableGeneric};
@@ -316,5 +318,7 @@ swift::cxx_translation::diagnoseRepresenationError(RepresentationError error,
     return Diagnostic(diag::expose_enum_case_type_to_cxx, vd);
   case UnrepresentableEnumCaseTuple:
     return Diagnostic(diag::expose_enum_case_tuple_to_cxx, vd);
+  case UnrepresentableProtocol:
+    return Diagnostic(diag::expose_protocol_to_cxx_unsupported, vd);
   }
 }

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -226,6 +226,9 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
   if (const auto *typeDecl = dyn_cast<NominalTypeDecl>(VD)) {
     if (isa<ProtocolDecl>(typeDecl))
       return {Unsupported, UnrepresentableProtocol};
+    // Swift's consume semantics are not yet supported in C++.
+    if (typeDecl->isMoveOnly())
+      return {Unsupported, UnrepresentableMoveOnly};
     if (typeDecl->isGeneric()) {
       if (isa<ClassDecl>(VD))
         return {Unsupported, UnrepresentableGeneric};
@@ -323,5 +326,8 @@ swift::cxx_translation::diagnoseRepresenationError(RepresentationError error,
     return Diagnostic(diag::expose_enum_case_tuple_to_cxx, vd);
   case UnrepresentableProtocol:
     return Diagnostic(diag::expose_protocol_to_cxx_unsupported, vd);
+  case UnrepresentableMoveOnly:
+    return Diagnostic(diag::expose_move_only_to_cxx, vd->getDescriptiveKind(),
+                      vd);
   }
 }

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -164,6 +164,9 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
   if (customNamesOnly)
     return StringRef();
 
+  if (isa<ConstructorDecl>(VD))
+    return "init";
+
   if (auto *mod = dyn_cast<ModuleDecl>(VD)) {
     if (mod->isStdlibModule())
       return "swift";

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2908,6 +2908,12 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
          !excludeForObjCImplementation(VD);
 }
 
+bool DeclAndTypePrinter::isVisible(const ValueDecl *vd) const {
+  return outputLang == OutputLanguageMode::Cxx
+             ? cxx_translation::isVisibleToCxx(vd, minRequiredAccess)
+             : isVisibleToObjC(vd, minRequiredAccess);
+}
+
 void DeclAndTypePrinter::print(const Decl *D) {
   getImpl().print(D);
 }

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -106,6 +106,10 @@ public:
   /// the options the printer was constructed with.
   bool shouldInclude(const ValueDecl *VD);
 
+  /// Returns true if \p vd is visible given the current access level and thus
+  /// can be included in the generated header.
+  bool isVisible(const ValueDecl *vd) const;
+
   void print(const Decl *D);
   void print(Type ty);
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -37,6 +37,10 @@ struct CxxDeclEmissionScope {
   std::vector<const ValueDecl *> additionalUnrepresentableDeclarations;
   /// Records the C++ declaration names already emitted in this lexical scope.
   llvm::StringSet<> emittedDeclarationNames;
+  /// Records the names of the function overloads already emitted in this
+  /// lexical scope.
+  llvm::StringMap<llvm::SmallVector<const AbstractFunctionDecl *, 2>>
+      emittedFunctionOverloads;
 };
 
 /// Responsible for printing a Swift Decl or Type in Objective-C, to be

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -820,18 +820,18 @@ public:
          emissionScope.additionalUnrepresentableDeclarations)
       removedVDList.push_back(removedVD);
 
+    // Do not report internal/private decls as unavailable.
     // @objc declarations are emitted in the Objective-C section, so do not
     // report them as unavailable. Also skip underscored decls from the standard
     // library. Also skip structs from the standard library, they can cause
     // ambiguities because of the arithmetic types that conflict with types we
     // already have in `swift::` namespace. Also skip `Error` protocol from
     // stdlib, we have experimental support for it.
-    // FIXME: Note unrepresented type aliases too.
     removedVDList.erase(
         llvm::remove_if(
             removedVDList,
-            [](const ValueDecl *vd) {
-              return vd->isObjC() ||
+            [&](const ValueDecl *vd) {
+              return !printer.isVisible(vd) || vd->isObjC() ||
                      (vd->isStdlibDecl() && !vd->getName().isSpecial() &&
                       vd->getBaseIdentifier().str().startswith("_")) ||
                      (vd->isStdlibDecl() && isa<StructDecl>(vd)) ||
@@ -897,6 +897,7 @@ public:
 
       // FIXME: Emit an unavailable stub for a function / function overload set
       // / variable.
+      // FIXME: Note unrepresented type aliases too.
       emitStubComment();
     }
   }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1369,16 +1369,6 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   }
 }
 
-static StringRef getConstructorName(const AbstractFunctionDecl *FD) {
-  auto name = cxx_translation::getNameForCxx(
-      FD, cxx_translation::CustomNamesOnly_t::CustomNamesOnly);
-  if (!name.empty()) {
-    assert(name.startswith("init"));
-    return name;
-  }
-  return "init";
-}
-
 void DeclAndTypeClangFunctionPrinter::printCxxMethod(
     DeclAndTypePrinter &declAndTypePrinter,
     const NominalTypeDecl *typeDeclContext, const AbstractFunctionDecl *FD,
@@ -1399,10 +1389,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
                       !isConstructor && !isStatic;
   modifiers.hasSymbolUSR = !isDefinition;
   auto result = printFunctionSignature(
-      FD, signature,
-      isConstructor ? getConstructorName(FD)
-                    : cxx_translation::getNameForCxx(FD),
-      resultTy, FunctionSignatureKind::CxxInlineThunk, modifiers);
+      FD, signature, cxx_translation::getNameForCxx(FD), resultTy,
+      FunctionSignatureKind::CxxInlineThunk, modifiers);
   assert(!result.isUnsupported() && "C signature should be unsupported too");
 
   declAndTypePrinter.printAvailability(os, FD);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2055,50 +2055,9 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
 
   // Verify that the declaration is exposable.
   auto repr = cxx_translation::getDeclRepresentation(VD);
-  if (repr.isUnsupported()) {
-    using namespace cxx_translation;
-    switch (*repr.error) {
-    case UnrepresentableObjC:
-      diagnose(attr->getLocation(), diag::expose_unsupported_objc_decl_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableAsync:
-      diagnose(attr->getLocation(), diag::expose_unsupported_async_decl_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableIsolatedInActor:
-      diagnose(attr->getLocation(),
-               diag::expose_unsupported_actor_isolated_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableRequiresClientEmission:
-      diagnose(attr->getLocation(),
-               diag::expose_unsupported_client_emission_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableGeneric:
-      diagnose(attr->getLocation(), diag::expose_generic_decl_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableGenericRequirements:
-      diagnose(attr->getLocation(), diag::expose_generic_requirement_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableThrows:
-      diagnose(attr->getLocation(), diag::expose_throwing_to_cxx,
-               VD->getDescriptiveKind(), VD);
-      break;
-    case UnrepresentableIndirectEnum:
-      diagnose(attr->getLocation(), diag::expose_indirect_enum_cxx, VD);
-      break;
-    case UnrepresentableEnumCaseType:
-      diagnose(attr->getLocation(), diag::expose_enum_case_type_to_cxx, VD);
-      break;
-    case UnrepresentableEnumCaseTuple:
-      diagnose(attr->getLocation(), diag::expose_enum_case_tuple_to_cxx, VD);
-      break;
-    }
-  }
+  if (repr.isUnsupported())
+    diagnose(attr->getLocation(),
+             cxx_translation::diagnoseRepresenationError(*repr.error, VD));
 
   // Verify that the name mentioned in the expose
   // attribute matches the supported name pattern.

--- a/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
@@ -24,4 +24,4 @@ public func unavailableInHeaderFunc(_ x: StructSeveralI64) -> StructSeveralI64 {
     return Structs.passThroughStructSeveralI64(i: 0, x, j: 2)
 }
 
-// CHECK-NOT: unavailableInHeaderFunc
+// CHECK: // Unavailable in C++: Swift global function 'unavailableInHeaderFunc(_:)'.

--- a/test/Interop/SwiftToCxx/expose-attr/expose-rename-to-unavailable-decl.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-rename-to-unavailable-decl.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Expose -enable-experimental-cxx-interop -emit-clang-header-path %t/expose.h
+// RUN: %FileCheck %s < %t/expose.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/expose.h -Wno-error=unused-function)
+
+// Verify that we do not emit unavailable C++ decl
+// with a colliding name.
+
+@_expose(Cxx, "Renamed")
+public class TestMe {
+}
+
+public class Renamed<T> {}
+
+// CHECK: class SWIFT_SYMBOL("s:6Expose6TestMeC") Renamed
+
+// CHECK: // Unavailable in C++: Swift generic class 'Renamed'.

--- a/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-overloads.swift
@@ -4,15 +4,15 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-
-
 public func overloadedFunc(_ x: Int) { }
 public func overloadedFunc(_ y: Float) { }
 
 public func overloadedFuncArgLabel(x _: Int) { }
 public func overloadedFuncArgLabel(y _: Float) { }
 
-// CHECK-DAG: void overloadedFunc(float y) noexcept
-// CHECK-DAG: void overloadedFunc(swift::Int x) noexcept
-// CHECK-DAG: void overloadedFuncArgLabel(float _1) noexcept
-// CHECK-DAG: void overloadedFuncArgLabel(swift::Int _1) noexcept
+// CHECK: void overloadedFunc(swift::Int x) noexcept
+// CHECK: void overloadedFuncArgLabel(swift::Int  _1) noexcept
+
+// CHECK: // Unavailable in C++: Swift global function 'overloadedFunc(_:)'.
+
+// CHECK: // Unavailable in C++: Swift global function 'overloadedFuncArgLabel(y:)'.

--- a/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
@@ -13,4 +13,4 @@ public func c() {}
 
 // CHECK: SWIFT_INLINE_THUNK void a() noexcept SWIFT_SYMBOL("s:9Functions1ayyF") {
 // CHECK: SWIFT_INLINE_THUNK void c() noexcept SWIFT_SYMBOL("s:9Functions1cyyF") {
-// CHECK-NOT: b(
+// CHECK: // Unavailable in C++: Swift global function 'b(_:)'.

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
@@ -9,11 +9,11 @@
 // CHECK:       namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
 // CHECK-EMPTY:
 // CHECK-EMPTY:
+// CHECK-NEXT: // Unavailable in C++: Swift global function 'alwaysEmitIntoClientFunc(_:)'.
+// CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
 
-// CHECK-NOT: SWIFT_INLINE_THUNK bool alwaysEmitIntoClientFunc(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NOT:   return _impl::$s9Functions24alwaysEmitIntoClientFuncyS2bF(x);
-// CHECK-NOT: }
+
 
 @_alwaysEmitIntoClient
 public func alwaysEmitIntoClientFunc(_ x: Bool) -> Bool { return !x }

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -9,11 +9,9 @@
 // CHECK:       namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
 // CHECK-EMPTY:
 // CHECK-EMPTY:
+// CHECK: // Unavailable in C++: Swift global function 'asyncFunc(_:)'.
+// CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
-
-// CHECK-NOT: SWIFT_INLINE_THUNK double asyncFunc(double x) noexcept {{.*}}{
-// CHECK-NOT:   return _impl::$s9Functions9asyncFuncyS2dYaF(x);
-// CHECK-NOT: }
 
 // REQUIRES: concurrency
 

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -126,6 +126,21 @@ public class DerivedClass: BaseClass {
 public class DerivedClassTwo: BaseClass {
 }
 
+public struct WrapOverloadedInits {
+    let x: Int
+
+    public init(_ x: Int) {
+        self.x = x
+    }
+    public init(_ x: Float) {
+        self.x = Int(x)
+    }
+}
+
+// CHECK: static SWIFT_INLINE_THUNK WrapOverloadedInits init
+// CHECK-SAME: (swift::Int x) SWIFT_SYMBOL("s:4Init19WrapOverloadedInitsVyACSicfc");
+// CHECK-NOT: WrapOverloadedInits init(
+
 // CHECK: BaseClass BaseClass::init(swift::Int x, swift::Int y) {
 // CHECK-NEXT: return _impl::_impl_BaseClass::makeRetained(_impl::$s4Init9BaseClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<BaseClass>::getTypeMetadata()));
 

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -103,6 +103,35 @@ public final class PassStructInClassMethod {
 // CHECK-NEXT: static SWIFT_INLINE_THUNK void staticMethod() SWIFT_SYMBOL("s:7Methods11LargeStructV12staticMethodyyFZ");
 // CHECK-NEXT: private
 
+public struct WrapOverloadedMethods {
+    let x: Int
+
+    public func method(_ x: Int) {
+    }
+    public func method(_ x: Float) {
+    }
+    public func method(argLabel y: Int64) {
+    }
+}
+
+// CHECK: WrapOverloadedMethods final {
+// CHECK: SWIFT_INLINE_THUNK void method
+// CHECK-SAME: (swift::Int x) const SWIFT_SYMBOL("s:7Methods014WrapOverloadedA0V6methodyySiF");
+// CHECK-NEXT: private:
+
+public struct WrapOverloadedMethodsSibling {
+    let x: Int
+
+    // Sibling method with same name should be emitted.
+    public func method(_ x: Int) {
+    }
+}
+
+// CHECK: WrapOverloadedMethodsSibling final {
+// CHECK: SWIFT_INLINE_THUNK void method
+// CHECK-SAME: (swift::Int x) const SWIFT_SYMBOL("s:7Methods014WrapOverloadedA7SiblingV6methodyySiF");
+// CHECK-NEXT: private:
+
 public func createClassWithMethods(_ x: Int) -> ClassWithMethods {
     return ClassWithMethods(x)
 }

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -14,4 +14,4 @@ public enum UseFoundationEnum {
 
 #endif
 
-// CHECK-NOT: UseFoundationEnum
+// CHECK: class UseFoundationEnum { } SWIFT_UNAVAILABLE_MSG("Swift enum 'UseFoundationEnum' cannot be represented in C++"); 

--- a/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/foundation-type-not-exposed-by-default-to-cxx.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -typecheck %s -typecheck -module-name UseFoundation -enable-experimental-cxx-interop -emit-clang-header-path %t/UseFoundation.h
 // RUN: %FileCheck %s < %t/UseFoundation.h
 
-#if canImport(Foundation)
+// REQUIRES: objc_interop
 
 import Foundation
 
@@ -12,6 +12,4 @@ public enum UseFoundationEnum {
     case B
 }
 
-#endif
-
-// CHECK: class UseFoundationEnum { } SWIFT_UNAVAILABLE_MSG("Swift enum 'UseFoundationEnum' cannot be represented in C++"); 
+// CHECK: class UseFoundationEnum { } SWIFT_UNAVAILABLE_MSG("Swift enum 'UseFoundationEnum' cannot be represented in C++");

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -118,6 +118,7 @@
 // CHECK-NEXT: private:
 
 // CHECK: class AnyKeyPath { } SWIFT_UNAVAILABLE_MSG("class 'AnyKeyPath' is not yet exposed to C++");
+// CHECK: class Comparable { } SWIFT_UNAVAILABLE_MSG("protocol 'Comparable' can not yet be represented in C++");
 // CHECK: class FloatingPointSign { } SWIFT_UNAVAILABLE_MSG("enum 'FloatingPointSign' is not yet exposed to C++");
 // CHECK: // Unavailable in C++: Swift global function 'abs(_:)'.
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -117,6 +117,10 @@
 // CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
+// CHECK: class AnyKeyPath { } SWIFT_UNAVAILABLE_MSG("class 'AnyKeyPath' is not yet exposed to C++");
+// CHECK: class FloatingPointSign { } SWIFT_UNAVAILABLE_MSG("enum 'FloatingPointSign' is not yet exposed to C++");
+// CHECK: // Unavailable in C++: Swift global function 'abs(_:)'.
+
 // CHECK: #pragma clang diagnostic push
 // CHECK: #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
 // CHECK: #if __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)

--- a/test/Interop/SwiftToCxx/unsupported/unexposed-non-public-api-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unexposed-non-public-api-in-cxx.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/apis.h
+// RUN: %FileCheck %s < %t/apis.h
+
+internal func takeFloat(_ x: Float) {}
+
+private struct PrivateStruct { let x: Int }
+
+class InternalClass {
+    let x: Int
+    init() { self.x = 0 }
+}
+
+protocol InternalProto {}
+
+// CHECK: namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: } // namespace Functions

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-enums-in-cxx.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
-// CHECK-NOT: unsupported
+// RUN: %check-interop-cxx-header-in-clang(%t/header.h)
 
 public typealias FnType = () -> ()
 
@@ -32,3 +32,11 @@ public enum unsupportedEnumProtocolType {
     case A
     case B(Error)
 }
+
+// CHECK: class unsupportedEnumAssociatedValueType { } SWIFT_UNAVAILABLE_MSG("enum 'unsupportedEnumAssociatedValueType' can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++");
+// CHECK-EMPTY:
+// CHECK-NEXT: class unsupportedEnumIndirect { } SWIFT_UNAVAILABLE_MSG("indirect enum 'unsupportedEnumIndirect' can not yet be represented in C++");
+// CHECK-EMPTY:
+// CHECK-NEXT: class unsupportedEnumMultipleAssociatedValues { } SWIFT_UNAVAILABLE_MSG("enum 'unsupportedEnumMultipleAssociatedValues' can not yet be represented in C++ as one of its cases has multiple associated values");
+// CHECK-EMPTY:
+// CHECK-NEXT: class unsupportedEnumProtocolType { } SWIFT_UNAVAILABLE_MSG("enum 'unsupportedEnumProtocolType' can not be represented in C++ as one of its cases has an associated value with type that can't be represented in C++");

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
@@ -5,10 +5,7 @@
 // RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
-// CHECK-NOT: unsupported
-// CHECK: HasMethods
-// CHECK: supported
-// CHECK-NOT: unsupported
+// RUN: %check-interop-cxx-header-in-clang(%t/header.h)
 
 public func supported() {}
 
@@ -44,3 +41,10 @@ public struct HasMethods {
         return false
     }
 }
+
+// CHECK: HasMethods
+// CHECK: supported
+
+// CHECK: // Unavailable in C++: Swift global function 'unsupportedAEIC()'.
+// CHECK-EMPTY:
+// CHECK-NEXT: // Unavailable in C++: Swift global function 'unsupportedThrows()'.

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -5,8 +5,7 @@
 // RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Decls -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/decls.h
 // RUN: %FileCheck %s < %t/decls.h
 
-// CHECK-NOT: unsupported
-// CHECK: supported
+// RUN: %check-interop-cxx-header-in-clang(%t/decls.h)
 
 public protocol Proto { init() }
 
@@ -35,3 +34,13 @@ public enum unsupportedGenericEnum<T: Proto> {
     case A
     case B(T)
 }
+
+// CHECK: supported
+
+// CHECK: // Unavailable in C++: Swift global function 'unsupportedFunc(_:)'.
+
+// CHECK: class unsupportedGenericClass { } SWIFT_UNAVAILABLE_MSG("generic generic class 'unsupportedGenericClass' can not yet be exposed to C++");
+// CHECK-EMPTY:
+// CHECK-NEXT: class unsupportedGenericEnum { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic enum 'unsupportedGenericEnum' can not yet be represented in C++");
+// CHECK-EMPTY:
+// CHECK-NEXT: class unsupportedGenericStruct { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'unsupportedGenericStruct' can not yet be represented in C++");

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -11,6 +11,11 @@ public func takesTuple(_ x: (Float, Float)) {}
 public func takesVoid(_ x: ()) {}
 
 // CHECK:     takeFloat
+
+protocol TestProtocol {}
+
+// CHECK: class TestProtocol { } SWIFT_UNAVAILABLE_MSG("protocol 'TestProtocol' can not yet be represented in C++");
+
 // CHECK: // Unavailable in C++: Swift global function 'takesTuple(_:)'.
 // CHECK: // Unavailable in C++: Swift global function 'takesVoid(_:)'.
 

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -12,13 +12,27 @@ public func takesVoid(_ x: ()) {}
 
 // CHECK:     takeFloat
 
-protocol TestProtocol {}
+@_moveOnly
+public enum MoveOnlyEnum {
+    case a
+}
+
+// CHECK: class MoveOnlyEnum { } SWIFT_UNAVAILABLE_MSG("move-only enum 'MoveOnlyEnum' can not yet be represented in C++");
+
+@_moveOnly
+public struct MoveOnlyStruct {
+    let x: Int
+}
+
+// CHECK: class MoveOnlyStruct { } SWIFT_UNAVAILABLE_MSG("move-only struct 'MoveOnlyStruct' can not yet be represented in C++");
+
+public protocol TestProtocol {}
 
 // CHECK: class TestProtocol { } SWIFT_UNAVAILABLE_MSG("protocol 'TestProtocol' can not yet be represented in C++");
 
 // CHECK: // Unavailable in C++: Swift global function 'takesTuple(_:)'.
 // CHECK: // Unavailable in C++: Swift global function 'takesVoid(_:)'.
 
-typealias unsupportedTypeAlias = () -> (Float, Float)
+public typealias unsupportedTypeAlias = () -> (Float, Float)
 
 // CHECK: // Unavailable in C++: Swift type alias 'unsupportedTypeAlias'

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -4,11 +4,16 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK:     takeFloat
-// CHECK-NOT: takes
-
 public func takeFloat(_ x: Float) {}
 
 public func takesTuple(_ x: (Float, Float)) {}
 
 public func takesVoid(_ x: ()) {}
+
+// CHECK:     takeFloat
+// CHECK: // Unavailable in C++: Swift global function 'takesTuple(_:)'.
+// CHECK: // Unavailable in C++: Swift global function 'takesVoid(_:)'.
+
+typealias unsupportedTypeAlias = () -> (Float, Float)
+
+// CHECK: // Unavailable in C++: Swift type alias 'unsupportedTypeAlias'


### PR DESCRIPTION
[interop][SwiftToCxx] emit unavailable type stubs for top level types that could not be emitted in the C++ section of the generated header

[interop][SwiftToCxx] avoid emitting ambiguous C++ overloads
Just do an arity check for now

[interop][SwiftToCxx] do not expose move-only Swift types