### PR TITLE
[5.9][interop][SwiftToCxx] avoid importing C++ stdlib in C++ section of ge…

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -542,14 +542,19 @@ static void writePostImportPrologue(raw_ostream &os, ModuleDecl &M) {
         "#endif\n\n";
 }
 
+static void writeObjCEpilogue(raw_ostream &os) {
+  // Pop out of `external_source_symbol` attribute
+  // before emitting the C++ section as the C++ section
+  // might include other files in it.
+  os << "#if __has_attribute(external_source_symbol)\n"
+        "# pragma clang attribute pop\n"
+        "#endif\n";
+}
+
 static void writeEpilogue(raw_ostream &os) {
-  os <<
-      "#if __has_attribute(external_source_symbol)\n"
-      "# pragma clang attribute pop\n"
-      "#endif\n"
-      "#pragma clang diagnostic pop\n"
-      // For the macro guard against recursive definition
-      "#endif\n";
+  os << "#pragma clang diagnostic pop\n"
+        // For the macro guard against recursive definition
+        "#endif\n";
 }
 
 static std::string computeMacroGuard(const ModuleDecl *M) {
@@ -577,6 +582,7 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
   });
   writePostImportPrologue(os, *M);
   emitObjCConditional(os, [&] { os << objcModuleContents.str(); });
+  writeObjCEpilogue(os);
   emitCxxConditional(os, [&] {
     // FIXME: Expose Swift with @expose by default.
     bool enableCxx = frontendOpts.ClangHeaderExposedDecls.has_value() ||

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck %t/print-string.swift -typecheck -module-name Stringer -enable-experimental-cxx-interop -emit-clang-header-path %t/Stringer.h
+
+// Ensure: we don't hit any spurios warnings instantiating
+// C++ standard library templates because of the generated header.
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument
+
+//--- print-string.swift
+
+public func printString(_ s: String) {
+}
+
+//--- test-stdlib.cpp
+
+#include "Stringer.h"
+#include <iostream>
+
+int main() {
+  // Ensure that template instantiations inside C++
+  // standard library in this call don't cause any new diagnostics
+  // because of the generated header.
+  std::cout << "test invoke std::cout\n" << std::endl;
+
+  auto _ = swift::String::init();
+  return 0;
+}

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -92,6 +92,9 @@
 
 // CHECK-LABEL: #if defined(__OBJC__)
 // CHECK-NEXT:  #endif
+// CHECK-NEXT:  #if __has_attribute(external_source_symbol)
+// CHECK-NEXT:  # pragma clang attribute pop
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  #if defined(__cplusplus)
 // CHECK-NEXT:  #pragma clang diagnostic push
 // CHECK-NEXT:  #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -443,10 +443,10 @@ SWIFT_CLASS("_TtC8comments13UnorderedList")
 @end
 
 #endif
-#if defined(__cplusplus)
-#endif
 #if __has_attribute(external_source_symbol)
 # pragma clang attribute pop
+#endif
+#if defined(__cplusplus)
 #endif
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
…nerated header inside of 'pragma clang attribute' block

Explanation: The C++ section of the generated header was emitted inside of `#pragma clang attribute push` `#pragma clang attribute external_source_symbol (...)` directive block, which meant that some C++ standard library headers included within the stdlib overlay in the C++ section of the generated header were affected by the pragma, which was wrong. This pragma is only meant for the ObjC section of the header, so this change ends the scope of the directive before the C++ section starts.
Scope: Swift's and C/ObjC/C++ interoperability, generated header printer.
Risk: Low. Even though this affects generated header in C/ObjC mode, this change only moves the location of the emitted `#pragma clang attribute pop` but doesn't introduce anything new into the generated header.
Testing: Swift unit tests, manual testing on some adopter projects and several Swift packages that import C.
PR: https://github.com/apple/swift/pull/65680
