### PR TITLE
[5.9] Allow simulator tests on Apple Silicon

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -916,8 +916,8 @@ if run_os in ('maccatalyst',):
   target_os_abi = 'macosx'
   target_os_is_maccatalyst = "TRUE"
   config.available_features.add("OS=ios")
-# macOS on ASi uses the stable ABI
-if run_os in ('macosx',) and run_cpu in ('arm64',):
+# macOS and simulators on ASi use the stable ABI
+if (run_os in ('macosx',) or 'simulator' in run_environment) and run_cpu in ('arm64',):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')
 if run_os in (
@@ -1154,13 +1154,13 @@ if run_vendor == 'apple':
     target_future_version = ''
 
     # Only permit non-executable tests for ARM on Darwin unless you are on macOS
-    if 'arm' in run_cpu and run_os not in ('macosx',):
+    if 'simulator' not in run_environment and run_os not in ('macosx',):
         if swift_test_mode != 'only_non_executable':
             raise RuntimeError('Device tests are currently only supported when '
             'the swift_test_mode is "only_non_executable". Current '
             'swift_test_mode is {}.'.format(swift_test_mode))
 
-    if 'arm' in run_cpu and not (run_os == 'macosx' or run_os == 'maccatalyst'):
+    if 'simulator' not in run_environment and not (run_os == 'macosx' or run_os == 'maccatalyst'):
        # iOS/tvOS/watchOS device
        if run_os == 'ios':
            lit_config.note('Testing iOS ' + config.variant_triple)
@@ -1199,7 +1199,7 @@ if run_vendor == 'apple':
        (sw_vers_name, sw_vers_vers, sw_vers_build) = \
             darwin_get_sdk_version(config.variant_sdk)
 
-    elif run_os == 'ios' or run_os == 'tvos' or run_os == 'watchos':
+    elif 'simulator' in run_environment:
         # iOS/tvOS/watchOS simulator
         if run_os == 'ios':
             config.available_features.add('DARWIN_SIMULATOR=ios')


### PR DESCRIPTION
Some of the conditions in lit.cfg assume a simulator always targets Intel, but this is not true after the introduction of Apple Silicon.

Rely instead on `run_environment`.

Addresses rdar://109040191

(cherry picked from commit 2c91c5482b1a4c02a7d43f004588ddb955678447)