### PR TITLE
Ensure that we serialize declarations in synthesized files

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -6230,7 +6230,12 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
       Scratch.push_back(synthesizedFile);
     files = llvm::makeArrayRef(Scratch);
   } else {
-    files = M->getFiles();
+    for (auto file : M->getFiles()) {
+      Scratch.push_back(file);
+      if (auto *synthesizedFile = file->getSynthesizedFile())
+        Scratch.push_back(synthesizedFile);
+    }
+    files = llvm::makeArrayRef(Scratch);
   }
   for (auto nextFile : files) {
     if (nextFile->hasEntryPoint())

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -2,7 +2,10 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/ModuleWithEquatable.swiftmodule %s -DMODULE_EXPORTING_TYPE -module-name ModuleWithEquatable -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/ModuleWithEquatable.swiftmodule %s -DMODULE_EXPORTING_TYPE -module-name ModuleWithEquatable -load-plugin-library %t/%target-library-name(MacroDefinition) -emit-module-interface-path %t/ModuleWithEquatable.swiftinterface
+
+// Check the generated .swiftinterface
+// RUN: %FileCheck -check-prefix INTERFACE %s < %t/ModuleWithEquatable.swiftinterface
 
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
@@ -22,6 +25,9 @@ macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacr
 public struct PublicEquatable {
   public init() { }
 }
+
+// INTERFACE: public struct PublicEquatable
+// INTERFACE: extension ModuleWithEquatable.PublicEquatable : Swift.Equatable
 
 #else
 import ModuleWithEquatable

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -2,10 +2,12 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/ModuleWithEquatable.swiftmodule %s -DMODULE_EXPORTING_TYPE -module-name ModuleWithEquatable -load-plugin-library %t/%target-library-name(MacroDefinition)
+
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
-// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5 -emit-tbd -emit-tbd-path %t/MacroUser.tbd
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -I %t
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5 -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
@@ -15,10 +17,20 @@ macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMa
 @attached(conformance)
 macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
 
+#if MODULE_EXPORTING_TYPE
+@Equatable
+public struct PublicEquatable {
+  public init() { }
+}
+
+#else
+import ModuleWithEquatable
+
 func requireEquatable(_ value: some Equatable) {
   print(value == value)
 }
 
+// expected-note@+1{{where 'some Hashable' = 'PublicEquatable'}}
 func requireHashable(_ value: some Hashable) {
   print(value.hashValue)
 }
@@ -43,6 +55,13 @@ requireEquatable(S2())
 requireHashable(S2())
 
 requireEquatable(E.Nested())
+
+#if TEST_DIAGNOSTICS
+requireEquatable(PublicEquatable())
+
+requireHashable(PublicEquatable())
+//expected-error@-1{{global function 'requireHashable' requires that 'PublicEquatable' conform to 'Hashable'}}
+#endif
 
 @attached(conformance)
 @attached(member, names: named(requirement))
@@ -70,3 +89,4 @@ func requiresP(_ value: (some P).Type) {
 
 // CHECK: Wrapped.requirement
 requiresP(Generic<Wrapped>.self)
+#endif


### PR DESCRIPTION
* Explanation: Module serialization was not walking the "synthesized" file that corresponds to a file unit, so anything written there---i.e., conformances generated by macro expansions---would get dropped. Make sure we visit those declarations, too, so that macro-generated conformances can be seen across modules.
* Scope: Narrow; the synthesized file is only used for macro-generated conformances, `Sendable` conformances, and AutoDiff.
* Risk: Low.
* Issue: rdar://109051626
* Original pull request: https://github.com/apple/swift/pull/65789