### PR TITLE
Eliminate some unnecessary shadowing generic parameters

### DIFF
--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift
@@ -242,7 +242,7 @@ public struct GenericMinimalHashableValue<Wrapped> : Equatable, Hashable {
     self.identity = identity
   }
 
-  public static func == <Wrapped>(
+  public static func ==(
     lhs: GenericMinimalHashableValue<Wrapped>,
     rhs: GenericMinimalHashableValue<Wrapped>
   ) -> Bool {
@@ -298,7 +298,7 @@ public class GenericMinimalHashableClass<Wrapped> : Equatable, Hashable {
     self.identity = identity
   }
 
-  public static func == <Wrapped>(
+  public static func ==(
     lhs: GenericMinimalHashableClass<Wrapped>,
     rhs: GenericMinimalHashableClass<Wrapped>
   ) -> Bool {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -3479,11 +3479,11 @@ struct Pair<T : Comparable> : Comparable {
   var first: T
   var second: T
 
-  static func == <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
+  static func ==(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
     return lhs.first == rhs.first && lhs.second == rhs.second
   }
 
-  static func < <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
+  static func <(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
     return [lhs.first, lhs.second].lexicographicallyPrecedes(
       [rhs.first, rhs.second])
   }

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -349,9 +349,9 @@ private func _myers<C,D>(
    * necessary) is significantly less than the worst-case n² memory use of the
    * descent algorithm.
    */
-  func _withContiguousStorage<C: Collection, R>(
-    for values: C,
-    _ body: (UnsafeBufferPointer<C.Element>) throws -> R
+  func _withContiguousStorage<Col: Collection, R>(
+    for values: Col,
+    _ body: (UnsafeBufferPointer<Col.Element>) throws -> R
   ) rethrows -> R {
     if let result = try values.withContiguousStorageIfAvailable(body) { return result }
     let array = ContiguousArray(values)


### PR DESCRIPTION
New warning exposed some unnecessarily shadowed generic parameters. Eliminate the shadowing to remove the warnings.