### PR TITLE
[AST] Added language feature for @_eagerMove.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -101,6 +101,7 @@ LANGUAGE_FEATURE(
 LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", hasSwiftSwiftParser)
 LANGUAGE_FEATURE(MoveOnly, 390, "noncopyable types", true)
 LANGUAGE_FEATURE(ParameterPacks, 393, "Value and type parameter packs", true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(LexicalLifetimes, 0, "@_eagerMove/@_noEagerMove/@_lexicalLifetimes annotations", true)
 
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3340,6 +3340,23 @@ static bool usesFeatureFreestandingExpressionMacros(Decl *decl) {
   return macro->getMacroRoles().contains(MacroRole::Expression);
 }
 
+static bool usesFeatureLexicalLifetimes(Decl *decl) {
+  return decl->getAttrs().hasAttribute<EagerMoveAttr>()
+         || decl->getAttrs().hasAttribute<NoEagerMoveAttr>()
+         || decl->getAttrs().hasAttribute<LexicalLifetimesAttr>();
+}
+
+static void
+suppressingFeatureLexicalLifetimes(PrintOptions &options,
+                                   llvm::function_ref<void()> action) {
+  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
+  options.ExcludeAttrList.push_back(DAK_EagerMove);
+  options.ExcludeAttrList.push_back(DAK_NoEagerMove);
+  options.ExcludeAttrList.push_back(DAK_LexicalLifetimes);
+  action();
+  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
 static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {

--- a/test/ModuleInterface/feature-LexicalLifetimes.swift
+++ b/test/ModuleInterface/feature-LexicalLifetimes.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/FeatureTest.swiftinterface) %s -module-name FeatureTest -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/FeatureTest.swiftinterface) -module-name FeatureTest -disable-availability-checking
+// RUN: %FileCheck %s < %t/FeatureTest.swiftinterface
+
+// CHECK: #if compiler(>=5.3) && $LexicalLifetimes
+// CHECK-NEXT: @_noEagerMove public struct Permanent {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public struct Permanent {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+@_noEagerMove
+public struct Permanent {}
+
+// CHECK: #if compiler(>=5.3) && $LexicalLifetimes
+// CHECK-NEXT: @_hasMissingDesignatedInitializers @_eagerMove public class Transient {
+// CHECK-NEXT:   deinit
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: @_hasMissingDesignatedInitializers public class Transient {
+// CHECK-NEXT:   deinit
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+@_eagerMove 
+public class Transient {}
+
+// CHECK: #if compiler(>=5.3) && $LexicalLifetimes
+// CHECK-NEXT: @_lexicalLifetimes public func lexicalInAModuleWithoutLexicalLifetimes(_ t: FeatureTest.Transient)
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func lexicalInAModuleWithoutLexicalLifetimes(_ t: FeatureTest.Transient)
+// CHECK-NEXT: #endif
+@_lexicalLifetimes
+public func lexicalInAModuleWithoutLexicalLifetimes(_ t: Transient) {}


### PR DESCRIPTION
The new `LexicalLifetimes` suppressible language feature results in declarations annotated with `@_eagerMove`, `@_noEagerMove`, and `@_lexicalLifetimes` to be printed with that attribute when it's available and without it when it's not.
