### PR TITLE
Fix crash when back-deploying concurrency to iOS 15.0/15.1-era OSs

### DIFF
--- a/stdlib/toolchain/Compatibility56/Concurrency/Actor.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/Actor.cpp
@@ -152,9 +152,14 @@ static bool vouchersDisabled;
 
 static void _initializeVouchersDisabled(void *ctxt) {
   if (__builtin_available(macOS 12.1, iOS 15.2, tvOS 15.2, watchOS 8.3, *)) {
+    // Concurrency library in the OS in new enough that it has voucher support.
     vouchersDisabled = false;
-  } else {
+  } else if (__builtin_available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
+    // Concurrency library in the OS falls in the range that has no voucher support.
     vouchersDisabled = true;
+  } else {
+    // Concurrency library is back-deployed on this OS, and has voucher support.
+    vouchersDisabled = false;
   }
 }
 

--- a/stdlib/toolchain/Compatibility56/Concurrency/Actor.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/Actor.cpp
@@ -146,3 +146,21 @@ void swift::adoptTaskVoucher(AsyncTask *task) {
 void swift::restoreTaskVoucher(AsyncTask *task) {
   ExecutorTrackingInfo::current()->restoreVoucher(task);
 }
+
+static swift_once_t voucherDisableCheckOnce;
+static bool vouchersDisabled;
+
+static void _initializeVouchersDisabled(void *ctxt) {
+  if (__builtin_available(macOS 12.1, iOS 15.2, tvOS 15.2, watchOS 8.3, *)) {
+    vouchersDisabled = false;
+  } else {
+    vouchersDisabled = true;
+  }
+}
+
+bool VoucherManager::vouchersAreDisabled() {
+  swift_once(&voucherDisableCheckOnce,
+             &_initializeVouchersDisabled,
+             nullptr);
+  return vouchersDisabled;
+}

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/VoucherSupport.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/VoucherSupport.h
@@ -31,6 +31,12 @@ class VoucherManager {
   /// async work.
   llvm::Optional<voucher_t> OriginalVoucher;
 
+  /// Determine whether vouchers are disabled entirely. This evaluates
+  /// true on platforms whose concurrency library does not support the
+  /// propagation of vouchers, in which case all of the operations of
+  /// this class must be no-ops.
+  static bool vouchersAreDisabled();
+
 public:
   VoucherManager() {
     SWIFT_TASK_DEBUG_LOG("[%p] Constructing VoucherManager", this);
@@ -41,6 +47,9 @@ public:
   /// VoucherManager object is destroyed. It may also be called in other
   /// places to restore the original voucher and reset the VoucherManager.
   void leave() {
+    if (vouchersAreDisabled())
+      return;
+
     if (OriginalVoucher) {
       SWIFT_TASK_DEBUG_LOG("[%p] Restoring original voucher %p", this,
                            *OriginalVoucher);
@@ -62,6 +71,9 @@ public:
   /// this is permanent. For Tasks, the voucher must be restored using
   /// restoreVoucher if the task suspends.
   void swapToJob(Job *job) {
+    if (vouchersAreDisabled())
+      return;
+
     SWIFT_TASK_DEBUG_LOG("[%p] Swapping jobs to %p", this, job);
     assert(job);
     assert(job->Voucher != SWIFT_DEAD_VOUCHER);
@@ -99,6 +111,9 @@ public:
   // Take the current thread's adopted voucher and place it back into the task
   // that previously owned it, re-adopting the thread's original voucher.
   void restoreVoucher(AsyncTask *task) {
+    if (vouchersAreDisabled())
+      return;
+
     SWIFT_TASK_DEBUG_LOG("[%p] Restoring %svoucher on task %p", this,
                          OriginalVoucher ? "" : "missing ", task);
     assert(OriginalVoucher);


### PR DESCRIPTION
The introduction of the library providing back-deployment fixes for Swift 5.6 concurrency libraries (and older) introduced a concurrency crash in the following OS version ranges

  - macOS [12.0, 12.1)
  - iOS [15.0, 15.2)
  - tvOS [15.0, 15.2)
  - watchOS [8.0, 8.3)

Neither older nor newer versions of the listed OSs were affected.

The actual bug involved a miscommunication between the code in the library that back-deploys fixes (`libswiftCompatibility56.a`) and the concurrency library in the OS itself. Specifically, the OS versions at the end of the ranges above introduced voucher support into the concurrency runtime in the OS (an important feature for performance). The code in `libswiftCompatibility56.a` that back-ports concurrency fixes also included the voucher support, which provides a consistent state for those OS versions and anything newer.

OS versions that predate the introduction of concurrency in the OS are similarly unaffected, because the embedded
`libswift_Concurrency.dylib` matches that of Swift 5.6, which includes voucher support.

The OS versions in the affected range include a concurrency library in the OS that does not manage vouchers. The `libswiftCompatibility56.a` back-deployed fixes library has code that works on the same data structures but does manage vouchers, leading to crashes when (say) a job allocated by the OS version didn't set the "voucher" field, but the `libswiftCompatibility56.a` tried to free it, essentially a form of overrelease.

The fix is to teach the voucher-handling code in
`libswiftCompatibility56.a` to first check what version of the OS it is executing on. If it's in the affected range, all handling of vouchers is disables so it acts like the concurrency library in the OS. For both earlier OS versions and later OS versions the voucher-handler code executes unchanged. This entirely library is disabled when running on OS versions containing the Swift 5.7 concurrency library (or newer), so those don't need to pay for the extra check when dealing with vouchers.

Fixes rdar://108837762, rdar://108864311, rdar://108958765.
