### PR TITLE
🍒[cxx-interop] Make `std.optional.value` nullable

### DIFF
--- a/stdlib/public/Cxx/CxxOptional.swift
+++ b/stdlib/public/Cxx/CxxOptional.swift
@@ -27,8 +27,9 @@ extension CxxOptional {
   }
 
   @inlinable
-  public var value: Wrapped {
+  public var value: Wrapped? {
     get {
+      guard hasValue else { return nil }
       return pointee
     }
   }

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -29,10 +29,11 @@ StdOptionalTestSuite.test("std::optional => Swift.Optional") {
 StdOptionalTestSuite.test("std::optional hasValue/value") {
   let nonNilOpt = getNonNilOptional()
   expectTrue(nonNilOpt.hasValue)
-  expectEqual(123, nonNilOpt.value)
+  expectEqual(123, nonNilOpt.value!)
 
   let nilOpt = getNilOptional()
   expectFalse(nilOpt.hasValue)
+  expectNil(nilOpt.value)
 }
 
 runAllTests()


### PR DESCRIPTION
**Explanation**:  This makes the access to `std::optional`'s wrapped value null-safe in Swift. It also allows using if-let and guard-let with C++ optionals.
**Scope**: Only affects the C++ standard library overlay.
**Risk**: Low, this only has an effect if C++ interop is enabled and the C++ stdlib is used from Swift.

rdar://109356566 / resolves https://github.com/apple/swift/issues/65918 (cherry picked from commit 7d7825591d63176643a7200bab0b774d9e14a0fb)