### PR TITLE
Documentation of dividingFullWidth

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1574,7 +1574,7 @@ ${assignmentOperatorComment(x.operator, True)}
   ///
   /// The resulting quotient must be representable within the bounds of the
   /// type. If the quotient of dividing `dividend` by this value is too large
-  /// to represent in the type, a runtime error may occur.
+  /// to represent in the type, a runtime error will occur.
   ///
   /// - Parameter dividend: A tuple containing the high and low parts of a
   ///   double-width integer. The `high` component of the value carries the

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2033,7 +2033,7 @@ where Magnitude: FixedWidthInteger & UnsignedInteger,
   ///
   /// The resulting quotient must be representable within the bounds of the
   /// type. If the quotient is too large to represent in the type, a runtime
-  /// error may occur.
+  /// error will occur.
   ///
   /// The following example divides a value that is too large to be represented
   /// using a single `Int` instance by another `Int` value. Because the quotient


### PR DESCRIPTION
The `FixedWidthInteger.dividingFullWidth` method is now documented to always trap if the result overflows the bounds of the type.
