### PR TITLE
Fix test on Windows by expanding "*{a,b,c}" wildcard syntax

### DIFF
--- a/test/Driver/Dependencies/one-way-external-fine.swift
+++ b/test/Driver/Dependencies/one-way-external-fine.swift
@@ -19,7 +19,9 @@
 // CHECK-SECOND-NOT: Handled
 
 // Don't change the .priors mod time
-// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
+// RUN: touch -t 201401240005 %t/*.swift
+// RUN: touch -t 201401240005 %t/*.swiftdeps
+// RUN: touch -t 201401240005 %t/*.json
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other1-external
@@ -29,7 +31,9 @@
 // CHECK-THIRD-DAG: Handled main.swift
 
 // Don't change the .priors mod time
-// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
+// RUN: touch -t 201401240005 %t/*.swift
+// RUN: touch -t 201401240005 %t/*.swiftdeps
+// RUN: touch -t 201401240005 %t/*.json
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other2-external
@@ -37,7 +41,9 @@
 
 
 // Don't change the .priors mod time
-// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
+// RUN: touch -t 201401240005 %t/*.swift
+// RUN: touch -t 201401240005 %t/*.swiftdeps
+// RUN: touch -t 201401240005 %t/*.json
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main1-external
@@ -48,7 +54,9 @@
 // CHECK-FOURTH-NOT: Handled other.swift
 
 // Don't change the .priors mod time
-// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
+// RUN: touch -t 201401240005 %t/*.swift
+// RUN: touch -t 201401240005 %t/*.swiftdeps
+// RUN: touch -t 201401240005 %t/*.json
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main2-external


### PR DESCRIPTION
Fixes the `one-way-external-fine.swift` test on Windows. This is the only test using the `touch -t 201401240005 *{a,b,c}` syntax. This works fine when run as-is, but misbehaves in `lit.py` and ends up creating files called `201401240005` and `}`. I couldn't quite figure out why, but expanding the wildcard syntax solves this.
