### PR TITLE
[Sema] SR-14649 Warning incorrectly suggests replacing unsafeBitCast …

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -927,7 +927,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       }
       
       // Unchecked casting to a subclass is better done by unsafeDowncast.
-      if (fromTy->isBindableToSuperclassOf(toTy)) {
+      if (TypeChecker::isSubtypeOf(toTy, fromTy,
+                                   const_cast<DeclContext *>(DC))) {
         Ctx.Diags.diagnose(DRE->getLoc(), diag::bitcasting_to_downcast,
                            fromTy, toTy)
           .fixItReplace(DRE->getNameLoc().getBaseNameLoc(),

--- a/test/Constraints/suspicious_bit_casts.swift
+++ b/test/Constraints/suspicious_bit_casts.swift
@@ -26,9 +26,9 @@ func castAToB(a: A) -> B {
   // expected-warning@+1{{'unsafeBitCast' from 'A' to 'B' can be replaced with 'unsafeDowncast'}} {{16-29=unsafeDowncast}}
   return Swift.unsafeBitCast(_:to:)(a, B.self)
 }
+
 func castCToD<T>(c: C<T>) -> D {
-  // expected-warning@+1{{'unsafeBitCast' from 'C<T>' to 'D' can be replaced with 'unsafeDowncast'}} {{10-23=unsafeDowncast}}
-  return unsafeBitCast(c, to: D.self)
+  return unsafeBitCast(c, to: D.self) // expected-no-warning
 }
 
 func castNToD<T>(n: N<T>) -> D {
@@ -254,4 +254,16 @@ func castBetweenIntAndPointer(p: UnsafePointer<Int>,
   _ = unsafeBitCast(iii, to: UnsafeRawPointer.self)
   // expected-warning@+1{{'unsafeBitCast' from 'UInt64' to 'UnsafeRawPointer' can be replaced with 'bitPattern:' initializer}}{{7-21=UnsafeRawPointer(bitPattern: UInt(}}{{24-52=))}}
   _ = unsafeBitCast(uuu, to: UnsafeRawPointer.self)
+}
+
+class GenericBase<T> {}
+
+func bitcastingGenericType<A, B>(_: A, x: GenericBase<B>) {
+  _ = unsafeBitCast(x, to: GenericBase<A>.self) // expected-no-warning
+}
+
+class Base {}
+
+func bitcastingBaseType<A: Base, B: Base>(_: A, x: B) {
+  _ = unsafeBitCast(x, to: A.self) // expected-no-warning
 }


### PR DESCRIPTION
…with unsafeDowncast

<!-- What's in this pull request? -->
Currently the `unsafeDowncast` replacement is suggested too often. This change simply stops making suggestions unless the exact types are known. 

If the exact types are not known, we cannot be sure that there is an `is-a` relationship. The two types may have the same memory representation/layout so `unsafeBitCast` would run whereas `unsafeDowncast` would crash. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
This is related to #57001 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
