### PR TITLE
🍒[cxx-interop] Explicitly disable `-fmodules-local-submodule-visibility`

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1255,6 +1255,9 @@ ClangImporter::create(ASTContext &ctx,
   // read them later.
   instance.getLangOpts().NeededByPCHOrCompilationUsesPCH = true;
 
+  // Clang implicitly enables this by default in C++20 mode.
+  instance.getLangOpts().ModulesLocalVisibility = false;
+
   if (importerOpts.Mode == ClangImporterOptions::Modes::PrecompiledModule)
     return importer;
 

--- a/test/Interop/Cxx/concepts/method-requires.swift
+++ b/test/Interop/Cxx/concepts/method-requires.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftxx-frontend -emit-ir -Xcc -std=gnu++20 -I %S/Inputs %s | %FileCheck %s
 //
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 import MethodRequires
 

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// FIXME: also test this in C++20 mode once rdar://108810356 is fixed.
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=gnu++20)
 //
 // REQUIRES: executable_test
 //


### PR DESCRIPTION
**Explanation**:  Clang implicitly enables local submodule visibility when compiling in C++20 mode. ClangImporter does not support it, so let's disable it explicitly.
**Scope**: Only has an effect when C++20 mode is enabled: the setting is unaltered when using older C++ modes.
**Risk**: Low, this does not change the ClangImporter's behavior when C++ interop is not enabled, or when using C++ language version older than C++20.

rdar://108959307 / https://github.com/apple/swift/issues/65710 (cherry picked from commit aed5614ec25fd174e094a30c1459649cbf267066)