### PR TITLE
[5.9🍒] account for errors importing ObjC method as async prop

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2864,12 +2864,16 @@ ImportedType ClangImporter::Implementation::importEffectfulPropertyType(
 
   // Import the parameter list and result type.
   ParameterList *bodyParams = nullptr;
-  ImportedType importedType;
-
   auto methodReturnType = importMethodParamsAndReturnType(
       dc, decl, decl->parameters(), false,
       isFromSystemModule, &bodyParams, name,
       asyncConvention, errorConvention, kind);
+
+  // was there a problem during import?
+  if (!methodReturnType)
+    return ImportedType();
+
+  assert(bodyParams);
 
   // getter mustn't have any parameters!
   if (bodyParams->size() != 0) {


### PR DESCRIPTION
• Description: Avoid crashing if the method import failed; as the `bodyParams` will be null in such a case.
• Risk: Very Low. Only adds a defensive check and removes an unused variable.
• Original PR: https://github.com/apple/swift/pull/65937
• Reviewed By: *pending*
• Testing: done manually
• Resolves: rdar://109377788