### PR TITLE
[5.9] IRGen: fix async vtable stubs

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2102,8 +2102,20 @@ void IRGenModule::emitVTableStubs() {
     }
 
     // For each eliminated method symbol create an alias to the stub.
-    auto *alias = llvm::GlobalAlias::create(llvm::GlobalValue::ExternalLinkage,
-                                            F.getName(), stub);
+    llvm::GlobalValue *alias = nullptr;
+    if (F.isAsync()) {
+      // TODO: We cannot directly create a pointer to `swift_deletedAsyncMethodError`
+      // to workaround a linker crash.
+      // Instead use the stub, which calls swift_deletedMethodError. This works because
+      // swift_deletedMethodError takes no parameters and simply aborts the program.
+      auto asyncLayout = getAsyncContextLayout(*this, const_cast<SILFunction *>(&F));
+      auto entity = LinkEntity::forSILFunction(const_cast<SILFunction *>(&F));
+      auto *fnPtr = emitAsyncFunctionPointer(*this, stub, entity, asyncLayout.getSize());
+      alias = fnPtr;
+    } else {
+      alias = llvm::GlobalAlias::create(llvm::GlobalValue::ExternalLinkage,
+                                        F.getName(), stub);
+    }
 
     if (F.getEffectiveSymbolLinkage() == SILLinkage::Hidden)
       alias->setVisibility(llvm::GlobalValue::HiddenVisibility);

--- a/test/IRGen/report_dead_method_call.swift
+++ b/test/IRGen/report_dead_method_call.swift
@@ -2,25 +2,31 @@
 
 // We compile with -O (optimizations) and -disable-access-control (which
 // allows use to "call" methods that are removed by dead code elimination).
-// RUN: %target-build-swift %S/Inputs/report_dead_method_call/main.swift %s -O -Xfrontend -disable-access-control -o %t/report_dead_method_call
+// RUN: %target-build-swift -parse-as-library %S/Inputs/report_dead_method_call/main.swift %s -O -Xfrontend -disable-access-control -Xfrontend -disable-availability-checking -o %t/report_dead_method_call
 
 // The private, unused methods are optimized away. The test calls these
 // methods anyway (since it has overridden the access control), so we
 // expect them to produce "Fatal error: Call of deleted method" when run.
 // RUN: %target-codesign %t/report_dead_method_call
 // RUN: %target-run %t/report_dead_method_call
+
 // REQUIRES: executable_test
+// REQUIRES: concurrency
+// UNSUPPORTED: freestanding
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
 
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 // UNSUPPORTED: swift_test_mode_optimize_with_implicit_dynamic
 
 private protocol PrivateProto {
 	func abc()
+	func abcAsync() async
 }
 
 struct PrivateStructC : PrivateProto {
-	func abc() {
-	}
+	func abc() {}
+	func abcAsync() async {}
 }
 
 struct Container {
@@ -33,14 +39,19 @@ func callProto() {
 	testProto(Container())
 }
 
+@inline(never)
+func callProtoAsync() async {
+	await testProtoAsync(Container())
+}
+
 private class Base {
-	func def() {
-	}
+	func def() {}
+	func defAsync() async {}
 }
 
 private class Derived : Base {
-	override func def() {
-	}
+	override func def() {}
+	override func defAsync() async {}
 }
 
 struct ClassContainer {
@@ -53,8 +64,14 @@ func callClass() {
 	testClass(ClassContainer())
 }
 
+@inline(never)
+func callClassAsync() async {
+	await testClassAsync(ClassContainer())
+}
+
 public class PublicBase {
-	private func ghi() {
-	}
+	private func ghi() { }
+
+  private func ghiAsync() async {}
 }
 

--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -1,12 +1,21 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
-// RUN: %swift-target-frontend -parse-as-library -static -O -module-name M -c -primary-file %t/A.swift %t/B.swift -S -emit-ir -o - | %FileCheck %t/A.swift -check-prefix CHECK
-// RUN: %swift-target-frontend -parse-as-library -static -O -module-name M -c %t/A.swift -primary-file %t/B.swift -S -emit-ir -o - | %FileCheck %t/B.swift -check-prefix CHECK
+// RUN: %swift-target-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c -primary-file %t/A.swift %t/B.swift -S -emit-ir -o - | %FileCheck %t/A.swift -check-prefix CHECK
+// RUN: %swift-target-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c %t/A.swift -primary-file %t/B.swift -S -emit-ir -o - | %FileCheck %t/B.swift -check-prefix CHECK
+
+// Verify that we can link successfully.
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -O %t/A.swift %t/B.swift -o %t/a.out
+
+// REQUIRES: concurrency
 
 //--- A.swift
 open class C {
-    private var i: [ObjectIdentifier:Any] = [:]
+  private var i: [ObjectIdentifier:Any] = [:]
+
+  private func foo() async {}
 }
+
+// CHECK: @"$s1M1CC3foo33_{{.*}}Tu" = hidden global %swift.async_func_pointer <{ {{.*}} @_swift_dead_method_stub
 
 // CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg" = hidden alias void (), void ()* @_swift_dead_method_stub
 // CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs" = hidden alias void (), void ()* @_swift_dead_method_stub
@@ -19,3 +28,10 @@ final class D: C {
 // CHECK: declare swiftcc %swift.bridge* @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"(%T1M1CC* swiftself) #0
 // CHECK: declare swiftcc void @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs"(%swift.bridge*, %T1M1CC* swiftself) #0
 // CHECK: declare swiftcc { i8*, %TSD* } @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM"(i8* noalias dereferenceable(32), %T1M1CC* swiftself) #0
+
+@main
+struct Main {
+  static func main() {
+  }
+}
+


### PR DESCRIPTION
**Description:** For deleted async vtable methods we need to create a async function pointer. If the optimizer removes a private class method, its symbol must still be generated in the binary, because derived classes in other translation units must be able to reference the symbol in the vtable of the derived class.
This all worked with regular methods, but we didn't do that for async methods.
It fixes a missing-symbol linker error.
**Risk:** Low. It only affects private async class methods which are removed by the optimizer. Generated code, which is actually executed, is not affected. The only change is to create the missing symbol in the binary.
**Reviewed by:** @nate-chandler 
**Testing:** CI testing via lit tests
**Original PR:** https://github.com/apple/swift/pull/65940
**Radar:** rdar://108924001
