### PR TITLE
[Observation] Member properties that have visibility attributes should rename using trailing trivia

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -95,7 +95,7 @@ extension DiagnosticsError {
 
 extension ModifierListSyntax {
   func privatePrefixed(_ prefix: String) -> ModifierListSyntax {
-    let modifier: DeclModifierSyntax = DeclModifierSyntax(name: "private")
+    let modifier: DeclModifierSyntax = DeclModifierSyntax(name: "private", trailingTrivia: .space)
     return ModifierListSyntax([modifier] + filter {
       switch $0.name.tokenKind {
       case .keyword(let keyword):

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -29,6 +29,11 @@ class ContainsWeak {
 }
 
 @Observable
+public class PublicContainsWeak {
+  public weak var obj: AnyObject? = nil
+}
+
+@Observable
 class ContainsUnowned {
   unowned var obj: AnyObject? = nil
 }


### PR DESCRIPTION
Variables declared with visibility and other modifiers ended up incorrectly synthesizing the storage without a trailing space after the private modifier.

```
public weak var obj: AnyObject? = nil
```

would incorrectly generate storage as:

```
privateweak var _obj: AnyObject? = nil
```

This change corrects that by adding a trailing trivia of a space on the private modifier.

Resolves: rdar://109121917