### PR TITLE
[move-only] Ensure that if we have an allocation that isn't fully initialized (and DI errors on it as such), the move checkers do not run on the allocation.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "definite-init"
+
 #include "DIMemoryUseCollector.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
@@ -18,6 +19,7 @@
 #include "swift/AST/Stmt.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/BasicBlockBits.h"
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/SIL/BasicBlockData.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
@@ -1140,7 +1142,15 @@ void LifetimeChecker::doIt() {
   }
 
   // If we emitted an error, there is no reason to proceed with load promotion.
-  if (!EmittedErrorLocs.empty()) return;
+  if (!EmittedErrorLocs.empty()) {
+    // Since we failed DI, for now, turn off the move checker on the entire
+    // function. With time, we should be able to allow for move checker checks
+    // to be emitted on unrelated allocations, but given where we are this is a
+    // good enough fix.
+    TheMemory.getFunction().addSemanticsAttr(
+        semantics::NO_MOVEONLY_DIAGNOSTICS);
+    return;
+  }
 
   // If the memory object has nontrivial type, then any destroy/release of the
   // memory object will destruct the memory.  If the memory (or some element

--- a/test/SILOptimizer/definite_init_markuninitialized_rootself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_rootself.sil
@@ -50,7 +50,7 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : $Int):
   return %3 : $RootClassWithIVars
 }
 
-// CHECK-LABEL: sil [ossa] @rootclass_test2
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @rootclass_test2
 sil [ossa] @rootclass_test2 : $@convention(method) (@owned RootClassWithIVars, Int) -> @owned RootClassWithIVars {
 bb0(%0 : @owned $RootClassWithIVars, %1 : $Int):
   %3 = mark_uninitialized [rootself] %0 : $RootClassWithIVars
@@ -74,7 +74,7 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : $Int):
   return %3 : $RootClassWithIVars  // expected-error {{return from initializer without initializing all stored properties}}
 }
 
-// CHECK-LABEL: sil [ossa] @rootclass_test3
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @rootclass_test3
 sil [ossa] @rootclass_test3 : $@convention(method) (@owned RootClassWithIVars, Int) -> @owned RootClassWithIVars {
 bb0(%0 : @owned $RootClassWithIVars, %1 : $Int):
   %3 = mark_uninitialized [rootself] %0 : $RootClassWithIVars

--- a/test/SILOptimizer/definite_init_markuninitialized_var.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_var.sil
@@ -11,7 +11,7 @@ import Swift
 sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
 sil @makesInt : $@convention(thin) () -> Int
 
-// CHECK-LABEL: sil [ossa] @use_before_init
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @use_before_init
 sil [ossa] @use_before_init : $@convention(thin) () -> Int {
 bb0:
   %0 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
@@ -85,7 +85,7 @@ bb0:
   return %5 : $Int
 }
 
-// CHECK-LABEL: sil [ossa] @tuple_elements1
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @tuple_elements1
 sil [ossa] @tuple_elements1 : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
@@ -101,7 +101,7 @@ bb0(%0 : $Int):
   return %99 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @tuple_elements2
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @tuple_elements2
 sil [ossa] @tuple_elements2 : $@convention(thin) (Int) -> (Int, Int) {
 bb0(%0 : $Int):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <(Int, Int)>
@@ -130,7 +130,7 @@ bb0(%0 : $*T, %1 : $*T):
   return %9 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @copy_addr2
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @copy_addr2
 sil [ossa] @copy_addr2 : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
@@ -145,7 +145,7 @@ bb0(%0 : $*T, %1 : $*T):
 sil [ossa] @takes_closure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
 sil [ossa] @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
 
-// CHECK-LABEL: sil [ossa] @closure_test
+// CHECK-LABEL: sil [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @closure_test
 sil [ossa] @closure_test : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>

--- a/test/SILOptimizer/moveonly_addresschecker_di_interactions.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_di_interactions.swift
@@ -1,0 +1,88 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy %s
+
+// This testStruct specifically testStructs how DI and the move checkers interact with each other
+
+func testStructSimpleNoInit() {
+    struct M: ~Copyable {
+        private let i: Int // expected-note {{'self.i' not initialized}}
+
+        // No initialization. Should get DI error and no crash.
+        init() {
+        } // expected-error {{return from initializer without initializing all stored properties}}
+    }
+}
+
+func testStructSimplePartialInit() {
+    struct M: ~Copyable {
+        private let i: Int
+        private let i2: Int // expected-note {{'self.i2' not initialized}}
+
+        init() {
+            i = 5
+        } // expected-error {{return from initializer without initializing all stored properties}}
+    }
+}
+
+func testStructSimplePartialInit2() {
+    struct M: ~Copyable {
+        private let i: Int = 5
+        private let i2: Int // expected-note {{'self.i2' not initialized}}
+
+        init() {
+        } // expected-error {{return from initializer without initializing all stored properties}}
+    }
+}
+
+func testStructGenericNoInit() {
+    struct M<T>: ~Copyable {
+        private let i: T // expected-note {{'self.i' not initialized}}
+
+        init() {
+        } // expected-error {{return from initializer without initializing all stored properties}}
+    }
+}
+
+func testStructGenericPartialInit() {
+    struct M<T>: ~Copyable {
+        private let i: T
+        private let i2: T // expected-note {{'self.i2' not initialized}}
+
+        init(_ t: T) {
+            self.i = t
+        } // expected-error {{return from initializer without initializing all stored properties}}
+    }
+}
+
+func testEnumNoInit() {
+    enum E : ~Copyable {
+        case first
+        case second
+
+        init() {
+        } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+    }
+}
+
+func testEnumNoInitWithPayload() {
+    @_moveOnly struct Empty {}
+
+    enum E : ~Copyable {
+        case first(Empty)
+        case second
+
+        init() {
+        } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+    }
+}
+
+func testEnumNoInitWithGenericPayload() {
+    @_moveOnly struct Empty {}
+
+    enum E<T> : ~Copyable {
+        case first(Empty)
+        case second(T)
+
+        init() {
+        } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+    }
+}


### PR DESCRIPTION
Previously we would crash.

The methodology here is that I added a flag to alloc_stack and alloc_box called had_di_error. DI if it emits an error on said alloc_stack/alloc_box will set the flag. If the move checker sees that flag then:

1. It doesn't process the allocation.
2. It acts as if it emitted an error meaning that it will eliminate the mark_must_check and convert any copies to non-asserting variants without emitting a "found a copy, please file a bug" error.

rdar://108993297
