### PR TITLE
[Macros] Support module-qualified attached macro lookup

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8591,6 +8591,8 @@ public:
 /// declaration/expression nodes.
 struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
   SourceLoc SigilLoc;
+  DeclNameRef ModuleName;
+  DeclNameLoc ModuleNameLoc;
   DeclNameRef MacroName;
   DeclNameLoc MacroNameLoc;
   SourceLoc LeftAngleLoc, RightAngleLoc;
@@ -8601,12 +8603,15 @@ struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
   ConcreteDeclRef macroRef;
 
   MacroExpansionInfo(SourceLoc sigilLoc,
+                     DeclNameRef moduleName,
+                     DeclNameLoc moduleNameLoc,
                      DeclNameRef macroName,
                      DeclNameLoc macroNameLoc,
                      SourceLoc leftAngleLoc, SourceLoc rightAngleLoc,
                      ArrayRef<TypeRepr *> genericArgs,
                      ArgumentList *argList)
-    : SigilLoc(sigilLoc), MacroName(macroName), MacroNameLoc(macroNameLoc),
+    : SigilLoc(sigilLoc), ModuleName(moduleName), ModuleNameLoc(moduleNameLoc),
+      MacroName(macroName), MacroNameLoc(macroNameLoc),
       LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
       GenericArgs(genericArgs), ArgList(argList) { }
 };

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6208,7 +6208,10 @@ public:
   }
 
   explicit MacroExpansionExpr(DeclContext *dc,
-                              SourceLoc sigilLoc, DeclNameRef macroName,
+                              SourceLoc sigilLoc,
+                              DeclNameRef moduleName,
+                              DeclNameLoc moduleNameLoc,
+                              DeclNameRef macroName,
                               DeclNameLoc macroNameLoc,
                               SourceLoc leftAngleLoc,
                               ArrayRef<TypeRepr *> genericArgs,
@@ -6218,6 +6221,8 @@ public:
                               bool isImplicit = false,
                               Type ty = Type());
 
+  DeclNameRef getModuleName() const { return info->ModuleName; }
+  DeclNameLoc getModuleNameLoc() const { return info->ModuleNameLoc; }
   DeclNameRef getMacroName() const { return info->MacroName; }
   DeclNameLoc getMacroNameLoc() const { return info->MacroNameLoc; }
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3226,6 +3226,8 @@ public:
   }
 
   SourceLoc getSigilLoc() const;
+  DeclNameRef getModuleName() const;
+  DeclNameLoc getModuleNameLoc() const;
   DeclNameRef getMacroName() const;
   DeclNameLoc getMacroNameLoc() const;
   SourceRange getGenericArgsRange() const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10566,8 +10566,8 @@ MacroExpansionDecl::MacroExpansionDecl(
 ) : Decl(DeclKind::MacroExpansion, dc) {
   ASTContext &ctx = dc->getASTContext();
   info = new (ctx) MacroExpansionInfo{
-      poundLoc, macro, macroLoc,
-      leftAngleLoc, rightAngleLoc, genericArgs,
+      poundLoc, /*moduleName*/ DeclNameRef(), /*moduleNameLoc*/ DeclNameLoc(),
+      macro, macroLoc, leftAngleLoc, rightAngleLoc, genericArgs,
       args ? args : ArgumentList::createImplicit(ctx, {})
   };
   Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2713,7 +2713,8 @@ TypeJoinExpr::forBranchesOfSingleValueStmtExpr(ASTContext &ctx, Type joinType,
 }
 
 MacroExpansionExpr::MacroExpansionExpr(
-    DeclContext *dc, SourceLoc sigilLoc, DeclNameRef macroName,
+    DeclContext *dc, SourceLoc sigilLoc, DeclNameRef moduleName,
+    DeclNameLoc moduleNameLoc, DeclNameRef macroName,
     DeclNameLoc macroNameLoc, SourceLoc leftAngleLoc,
     ArrayRef<TypeRepr *> genericArgs, SourceLoc rightAngleLoc,
     ArgumentList *argList, MacroRoles roles, bool isImplicit,
@@ -2722,7 +2723,7 @@ MacroExpansionExpr::MacroExpansionExpr(
     Rewritten(nullptr), Roles(roles), SubstituteDecl(nullptr) {
   ASTContext &ctx = dc->getASTContext();
   info = new (ctx) MacroExpansionInfo{
-      sigilLoc, macroName, macroNameLoc,
+      sigilLoc, moduleName, moduleNameLoc, macroName, macroNameLoc,
       leftAngleLoc, rightAngleLoc, genericArgs,
       argList ? argList : ArgumentList::createImplicit(ctx, {})
   };

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9806,7 +9806,6 @@ Parser::parseDeclMacroExpansion(ParseDeclOptions flags,
   return makeParserResult(
       status,
       new (Context) MacroExpansionDecl(
-        CurDeclContext, poundLoc, macroNameRef, macroNameLoc,
-        leftAngleLoc, Context.AllocateCopy(genericArgs), rightAngleLoc,
-        argList));
+        CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
+        Context.AllocateCopy(genericArgs), rightAngleLoc, argList));
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3413,8 +3413,9 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
   return makeParserResult(
       status,
       new (Context) MacroExpansionExpr(
-          CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
-          Context.AllocateCopy(genericArgs), rightAngleLoc, argList,
+          CurDeclContext, poundLoc, DeclNameRef(), DeclNameLoc(), macroNameRef,
+          macroNameLoc, leftAngleLoc, Context.AllocateCopy(genericArgs),
+          rightAngleLoc, argList,
           CurDeclContext->isTypeContext()
               ? MacroRole::Declaration
               : getFreestandingMacroRoles()));

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2938,9 +2938,10 @@ namespace {
         auto macro = cast<MacroDecl>(overload.choice.getDecl());
         ConcreteDeclRef macroRef = resolveConcreteDeclRef(macro, locator);
         auto expansion = new (ctx) MacroExpansionExpr(
-            dc, expr->getStartLoc(), DeclNameRef(macro->getName()),
-            DeclNameLoc(expr->getLoc()), SourceLoc(), {}, SourceLoc(), nullptr,
-            MacroRole::Expression, /*isImplicit=*/true, expandedType);
+            dc, expr->getStartLoc(), DeclNameRef(), DeclNameLoc(),
+            DeclNameRef(macro->getName()), DeclNameLoc(expr->getLoc()),
+            SourceLoc(), {}, SourceLoc(), nullptr, MacroRole::Expression,
+            /*isImplicit=*/true, expandedType);
         expansion->setMacroRef(macroRef);
         (void)evaluateOrDefault(
             ctx.evaluator, ExpandMacroExpansionExprRequest{expansion}, None);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1527,7 +1527,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   // So bail out to prevent diagnostics from the contraint system.
   if (macroRef.getAttr()) {
     auto foundMacros = TypeChecker::lookupMacros(
-        dc, macroRef.getMacroName(), SourceLoc(), roles);
+        dc, macroRef.getModuleName(), macroRef.getMacroName(),
+        SourceLoc(), roles);
     if (foundMacros.empty())
       return ConcreteDeclRef();
   }
@@ -1543,7 +1544,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   } else {
     SourceRange genericArgsRange = macroRef.getGenericArgsRange();
     macroExpansion = new (ctx) MacroExpansionExpr(
-      dc, macroRef.getSigilLoc(), macroRef.getMacroName(),
+      dc, macroRef.getSigilLoc(), macroRef.getModuleName(),
+      macroRef.getModuleNameLoc(), macroRef.getMacroName(),
       macroRef.getMacroNameLoc(), genericArgsRange.Start,
       macroRef.getGenericArgs(), genericArgsRange.End,
       macroRef.getArgs(), roles);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -924,9 +924,10 @@ lookupPrecedenceGroupForInfixOperator(DeclContext *dc, Expr *op, bool diagnose);
 PrecedenceGroupLookupResult
 lookupPrecedenceGroup(DeclContext *dc, Identifier name, SourceLoc nameLoc);
 
-SmallVector<MacroDecl *, 1>
-lookupMacros(DeclContext *dc, DeclNameRef macroName, SourceLoc loc,
-             MacroRoles contexts);
+SmallVector<MacroDecl *, 1> lookupMacros(DeclContext *dc,
+                                         DeclNameRef moduleName,
+                                         DeclNameRef macroName, SourceLoc loc,
+                                         MacroRoles roles);
 
 enum class UnsupportedMemberTypeAccessKind : uint8_t {
   None,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -832,14 +832,23 @@ public struct AddCompletionHandler: PeerMacro {
     // Drop the @addCompletionHandler attribute from the new declaration.
     let newAttributeList = AttributeListSyntax(
       funcDecl.attributes?.filter {
-        guard case let .attribute(attribute) = $0,
-              let attributeType = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self),
-              let nodeType = node.attributeName.as(SimpleTypeIdentifierSyntax.self)
-        else {
+        guard case let .attribute(attribute) = $0 else {
           return true
         }
 
-        return attributeType.name.text != nodeType.name.text
+        if let attributeType = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self),
+           let nodeType = node.attributeName.as(SimpleTypeIdentifierSyntax.self) {
+          return attributeType.name.text != nodeType.name.text
+        }
+        if let attributeMemberType = attribute.attributeName.as(MemberTypeIdentifierSyntax.self),
+           let attributeModuleName = attributeMemberType.baseType.as(SimpleTypeIdentifierSyntax.self),
+           let nodeMemberType = node.attributeName.as(MemberTypeIdentifierSyntax.self),
+           let moduleName = nodeMemberType.baseType.as(SimpleTypeIdentifierSyntax.self) {
+          return attributeModuleName.name.text != moduleName.name.text ||
+              nodeMemberType.name.text != attributeMemberType.name.text
+        }
+
+        return true
       } ?? []
     )
 

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -37,10 +37,17 @@ macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition", type
 macro addCompletionHandlerArbitrarily(_: Int) = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
 
 struct S {
+#if IMPORT_MACRO_LIBRARY
+  @macro_library.addCompletionHandler // test module qualified macro lookup
+  func f(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+#else
   @addCompletionHandler
   func f(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }
+#endif
 
   // CHECK-DUMP: @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_.swift
   // CHECK-DUMP: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {


### PR DESCRIPTION
Allow attached macro expansion syntax to have a module qualifier, i.e. `@Foo.Bar`.

rdar://108621205