### PR TITLE
[5.9][CodeCompletion] Fix an assertion failure found by the stress tester

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2925,7 +2925,7 @@ public:
   /// Whether the argument \p Arg occurs after the code completion token and
   /// thus should be ignored and not generate any fixes.
   bool isArgumentIgnoredForCodeCompletion(Expr *Arg) const {
-    return IgnoredArguments.count(Arg) > 0;
+    return IgnoredArguments.count(Arg) > 0 && isForCodeCompletion();
   }
 
   /// Whether the constraint system has ignored any arguments for code

--- a/test/IDE/complete_call_pattern_heuristics.swift
+++ b/test/IDE/complete_call_pattern_heuristics.swift
@@ -34,3 +34,7 @@ func testArg2Name3() {
 // LABELED_FIRSTARG-DAG: Pattern/Local/Flair[ArgLabels]: {#arg1: Int#}[#Int#];
 // LABELED_FIRSTARG-NOT: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
 
+func subscriptAccess(info: [String: Int]) {
+  info[#^SUBSCRIPT_ACCESS^#]
+// SUBSCRIPT_ACCESS: Pattern/Local/Flair[ArgLabels]:     {#keyPath: KeyPath<[String : Int], Value>#}[#KeyPath<[String : Int], Value>#]; name=keyPath:
+}

--- a/validation-test/IDE/crashers_2_fixed/0038-setTypeForArgumentIgnoredForCompletion.swift
+++ b/validation-test/IDE/crashers_2_fixed/0038-setTypeForArgumentIgnoredForCompletion.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+func overloaded(content: () -> Int) {}
+func overloaded(@MyResultBuilder stuff: () -> Int) {}
+
+@resultBuilder struct MyResultBuilder {
+  static func buildExpression(_ content: Int) -> Int { content }
+  static func buildBlock() -> Int { 4 }
+}
+
+struct HStack {
+  init(spacing: Double, @MyResultBuilder content: () -> Int) {}
+  func qadding(_ length: Double) { }
+}
+
+func test() {
+  overloaded {
+    HStack(spacing: #^COMPLETE^#) {}
+      .qadding(32)
+  }
+}
+
+// COMPLETE: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Double#]; name=0


### PR DESCRIPTION
* **Explanation**: This fixes an assertion failure that was found by the stress tester. We were returning `true` from `isArgumentIgnoredForCodeCompletion` even if we weren’t type checking for code completion, which we shouldn’t do.
* **Scope**: Code completion
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://109170907
* **Reviewer**:  @xedin on https://github.com/apple/swift/pull/65818