### PR TITLE
[stdlib] Fix String.reserveCapacity underallocation

### DIFF
--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -84,7 +84,7 @@ extension _StringGuts {
   internal init(_initialCapacity capacity: Int) {
     self.init()
     if _slowPath(capacity > _SmallString.capacity) {
-      self.grow(capacity) // TODO: no factor should be applied
+      self.grow(capacity)
     }
   }
 
@@ -94,20 +94,28 @@ extension _StringGuts {
     if let currentCap = self.uniqueNativeCapacity, currentCap >= n { return }
 
     // Grow
-    self.grow(n) // TODO: no factor should be applied
+    self.grow(n)
   }
 
   // Grow to accommodate at least `n` code units
   @usableFromInline
   internal mutating func grow(_ n: Int) {
-    defer { self._invariantCheck() }
+    defer {
+      self._invariantCheck()
+      _internalInvariant(
+        self.uniqueNativeCapacity != nil && self.uniqueNativeCapacity! >= n)
+    }
 
     _internalInvariant(
       self.uniqueNativeCapacity == nil || self.uniqueNativeCapacity! < n)
 
-    // TODO: Don't do this! Growth should only happen for append...
-    let growthTarget = Swift.max(n, (self.uniqueNativeCapacity ?? 0) * 2)
+    // We're non-unique OR smaller than requested, so as we copy to new storage,
+    // choose a size that at least stores the current contents.
+    let growthTarget = Swift.max(n, self.utf8Count)
 
+    // `isFastUTF8` is not the same as `isNative`. It can include small
+    // strings or foreign strings that provide contiguous UTF-8 access, so
+    // we fall back to `utf8Count` if necessary.
     if _fastPath(isFastUTF8) {
       let isASCII = self.isASCII
       let storage = self.withFastUTF8 {

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2371,21 +2371,43 @@ StringTests.test("SmallString.zeroTrailingBytes") {
 }
 
 StringTests.test("String.CoW.reserveCapacity") {
-  for _ in 0..<100 {
-    var str = String(repeating: "a", count: 100)
-    var copy = str
-    copy.reserveCapacity(20)
-    copy.append(contentsOf: String(repeating: "z", count: 50))
-  }
+  // Test that reserveCapacity(_:) doesn't actually shrink capacity
+  var str = String(repeating: "a", count: 20)
+  str.reserveCapacity(10)
+  expectGE(str.capacity, 20)
+  str.reserveCapacity(30)
+  expectGE(str.capacity, 30)
+  let preGrowCapacity = str.capacity
+  
+  // Growth shouldn't be linear
+  str.append(contentsOf: String(repeating: "z", count: 20))
+  expectGE(str.capacity, preGrowCapacity * 2)
+  
+  // Capacity can shrink when copying, but not below the count
+  var copy = str
+  copy.reserveCapacity(30)
+  expectGE(copy.capacity, copy.count)
+  expectLT(copy.capacity, str.capacity)
 }
 
 StringTests.test("NSString.CoW.reserveCapacity") {
 #if _runtime(_ObjC)
-  let nsstr = NSString(string: String(repeating: "a", count: 100))
-  var str = nsstr as String
+  func newNSString() -> NSString {
+    NSString(string: String(repeating: "a", count: 20))
+  }
+  
+  // Test that reserveCapacity(_:) doesn't actually shrink capacity
+  var str = newNSString() as String
   var copy = str
-  copy.reserveCapacity(20)
-  copy.append(contentsOf: String(repeating: "z", count: 50))
+  copy.reserveCapacity(10)
+  copy.reserveCapacity(30)
+  expectGE(copy.capacity, 30)
+  
+  var str2 = newNSString() as String
+  var copy2 = str2
+  copy2.append(contentsOf: String(repeating: "z", count: 10))
+  expectGE(copy2.capacity, 30)
+  expectLT(copy2.capacity, 40)
 #endif
 }
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2370,4 +2370,23 @@ StringTests.test("SmallString.zeroTrailingBytes") {
   }
 }
 
+StringTests.test("String.CoW.reserveCapacity") {
+  for _ in 0..<100 {
+    var str = String(repeating: "a", count: 100)
+    var copy = str
+    copy.reserveCapacity(20)
+    copy.append(contentsOf: String(repeating: "z", count: 50))
+  }
+}
+
+StringTests.test("NSString.CoW.reserveCapacity") {
+#if _runtime(_ObjC)
+  let nsstr = NSString(string: String(repeating: "a", count: 100))
+  var str = nsstr as String
+  var copy = str
+  copy.reserveCapacity(20)
+  copy.append(contentsOf: String(repeating: "z", count: 50))
+#endif
+}
+
 runAllTests()


### PR DESCRIPTION
When called on a string that is not uniquely referenced, `String.reserveCapacity(_:)` ignores the current capacity, using the passed-in capacity for the size of its new storage. This can result in an underallocation and write past the end of the new buffer.

This fix changes the new size calculation to use the current UTF-8 count as the minimum. ~At the same time, it removes a growth factor from that calculation, as the appropriate growth is already being factored in upstream at all call sites.~

rdar://109275875
Fixes #53483