### PR TITLE
[5.9-20230510][AST] Use a different operator for member attribute macros

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -399,7 +399,7 @@ Entities
   macro-discriminator-list ::= macro-discriminator-list? file-discriminator? macro-expansion-operator INDEX
 
   macro-expansion-operator ::= decl-name identifier 'fMa' // attached accessor macro
-  macro-expansion-operator ::= decl-name identifier 'fMA' // attached member-attribute macro
+  macro-expansion-operator ::= decl-name identifier 'fMr' // attached member-attribute macro
   macro-expansion-operator ::= identifier 'fMf' // freestanding macro
   macro-expansion-operator ::= decl-name identifier 'fMm' // attached member macro
   macro-expansion-operator ::= decl-name identifier 'fMp' // attached peer macro

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3977,7 +3977,7 @@ void ASTMangler::appendMacroExpansionOperator(
     break;
 
   case MacroRole::MemberAttribute:
-    appendOperator("fMA", Index(discriminator));
+    appendOperator("fMr", Index(discriminator));
     break;
 
   case MacroRole::Member:

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4070,7 +4070,7 @@ NodePointer Demangler::demangleMacroExpansion() {
     isFreestanding = false;
     break;
 
-  case 'A':
+  case 'r':
     kind = Node::Kind::MemberAttributeAttachedMacroExpansion;
     isAttached = true;
     isFreestanding = false;

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1079,7 +1079,7 @@ ManglingError Remangler::mangleAccessorAttachedMacroExpansion(
 
 ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
     Node *node, unsigned depth) {
-  Buffer << "fMA";
+  Buffer << "fMr";
   RETURN_IF_ERROR(mangleIndex(node, depth + 1));
   return mangleChildNodes(node, depth + 1);
 }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2919,7 +2919,7 @@ ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
   RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMA";
+  Buffer << "fMr";
   return mangleChildNode(node, 3, depth + 1);
 }
 

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -172,16 +172,16 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:1 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift) "@accessViaStorage"
+// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMr_.swift) "@accessViaStorage"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV1y13myTypeWrapperfMA0_.swift) "@accessViaStorage"
+// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV1y13myTypeWrapperfMr0_.swift) "@accessViaStorage"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 25:1-25:1 (@__swiftmacro_9MacroUser1S13myTypeWrapperfMm_.swift) "private var _storage = _Storage()"
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 21:1-21:15 ""
 
 //##-- Cursor info on the attribute expanded by @myTypeWrapper
-// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=1 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -req-opts=retrieve_symbol_graph=1 -offset=1 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMr_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_CURSOR %s
 // NESTED_ATTACHED_CURSOR: source.lang.swift.ref.macro
 // NESTED_ATTACHED_CURSOR-SAME: macro_basic.swift:10:27-10:43
 // NESTED_ATTACHED_CURSOR-LABEL: SYMBOL GRAPH BEGIN
@@ -200,7 +200,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // NESTED_ATTACHED_CURSOR-NEXT: ACTIONS END
 
 //##-- Expansion on the attribute expanded by @myTypeWrapper
-// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:1 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:1 @__swiftmacro_9MacroUser1SV1x13myTypeWrapperfMr_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
 // NESTED_ATTACHED_EXPAND: source.edit.kind.active:
 // NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1x16accessViaStoragefMa_.swift) "{
 // NESTED_ATTACHED_EXPAND-NEXT:  get {


### PR DESCRIPTION
* Explanation: Mangled macro names are currently used as the name we write the expansion to on-disk. Having names that only differ in case-sensitivity then causes issues on case-insensitive file systems. Update the operator of member attributes so that it doesn't collide with accessor macros.
* Scope: Macros
* Risk: Very low - is just slightly adjusting member attribute mangling and we verify being able to demangle when retrieving the mangled name.
* Testing: Updated existing tests that check for the mangled name.
* Original PR: https://github.com/apple/swift/pull/65963