### PR TITLE
[AST] Allocate PlaceholderTypes in the correct arena

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8475,8 +8475,8 @@ namespace {
       exprType = solution.simplifyType(exprType);
       // assert((!expr->getType() || expr->getType()->isEqual(exprType)) &&
       //       "Mismatched types!");
-      assert(!exprType->hasTypeVariable() &&
-             "Should not write type variable into expression!");
+      assert(!exprType->getRecursiveProperties().isSolverAllocated() &&
+             "Should not write solver allocated type into expression!");
       assert(!exprType->hasPlaceholder() &&
              "Should not write type placeholders into expression!");
       expr->setType(exprType);
@@ -8486,8 +8486,10 @@ namespace {
           Type componentType;
           if (cs.hasType(kp, i)) {
             componentType = solution.simplifyType(cs.getType(kp, i));
-            assert(!componentType->hasTypeVariable() &&
-                   "Should not write type variable into key-path component");
+            assert(
+                !componentType->getRecursiveProperties().isSolverAllocated() &&
+                "Should not write solver allocated type into key-path "
+                "component!");
             assert(!componentType->hasPlaceholder() &&
                    "Should not write type placeholder into key-path component");
             kp->getMutableComponents()[i].setComponentType(componentType);

--- a/test/Constraints/rdar44770297.swift
+++ b/test/Constraints/rdar44770297.swift
@@ -8,4 +8,8 @@ func foo<T: P>(_: () throws -> T) -> T.A? { // expected-note {{where 'T' = 'Neve
   fatalError()
 }
 
-let _ = foo() {fatalError()} & nil // expected-error {{global function 'foo' requires that 'Never' conform to 'P'}}
+let _ = foo() {fatalError()} & nil
+// expected-error@-1 {{global function 'foo' requires that 'Never' conform to 'P'}}
+// expected-error@-2 {{value of optional type 'Never.A?' must be unwrapped to a value of type 'Never.A'}}
+// expected-note@-3 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+// expected-note@-4 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-65360.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-65360.swift
@@ -13,7 +13,8 @@ let _: () -> Void = {
   // expected-error@-1 {{cannot convert value of type 'Any?' to specified type '(_, _)}}
 }
 
-let _: () -> Void = { // expected-error {{unable to infer closure type in the current context}}
+let _: () -> Void = {
   for case (0)? in [a] {}
   for case (0, 0) in [a] {}
+  // expected-error@-1 {{cannot convert value of type 'Any?' to expected element type '(_, _)'}}
 }


### PR DESCRIPTION
Second attempt at 97be0424b4afeb47973f0a1544cc89a762d9bac6.

We shouldn't be allocating placeholders for type variables in the permanent arena, and we should be caching them such that equality works.

To achieve this, we need to introduce a new "solver allocated" type property. This is required because we don't want to mark placeholder types with type variable originators as themselves having type variables, as it's not part of their structural type. Also update ErrorType to use this bit, though I don't believe we currently create ErrorTypes with type variable originators.