### PR TITLE
tests: Fix module loading prefer-serialized test failure on Windows

### DIFF
--- a/test/ModuleInterface/Inputs/make-unreadable.py
+++ b/test/ModuleInterface/Inputs/make-unreadable.py
@@ -30,7 +30,7 @@ if platform.system() == 'Windows':
 
     for path in sys.argv[1:]:
         subprocess.call(['icacls', path, '/deny',
-                         '{}:(R)'.format(user_name)])
+                         '{}:(RD)'.format(user_name)])
 else:
     for path in sys.argv[1:]:
         subprocess.call(['chmod', 'a-r', path])


### PR DESCRIPTION
Fixes three tests failing on Windows:

```
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/force-module-loading-mode-archs.swift
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/force-module-loading-mode-framework.swift
  Swift(windows-x86_64) :: ModuleInterface/ModuleCache/force-module-loading-mode.swift
```

These test cases remove read access to the `.swiftmodule` . The expected behavior is that the compiler checks `fs.exists("path-to.swiftmodule")` , determines that the file exists and chooses to use it instead of the `.swiftinterface`. Compilation then fails because the file cannot be read.

https://github.com/apple/swift/blob/e22cf2e993267639ad8875707cadf401eb97d98b/lib/Frontend/ModuleInterfaceLoader.cpp#L752

On Windows, we were denying `R` access, which is broader than only read access to file contents but also includes file attributes and permissions. This caused `fs.exists` to fail since it relies on `fs.status`, which could not open the file with `CreateFileW`. The fix is is to only deny `RD - read data/list directory` access.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
