### PR TITLE
Frontend: Don't append `-target-min-inlining-target target` to implicit module builds

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -532,6 +532,18 @@ public:
       DependencyTracker *tracker = nullptr);
 };
 
+struct SwiftInterfaceInfo {
+  /// The compiler arguments that were encoded in the swiftinterface.
+  SmallVector<const char *, 64> Arguments;
+
+  /// The string following `swift-compiler-version:` in the swiftinterface.
+  std::string CompilerVersion;
+
+  /// The tools version of the compiler (e.g. 5.8) that emitted the
+  /// swiftinterface. This is extracted from the `CompilerVersion` string.
+  llvm::Optional<version::Version> CompilerToolsVersion;
+};
+
 struct InterfaceSubContextDelegateImpl: InterfaceSubContextDelegate {
 private:
   SourceManager &SM;
@@ -558,8 +570,7 @@ private:
                                      bool suppressRemarks,
                                      RequireOSSAModules_t requireOSSAModules);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
-                                           SmallVectorImpl<const char *> &SubArgs,
-                                           std::string &CompilerVersion,
+                                           SwiftInterfaceInfo &interfaceInfo,
                                            StringRef interfacePath,
                                            SourceLoc diagnosticLoc);
 public:

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -75,8 +75,26 @@ struct ModuleInterfaceOptions {
 extern version::Version InterfaceFormatVersion;
 std::string getSwiftInterfaceCompilerVersionForCurrentCompiler(ASTContext &ctx);
 
+/// A regex that matches lines like this:
+///
+///     // swift-interface-format-version: 1.0
+///
+/// and extracts "1.0".
 llvm::Regex getSwiftInterfaceFormatVersionRegex();
+
+/// A regex that matches lines like this:
+///
+///     // swift-compiler-version: Apple Swift version 5.8 (swiftlang-5.8.0.117.59)
+///
+/// and extracts "Apple Swift version 5.8 (swiftlang-5.8.0.117.59)".
 llvm::Regex getSwiftInterfaceCompilerVersionRegex();
+
+/// A regex that matches strings like this:
+///
+///     Apple Swift version 5.8
+///
+/// and extracts "5.8".
+llvm::Regex getSwiftInterfaceCompilerToolsVersionRegex();
 
 /// Emit a stable module interface for \p M, which can be used by a client
 /// source file to import this module, subject to options given by \p Opts.

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -122,6 +122,10 @@ llvm::Regex swift::getSwiftInterfaceCompilerVersionRegex() {
                      ": (.+)$", llvm::Regex::Newline);
 }
 
+llvm::Regex swift::getSwiftInterfaceCompilerToolsVersionRegex() {
+  return llvm::Regex("Swift version ([0-9\\.]+)", llvm::Regex::Newline);
+}
+
 // MARK(https://github.com/apple/swift/issues/43510): Module name shadowing warnings
 //
 // When swiftc emits a module interface, it qualifies most types with their

--- a/test/Interpreter/implicit-module-build-overload-availability-inlinable-function.swift
+++ b/test/Interpreter/implicit-module-build-overload-availability-inlinable-function.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/NonAPI)
+// RUN: %empty-directory(%t/API)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-module-interface(%t/NonAPI/Library.swiftinterface) %t/Library.swift -module-name Library -target %target-swift-abi-5.8-triple
+// RUN: %target-swift-emit-module-interface(%t/API/Library.swiftinterface) %t/Library.swift -module-name Library -target %target-swift-abi-5.8-triple -library-level api
+
+// Build Client.swift against the Library.swiftinterface without
+// `-library-level api`. Since the deployment target of the library is
+// SwiftStdlib 5.8, the newer overload that returns a String should be selected
+// by overload resolution during the implicit module build.
+
+// RUN: %target-build-swift %t/Client.swift -o %t/NonAPI/client -I %t/NonAPI/
+// RUN: %target-codesign %t/NonAPI/client
+// RUN: %target-run %t/NonAPI/client | %FileCheck %s --check-prefix=CHECK-NON-API
+
+// Build Client.swift against the Library.swiftinterface with
+// `-library-level api`. Since the deployment target of the client that will
+// get a copy of `fragileFuncUsingOverload()` is earlier than SwiftStdlib 5.8,
+// the older overload returning an Int should be selected during the implicit
+// module build even though the library targets SwiftStdlib 5.8.
+
+// RUN: %target-build-swift %t/Client.swift -o %t/API/client -I %t/API/
+// RUN: %target-codesign %t/API/client
+// RUN: %target-run %t/API/client | %FileCheck %s --check-prefix=CHECK-API
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+//--- Library.swift
+
+@_disfavoredOverload
+@_alwaysEmitIntoClient
+public func overloadedFunc() -> Int {
+  return 1234
+}
+
+@available(SwiftStdlib 5.8, *)
+@_alwaysEmitIntoClient
+public func overloadedFunc() -> String {
+  return "String"
+}
+
+@_alwaysEmitIntoClient
+public func fragileFuncUsingOverload() -> any CustomStringConvertible {
+  return overloadedFunc()
+}
+
+//--- Client.swift
+
+import Library
+
+// CHECK-NON-API: String
+// CHECK-API: 1234
+print(fragileFuncUsingOverload())

--- a/test/ModuleInterface/availability-library-level-api-5_8.swiftinterface
+++ b/test/ModuleInterface/availability-library-level-api-5_8.swiftinterface
@@ -1,0 +1,18 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.8 (swiftlang-5.8.0.117.59 clang-1403.0.22.8.50)
+// swift-module-flags: -target arm64-apple-macosx11 -enable-library-evolution -swift-version 5 -library-level api -module-name Test
+
+// RUN: %target-swift-frontend -typecheck-module-from-interface -verify -module-name Test %s
+
+// REQUIRES: OS=macosx
+
+import Swift
+
+@available(macOS 11, *)
+public struct S {}
+
+// This typealias ought to be @available(macOS 11, *) since it references `S`
+// and the module was compiled with `-library-level api`. However, given that
+// the interface was produced with tools that are older than Swift 5.9 we
+// typecheck availability with the deployment target as the floor.
+public typealias A = S

--- a/test/ModuleInterface/availability-library-level-api-5_9.swiftinterface
+++ b/test/ModuleInterface/availability-library-level-api-5_9.swiftinterface
@@ -1,0 +1,17 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.9
+// swift-module-flags: -target arm64-apple-macosx11 -enable-library-evolution -swift-version 5 -library-level api -module-name Test
+
+// RUN: not %target-swift-frontend -typecheck-module-from-interface -module-name Test %s 2>&1 | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import Swift
+
+@available(macOS 11, *)
+public struct S {}
+
+public typealias A = S
+
+// CHECK: error: 'S' is only available in macOS 11 or newer; clients of 'Test' may have a lower deployment target
+// CHECK: error: failed to verify module interface of 'Test' due to the errors above;


### PR DESCRIPTION
When performing an implicit module build, the frontend was appending `-target-min-inlining-target target` to the command line. This was overriding the implicit `-target-min-inlining-target min` argument that is implied when `-library-level api` is specified. As a result, the wrong overload could be picked when compiling the body of an inlinable function to SIL for emission into the client, potentially resulting in crashes when the client of the module is back deployed to an older OS.

Resolves rdar://109336472
