### PR TITLE
Witness selection should pick exact matches for effect overloads

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1196,8 +1196,12 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
       matchKind = MatchKind::RenamedMatch;
     else if (requiresNonSendable)
       matchKind = MatchKind::RequiresNonSendable;
-    else if (getEffects(witness).containsOnly(getEffects(req)))
+    else if (getEffects(req) - getEffects(witness))
+      // when the difference is non-empty, the witness has fewer effects.
       matchKind = MatchKind::FewerEffects;
+
+    assert(getEffects(req).contains(getEffects(witness))
+               && "witness has more effects than requirement?");
 
     // Success. Form the match result.
     RequirementMatch result(witness,

--- a/test/Interpreter/async_witness_matching.swift
+++ b/test/Interpreter/async_witness_matching.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  -Xfrontend -disable-availability-checking %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+// Ensures the more exact witness from S is chosen
+// to fulfill the requirement from P.
+// See: https://github.com/apple/swift/issues/60318
+
+protocol P {
+  func foo() async -> String
+}
+
+struct S: P {
+  func foo() -> String { "plain" }
+  func foo() async -> String { "async" }
+}
+
+let p: P = S()
+let ans = await p.foo()
+print(ans)
+// CHECK: async


### PR DESCRIPTION
You can overload a function based on its `async`-ness, and resolution is carried out based on async-ness of calling context.

But during protocol conformance checking, for an `async` requirement we were accidentally choosing the non-`async overload instead of the `async` one. The `async` one is the choice people would expect, since the `async` requirement is in essence the "context" that forwards to the underlying witness. This intended behavior is also inferred from:

https://github.com/apple/swift/pull/40088

The problem boiled down to a bad check when categorizing the witness matches prior to ranking them.

Resolves rdar://109135488 / https://github.com/apple/swift/issues/60318

TODO:
- [x] add tests