### PR TITLE
[5.9][move-only] A series of batched commits.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -112,9 +112,6 @@ PASS(AccessMarkerElimination, "access-marker-elim",
      "Access Marker Elimination.")
 PASS(AddressLowering, "address-lowering",
      "SIL Address Lowering")
-PASS(EarlyAllocBoxToStack, "early-allocbox-to-stack",
-     "Stack Promotion of Box Objects. Doesn't attempt to promote noncopyable "
-     "types captured by escaping closures")
 PASS(AllocBoxToStack, "allocbox-to-stack",
      "Stack Promotion of Box Objects")
 IRGEN_PASS(AllocStackHoisting, "alloc-stack-hoisting",

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4261,7 +4261,18 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
     }
   }
 
+  // TODO: This does not take into account resilience, we should probably use
+  // getArgumentType()... but we do not have the SILFunctionType here...
   assert(param.getInterfaceType() == value.getType().getASTType());
+
+  // If we have an indirect_guaranteed argument, move this using store_borrow
+  // into an alloc_stack.
+  if (param.isIndirectInGuaranteed() && value.getType().isObject()) {
+    SILValue alloca = SGF.emitTemporaryAllocation(loc, value.getType());
+    value = SGF.emitFormalEvaluationManagedStoreBorrow(loc, value.getValue(),
+                                                       alloca);
+  }
+
   args[argIndex++] = value;
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4267,7 +4267,8 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
 
   // If we have an indirect_guaranteed argument, move this using store_borrow
   // into an alloc_stack.
-  if (param.isIndirectInGuaranteed() && value.getType().isObject()) {
+  if (SGF.silConv.useLoweredAddresses() &&
+      param.isIndirectInGuaranteed() && value.getType().isObject()) {
     SILValue alloca = SGF.emitTemporaryAllocation(loc, value.getType());
     value = SGF.emitFormalEvaluationManagedStoreBorrow(loc, value.getValue(),
                                                        alloca);

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -778,7 +778,17 @@ ManagedValue SILGenBuilder::createStoreBorrow(SILLocation loc,
                                               SILValue address) {
   assert(value.getOwnershipKind() == OwnershipKind::Guaranteed);
   auto *sbi = createStoreBorrow(loc, value.getValue(), address);
+  SGF.Cleanups.pushCleanup<EndBorrowCleanup>(sbi);
   return ManagedValue(sbi, CleanupHandle::invalid());
+}
+
+ManagedValue SILGenBuilder::createFormalAccessStoreBorrow(SILLocation loc,
+                                                          ManagedValue value,
+                                                          SILValue address) {
+  assert(value.getOwnershipKind() == OwnershipKind::Guaranteed);
+  auto *sbi = createStoreBorrow(loc, value.getValue(), address);
+  return SGF.emitFormalEvaluationManagedBorrowedRValueWithCleanup(
+      loc, value.getValue(), sbi);
 }
 
 ManagedValue SILGenBuilder::createStoreBorrowOrTrivial(SILLocation loc,

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -202,6 +202,8 @@ public:
   using SILBuilder::createStoreBorrow;
   ManagedValue createStoreBorrow(SILLocation loc, ManagedValue value,
                                  SILValue address);
+  ManagedValue createFormalAccessStoreBorrow(SILLocation loc, ManagedValue value,
+                                             SILValue address);
 
   /// Create a store_borrow if we have a non-trivial value and a store [trivial]
   /// otherwise.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -39,8 +39,12 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 }
 
 SILValue SILGenFunction::emitSelfDeclForDestructor(VarDecl *selfDecl) {
+  SILFunctionConventions conventions = F.getConventionsInContext();
+
   // Emit the implicit 'self' argument.
-  SILType selfType = getLoweredType(selfDecl->getType());
+  SILType selfType = conventions.getSILArgumentType(
+      conventions.getNumSILArguments() - 1, F.getTypeExpansionContext());
+  selfType = F.mapTypeIntoContext(selfType);
   SILValue selfValue = F.begin()->createFunctionArgument(selfType, selfDecl);
 
   // If we have a move only type, then mark it with mark_must_check so we can't

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
@@ -105,7 +105,6 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
                << '\n');
 
     bool madeChange = false;
-    unsigned diagCount = 0;
     if (moveIntroducersToProcess.empty()) {
       LLVM_DEBUG(llvm::dbgs() << "No move introducers found?!\n");
     } else {
@@ -113,12 +112,11 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
       MoveOnlyAddressChecker checker{getFunction(), diagnosticEmitter,
                                      allocator, domTree, poa};
       madeChange = checker.check(moveIntroducersToProcess);
-      diagCount = checker.diagnosticEmitter.getDiagnosticCount();
     }
 
     // If we did not emit any diagnostics, emit a diagnostic if we missed any
     // copies.
-    if (!diagCount) {
+    if (!diagnosticEmitter.emittedDiagnostic()) {
       emitCheckerMissedCopyOfNonCopyableTypeErrors(getFunction(),
                                                    diagnosticEmitter);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -225,6 +225,7 @@
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FrozenMultiMap.h"
@@ -490,6 +491,92 @@ static bool isInOutDefThatNeedsEndOfFunctionLiveness(MarkMustCheckInst *markedAd
 
 
   return false;
+}
+
+//===----------------------------------------------------------------------===//
+//                       MARK: Partial Apply Utilities
+//===----------------------------------------------------------------------===//
+
+static bool findNonEscapingPartialApplyUses(
+    PartialApplyInst *pai, TypeTreeLeafTypeRange leafRange,
+    llvm::SmallMapVector<SILInstruction *, TypeTreeLeafTypeRange, 4>
+        &livenessUses) {
+  StackList<Operand *> worklist(pai->getFunction());
+  for (auto *use : pai->getUses())
+    worklist.push_back(use);
+
+  LLVM_DEBUG(llvm::dbgs() << "Searching for partial apply uses!\n");
+  while (!worklist.empty()) {
+    auto *use = worklist.pop_back_val();
+
+    if (use->isTypeDependent())
+      continue;
+
+    auto *user = use->getUser();
+
+    // These instructions do not cause us to escape.
+    if (isIncidentalUse(user) || isa<DestroyValueInst>(user))
+      continue;
+
+    // Look through these instructions.
+    if (isa<BeginBorrowInst>(user) || isa<CopyValueInst>(user) ||
+        isa<MoveValueInst>(user) ||
+        // If we capture this partial_apply in another partial_apply, then we
+        // know that said partial_apply must not have escaped the value since
+        // otherwise we could not have an inout_aliasable argument or be
+        // on_stack. Process it recursively so that we treat uses of that
+        // partial_apply and applies of that partial_apply as uses of our
+        // partial_apply.
+        //
+        // We have this separately from the other look through sections so that
+        // we can make it clearer what we are doing here.
+        isa<PartialApplyInst>(user)) {
+      for (auto *use : cast<SingleValueInstruction>(user)->getUses())
+        worklist.push_back(use);
+      continue;
+    }
+
+    // If we have a mark_dependence and are the value, look through the
+    // mark_dependence.
+    if (auto *mdi = dyn_cast<MarkDependenceInst>(user)) {
+      if (mdi->getValue() == use->get()) {
+        for (auto *use : mdi->getUses())
+          worklist.push_back(use);
+        continue;
+      }
+    }
+
+    if (auto apply = FullApplySite::isa(user)) {
+      // If we apply the function or pass the function off to an apply, then we
+      // need to treat the function application as a liveness use of the
+      // variable since if the partial_apply is invoked within the function
+      // application, we may access the captured variable.
+      livenessUses.insert({user, leafRange});
+      if (apply.beginsCoroutineEvaluation()) {
+        // If we have a coroutine, we need to treat the abort_apply and
+        // end_apply as liveness uses since once we execute one of those
+        // instructions, we have returned control to the coroutine which means
+        // that we could then access the captured variable again.
+        auto *bai = cast<BeginApplyInst>(user);
+        SmallVector<EndApplyInst *, 4> endApplies;
+        SmallVector<AbortApplyInst *, 4> abortApplies;
+        bai->getCoroutineEndPoints(endApplies, abortApplies);
+        for (auto *eai : endApplies)
+          livenessUses.insert({eai, leafRange});
+        for (auto *aai : abortApplies)
+          livenessUses.insert({aai, leafRange});
+      }
+      continue;
+    }
+
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "Found instruction we did not understand... returning false!\n");
+    LLVM_DEBUG(llvm::dbgs() << "Instruction: " << *user);
+    return false;
+  }
+
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1639,10 +1726,15 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
                    << "Found mark must check [nocopy] error: " << *user);
         auto *fArg = dyn_cast<SILFunctionArgument>(
             stripAccessMarkers(markedValue->getOperand()));
-        if (fArg && fArg->isClosureCapture() && fArg->getType().isAddress()) {
-          moveChecker.diagnosticEmitter.emitPromotedBoxArgumentError(
-              markedValue, fArg);
+        // If we have a closure captured that we specialized, we should have a
+        // no consume or assign and should emit a normal guaranteed diagnostic.
+        if (fArg && fArg->isClosureCapture() &&
+            fArg->getArgumentConvention().isInoutConvention()) {
+          assert(checkKind == MarkMustCheckInst::CheckKind::NoConsumeOrAssign);
+          moveChecker.diagnosticEmitter.emitObjectGuaranteedDiagnostic(
+              markedValue);
         } else {
+          // Otherwise, we need to emit an escaping closure error.
           moveChecker.diagnosticEmitter
               .emitAddressEscapingClosureCaptureLoadedAndConsumed(markedValue);
         }
@@ -1802,6 +1894,17 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
   }
 
   if (auto *pas = dyn_cast<PartialApplyInst>(user)) {
+    if (auto *fArg = dyn_cast<SILFunctionArgument>(
+            stripAccessMarkers(markedValue->getOperand()))) {
+      // If we are processing an inout convention and we emitted an error on the
+      // partial_apply, we shouldn't process this mark_must_check, but squelch
+      // the compiler doesn't understand error.
+      if (fArg->getArgumentConvention().isInoutConvention() &&
+          pas->getCalleeFunction()->hasSemanticsAttr(
+              semantics::NO_MOVEONLY_DIAGNOSTICS)) {
+      }
+    }
+
     if (pas->isOnStack() ||
         ApplySite(pas).getArgumentConvention(*op).isInoutConvention()) {
       LLVM_DEBUG(llvm::dbgs() << "Found on stack partial apply or inout usage!\n");
@@ -1813,13 +1916,18 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
         return false;
       }
 
-      useState.livenessUses.insert({user, *leafRange});
-      for (auto *use : pas->getConsumingUses()) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "Adding consuming use of partial apply as liveness use: "
-                   << *use->getUser());
-        useState.livenessUses.insert({use->getUser(), *leafRange});
+      // Attempt to find calls of the non-escaping partial apply and places
+      // where the partial apply is passed to a function. We treat those as
+      // liveness uses. If we find a use we don't understand, we return false
+      // here.
+      if (!findNonEscapingPartialApplyUses(pas, *leafRange,
+                                           useState.livenessUses)) {
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "Failed to understand use of a non-escaping partial apply?!\n");
+        return false;
       }
+
       return true;
     }
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1902,6 +1902,8 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
       if (fArg->getArgumentConvention().isInoutConvention() &&
           pas->getCalleeFunction()->hasSemanticsAttr(
               semantics::NO_MOVEONLY_DIAGNOSTICS)) {
+        diagnosticEmitter.emitEarlierPassEmittedDiagnostic(markedValue);
+        return false;
       }
     }
 
@@ -2652,9 +2654,19 @@ bool MoveOnlyAddressChecker::check(
     LLVM_DEBUG(llvm::dbgs() << "Visiting: " << *markedValue);
 
     // Perform our address check.
+    unsigned diagnosticEmittedByEarlierPassCount =
+      diagnosticEmitter.getDiagnosticEmittedByEarlierPassCount();
     if (!pimpl.performSingleCheck(markedValue)) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Failed to perform single check! Emitting error!\n");
+      if (diagnosticEmittedByEarlierPassCount !=
+          diagnosticEmitter.getDiagnosticEmittedByEarlierPassCount()) {
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "Failed to perform single check but found earlier emitted "
+               "error. Not emitting checker doesn't understand diagnostic!\n");
+        continue;
+      }
+      LLVM_DEBUG(llvm::dbgs() << "Failed to perform single check! Emitting "
+                                 "compiler doesn't understand diagnostic!\n");
       // If we fail the address check in some way, set the diagnose!
       diagnosticEmitter.emitCheckerDoesntUnderstandDiagnostic(markedValue);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -179,7 +179,7 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
     // remain. If we emitted a diagnostic, we just want to rewrite all of the
     // non-copyable copies into explicit variants below and let the user
     // recompile.
-    if (!checker.diagnosticEmitter.getDiagnosticCount()) {
+    if (!checker.diagnosticEmitter.emittedDiagnostic()) {
       emitCheckerMissedCopyOfNonCopyableTypeErrors(getFunction(),
                                                    checker.diagnosticEmitter);
     }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -125,7 +125,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // This guarantees that stack-promotable boxes have [static] enforcement.
   P.addAccessEnforcementSelection();
 
-  P.addEarlyAllocBoxToStack();
+  P.addAllocBoxToStack();
   P.addNoReturnFolding();
   addDefiniteInitialization(P);
 
@@ -168,11 +168,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   //
   // End Ownership Optimizations
   //===---
-
-  // Now that we have finished checking noncopyable types, run later alloc box
-  // to stack, so that we promote to the stack any heap boxes that are captured
-  // by escaping closures where the closure does not actually escape.
-  P.addAllocBoxToStack();
 
 #ifndef NDEBUG
   // Add a verification pass to check our work when skipping

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -1041,7 +1041,7 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
         auto boxType = F->getArgument(index)->getType().castTo<SILBoxType>();
         bool isMutable = boxType->getLayout()->getFields()[0].isMutable();
         auto checkKind =
-            isMutable ? MarkMustCheckInst::CheckKind::AssignableButNotConsumable
+            isMutable ? MarkMustCheckInst::CheckKind::ConsumableAndAssignable
                       : MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
         hoistMarkMustCheckInsts(ClonedFn->getArgument(index), checkKind);
       }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -16,7 +16,6 @@
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/BlotMapVector.h"
 #include "swift/Basic/GraphNodeWorklist.h"
-#include "swift/Basic/OptionSet.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/Dominance.h"
@@ -87,18 +86,6 @@ static bool useCaptured(Operand *UI) {
 
   return true;
 }
-
-namespace {
-
-enum class AllocBoxToStackFlags {
-  InAppliedFunction = 0x1,
-  CanPromoteNonCopyableCapturedByEscapingClosure = 0x2,
-  HasMoveOnlyBox = 0x4,
-};
-
-using AllocBoxToStackOptions = OptionSet<AllocBoxToStackFlags>;
-
-} // namespace
 
 //===----------------------------------------------------------------------===//
 //                 Liveness for alloc_box Promotion
@@ -314,7 +301,7 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
 }
 
 static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
-    SILValue Box, AllocBoxToStackOptions Options, SmallVectorImpl<Operand *> &,
+    SILValue Box, bool inAppliedFunction, SmallVectorImpl<Operand *> &,
     SmallPtrSetImpl<SILFunction *> &, unsigned CurrentRecurDepth);
 
 /// checkLocalApplyBody - Check the body of an apply's callee to see
@@ -324,8 +311,7 @@ static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
 static bool checkLocalApplyBody(Operand *O,
                                 SmallVectorImpl<Operand *> &PromotedOperands,
                                 SmallPtrSetImpl<SILFunction *> &VisitedCallees,
-                                unsigned CurrentRecurDepth,
-                                AllocBoxToStackOptions Options) {
+                                unsigned CurrentRecurDepth) {
   SILFunction *F = ApplySite(O->getUser()).getReferencedFunctionOrNull();
   // If we cannot examine the function body, assume the worst.
   if (!F || F->empty())
@@ -337,11 +323,10 @@ static bool checkLocalApplyBody(Operand *O,
   if (!iter.second)
     return false;
 
-  Options |= {AllocBoxToStackFlags::InAppliedFunction};
-
   auto calleeArg = F->getArgument(ApplySite(O->getUser()).getCalleeArgIndex(*O));
   auto res = !recursivelyFindBoxOperandsPromotableToAddress(
-      calleeArg, Options, PromotedOperands, VisitedCallees,
+      calleeArg,
+      /* inAppliedFunction = */ true, PromotedOperands, VisitedCallees,
       CurrentRecurDepth + 1);
   return res;
 }
@@ -385,7 +370,7 @@ static bool isOptimizableApplySite(ApplySite Apply) {
 /// box is passed don't have any unexpected uses, `PromotedOperands` will be
 /// populated with the box arguments in DFS order.
 static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
-    SILValue Box, AllocBoxToStackOptions Options,
+    SILValue Box, bool inAppliedFunction,
     SmallVectorImpl<Operand *> &PromotedOperands,
     SmallPtrSetImpl<SILFunction *> &VisitedCallees,
     unsigned CurrentRecurDepth = 0) {
@@ -409,8 +394,7 @@ static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
     // Projections are fine as well.
     if (isa<StrongRetainInst>(User) || isa<StrongReleaseInst>(User) ||
         isa<ProjectBoxInst>(User) || isa<DestroyValueInst>(User) ||
-        (!Options.contains(AllocBoxToStackFlags::InAppliedFunction) &&
-         isa<DeallocBoxInst>(User)) ||
+        (!inAppliedFunction && isa<DeallocBoxInst>(User)) ||
         isa<EndBorrowInst>(User))
       continue;
 
@@ -429,17 +413,8 @@ static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
       }
       switch (Apply.getKind()) {
       case ApplySiteKind::PartialApplyInst: {
-        // If we have a noncopyable type in a box and we were passed in the
-        // option that tells us that we should not promote any boxes that are
-        // captured by an escaping closure (even if we can prove the closure
-        // does not escape), treat the partial apply use as an escape.
-        if (Box->getType().isBoxedNonCopyableType(Box->getFunction()) &&
-            !Options.contains(
-                AllocBoxToStackFlags::
-                    CanPromoteNonCopyableCapturedByEscapingClosure))
-          break;
         if (checkLocalApplyBody(Op, LocalPromotedOperands, VisitedCallees,
-                                CurrentRecurDepth, Options) &&
+                                CurrentRecurDepth) &&
             !partialApplyEscapes(cast<PartialApplyInst>(User),
                                  /* examineApply = */ true)) {
           LocalPromotedOperands.push_back(Op);
@@ -452,7 +427,7 @@ static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
       case ApplySiteKind::TryApplyInst:
         if (isOptimizableApplySite(Apply) &&
             checkLocalApplyBody(Op, LocalPromotedOperands, VisitedCallees,
-                                CurrentRecurDepth, Options)) {
+                                CurrentRecurDepth)) {
           LocalPromotedOperands.push_back(Op);
           continue;
         }
@@ -475,13 +450,13 @@ static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
 
 /// canPromoteAllocBox - Can we promote this alloc_box to an alloc_stack?
 static bool canPromoteAllocBox(AllocBoxInst *ABI,
-                               SmallVectorImpl<Operand *> &PromotedOperands,
-                               AllocBoxToStackOptions Options) {
+                               SmallVectorImpl<Operand *> &PromotedOperands) {
   SmallPtrSet<SILFunction *, 8> VisitedCallees;
   // Scan all of the uses of the address of the box to see if any
   // disqualifies the box from being promoted to the stack.
   if (auto *User = recursivelyFindBoxOperandsPromotableToAddress(
-          ABI, Options, PromotedOperands, VisitedCallees,
+          ABI,
+          /* inAppliedFunction = */ false, PromotedOperands, VisitedCallees,
           /* CurrentRecurDepth = */ 0)) {
     (void)User;
     // Otherwise, we have an unexpected use.
@@ -1246,8 +1221,6 @@ static unsigned rewritePromotedBoxes(AllocBoxToStackState &pass) {
 }
 
 namespace {
-
-template <bool CanPromoteMoveOnlyCapturedByEscapingClosure>
 class AllocBoxToStack : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
@@ -1256,16 +1229,10 @@ class AllocBoxToStack : public SILFunctionTransform {
       return;
 
     AllocBoxToStackState pass(this);
-
-    AllocBoxToStackOptions Options;
-    if (CanPromoteMoveOnlyCapturedByEscapingClosure)
-      Options |=
-          AllocBoxToStackFlags::CanPromoteNonCopyableCapturedByEscapingClosure;
-
     for (auto &BB : *getFunction()) {
       for (auto &I : BB)
         if (auto *ABI = dyn_cast<AllocBoxInst>(&I))
-          if (canPromoteAllocBox(ABI, pass.PromotedOperands, Options))
+          if (canPromoteAllocBox(ABI, pass.PromotedOperands))
             pass.Promotable.push_back(ABI);
     }
 
@@ -1284,13 +1251,8 @@ class AllocBoxToStack : public SILFunctionTransform {
     }
   }
 };
-
 } // end anonymous namespace
 
 SILTransform *swift::createAllocBoxToStack() {
-  return new AllocBoxToStack<true>();
-}
-
-SILTransform *swift::createEarlyAllocBoxToStack() {
-  return new AllocBoxToStack<false>();
+  return new AllocBoxToStack();
 }

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -607,10 +607,8 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
 // CHECK: } // end sil function '$s16moveonly_closure29testGlobalClosureCaptureInOutyyAA9SingleEltVzFyycfU_'
 var globalClosureCaptureInOut: () -> () = {}
 func testGlobalClosureCaptureInOut(_ x: inout SingleElt) {
-    // expected-error @-1 {{'x' consumed but not reinitialized before end of function}}
-    // expected-note @-2 {{'x' is declared 'inout'}}
+    // expected-note @-1 {{'x' is declared 'inout'}}
     globalClosureCaptureInOut = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-        // expected-note @-1 {{consuming use here}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -652,9 +650,7 @@ func testGlobalClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalLetClosureCaptureInOutyyAA9SingleEltVzFyycfU_'
 func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
-    // expected-error @-2 {{'x' consumed but not reinitialized before end of function}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-        // expected-note @-1 {{consuming use here}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -700,10 +696,8 @@ func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK:   apply {{%.*}}([[LOADED_READ]], [[LOADED_TAKE]])
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzFyycfU_'
 func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
-    // expected-error @-1 {{'x' consumed but not reinitialized before end of function}}
-    // expected-note @-2 {{'x' is declared 'inout'}}
-    var f = { // expected-note {{consuming use here}}
-        // expected-error @-1 {{escaping closure captures 'inout' parameter 'x'}}
+    // expected-note @-1 {{'x' is declared 'inout'}}
+    var f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -750,10 +744,8 @@ func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK:   apply {{%.*}}([[LOADED_READ]], [[LOADED_TAKE]])
 // CHECK: } // end sil function '$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztFyycfU_'
 func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) {
-    // expected-error @-1 {{'x' consumed but not reinitialized before end of function}}
-    // expected-note @-2 {{'x' is declared 'inout'}}
+    // expected-note @-1 {{'x' is declared 'inout'}}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-        // expected-note @-1 {{consuming use here}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -805,9 +797,7 @@ func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) 
 // CHECK: } // end sil function '$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztFyycfU_'
 func testConsumingEscapeClosureCaptureInOut(_ f: consuming @escaping () -> (), _ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
-    // expected-error @-2 {{'x' consumed but not reinitialized before end of function}}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
-        // expected-note @-1 {{consuming use here}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -618,7 +618,6 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
 var globalClosureCaptureInOut: () -> () = {}
 func testGlobalClosureCaptureInOut(_ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     globalClosureCaptureInOut = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -708,7 +707,6 @@ func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzFyycfU_'
 func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     var f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -757,7 +755,6 @@ func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztFyycfU_'
 func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -810,7 +807,6 @@ func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) 
 // CHECK: } // end sil function '$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztFyycfU_'
 func testConsumingEscapeClosureCaptureInOut(_ f: consuming @escaping () -> (), _ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -126,14 +126,21 @@ func testGlobalClosureCaptureVar() {
 // CHECK: } // end sil function '$s16moveonly_closure29testLocalLetClosureCaptureVaryyFyycfU_'
 func testLocalLetClosureCaptureVar() {
     var x = SingleElt()
+    // expected-error @-1 {{'x' consumed more than once}}
+    // expected-error @-2 {{'x' used after consume}}
+    // expected-error @-3 {{'x' used after consume}}
     x = SingleElt()
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+        borrowConsumeVal(x, x)
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
+        // expected-note @-3 {{non-consuming use here}}
+        // expected-note @-4 {{non-consuming use here}}
+        // expected-note @-5 {{consuming use here}}
     }
     f()
 }
@@ -409,11 +416,14 @@ func testGlobalClosureCaptureLet() {
 // CHECK: } // end sil function '$s16moveonly_closure026testLocalLetClosureCaptureE0yyFyycfU_'
 func testLocalLetClosureCaptureLet() {
     let x = SingleElt()
+    // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        borrowConsumeVal(x, x) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -608,6 +618,7 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
 var globalClosureCaptureInOut: () -> () = {}
 func testGlobalClosureCaptureInOut(_ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     globalClosureCaptureInOut = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -697,6 +708,7 @@ func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzFyycfU_'
 func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     var f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -745,6 +757,7 @@ func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztFyycfU_'
 func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -797,6 +810,7 @@ func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) 
 // CHECK: } // end sil function '$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztFyycfU_'
 func testConsumingEscapeClosureCaptureInOut(_ f: consuming @escaping () -> (), _ x: inout SingleElt) {
     // expected-note @-1 {{'x' is declared 'inout'}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check}}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x'}}
         borrowVal(x) // expected-note {{captured here}}
         consumeVal(x) // expected-note {{captured here}}
@@ -920,6 +934,24 @@ func testGlobalClosureCaptureConsuming(_ x: consuming SingleElt) {
 // CHECK:   end_access [[READ_ACCESS]]
 // CHECK: } // end sil function '$s16moveonly_closure35testLocalLetClosureCaptureConsumingyyAA9SingleEltVnFyycfU_'
 func testLocalLetClosureCaptureConsuming(_ x: consuming SingleElt) {
+    // expected-error @-1 {{'x' consumed more than once}}
+    // expected-error @-2 {{'x' used after consume}}
+    // expected-error @-3 {{'x' used after consume}}
+    let f = {
+        borrowVal(x)
+        consumeVal(x) // expected-note {{consuming use here}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+        borrowConsumeVal(x, x) // expected-note {{non-consuming use here}}
+        // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
+        // expected-note @-2 {{conflicting access is here}}
+        // expected-note @-3 {{consuming use here}}
+        // expected-note @-4 {{non-consuming use here}}
+    }
+    f()
+}
+
+func testLocalLetClosureCaptureConsuming2(_ x: consuming SingleElt) -> (() -> ()) {
     let f = {
         borrowVal(x)
         consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -929,7 +961,9 @@ func testLocalLetClosureCaptureConsuming(_ x: consuming SingleElt) {
         // expected-note @-2 {{conflicting access is here}}
     }
     f()
+    return f
 }
+
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure35testLocalVarClosureCaptureConsumingyyAA9SingleEltVnF : $@convention(thin) (@owned SingleElt) -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
@@ -1136,11 +1170,14 @@ func testGlobalClosureCaptureOwned(_ x: __owned SingleElt) {
 // CHECK:   apply {{%.*}}([[LOADED_READ]], [[LOADED_TAKE]])
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalLetClosureCaptureOwnedyyAA9SingleEltVnFyycfU_'
 func testLocalLetClosureCaptureOwned(_ x: __owned SingleElt) {
+    // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        consumeVal(x) // expected-note {{consuming use here}}
+        borrowConsumeVal(x, x) // expected-note {{consuming use here}}
     }
     f()
 }

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
+
+//////////////////////
+// MARK: DeinitTest //
+//////////////////////
+
+// CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution10DeinitTestVfD : $@convention(method) (@in DeinitTest) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*DeinitTest):
+// CHECK:   drop_deinit [[ARG]]
+// CHECK: } // end sil function '$s26moveonly_library_evolution10DeinitTestVfD'
+public struct DeinitTest : ~Copyable {
+    deinit {
+    }
+}

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,5 +1,21 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
 
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+public struct EmptyStruct : ~Copyable {}
+public struct NonEmptyStruct : ~Copyable {
+    var e = EmptyStruct()
+}
+public class CopyableKlass {
+    var s = NonEmptyStruct()
+
+    let letStruct = NonEmptyStruct()
+}
+
+public func borrowVal(_ x: borrowing EmptyStruct) {}
+
 //////////////////////
 // MARK: DeinitTest //
 //////////////////////
@@ -11,4 +27,25 @@
 public struct DeinitTest : ~Copyable {
     deinit {
     }
+}
+
+//////////////////////////////////////////
+// MARK: Caller Argument Spilling Tests //
+//////////////////////////////////////////
+
+// CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution29callerArgumentSpillingTestArgyyAA13CopyableKlassCF : $@convention(thin) (@guaranteed CopyableKlass) -> () {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $CopyableKlass):
+// CHECK:    [[ADDR:%.*]] = ref_element_addr [[ARG]]
+// CHECK:    [[MARKED_ADDR:%.*]] = mark_must_check [no_consume_or_assign] [[ADDR]]
+// CHECK:    [[LOADED_VALUE:%.*]] = load [copy] [[MARKED_ADDR]]
+// CHECK:    [[BORROWED_LOADED_VALUE:%.*]] = begin_borrow [[LOADED_VALUE]]
+// CHECK:    [[EXT:%.*]] = struct_extract [[BORROWED_LOADED_VALUE]]
+// CHECK:    [[SPILL:%.*]] = alloc_stack $EmptyStruct
+// CHECK:    [[STORE_BORROW:%.*]] = store_borrow [[EXT]] to [[SPILL]]
+// CHECK:    apply {{%.*}}([[STORE_BORROW]]) : $@convention(thin) (@in_guaranteed EmptyStruct) -> ()
+// CHECK:    end_borrow [[STORE_BORROW]]
+// CHECK:    end_borrow [[BORROWED_LOADED_VALUE]]
+// CHECK: } // end sil function '$s26moveonly_library_evolution29callerArgumentSpillingTestArgyyAA13CopyableKlassCF'
+public func callerArgumentSpillingTestArg(_ x: CopyableKlass) {
+    borrowVal(x.letStruct.e)
 }

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -22,7 +22,6 @@ public func borrowVal(_ x: borrowing EmptyStruct) {}
 
 // CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution10DeinitTestVfD : $@convention(method) (@in DeinitTest) -> () {
 // CHECK: bb0([[ARG:%.*]] : $*DeinitTest):
-// CHECK:   drop_deinit [[ARG]]
 // CHECK: } // end sil function '$s26moveonly_library_evolution10DeinitTestVfD'
 public struct DeinitTest : ~Copyable {
     deinit {

--- a/test/SILOptimizer/allocbox_to_stack_noncopyable.sil
+++ b/test/SILOptimizer/allocbox_to_stack_noncopyable.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-copy-propagation=requested-passes-only | %FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all %s -early-allocbox-to-stack -enable-copy-propagation=requested-passes-only | %FileCheck -check-prefix=EARLY %s
 
 sil_stage raw
 
@@ -162,13 +161,6 @@ bb3:
   return %30 : $()
 }
 
-// Make sure that if our box is captured by a partial_apply, we do not process
-// it with the early allocbox to stack, but we do with the normal allocbox to
-// stack.
-// EARLY: sil hidden [ossa] @earlyallocbox_to_stack_partial_apply_test_caller : $@convention(thin) (@owned NonTrivialStruct) -> () {
-// EARLY: alloc_box ${ var NonTrivialStruct }, var, name "x"
-// EARLY: } // end sil function 'earlyallocbox_to_stack_partial_apply_test_caller'
-//
 // CHECK: sil hidden [ossa] @earlyallocbox_to_stack_partial_apply_test_caller : $@convention(thin) (@owned NonTrivialStruct) -> () {
 // CHECK: alloc_stack [lexical] $NonTrivialStruct, var, name "x"
 // CHECK: } // end sil function 'earlyallocbox_to_stack_partial_apply_test_caller'

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-copy-propagation=requested-passes-only -enable-lexical-borrow-scopes=false | %FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all %s -early-allocbox-to-stack -enable-copy-propagation=requested-passes-only -enable-lexical-borrow-scopes=false | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/allocboxtostack_escape.swift
+++ b/test/SILOptimizer/allocboxtostack_escape.swift
@@ -12,9 +12,7 @@ func testError() -> (() -> ()) {
   // We emit this error twice since we run allocbox to stack twice in the pipeline for now. This is not an official feature, so it is ok for now.
   @_semantics("boxtostack.mustbeonstack")
   var x = Box<Klass>(value: Klass()) // expected-error {{Can not promote value from heap to stack due to value escaping}}
-  // expected-error @-1 {{Can not promote value from heap to stack due to value escaping}}
   let result = { // expected-note {{value escapes here}}
-      // expected-note @-1 {{value escapes here}}
     myPrint(&x)
   }
   return result

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -76,6 +76,7 @@ public struct AddressOnlyGeneric<T : P> {
 sil @get_aggstruct : $@convention(thin) () -> @owned AggStruct
 sil @nonConsumingUseKlass : $@convention(thin) (@guaranteed Klass) -> ()
 sil @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+sil @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
 sil @classConsume : $@convention(thin) (@owned Klass) -> () // user: %18
 sil @copyableClassConsume : $@convention(thin) (@owned CopyableKlass) -> () // user: %24
 sil @copyableClassUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed CopyableKlass) -> () // user: %16
@@ -364,4 +365,145 @@ bb0(%0 : @closureCapture @guaranteed $<τ_0_0 where τ_0_0 : P> { var AddressOnl
   end_access %17 : $*AddressOnlyGeneric<T>
   %22 = tuple ()
   return %22 : $()
+}
+
+//////////////////////////
+// MARK: Coroutine Test //
+//////////////////////////
+
+sil [ossa] @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields () {
+bb0(%0 : @guaranteed $@callee_guaranteed () -> ()):
+  %1 = tuple ()
+  yield %1 : $(), resume bb1, unwind bb2
+
+bb1:
+  return %1 : $()
+
+bb2:
+  unwind
+}
+
+sil private [ossa] @$s23coroutine_partial_applyTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> () {
+bb0(%0 : @closureCapture $*NonTrivialStruct):
+  %1 = mark_must_check [no_consume_or_assign] %0 : $*NonTrivialStruct
+  debug_value %1 : $*NonTrivialStruct, let, name "e", argno 1, expr op_deref
+  %3 = load_borrow %1 : $*NonTrivialStruct
+  end_borrow %3 : $NonTrivialStruct
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil [ossa] @coroutine_caller_uses_partial_apply : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct, let, name "e"
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct // expected-error {{'e' used after consume}}
+  store %0 to [init] %2 : $*NonTrivialStruct
+  mark_function_escape %2 : $*NonTrivialStruct
+
+  %5 = function_ref @$s23coroutine_partial_applyTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%2) : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+
+  %7 = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+
+  %8 = function_ref @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  (%9, %10) = begin_apply %8(%6) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %12 = apply %7(%11) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  end_apply %10 // expected-note {{non-consuming use here}}
+  destroy_value %6 : $@callee_guaranteed () -> ()
+  destroy_addr %2 : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %17 = tuple ()
+  return %17 : $()
+}
+
+sil [ossa] @coroutine_caller_uses_partial_apply2 : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct, let, name "e"
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct // expected-error {{'e' used after consume}}
+  store %0 to [init] %2 : $*NonTrivialStruct
+  mark_function_escape %2 : $*NonTrivialStruct
+
+  %5 = function_ref @$s23coroutine_partial_applyTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%2) : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+
+  %7 = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+
+  %8 = function_ref @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  (%9, %10) = begin_apply %8(%6) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %12 = apply %7(%11) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  abort_apply %10 // expected-note {{non-consuming use here}}
+  destroy_value %6 : $@callee_guaranteed () -> ()
+  destroy_addr %2 : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// This test has some copy_value that are eliminated by the object checker. We
+// are just testing the address checker here so we get a copy of noncopyable
+// typed value error since we do not run the object checker. But it is ok since
+// it doesn't effect the underlying test case.
+sil [ossa] @coroutine_caller_uses_partial_apply_reinit : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = copy_value %0 : $NonTrivialStruct // expected-error {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+  %2 = mark_must_check [no_consume_or_assign] %1 : $NonTrivialStruct
+  debug_value %2 : $NonTrivialStruct, let, name "x", argno 1
+  %4 = alloc_stack $NonTrivialStruct, let, name "e"
+  %5 = mark_must_check [consumable_and_assignable] %4 : $*NonTrivialStruct
+  %6 = copy_value %2 : $NonTrivialStruct // expected-error {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+  store %6 to [init] %5 : $*NonTrivialStruct
+  mark_function_escape %5 : $*NonTrivialStruct
+  %9 = function_ref @$s23coroutine_partial_applyTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+  %10 = partial_apply [callee_guaranteed] %9(%5) : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+  %11 = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %12 = function_ref @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  (%13, %14) = begin_apply %12(%10) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  %15 = load [copy] %5 : $*NonTrivialStruct
+  %16 = apply %11(%15) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %17 = copy_value %2 : $NonTrivialStruct // expected-error {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+  store %17 to [init] %5 : $*NonTrivialStruct
+  abort_apply %14
+  destroy_value %2 : $NonTrivialStruct
+  destroy_value %10 : $@callee_guaranteed () -> ()
+  destroy_addr %5 : $*NonTrivialStruct
+  dealloc_stack %4 : $*NonTrivialStruct
+  %24 = tuple ()
+  return %24 : $()
+}
+
+sil [ossa] @coroutine_caller_uses_partial_apply_different_cfg : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct, let, name "e"
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
+  // expected-error @-1 {{'e' used after consume}}
+  // expected-error @-2 {{'e' used after consume}}
+  store %0 to [init] %2 : $*NonTrivialStruct
+  mark_function_escape %2 : $*NonTrivialStruct
+  %5 = function_ref @$s23coroutine_partial_applyTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%2) : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+  %7 = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %8 = function_ref @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  (%9, %10) = begin_apply %8(%6) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  %12 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %13 = apply %7(%12) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  abort_apply %10 // expected-note {{non-consuming use here}}
+  br bb3
+
+bb2:
+  %16 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %17 = apply %7(%16) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  end_apply %10 // expected-note {{non-consuming use here}}
+  br bb3
+
+bb3:
+  destroy_value %6 : $@callee_guaranteed () -> ()
+  destroy_addr %2 : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %23 = tuple ()
+  return %23 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3116,9 +3116,8 @@ public func closureCaptureClassUseAfterConsumeError() {
 }
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-note @-2 {{'x2' is declared 'inout'}}
-    let f = { // expected-note {{consuming use here}}
+    // expected-note @-1 {{'x2' is declared 'inout'}}
+    let f = {
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}
         consumeVal(x2) // expected-note {{captured here}}
@@ -3230,12 +3229,10 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-note @-4 {{'x2' is declared 'inout'}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-              // expected-note @-1 {{consuming use here}}
         defer { // expected-note {{captured indirectly by this call}}
             borrowVal(x2) // expected-note {{captured here}}
             consumeVal(x2) // expected-note {{captured here}}
@@ -3280,11 +3277,9 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-note @-1 {{'x2' is declared 'inout'}}
     // expected-note @-2 {{'x2' is declared 'inout'}}
-    // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-              // expected-note @-1 {{consuming use here}}
         let g = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
             // expected-note @-1 {{captured indirectly by this call}}
             borrowVal(x2)

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3235,13 +3235,8 @@ public func closureVarCaptureClassUseAfterConsumeError() {
     let _ = x3
 }
 
-// TODO: The reason why we emit the moveonly type is that correctly the checker
-// realizes that the partial_apply has escaped, but does not understand that
-// this case has already been diagnosed properly by the escaping inout
-// diagnostic, so we shouldn't try to process it.
 public func closureVarCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-note @-1 {{'x2' is declared 'inout'}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     var f = {}
     f = {
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3040,10 +3040,13 @@ extension AddressOnlyProtocol {
 }
 
 /////////////////////////////
-// Closure and Defer Tests //
+// MARK: Closure Let Tests //
 /////////////////////////////
 
-public func closureClassUseAfterConsume1() {
+// These are considered to be non-escaping since we are not storing them into
+// memory.
+
+public func closureLetClassUseAfterConsume1() {
     let f = {
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
@@ -3054,7 +3057,7 @@ public func closureClassUseAfterConsume1() {
     f()
 }
 
-public func closureClassUseAfterConsume2() {
+public func closureLetClassUseAfterConsume2() {
     let f = { () in
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
@@ -3065,7 +3068,7 @@ public func closureClassUseAfterConsume2() {
     f()
 }
 
-public func closureClassUseAfterConsumeArg(_ argX: inout Klass) {
+public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
     // TODO: Fix this
     let f = { (_ x2: inout Klass) in
         // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
@@ -3079,10 +3082,125 @@ public func closureClassUseAfterConsumeArg(_ argX: inout Klass) {
 }
 
 // We do not support captures of vars by closures today.
-public func closureCaptureClassUseAfterConsume() {
-    var x2 = Klass()
+public func closureLetCaptureClassUseAfterConsume() {
+    var x2 = Klass() // expected-error {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+    }
+    f()
+}
+
+public func closureLetCaptureClassUseAfterConsume2() {
+    var x2 = Klass() // expected-error {{'x2' consumed in closure but not reinitialized before end of closure}}
+    x2 = Klass()
+    let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+}
+
+public func closureLetCaptureClassUseAfterConsumeError() {
+    var x2 = Klass() // expected-error {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    x2 = Klass()
+    let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+    }
+    f()
+    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consuming use here}}
+    x2 = Klass()
+    let _ = x3
+}
+
+public func closureLetCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
+    // expected-note @-1 {{'x2' is declared 'inout'}}
+    let f = {
+        // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
+        borrowVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
+    }
+    f()
+}
+
+func closureLetStoreClosureInVariableIsEscape() {
+    let s = NonTrivialStruct()
+
+    struct StoreClosure {
+        var f: () -> ()
+    }
+
+    let f = {
+        borrowVal(s)
+        consumeVal(s) // expected-error {{'s' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    let c = StoreClosure(f: f)
+    _ = c
+    consumeVal(s) // expected-error {{'s' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+/////////////////////////////
+// MARK: Closure Var Tests //
+/////////////////////////////
+
+// These are considered to be escaping since we are storing them into a
+// var. This matches the behavior of how we emit inout diagnostics.
+
+public func closureVarClassUseAfterConsume1() {
+    var f = {}
+    f = {
+        var x2 = Klass() // expected-error {{'x2' consumed more than once}}
+        x2 = Klass()
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+}
+
+public func closureVarClassUseAfterConsume2() {
+    var f = { () in}
+    f = { () in
+        var x2 = Klass() // expected-error {{'x2' consumed more than once}}
+        x2 = Klass()
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+}
+
+public func closureVarClassUseAfterConsumeArg(_ argX: inout Klass) {
+    // TODO: Fix this
+    var f = { (_ x2: inout Klass) in}
+    f = { (_ x2: inout Klass) in
+        // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+        // expected-error @-2 {{'x2' consumed more than once}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+    }
+    f(&argX)
+}
+
+// We do not support captures of vars by closures today.
+public func closureVarCaptureClassUseAfterConsume() {
+    var x2 = Klass()
+    x2 = Klass()
+    var f = {}
+    f = {
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -3090,20 +3208,22 @@ public func closureCaptureClassUseAfterConsume() {
     f()
 }
 
-public func closureCaptureClassUseAfterConsume2() {
+public func closureVarCaptureClassUseAfterConsume2() {
     var x2 = Klass()
     x2 = Klass()
-    let f = {
+    var f = {}
+    f = {
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     }
     f()
 }
 
-public func closureCaptureClassUseAfterConsumeError() {
-    var x2 = Klass()
+public func closureVarCaptureClassUseAfterConsumeError() {
+    var x2 = Klass() 
     x2 = Klass()
-    let f = {
+    var f = {}
+    f = {
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -3115,9 +3235,15 @@ public func closureCaptureClassUseAfterConsumeError() {
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
+// TODO: The reason why we emit the moveonly type is that correctly the checker
+// realizes that the partial_apply has escaped, but does not understand that
+// this case has already been diagnosed properly by the escaping inout
+// diagnostic, so we shouldn't try to process it.
+public func closureVarCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-note @-1 {{'x2' is declared 'inout'}}
-    let f = {
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    var f = {}
+    f = {
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}
         consumeVal(x2) // expected-note {{captured here}}
@@ -3125,6 +3251,10 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     }
     f()
 }
+
+///////////////////////
+// MARK: Defer Tests //
+///////////////////////
 
 public func deferCaptureClassUseAfterConsume() {
     var x2 = Klass()
@@ -3171,7 +3301,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     print("foo")
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume() {
+public func closureLetAndDeferCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -3189,14 +3319,14 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume2() {
-    var x2 = Klass()
+public func closureLetAndDeferCaptureClassUseAfterConsume2() {
+    var x2 = Klass() // expected-error {{'x2' used after consume}}
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        defer {
+        consumeVal(x2) // expected-note {{consuming use here}}
+        defer { // expected-note {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -3208,14 +3338,14 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume3() {
-    var x2 = Klass()
+public func closureLetAndDeferCaptureClassUseAfterConsume3() {
+    var x2 = Klass() // expected-error {{'x2' used after consume}}
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = { 
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        defer {
+        consumeVal(x2) // expected-note {{consuming use here}}
+        defer { // expected-note {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -3225,10 +3355,10 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2)
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
+public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-note @-3 {{'x2' is declared 'inout'}}
@@ -3246,37 +3376,45 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     f()
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume() {
-    var x2 = Klass()
+///////////////////////////////////////////
+// MARK: Multiple Levels of Let Closures //
+///////////////////////////////////////////
+
+public func closureLetAndClosureCaptureClassUseAfterConsume() {
+    var x2 = Klass() // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
         }
         g()
     }
     f()
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume2() {
-    var x2 = Klass()
+public func closureLetAndClosureCaptureClassUseAfterConsume2() {
+    var x2 = Klass() // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2)
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
+public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-note @-1 {{'x2' is declared 'inout'}}
     // expected-note @-2 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -3295,6 +3433,285 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
         g()
     }
     f()
+}
+
+/////////////////////////////////
+// MARK: Defer and Var Closure //
+/////////////////////////////////
+
+public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = Klass() // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = Klass()
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = {
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+// TODO: MG
+public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = Klass()
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    x2 = x
+    // expected-note @-1 {{consuming use here}}
+    var f = {}
+    f = {
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+}
+
+public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    var f = {}
+    f = {// expected-note {{closure capture here}}
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+// TODO: MG
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+}
+
+///////////////////////////////////////////
+// MARK: Multiple Levels of Var Closures //
+///////////////////////////////////////////
+
+public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = Klass()
+    x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = Klass()
+    x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    _ = x3
+}
+
+public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = x
+    // expected-note @-1 {{consuming use here}}
+    x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    _ = x3
+}
+
+public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    var f = {}
+    f = {// expected-note {{closure capture here}}
+        var g = {}
+        g = {// expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
 }
 
 /////////////////////////////

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-library-evolution %s
+
+// This test is used to validate that we properly handle library evolution code
+// until we can get all of the normal moveonly_addresschecker_diagnostics test
+// case to pass.
+
+////////////////////////
+// MARK: Deinit Tests //
+////////////////////////
+
+public struct DeinitTest : ~Copyable {
+    deinit {}
+}
+
+public protocol P {}
+
+// Once rdar://109170600 is fixed (which tracks us being unable to do this), we
+// should be able to use the : ~Copyable syntax.
+@_moveOnly
+public struct GenericDeinitTest<T : P> {
+    deinit {}
+}
+

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -8,6 +8,21 @@
 // MARK: Deinit Tests //
 ////////////////////////
 
+@_moveOnly public struct EmptyStruct {}
+@_moveOnly public struct NonEmptyStruct {
+    var e = EmptyStruct()
+}
+public class CopyableKlass {
+    var s = NonEmptyStruct()
+}
+
+public func borrowVal(_ x: borrowing NonEmptyStruct) {}
+public func borrowVal(_ x: borrowing EmptyStruct) {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
 public struct DeinitTest : ~Copyable {
     deinit {}
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-library-evolution %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution %s
 
 // This test is used to validate that we properly handle library evolution code
 // until we can get all of the normal moveonly_addresschecker_diagnostics test
 // case to pass.
 
 ////////////////////////
-// MARK: Deinit Tests //
+// MARK: Declarations //
 ////////////////////////
 
 @_moveOnly public struct EmptyStruct {}
@@ -13,11 +13,17 @@
     var e = EmptyStruct()
 }
 public class CopyableKlass {
-    var s = NonEmptyStruct()
+    var varS = NonEmptyStruct()
+    var letS = NonEmptyStruct()
 }
 
 public func borrowVal(_ x: borrowing NonEmptyStruct) {}
 public func borrowVal(_ x: borrowing EmptyStruct) {}
+public func consumeVal(_ x: consuming NonEmptyStruct) {}
+public func consumeVal(_ x: consuming EmptyStruct) {}
+
+let copyableKlassLetGlobal = CopyableKlass()
+var copyableKlassVarGlobal = CopyableKlass()
 
 /////////////////
 // MARK: Tests //
@@ -36,3 +42,134 @@ public struct GenericDeinitTest<T : P> {
     deinit {}
 }
 
+//////////////////////////////////////////
+// MARK: Caller Argument Let Spill Test //
+//////////////////////////////////////////
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    borrowVal(x.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestLetGlobal() {
+    borrowVal(copyableKlassLetGlobal.letS.e)
+}
+
+public func callerBorrowClassLetFieldForArgumentSpillingTestVarGlobal() {
+    borrowVal(copyableKlassVarGlobal.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    consumeVal(x.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestLetGlobal() {
+    consumeVal(copyableKlassLetGlobal.letS.e)
+}
+
+public func callerConsumeClassLetFieldForArgumentSpillingTestVarGlobal() {
+    consumeVal(copyableKlassVarGlobal.letS.e)
+}
+
+////////////////////
+// MARK: Var Test //
+////////////////////
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    borrowVal(x.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestLetGlobal() {
+    borrowVal(copyableKlassLetGlobal.varS.e)
+}
+
+public func callerBorrowClassVarFieldForArgumentSpillingTestVarGlobal() {
+    borrowVal(copyableKlassVarGlobal.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestLet() {
+    let x = CopyableKlass()
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestVar() {
+    var x = CopyableKlass()
+    x = CopyableKlass()
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestArg(_ x: CopyableKlass) {
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestInOutArg(_ x: inout CopyableKlass) {
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
+    consumeVal(x.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestLetGlobal() {
+    consumeVal(copyableKlassLetGlobal.varS.e)
+}
+
+public func callerConsumeClassVarFieldForArgumentSpillingTestVarGlobal() {
+    consumeVal(copyableKlassVarGlobal.varS.e)
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -35,10 +35,7 @@ public struct DeinitTest : ~Copyable {
 
 public protocol P {}
 
-// Once rdar://109170600 is fixed (which tracks us being unable to do this), we
-// should be able to use the : ~Copyable syntax.
-@_moveOnly
-public struct GenericDeinitTest<T : P> {
+public struct GenericDeinitTest<T : P> : ~Copyable {
     deinit {}
 }
 

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2787,9 +2787,7 @@ public func closureCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expec
 
 public func closureCaptureClassUseAfterConsume2(_ x2: inout Klass) {
     // expected-note @-1 {{'x2' is declared 'inout'}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-        // expected-note @-1 {{consuming use here}}
         borrowVal(x2) // expected-note {{captured here}}
         consumeVal(x2) // expected-note {{captured here}}
         consumeVal(x2)  // expected-note {{captured here}}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2956,10 +2956,8 @@ public func closureVarCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // ex
     f()
 }
 
-// TODO: MG
 public func closureVarCaptureClassUseAfterConsume2(_ x2: inout Klass) {
     // expected-note @-1 {{'x2' is declared 'inout'}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     var f = {}
     f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2727,10 +2727,10 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 }
 
 /////////////////////////////
-// Closure and Defer Tests //
+// MARK: Closure Let Tests //
 /////////////////////////////
 
-public func closureClassUseAfterConsume1(_ x: borrowing Klass) {
+public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{closure capture here}}
@@ -2743,7 +2743,7 @@ public func closureClassUseAfterConsume1(_ x: borrowing Klass) {
     f()
 }
 
-public func closureClassUseAfterConsume2(_ argX: borrowing Klass) {
+public func closureLetClassUseAfterConsume2(_ argX: borrowing Klass) {
     let f = { (_ x: borrowing Klass) in // expected-error {{'x' has guaranteed ownership but was consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
                    // expected-note @-1 {{consuming use here}}
@@ -2754,7 +2754,7 @@ public func closureClassUseAfterConsume2(_ argX: borrowing Klass) {
     f(argX)
 }
 
-public func closureClassUseAfterConsumeArg(_ argX: borrowing Klass) {
+public func closureLetClassUseAfterConsumeArg(_ argX: borrowing Klass) {
     let f = { (_ x2: borrowing Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2763,29 +2763,33 @@ public func closureClassUseAfterConsumeArg(_ argX: borrowing Klass) {
     f(argX)
 }
 
-public func closureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+public func closureLetCaptureClassUseAfterConsume(_ x: consuming Klass) {
+    let x2 = x // expected-error {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
 
-public func closureCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}} 
     x2 = x  // expected-note {{consuming use here}}
 
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
     f()
 }
 
-public func closureCaptureClassUseAfterConsume2(_ x2: inout Klass) {
+public func closureLetCaptureClassUseAfterConsume2(_ x2: inout Klass) {
     // expected-note @-1 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}
@@ -2795,7 +2799,8 @@ public func closureCaptureClassUseAfterConsume2(_ x2: inout Klass) {
     f()
 }
 
-public func closureCaptureClassUseAfterConsume3(_ x2: inout Klass) {
+// TODO: We are considering this to be an escaping use.
+public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     func useClosure(_ x: () -> ()) {}
@@ -2809,19 +2814,21 @@ public func closureCaptureClassUseAfterConsume3(_ x2: inout Klass) {
 }
 
 
-public func closureCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture here}}
@@ -2832,8 +2839,103 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     f()
 }
 
-public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+public func closureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+}
+
+public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+    }
+    f()
+}
+
+public func closureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+    let x3 = x2
+    let _ = x3
+}
+
+public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    let f = {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+    }
+    f()
+    let x3 = x2 // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    x2 = Klass()
+    let _ = x3
+}
+
+/////////////////////////////
+// MARK: Closure Var tests //
+/////////////////////////////
+
+public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
+    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = { // expected-note {{closure capture here}}
+        let x2 = x // expected-error {{'x2' consumed more than once}}
+        // expected-note @-1 {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+}
+
+public func closureVarClassUseAfterConsume2(_ argX: borrowing Klass) {
+    var f = {(_ x: borrowing Klass) in }
+    f = { (_ x: borrowing Klass) in // expected-error {{'x' has guaranteed ownership but was consumed}}
+        let x2 = x // expected-error {{'x2' consumed more than once}}
+        // expected-note @-1 {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f(argX)
+}
+
+public func closureVarClassUseAfterConsumeArg(_ argX: borrowing Klass) {
+    var f = {(_ x2: borrowing Klass) in}
+    f = { (_ x2: borrowing Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f(argX)
+}
+
+public func closureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = { 
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
@@ -2841,8 +2943,12 @@ public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     f()
 }
 
-public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    let f = {
+public func closureVarCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = x // expected-note {{consuming use here}}
+    x2 = x  // expected-note {{consuming use here}}
+
+    var f = {}
+    f = { 
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -2850,8 +2956,48 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     f()
 }
 
-public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    let f = {
+// TODO: MG
+public func closureVarCaptureClassUseAfterConsume2(_ x2: inout Klass) {
+    // expected-note @-1 {{'x2' is declared 'inout'}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    var f = {}
+    f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
+        borrowVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
+        consumeVal(x2)  // expected-note {{captured here}}
+    }
+    f()
+}
+
+public func closureVarCaptureClassUseAfterConsume3(_ x2: inout Klass) {
+    // expected-note @-1 {{'x2' is declared 'inout'}}
+    func useClosure(_ x: @escaping () -> ()) {}
+
+    useClosure { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
+        borrowVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
+    }
+}
+
+public func closureVarCaptureClassUseAfterConsume4(_ x2: inout Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    func useClosure(_ x: () -> ()) {}
+
+    useClosure {
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
+    }
+}
+
+
+public func closureVarCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = { 
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
@@ -2861,8 +3007,53 @@ public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
     let _ = x3
 }
 
-public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
-    let f = {
+public func closureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    var f = {}
+    f = { // expected-note {{closure capture here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+    }
+    f()
+}
+
+public func closureVarCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    var f = {}
+    f = { 
+        borrowVal(x2)
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    f()
+}
+
+public func closureVarCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    var f = {}
+    f = { 
+        borrowVal(x2)
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    }
+    f()
+}
+
+public func closureVarCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    var f = {}
+    f = { 
+        borrowVal(x2)
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    f()
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let _ = x3
+}
+
+public func closureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    var f = {}
+    f = { 
         borrowVal(x2)
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
         consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -2873,6 +3064,10 @@ public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     x2 = Klass()
     let _ = x3
 }
+
+///////////////////////
+// MARK: Defer Tests //
+///////////////////////
 
 public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
@@ -2957,7 +3152,11 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+/////////////////////////////////
+// MARK: Defer and Let Closure //
+/////////////////////////////////
+
+public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
@@ -2971,12 +3170,13 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { /
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     // TODO: This is wrong
     let x2 = x // expected-error {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -2988,12 +3188,13 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { 
 }
 
 // TODO: MG
-public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3002,10 +3203,10 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { 
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture here}}
@@ -3019,7 +3220,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass)
     f()
 }
 
-public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
@@ -3032,7 +3233,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Kla
     f()
 }
 
-public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
@@ -3048,7 +3249,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming 
 }
 
 // TODO: MG
-public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
@@ -3059,10 +3260,10 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Kl
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }
 
-public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     let f = {
@@ -3075,61 +3276,74 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2)
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+///////////////////////////////////////////
+// MARK: Multiple Levels of Let Closures //
+///////////////////////////////////////////
+
+public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-4 {{'x2' consumed more than once}}
 
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consuming use here}}
     _ = x3
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x
     // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed more than once}}
     x2 = x
     // expected-note @-1 {{consuming use here}}
 
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consuming use here}}
     _ = x3
 }
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
@@ -3144,8 +3358,431 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klas
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    let f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    let f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2)
+}
+
+public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    let f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2)
+}
+
+public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' used after consume}}
+    let f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-note {{consuming use here}}
+    f() // expected-note {{non-consuming use here}}
+}
+
+/////////////////////////////////
+// MARK: Defer and Var Closure //
+/////////////////////////////////
+
+public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-error {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-note @-1 {{consuming use here}}
+    var f = {}
+    f = {
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+// TODO: MG
+public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x
+    // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = {
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    var f = {}
+    f = {// expected-note {{closure capture here}}
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+}
+
+// TODO: MG
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    var f = {}
+    f = {
+        defer {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        print("foo")
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+}
+
+///////////////////////////////////////////
+// MARK: Multiple Levels of Var Closures //
+///////////////////////////////////////////
+
+public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    _ = x3
+}
+
+public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = x
+    // expected-note @-1 {{consuming use here}}
+    x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    _ = x3
+}
+
+public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    var f = {}
+    f = {// expected-note {{closure capture here}}
+        var g = {}
+        g = {// expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    var f = {}
+    f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+}
+
+/////////////////////////////////
+// MARK: Var and Let Functions //
+/////////////////////////////////
+
+public func closureVarAndClosureLetCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-note {{consuming use here}}
+    var f = {}
+    f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    f()
+}
+
+public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    var f = {}
+    f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    _ = x3
+}
+
+public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = x
+    // expected-note @-1 {{consuming use here}}
+    x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    var f = {}
+    f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    _ = x3
+}
+
+public func closureVarAndClosureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    var f = {}
+    f = {// expected-note {{closure capture here}}
+let g = {// expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    var f = {}
+    f = {
         let g = {
             borrowVal(x2)
             consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
@@ -3156,8 +3793,9 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned K
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    let f = {
+public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    var f = {}
+    f = {
         let g = {
             borrowVal(x2)
             consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -3168,8 +3806,9 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consumin
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    let f = {
+public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    var f = {}
+    f = {
         let g = {
             borrowVal(x2)
             consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
@@ -3181,8 +3820,9 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned 
     consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
-    let f = {
+public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    var f = {}
+    f = {
         let g = {
             borrowVal(x2)
             consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
@@ -3194,9 +3834,138 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consumin
     consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
 }
 
-/////////////////////////////
-// Tests For Move Operator //
-/////////////////////////////
+public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x // expected-note {{consuming use here}}
+    let f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    f()
+}
+
+public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    let f = {
+        let h = {
+            var g = {}
+            g = {
+                borrowVal(x2)
+                consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+                consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            }
+            g()
+        }
+        h()
+        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    _ = x3
+}
+
+public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+    var x2 = x
+    // expected-note @-1 {{consuming use here}}
+    x2 = x
+    // expected-note @-1 {{consuming use here}}
+
+    let f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    _ = x3
+}
+
+public func closureLetAndClosureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = {// expected-note {{closure capture here}}
+        var g = {}
+        g = {// expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    let f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
+    let f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+}
+
+public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
+    let f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+}
+
+public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
+    let f = {
+        var g = {}
+        g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+}
+
+///////////////////////////////////
+// MARK: Tests For Move Operator //
+///////////////////////////////////
 
 func moveOperatorTest(_ k: __owned Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1200,28 +1200,39 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
 // We do not support captures of vars by closures today.
 public func closureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = NonTrivialStruct()
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed more than once}}
+    // expected-error @-5 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    var x4 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    x4 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
+    var x4 = x2 // expected-note {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
+    x4 = x2 // expected-note {{consuming use here}}
     _ = x4
     let _ = x3
 }
@@ -1304,10 +1315,11 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        defer {
+        consumeVal(x2) // expected-note {{consuming use here}}
+        defer { // expected-note {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -1323,10 +1335,11 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        defer {
+        consumeVal(x2) // expected-note {{consuming use here}}
+        defer { // expected-note {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -1336,7 +1349,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2)
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
@@ -1359,12 +1372,15 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
 
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
         }
         g()
     }
@@ -1373,19 +1389,41 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2)
 }
 
+public func closureAndClosureCaptureClassUseAfterConsume3() {
+    var x2 = NonTrivialStruct()
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' used after consume}}
+    x2 = NonTrivialStruct()
+    let f = {
+        let g = {
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
+        }
+        g()
+    }
+    f()
+    consumeVal(x2) // expected-note {{consuming use here}}
+    f() // expected-note {{non-consuming use here}}
+}
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-note @-1 {{'x2' is declared 'inout'}}

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1227,9 +1227,8 @@ public func closureCaptureClassUseAfterConsumeError() {
 }
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-note @-2 {{'x2' is declared 'inout'}}
-    let f = { // expected-note {{consuming use here}}
+    // expected-note @-1 {{'x2' is declared 'inout'}}
+    let f = {
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}
         consumeVal(x2) // expected-note {{captured here}}
@@ -1341,12 +1340,10 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-note @-4 {{'x2' is declared 'inout'}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-              // expected-note @-1 {{consuming use here}}
         defer { // expected-note {{captured indirectly by this call}}
             borrowVal(x2) // expected-note {{captured here}}
             consumeVal(x2) // expected-note {{captured here}}
@@ -1391,11 +1388,9 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-note @-1 {{'x2' is declared 'inout'}}
     // expected-note @-2 {{'x2' is declared 'inout'}}
-    // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-              // expected-note @-1 {{consuming use here}}
         let g = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
             // expected-note @-1 {{captured indirectly by this call}}
             borrowVal(x2)

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1762,23 +1762,28 @@ public func closureClassUseAfterConsumeArg(_ argX: borrowing NonTrivialStruct) {
 
 public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2
     let _ = x3
 }
 
@@ -1794,43 +1799,54 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStru
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
     f()
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2
     let _ = x3
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' consumed more than once}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}} 
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     let _ = x3
 }
 
@@ -1934,8 +1950,9 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivial
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -1950,8 +1967,9 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivia
     let x2 = x
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -1960,7 +1978,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivia
         consumeVal("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -2015,7 +2033,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned No
         consumeVal("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
@@ -2031,16 +2049,18 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
         consumeVal("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2)
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
@@ -2049,16 +2069,18 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivi
 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }
 
 
@@ -2078,11 +2100,13 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonT
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
@@ -2090,11 +2114,14 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming use here}}
         }
         g()
     }
@@ -2102,27 +2129,31 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consumin
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2)
 }


### PR DESCRIPTION
This PR contains a few batched changes for 5.9. There is at least one change
that just updates tests and another that eliminates a dead field. I didn't create CCC for them.
Here are the CCC for the major changes:

Commit f634acf0b6edab06052ba03b78d651573b18db6a

• Description: [move-only] Fix a thinko where we are treating inout convention
  as a consuming use instead of liveness use. The effect of this change is that
  when we were capturing an inout in a closure, we were treating it as if it was
  consuming it causing us to give the wrong diagnostic.
• Risk: Low risk. Only affects noncopyable types.
• Original PR: https://github.com/apple/swift/pull/65864
• Reviewed By: @jckarter
• Testing: I added tests/updated other tests to make sure this did not happen.
• Resolves: rdar://109217216

Commit a10a5dbb07369a92f33d76b7a44369bcb59934ea

• Description: [move-only] Ensure that resilient deinits take their self
  argument as an address argument instead of an object. The function signature
  was already correct, just the logic in SILGen around cerating the SIL argument
  assumed that we would always have an object since it was setup originally just
  to support classes which even when resilient are still objects.
• Risk: Low risk. Only affects noncopyable types.
• Original PR: https://github.com/apple/swift/pull/65842
• Reviewed By: @jckarter
• Testing: I added tests/updated other tests to make sure this did not happen.
• Resolves: rdar://109170069

Commit a10a5dbb07369a92f33d76b7a44369bcb59934ea

• Description: [move-only] Teach the move only object checker how to handle
  concrete resilient guaranteed arguments.

  The only difference from normal concrete guaranteed parameter emission is we
  have a load_borrow on the argument before the copy_value. That is instead of:
  
  ```
  bb0(%0 : @guaranteed $Type):
    %1 = copy_value %0
    %2 = mark_must_check [no_consume_or_assign] %1
  ```
  
  we have,
  
  ```
  bb0(%0 : $*Type): // in_guaranteed
    %1 = load_borrow %0
    %2 = copy_value %1
    %3 = mark_must_check [no_consume_or_assign] %2
  ```
  
  So I just needed to update the checker to recognize that pattern.
  
  This is tested by just making sure that the checker can handle the borrowVal in
  the tests without emitting an error.

• Risk: Low risk. Only affects noncopyable types.
• Original PR: #65842
• Reviewed By: @jckarter
• Testing: I added tests/updated other tests to make sure this did not happen.
• Resolves: rdar://109170906

Commit 43fb28f6082bb6bb3d14543daf207f5a1b69b701 && dddafe8d36b9ee97bd9fb287adbbb2fe0cdb937a

• Description: [move-only] Spill noncopyable types that are objects using
  store_borrow if we call a resilient function that takes it in_guaranteed.

  This is a typical update needed around library-evolution. Since we are inside
  the module itself, the value is concrete and thus an object, but the API it
  uses is resilient, so we have to pass it as an address.

  The second commit is just a small update to the first that fixes an issue
  where we were not properly handling opaque values with this code path. I just
  didn't squash the two commits.

• Risk: Low risk. Only affects noncopyable types.
• Original PR: #65842
• Reviewed By: @jckarter
• Testing: I added tests/updated other tests to make sure this did not happen.
• Resolves: rdar://109171001

Commit d2b7e70d42cecd43139d6f5850a36dc61f9bf77d
Commit cd3734c000539c7c7a5f907c80a7f0a5b1a45864
Commit de5737df9515b67949e3c1adbb372633313bfe71
Commit a6edf15e957af7683780cda19eb07b91d9f44852
Commit 052ecd1ae1930aa119e9c028dd18e7e6f118ffe3

• Description: Originally, we were going to follow the AST in a strict way in
  terms of what closures are considered escaping or not from a diagnostics
  perspective. Upon further investigation I found that we actually do something
  different for inout escaping semantics and by treating the AST as the one
  point of truth, we are being inconsistent with the rest of the compiler. As an
  example, the following code is considered by the compiler to not be an invalid
  escaping use of an inout implying that we do not consider the closure to be
  escaping:
  
  ```
  func f(_ x: inout Int) {
    let g = {
      _ = x
    }
  }
  ```
  
  in contrast, a var is always considered to be an escape:
  
  ```
  func f(_ x: inout Int) {
    var g = {
      _ = x
    }
  }
  
  test2.swift:3:13: error: escaping closure captures 'inout' parameter 'x'
      var g = {
              ^
  test2.swift:2:10: note: parameter 'x' is declared 'inout'
  func f(_ x: inout Int) {
           ^
  test2.swift:4:11: note: captured here
          _ = x
            ^
  ```
  
  Of course, if we store the let into memory, we get the error one would expect:
  
  ```
  var global: () -> () = {}
  func f(_ x: inout Int) {
    let g = {
      _ = x
    }
    global = g
  }
  
  test2.swift:4:11: error: escaping closure captures 'inout' parameter 'x'
    let g = {
            ^
  test2.swift:3:10: note: parameter 'x' is declared 'inout'
  func f(_ x: inout Int) {
           ^
  test2.swift:5:7: note: captured here
      _ = x
        ^
  ```
  
  By reverting to the old behavior where allocbox to stack ran early,
  noncopyable types now have the same sort of semantics: let closures that
  capture a noncopyable type that do not on the face of it escape are considered
  non-escaping, while if the closure is ever stored into memory (e.x.: store
  into a global, into a local var) or escapes, we get the appropriate escaping
  diagnostics. E.x.:
  
  ```
  public struct E : ~Copyable {}
  public func borrowVal(_ e: borrowing E) {}
  public func consumeVal(_ e: consuming E) {}
  
  func f1() {
    var e = E()
  
    // Mutable borrowing use of e. We can consume e as long as we reinit at end
    // of function. We don't here, so we get an error.
    let c1: () -> () = {
      borrowVal(e)
      consumeVal(e)
    }
  
    // Mutable borrowing use of e. We can consume e as long as we reinit at end
    // of function. We do do that here, so no error.
    let c2: () -> () = {
      borrowVal(e)
      consumeVal(e)
      e = E()
    }
  }
  
  ```
  
  Additionally, I did follow on work to ensure that:

  1. In these cases we treat applications of the partial_apply or passing the
  partial_apply off to a function as the liveness requiring uses rather than the
  partial_apply formation and the end lifetime of the partial_apply.

  2. When we do have an escaping partial_apply where we emit an inout capture
  error (and thus bail out of move checking early), we no longer attempt to emit
  "copy of noncopyable type" errors.

• Risk: Low risk. Only affects noncopyable types.
• Original PR: #65911
• Reviewed By: @jckarter
• Testing: I added tests/updated other tests to make sure this did not happen.
• Resolves: rdar://109426644