### PR TITLE
[5.9] Implement `Codable` conformance for `Never`

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -42,6 +42,23 @@ extension Never: Identifiable {
   }
 }
 
+@available(SwiftStdlib 5.9, *)
+extension Never: Encodable {
+  @available(SwiftStdlib 5.9, *)
+  public func encode(to encoder: any Encoder) throws {}
+}
+
+@available(SwiftStdlib 5.9, *)
+extension Never: Decodable {
+  @available(SwiftStdlib 5.9, *)
+  public init(from decoder: any Decoder) throws {
+    let context = DecodingError.Context(
+      codingPath: decoder.codingPath,
+      debugDescription: "Unable to decode an instance of Never.")
+    throw DecodingError.typeMismatch(Never.self, context)
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Standardized aliases
 //===----------------------------------------------------------------------===//

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -73,6 +73,8 @@ Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
 Constructor _SmallString.init(taggedCocoa:) has mangled name changing from 'Swift._SmallString.init(taggedCocoa: Swift.AnyObject) -> Swift._SmallString' to 'Swift._SmallString.init(taggedCocoa: Swift.AnyObject) -> Swift.Optional<Swift._SmallString>'
 Constructor _SmallString.init(taggedCocoa:) has return type change from Swift._SmallString to Swift._SmallString?
+Enum Never has added a conformance to an existing protocol Decodable
+Enum Never has added a conformance to an existing protocol Encodable
 Enum Never has added a conformance to an existing protocol Identifiable
 
 // These haven't actually been removed; they are simply marked unavailable.

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -669,6 +669,20 @@ class TestCodable : TestCodableSuper {
         }
     }
 
+    // MARK: - Never
+    @available(SwiftStdlib 5.9, *)
+    func test_Never() {
+        struct Nope: Codable {
+            var no: Never
+        }
+      
+        do {
+            let neverJSON = Data(#"{"no":"never"}"#.utf8)
+            _ = try JSONDecoder().decode(Nope.self, from: neverJSON)
+            fatalError("Incorrectly decoded `Never` instance.")
+        } catch {}
+    }
+
     // MARK: - NSRange
     lazy var nsrangeValues: [Int : NSRange] = [
         #line : NSRange(),
@@ -1056,6 +1070,10 @@ if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
 if #available(SwiftStdlib 5.6, *) {
     tests["test_Dictionary_JSON"] = TestCodable.test_Dictionary_JSON
+}
+
+if #available(SwiftStdlib 5.9, *) {
+    tests["test_Never"] = TestCodable.test_Never
 }
 
 var CodableTests = TestSuite("TestCodable")

--- a/test/stdlib/Never.swift
+++ b/test/stdlib/Never.swift
@@ -11,3 +11,13 @@ _ = ConformsToComparable<Never>()
 
 struct ConformsToHashable<T: Hashable> {}
 _ = ConformsToHashable<Never>()
+
+if #available(SwiftStdlib 5.5, *) {
+  struct ConformsToIdentifiable<T: Identifiable> {}
+  _ = ConformsToIdentifiable<Never>()
+}
+
+if #available(SwiftStdlib 5.9, *) {
+  struct ConformsToCodable<T: Codable> {}
+  _ = ConformsToCodable<Never>()
+}


### PR DESCRIPTION
This is the implementation of [SE-0396: Conform `Never` to `Codable`](https://github.com/apple/swift-evolution/blob/main/proposals/0396-never-codable.md) for the 5.9 branch.