### PR TITLE
[5.9][Macros] Terminate parsing expanded members if no progress is made

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2084,10 +2084,10 @@ WARNING(macro_expression_attribute_removed,PointsToFirstBadToken,
       "@expression has been removed in favor of @freestanding(expression)", ())
 
 ERROR(unexpected_attribute_expansion,PointsToFirstBadToken,
-      "unexpected token '%0' in expanded attribute list'",
+      "unexpected token '%0' in expanded attribute list",
       (StringRef))
 ERROR(unexpected_member_expansion,PointsToFirstBadToken,
-      "unexpected token '%0' in expanded member list'",
+      "unexpected token '%0' in expanded member list",
       (StringRef))
 
 ERROR(parser_round_trip_error,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7314,10 +7314,14 @@ void Parser::parseExpandedMemberList(SmallVectorImpl<ASTNode> &items) {
   auto *idc = dyn_cast<IterableDeclContext>(decl);
   bool previousHadSemi = true;
 
+  SourceLoc startingLoc = Tok.getLoc();
   while (!Tok.is(tok::eof)) {
     parseDeclItem(previousHadSemi,
                   getMemberParseDeclOptions(idc),
                   [&](Decl *d) { items.push_back(d); });
+
+    if (Tok.getLoc() == startingLoc)
+      break;
   }
 
   // Consume remaining tokens.

--- a/test/Macros/macro_invalid.swift
+++ b/test/Macros/macro_invalid.swift
@@ -1,0 +1,40 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// Create the plugin
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroPlugin) -module-name=MacroPlugin %t/MacroPlugin.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroPlugin) -module-name TestModule %t/TestModule.swift 2>&1 | %FileCheck %s
+// CHECK: unexpected token '}' in expanded member list
+
+//--- MacroPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct InvalidMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let invalidMember: DeclSyntax =
+      """
+      // no member here
+      }
+      """
+
+    return [
+      invalidMember
+    ]
+  }
+}
+
+//--- TestModule.swift
+@attached(member)
+public macro InvalidMember() = #externalMacro(module: "MacroPlugin", type: "InvalidMemberMacro")
+
+@InvalidMember
+struct TestStruct { }


### PR DESCRIPTION
* Explanation: A macro plugin producing an invalid member could cause an infinite loop during parsing.
* Scope: Macros
* Risk: Very low, terminates a parsing loop when no progress has been made.
* Testing: Added a test for the invalid case. Existing tests check correct parsing of members.
* Original PR: https://github.com/apple/swift/pull/65737