### PR TITLE
Add @_used and @_section attributes for global variables and top-level functions

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -832,6 +832,12 @@ Fully bypasses access control, allowing access to private declarations
 in the imported module. The imported module needs to be compiled with
 `-Xfrontend -enable-private-imports` for this to work.
 
+## `@_section("section_name")`
+
+Places a global variable or a top-level function into a section of the object
+file with the given name. It's the equivalent of clang's
+`__attribute__((section))`.
+
 ## `@_semantics("uniquely.recognized.id")`
 
 Allows the optimizer to make use of some key invariants in performance critical
@@ -993,6 +999,12 @@ for more details.
 ## `@_unsafeInheritExecutor`
 
 This `async` function uses the pre-SE-0338 semantics of unsafely inheriting the caller's executor.  This is an underscored feature because the right way of inheriting an executor is to pass in the required executor and switch to it.  Unfortunately, there are functions in the standard library which need to inherit their caller's executor but cannot change their ABI because they were not defined as `@_alwaysEmitIntoClient` in the initial release.
+
+## `@_used`
+
+Marks a global variable or a top-level function as "used externally" even if it
+does not have visible users in the compilation unit. It's the equivalent of
+clang's `__attribute__((used))`.
 
 ## `@_weakLinked`
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -502,6 +502,24 @@ public:
   }
 };
 
+/// Defines the @_section attribute.
+class SectionAttr : public DeclAttribute {
+public:
+  SectionAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+    : DeclAttribute(DAK_Section, AtLoc, Range, Implicit),
+      Name(Name) {}
+
+  SectionAttr(StringRef Name, bool Implicit)
+    : SectionAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
+
+  /// The section name.
+  const StringRef Name;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Section;
+  }
+};
+
 /// Defines the @_cdecl attribute.
 class CDeclAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -332,6 +332,8 @@ ERROR(performance_unknown_callees,none,
       "called function is not known at compile time and can have unpredictable performance", ())
 ERROR(performance_callee_unavailable,none,
       "called function is not available in this module and can have unpredictable performance", ())
+ERROR(section_attr_on_non_const_global,none,
+      "global variable must be a compile-time constant to use @_section attribute", ())
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1702,6 +1702,9 @@ ERROR(cdecl_empty_name,none,
 ERROR(cdecl_throws,none,
       "raising errors from @_cdecl functions is not supported", ())
 
+// @_used and @_section
+ERROR(section_linkage_markers_disabled,none,
+      "attribute requires '-enable-experimental-feature SymbolLinkageMarkers'", ())
 ERROR(used_not_at_top_level,none,
       "@_used can only be applied to global functions and variables", ())
 ERROR(section_not_at_top_level,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1702,6 +1702,13 @@ ERROR(cdecl_empty_name,none,
 ERROR(cdecl_throws,none,
       "raising errors from @_cdecl functions is not supported", ())
 
+ERROR(used_not_at_top_level,none,
+      "@_used can only be applied to global functions and variables", ())
+ERROR(section_not_at_top_level,none,
+      "@_section can only be applied to global functions and variables", ())
+ERROR(section_empty_name,none,
+      "@_section section name cannot be empty", ())
+
 ERROR(expose_only_non_other_attr,none,
       "@_expose attribute cannot be applied to an '%0' declaration", (StringRef))
 ERROR(expose_inside_unexposed_decl,none,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -122,6 +122,9 @@ EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, true)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 
+// Whether to enable @_used and @_section attributes
+EXPERIMENTAL_FEATURE(SymbolLinkageMarkers, true)
+
 // FIXME: MoveOnlyClasses is not intended to be in production,
 // but our tests currently rely on it, and we want to run those
 // tests in non-asserts builds too.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -291,6 +291,9 @@ private:
   /// The function's remaining set of specialize attributes.
   std::vector<SILSpecializeAttr*> SpecializeAttrSet;
 
+  /// Name of a section if @_section attribute was used, otherwise empty.
+  StringRef Section;
+
   /// Has value if there's a profile for this function
   /// Contains Function Entry Count
   ProfileCounter EntryCount;
@@ -345,6 +348,9 @@ private:
   /// preserved and exported more widely than its Swift linkage and usage
   /// would indicate.
   unsigned HasCReferences : 1;
+
+  /// Whether attribute @_used was present
+  unsigned MarkedAsUsed : 1;
 
   /// Whether cross-module references to this function should always use weak
   /// linking.
@@ -1233,6 +1239,14 @@ public:
     auto *V = getLocation().getAsASTNode<ValueDecl>();
     return V && V->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>();
   }
+
+  /// Return whether this function has attribute @_used on it
+  bool markedAsUsed() const { return MarkedAsUsed; }
+  void setMarkedAsUsed(bool value) { MarkedAsUsed = value; }
+
+  /// Return custom section name if @_section was used, otherwise empty
+  StringRef section() const { return Section; }
+  void setSection(StringRef value) { Section = value; }
 
   /// Returns true if this function belongs to a declaration that returns
   /// an opaque result type with one or more availability conditions that are

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -190,6 +190,21 @@ public:
     StaticInitializerBlock.eraseAllInstructions(Module);
   }
 
+  /// Returns true if this global variable has `@_used` attribute.
+  bool markedAsUsed() const {
+    auto *V = getDecl();
+    return V && V->getAttrs().hasAttribute<UsedAttr>();
+  }
+
+  /// Returns a SectionAttr if this global variable has `@_section` attribute.
+  SectionAttr *getSectionAttr() const {
+    auto *V = getDecl();
+    if (!V)
+      return nullptr;
+
+    return V->getAttrs().getAttribute<SectionAttr>();
+  }
+
   /// Return whether this variable corresponds to a Clang node.
   bool hasClangNode() const;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3211,6 +3211,10 @@ static bool usesFeatureTupleConformances(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureSymbolLinkageMarkers(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureLayoutPrespecialization(Decl *decl) {
   auto &attrs = decl->getAttrs();
   return std::any_of(attrs.begin(), attrs.end(), [](auto *attr) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3212,7 +3212,14 @@ static bool usesFeatureTupleConformances(Decl *decl) {
 }
 
 static bool usesFeatureSymbolLinkageMarkers(Decl *decl) {
-  return false;
+  auto &attrs = decl->getAttrs();
+  return std::any_of(attrs.begin(), attrs.end(), [](auto *attr) {
+    if (isa<UsedAttr>(attr))
+      return true;
+    if (isa<SectionAttr>(attr))
+      return true;
+    return false;
+  });
 }
 
 static bool usesFeatureLayoutPrespecialization(Decl *decl) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1130,6 +1130,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     Printer << ")";
     break;
 
+  case DAK_Section:
+    Printer.printAttrName("@_section");
+    Printer << "(\"" << cast<SectionAttr>(this)->Name << "\")";
+    break;
+
   case DAK_ObjC: {
     Printer.printAttrName("@objc");
     llvm::SmallString<32> scratch;
@@ -1602,6 +1607,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "backDeployed";
   case DAK_Expose:
     return "_expose";
+  case DAK_Section:
+    return "_section";
   case DAK_Documentation:
     return "_documentation";
   case DAK_MacroRole:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2937,6 +2937,46 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     break;
   }
+
+  case DAK_Section: {
+    if (!consumeIf(tok::l_paren)) {
+      diagnose(Loc, diag::attr_expected_lparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return makeParserSuccess();
+    }
+
+    if (Tok.isNot(tok::string_literal)) {
+      diagnose(Loc, diag::attr_expected_string_literal, AttrName);
+      return makeParserSuccess();
+    }
+
+    auto Name = getStringLiteralIfNotInterpolated(
+        Loc, ("'" + AttrName + "'").str());
+
+    consumeToken(tok::string_literal);
+
+    if (Name.has_value())
+      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+    else
+      DiscardAttribute = true;
+
+    if (!consumeIf(tok::r_paren)) {
+      diagnose(Loc, diag::attr_expected_rparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return makeParserSuccess();
+    }
+
+    // @_section in a local scope is not allowed.
+    if (CurDeclContext->isLocalContext()) {
+      diagnose(Loc, diag::attr_only_at_non_local_scope, AttrName);
+    }
+
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) SectionAttr(Name.value(), AtLoc,
+                                               AttrRange, /*Implicit=*/false));
+
+    break;
+  }
   
   case DAK_Alignment: {
     if (!consumeIf(tok::l_paren)) {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -204,6 +204,7 @@ void SILFunction::init(
   this->InlineStrategy = inlineStrategy;
   this->Linkage = unsigned(Linkage);
   this->HasCReferences = false;
+  this->MarkedAsUsed = false;
   this->IsAlwaysWeakImported = false;
   this->IsDynamicReplaceable = isDynamic;
   this->ExactSelfClass = isExactSelfClass;
@@ -280,11 +281,13 @@ void SILFunction::createSnapshot(int id) {
   newSnapshot->ObjCReplacementFor = ObjCReplacementFor;
   newSnapshot->SemanticsAttrSet = SemanticsAttrSet;
   newSnapshot->SpecializeAttrSet = SpecializeAttrSet;
+  newSnapshot->Section = Section;
   newSnapshot->Availability = Availability;
   newSnapshot->specialPurpose = specialPurpose;
   newSnapshot->perfConstraints = perfConstraints;
   newSnapshot->GlobalInitFlag = GlobalInitFlag;
   newSnapshot->HasCReferences = HasCReferences;
+  newSnapshot->MarkedAsUsed = MarkedAsUsed;
   newSnapshot->IsAlwaysWeakImported = IsAlwaysWeakImported;
   newSnapshot->HasOwnership = HasOwnership;
   newSnapshot->IsWithoutActuallyEscapingThunk = IsWithoutActuallyEscapingThunk;
@@ -856,6 +859,9 @@ SILFunction::isPossiblyUsedExternally() const {
     return true;
 
   if (isRuntimeAccessible())
+    return true;
+
+  if (markedAsUsed())
     return true;
 
   // Declaration marked as `@_alwaysEmitIntoClient` that

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3236,6 +3236,12 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[_specialize "; Attr->print(OS); OS << "] ";
   }
 
+  if (markedAsUsed())
+    OS << "[used] ";
+
+  if (!section().empty())
+    OS << "[section \"" << section() << "\"] ";
+
   // TODO: Handle clang node owners which don't have a name.
   if (hasClangNode() && getClangNodeOwner()->hasName()) {
     OS << "[clang ";

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -476,6 +476,14 @@ private:
     SILModule *module = getModule();
 
     PerformanceDiagnostics diagnoser(*module, getAnalysis<BasicCalleeAnalysis>());
+
+    // Check that @_section is only on constant globals
+    for (SILGlobalVariable &g : module->getSILGlobals()) {
+      if (!g.getStaticInitializerValue() && g.getSectionAttr())
+        module->getASTContext().Diags.diagnose(
+            g.getDecl()->getLoc(), diag::section_attr_on_non_const_global);
+    }
+
     bool annotatedFunctionsFound = false;
 
     for (SILFunction &function : *module) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -253,6 +253,8 @@ public:
 
   void visitCDeclAttr(CDeclAttr *attr);
   void visitExposeAttr(ExposeAttr *attr);
+  void visitUsedAttr(UsedAttr *attr);
+  void visitSectionAttr(SectionAttr *attr);
 
   void visitDynamicCallableAttr(DynamicCallableAttr *attr);
 
@@ -2066,6 +2068,22 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
       diagnose(attr->getLocation(), diag::expose_invalid_name_pattern_init,
                attr->Name);
   }
+}
+
+void AttributeChecker::visitUsedAttr(UsedAttr *attr) {
+  // Only top-level func/var decls are currently supported.
+  if (D->getDeclContext()->isTypeContext())
+    diagnose(attr->getLocation(), diag::used_not_at_top_level);
+}
+
+void AttributeChecker::visitSectionAttr(SectionAttr *attr) {
+  // Only top-level func/var decls are currently supported.
+  if (D->getDeclContext()->isTypeContext())
+    diagnose(attr->getLocation(), diag::section_not_at_top_level);
+
+  // The name must not be empty.
+  if (attr->Name.empty())
+    diagnose(attr->getLocation(), diag::section_empty_name);
 }
 
 void AttributeChecker::visitUnsafeNoObjCTaggedPointerAttr(

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2071,12 +2071,22 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
 }
 
 void AttributeChecker::visitUsedAttr(UsedAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::SymbolLinkageMarkers)) {
+    diagnoseAndRemoveAttr(attr, diag::section_linkage_markers_disabled);
+    return;
+  }
+  
   // Only top-level func/var decls are currently supported.
   if (D->getDeclContext()->isTypeContext())
     diagnose(attr->getLocation(), diag::used_not_at_top_level);
 }
 
 void AttributeChecker::visitSectionAttr(SectionAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::SymbolLinkageMarkers)) {
+    diagnoseAndRemoveAttr(attr, diag::section_linkage_markers_disabled);
+    return;
+  }
+
   // Only top-level func/var decls are currently supported.
   if (D->getDeclContext()->isTypeContext())
     diagnose(attr->getLocation(), diag::section_not_at_top_level);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1546,6 +1546,8 @@ namespace  {
     UNINTERESTING_ATTR(UsableFromInline)
     UNINTERESTING_ATTR(ObjCNonLazyRealization)
     UNINTERESTING_ATTR(UnsafeNoObjCTaggedPointer)
+    UNINTERESTING_ATTR(Used)
+    UNINTERESTING_ATTR(Section)
     UNINTERESTING_ATTR(SwiftNativeObjCRuntimeBase)
     UNINTERESTING_ATTR(ShowInInterface)
     UNINTERESTING_ATTR(Specialize)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 783; // pack element type
+const uint16_t SWIFTMODULE_VERSION_MINOR = 784; // used and section attrs
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2035,6 +2035,12 @@ namespace decls_block {
     SILGenName_DECL_ATTR,
     BCFixed<1>, // implicit flag
     BCBlob      // _silgen_name
+  >;
+
+  using SectionDeclAttrLayout = BCRecordLayout<
+    Section_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // _section
   >;
 
   using CDeclDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3047,6 +3047,15 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_Section: {
+      auto *theAttr = cast<SectionAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[SectionDeclAttrLayout::Code];
+      SectionDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                           theAttr->isImplicit(),
+                                           theAttr->Name);
+      return;
+    }
+
     case DAK_Documentation: {
       auto *theAttr = cast<DocumentationAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[DocumentationDeclAttrLayout::Code];

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -1,10 +1,6 @@
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-sil | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-TOPLEVEL
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-ir  | %FileCheck %s --check-prefix=IR --check-prefix=IR-TOPLEVEL
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-LIBRARY
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR --check-prefix=IR-LIBRARY
-
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -S                   | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
-// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -S -parse-as-library | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -S 		-parse-as-library | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
 
 // REQUIRES: swift_in_compiler
 
@@ -14,41 +10,29 @@
 @_section("__TEXT,__mysection") public var g3: Bool = true
 @_section("__TEXT,__mysection") func foo() {}
 
-// SIL:         @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g0: Int { get set }
-// SIL:         @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g1: (Int, Int) { get set }
-// SIL:         @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g2: Bool { get set }
-// SIL:         @_section("__TEXT,__mysection") func foo()
-// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g0_WZ : $@convention(c)
-// SIL-LIBRARY: sil hidden [global_init] @$s7section2g0Sivau : $@convention(thin)
-// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g1_WZ : $@convention(c)
-// SIL-LIBRARY: sil hidden [global_init] @$s7section2g1Si_Sitvau : $@convention(thin)
-// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g2_WZ : $@convention(c)
-// SIL-LIBRARY: sil hidden [global_init] @$s7section2g2Sbvau : $@convention(thin)
-// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g3_WZ : $@convention(c)
-// SIL-LIBRARY: sil [global_init] @$s7section2g3Sbvau : $@convention(thin)
-// SIL:         sil hidden [section "__TEXT,__mysection"] @$s7section3fooyyF : $@convention(thin)
+// SIL: @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g0: Int { get set }
+// SIL: @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g1: (Int, Int) { get set }
+// SIL: @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g2: Bool { get set }
+// SIL: @_section("__TEXT,__mysection") func foo()
+// SIL: sil private [global_init_once_fn] @$s7section2g0_WZ : $@convention(c)
+// SIL: sil hidden [global_init] @$s7section2g0Sivau : $@convention(thin)
+// SIL: sil private [global_init_once_fn] @$s7section2g1_WZ : $@convention(c)
+// SIL: sil hidden [global_init] @$s7section2g1Si_Sitvau : $@convention(thin)
+// SIL: sil private [global_init_once_fn] @$s7section2g2_WZ : $@convention(c)
+// SIL: sil hidden [global_init] @$s7section2g2Sbvau : $@convention(thin)
+// SIL: sil private [global_init_once_fn] @$s7section2g3_WZ : $@convention(c)
+// SIL: sil [global_init] @$s7section2g3Sbvau : $@convention(thin)
+// SIL: sil hidden [section "__TEXT,__mysection"] @$s7section3fooyyF : $@convention(thin)
 
-// IR-LIBRARY:  @"$s7section2g0_Wz" = internal global i64 0
-
-// IR-LIBRARY:  @"$s7section2g0Sivp" = hidden global %TSi <{ i64 1 }>, section "__TEXT,__mysection"
-// IR-TOPLEVEL: @"$s7section2g0Sivp" = hidden global %TSi zeroinitializer, section "__TEXT,__mysection"
-
-// IR-LIBRARY:  @"$s7section2g1_Wz" = internal global i64 0
-
-// IR-LIBRARY:  @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> <{ %TSi <{ i64 42 }>, %TSi <{ i64 43 }> }>, section "__TEXT,__mysection"
-// IR-TOPLEVEL: @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> zeroinitializer, section "__TEXT,__mysection"
-
-// IR-LIBRARY:  @"$s7section2g2_Wz" = internal global i64 0
-
-// IR-LIBRARY:  @"$s7section2g2Sbvp" = hidden global %TSb <{ i1 true }>, section "__TEXT,__mysection"
-// IR-TOPLEVEL: @"$s7section2g2Sbvp" = hidden global %TSb zeroinitializer, section "__TEXT,__mysection"
-
-// IR-LIBRARY:  @"$s7section2g3_Wz" = internal global i64 0
-
-// IR-LIBRARY:  @"$s7section2g3Sbvp" = {{.*}}global %TSb <{ i1 true }>, section "__TEXT,__mysection"
-// IR-TOPLEVEL: @"$s7section2g3Sbvp" = {{.*}}global %TSb zeroinitializer, section "__TEXT,__mysection"
-
-// IR:          define {{.*}}@"$s7section3fooyyF"(){{.*}} section "__TEXT,__mysection"
+// IR:  @"$s7section2g0_Wz" = internal global i64 0
+// IR:  @"$s7section2g0Sivp" = hidden global %TSi <{ i64 1 }>, section "__TEXT,__mysection"
+// IR:  @"$s7section2g1_Wz" = internal global i64 0
+// IR:  @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> <{ %TSi <{ i64 42 }>, %TSi <{ i64 43 }> }>, section "__TEXT,__mysection"
+// IR:  @"$s7section2g2_Wz" = internal global i64 0
+// IR:  @"$s7section2g2Sbvp" = hidden global %TSb <{ i1 true }>, section "__TEXT,__mysection"
+// IR:  @"$s7section2g3_Wz" = internal global i64 0
+// IR:  @"$s7section2g3Sbvp" = {{.*}}global %TSb <{ i1 true }>, section "__TEXT,__mysection"
+// IR:  define {{.*}}@"$s7section3fooyyF"(){{.*}} section "__TEXT,__mysection"
 
 // ASM: .section{{.*}}__TEXT,__mysection
 // ASM-NOT: .section

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -1,0 +1,64 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-sil | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-TOPLEVEL
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  | %FileCheck %s --check-prefix=IR --check-prefix=IR-TOPLEVEL
+// RUN: %target-swift-frontend -primary-file %s -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-LIBRARY
+// RUN: %target-swift-frontend -primary-file %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR --check-prefix=IR-LIBRARY
+
+// RUN: %target-swift-frontend -primary-file %s -S                   | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
+// RUN: %target-swift-frontend -primary-file %s -S -parse-as-library | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
+
+// REQUIRES: swift_in_compiler
+
+@_section("__TEXT,__mysection") var g0: Int = 1
+@_section("__TEXT,__mysection") var g1: (Int, Int) = (42, 43)
+@_section("__TEXT,__mysection") var g2: Bool = true
+@_section("__TEXT,__mysection") public var g3: Bool = true
+@_section("__TEXT,__mysection") func foo() {}
+
+// SIL:         @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g0: Int { get set }
+// SIL:         @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g1: (Int, Int) { get set }
+// SIL:         @_section("__TEXT,__mysection") @_hasStorage @_hasInitialValue var g2: Bool { get set }
+// SIL:         @_section("__TEXT,__mysection") func foo()
+// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g0_WZ : $@convention(c)
+// SIL-LIBRARY: sil hidden [global_init] @$s7section2g0Sivau : $@convention(thin)
+// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g1_WZ : $@convention(c)
+// SIL-LIBRARY: sil hidden [global_init] @$s7section2g1Si_Sitvau : $@convention(thin)
+// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g2_WZ : $@convention(c)
+// SIL-LIBRARY: sil hidden [global_init] @$s7section2g2Sbvau : $@convention(thin)
+// SIL-LIBRARY: sil private [global_init_once_fn] @$s7section2g3_WZ : $@convention(c)
+// SIL-LIBRARY: sil [global_init] @$s7section2g3Sbvau : $@convention(thin)
+// SIL:         sil hidden [section "__TEXT,__mysection"] @$s7section3fooyyF : $@convention(thin)
+
+// IR-LIBRARY:  @"$s7section2g0_Wz" = internal global i64 0
+
+// IR-LIBRARY:  @"$s7section2g0Sivp" = hidden global %TSi <{ i64 1 }>, section "__TEXT,__mysection"
+// IR-TOPLEVEL: @"$s7section2g0Sivp" = hidden global %TSi zeroinitializer, section "__TEXT,__mysection"
+
+// IR-LIBRARY:  @"$s7section2g1_Wz" = internal global i64 0
+
+// IR-LIBRARY:  @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> <{ %TSi <{ i64 42 }>, %TSi <{ i64 43 }> }>, section "__TEXT,__mysection"
+// IR-TOPLEVEL: @"$s7section2g1Si_Sitvp" = hidden global <{ %TSi, %TSi }> zeroinitializer, section "__TEXT,__mysection"
+
+// IR-LIBRARY:  @"$s7section2g2_Wz" = internal global i64 0
+
+// IR-LIBRARY:  @"$s7section2g2Sbvp" = hidden global %TSb <{ i1 true }>, section "__TEXT,__mysection"
+// IR-TOPLEVEL: @"$s7section2g2Sbvp" = hidden global %TSb zeroinitializer, section "__TEXT,__mysection"
+
+// IR-LIBRARY:  @"$s7section2g3_Wz" = internal global i64 0
+
+// IR-LIBRARY:  @"$s7section2g3Sbvp" = {{.*}}global %TSb <{ i1 true }>, section "__TEXT,__mysection"
+// IR-TOPLEVEL: @"$s7section2g3Sbvp" = {{.*}}global %TSb zeroinitializer, section "__TEXT,__mysection"
+
+// IR:          define {{.*}}@"$s7section3fooyyF"(){{.*}} section "__TEXT,__mysection"
+
+// ASM: .section{{.*}}__TEXT,__mysection
+// ASM-NOT: .section
+// ASM: $s7section3fooyyF:
+// ASM-linux-gnu: .section{{.*}}__TEXT,__mysection
+// ASM-NOT: .section
+// ASM: $s7section2g0Sivp:
+// ASM-NOT: .section
+// ASM: $s7section2g1Si_Sitvp:
+// ASM-NOT: .section
+// ASM: $s7section2g2Sbvp:
+// ASM-NOT: .section
+// ASM: $s7section2g3Sbvp:

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -1,10 +1,10 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-sil | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-TOPLEVEL
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  | %FileCheck %s --check-prefix=IR --check-prefix=IR-TOPLEVEL
-// RUN: %target-swift-frontend -primary-file %s -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-LIBRARY
-// RUN: %target-swift-frontend -primary-file %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR --check-prefix=IR-LIBRARY
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-sil | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-TOPLEVEL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-ir  | %FileCheck %s --check-prefix=IR --check-prefix=IR-TOPLEVEL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL --check-prefix=SIL-LIBRARY
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR --check-prefix=IR-LIBRARY
 
-// RUN: %target-swift-frontend -primary-file %s -S                   | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
-// RUN: %target-swift-frontend -primary-file %s -S -parse-as-library | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -S                   | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -S -parse-as-library | %FileCheck %s --check-prefix=ASM --check-prefix ASM-%target-os
 
 // REQUIRES: swift_in_compiler
 

--- a/test/IRGen/section_non_const.swift
+++ b/test/IRGen/section_non_const.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -parse-as-library -emit-sil %s -o /dev/null -verify
+
+// REQUIRES: swift_in_compiler
+
+@_section("__TEXT,__mysection") var g0: Int = 1
+@_section("__TEXT,__mysection") var g1: (Int, Int) = (1, 2)
+@_section("__TEXT,__mysection") var g2: [Int] = [1, 2, 3] // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
+@_section("__TEXT,__mysection") var g3: [Int:Int] = [:] // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
+@_section("__TEXT,__mysection") var g4: UInt = 42
+@_section("__TEXT,__mysection") var g5: String = "hello" // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
+@_section("__TEXT,__mysection") var g6: Any = 1 // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
+@_section("__TEXT,__mysection") var g7: UInt8 = 42
+@_section("__TEXT,__mysection") var g8: Int = 5 * 5

--- a/test/IRGen/used.swift
+++ b/test/IRGen/used.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -primary-file %s    -emit-sil | %FileCheck %s --check-prefix=SIL
-// RUN: %target-swift-frontend -primary-file %s -O -emit-sil | %FileCheck %s --check-prefix=SIL
-// RUN: %target-swift-frontend -primary-file %s    -emit-ir  | %FileCheck %s --check-prefix=IR
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir  | %FileCheck %s --check-prefix=IR
-// RUN: %target-swift-frontend -primary-file %s    -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
-// RUN: %target-swift-frontend -primary-file %s -O -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
-// RUN: %target-swift-frontend -primary-file %s    -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s    -emit-sil | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -O -emit-sil | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s    -emit-ir  | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -O -emit-ir  | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s    -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -O -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s    -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -primary-file %s -O -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
 
 // REQUIRES: swift_in_compiler
 

--- a/test/IRGen/used.swift
+++ b/test/IRGen/used.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -primary-file %s    -emit-sil | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -primary-file %s -O -emit-sil | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -primary-file %s    -emit-ir  | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir  | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -primary-file %s    -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -primary-file %s -O -emit-sil -parse-as-library | %FileCheck %s --check-prefix=SIL
+// RUN: %target-swift-frontend -primary-file %s    -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=IR
+
+// REQUIRES: swift_in_compiler
+
+@_used var g0: Int = 1
+@_used var g1: (Int, Int) = (42, 43)
+@_used var g2: Bool = true
+@_used func foo() {}
+
+// SIL: @_used @_hasStorage @_hasInitialValue var g0: Int { get set }
+// SIL: @_used @_hasStorage @_hasInitialValue var g1: (Int, Int) { get set }
+// SIL: @_used @_hasStorage @_hasInitialValue var g2: Bool { get set }
+// SIL: @_used func foo()
+
+// SIL: sil_global hidden @$s4used2g0Sivp : $Int
+// SIL: sil_global hidden @$s4used2g1Si_Sitvp : $(Int, Int)
+// SIL: sil_global hidden @$s4used2g2Sbvp : $Bool
+
+// SIL: sil hidden [used] @$s4used3fooyyF : $@convention(thin)
+
+// IR:      @llvm{{(\.compiler)?}}.used = appending global [{{.*}} x i8*] [
+// IR-SAME: i8* bitcast (%TSi* @"$s4used2g0Sivp" to i8*)
+// IR-SAME: i8* bitcast (<{ %TSi, %TSi }>* @"$s4used2g1Si_Sitvp" to i8*)
+// IR-SAME: i8* bitcast (%TSb* @"$s4used2g2Sbvp" to i8*)
+// IR-SAME: i8* bitcast (void ()* @"$s4used3fooyyF" to i8*)

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -922,6 +922,21 @@ DECL_MODIFIER_KINDS = [
                   ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=142),
     DeclAttributeAlias('freestanding', 'MacroRole'),
+
+    SimpleDeclAttribute('_used', 'Used',
+                        OnAbstractFunction, OnVar,
+                        UserInaccessible,
+                        ABIBreakingToAdd, ABIBreakingToRemove,
+                        APIBreakingToAdd, APIBreakingToRemove,
+                        code=143),
+
+    DeclAttribute('_section', 'Section',
+                  OnAbstractFunction, OnVar,
+                  UserInaccessible,
+                  ABIBreakingToAdd, ABIBreakingToRemove,
+                  APIBreakingToAdd, APIBreakingToRemove,
+                  code=144),
+
 ]
 
 DEPRECATED_MODIFIER_KINDS = [


### PR DESCRIPTION
Add @_used and @_section attributes for global variables and top-level functions

This adds:
- @_used attribute that flags as a global variable or a top-level function as "do not dead-strip" via llvm.used, roughly the equivalent of `__attribute__((used))` in C/C++.
- @_section("...") attribute that places a global variable or a top-level function into a section with that name, roughly the equivalent of `__attribute__((section("...")))` in C/C++.
