### PR TITLE
[5.9] Limit loading error when importing a module with package name built from interface

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -825,15 +825,6 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
     if (loadedModuleFile->isConcurrencyChecked())
       M.setIsConcurrencyChecked();
     if (!loadedModuleFile->getModulePackageName().empty()) {
-      if (loadedModuleFile->isBuiltFromInterface() &&
-          loadedModuleFile->getModulePackageName().str() == Ctx.LangOpts.PackageName) {
-        Ctx.Diags.diagnose(SourceLoc(),
-                           diag::in_package_module_not_compiled_from_source,
-                           M.getBaseIdentifier(),
-                           Ctx.LangOpts.PackageName,
-                           loadedModuleFile->getModuleSourceFilename()
-                           );
-      }
       M.setPackageName(Ctx.getIdentifier(loadedModuleFile->getModulePackageName()));
     }
     M.setUserModuleVersion(loadedModuleFile->getUserModuleVersion());

--- a/test/Sema/accessibility_package_import_interface.swift
+++ b/test/Sema/accessibility_package_import_interface.swift
@@ -1,0 +1,149 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// TEST Build Dep with package symbols
+// RUN: %target-swift-frontend -emit-module %t/Dep.swift \
+// RUN:   -module-name Dep -swift-version 5 -I %t \
+// RUN:   -package-name myPkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Dep.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Dep.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Dep.private.swiftinterface
+
+// TEST Dep private interface should contain the package name
+// RUN: %target-swift-typecheck-module-from-interface(%t/Dep.private.swiftinterface) -module-name Dep -I %t
+// RUN: %FileCheck %s --check-prefix=CHECK-DEP-PRIVATE < %t/Dep.private.swiftinterface
+// CHECK-DEP-PRIVATE: -package-name myPkg
+
+// TEST Dep.swiftmodule should contain package name and package symbols
+// RUN: llvm-bcanalyzer --dump %t/Dep.swiftmodule | %FileCheck %s --check-prefix=CHECK-DEP-BC
+// CHECK-DEP-BC: <MODULE_PACKAGE_NAME abbrevid=6/> blob data = 'myPkg'
+
+// TEST Lib should load Dep.swiftmodule and access package decls if in the same package and error if not
+
+// RUN: %target-swift-frontend -typecheck %t/Lib.swift -package-name myPkg -I %t -verify
+
+// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -package-name otherPkg -I %t -Rmodule-loading 2> %t/result-binary-other-pkg.output
+// RUN: %FileCheck %s --check-prefix=CHECK-DIFF-PKG < %t/result-binary-other-pkg.output
+
+// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -I %t -Rmodule-loading 2> %t/result-binary-no-pkg.output
+// RUN: %FileCheck %s --check-prefix=CHECK-DIFF-PKG < %t/result-binary-no-pkg.output
+
+// CHECK-DIFF-PKG: remark: loaded module 'Dep'
+// CHECK-DIFF-PKG: error: cannot find 'packageFuncInlinable' in scope
+// CHECK-DIFF-PKG: error: cannot find 'packageFunc' in scope
+// CHECK-DIFF-PKG: error: cannot find 'PackageKlassUFI' in scope
+
+// TEST Remove Dep binary and build it from interface
+// RUN: rm %t/Dep.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Dep.private.swiftinterface \
+// RUN:   -module-name Dep -I %t \
+// RUN:   -o %t/Dep.swiftmodule
+
+// TEST Dep binary built from interface should contain package name but no package symbols
+// RUN: llvm-bcanalyzer --dump %t/Dep.swiftmodule | %FileCheck %s --check-prefix=CHECK-DEP-INTER-BC
+// CHECK-DEP-INTER-BC: <MODULE_PACKAGE_NAME abbrevid=7/> blob data = 'myPkg'
+
+// TEST Lib should error on loading Dep built from interface and accessing package symbols (unless usableFromInline or inlinable)
+// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -package-name myPkg -I %t 2> %t/result-access.output
+// RUN: %FileCheck %s --check-prefix CHECK-LIB < %t/result-access.output
+// CHECK-LIB: error: module 'Dep' is in package 'myPkg' but was built from interface; modules of the same package can only be loaded if built from source
+// CHECK-LIB: error: cannot find 'packageFunc' in scope
+// CHECK-LIB: error: value of type 'PackageKlassUFI' has no member 'packageVar'
+
+// TEST Remove and rebuild Dep from source
+// RUN: rm %t/Dep.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Dep.swift \
+// RUN:   -module-name Dep -swift-version 5 -I %t \
+// RUN:   -package-name myPkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Dep.swiftmodule
+
+// TEST Build LibPass with package name
+// RUN: %target-swift-frontend -emit-module %t/LibPass.swift \
+// RUN:   -module-name LibPass -swift-version 5 -I %t \
+// RUN:   -package-name myPkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/LibPass.swiftmodule \
+// RUN:   -emit-module-interface-path %t/LibPass.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/LibPass.private.swiftinterface
+
+// TEST Loading LibPass and accessing lib func should pass
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -package-name myPkg -I %t -verify
+
+// TEST Building LibPass from interface with Dep (built from interface) should succeed with or without package name
+// Without package name
+// RUN: rm %t/Dep.swiftmodule
+// RUN: rm %t/LibPass.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/LibPass.private.swiftinterface \
+// RUN:   -module-name LibPass -I %t \
+// RUN:   -o %t/LibPass.swiftmodule
+
+// With package name
+// RUN: rm %t/LibPass.swiftmodule
+// RUN: %target-swift-frontend -compile-module-from-interface %t/LibPass.private.swiftinterface \
+// RUN:   -module-name LibPass -I %t \
+// RUN:   -package-name myPkg \
+// RUN:   -o %t/LibPass.swiftmodule
+
+
+//--- Dep.swift
+@usableFromInline
+package class PackageKlassUFI {
+  @usableFromInline package init() {}
+  @usableFromInline package var packageVarUFI: String = "pkgUFI"
+  package var packageVar: String = "pkg"
+}
+
+package func packageFunc() {
+  print("package func")
+}
+
+@inlinable
+package func packageFuncInlinable() {
+  print("inlinable package func")
+}
+
+public func publicFunc() {
+  print("public func")
+}
+
+@inlinable
+public func publicFuncInlinable() {
+  print("inlinable public func")
+}
+
+//--- Lib.swift
+import Dep
+
+public func libFunc() {
+  publicFuncInlinable()
+  publicFunc()
+  packageFuncInlinable()
+  packageFunc()
+  let x = PackageKlassUFI()
+  let y = x.packageVarUFI
+  let z = x.packageVar
+  print(x, y, z)
+}
+
+
+//--- LibPass.swift
+import Dep
+
+public func libFunc() {
+  publicFuncInlinable()
+  publicFunc()
+  packageFuncInlinable()
+  let x = PackageKlassUFI()
+  let y = x.packageVarUFI
+  print(x, y)
+}
+
+
+//--- Client.swift
+import LibPass
+
+public func clientFunc() {
+  libFunc()
+}

--- a/test/api-digester/import-module-with-package-name.swift
+++ b/test/api-digester/import-module-with-package-name.swift
@@ -1,0 +1,105 @@
+// REQUIRES: VENDOR=apple
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t.mod)
+// RUN: %empty-directory(%t.sdk)
+// RUN: %empty-directory(%t.module-cache)
+// RUN: split-file %s %t
+
+// Make sure api-digester loads an interface with package-name correctly
+
+// Generate module Lib
+// RUN: %target-swift-frontend  %t/Lib.swift -emit-module -module-name Lib -emit-module-path %t.mod/Lib.swiftmodule -emit-module-interface-path %t.mod/Lib.swiftinterface -emit-private-module-interface-path %t.mod/Lib.private.swiftinterface -package-name myLib -parse-as-library -enable-library-evolution -module-cache-path %t.module-cache -swift-version 5
+
+// Dumping sdk for Lib ABI via .swiftmodule file should work
+// RUN: %api-digester -dump-sdk -abort-on-module-fail -abi -module Lib -o - -module-cache-path %t.module-cache -I %t.mod > %t.dump-lib-binary.json
+// RUN: %FileCheck -check-prefix=LIB-BINARY %s < %t.dump-lib-binary.json
+// LIB-BINARY: PkgKlass
+// LIB-BINARY: pkgFunc
+// LIB-BINARY: PublicStruct
+// LIB-BINARY: PkgKlassUFI
+// LIB-BINARY: libFunc
+
+// Dumping sdk file for Lib ABI via .swiftinterface file should work
+// RUN: %api-digester -dump-sdk -abort-on-module-fail -abi -module Lib -use-interface-for-module Lib -o - -module-cache-path %t.module-cache -I %t.mod > %t.dump-lib-interface.json
+// RUN: %FileCheck -check-prefix=LIB-INTERFACE %s < %t.dump-lib-interface.json
+// LIB-INTERFACE-NOT: PkgKlass
+// LIB-INTERFACE-NOT: pkgFunc
+// LIB-INTERFACE: PublicStruct
+// LIB-INTERFACE: PkgKlassUFI
+// LIB-INTERFACE: libFunc
+
+// Generate module Client
+// RUN: %target-swift-frontend %t/Client.swift -emit-module -module-name Client -emit-module-path %t.mod/Client.swiftmodule -emit-module-interface-path %t.mod/Client.swiftinterface -emit-private-module-interface-path %t.mod/Client.private.swiftinterface -package-name myLib -parse-as-library -enable-library-evolution -module-cache-path %t.module-cache -swift-version 5  -I %t.mod
+
+// RUN: rm -f %t.mod/Lib.swiftmodule
+// RUN: rm -f %t.module-cache/Lib*.swiftmodule
+
+// Dumping sdk for Client ABI via .swiftmodule file should work
+// RUN: %api-digester -dump-sdk -abort-on-module-fail -abi -module Client -o - -module-cache-path %t.module-cache -I %t.mod > %t.dump-client-binary.json
+// RUN: %FileCheck -check-prefix=CLIENT-BINARY %s < %t.dump-client-binary.json
+// CLIENT-BINARY-NOT: PkgKlass
+// CLIENT-BINARY-NOT: pkgFunc
+// CLIENT-BINARY-NOT: PublicStruct
+// CLIENT-BINARY-NOT: PkgKlassUFI
+// CLIENT-BINARY-NOT: libFunc
+// CLIENT-BINARY: clientFunc
+// CLIENT-BINARY: clientFuncInlinable
+
+// Dumping sdk for Client ABI via .swiftinterface file should work
+// RUN: %api-digester -dump-sdk -abort-on-module-fail -abi -module Client -use-interface-for-module Client -o - -module-cache-path %t.module-cache -I %t.mod > %t.dump-client-interface.json
+// RUN: %FileCheck -check-prefix=CLIENT-INTERFACE %s < %t.dump-client-interface.json
+// CLIENT-INTERFACE-NOT: PkgKlass
+// CLIENT-INTERFACE-NOT: pkgFunc
+// CLIENT-INTERFACE-NOT: PublicStruct
+// CLIENT-INTERFACE-NOT: PkgKlassUFI
+// CLIENT-INTERFACE-NOT: libFunc
+// CLIENT-INTERFACE: clientFunc
+// CLIENT-INTERFACE: clientFuncInlinable
+
+
+//--- Lib.swift
+package class PkgKlass {
+  package class func foo() {}
+  package func foo2(_ : Int) {}
+  package weak var bar : PkgKlass?
+  package var bar2 : PkgKlass?
+}
+
+package func pkgFunc() -> (PkgKlass) -> () { return { _ in } }
+
+public struct PublicStruct {
+  package init(_ : PkgKlass?) {}
+  public static func baz(_ arg: String?) {}
+}
+
+@usableFromInline
+package struct PkgKlassUFI {
+  @usableFromInline
+  package init() {}
+  @usableFromInline
+  package func ufiFunc() {}
+}
+
+@inlinable
+public func libFunc() {
+  PkgKlassUFI().ufiFunc()
+}
+
+//--- Client.swift
+import Lib
+
+public func clientFunc() {
+  PkgKlass.foo()
+  let result = pkgFunc()
+  let s = PublicStruct(nil)
+  PublicStruct.baz("")
+  print(s, result)
+}
+
+@inlinable
+public func clientFuncInlinable() {
+  let x = PkgKlassUFI()
+  libFunc()
+  print(x)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65481 & https://github.com/apple/swift/pull/65855

Explanation: Previously a diagnostic was added to show an error when loading a module with package name if it was built from interface. It was expected if the file being built is a .swift file. If it's an interface, however, it should not throw an error (since interface files do not contain `package` symbols unless inlinable or usableFromInline). The change in this PR adds the check and was previously merged to main (Ref: rdar://108633068). This PR needs to be in 5.9 as it happens to fix a blocker for adoption of the `package` access modifier: the error occurs during a build that runs api-digester which treats the source as an interface, leading to a build failure.  

Scope: Unblocks building Swift projects containing `package` access modifier that run api-digester.
Issue: rdar://108945440
Risk: Low. The change is minimal as it checks the source kind before throwing an error.
Testing: Tests were added to ensure that it does not throw an error if the source kind is interface.
Reviewer: @xymus @tshortli @nkcsgexi 