### PR TITLE
[5.9][interop] do not import function template with templated rvalue / per…

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2337,6 +2337,12 @@ ClangImporter::Implementation::importParameterType(
       return None;
   } else if (isa<clang::ReferenceType>(paramTy) &&
              isa<clang::TemplateTypeParmType>(paramTy->getPointeeType())) {
+    // We don't support rvalue reference / universal perfect ref, bail.
+    if (paramTy->isRValueReferenceType()) {
+      addImportDiagnosticFn(Diagnostic(diag::rvalue_ref_params_not_imported));
+      return None;
+    }
+
     auto templateParamType =
         cast<clang::TemplateTypeParmType>(paramTy->getPointeeType());
     swiftParamTy = findGenericTypeInGenericDecls(

--- a/test/Interop/Cxx/reference/reference-cannot-import-diagnostic.swift
+++ b/test/Interop/Cxx/reference/reference-cannot-import-diagnostic.swift
@@ -1,5 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop
 // RUN: not %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 //--- Inputs/module.modulemap
@@ -12,13 +13,20 @@ module Test {
 
 void acceptRValueRef(int &&);
 
+template<class T>
+void notStdMove(T &&);
+
 //--- test.swift
 
 import Test
 
 public func test() {
   var x: CInt = 2
-  acceptRValueRef(x)
+  acceptRValueRef(x) // expected-error {{cannot find 'acceptRValueRef' in scope}}
   // CHECK: note: function 'acceptRValueRef' unavailable (cannot import)
+  // CHECK: note: C++ functions with rvalue reference parameters are unavailable in Swift
+
+  notStdMove(x) // expected-error {{cannot find 'notStdMove' in scope}}
+  // CHECK: note: function 'notStdMove' unavailable (cannot import)
   // CHECK: note: C++ functions with rvalue reference parameters are unavailable in Swift
 }

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -20,7 +20,6 @@
 
 // CHECK: func lvalueReference<T>(_ ref: inout T)
 // CHECK: func constLvalueReference<T>(_: T)
-// CHECK: func forwardingReference<T>(_: inout T)
 // CHECK: func PointerTemplateParameter<T>(_: UnsafeMutablePointer<T>)
 
 // CHECK: enum Orbiters {


### PR DESCRIPTION
…fect forwarding ref

they can cause compiler crashes

(cherry picked from commit 196c717a3ddf9c62ceac1ec53ae376cb6a00bcb1)

Explanation: C++ templated universal references `T &&` are not fully yet supported and lead to compiler crashes for some types. Disable them for now.
Scope: Swift's and C++ interoperability, clang importer, type importer
Risk: Low. This only affects C++ templated functions.
Testing: Swift unit tests, manual testing on some adopter projects and several Swift packages that import C.
PR: https://github.com/apple/swift/pull/65665
Reviewer: @egorzhdan 