### PR TITLE
[Macros] Update for SwiftSyntaxMacroExpansion module

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -32,5 +32,6 @@ add_pure_swift_host_library(swiftASTGen STATIC
     SwiftSyntax::SwiftParserDiagnostics
     SwiftSyntax::SwiftSyntax
     SwiftSyntax::SwiftSyntaxMacros
+    SwiftSyntax::SwiftSyntaxMacroExpansion
     swiftLLVMJSON
 )

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -37,10 +37,10 @@ let package = Package(
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax"),
         "swiftLLVMJSON"
       ],
       path: "Sources/ASTGen",
-      exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSetttings
     ),
     .target(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ if (SWIFT_SWIFT_PARSER)
     SwiftOperators
     SwiftSyntaxBuilder
     SwiftSyntaxMacros
+    SwiftSyntaxMacroExpansion
     SwiftCompilerPluginMessageHandling
   )
 

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -18,6 +18,7 @@ if (SWIFT_SWIFT_PARSER)
       $<TARGET_OBJECTS:_swiftCSwiftPluginServer>
     SWIFT_DEPENDENCIES
       SwiftSyntax::SwiftSyntaxMacros
+      SwiftSyntax::SwiftSyntaxMacroExpansion
       SwiftSyntax::SwiftCompilerPluginMessageHandling
       swiftLLVMJSON
   )


### PR DESCRIPTION
Share the same expansion logic between `ASTGen` and `SwiftCompilerMessageHandling`
