### PR TITLE
Add a few diagnostics for variadic generic types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5411,6 +5411,9 @@ ERROR(vararg_not_allowed,none,
 ERROR(experimental_type_with_parameter_pack,none,
       "generic types with parameter packs are experimental",
       ())
+ERROR(more_than_one_parameter_pack_in_type,none,
+      "generic type cannot have more than one pack", ())
+
 ERROR(expansion_not_allowed,none,
       "pack expansion %0 can only appear in a function parameter list, "
       "tuple element, or generic argument list", (Type))
@@ -5432,7 +5435,7 @@ ERROR(pack_reference_must_be_in_expansion,none,
       "pack reference %0 requires expansion using keyword 'repeat'",
       (TypeRepr*))
 ERROR(pack_type_requires_keyword_each,none,
-      "pack type %0 must be referenced with 'each'",
+      "type pack %0 must be referenced with 'each'",
       (TypeRepr*))
 ERROR(tuple_duplicate_label,none,
       "cannot create a tuple with a duplicate element label", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5411,9 +5411,12 @@ ERROR(vararg_not_allowed,none,
 ERROR(experimental_type_with_parameter_pack,none,
       "generic types with parameter packs are experimental",
       ())
-ERROR(more_than_one_parameter_pack_in_type,none,
-      "generic type cannot have more than one pack", ())
-
+ERROR(more_than_one_pack_in_type,none,
+      "generic type cannot declare more than one type pack", ())
+ERROR(enum_with_pack,none,
+      "enums cannot declare a type pack", ())
+ERROR(superclass_with_pack,none,
+      "cannot inherit from a generic class that declares a type pack", ())
 ERROR(expansion_not_allowed,none,
       "pack expansion %0 can only appear in a function parameter list, "
       "tuple element, or generic argument list", (Type))

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -485,7 +485,7 @@ static void checkGenericParams(GenericContext *ownerCtx) {
       }
 
       if (hasPack) {
-        gp->diagnose(diag::more_than_one_parameter_pack_in_type);
+        gp->diagnose(diag::more_than_one_pack_in_type);
       }
 
       hasPack = true;
@@ -2555,6 +2555,17 @@ public:
   void visitEnumDecl(EnumDecl *ED) {
     checkUnsupportedNestedType(ED);
 
+    // Temporary restriction until we figure out pattern matching and
+    // enum case construction with packs.
+    if (auto genericSig = ED->getGenericSignature()) {
+      for (auto paramTy : genericSig.getGenericParams()) {
+        if (paramTy->isParameterPack()) {
+          ED->diagnose(diag::enum_with_pack);
+          break;
+        }
+      }
+    }
+
     // FIXME: Remove this once we clean up the mess involving raw values.
     (void) ED->getInterfaceType();
 
@@ -2834,6 +2845,18 @@ public:
       else if (superclass->isActor())
         CD->diagnose(diag::actor_inheritance,
                      /*distributed=*/CD->isDistributedActor());
+
+      // Enforce a temporary restriction on inheriting from a superclass
+      // type with a pack, until we figure out the semantics of method
+      // overrides in these situations.
+      if (auto genericSig = superclass->getGenericSignature()) {
+        for (auto paramTy : genericSig.getGenericParams()) {
+          if (paramTy->isParameterPack()) {
+            CD->diagnose(diag::superclass_with_pack);
+            break;
+          }
+        }
+      }
     }
 
     if (CD->isDistributedActor()) {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -103,28 +103,28 @@ func returnEachPackReference<each T>(_ t: repeat each T) -> each T { // expected
   fatalError()
 }
 
-// expected-error@+1 {{pack type 'T' must be referenced with 'each'}}{{63-63=each }}
+// expected-error@+1 {{type pack 'T' must be referenced with 'each'}}{{63-63=each }}
 func returnRepeatTuple<each T>(_ t: repeat each T) -> (repeat T) {
   fatalError()
 }
 
 // expected-error@+2 {{pack reference 'T' requires expansion using keyword 'repeat'}}
-// expected-error@+1 {{pack type 'T' must be referenced with 'each'}}{{55-55=each }}
+// expected-error@+1 {{type pack 'T' must be referenced with 'each'}}{{55-55=each }}
 func parameterAsPackTypeWithoutExpansion<each T>(_ t: T) {
 }
 
 // expected-error@+2 {{pack reference 'T' requires expansion using keyword 'repeat'}}
-// expected-error@+1 {{pack type 'T' must be referenced with 'each'}}{{57-57=each }}
+// expected-error@+1 {{type pack 'T' must be referenced with 'each'}}{{57-57=each }}
 func returnPackReference<each T>(_ t: repeat each T) -> T {
   fatalError()
 }
 
 func packTypeParameterOutsidePackExpansionType<each T>(_ t: T,
   // expected-error@-1 {{pack reference 'T' requires expansion using keyword 'repeat'}}
-  // expected-error@-2 {{pack type 'T' must be referenced with 'each'}}{{61-61=each }}
+  // expected-error@-2 {{type pack 'T' must be referenced with 'each'}}{{61-61=each }}
                                                        _ a: Array<T>) {
   // expected-error@-1 {{pack reference 'T' requires expansion using keyword 'repeat'}}
-  // expected-error@-2 {{pack type 'T' must be referenced with 'each'}}{{67-67=each }}
+  // expected-error@-2 {{type pack 'T' must be referenced with 'each'}}{{67-67=each }}
 }
 
 func expansionOfNonPackType<T>(_ t: repeat each T) {}

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: asserts
 
+struct MultiplePack<each T, each U> {} // expected-error {{generic type cannot have more than one pack}}
+typealias MultiplePackAlias<each T, each U> = (repeat each T, repeat each U) // expected-error {{generic type cannot have more than one pack}}
+
 func bindAll() {
   struct Bind<each U> {}
 

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -1,10 +1,31 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
 
+// Because of -enable-experimental-feature VariadicGenerics
 // REQUIRES: asserts
 
-struct MultiplePack<each T, each U> {} // expected-error {{generic type cannot have more than one pack}}
-typealias MultiplePackAlias<each T, each U> = (repeat each T, repeat each U) // expected-error {{generic type cannot have more than one pack}}
+// Disallowed cases
+struct MultiplePack<each T, each U> {} // expected-error {{generic type cannot declare more than one type pack}}
+typealias MultiplePackAlias<each T, each U> = (repeat each T, repeat each U) // expected-error {{generic type cannot declare more than one type pack}}
 
+// Temporary limitations
+enum EnumWithPack<each T> { // expected-error {{enums cannot declare a type pack}}
+  case cheddar
+}
+
+class ClassWithPack<each T> {}
+
+struct OuterStruct<each T> {
+  enum NestedEnum { // expected-error {{enums cannot declare a type pack}}
+    case smokedGouda
+  }
+
+  class NestedClass {}
+}
+
+class BadInheritance1: ClassWithPack<Int> {} // expected-error {{cannot inherit from a generic class that declares a type pack}}
+class BadInheritance2: OuterStruct<Int>.NestedClass {} // expected-error {{cannot inherit from a generic class that declares a type pack}}
+
+// Type resolution of variadic type aliases
 func bindAll() {
   struct Bind<each U> {}
 

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -30,7 +30,7 @@ func f5<each T>() -> () -> (repeat each T) {}
 
 func f6<each T>() -> (repeat each T) -> () {}
 
-enum E<each T> {
+enum E<each T> { // expected-error {{enums cannot declare a type pack}}
   case f1(_: repeat each T)
 
   case f2(_: G<repeat each T>)


### PR DESCRIPTION
A variadic generic type cannot declare more than one pack in its generic parameter list. This is an intentional restriction in the design.

Also the current implementation does not support variadic enums, or inheritance from variadic classes. These last two will go away eventually.