### PR TITLE
Concurrency: Revert workarounds for `@backDeployed` condfails

### DIFF
--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -135,10 +135,10 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
+  @inlinable
   @discardableResult
   @_unsafeInheritExecutor
-  @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
-  @_backDeploy(before: SwiftStdlib 5.8)
+  @backDeployed(before: SwiftStdlib 5.8)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #file, line: UInt = #line) async rethrows -> R {
     return try await withValueImpl(valueDuringOperation, operation: operation, file: file, line: line)
@@ -165,8 +165,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @inlinable
   @discardableResult
   @_unsafeInheritExecutor
-  @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
-  @_backDeploy(before: SwiftStdlib 5.9)
+  @backDeployed(before: SwiftStdlib 5.9)
   internal func withValueImpl<R>(_ valueDuringOperation: __owned Value, operation: () async throws -> R,
                                  file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -135,10 +135,10 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
+  @inlinable
   @discardableResult
   @_unsafeInheritExecutor
-  @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
-  @_backDeploy(before: SwiftStdlib 5.8)
+  @backDeployed(before: SwiftStdlib 5.8)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #fileID, line: UInt = #line) async rethrows -> R {
     return try await withValueImpl(valueDuringOperation, operation: operation, file: file, line: line)
@@ -165,8 +165,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @inlinable
   @discardableResult
   @_unsafeInheritExecutor
-  @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
-  @_backDeploy(before: SwiftStdlib 5.9)
+  @backDeployed(before: SwiftStdlib 5.9)
   internal func withValueImpl<R>(_ valueDuringOperation: __owned Value, operation: () async throws -> R,
                                  file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -31,8 +31,7 @@
 // false positives, or if you have special permission to break things.) You can
 // find a diff of what needs to be added in the output of the failed test run.
 // The order of lines doesn't matter, and you can also include comments to refer
-// to any bugs you filed. Remember that in almost all cases you'll want to edit
-// the stability-stdlib-abi-without-asserts.test file instead of this one.
+// to any bugs you filed.
 //
 // Thank you for your help ensuring the stdlib remains compatible with its past!
 //                                            -- Your friendly stdlib engineers
@@ -71,5 +70,8 @@ Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 // The ABI checker seems to be confused by this case.
 // rdar://106833284 (ABI checker confused with overload getting deprecated)
 Func Executor.enqueue(_:) is a new API without @available attribute
+
+// This function correctly inherits its availability from the TaskLocal struct.
+Func TaskLocal.withValueImpl(_:operation:file:line:) is a new API without @available attribute
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
All compilers that must be able to compile the standard library's textual interface accept the following:
- back deployed functions declared without `@available`
- `@inlinable` back deployed functions
- `defer` blocks in back deployed functions

We can therefore revert the workarounds added in https://github.com/apple/swift/pull/62946/ and https://github.com/apple/swift/pull/62928/.

Resolves rdar://104085810