### PR TITLE
Sema: Look through `FunctionConversionExpr` in `getEnclosingApplyExpr()`

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3394,7 +3394,8 @@ private:
              isa<SelfApplyExpr>(parents[idx]) || // obj.f(a)
              isa<IdentityExpr>(parents[idx]) || // (f)(a)
              isa<ForceValueExpr>(parents[idx]) || // f!(a)
-             isa<BindOptionalExpr>(parents[idx])); // f?(a)
+             isa<BindOptionalExpr>(parents[idx]) || // f?(a)
+             isa<FunctionConversionExpr>(parents[idx]));
 
     auto *call = dyn_cast<ApplyExpr>(parents[idx]);
     if (!call || call->getFn() != parents[idx+1])


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/61481.

There is already a test case exercising this case but there happens to be no observable difference in the compiler output because `noasync` diagnostics already gracefully fall back to looking up the diagnostic `SourceLoc` another way.

Resolves rdar://100883622.