### PR TITLE
[5.9][interop][SwiftToCxx] add swift::String overlay constructor for const…

### DIFF
--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -35,6 +35,17 @@ SWIFT_INLINE_THUNK T_0_0 get() const
 
 #ifndef SWIFT_CXX_INTEROP_HIDE_STL_OVERLAY
 
+/// Constructs a Swift string from a C string.
+SWIFT_INLINE_THUNK String(const char *cString) noexcept {
+  if (!cString) {
+    auto res = _impl::$sS2SycfC();
+    memcpy(_getOpaquePointer(), &res, sizeof(res));
+    return;
+  }
+  auto res = _impl::$sSS7cStringSSSPys4Int8VG_tcfC(cString);
+  memcpy(_getOpaquePointer(), &res, sizeof(res));
+}
+
 /// Constructs a Swift string from a C++ string.
 SWIFT_INLINE_THUNK String(const std::string &str) noexcept {
   auto res = _impl::$sSS7cStringSSSPys4Int8VG_tcfC(str.c_str());

--- a/test/Interop/SwiftToCxx/stdlib/string/string-conversions.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-conversions.cpp
@@ -34,8 +34,17 @@ int main() {
   {
     auto s = String("hello world");
     printString(s);
+    swift::String s2 = "Hello literal";
+    printString(s2);
+    const char *literal = "Test literal via ptr";
+    printString(literal);
+    swift::String s3 = nullptr;
+    printString(s3);
   }
 // CHECK: '''hello world'''
+// CHECK-NEXT: '''Hello literal'''
+// CHECK-NEXT: '''Test literal via ptr'''
+// CHECK-NEXT: ''''''
 
   {
     std::string str = "test std::string";


### PR DESCRIPTION
…ructing it directly from a C string literal

resolves https://github.com/apple/swift/issues/63448

Explanation: It was not possible to construct `swift::String` type that represents Swift's String type in C++ from a C++ string literal / C string. This change adds a new C++ constructor to this type to ensure that it can be implicitly constructed from a string literal / C string.
Scope: Swift's and C++ interoperability, Swift's standard library overlay for C++.
Risk: Low. This type is not adopted yet in C++ adopters.
Testing: Swift unit tests, manual testing on some adopter projects and several Swift packages that import C.
PR: https://github.com/apple/swift/pull/65683
Reviewer: @egorzhdan 