### PR TITLE
[CSBindings] Mark type variables that represent type parameter packs as "involving type variables"

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -148,6 +148,12 @@ bool BindingSet::isDelayed() const {
 }
 
 bool BindingSet::involvesTypeVariables() const {
+  // This type variable always depends on a pack expansion variable
+  // which should be inferred first if possible.
+  if (TypeVar->getImpl().getGenericParameter() &&
+      TypeVar->getImpl().canBindToPack())
+    return true;
+
   // This is effectively O(1) right now since bindings are re-computed
   // on each step of the solver, but once bindings are computed
   // incrementally it becomes more important to double-check that

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -148,11 +148,6 @@ bool BindingSet::isDelayed() const {
 }
 
 bool BindingSet::involvesTypeVariables() const {
-  // This type variable always depends on a pack expansion variable
-  // which should be inferred first if possible.
-  if (TypeVar->getImpl().canBindToPack())
-    return true;
-
   // This is effectively O(1) right now since bindings are re-computed
   // on each step of the solver, but once bindings are computed
   // incrementally it becomes more important to double-check that

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -718,3 +718,26 @@ func isHashable_is(_ error: Error) -> Bool {
 func isHashable_composition(_ error: Error & AnyObject) -> Bool {
   error is AnyHashable // OK
 }
+
+// rdar://109381194 - incorrect ambiguity while comparing collections
+do {
+  class A : Hashable, Equatable {
+    func hash(into hasher: inout Hasher) {
+    }
+
+    static func == (lhs: A, rhs: A) -> Bool {
+      false
+    }
+  }
+
+  class B : A {}
+
+  func test(a: [B], b: [String: B]) {
+    assert(Set(a) == Set(b.values.map { $0 as A })) // ok
+  }
+
+  func test(a: [A], b: [B]) {
+    assert(Set(a) == Set(b.map { $0 as A })) // Ok
+    assert(Set(b.map { $0 as A }) == Set(a)) // Ok
+  }
+}


### PR DESCRIPTION
Such type variables are always dependent on pack expansion type variables
which should be bound first.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
