### PR TITLE
Try using withContiguousStorageIfAvailable in RangeReplaceableCollection.append(contentsOf:) before falling back to a slow element-by-element loop.

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -455,7 +455,6 @@ extension RangeReplaceableCollection {
     where S.Element == Element {
     
     let done:Void? = newElements.withContiguousStorageIfAvailable {
-      _onFastPath()
       replaceSubrange(endIndex..<endIndex, with: $0)
     }
       

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -453,11 +453,18 @@ extension RangeReplaceableCollection {
   @inlinable
   public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
-
-    let approximateCapacity = self.count + newElements.underestimatedCount
-    self.reserveCapacity(approximateCapacity)
-    for element in newElements {
-      append(element)
+    
+    let done:Void? = newElements.withContiguousStorageIfAvailable {
+      _onFastPath()
+      replaceSubrange(endIndex..<endIndex, with: $0)
+    }
+      
+    if done == nil {
+      let approximateCapacity = self.count + newElements.underestimatedCount
+      self.reserveCapacity(approximateCapacity)
+      for element in newElements {
+        append(element)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes rdar://109059874

Should make a bunch of operations on naive RRC implementations much faster