### PR TITLE
Update `-strict-concurrency` help text

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -794,7 +794,7 @@ def warn_concurrency : Flag<["-"], "warn-concurrency">,
 def strict_concurrency : Joined<["-"], "strict-concurrency=">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Specify the how strict concurrency checking will be. The value may "
-           "be 'explicit' (most 'Sendable' checking is disabled), "
+           "be 'minimal' (most 'Sendable' checking is disabled), "
            "'targeted' ('Sendable' checking is enabled in code that uses the "
            "concurrency model, or 'complete' ('Sendable' and other checking is "
            "enabled for all code in the module)">;


### PR DESCRIPTION
The value `explicit` for the `-strict-concurrency` compiler option was changed to `minimal` during [the original addition of the option](https://github.com/apple/swift/pull/42523).