### PR TITLE
[5.9][CodeCompletion] Don’t crash when completing in a parameter position that only constraints one of two primary associated protocol types

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -724,16 +724,16 @@ Type GenericSignatureImpl::getDependentUpperBounds(Type type) const {
           argTypes.push_back(reducedType);
       }
 
-      // We should have either constrained all primary associated types,
-      // or none of them.
-      if (!argTypes.empty()) {
-        if (argTypes.size() != primaryAssocTypes.size()) {
-          llvm::errs() << "Not all primary associated types constrained?\n";
-          llvm::errs() << "Interface type: " << type << "\n";
-          llvm::errs() << GenericSignature(this) << "\n";
-          abort();
-        }
-
+      // If we have constrained all primary associated types, create a
+      // parameterized protocol type. During code completion, we might call
+      // `getExistentialType` (which calls this method) on a generic parameter
+      // that doesn't have all parameters specified, e.g. to get a consise
+      // description of the parameter type to the following function.
+      //
+      // func foo<P: Publisher>(p: P) where P.Failure == Never
+      //
+      // In that case just add the base type in the default branch below.
+      if (argTypes.size() == primaryAssocTypes.size()) {
         types.push_back(ParameterizedProtocolType::get(ctx, baseType, argTypes));
         continue;
       }

--- a/validation-test/IDE/crashers_2_fixed/0039-not-all-primary-assoc-types-specified.swift
+++ b/validation-test/IDE/crashers_2_fixed/0039-not-all-primary-assoc-types-specified.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+protocol Publisher<Output, Failure> {
+  associatedtype Output
+  associatedtype Failure
+}
+
+func foo<P: Publisher>(_ publisher: P) where P.Failure == Never
+
+func test() {
+  foo(#^COMPLETE^#)
+  // Make sure we don’t crash
+  // COMPLETE: Begin completions
+}


### PR DESCRIPTION
* **Explanation**: When completing, we call `getExistentialType` on the contextual type to get a nice and concise description of the contextual parameter’s type that doesn’t contain archetypes and which we can also serialize into a USR so we are able to calculate type relations for code completion results from the code completion cache.
When completing in a position that has a contextual type which only constrains one of two primary associated protocol types, this fails because `getExistentialType` (which calls `getDependentUpperBounds`) tries to form a `ParameterizedProtocolType`, which fails since not all primary associated types have been constrained.
AFAICT the fix here is to just fall back to the default behavior of returning the plain protocol type instead of `abort`ing.
* **Scope**: Anything that calls `ArchetypeType::getExistentialType`, which isn’t very narrowly-scoped
* **Risk**: Very low, we were always `abort`ing in this before
* **Testing**: Added test case
* **Issue**: rdar://108835466
* **Reviewer**:  @slavapestov on https://github.com/apple/swift/pull/65847