### PR TITLE
[cxx-interop] Make `std.optional.value` nullable

### DIFF
--- a/stdlib/public/Cxx/CxxOptional.swift
+++ b/stdlib/public/Cxx/CxxOptional.swift
@@ -27,8 +27,9 @@ extension CxxOptional {
   }
 
   @inlinable
-  public var value: Wrapped {
+  public var value: Wrapped? {
     get {
+      guard hasValue else { return nil }
       return pointee
     }
   }

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -29,10 +29,11 @@ StdOptionalTestSuite.test("std::optional => Swift.Optional") {
 StdOptionalTestSuite.test("std::optional hasValue/value") {
   let nonNilOpt = getNonNilOptional()
   expectTrue(nonNilOpt.hasValue)
-  expectEqual(123, nonNilOpt.value)
+  expectEqual(123, nonNilOpt.value!)
 
   let nilOpt = getNilOptional()
   expectFalse(nilOpt.hasValue)
+  expectNil(nilOpt.value)
 }
 
 runAllTests()


### PR DESCRIPTION
This adds a null-safe way of retrieving the wrapped value of `std::optional` and also allows using if-let syntax with C++ optional values:
```swift
if let x = getOptional().value {
  // ...
}
```

rdar://109356566 / resolves https://github.com/apple/swift/issues/65918