### PR TITLE
[5.9-20230510][CSBindings] Mark type variables that represent type parameter packs …

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -150,7 +150,8 @@ bool BindingSet::isDelayed() const {
 bool BindingSet::involvesTypeVariables() const {
   // This type variable always depends on a pack expansion variable
   // which should be inferred first if possible.
-  if (TypeVar->getImpl().canBindToPack())
+  if (TypeVar->getImpl().getGenericParameter() &&
+      TypeVar->getImpl().canBindToPack())
     return true;
 
   // This is effectively O(1) right now since bindings are re-computed

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -718,3 +718,26 @@ func isHashable_is(_ error: Error) -> Bool {
 func isHashable_composition(_ error: Error & AnyObject) -> Bool {
   error is AnyHashable // OK
 }
+
+// rdar://109381194 - incorrect ambiguity while comparing collections
+do {
+  class A : Hashable, Equatable {
+    func hash(into hasher: inout Hasher) {
+    }
+
+    static func == (lhs: A, rhs: A) -> Bool {
+      false
+    }
+  }
+
+  class B : A {}
+
+  func test(a: [B], b: [String: B]) {
+    assert(Set(a) == Set(b.values.map { $0 as A })) // ok
+  }
+
+  func test(a: [A], b: [B]) {
+    assert(Set(a) == Set(b.map { $0 as A })) // Ok
+    assert(Set(b.map { $0 as A }) == Set(a)) // Ok
+  }
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -455,6 +455,7 @@ do {
   func test_misplaced_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
     return (repeat each value.makeA())
     // expected-error@-1 {{pack reference 'each T' can only appear in pack expansion}}
+    // expected-error@-2 {{pack reference 'each T.A' can only appear in pack expansion}}
   }
 }
 


### PR DESCRIPTION
…as "involving type variables"

---

- Explanation:

Such type variables are always dependent on pack expansion type variables which should be bound first.

- Scope: Expressions with value pack expansions.

- Main Branch PR: https://github.com/apple/swift/pull/65962

- Risk: Very Low (The change narrows the original check down to only situations with value pack expansions)

- Reviewed By: @hborla 

- Testing: Added regression test-cases to the suite.

Resolves: rdar://109381194

(cherry picked from commit 5b5b3dd6923e6eb6c4a8959db7435a333ba5f797) 
(cherry picked from commit ce826c2137d0dd157ba1926da5ef75c9d13e3441) 
(cherry picked from commit 1728cca5f069215c3ab51dc01a68ec339641aab3)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
