### PR TITLE
[5.8][Runtime] Fix swift_weakTakeStrong().

### DIFF
--- a/stdlib/public/runtime/WeakReference.h
+++ b/stdlib/public/runtime/WeakReference.h
@@ -175,8 +175,9 @@ class WeakReference {
   HeapObject *nativeTakeStrongFromBits(WeakReferenceBits bits) {
     auto side = bits.getNativeOrNull();
     if (side) {
+      auto obj = side->tryRetain();
       side->decrementWeak();
-      return side->tryRetain();
+      return obj;
     } else {
       return nullptr;
     }


### PR DESCRIPTION
It turns out that when taking the last weak reference for an object that has been deallocated, we might have returned a non-null pointer when we shouldn't have.  Which is exciting.

rdar://106375185, rdar://109151498
