### PR TITLE
[ASTScopes] Fix scope expansion for if/switch expressions

### DIFF
--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -263,3 +263,98 @@ func nestedType() throws -> Int {
     0
   }
 }
+
+// MARK: Bindings
+
+enum E {
+  case e(Int)
+}
+
+struct S {
+  var i: Int
+
+  mutating func testAssign1(_ x: E) {
+    i = if case .e(let y) = x { y } else { 0 }
+  }
+
+
+  mutating func testAssign2(_ x: E) {
+    i = if case .e(let y) = x { Int(y) } else { 0 }
+  }
+
+  func testAssign3(_ x: E) {
+    var i = 0
+    i = if case .e(let y) = x { y } else { 0 }
+    _ = i
+  }
+
+  func testAssign4(_ x: E) {
+    var i = 0
+    let _ = {
+      i = if case .e(let y) = x { y } else { 0 }
+    }
+    _ = i
+  }
+
+  mutating func testAssign5(_ x: E) {
+    i = switch Bool.random() {
+    case true:
+      if case .e(let y) = x { y } else { 0 }
+    case let z:
+      z ? 0 : 1
+    }
+  }
+
+  mutating func testAssign6(_ x: E) {
+    i = if case .e(let y) = x {
+      switch Bool.random() {
+      case true: y
+      case false: y
+      }
+    } else {
+      0
+    }
+  }
+
+  mutating func testAssign7(_ x: E?) {
+    i = if let x = x {
+      switch x {
+      case .e(let y): y
+      }
+    } else {
+      0
+    }
+  }
+
+  func testReturn1(_ x: E) -> Int {
+    if case .e(let y) = x { y } else { 0 }
+  }
+
+  func testReturn2(_ x: E) -> Int {
+    return if case .e(let y) = x { y } else { 0 }
+  }
+
+  func testReturn3(_ x: E) -> Int {
+    {
+      if case .e(let y) = x { y } else { 0 }
+    }()
+  }
+
+  func testReturn4(_ x: E) -> Int {
+    return {
+      if case .e(let y) = x { y } else { 0 }
+    }()
+  }
+
+  func testBinding1(_ x: E) -> Int {
+    let i = if case .e(let y) = x { y } else { 0 }
+    return i
+  }
+
+  func testBinding2(_ x: E) -> Int {
+    let i = {
+      if case .e(let y) = x { y } else { 0 }
+    }()
+    return i
+  }
+}

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -358,3 +358,108 @@ func nestedType() throws -> Int {
     0
   }
 }
+
+// MARK: Bindings
+
+enum F {
+  case e(Int)
+}
+
+struct S {
+  var i: Int
+
+  mutating func testAssign1(_ x: F) {
+    i = switch x {
+    case .e(let y): y
+    }
+  }
+
+  mutating func testAssign2(_ x: F) {
+    i = switch x {
+    case .e(let y): Int(y)
+    }
+  }
+
+  func testAssign3(_ x: F) {
+    var i = 0
+    i = switch x {
+    case .e(let y): y
+    }
+    _ = i
+  }
+
+  func testAssign4(_ x: F) {
+    var i = 0
+    let _ = {
+      i = switch x {
+      case .e(let y): y
+      }
+    }
+    _ = i
+  }
+
+  mutating func testAssign5(_ x: F) {
+    i = switch Bool.random() {
+    case true:
+      switch x {
+      case .e(let y): y
+      }
+    case let z:
+      z ? 0 : 1
+    }
+  }
+
+  mutating func testAssign6(_ x: F) {
+    i = switch x {
+    case .e(let y):
+      switch Bool.random() {
+      case true: y
+      case false: y
+      }
+    }
+  }
+
+  func testReturn1(_ x: F) -> Int {
+    switch x {
+    case .e(let y): y
+    }
+  }
+
+  func testReturn2(_ x: F) -> Int {
+    return switch x {
+    case .e(let y): y
+    }
+  }
+
+  func testReturn3(_ x: F) -> Int {
+    {
+      switch x {
+      case .e(let y): y
+      }
+    }()
+  }
+
+  func testReturn4(_ x: F) -> Int {
+    return {
+      switch x {
+      case .e(let y): y
+      }
+    }()
+  }
+
+  func testBinding1(_ x: F) -> Int {
+    let i = switch x {
+    case .e(let y): y
+    }
+    return i
+  }
+
+  func testBinding2(_ x: F) -> Int {
+    let i = {
+      switch x {
+      case .e(let y): y
+      }
+    }()
+    return i
+  }
+}


### PR DESCRIPTION
Previously we could miss the scopes present in if/switch expressions if they were nested in another expression, such as an AssignExpr. Fix the logic such that we properly walk over a given expression looking for if/switch scopes, the same as what we do for closures.

rdar://109192116
Resolves #66412