### PR TITLE
docs: Fix shell var substitution in `GettingStarted.md`

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -471,12 +471,12 @@ platform=$([[ $(uname) == Darwin ]] && echo macosx || echo linux)
 
 After setting that variable you can rebuild the compiler incrementally with this command:
 ```sh
-ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-$(platform)-$(uname -m) bin/swift-frontend
+ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-${platform}-$(uname -m) bin/swift-frontend
 ```
 
 To rebuild everything that has its sources located in the `swift` repository, including the standard library:
 ```sh
-ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-$(platform)-$(uname -m)
+ninja -C ../build/Ninja-RelWithDebInfoAssert/swift-${platform}-$(uname -m)
 ```
 
 Similarly, you can rebuild other projects like Foundation or Dispatch by substituting their respective subdirectories in the commands above.


### PR DESCRIPTION
We're supposed to use `${platform}` for substituting this previously defined variable. Currently used `$(platform)` will try to run a command named `platform`, which doesn't make sense.
