### PR TITLE
[android][test] Fix a handful of tests and disable one CxxToSwiftToCxx bridging test

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1459,9 +1459,10 @@ void ToolChain::getClangLibraryPath(const ArgList &Args,
   getResourceDirPath(LibPath, Args, /*Shared=*/true);
   // Remove platform name.
   llvm::sys::path::remove_filename(LibPath);
-  llvm::sys::path::append(LibPath, "clang", "lib",
-                          T.isOSDarwin() ? "darwin"
-                                         : getPlatformNameForTriple(T));
+  StringRef platformName = "darwin";
+  if (!T.isOSDarwin())
+    platformName = T.isAndroid() ? "linux" : getPlatformNameForTriple(T);
+  llvm::sys::path::append(LibPath, "clang", "lib", platformName);
 }
 
 /// Get the runtime library link path, which is platform-specific and found

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -1,5 +1,3 @@
-// REQUIRES: lld_lto
-
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-unknown-linux-gnu    | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-linux-gnu
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-thin -target x86_64-unknown-windows-msvc | %FileCheck %s --check-prefix=CHECK-SIMPLE-THIN --check-prefix=CHECK-SIMPLE-THIN-windows-msvc
 

--- a/test/Driver/lto-output-mode-clash.swift
+++ b/test/Driver/lto-output-mode-clash.swift
@@ -1,5 +1,3 @@
-// REQUIRES: lld_lto
-
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -static -emit-library -target x86_64-apple-macosx10.9 | %FileCheck %s
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -emit-library -target x86_64-apple-macosx10.9 | %FileCheck %s
 // RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -c -target x86_64-apple-macosx10.9 | %FileCheck %s

--- a/test/Driver/static-stdlib-linux-lld.swift
+++ b/test/Driver/static-stdlib-linux-lld.swift
@@ -1,7 +1,6 @@
 // Statically link a "hello world" program
 // REQUIRES: OS=linux-gnu
 // REQUIRES: static_stdlib
-// REQUIRES: lld_lto
 print("hello world!")
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -static-stdlib -use-ld=lld %import-static-libdispatch -o %t/static-stdlib-lld %s

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -51,6 +51,8 @@
 // ASM-NOT: .section
 // ASM: $s7section3fooyyF:
 // ASM-linux-gnu: .section{{.*}}__TEXT,__mysection
+// ASM-linux-android: .section{{.*}}__TEXT,__mysection
+// ASM-linux-androideabi: .section{{.*}}__TEXT,__mysection
 // ASM-NOT: .section
 // ASM: $s7section2g0Sivp:
 // ASM-NOT: .section

--- a/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
@@ -9,13 +9,9 @@ import Constructors
 import TypeClassification
 
 // ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift35copyWithUserProvidedCopyConstructorySo03Has{{cdeF0V_ACtACF|efgH0V_ADtADF}}"
-// ITANIUM_ARM-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])
-// ITANIUM_ARM: [[ARG0_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
-// ITANIUM_ARM: [[ARG1_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM-SAME: (ptr {{.*}}[[ARG0:%.*]], ptr {{.*}}[[ARG1:%.*]], ptr {{.*}}[[ARG2:%.*]])
+// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(ptr [[ARG0]], ptr [[ARG2]])
+// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(ptr [[ARG1]], ptr [[ARG2]])
 // ITANIUM_ARM: ret void
 
 public func copyWithUserProvidedCopyConstructor(_ x: HasUserProvidedCopyConstructor)

--- a/test/Interop/Cxx/class/constructors-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-android.swift
@@ -9,13 +9,13 @@ import Constructors
 import TypeClassification
 
 public func createHasVirtualBase() -> HasVirtualBase {
-  // ITANIUM_ARM: define protected swiftcc void @"$s7MySwift20createHasVirtualBaseSo0deF0VyF"(%TSo14HasVirtualBaseV* noalias nocapture sret({{.*}}) %0)
+  // ITANIUM_ARM: define protected swiftcc void @"$s7MySwift20createHasVirtualBaseSo0deF0VyF"(ptr noalias nocapture sret({{.*}}) %0)
   // To verify that the thunk is inlined, make sure there's no intervening
   // `define`, i.e. the call to the C++ constructor happens in
   // createHasVirtualBase(), not some later function.
   // ITANIUM_ARM-NOT: define
   // Note `this` return type.
-  // ITANIUM_ARM: call void @_ZN14HasVirtualBaseC1E7ArgType(%struct.HasVirtualBase* %{{[0-9]+}}, i64 %{{[0-9]+}})
+  // ITANIUM_ARM: call void @_ZN14HasVirtualBaseC1E7ArgType(ptr %{{[0-9]+}}, i64 %{{[0-9]+}})
   return HasVirtualBase(ArgType())
 }
 
@@ -23,7 +23,7 @@ public func createImplicitDefaultConstructor() -> ImplicitDefaultConstructor {
   // ITANIUM_ARM: define protected swiftcc i32 @"$s7MySwift32createImplicitDefaultConstructorSo0deF0VyF"()
   // ITANIUM_ARM-NOT: define
   // Note `this` return type.
-  // ITANIUM_ARM: call void @_ZN26ImplicitDefaultConstructorC2Ev(%struct.ImplicitDefaultConstructor* %{{[0-9]+}})
+  // ITANIUM_ARM: call void @_ZN26ImplicitDefaultConstructorC2Ev(ptr %{{[0-9]+}})
   return ImplicitDefaultConstructor()
 }
 
@@ -32,11 +32,8 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
   // ITANIUM_ARM: [[MEMBER:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
   // ITANIUM_ARM: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
-  // ITANIUM_ARM: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
-  // ITANIUM_ARM: [[TMP_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TMP]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: [[MEMBER_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
+  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2Ev(ptr [[MEMBER]])
+  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2ERKS_(ptr [[TMP]], ptr [[MEMBER]])
   // ITANIUM_ARM: ret void
   let member = StructWithCopyConstructorAndValue()
   let obj = StructWithSubobjectCopyConstructorAndValue(member: member)
@@ -45,11 +42,10 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
 public func createTemplatedConstructor() {
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift26createTemplatedConstructoryyF"()
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
-  // ITANIUM_ARM: [[IVAL:%.*]] = load i64, i64*
-  // ITANIUM_ARM: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo20TemplatedConstructorV* [[OBJ]] to %struct.TemplatedConstructor*
-  // ITANIUM_ARM:  call void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i64 [[IVAL]])
+  // ITANIUM_ARM: [[IVAL:%.*]] = load i64, ptr
+  // ITANIUM_ARM: call void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(ptr [[OBJ]], i64 [[IVAL]])
   // ITANIUM_ARM: ret void
   
-  // ITANIUM_ARM-LABEL: define {{.*}}void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, i64 {{.*}})
+  // ITANIUM_ARM-LABEL: define {{.*}}void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(ptr {{.*}}, i64 {{.*}})
   let templated = TemplatedConstructor(ArgType())
 }

--- a/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
+++ b/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
@@ -20,7 +20,7 @@ public func copyAssign() {
 // CHECK: call {{void|ptr}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignC2Ev|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(ptr %[[COPY_INSTANCE:.*]])
 // CHECK: call {{void|ptr}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignC2Ev|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(ptr %[[COPY_INSTANCE2:.*]])
 // CHECK: call {{void|ptr}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignD1Ev|_ZN31NonTrivialCopyAndCopyMoveAssignD2Ev|"\?\?1NonTrivialCopyAndCopyMoveAssign@@QEAA@XZ"}}(ptr %[[COPY_INSTANCE]])
-// CHECK: call {{void|ptr}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1EOS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2EOS_|_ZN31NonTrivialCopyAndCopyMoveAssignC1ERKS_Tm|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_Tm|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@AEBU0@@Z"}}(
+// CHECK: call {{void|(noundef )?ptr}} @{{_ZN31NonTrivialCopyAndCopyMoveAssignC1EOS_|_ZN31NonTrivialCopyAndCopyMoveAssignC2EOS_|_ZN31NonTrivialCopyAndCopyMoveAssignC1ERKS_Tm|_ZN31NonTrivialCopyAndCopyMoveAssignC2ERKS_Tm|"\?\?0NonTrivialCopyAndCopyMoveAssign@@QEAA@AEBU0@@Z"}}(
 // CHECK-SAME: %[[COPY_INSTANCE]],
 // CHECK-SAME: ptr
 // CHECK-SAME: %[[COPY_INSTANCE2]])

--- a/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/use-cxxstdlib-types-in-module-interface.swift
@@ -40,7 +40,7 @@ public:
     std::vector<SimplePOD * _Nullable> getMutPODPtrItems() const;
 };
 
-// CHECK: func getPODItems() -> std{{\.__1\.|\.}}vector<SimplePOD, allocator<SimplePOD>>
-// CHECK: func getFRTItems() -> std{{\.__1\.|\.}}vector<FRTType, allocator<FRTType>>
-// CHECK: func getPODPtrItems() -> std{{\.__1\.|\.}}vector<UnsafePointer<SimplePOD>, allocator<UnsafePointer<SimplePOD>>>
-// CHECK: func getMutPODPtrItems() -> std{{\.__1\.|\.}}vector<UnsafeMutablePointer<SimplePOD>, allocator<UnsafeMutablePointer<SimplePOD>>>
+// CHECK: func getPODItems() -> std{{\.__(ndk)?1\.|\.}}vector<SimplePOD, allocator<SimplePOD>>
+// CHECK: func getFRTItems() -> std{{\.__(ndk)?1\.|\.}}vector<FRTType, allocator<FRTType>>
+// CHECK: func getPODPtrItems() -> std{{\.__(ndk)?1\.|\.}}vector<UnsafePointer<SimplePOD>, allocator<UnsafePointer<SimplePOD>>>
+// CHECK: func getMutPODPtrItems() -> std{{\.__(ndk)?1\.|\.}}vector<UnsafeMutablePointer<SimplePOD>, allocator<UnsafeMutablePointer<SimplePOD>>>

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
@@ -5,5 +5,5 @@ import ClassTemplateNonTypeParameter
 let p = MagicIntPair()
 let t = MagicIntTriple()
 
-// CHECK: @"${{s4main1pSo0034MagicArrayInt32_UInt_2_zoAFhhiEngcVvp|s4main1pSo0036MagicArrayInt32_UInt64_2_JsAEiFiuomcVvp}}"
-// CHECK: @"${{s4main1tSo0034MagicArrayInt32_UInt_3_zoAFhhiEngcVvp|s4main1tSo0036MagicArrayInt32_UInt64_3_JsAEiFiuomcVvp}}"
+// CHECK: @"${{s4main1pSo0034MagicArrayInt32_UInt_2_zoAFhhiEngcVvp|s4main1pSo0036MagicArrayInt32_UInt(64|32)_2_JsAEiFiuomcVvp}}"
+// CHECK: @"${{s4main1tSo0034MagicArrayInt32_UInt_3_zoAFhhiEngcVvp|s4main1tSo0036MagicArrayInt32_UInt(64|32)_3_JsAEiFiuomcVvp}}"

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -20,6 +20,8 @@
 
 // RUN: %target-interop-build-clangxx -fsyntax-only -x c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++20 -c -fmodules -fcxx-modules -I %t
 
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 //--- header.h
 
 struct Trivial {

--- a/test/Interpreter/llvm_link_time_opt.swift
+++ b/test/Interpreter/llvm_link_time_opt.swift
@@ -1,7 +1,7 @@
 // UNSUPPORTED: OS=windows-msvc
 // static library is not well supported yet on Windows
 
-// REQUIRES: lld_lto
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // For LTO, the linker dlopen()'s the libLTO library, which is a scenario that
 // ASan cannot work in ("Interceptors are not working, AddressSanitizer is

--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -13,7 +13,7 @@
 
 // CHECK: CONFORMANCES:
 // CHECK: =============
-// CHECK-DAG: 16ConformanceCheck10SomeStructV6${{[0-9a-f]*}}yXZ0c6NestedD06${{[0-9a-f]*}}LLV (ConformanceCheck.SomeStruct.(unknown context at ${{[0-9a-f]*}}).(SomeNestedStruct in ${{[0-9a-f]*}})) : ConformanceCheck.MyProto
+// CHECK-DAG: 16ConformanceCheck10SomeStructV{{[56]}}${{[0-9a-f]*}}yXZ0c6NestedD0{{[56]}}${{[0-9a-f]*}}LLV (ConformanceCheck.SomeStruct.(unknown context at ${{[0-9a-f]*}}).(SomeNestedStruct in ${{[0-9a-f]*}})) : ConformanceCheck.MyProto
 // CHECK-DAG: 16ConformanceCheck3fooV3barV3bazV3quxV4quuxV5corgeV6graultV6garplyV5waldoV4fredV5plughV5xyzzyV4thudV18SomeConformingTypeV (ConformanceCheck.foo.bar.baz.qux.quux.corge.grault.garply.waldo.fred.plugh.xyzzy.thud.SomeConformingType) : ConformanceCheck.MyProto
 // CHECK-DAG: 16ConformanceCheck7StructAV (ConformanceCheck.StructA) : ConformanceCheck.MyProto, Swift.Hashable, Swift.Equatable
 // CHECK-DAG: 16ConformanceCheck2E4O (ConformanceCheck.E4) : ConformanceCheck.P1, ConformanceCheck.P2, ConformanceCheck.P3

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -501,8 +501,6 @@ swift_backtrace = os.environ.get('SWIFT_BACKTRACE')
 if swift_backtrace:
     config.environment['SWIFT_BACKTRACE'] = swift_backtrace
 
-config.available_features.add('lld_lto')
-
 threading = lit_config.params.get('threading', 'none')
 config.available_features.add('threading_{}'.format(threading))
 if threading != "none":


### PR DESCRIPTION
Also, make the analogous change to https://github.com/apple/swift-driver/pull/1372, which gets the sanitizer tests working on Android again, and remove the `lld_lto` feature in the tests, which is now unused.

[The first test initially worked](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/3472/consoleText), but then something changed in trunk to add the `noundef`, breaking the test.

The second broke a couple weeks ago because of the last command line added in #65662, as I think those C++ modules don't currently work on Android, so I disabled the test.

@hyp and @drodriguez, this should get the Android CI passing again.