### PR TITLE
Call python3 to execute XCTest's build_script.py.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2326,7 +2326,7 @@ for host in "${ALL_HOSTS[@]}"; do
                       XCTEST_BUILD_ARGS="--release"
                   fi
 
-                  call "${XCTEST_SOURCE_DIR}"/build_script.py \
+                  call python3 "${XCTEST_SOURCE_DIR}"/build_script.py \
                       --swiftc="${SWIFTC_BIN}" \
                       --build-dir="${XCTEST_BUILD_DIR}" \
                       --foundation-build-dir="${FOUNDATION_BUILD_DIR}" \
@@ -2825,7 +2825,7 @@ for host in "${ALL_HOSTS[@]}"; do
                   echo "--- Running tests for ${product} ---"
                   FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
                   XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-                  call "${XCTEST_SOURCE_DIR}"/build_script.py test \
+                  call python3 "${XCTEST_SOURCE_DIR}"/build_script.py test \
                       --swiftc="${SWIFTC_BIN}" \
                       --lit="${LLVM_SOURCE_DIR}/utils/lit/lit.py" \
                       --foundation-build-dir="${FOUNDATION_BUILD_DIR}" \


### PR DESCRIPTION
A workaround for the fact that fixing this in XCTest's repository (https://github.com/apple/swift-corelibs-xctest/pull/441) is blocked on XCTest's CI being broken for unrelated reasons (and ones which I cannot reproduce locally).
