### PR TITLE
[ClangImporter] Query `Preprocessor::macros` instead of `getPreprocessingRecord` for header printing

### DIFF
--- a/test/IDE/Inputs/print_clang_header/header-to-print.h
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h
@@ -7,6 +7,9 @@
 #undef MACRO_GOT_UNDEFINED
 #define MY_MACRO 1
 
+#define MACRO_DUP 2
+#define MACRO_DUP 3
+
 void doSomethingInHead(int arg);
 
 @interface BaseInHead

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
@@ -4,6 +4,8 @@ import Dispatch
 
 var MY_MACRO: Int32 { get }
 
+var MACRO_DUP: Int32 { get }
+
 func doSomethingInHead(_ arg: Int32)
 
 class BaseInHead {

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
@@ -1,6 +1,8 @@
 
 var MY_MACRO: Int32 { get }
 
+var MACRO_DUP: Int32 { get }
+
 func doSomethingInHead(_ arg: Int32)
 
 class BaseInHead {

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
@@ -4,6 +4,8 @@ import Dispatch
 
 var MY_MACRO: Int32 { get }
 
+var MACRO_DUP: Int32 { get }
+
 func doSomethingInHead(_ arg: Int32)
 
 class BaseInHead {

--- a/test/IDE/print_clang_header.swift
+++ b/test/IDE/print_clang_header.swift
@@ -1,8 +1,6 @@
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
 // REQUIRES: objc_interop
 
-// REQUIRES: rdar102151774
-
 // RUN: echo '#include "header-to-print.h"' > %t.m
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.txt
@@ -19,9 +17,6 @@
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml -Xclang -fmodule-name=Foo > %t.framework.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.framework.txt
 
-// Test header interface printing from a clang module, with the preprocessing record enabled before the CC args.
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -Xcc -Xclang -Xcc -detailed-preprocessing-record -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml > %t.module.txt
+// Test header interface printing from a clang module.
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml > %t.module.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.module.printed.txt %t.module.txt
-// Test header interface printing from a clang module, with the preprocessing record enabled by the CC args.
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml -Xclang -detailed-preprocessing-record > %t.module2.txt
-// RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.module.printed.txt %t.module2.txt


### PR DESCRIPTION
This better matches what the clang importer does normally, avoids a Clang issue where `getPreprocessedEntitiesInRange` returns incorrect results (rdar://109254260), and avoids the need to enable the preprocessor record. This then lets us re-enable `print_clang_headers.swift`.

rdar://102151774
