### PR TITLE
allow `discard` in generic noncopyable type

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -189,7 +189,7 @@ bool TypeBase::isMarkerExistential() {
 }
 
 bool TypeBase::isPureMoveOnly() {
-  if (auto *nom = getNominalOrBoundGenericNominal())
+  if (auto *nom = getAnyNominal())
     return nom->isMoveOnly();
 
   // if any components of the tuple are move-only, then the tuple is move-only.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -912,8 +912,9 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
 }
 
 bool IsMoveOnlyRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
-  // For now only do this for nominal type decls.
-  if (isa<NominalTypeDecl>(decl)) {
+  // TODO: isPureMoveOnly and isMoveOnly and other checks are all spread out
+  // and need to be merged together.
+  if (isa<ClassDecl>(decl) || isa<StructDecl>(decl) || isa<EnumDecl>(decl)) {
       if (decl->getAttrs().hasAttribute<MoveOnlyAttr>()) {
         if (!decl->getASTContext().supportsMoveOnlyTypes())
             decl->diagnose(diag::moveOnly_requires_lexical_lifetimes);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1262,7 +1262,7 @@ public:
     // check the kind of type this discard statement appears within.
     if (!diagnosed) {
       auto *nominalDecl = fn->getDeclContext()->getSelfNominalTypeDecl();
-      Type nominalType = nominalDecl->getDeclaredType();
+      Type nominalType = nominalDecl->getDeclaredTypeInContext();
 
       // must be noncopyable
       if (!nominalType->isPureMoveOnly()) {

--- a/test/Sema/discard.swift
+++ b/test/Sema/discard.swift
@@ -161,3 +161,9 @@ enum NoDeinitEnum: ~Copyable {
     discard self // expected-error {{'discard' has no effect for type 'NoDeinitEnum' unless it has a deinitializer}}{{5-18=}}
   }
 }
+
+struct HasGenericNotStored<T>: ~Copyable {
+  consuming func discard() { discard self }
+  func identity(_ t: T) -> T { return t }
+  deinit{}
+}

--- a/test/Sema/discard_trivially_destroyed.swift
+++ b/test/Sema/discard_trivially_destroyed.swift
@@ -98,3 +98,15 @@ struct AllOK: ~Copyable {
   consuming func doDiscard() { discard self }
   deinit {}
 }
+
+struct HasGenericStored<T>: ~Copyable {
+  let t: T // expected-note {{type 'T' cannot be trivially destroyed}}
+  consuming func discard() { discard self } // expected-error {{can only 'discard' type 'HasGenericStored<T>' if it contains trivially-destroyed stored properties at this time}}
+  deinit{}
+}
+
+struct HasAny: ~Copyable {
+  var t: Any // expected-note {{type 'Any' cannot be trivially destroyed}}
+  consuming func discard() { discard self } // expected-error {{can only 'discard' type 'HasAny' if it contains trivially-destroyed stored properties at this time}}
+  deinit{}
+}


### PR DESCRIPTION
A bug was preventing you from writing `discard self` in a consuming method of a generic noncopyable type.

The main cause was the `isPureMoveOnly` ignored
unbound generic types, claiming none of them are
noncopyable. Then I also needed to pass the contextual type with the vars bound to the type checker.

rdar://108975216