### PR TITLE
[move-only] Batched resilient changes

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4261,7 +4261,18 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
     }
   }
 
+  // TODO: This does not take into account resilience, we should probably use
+  // getArgumentType()... but we do not have the SILFunctionType here...
   assert(param.getInterfaceType() == value.getType().getASTType());
+
+  // If we have an indirect_guaranteed argument, move this using store_borrow
+  // into an alloc_stack.
+  if (param.isIndirectInGuaranteed() && value.getType().isObject()) {
+    SILValue alloca = SGF.emitTemporaryAllocation(loc, value.getType());
+    value = SGF.emitFormalEvaluationManagedStoreBorrow(loc, value.getValue(),
+                                                       alloca);
+  }
+
   args[argIndex++] = value;
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4267,7 +4267,8 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
 
   // If we have an indirect_guaranteed argument, move this using store_borrow
   // into an alloc_stack.
-  if (param.isIndirectInGuaranteed() && value.getType().isObject()) {
+  if (SGF.silConv.useLoweredAddresses() &&
+      param.isIndirectInGuaranteed() && value.getType().isObject()) {
     SILValue alloca = SGF.emitTemporaryAllocation(loc, value.getType());
     value = SGF.emitFormalEvaluationManagedStoreBorrow(loc, value.getValue(),
                                                        alloca);

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -778,7 +778,17 @@ ManagedValue SILGenBuilder::createStoreBorrow(SILLocation loc,
                                               SILValue address) {
   assert(value.getOwnershipKind() == OwnershipKind::Guaranteed);
   auto *sbi = createStoreBorrow(loc, value.getValue(), address);
+  SGF.Cleanups.pushCleanup<EndBorrowCleanup>(sbi);
   return ManagedValue(sbi, CleanupHandle::invalid());
+}
+
+ManagedValue SILGenBuilder::createFormalAccessStoreBorrow(SILLocation loc,
+                                                          ManagedValue value,
+                                                          SILValue address) {
+  assert(value.getOwnershipKind() == OwnershipKind::Guaranteed);
+  auto *sbi = createStoreBorrow(loc, value.getValue(), address);
+  return SGF.emitFormalEvaluationManagedBorrowedRValueWithCleanup(
+      loc, value.getValue(), sbi);
 }
 
 ManagedValue SILGenBuilder::createStoreBorrowOrTrivial(SILLocation loc,

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -202,6 +202,8 @@ public:
   using SILBuilder::createStoreBorrow;
   ManagedValue createStoreBorrow(SILLocation loc, ManagedValue value,
                                  SILValue address);
+  ManagedValue createFormalAccessStoreBorrow(SILLocation loc, ManagedValue value,
+                                             SILValue address);
 
   /// Create a store_borrow if we have a non-trivial value and a store [trivial]
   /// otherwise.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -39,8 +39,12 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 }
 
 SILValue SILGenFunction::emitSelfDeclForDestructor(VarDecl *selfDecl) {
+  SILFunctionConventions conventions = F.getConventionsInContext();
+
   // Emit the implicit 'self' argument.
-  SILType selfType = getLoweredType(selfDecl->getType());
+  SILType selfType = conventions.getSILArgumentType(
+      conventions.getNumSILArguments() - 1, F.getTypeExpansionContext());
+  selfType = F.mapTypeIntoContext(selfType);
   SILValue selfValue = F.begin()->createFunctionArgument(selfType, selfDecl);
 
   // If we have a move only type, then mark it with mark_must_check so we can't

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
+
+//////////////////////
+// MARK: DeinitTest //
+//////////////////////
+
+// CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution10DeinitTestVfD : $@convention(method) (@in DeinitTest) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*DeinitTest):
+// CHECK:   drop_deinit [[ARG]]
+// CHECK: } // end sil function '$s26moveonly_library_evolution10DeinitTestVfD'
+public struct DeinitTest : ~Copyable {
+    deinit {
+    }
+}

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,5 +1,21 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
 
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+public struct EmptyStruct : ~Copyable {}
+public struct NonEmptyStruct : ~Copyable {
+    var e = EmptyStruct()
+}
+public class CopyableKlass {
+    var s = NonEmptyStruct()
+
+    let letStruct = NonEmptyStruct()
+}
+
+public func borrowVal(_ x: borrowing EmptyStruct) {}
+
 //////////////////////
 // MARK: DeinitTest //
 //////////////////////
@@ -11,4 +27,25 @@
 public struct DeinitTest : ~Copyable {
     deinit {
     }
+}
+
+//////////////////////////////////////////
+// MARK: Caller Argument Spilling Tests //
+//////////////////////////////////////////
+
+// CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution29callerArgumentSpillingTestArgyyAA13CopyableKlassCF : $@convention(thin) (@guaranteed CopyableKlass) -> () {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $CopyableKlass):
+// CHECK:    [[ADDR:%.*]] = ref_element_addr [[ARG]]
+// CHECK:    [[MARKED_ADDR:%.*]] = mark_must_check [no_consume_or_assign] [[ADDR]]
+// CHECK:    [[LOADED_VALUE:%.*]] = load [copy] [[MARKED_ADDR]]
+// CHECK:    [[BORROWED_LOADED_VALUE:%.*]] = begin_borrow [[LOADED_VALUE]]
+// CHECK:    [[EXT:%.*]] = struct_extract [[BORROWED_LOADED_VALUE]]
+// CHECK:    [[SPILL:%.*]] = alloc_stack $EmptyStruct
+// CHECK:    [[STORE_BORROW:%.*]] = store_borrow [[EXT]] to [[SPILL]]
+// CHECK:    apply {{%.*}}([[STORE_BORROW]]) : $@convention(thin) (@in_guaranteed EmptyStruct) -> ()
+// CHECK:    end_borrow [[STORE_BORROW]]
+// CHECK:    end_borrow [[BORROWED_LOADED_VALUE]]
+// CHECK: } // end sil function '$s26moveonly_library_evolution29callerArgumentSpillingTestArgyyAA13CopyableKlassCF'
+public func callerArgumentSpillingTestArg(_ x: CopyableKlass) {
+    borrowVal(x.letStruct.e)
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-library-evolution %s
+
+// This test is used to validate that we properly handle library evolution code
+// until we can get all of the normal moveonly_addresschecker_diagnostics test
+// case to pass.
+
+////////////////////////
+// MARK: Deinit Tests //
+////////////////////////
+
+public struct DeinitTest : ~Copyable {
+    deinit {}
+}
+
+public protocol P {}
+
+// Once rdar://109170600 is fixed (which tracks us being unable to do this), we
+// should be able to use the : ~Copyable syntax.
+@_moveOnly
+public struct GenericDeinitTest<T : P> {
+    deinit {}
+}
+

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -8,6 +8,21 @@
 // MARK: Deinit Tests //
 ////////////////////////
 
+@_moveOnly public struct EmptyStruct {}
+@_moveOnly public struct NonEmptyStruct {
+    var e = EmptyStruct()
+}
+public class CopyableKlass {
+    var s = NonEmptyStruct()
+}
+
+public func borrowVal(_ x: borrowing NonEmptyStruct) {}
+public func borrowVal(_ x: borrowing EmptyStruct) {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
 public struct DeinitTest : ~Copyable {
     deinit {}
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-library-evolution %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution %s
 
 // This test is used to validate that we properly handle library evolution code
 // until we can get all of the normal moveonly_addresschecker_diagnostics test
 // case to pass.
 
 ////////////////////////
-// MARK: Deinit Tests //
+// MARK: Declarations //
 ////////////////////////
 
 @_moveOnly public struct EmptyStruct {}
@@ -13,11 +13,17 @@
     var e = EmptyStruct()
 }
 public class CopyableKlass {
-    var s = NonEmptyStruct()
+    var varS = NonEmptyStruct()
+    var letS = NonEmptyStruct()
 }
 
 public func borrowVal(_ x: borrowing NonEmptyStruct) {}
 public func borrowVal(_ x: borrowing EmptyStruct) {}
+public func consumeVal(_ x: consuming NonEmptyStruct) {}
+public func consumeVal(_ x: consuming EmptyStruct) {}
+
+let copyableKlassLetGlobal = CopyableKlass()
+var copyableKlassVarGlobal = CopyableKlass()
 
 /////////////////
 // MARK: Tests //
@@ -36,3 +42,134 @@ public struct GenericDeinitTest<T : P> {
     deinit {}
 }
 
+//////////////////////////////////////////
+// MARK: Caller Argument Let Spill Test //
+//////////////////////////////////////////
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestLetGlobal() {
+    borrowVal(copyableKlassLetGlobal.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestVarGlobal() {
+    borrowVal(copyableKlassVarGlobal.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestLetGlobal() {
+    consumeVal(copyableKlassLetGlobal.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestVarGlobal() {
+    consumeVal(copyableKlassVarGlobal.letS.e)
+}
+
+////////////////////
+// MARK: Var Test //
+////////////////////
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestLetGlobal() {
+    borrowVal(copyableKlassLetGlobal.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestVarGlobal() {
+    borrowVal(copyableKlassVarGlobal.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestLetGlobal() {
+    consumeVal(copyableKlassLetGlobal.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestVarGlobal() {
+    consumeVal(copyableKlassVarGlobal.varS.e)
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -35,10 +35,7 @@ public struct DeinitTest : ~Copyable {
 
 public protocol P {}
 
-// Once rdar://109170600 is fixed (which tracks us being unable to do this), we
-// should be able to use the : ~Copyable syntax.
-@_moveOnly
-public struct GenericDeinitTest<T : P> {
+public struct GenericDeinitTest<T : P> : ~Copyable {
     deinit {}
 }
 


### PR DESCRIPTION
In this PR, I include 3 small batched changes that fix some of the issues we are seeing with resilience. Specifically:

1. I discovered that a resilient struct's deinit was having its self argument to the deinit created as an object despite the SILFunctionType having an @in argument.
2. I fixed the move checker to understand how to check a resilient function argument that is concrete within the function implementation. The issue was that we were adding a load_borrow and then performing normal codegen. I just needed to teach the checker to understand how to handle the load_borrow.
3. I fixed the emission when we were passing a concrete type in a module to a resilient function that took it as a borrowed in_guaranteed. To do this, I just changed it to use a store_borrow.