### PR TITLE
[cxx-interop] Do not run a test in C++20 mode

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=gnu++20)
+// FIXME: also run in C++20 mode when conformance works properly on UBI platform (rdar://109366764):
+// %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=gnu++20)
 //
 // REQUIRES: executable_test
 //


### PR DESCRIPTION
This test is failing on UBI platform in C++20 mode:

```
Command Output (stderr):
--
<unknown>:0: warning: the '-enable-experimental-cxx-interop' flag is deprecated; please pass '-cxx-interoperability-mode=' instead
<unknown>:0: note: Swift will maintain source compatibility for imported APIs based on the selected compatibility mode, so updating the Swift compiler will not change how APIs are imported
<unknown>:0: warning: the '-enable-experimental-cxx-interop' flag is deprecated; please pass '-cxx-interoperability-mode=' instead
<unknown>:0: note: Swift will maintain source compatibility for imported APIs based on the selected compatibility mode, so updating the Swift compiler will not change how APIs are imported
/home/build-user/swift/test/Interop/Cxx/stdlib/use-std-vector.swift:41:14: error: for-in loop requires 'Vector' (aka 'std.vector<Int32, allocator<Int32>>') to conform to 'Sequence'
    for e in v {
             ^
/home/build-user/swift/test/Interop/Cxx/stdlib/use-std-vector.swift:52:15: error: value of type 'Vector' (aka 'std.vector<Int32, allocator<Int32>>') has no member 'map'
    let a = v.map { $0 + 5 }
            ~ ^~~

```

This makes sure we don't run this test in C++20 mode until the conformance to `CxxSequence` is synthesized correctly on UBI.

rdar://109366764