### PR TITLE
[cxx-interop] implicitly imported CxxShim module should not force cli…

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1176,7 +1176,7 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
   }
 
   if (Invocation.getLangOptions().EnableCXXInterop && canImportCxxShim()) {
-    pushImport(CXX_SHIM_NAME);
+    pushImport(CXX_SHIM_NAME, {ImportFlags::ImplementationOnly});
   }
 
   imports.ShouldImportUnderlyingModule = frontendOpts.ImportUnderlyingModule;

--- a/test/Interop/Cxx/implementation-only-imports/Inputs/helper.h
+++ b/test/Interop/Cxx/implementation-only-imports/Inputs/helper.h
@@ -11,10 +11,17 @@ public:
   MagicWrapper operator - (MagicWrapper other) {
       return MagicWrapper{_number - other._number};
   }
+
+  int baseMethod() const { return 42; }
 };
 
 inline MagicWrapper operator + (MagicWrapper lhs, MagicWrapper rhs) {
   return MagicWrapper{lhs._number + rhs._number};
 }
+
+class MagicWrapperDerived: public MagicWrapper {
+public:
+  MagicWrapperDerived() { };
+};
 
 #endif // TEST_INTEROP_CXX_IMPLEMENTATION_ONLY_IMPORTS_INPUTS_HELPER_H

--- a/test/Interop/Cxx/implementation-only-imports/Inputs/use-cxx-stdlib-impl-only.swift
+++ b/test/Interop/Cxx/implementation-only-imports/Inputs/use-cxx-stdlib-impl-only.swift
@@ -1,0 +1,6 @@
+@_implementationOnly import CxxStdlib
+
+public func testUsesCxxStdlib() {
+  let string = std.string()
+  print(String(string))
+}

--- a/test/Interop/Cxx/implementation-only-imports/Inputs/use-module-a-impl-only.swift
+++ b/test/Interop/Cxx/implementation-only-imports/Inputs/use-module-a-impl-only.swift
@@ -1,0 +1,7 @@
+@_implementationOnly import UserA
+
+public func testUsesA() {
+  let wrapper = MagicWrapperDerived()
+  // This will force Swift to use __swift_interopStaticCast from CxxShim here.
+  print(wrapper.baseMethod())
+}

--- a/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-interop-module-without-interop.swift
+++ b/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-interop-module-without-interop.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/Inputs/use-module-a-impl-only.swift -I %S/Inputs/ -module-name UseModuleAImplOnly -emit-module -emit-module-path %t/UseModuleAImplOnly.swiftmodule -cxx-interoperability-mode=default
+
+// RUN: %target-swift-frontend %s -typecheck -module-name TestMod -I %t -I %S/Inputs
+
+// Check that we have used something from CxxShim in 'UseModuleAImplOnly'
+// RUN: %target-swift-frontend %S/Inputs/use-module-a-impl-only.swift -I %S/Inputs/ -module-name UseModuleAImplOnly -emit-module -emit-module-path %t/UseModuleAImplOnly.swiftmodule -cxx-interoperability-mode=default -emit-sil -o - | %FileCheck %s
+// CHECK: __swift_interopStaticCast
+
+import UseModuleAImplOnly
+
+public func testCallsAPI() {
+    testUsesA()
+}

--- a/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxxstdlib-interop-module-without-interop.swift
+++ b/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxxstdlib-interop-module-without-interop.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/Inputs/use-cxx-stdlib-impl-only.swift -I %S/Inputs/ -module-name UseCxxStdlibImplOnly -emit-module -emit-module-path %t/UseCxxStdlibImplOnly.swiftmodule -cxx-interoperability-mode=default
+
+// RUN: %target-swift-frontend %s -typecheck -module-name TestMod -I %t -I %S/Inputs
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+import UseCxxStdlibImplOnly
+
+public func testCallsAPI() {
+    testUsesCxxStdlib()
+}


### PR DESCRIPTION
…ent modules to enable C++ interoperability

Fixes https://github.com/apple/swift/issues/65831
