### PR TITLE
Don't include <thread> in MetadataCache.h, all we need there is <atomic>

### DIFF
--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -23,7 +23,7 @@
 #include "llvm/ADT/STLExtras.h"
 
 #include <condition_variable>
-#include <thread>
+#include <atomic>
 
 #ifndef SWIFT_DEBUG_RUNTIME
 #define SWIFT_DEBUG_RUNTIME 0


### PR DESCRIPTION
This is to allow building on platforms/environments where `<thread>` might not be available.