### PR TITLE
DeadFunctionElimination: an `alloc_global` instruction keeps the referenced global alive

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -362,6 +362,8 @@ class DeadFunctionAndGlobalElimination {
             ensureKeyPathComponentIsAlive(component);
         } else if (auto *GA = dyn_cast<GlobalAddrInst>(&I)) {
           ensureAlive(GA->getReferencedGlobal());
+        } else if (auto *agi = dyn_cast<AllocGlobalInst>(&I)) {
+          ensureAlive(agi->getReferencedGlobal());
         } else if (auto *GV = dyn_cast<GlobalValueInst>(&I)) {
           ensureAlive(GV->getReferencedGlobal());
         } else if (auto *HSI = dyn_cast<HasSymbolInst>(&I)) {

--- a/test/SILOptimizer/remove_unused_func.sil
+++ b/test/SILOptimizer/remove_unused_func.sil
@@ -6,6 +6,9 @@ sil_stage canonical
 import Builtin
 import Swift
 
+// CHECK-LABEL: sil_global private @privateGlobal
+sil_global private @privateGlobal : $Int64
+
 // This function needs to be removed.
 // KEEP-NOT: @remove_me
 
@@ -25,6 +28,7 @@ sil_global @globalFunctionPointer : $@callee_guaranteed () -> () = {
 // CHECK-LABEL: sil private @alivePrivateFunc
 sil private @alivePrivateFunc : $@convention(thin) () -> () {
 bb0:
+  alloc_global @privateGlobal
   %0 = tuple ()
   return %0 : $()
 }


### PR DESCRIPTION
Fixes a crash caused by a deleted global variable which is still referenced by an `alloc_global` instruction.

rdar://109093730
