### PR TITLE
[Macros] Fix lookup of macro-produced variables

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10333,9 +10333,12 @@ void MissingDecl::forEachMacroExpandedDecl(MacroExpandedDeclCallback callback) {
   auto *baseDecl = unexpandedMacro.baseDecl;
   if (!macroRef || !baseDecl)
     return;
+  auto *module = getModuleContext();
 
   baseDecl->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
-    auto *sf = auxiliaryDecl->getInnermostDeclContext()->getParentSourceFile();
+    SourceFile *sf = auxiliaryDecl->getLoc()
+        ? module->getSourceFileContainingLocation(auxiliaryDecl->getLoc())
+        : auxiliaryDecl->getInnermostDeclContext()->getParentSourceFile();
     // We only visit auxiliary decls that are macro expansions associated with
     // this macro reference.
     if (auto *med = macroRef.dyn_cast<MacroExpansionDecl *>()) {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1040,7 +1040,10 @@ void IterableDeclContext::addMemberSilently(Decl *member, Decl *hint,
       return;
 
     // Synthesized member macros can add new members in a macro expansion buffer.
-    auto *memberSourceFile = member->getInnermostDeclContext()->getParentSourceFile();
+    SourceFile *memberSourceFile = member->getLoc()
+        ? member->getModuleContext()
+                ->getSourceFileContainingLocation(member->getLoc())
+        : member->getInnermostDeclContext()->getParentSourceFile();
     if (memberSourceFile->getFulfilledMacroRole() == MacroRole::Member ||
         memberSourceFile->getFulfilledMacroRole() == MacroRole::Peer)
       return;

--- a/test/Macros/Inputs/freestanding_macro_library.swift
+++ b/test/Macros/Inputs/freestanding_macro_library.swift
@@ -12,3 +12,6 @@ public macro bitwidthNumberedStructs(_ baseName: String) = #externalMacro(module
 
 @freestanding(expression)
 public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+@freestanding(declaration, names: named(value))
+public macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")

--- a/test/Macros/Inputs/macro_library.swift
+++ b/test/Macros/Inputs/macro_library.swift
@@ -38,3 +38,6 @@ public macro addCompletionHandler() = #externalMacro(module: "MacroDefinition", 
 
 @attached(peer, names: suffixed(Builder))
 public macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition", type: "AddClassReferencingSelfMacro")
+
+@attached(peer, names: named(value))
+public macro declareVarValuePeer() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1413,3 +1413,24 @@ public struct MultiStatementClosure: ExpressionMacro {
       """
   }
 }
+
+public struct VarValueMacro: DeclarationMacro, PeerMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> [DeclSyntax] {
+    return [
+      "var value: Int { 1 }"
+    ]
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "var value: Int { 1 }"
+    ]
+  }
+}

--- a/test/Macros/macro_attribute_expansiondecl.swift
+++ b/test/Macros/macro_attribute_expansiondecl.swift
@@ -66,10 +66,9 @@ public struct LocalFuncAndVarMacro: DeclarationMacro {
 @available(SwiftStdlib 9999, *)
 #globalDecls
 
-func testGlobal() { // expected-note {{add @available attribute to enclosing global function}}
+func testGlobal() { // expected-note 2 {{add @available attribute to enclosing global function}}
   globalFunc() // expected-error {{'globalFunc()' is only available in macOS 9999 or newer}} expected-note {{add 'if #available' version check}}
-  // FIXME(109376568): Global variable introduced by macro expansion not found
-  _ = globalVar // expected-error {{cannot find 'globalVar' in scope}}
+  _ = globalVar // expected-error {{'globalVar' is only available in macOS 9999 or newer}} expected-note {{add 'if #available' version check}}
 }
 
 struct S {

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -31,6 +31,8 @@ import macro_library
 macro addCompletionHandler() = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
 @attached(peer, names: suffixed(Builder))
 macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition", type: "AddClassReferencingSelfMacro")
+@attached(peer, names: named(value))
+macro declareVarValuePeer() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
 #endif
 
 @attached(peer, names: arbitrary)
@@ -166,8 +168,6 @@ struct S2 {
 macro myPropertyWrapper() =
     #externalMacro(module: "MacroDefinition", type: "PropertyWrapperMacro")
 
-struct Date { }
-
 struct MyWrapperThingy<T> {
   var storage: T
 
@@ -191,4 +191,15 @@ struct S3 {
   init(x: Int) {
     self._x = MyWrapperThingy(storage: x)
   }
+}
+
+@declareVarValuePeer
+struct Date {
+  @declareVarValuePeer
+  func foo() {}
+}
+
+func testVarPeer() {
+  _ = value
+  _ = Date().value
 }

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -32,6 +32,7 @@ macro anonymousTypes(public: Bool = false, _: () -> String) = #externalMacro(mod
 macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
 @freestanding(declaration, names: arbitrary) macro bitwidthNumberedStructs(_ baseName: String) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+@freestanding(declaration, names: named(value)) macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
 #endif
 
 // Test unqualified lookup from within a macro expansion
@@ -79,3 +80,9 @@ func testArbitraryAtGlobal() {
 
 // DIAG_BUFFERS: @__swiftmacro_9MacroUser33_{{.*}}9stringifyfMf1_{{.*}}warning: 'deprecated()' is deprecated
 // DIAG_BUFFERS: @__swiftmacro_9MacroUser33_{{.*}}9stringifyfMf2_{{.*}}warning: 'deprecated()' is deprecated
+
+#varValue
+
+func testGlobalVariable() {
+  _ = value
+}


### PR DESCRIPTION
Calling `getInnermostDeclContext()->getParentSourceFile()` on a macro-produced decl does not seem to be a reliable way to obtain the macro expansion source file, because `PatternBindingDecl` is not a `DeclContext` and `getInnermostDeclContext()` falls back outside the macro expansion file. This patch switches to using `getSourceFileContainingLocation` instead.

Resolves rdar://109376568.