### PR TITLE
[5.9] [ClangImporter] don't add swift_attr files to a module's auxiliary files

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7561,7 +7561,6 @@ SourceFile &ClangImporter::Implementation::getClangSwiftAttrSourceFile(
   auto sourceFile = new (SwiftContext) SourceFile(
       module, SourceFileKind::Library, None);
   ClangSwiftAttrSourceFiles.insert({&module, sourceFile});
-  module.addAuxiliaryFile(*sourceFile);
   return *sourceFile;
 }
 

--- a/test/SymbolGraph/ClangImporter/SwiftAttrExtension.swift
+++ b/test/SymbolGraph/ClangImporter/SwiftAttrExtension.swift
@@ -1,0 +1,28 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/SwiftAttr)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -emit-module-path %t/SwiftAttrExtension.swiftmodule -enable-objc-interop -I %t/SwiftAttr -module-name SwiftAttrExtension -emit-symbol-graph -emit-symbol-graph-dir %t %t/Extension.swift
+// RUN: %FileCheck %s --input-file %t/SwiftAttrExtension@SwiftAttr.symbols.json
+
+//--- SwiftAttr/module.modulemap
+module SwiftAttr {
+  header "SwiftAttr.h"
+}
+
+//--- SwiftAttr/SwiftAttr.h
+@import Foundation;
+
+__attribute__((swift_attr("@_nonSendable(_assumed)")))
+@interface MyObjcClass : NSObject
+@end
+
+//--- Extension.swift
+import SwiftAttr
+
+extension MyObjcClass {
+  // CHECK: s:So11MyObjcClassC18SwiftAttrExtensionE8someFuncyyF
+  public func someFunc() {}
+}


### PR DESCRIPTION
Cherry-pick of #65867

- **Explanation**: This PR removes empty marker `SourceFile`s that correspond to imported `__attribute__((swift_attr))` attributes from a module's auxiliary files.
- **Scope**: Fixes a crash in SourceEntityWalker when Swift code extends Objective-C code decorated with a `swift_attr` attribute.
- **Issue**: rdar://107624995
- **Risk**: Low. The auxiliary file in question had no content and no backing buffer, and was only used to feed the parser during the Clang import. The SourceFile is not useful after the import is finished.
- **Testing**: A test has been added to ensure that this code pattern does not crash SymbolGraphGen, one of the users of SourceEntityWalker.
- **Reviewer**: @bnbarham 