### PR TITLE
[cxx-interop] Do not mix up computed properties from different records

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2437,7 +2437,7 @@ namespace {
           structResult->setIsCxxNonTrivial(
               isNonTrivialForPurposeOfCalls(cxxRecordDecl));
 
-        for (auto &getterAndSetter : Impl.GetterSetterMap) {
+        for (auto &getterAndSetter : Impl.GetterSetterMap[result]) {
           auto getter = getterAndSetter.second.first;
           auto setter = getterAndSetter.second.second;
           // We cannot make a computed property without a getter.
@@ -3521,13 +3521,17 @@ namespace {
 
       if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties ||
           hasComputedPropertyAttr(decl)) {
-        CXXMethodBridging bridgingInfo(decl);
-        if (bridgingInfo.classify() == CXXMethodBridging::Kind::getter) {
-          auto name = bridgingInfo.getClangName().drop_front(3);
-          Impl.GetterSetterMap[name].first = static_cast<FuncDecl *>(method);
-        } else if (bridgingInfo.classify() == CXXMethodBridging::Kind::setter) {
-          auto name = bridgingInfo.getClangName().drop_front(3);
-          Impl.GetterSetterMap[name].second = static_cast<FuncDecl *>(method);
+        if (auto funcDecl = dyn_cast_or_null<FuncDecl>(method)) {
+          auto parent = funcDecl->getParent()->getSelfNominalTypeDecl();
+          CXXMethodBridging bridgingInfo(decl);
+          if (bridgingInfo.classify() == CXXMethodBridging::Kind::getter) {
+            auto name = bridgingInfo.getClangName().drop_front(3);
+            Impl.GetterSetterMap[parent][name].first = funcDecl;
+          } else if (bridgingInfo.classify() ==
+                     CXXMethodBridging::Kind::setter) {
+            auto name = bridgingInfo.getClangName().drop_front(3);
+            Impl.GetterSetterMap[parent][name].second = funcDecl;
+          }
         }
       }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -603,7 +603,10 @@ public:
   /// Keep track of subscript declarations based on getter/setter
   /// pairs.
   llvm::DenseMap<std::pair<FuncDecl *, FuncDecl *>, SubscriptDecl *> Subscripts;
-  llvm::DenseMap<llvm::StringRef, std::pair<FuncDecl *, FuncDecl *>>
+
+  llvm::DenseMap<
+      NominalTypeDecl *,
+      llvm::DenseMap<llvm::StringRef, std::pair<FuncDecl *, FuncDecl *>>>
       GetterSetterMap;
 
   /// Keep track of getter/setter pairs for functions imported from C++

--- a/test/Interop/Cxx/ergonomics/explicit-computed-properties-typechecker.swift
+++ b/test/Interop/Cxx/ergonomics/explicit-computed-properties-typechecker.swift
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-build-swift %t/test.swift -I %t/Inputs -Xfrontend -enable-experimental-cxx-interop -typecheck
+
+//--- Inputs/module.modulemap
+module Test {
+  header "test.h"
+  requires cplusplus
+}
+
+//--- Inputs/test.h
+
+#define SWIFT_COMPUTED_PROPERTY \
+__attribute__((swift_attr("import_computed_property")))
+
+struct FirstRecordWithX {
+  int getX() const SWIFT_COMPUTED_PROPERTY { return 42; }
+};
+
+struct SecondRecordWithXUsesFirst {
+  int getX() const SWIFT_COMPUTED_PROPERTY { return 21; }
+
+  const FirstRecordWithX * getY() const { return nullptr; }
+};
+
+//--- test.swift
+
+import Test
+
+func test(_ val: SecondRecordWithXUsesFirst) {
+  let _ = val.x
+}


### PR DESCRIPTION
If two different C++ structs have methods with the same name, both annotated with `SWIFT_COMPUTED_PROPERTY`, ClangImporter previously confused them when one of the structs referenced the other struct.

rdar://108990490 / resolves https://github.com/apple/swift/issues/65675