### PR TITLE
[Executors] Fix delegation chain of Excecutor.enqueue for Job specifically

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -102,12 +102,16 @@ public protocol SerialExecutor: Executor {
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.9, *)
 extension Executor {
+
+  // Delegation goes like this:
+  // Unowned Job -> Executor Job -> Job -> ---||---
+
   public func enqueue(_ job: UnownedJob) {
     self.enqueue(ExecutorJob(job))
   }
 
   public func enqueue(_ job: __owned ExecutorJob) {
-    self.enqueue(UnownedJob(job))
+    self.enqueue(Job(job))
   }
 
   public func enqueue(_ job: __owned Job) {

--- a/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
+++ b/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
@@ -9,30 +9,51 @@
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 
-final class InlineExecutor: SerialExecutor, CustomStringConvertible {
+final class InlineExecutor_UnownedJob: SerialExecutor, CustomStringConvertible {
   public func enqueue(_ job: UnownedJob) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }
+
+  var description: Swift.String {
+    "\(Self.self)()"
+  }
+}
+final class InlineExecutor_Job: SerialExecutor, CustomStringConvertible {
   public func enqueue(_ job: __owned Job) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }
+
+  var description: Swift.String {
+    "\(Self.self)()"
+  }
+}
+
+final class InlineExecutor_ExecutorJob: SerialExecutor, CustomStringConvertible {
   public func enqueue(_ job: __owned ExecutorJob) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }
 
   var description: Swift.String {
-    "InlineExecutor()"
+    "\(Self.self)()"
   }
 }
 
-let inlineExecutor = InlineExecutor()
+let inlineExecutor_UnownedJob = InlineExecutor_UnownedJob()
+let inlineExecutor_Job = InlineExecutor_Job()
+let inlineExecutor_ExecutorJob = InlineExecutor_ExecutorJob()
 
 actor Custom {
   var count = 0
 
+  let selectedExecutor: any SerialExecutor
+
   nonisolated var unownedExecutor: UnownedSerialExecutor {
-    print("custom unownedExecutor")
-    return inlineExecutor.asUnownedSerialExecutor()
+    print("unownedExecutor: \(self.selectedExecutor)")
+    return selectedExecutor.asUnownedSerialExecutor()
+  }
+
+  init(selectedExecutor: some SerialExecutor) {
+    self.selectedExecutor = selectedExecutor
   }
 
   func report() async {
@@ -44,20 +65,40 @@ actor Custom {
 @available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
-    print("begin")
-    let actor = Custom()
-    await actor.report()
-    await actor.report()
-    await actor.report()
+    print("begin - unowned")
+    let one = Custom(selectedExecutor: inlineExecutor_UnownedJob)
+    await one.report()
+    await one.report()
+
+    print("begin - job")
+    let two = Custom(selectedExecutor: inlineExecutor_Job)
+    await two.report()
+    await two.report()
+
+    print("begin - executor job")
+    let three = Custom(selectedExecutor: inlineExecutor_ExecutorJob)
+    await three.report()
+    await three.report()
+
     print("end")
   }
 }
 
-// CHECK:      begin
-// CHECK-NEXT: custom unownedExecutor
+// CHECK:      begin - unowned
+// CHECK-NEXT: unownedExecutor: InlineExecutor_UnownedJob
 // CHECK-NEXT: custom.count == 0
-// CHECK-NEXT: custom unownedExecutor
+// CHECK-NEXT: unownedExecutor: InlineExecutor_UnownedJob
 // CHECK-NEXT: custom.count == 1
-// CHECK-NEXT: custom unownedExecutor
-// CHECK-NEXT: custom.count == 2
+
+// CHECK:      begin - job
+// CHECK-NEXT: unownedExecutor: InlineExecutor_Job
+// CHECK-NEXT: custom.count == 0
+// CHECK-NEXT: unownedExecutor: InlineExecutor_Job
+// CHECK-NEXT: custom.count == 1
+
+// CHECK:      begin - executor job
+// CHECK-NEXT: unownedExecutor: InlineExecutor_ExecutorJob
+// CHECK-NEXT: custom.count == 0
+// CHECK-NEXT: unownedExecutor: InlineExecutor_ExecutorJob
+// CHECK-NEXT: custom.count == 1
 // CHECK-NEXT: end


### PR DESCRIPTION
Resolves: rdar://108788736

Since we now have THREE overloads of enqueue and must allow implementing just ONE of them, the delegation pattern must form a ring:  `Unowned Job -> Executor Job -> Job -> ---||---` we didn't do this and delegated to UnownedJob based on directly from ExecutorJob which would have caused an infinite cycle if only (_deprecated_) `Job` based enqueue was implemented. We issue warnings in typechecking and **require** that one of these methods will be implemented already, so the "cyclic delegation" is always safe -- at least one of the methods will break the cycle by having an end user implement it.

