### PR TITLE
[Parser] Check let/var context when fix-it moving attributes from type to decl

### DIFF
--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -348,3 +348,21 @@ enum E1 {
 }
 
 @_custom func testCustomAttribute() {} // expected-error {{unknown attribute '_custom'}}
+
+// https://github.com/apple/swift/issues/65705
+struct GI65705<A> {}
+struct I65705 {
+  let m1: @discardableResult () -> Int // expected-error {{attribute can only be applied to declarations, not types}} {{11-30=}} {{none}}
+  var m2: @discardableResult () -> Int // expected-error {{attribute can only be applied to declarations, not types}} {{11-30=}} {{none}}
+  let m3: GI65705<@discardableResult () -> Int> // expected-error{{attribute can only be applied to declarations, not types}} {{19-37=}} {{none}}
+
+  func f1(_: inout @discardableResult Int) {} // expected-error {{attribute can only be applied to declarations, not types}} {{20-39=}} {{3-3=@discardableResult }} {{none}}
+  func f2(_: @discardableResult Int) {} // expected-error {{attribute can only be applied to declarations, not types}} {{14-33=}} {{3-3=@discardableResult }} {{none}}
+
+  func stmt(_ a: Int?) {
+    if let _: @discardableResult Int = a { // expected-error {{attribute can only be applied to declarations, not types}} {{15-34=}} 
+    }
+    if var _: @discardableResult Int = a { // expected-error {{attribute can only be applied to declarations, not types}} {{15-34=}}
+    }
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Very small diagnostic QOI one
When in a declaration, the fix-it to move the attribute cannot be applied in all cases. So doing extra checks to be more conservative and add a couple of more test for this. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/65705

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
