### PR TITLE
[5.9][CodeComplete] Offer completions after `~` in an inheritance clause

### DIFF
--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -228,6 +228,9 @@ enum class CompletionKind : uint8_t {
   ForEachPatternBeginning,
   TypeAttrBeginning,
   OptionalBinding,
+
+  /// Completion after `~` in an inheritance clause.
+  WithoutConstraintType
 };
 
 enum class CodeCompletionDiagnosticSeverity : uint8_t {

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -620,6 +620,8 @@ public:
   void getStmtLabelCompletions(SourceLoc Loc, bool isContinue);
 
   void getOptionalBindingCompletions(SourceLoc Loc);
+
+  void getWithoutConstraintTypes();
 };
 
 } // end namespace ide

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -261,6 +261,8 @@ public:
   virtual void completeTypeAttrBeginning() {};
 
   virtual void completeOptionalBinding(){};
+
+  virtual void completeWithoutConstraintType(){};
 };
 
 class DoneParsingCallback {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -305,6 +305,7 @@ public:
   void completeForEachPatternBeginning(bool hasTry, bool hasAwait) override;
   void completeTypeAttrBeginning() override;
   void completeOptionalBinding() override;
+  void completeWithoutConstraintType() override;
 
   void doneParsing(SourceFile *SrcFile) override;
 
@@ -664,6 +665,11 @@ void CodeCompletionCallbacksImpl::completeOptionalBinding() {
   Kind = CompletionKind::OptionalBinding;
 }
 
+void CodeCompletionCallbacksImpl::completeWithoutConstraintType() {
+  CurDeclContext = P.CurDeclContext;
+  Kind = CompletionKind::WithoutConstraintType;
+}
+
 void CodeCompletionCallbacksImpl::completeTypeAttrBeginning() {
   CurDeclContext = P.CurDeclContext;
   Kind = CompletionKind::TypeAttrBeginning;
@@ -975,6 +981,7 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
   case CompletionKind::StmtLabel:
   case CompletionKind::TypeAttrBeginning:
   case CompletionKind::OptionalBinding:
+  case CompletionKind::WithoutConstraintType:
     break;
 
   case CompletionKind::EffectsSpecifier:
@@ -2054,6 +2061,11 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
   case CompletionKind::OptionalBinding: {
     SourceLoc Loc = P.Context.SourceMgr.getIDEInspectionTargetLoc();
     Lookup.getOptionalBindingCompletions(Loc);
+    break;
+  }
+
+  case CompletionKind::WithoutConstraintType: {
+    Lookup.getWithoutConstraintTypes();
     break;
   }
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3348,3 +3348,9 @@ void CompletionLookup::getOptionalBindingCompletions(SourceLoc Loc) {
   lookupVisibleDecls(FilteringConsumer, CurrDeclContext,
                      /*IncludeTopLevel=*/false, Loc);
 }
+
+void CompletionLookup::getWithoutConstraintTypes() {
+  // FIXME: Once we have a typealias declaration for copyable, we should be
+  // returning that instead of a keyword (rdar://109107817).
+  addKeyword("Copyable");
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5783,6 +5783,13 @@ ParserStatus Parser::parseInheritance(
             TildeCopyableLoc = tildeLoc;
 
           continue;
+        } else if (nextTok.is(tok::code_complete)) {
+          consumeToken(); // consume '~'
+          Status.setHasCodeCompletionAndIsError();
+          if (CodeCompletionCallbacks) {
+            CodeCompletionCallbacks->completeWithoutConstraintType();
+          }
+          consumeToken(tok::code_complete);
         }
 
         // can't suppress whatever is between '~' and ',' or '{'.

--- a/test/IDE/complete_without_constraint_type.swift
+++ b/test/IDE/complete_without_constraint_type.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+struct FileDescriptor: ~#^COMPLETE^# {}
+// FIXME: This should be emitting a `Copyable` declaration instead of a keyword, once there is a declaration for `Copyable`
+// COMPLETE: Keyword/None:                       Copyable; name=Copyable


### PR DESCRIPTION
* **Explanation**: We should only be suggesting `Copyable` after `~` in an inheritance clause, in accordance with [SE-0390](https://github.com/apple/swift-evolution/blob/main/proposals/0390-noncopyable-structs-and-enums.md)
* **Scope**: Code completion after `~` in inheritance clauses
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://109063223
* **Reviewer**:  @rintaro on https://github.com/apple/swift/pull/65805