### PR TITLE
Add default lit timeout to prevent hanging tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -28,7 +28,7 @@ tvos
 watchos
 test
 validation-test
-lit-args=-v
+lit-args=-v --timeout=600
 compiler-vendor=apple
 
 verbose-build
@@ -302,7 +302,7 @@ lldb-assertions
 
 [preset: lldb-pull-request]
 lldb
-lit-args=-v 
+lit-args=-v --timeout=600
 
 lldb-use-system-debugserver
 release-debuginfo
@@ -320,7 +320,7 @@ skip-early-swift-driver
 [preset: buildbot_incremental_base]
 test
 validation-test
-lit-args=-v --time-tests
+lit-args=-v --time-tests --timeout=600
 
 compiler-vendor=apple
 
@@ -677,7 +677,7 @@ build-subdir=buildbot_incremental_llvmonly
 release-debug
 assertions
 test=0
-lit-args=-v
+lit-args=-v --timeout=600
 
 compiler-vendor=apple
 
@@ -701,7 +701,7 @@ lldb
 release
 test
 
-lit-args=-v --time-tests
+lit-args=-v --time-tests --timeout=600
 skip-build-benchmarks
 no-swift-stdlib-assertions
 lldb-use-system-debugserver
@@ -894,7 +894,7 @@ libdispatch
 indexstore-db
 sourcekit-lsp
 swiftdocc
-lit-args=-v --time-tests
+lit-args=-v --time-tests --timeout=600
 
 # rdar://problem/31454823
 lldb-test-swift-only
@@ -955,7 +955,7 @@ validation-test
 long-test
 stress-test
 test-optimized
-lit-args=-v --time-tests
+lit-args=-v --time-tests --timeout=600
 
 build-ninja
 
@@ -1046,7 +1046,7 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-lit-args=-v
+lit-args=-v --timeout=600
 
 install-foundation
 install-libdispatch
@@ -1064,7 +1064,7 @@ validation-test
 long-test
 stress-test
 foundation
-lit-args=-v
+lit-args=-v --timeout=600
 indexstore-db=0
 sourcekit-lsp=0
 
@@ -1121,7 +1121,7 @@ verbose-build
 
 test
 validation-test
-lit-args=-v
+lit-args=-v --timeout=600
 
 build-ninja
 reconfigure
@@ -2147,7 +2147,7 @@ skip-build-benchmarks
 
 test
 validation-test
-lit-args=-v
+lit-args=-v --timeout=600
 
 skip-test-ios
 skip-test-tvos
@@ -2158,7 +2158,7 @@ skip-reconfigure
 
 test
 validation-test
-lit-args=-v
+lit-args=-v --timeout=600
 
 skip-test-osx
 skip-test-tvos
@@ -2168,7 +2168,7 @@ skip-reconfigure
 [preset: mixin_buildbot_incremental,test=tvOS,type=simulator]
 test
 validation-test
-lit-args=-v
+lit-args=-v --timeout=600
 
 skip-test-osx
 skip-test-watchos
@@ -2179,7 +2179,7 @@ skip-reconfigure
 
 test
 validation-test
-lit-args=-v
+lit-args=-v --timeout=600
 
 skip-test-osx
 skip-test-tvos
@@ -2405,7 +2405,7 @@ skip-test-tvos
 skip-test-watchos
 skip-build-benchmark
 verbose-build
-lit-args=-v
+lit-args=-v --timeout=600
 reconfigure
 build-ninja
 
@@ -2472,7 +2472,7 @@ native-llvm-tools-path=%(toolchain_path)s
 native-clang-tools-path=%(toolchain_path)s
 
 build-ninja
-lit-args=--filter=':: (stdlib/|Concurrency/)' -v
+lit-args=--filter=':: (stdlib/|Concurrency/)' -v --timeout=600
 only-executable-test
 
 [preset: stdlib_RD_standalone,build]

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -569,7 +569,7 @@ def create_argument_parser():
                 'optimization')
 
     option('--lit-args', store,
-           default='-sv',
+           default='-sv --timeout=600',
            metavar='LITARGS',
            help='lit args to use when testing')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -204,7 +204,7 @@ EXPECTED_DEFAULTS = {
     'zlib_build_variant': 'Debug',
     'curl_build_variant': 'Debug',
     'bootstrapping_mode': None,
-    'lit_args': '-sv',
+    'lit_args': '-sv --timeout=600',
     'llbuild_assertions': True,
     'lldb_assertions': True,
     'lldb_build_variant': 'Debug',


### PR DESCRIPTION
## in This PR
* Added lit timeout as a default argument to the lit testing (`--timeout=600`)
* Updated all build presets which set lit timeouts to also include `--timeout=600`

This will ensure that tests never hang without output when running in engineers environments, nor in any of the CI, thus freeing up resources and reporting on the timed out tests properly.

This does have the consequence of failing to run tests on any environment where psutil is not installed, by default Lit will throw a fatal error when users attempt to set a timeout without psutil
```
fatal: Setting a timeout per test not supported. Requires the Python psutil module but it could not be found. Try installing it via pip or via your operating system's package manager.
```
But we get the benefit of ensuring that anyone using the build script by default will have the timeout failsafe unless they, or their build preset, intentionally overwrite the lit arguments and don't include the timeout