### PR TITLE
[5.9-20230510] [Macros] Improve diagnostics for missing macro implementation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7034,8 +7034,9 @@ ERROR(macro_undefined,PointsToFirstBadToken,
       "no macro named %0", (Identifier))
 ERROR(external_macro_not_found,none,
       "external macro implementation type '%0.%1' could not be found for "
-      "macro %2; the type must be public and provided via "
-      "'-load-plugin-library'", (StringRef, StringRef, DeclName))
+      "macro %2; the type must be public and provided by a macro target in a "
+      "Swift package, or via '-plugin-path' or '-load-plugin-library'",
+      (StringRef, StringRef, DeclName))
 ERROR(macro_must_be_defined,none,
       "macro %0 requires a definition", (DeclName))
 ERROR(external_macro_outside_macro_definition,none,

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -38,7 +38,7 @@ struct SkipNestedType {
 
   // We select the macro, not the property wrapper.
   @m1 var x: Int = 0
-  // expected-error@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'; the type must be public and provided via '-load-plugin-library'}}
+  // expected-error@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'}}
 }
 
 struct TestMacroArgs {

--- a/test/Macros/external-macro-without-decl.swift
+++ b/test/Macros/external-macro-without-decl.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -module-name Swift -parse-stdlib
 
 // expected-warning@+2{{@expression has been removed in favor of @freestanding(expression)}}
-// expected-warning@+1{{external macro implementation type 'A.B' could not be found for macro 'myMacro()'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@+1{{external macro implementation type 'A.B' could not be found for macro 'myMacro()'}}
 @expression macro myMacro() = #externalMacro(module: "A", type: "B")
 
 // Protocols needed for string literals to work

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -137,7 +137,7 @@ func shadow(a: Int, b: Int, stringify: Int) {
 }
 
 func testMissing() {
-  #missingMacro1("hello") // expected-error{{external macro implementation type 'MissingModule.MissingType' could not be found for macro 'missingMacro1'; the type must be public and provided via '-load-plugin-library'}}
+  #missingMacro1("hello") // expected-error{{external macro implementation type 'MissingModule.MissingType' could not be found for macro 'missingMacro1'; the type must be public and provided by a macro target in a Swift package, or via '-plugin-path' or '-load-plugin-library'}}
 }
 
 @freestanding(expression) macro undefined() // expected-error{{macro 'undefined()' requires a definition}}

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -6,16 +6,16 @@ protocol P { }
 protocol Q { associatedtype Assoc }
 
 @freestanding(expression) macro m1() -> Int = #externalMacro(module: "A", type: "M1")
-// expected-warning@-1{{external macro implementation type 'A.M1' could not be found for macro 'm1()'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M1' could not be found for macro 'm1()'}}
 // expected-note@-2{{'m1()' declared here}}
 @freestanding(expression) macro m2(_: Int) = #externalMacro(module: "A", type: "M2")
-// expected-warning@-1{{external macro implementation type 'A.M2' could not be found for macro 'm2'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M2' could not be found for macro 'm2'}}
 @freestanding(expression) macro m3(a b: Int) -> Int = #externalMacro(module: "A", type: "M3")
-// expected-warning@-1{{external macro implementation type 'A.M3' could not be found for macro 'm3(a:)'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M3' could not be found for macro 'm3(a:)'}}
 @freestanding(expression) macro m4<T: Q>() -> T = #externalMacro(module: "A", type: "M4") where T.Assoc: P
-// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm4()'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm4()'}}
 @freestanding(expression) macro m5<T: P>(_: T) = #externalMacro(module: "A", type: "M4")
-// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm5'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm5'}}
 
 @freestanding(expression) macro m6 = A // expected-error{{expected '(' for macro parameters or ':' for a value-like macro}}
 // expected-error@-1{{by a macro expansion}}
@@ -23,18 +23,18 @@ protocol Q { associatedtype Assoc }
 // expected-error @+2 {{expected '('}}
 // expected-error @+1 {{macro 'm7' must declare its applicable roles}}
 @freestanding macro m7(_: String) = #externalMacro(module: "A", type: "M4")
-// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm7'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm7'}}
 
 // expected-error @+2 {{expected a freestanding macro role such as 'expression'}}
 // expected-error @+1 {{macro 'm8' must declare its applicable roles}}
 @freestanding(abc) macro m8(_: String) = #externalMacro(module: "A", type: "M4")
-// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm8'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm8'}}
 @freestanding(declaration, names: arbitrary) macro m9(_: String) = #externalMacro(module: "A", type: "M4")
-// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm9'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm9'}}
 
 @freestanding(expression) @freestanding(declaration, names: named(Foo)) @attached(accessor)
 macro m10(_: String) = #externalMacro(module: "A", type: "M4")
-// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm10'; the type must be public and provided via '-load-plugin-library'}}
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm10'}}
 
 @attached(
   accessor,
@@ -55,4 +55,4 @@ macro am2() -> Void
 
 #m1 + 1
 // expected-warning @-1 {{result of operator '+' is unused}}
-// expected-error @-2 {{external macro implementation type 'A.M1' could not be found for macro 'm1()'; the type must be public and provided via '-load-plugin-library'}}
+// expected-error @-2 {{external macro implementation type 'A.M1' could not be found for macro 'm1()'}}


### PR DESCRIPTION
Cherry-pick #65814

---

* **Explanation**: Improve an incorrect diagnostic message that misleads people to using `-load-plugin-library` to load plugin libraries, whereas most developers should actually be using a Swift package dependency for a self-defined or open-source macro implementation.
* **Scope**: One type checker diagnostic message
* **Risk**: Low
* **Testing**: Updated tests for the new diagnostic