### PR TITLE
[Mem2Reg] Complete new enum phi lifetimes.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -938,7 +938,7 @@ public:
 
 private:
   /// Promote AllocStacks into SSA.
-  void promoteAllocationToPhi();
+  void promoteAllocationToPhi(BlockSetVector &livePhiBlocks);
 
   /// Replace the dummy nodes with new block arguments.
   void addBlockArguments(BlockSetVector &phiBlocks);
@@ -1685,7 +1685,8 @@ void StackAllocationPromoter::pruneAllocStackUsage() {
   LLVM_DEBUG(llvm::dbgs() << "*** Finished pruning : " << *asi);
 }
 
-void StackAllocationPromoter::promoteAllocationToPhi() {
+void StackAllocationPromoter::promoteAllocationToPhi(
+    BlockSetVector &livePhiBlocks) {
   LLVM_DEBUG(llvm::dbgs() << "*** Placing Phis for : " << *asi);
 
   // A list of blocks that will require new Phi values.
@@ -1781,10 +1782,6 @@ void StackAllocationPromoter::promoteAllocationToPhi() {
   // Replace the dummy values with new block arguments.
   addBlockArguments(phiBlocks);
 
-  // The blocks which still have new phis after fixBranchesAndUses runs.  These
-  // are not necessarily the same as phiBlocks because fixBranchesAndUses
-  // removes superfluous proactive phis.
-  BlockSetVector livePhiBlocks(asi->getFunction());
   // Hook up the Phi nodes, loads, and debug_value_addr with incoming values.
   fixBranchesAndUses(phiBlocks, livePhiBlocks);
 
@@ -1801,8 +1798,13 @@ void StackAllocationPromoter::run() {
   // per block and the last store is recorded.
   pruneAllocStackUsage();
 
+  // The blocks which still have new phis after fixBranchesAndUses runs.  These
+  // are not necessarily the same as phiBlocks because fixBranchesAndUses
+  // removes superfluous proactive phis.
+  BlockSetVector livePhiBlocks(asi->getFunction());
+
   // Replace AllocStacks with Phi-nodes.
-  promoteAllocationToPhi();
+  promoteAllocationToPhi(livePhiBlocks);
 
   // Make sure that all of the allocations were promoted into registers.
   assert(isWriteOnlyAllocation(asi) && "Non-write uses left behind");

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1816,6 +1816,12 @@ void StackAllocationPromoter::run() {
   // Use the lifetime completion utility to complete such lifetimes.
   // First, collect the stored values to complete.
   if (asi->getType().isOrHasEnum()) {
+    for (auto *block : livePhiBlocks) {
+      SILPhiArgument *argument = cast<SILPhiArgument>(
+          block->getArgument(block->getNumArguments() - 1));
+      assert(argument->isPhi());
+      valuesToComplete.push_back(argument);
+    }
     for (auto it : initializationPoints) {
       auto *si = it.second;
       auto stored = si->getOperand(CopyLikeInstruction::Src);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1818,10 +1818,8 @@ void StackAllocationPromoter::run() {
       auto *si = it.second;
       auto stored = si->getOperand(CopyLikeInstruction::Src);
       valuesToComplete.push_back(stored);
-      if (lexicalLifetimeEnsured(asi)) {
-        if (auto lexical = getLexicalValueForStore(si, asi)) {
-          valuesToComplete.push_back(lexical);
-        }
+      if (auto lexical = getLexicalValueForStore(si, asi)) {
+        valuesToComplete.push_back(lexical);
       }
     }
   }

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -1,11 +1,29 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -mem2reg | %FileCheck %s
 
 import Builtin
-import Swift
 
 //////////////////
 // Declarations //
 //////////////////
+
+typealias AnyObject = Builtin.AnyObject
+
+struct Int64 {
+  var _value : Builtin.Int64
+}
+
+struct Int {
+  var _value : Builtin.Int64
+}
+
+struct Bool {
+  var _value : Builtin.Int1
+}
+
+enum FakeOptional<T> {
+case some(T)
+case none
+}
 
 class Klass {}
 
@@ -492,22 +510,22 @@ bb0:
 // CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks :
 // CHECK-NOT:         alloc_stack
 // CHECK:       } // end sil function 'test_optional_in_multiple_blocks'
-sil [ossa] @test_optional_in_multiple_blocks : $@convention(method) (@guaranteed Optional<Klass>) -> () {
-bb0(%0 : @guaranteed $Optional<Klass>):
-  %1 = copy_value %0 : $Optional<Klass>
-  %32 = alloc_stack $Optional<Klass>
-  store %1 to [init] %32 : $*Optional<Klass>
-  switch_enum %0 : $Optional<Klass>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb5
+sil [ossa] @test_optional_in_multiple_blocks : $@convention(method) (@guaranteed FakeOptional<Klass>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Klass>):
+  %1 = copy_value %0 : $FakeOptional<Klass>
+  %32 = alloc_stack $FakeOptional<Klass>
+  store %1 to [init] %32 : $*FakeOptional<Klass>
+  switch_enum %0 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb6, case #FakeOptional.none!enumelt: bb5
 
 bb5:
-  dealloc_stack %32 : $*Optional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb6(%50 : @guaranteed $Klass):
-  %53 = load [copy] %32 : $*Optional<Klass>
-  destroy_value %53 : $Optional<Klass>
-  destroy_addr %32 : $*Optional<Klass>
-  dealloc_stack %32 : $*Optional<Klass>
+  %53 = load [copy] %32 : $*FakeOptional<Klass>
+  destroy_value %53 : $FakeOptional<Klass>
+  destroy_addr %32 : $*FakeOptional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb7:
@@ -518,22 +536,22 @@ bb7:
 // CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks_lexical :
 // CHECK-NOT:         alloc_stack
 // CHECK:       } // end sil function 'test_optional_in_multiple_blocks_lexical'
-sil [ossa] @test_optional_in_multiple_blocks_lexical : $@convention(method) (@guaranteed Optional<Klass>) -> () {
-bb0(%0 : @guaranteed $Optional<Klass>):
-  %1 = copy_value %0 : $Optional<Klass>
-  %32 = alloc_stack [lexical] $Optional<Klass>
-  store %1 to [init] %32 : $*Optional<Klass>
-  switch_enum %0 : $Optional<Klass>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb5
+sil [ossa] @test_optional_in_multiple_blocks_lexical : $@convention(method) (@guaranteed FakeOptional<Klass>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Klass>):
+  %1 = copy_value %0 : $FakeOptional<Klass>
+  %32 = alloc_stack [lexical] $FakeOptional<Klass>
+  store %1 to [init] %32 : $*FakeOptional<Klass>
+  switch_enum %0 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb6, case #FakeOptional.none!enumelt: bb5
 
 bb5:
-  dealloc_stack %32 : $*Optional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb6(%50 : @guaranteed $Klass):
-  %53 = load [copy] %32 : $*Optional<Klass>
-  destroy_value %53 : $Optional<Klass>
-  destroy_addr %32 : $*Optional<Klass>
-  dealloc_stack %32 : $*Optional<Klass>
+  %53 = load [copy] %32 : $*FakeOptional<Klass>
+  destroy_value %53 : $FakeOptional<Klass>
+  destroy_addr %32 : $*FakeOptional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb7:
@@ -544,23 +562,23 @@ bb7:
 // CHECK-LABEL: sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue :
 // CHECK-NOT:         alloc_stack
 // CHECK:       } // end sil function 'test_optional_in_multiple_blocks_lexical_storedvalue'
-sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue : $@convention(method) (@owned Optional<Klass>) -> () {
-bb0(%0 : @owned $Optional<Klass>):
-  %1 = copy_value %0 : $Optional<Klass>
-  %32 = alloc_stack $Optional<Klass>
-  store %0 to [init] %32 : $*Optional<Klass>
-  switch_enum %1 : $Optional<Klass>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb5
+sil [ossa] @test_optional_in_multiple_blocks_lexical_storedvalue : $@convention(method) (@owned FakeOptional<Klass>) -> () {
+bb0(%0 : @owned $FakeOptional<Klass>):
+  %1 = copy_value %0 : $FakeOptional<Klass>
+  %32 = alloc_stack $FakeOptional<Klass>
+  store %0 to [init] %32 : $*FakeOptional<Klass>
+  switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb6, case #FakeOptional.none!enumelt: bb5
 
 bb5:
-  dealloc_stack %32 : $*Optional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb6(%50 : @owned $Klass):
-  %53 = load [copy] %32 : $*Optional<Klass>
-  destroy_value %53 : $Optional<Klass>
+  %53 = load [copy] %32 : $*FakeOptional<Klass>
+  destroy_value %53 : $FakeOptional<Klass>
   destroy_value %50 : $Klass
-  destroy_addr %32 : $*Optional<Klass>
-  dealloc_stack %32 : $*Optional<Klass>
+  destroy_addr %32 : $*FakeOptional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb7:
@@ -571,20 +589,20 @@ bb7:
 // CHECK-LABEL: sil [ossa] @optimize_optional_in_single_block :
 // CHECK-NOT:     alloc_stack
 // CHECK:       } // end sil function 'optimize_optional_in_single_block'
-sil [ossa] @optimize_optional_in_single_block : $@convention(method) (@guaranteed Optional<Klass>) -> () {
-bb0(%0 : @guaranteed $Optional<Klass>):
-  switch_enum %0 : $Optional<Klass>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb5
+sil [ossa] @optimize_optional_in_single_block : $@convention(method) (@guaranteed FakeOptional<Klass>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<Klass>):
+  switch_enum %0 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb6, case #FakeOptional.none!enumelt: bb5
 
 bb5:
   br bb7
 
 bb6(%50 : @guaranteed $Klass):
-  %32 = alloc_stack $Optional<Klass>
-  %1 = copy_value %0 : $Optional<Klass>
-  store %1 to [init] %32 : $*Optional<Klass>
-  %53 = load [take] %32 : $*Optional<Klass>
-  destroy_value %53 : $Optional<Klass>
-  dealloc_stack %32 : $*Optional<Klass>
+  %32 = alloc_stack $FakeOptional<Klass>
+  %1 = copy_value %0 : $FakeOptional<Klass>
+  store %1 to [init] %32 : $*FakeOptional<Klass>
+  %53 = load [take] %32 : $*FakeOptional<Klass>
+  destroy_value %53 : $FakeOptional<Klass>
+  dealloc_stack %32 : $*FakeOptional<Klass>
   br bb7
 
 bb7:

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -610,3 +610,50 @@ bb7:
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @switch_enum_out_of_new_phi_block : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK:       } // end sil function 'switch_enum_out_of_new_phi_block'
+sil [ossa] @switch_enum_out_of_new_phi_block : $() -> () {
+entry:
+  %addr = alloc_stack $FakeOptional<Klass>
+  cond_br undef, store_none, agg_either
+
+store_none:
+  %none1 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  store %none1 to [init] %addr : $*FakeOptional<Klass>
+  br switcheroo
+
+agg_either:
+  cond_br undef, agg_some, agg_none
+
+agg_some:
+  %Klass = apply undef() : $@convention(thin) () -> (@owned Klass)
+  %some = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %Klass : $Klass
+  br store_maybe(%some : $FakeOptional<Klass>)
+
+agg_none:
+  %none2 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  br store_maybe(%none2 : $FakeOptional<Klass>)
+
+store_maybe(%maybe : @owned $FakeOptional<Klass>):
+  store %maybe to [init] %addr : $*FakeOptional<Klass>
+  br switcheroo
+
+switcheroo:
+  %borrow = load_borrow %addr : $*FakeOptional<Klass>
+  switch_enum %borrow : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb14, case #FakeOptional.none!enumelt: bb15
+
+bb14(%some_borrowed : @guaranteed $Klass):
+  end_borrow %borrow : $FakeOptional<Klass>
+  destroy_addr %addr : $*FakeOptional<Klass>
+  br bb16
+
+bb15:
+  end_borrow %borrow : $FakeOptional<Klass>
+  br bb16
+
+bb16:
+  dealloc_stack %addr : $*FakeOptional<Klass>
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
When multi-block `alloc_stack`s of enum type with users are promoted, lifetimes of stored values are completed to compensate for the legality of not `destroy_addr`ing the `alloc_stack` in blocks where no non-trivial value is known to be stored (the none case block of a `switch_enum` of a `load_borrow` of the `alloc_stack`, e.g.).

Here, phis created during promotion are lifetime completed as well.
