### PR TITLE
Don't double allocate when making a foreign string native

### DIFF
--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -294,8 +294,11 @@ extension String {
         String._uncheckedFromUTF8($0)
       }
     }
-    return Array(str.utf8).withUnsafeBufferPointer {
-      String._uncheckedFromUTF8($0)
+    let count = str.uft8.count
+    return String(unsafeUninitializedCapacity: count) { buffer in
+      var (_, end) = str.utf8._copyContents(initializing: buffer)
+      _internalInvariant(end == buffer.endIndex, "Buffer too large for new string")
+      return count
     }
   }
 }


### PR DESCRIPTION
Converting a string with non-contiguous-UTF-8 storage to a native Swift string performs a double allocation: once to fill an array with the UTF-8 data, and then again for the new string itself.

This change removes the intermediate array, directly allocating the new string and then copying the UTF-8 into that new buffer.