### PR TITLE
Fix missing indexing data with overloaded type

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -1145,11 +1145,10 @@ public:
 class FixedTypeRepr : public TypeRepr {
   Type Ty;
   SourceLoc Loc;
-  bool IsSelf;
 
 public:
-  FixedTypeRepr(Type Ty, SourceLoc Loc, bool IsSelf = false)
-    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc), IsSelf(IsSelf) {}
+  FixedTypeRepr(Type Ty, SourceLoc Loc)
+    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc) {}
 
   // SmallVector::emplace_back will never need to call this because
   // we reserve the right size, but it does try statically.
@@ -1160,9 +1159,6 @@ public:
   /// Retrieve the location.
   SourceLoc getLoc() const { return Loc; }
 
-  /// Retrieve whether this was written as 'Self'.
-  bool getIsSelf() const { return IsSelf; }
-
   /// Retrieve the fixed type.
   Type getType() const { return Ty; }
 
@@ -1170,6 +1166,33 @@ public:
     return T->getKind() == TypeReprKind::Fixed;
   }
   static bool classof(const FixedTypeRepr *T) { return true; }
+
+private:
+  SourceLoc getStartLocImpl() const { return Loc; }
+  SourceLoc getEndLocImpl() const { return Loc; }
+  void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
+  friend class TypeRepr;
+};
+
+/// A TypeRepr for uses of 'Self' in the type of a declaration.
+class SelfTypeRepr : public TypeRepr {
+  Type Ty;
+  SourceLoc Loc;
+
+public:
+  SelfTypeRepr(Type Ty, SourceLoc Loc)
+    : TypeRepr(TypeReprKind::Self), Ty(Ty), Loc(Loc) {}
+
+  /// Retrieve the location.
+  SourceLoc getLoc() const { return Loc; }
+
+  /// Retrieve the fixed type.
+  Type getType() const { return Ty; }
+
+  static bool classof(const TypeRepr *T) {
+    return T->getKind() == TypeReprKind::Self;
+  }
+  static bool classof(const SelfTypeRepr *T) { return true; }
 
 private:
   SourceLoc getStartLocImpl() const { return Loc; }
@@ -1438,6 +1461,7 @@ inline bool TypeRepr::isSimple() const {
   case TypeReprKind::Pack:
   case TypeReprKind::Tuple:
   case TypeReprKind::Fixed:
+  case TypeReprKind::Self:
   case TypeReprKind::Array:
   case TypeReprKind::SILBox:
   case TypeReprKind::Isolated:

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -1145,10 +1145,11 @@ public:
 class FixedTypeRepr : public TypeRepr {
   Type Ty;
   SourceLoc Loc;
+  bool IsSelf;
 
 public:
-  FixedTypeRepr(Type Ty, SourceLoc Loc)
-    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc) {}
+  FixedTypeRepr(Type Ty, SourceLoc Loc, bool IsSelf = false)
+    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc), IsSelf(IsSelf) {}
 
   // SmallVector::emplace_back will never need to call this because
   // we reserve the right size, but it does try statically.
@@ -1158,6 +1159,9 @@ public:
 
   /// Retrieve the location.
   SourceLoc getLoc() const { return Loc; }
+
+  /// Retrieve whether this was written as 'Self'.
+  bool getIsSelf() const { return IsSelf; }
 
   /// Retrieve the fixed type.
   Type getType() const { return Ty; }

--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -74,7 +74,8 @@ ABSTRACT_TYPEREPR(Specifier, TypeRepr)
   SPECIFIER_TYPEREPR(CompileTimeConst, SpecifierTypeRepr)
 TYPEREPR(Fixed, TypeRepr)
 TYPEREPR(SILBox, TypeRepr)
-LAST_TYPEREPR(SILBox)
+TYPEREPR(Self, TypeRepr)
+LAST_TYPEREPR(Self)
 
 #undef SPECIFIER_TYPEREPR
 #undef ABSTRACT_TYPEREPR

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3335,6 +3335,22 @@ public:
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
+  void visitSelfTypeRepr(SelfTypeRepr *T) {
+    printCommon("type_self");
+    auto Ty = T->getType();
+    if (Ty) {
+      auto &srcMgr =  Ty->getASTContext().SourceMgr;
+      if (T->getLoc().isValid()) {
+        OS << " location=@";
+        T->getLoc().print(OS, srcMgr);
+      } else {
+        OS << " location=<<invalid>>";
+      }
+    }
+    OS << " type="; Ty.dump(OS);
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+  }
+
   void visitSILBoxTypeRepr(SILBoxTypeRepr *T) {
     printCommon("sil_box");
     Indent += 2;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -2166,6 +2166,10 @@ bool Traversal::visitFixedTypeRepr(FixedTypeRepr *T) {
   return false;
 }
 
+bool Traversal::visitSelfTypeRepr(SelfTypeRepr *T) {
+  return false;
+}
+
 bool Traversal::visitSILBoxTypeRepr(SILBoxTypeRepr *T) {
   for (auto &field : T->getFields()) {
     if (doIt(field.getFieldType()))

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2773,6 +2773,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
 
   case TypeReprKind::Fixed:
     llvm_unreachable("Cannot get fixed TypeReprs in name lookup");
+  case TypeReprKind::Self:
+    llvm_unreachable("Cannot get fixed SelfTypeRepr in name lookup");
 
   case TypeReprKind::Optional:
   case TypeReprKind::ImplicitlyUnwrappedOptional:

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -629,6 +629,11 @@ void FixedTypeRepr::printImpl(ASTPrinter &Printer,
   getType().print(Printer, Opts);
 }
 
+void SelfTypeRepr::printImpl(ASTPrinter &Printer,
+                             const PrintOptions &Opts) const {
+  getType().print(Printer, Opts);
+}
+
 void SILBoxTypeRepr::printImpl(ASTPrinter &Printer,
                                const PrintOptions &Opts) const {
   // TODO

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -634,13 +634,15 @@ ASTWalker::PreWalkAction SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
       return Action::StopIf(!Continue);
     }
   } else if (auto FT = dyn_cast<FixedTypeRepr>(T)) {
+    auto Data = ReferenceMetaData(SemaReferenceKind::TypeRef, None);
+    Data.isImplicitCtorType = FT->getIsSelf();
     ValueDecl *VD = FT->getType()->getAnyGeneric();
-    if (auto DT = FT->getType()->getAs<DynamicSelfType>())
+    if (auto DT = FT->getType()->getAs<DynamicSelfType>()) {
       VD = DT->getSelfType()->getAnyGeneric();
+      Data.isImplicitCtorType = true;
+    }
 
     if (VD) {
-      auto Data = ReferenceMetaData(SemaReferenceKind::TypeRef, None);
-      Data.isImplicitCtorType = true;
       auto Continue = passReference(VD, FT->getType(), FT->getLoc(),
                                     FT->getSourceRange(), Data);
       return Action::StopIf(!Continue);

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -636,6 +636,7 @@ ASTWalker::PreWalkAction SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
   } else if (auto FT = dyn_cast<FixedTypeRepr>(T)) {
     if (ValueDecl *VD = FT->getType()->getAnyGeneric()) {
       auto Data = ReferenceMetaData(SemaReferenceKind::TypeRef, None);
+      Data.isImplicitCtorType = true;
       auto Continue = passReference(VD, FT->getType(), FT->getLoc(),
                                     FT->getSourceRange(), Data);
       return Action::StopIf(!Continue);

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -220,6 +220,10 @@ public:
   FoundResult visitFixedTypeRepr(FixedTypeRepr *T) {
     return handleParent(T, ArrayRef<TypeRepr*>());
   }
+
+  FoundResult visitSelfTypeRepr(SelfTypeRepr *T) {
+    return handleParent(T, ArrayRef<TypeRepr*>());
+  }
 };
 
 struct ConversionFunctionInfo {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -624,12 +624,19 @@ namespace {
                               locator, implicit, semantics);
       }
 
-      if (isa<TypeDecl>(decl) && !isa<ModuleDecl>(decl)) {
-        auto typeExpr = TypeExpr::createImplicitHack(
-            loc.getBaseNameLoc(), adjustedFullType->getMetatypeInstanceType(), ctx);
-        typeExpr->setImplicit(implicit);
-        cs.cacheType(typeExpr);
-        return typeExpr;
+      if (auto *typeDecl = dyn_cast<TypeDecl>(decl)) {
+        if (!isa<ModuleDecl>(decl)) {
+          TypeExpr *typeExpr = nullptr;
+          if (implicit) {
+            typeExpr = TypeExpr::createImplicitHack(
+                loc.getBaseNameLoc(), adjustedFullType->getMetatypeInstanceType(), ctx);
+          } else {
+            typeExpr = TypeExpr::createForDecl(loc, typeDecl, dc);
+            typeExpr->setType(adjustedFullType);
+          }
+          cs.cacheType(typeExpr);
+          return typeExpr;
+        }
       }
 
       auto ref = resolveConcreteDeclRef(decl, locator);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -627,6 +627,7 @@ namespace {
       if (isa<TypeDecl>(decl) && !isa<ModuleDecl>(decl)) {
         auto typeExpr = TypeExpr::createImplicitHack(
             loc.getBaseNameLoc(), adjustedFullType->getMetatypeInstanceType(), ctx);
+        typeExpr->setImplicit(implicit);
         cs.cacheType(typeExpr);
         return typeExpr;
       }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -597,7 +597,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
           if (typeContext->getSelfClassDecl())
             SelfType = DynamicSelfType::get(SelfType, Context);
           return new (Context)
-              TypeExpr(new (Context) FixedTypeRepr(SelfType, Loc));
+              TypeExpr(new (Context) FixedTypeRepr(SelfType, Loc, /*IsSelf=*/true));
         }
       }
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -597,7 +597,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
           if (typeContext->getSelfClassDecl())
             SelfType = DynamicSelfType::get(SelfType, Context);
           return new (Context)
-              TypeExpr(new (Context) FixedTypeRepr(SelfType, Loc, /*IsSelf=*/true));
+              TypeExpr(new (Context) SelfTypeRepr(SelfType, Loc));
         }
       }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2555,6 +2555,9 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
 
   case TypeReprKind::Fixed:
     return cast<FixedTypeRepr>(repr)->getType();
+
+  case TypeReprKind::Self:
+    return cast<SelfTypeRepr>(repr)->getType();
   }
   llvm_unreachable("all cases should be handled");
 }
@@ -5203,6 +5206,7 @@ public:
     case TypeReprKind::ImplicitlyUnwrappedOptional:
     case TypeReprKind::Tuple:
     case TypeReprKind::Fixed:
+    case TypeReprKind::Self:
     case TypeReprKind::Array:
     case TypeReprKind::SILBox:
     case TypeReprKind::Isolated:

--- a/test/Index/index_ambiguous_type.swift
+++ b/test/Index/index_ambiguous_type.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Validate that we get index references for almost ambiguous types
+
+// RUN: %target-swift-frontend -emit-module -o %t %t/file1.swift
+// RUN: %target-swift-frontend -emit-module -o %t %t/file2.swift
+
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/file3.swift -I %t > %t/output.txt
+// RUN: %FileCheck %s < %t/output.txt
+
+//--- file1.swift
+public struct Thing {
+  public init(string: String) {}
+
+  public struct Nested {
+    public init(string: String) {}
+  }
+
+  public struct Nested2<T> {
+    public init(value: T) {}
+  }
+}
+//--- file2.swift
+public struct Thing {}
+
+//--- file3.swift
+import file1
+import file2
+
+func foo() {
+  // CHECK: 7:7 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 7:7 | constructor/Swift | init(string:) | s:5file15ThingV6stringACSS_tcfc | Ref,Call,RelCall,RelCont | rel: 1
+  _ = Thing(string: "lol")
+  // CHECK: 10:7 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 10:13 | constructor/Swift | init(string:) | s:5file15ThingV6stringACSS_tcfc | Ref,Call,RelCall,RelCont | rel: 1
+  _ = Thing.init(string: "lol")
+  // CHECK: 14:7 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 14:13 | struct/Swift | Nested | s:5file15ThingV6NestedV | Ref,RelCont | rel: 1
+  // TODO: 14:13 | constructor/Swift | init(string:)
+  _ = Thing.Nested(string: "lol")
+  // CHECK: 18:7 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 18:13 | struct/Swift | Nested | s:5file15ThingV6NestedV | Ref,RelCont | rel: 1
+  // CHECK: 18:20 | constructor/Swift | init(string:) | s:5file15ThingV6NestedV6stringAESS_tcfc | Ref,Call,RelCall,RelCont | rel: 1
+  _ = Thing.Nested.init(string: "lol")
+  // CHECK: 23:7 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 23:13 | struct/Swift | Nested2 | s:5file15ThingV7Nested2V | Ref,RelCont | rel: 1
+  // TODO: 23:13 | constructor/Swift | init(value:)
+  // TODO: 23:21 | struct/Swift | Int | s:Si | Ref,RelCont | rel: 1
+  _ = Thing.Nested2<Int>(value: 0)
+  // CHECK: 28:7 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 28:13 | struct/Swift | Nested2 | s:5file15ThingV7Nested2V | Ref,RelCont | rel: 1
+  // TODO: 28:21 | struct/Swift | Int | s:Si | Ref,RelCont | rel: 1
+  // CHECK: 28:26 | constructor/Swift | init(value:) | s:5file15ThingV7Nested2V5valueAEy_xGx_tcfc | Ref,Call,RelCall,RelCont | rel: 1
+  _ = Thing.Nested2<Int>.init(value: 0)
+  // CHECK: 34:7 | module/Swift | file1 | c:@M@file1 | Ref,RelCont | rel: 1
+  // CHECK: 34:13 | struct/Swift | Thing | s:5file15ThingV | Ref,RelCont | rel: 1
+  // CHECK: 34:19 | struct/Swift | Nested2 | s:5file15ThingV7Nested2V | Ref,RelCont | rel: 1
+  // CHECK: 34:19 | constructor/Swift | init(value:) | s:5file15ThingV7Nested2V5valueAEy_xGx_tcfc | Ref,Call,RelCall,RelCont | rel: 1
+  // CHECK: 34:27 | struct/Swift | Int | s:Si | Ref,RelCont | rel: 1
+  _ = file1.Thing.Nested2<Int>(value: 0)
+}


### PR DESCRIPTION
When you have a type that's ambiguous because it's defined in 2 imported modules, but you don't have to disambiguate by using the module name, previously no index references were produced. Now most are for the common case, but notably nested type constructors and generics still aren't emitted, partially because of https://github.com/apple/swift/issues/65726

Fixes: https://github.com/apple/swift/issues/64598