### PR TITLE
[RequirementMachine] InferredGenericSignatureRequest uses valid location for generic signature requirements.

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -770,7 +770,7 @@ InferredGenericSignatureRequest::evaluate(
   }();
 
   for (const auto &req : parentSig.getRequirements())
-    requirements.push_back({req, SourceLoc(), /*wasInferred=*/false});
+    requirements.push_back({req, loc, /*wasInferred=*/false});
 
   DeclContext *lookupDC = nullptr;
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -748,6 +748,27 @@ InferredGenericSignatureRequest::evaluate(
 
   SmallVector<StructuralRequirement, 4> requirements;
   SmallVector<RequirementError, 4> errors;
+
+  SourceLoc loc = [&]() {
+    if (genericParamList) {
+      auto loc = genericParamList->getLAngleLoc();
+      if (loc.isValid())
+        return loc;
+    }
+    if (whereClause) {
+      auto loc = whereClause.getLoc();
+      if (loc.isValid())
+        return loc;
+    }
+    for (auto sourcePair : inferenceSources) {
+      auto *typeRepr = sourcePair.getTypeRepr();
+      auto loc = typeRepr ? typeRepr->getStartLoc() : SourceLoc();
+      if (loc.isValid())
+        return loc;
+    }
+    return SourceLoc();
+  }();
+
   for (const auto &req : parentSig.getRequirements())
     requirements.push_back({req, SourceLoc(), /*wasInferred=*/false});
 
@@ -760,10 +781,7 @@ InferredGenericSignatureRequest::evaluate(
     return false;
   };
 
-  SourceLoc loc;
   if (genericParamList) {
-    loc = genericParamList->getLAngleLoc();
-
     // Extensions never have a parent signature.
     assert(genericParamList->getOuterParameters() == nullptr || !parentSig);
 
@@ -810,9 +828,6 @@ InferredGenericSignatureRequest::evaluate(
   if (whereClause) {
     lookupDC = whereClause.dc;
 
-    if (loc.isInvalid())
-      loc = whereClause.getLoc();
-
     std::move(whereClause).visitRequirements(
         TypeResolutionStage::Structural,
         visitRequirement);
@@ -825,8 +840,6 @@ InferredGenericSignatureRequest::evaluate(
   for (auto sourcePair : inferenceSources) {
     auto *typeRepr = sourcePair.getTypeRepr();
     auto typeLoc = typeRepr ? typeRepr->getStartLoc() : SourceLoc();
-    if (loc.isInvalid())
-      loc = typeLoc;
 
     inferRequirements(sourcePair.getType(), typeLoc, moduleForInference,
                       lookupDC, requirements);

--- a/test/AutoDiff/SILOptimizer/generics.swift
+++ b/test/AutoDiff/SILOptimizer/generics.swift
@@ -52,11 +52,13 @@ func foo<T>(_ x: Wrapper<T>) {
 // Test case where associated derivative function's requirements are met.
 extension Wrapper where Scalar : Numeric {
   @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Differentiable'}}
+  // expected-warning@-1 {{redundant conformance constraint 'Scalar' : 'Numeric'}}
   func mean() -> Wrapper {
     return self
   }
 
   @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Differentiable'}}
+  // expected-warning@-1 {{redundant conformance constraint 'Scalar' : 'Numeric'}}
   func variance() -> Wrapper {
     return mean() // ok
   }
@@ -217,7 +219,7 @@ let _: @differentiable(reverse) (Float, Float) -> TF_546<Float> = { r, i in
 struct TF_652<Scalar> {}
 extension TF_652 : Differentiable where Scalar : FloatingPoint {}
 
-@differentiable(reverse, wrt: x where Scalar: FloatingPoint)
+@differentiable(reverse, wrt: x where Scalar: FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Numeric'}}
 func test<Scalar: Numeric>(x: TF_652<Scalar>) -> TF_652<Scalar> {
   for _ in 0..<10 {
     let _ = x
@@ -293,7 +295,7 @@ struct TF_697_Sequential<Layer1: TF_697_Module, Layer2: TF_697_Layer>: TF_697_Mo
         layer2.callLayer(layer1.callModule(input))
     }
 }
-extension TF_697_Sequential: TF_697_Layer where Layer1: TF_697_Layer {
+extension TF_697_Sequential: TF_697_Layer where Layer1: TF_697_Layer { // expected-warning {{redundant conformance constraint 'Layer1' : 'TF_697_Module'}}
     @differentiable(reverse)
     func callLayer(_ input: Layer1.Input) -> Layer2.Output {
         layer2.callLayer(layer1.callLayer(input))

--- a/test/Generics/concrete_contraction_unrelated_typealias.swift
+++ b/test/Generics/concrete_contraction_unrelated_typealias.swift
@@ -25,7 +25,7 @@ class GenericDelegateProxy<P : AnyObject, D> {
 
   // CHECK-LABEL: .GenericDelegateProxy.init(_:)@
   // CHECK-NEXT: <P, D, Proxy where P == Proxy.[DelegateProxyType]Parent, D == Proxy.[DelegateProxyType]Delegate, Proxy : GenericDelegateProxy<P, D>, Proxy : DelegateProxyType>
-  init<Proxy: DelegateProxyType>(_: Proxy.Type)
+  init<Proxy: DelegateProxyType>(_: Proxy.Type) // expected-warning {{redundant constraint 'P' : 'AnyObject'}}
     where Proxy: GenericDelegateProxy<P, D>,
           Proxy.Parent == P, // expected-warning {{redundant same-type constraint 'GenericDelegateProxy<P, D>.Parent' (aka 'P') == 'P'}}
           Proxy.Delegate == D {} // expected-warning {{redundant same-type constraint 'GenericDelegateProxy<P, D>.Delegate' (aka 'D') == 'D'}}

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -13,7 +13,7 @@ extension G1 where T == S {}
 
 // CHECK: ExtensionDecl line={{.*}} base=G1
 // CHECK-NEXT: Generic signature: <T where T == C>
-extension G1 where T == C {}
+extension G1 where T == C {} // expected-warning {{redundant constraint 'T' : 'AnyObject'}}
 
 struct G2<U> {}
 

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -64,6 +64,7 @@ struct OverlappingSub<T: P1> {}
 // CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
 // CHECK-NEXT:   conforms_to: T P4)
 extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
+// expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 func overlapping_sub_good<U: P4>(_: U) {
     takes_P2(OverlappingSub<U>())
 }
@@ -175,6 +176,7 @@ struct ClassMoreSpecific<T: C1> {}
 // CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
 // CHECK-NEXT:   superclass: T C3)
 extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
+// expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
 func class_more_specific_good<U: C3>(_: U) {
     takes_P2(ClassMoreSpecific<U>())
 }
@@ -343,7 +345,7 @@ struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
 // CHECK-NEXT:   conforms_to: T P1
 // CHECK-NEXT:   same_type: T U)
-extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}
+extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
 
 // Checking of conditional requirements for existential conversions.
 func existential_good<T: P1>(_: T.Type) {

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -63,4 +63,4 @@ struct G<X : Base, Y> {}
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=G
 // CHECK-NEXT: Generic signature: <X, Y where X == Derived<Y>, Y : C>
-extension G where X == Derived<Y> {}
+extension G where X == Derived<Y> {} // expected-warning {{redundant superclass constraint 'X' : 'Base'}}

--- a/test/Generics/issue-61192.swift
+++ b/test/Generics/issue-61192.swift
@@ -11,5 +11,6 @@ struct G<A>: P {}
 struct Body<T: P> where T.A == C {
   // CHECK-LABEL: .init(_:)@
   // CHECK-NEXT: <T, U where T == G<C>, U : P, U.[P]A == C>
-  init<U: P>(_: U) where T == G<T.A>, U.A == T.A {}
+  init<U: P>(_: U) where T == G<T.A>, U.A == T.A {} // expected-warning {{redundant same-type constraint 'T.A' == 'C'}} 
+  // expected-warning@-1 {{redundant conformance constraint 'T' : 'P'}}
 }

--- a/test/Generics/rdar108963047.swift
+++ b/test/Generics/rdar108963047.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol HasElt {
+  associatedtype Element
+}
+struct IntElement : HasElt {
+  typealias Element = Int
+}
+struct FloatElement : HasElt {
+  typealias Element = Float
+}
+
+struct G<T: HasElt> where T.Element == Float {
+  func foo() where T == IntElement {} // expected-error {{generic signature requires types 'IntElement.Element' (aka 'Int') and 'Float' to be the same}}
+}

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -45,7 +45,7 @@ struct UnresolvedWithConcreteBase<A, B> {
 // produces two warnings about redundant requirements.
 struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C, D, E where A == S1<C, E, S2<D>>, B : P2, C : P1, D == B.[P2]T, E == D.[P1]T, B.[P2]T == C.[P1]T>
-  init<C, D, E>(_: C)
+  init<C, D, E>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
     where C : P1,
           D : P1, // expected-warning {{redundant conformance constraint 'D' : 'P1'}}
           C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
@@ -57,7 +57,7 @@ struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
 // Same as above but without the warnings.
 struct OriginalExampleWithoutWarning<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C, D, E where A == S1<C, E, S2<D>>, B : P2, C : P1, D == B.[P2]T, E == D.[P1]T, B.[P2]T == C.[P1]T>
-  init<C, D, E>(_: C)
+  init<C, D, E>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
     where C : P1,
           A == S1<C, C.T.T, S2<C.T>>,
           C.T == D,
@@ -67,7 +67,7 @@ struct OriginalExampleWithoutWarning<A, B> where A : P2, B : P2, A.T == B.T {
 // Same as above but without unnecessary generic parameters.
 struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C where A == S1<C, B.[P2]T.[P1]T, S2<B.[P2]T>>, B : P2, C : P1, B.[P2]T == C.[P1]T>
-  init<C>(_: C)
+  init<C>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
     where C : P1,
           C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
           A == S1<C, C.T.T, S2<C.T>> {}
@@ -77,7 +77,7 @@ struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T 
 // or the warning.
 struct WithoutBogusGenericParametersWithoutWarning<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C where A == S1<C, B.[P2]T.[P1]T, S2<B.[P2]T>>, B : P2, C : P1, B.[P2]T == C.[P1]T>
-  init<C>(_: C)
+  init<C>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
     where C : P1,
           A == S1<C, C.T.T, S2<C.T>> {}
 }

--- a/test/Generics/rdar77462797.swift
+++ b/test/Generics/rdar77462797.swift
@@ -11,21 +11,21 @@ class S<T : P> : Q {}
 
 struct G<X, Y> where X : Q {
   // no redundancies
-  func foo1() where X == S<Y> {}
+  func foo1() where X == S<Y> {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
   // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
 
   // 'Y : P' is redundant, but only via an inferred requirement from S<Y>,
   // so we should not diagnose it
-  func foo2() where X == S<Y>, Y : P {}
+  func foo2() where X == S<Y>, Y : P {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
   // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
 
   // 'X : Q' is redundant
-  func foo3() where X : Q, X == S<Y>, Y : P {}
+  func foo3() where X : Q, X == S<Y>, Y : P {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
   // expected-warning@-1 {{redundant conformance constraint 'S<Y>' : 'Q'}}
   // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
 
   // 'T.T : P' is redundant
-  func foo4<T : Q>(_: T) where X == S<Y>, T.T : P {}
+  func foo4<T : Q>(_: T) where X == S<Y>, T.T : P {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
   // expected-warning@-1 {{redundant conformance constraint 'T.T' : 'P'}}
   // CHECK: Generic signature: <X, Y, T where X == S<Y>, Y : P, T : Q>
 }

--- a/test/Generics/rdar91771352.swift
+++ b/test/Generics/rdar91771352.swift
@@ -4,21 +4,21 @@
 public struct G<T: P1, U: P1> {
   // CHECK-LABEL: .f1()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f1() where T == U {}
+  public func f1() where T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
 
   // CHECK-LABEL: .f2()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f2() where T == U, T.A.B == T {}
+  public func f2() where T == U, T.A.B == T {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
   // expected-warning@-1 {{redundant same-type constraint 'T.A.B' == 'T'}}
 
   // CHECK-LABEL: .f3()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f3() where T.A.B == T, T == U {}
+  public func f3() where T.A.B == T, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
   // expected-warning@-1 {{redundant same-type constraint 'T.A.B' == 'T'}}
 
   // CHECK-LABEL: .f4()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f4() where U.A.B == U, T == U {}
+  public func f4() where U.A.B == U, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
   // expected-warning@-1 {{redundant same-type constraint 'U.A.B' == 'U'}}
 }
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -178,8 +178,11 @@ extension RangeReplaceableCollection
 // CHECK: Generic signature: <T, V where T == Range<Int>>
 // CHECK-NEXT: Canonical generic signature: <τ_0_0, τ_1_0 where τ_0_0 == Range<Int>>
 struct X14<T> where T.Iterator == IndexingIterator<T> {
-	func recursiveConcreteSameType<V>(_: V) where T == Range<Int> { }
-  // expected-warning@-1 {{redundant same-type constraint 'T' == 'Range<Int>'}}
+	func recursiveConcreteSameType<V>(_: V) where T == Range<Int> { } // expected-warning {{redundant conformance constraint 'Range<Int>' : 'Collection'}}
+  // expected-warning@-1 {{redundant conformance constraint 'Int' : 'Strideable'}}
+  // expected-warning@-2 {{redundant conformance constraint 'Int' : 'SignedInteger'}}
+  // expected-warning@-3 {{redundant same-type constraint 'Range<Int>.Iterator' (aka 'IndexingIterator<Range<Int>>') == 'IndexingIterator<T>'}}
+  // expected-warning@-4 {{redundant same-type constraint 'T' == 'Range<Int>'}}
 }
 
 // rdar://problem/30478915
@@ -205,7 +208,7 @@ struct X9<T: P12, U: P12> where T.B == U.B {
   // CHECK-LABEL: X9.upperSameTypeConstraint
 	// CHECK: Generic signature: <T, U, V where T == X8, U : P12, U.[P12]B == X7>
   // CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 == X8, τ_0_1 : P12, τ_0_1.[P12]B == X7>
-	func upperSameTypeConstraint<V>(_: V) where T == X8 { }
+	func upperSameTypeConstraint<V>(_: V) where T == X8 { } // expected-warning {{redundant conformance constraint 'X8' : 'P12'}}
 }
 
 protocol P13 {
@@ -221,7 +224,7 @@ struct X11<T: P12, U: P12> where T.B == U.B.A {
 	// CHECK-LABEL: X11.upperSameTypeConstraint
 	// CHECK: Generic signature: <T, U, V where T : P12, U == X10, T.[P12]B == X10>
 	// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 : P12, τ_0_1 == X10, τ_0_0.[P12]B == X10>
-	func upperSameTypeConstraint<V>(_: V) where U == X10 { }
+	func upperSameTypeConstraint<V>(_: V) where U == X10 { } // expected-warning {{redundant conformance constraint 'X10' : 'P12'}}
 }
 
 protocol P16 {
@@ -237,7 +240,8 @@ struct X16<X, Y> : P16 {
 // CHECK-LABEL: .X17.bar@
 // CHECK: Generic signature: <S, T, U, V where S == X16<X3, X15>, T == X3, U == X15>
 struct X17<S: P16, T, U> where S.A == (T, U) {
-	func bar<V>(_: V) where S == X16<X3, X15> { }
+	func bar<V>(_: V) where S == X16<X3, X15> { } // expected-warning {{redundant conformance constraint 'X16<X3, X15>' : 'P16'}}
+  // expected-warning@-1 {{redundant same-type constraint 'X16<X3, X15>.A' (aka '(X3, X15)') == '(T, U)'}}
 }
 
 // Same-type constraints that are self-derived via a parent need to be
@@ -257,7 +261,7 @@ struct X18: P18, P17 {
 // CHECK-LABEL: .X19.foo@
 // CHECK: Generic signature: <T, U where T == X18>
 struct X19<T: P18> where T == T.A {
-  func foo<U>(_: U) where T == X18 { }
+  func foo<U>(_: U) where T == X18 { } // expected-warning {{redundant conformance constraint 'X18' : 'P18'}}
   // expected-warning@-1 {{redundant same-type constraint 'T' == 'X18'}}
 }
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -224,23 +224,6 @@ struct X11<T: P12, U: P12> where T.B == U.B.A {
 	func upperSameTypeConstraint<V>(_: V) where U == X10 { }
 }
 
-#if _runtime(_ObjC)
-// rdar://problem/30610428
-@objc protocol P14 { }
-
-class X12<S: AnyObject> {
-  func bar<V>(v: V) where S == P14 {
-  }
-}
-
-@objc protocol P15: P14 { }
-
-class X13<S: P14> {
-  func bar<V>(v: V) where S == P15 {
-  }
-}
-#endif
-
 protocol P16 {
 	associatedtype A
 }

--- a/test/Generics/requirement_inference_objc.swift
+++ b/test/Generics/requirement_inference_objc.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+
+// REQUIRES: objc_interop
+
+// rdar://problem/30610428
+@objc protocol P14 { }
+
+class X12<S: AnyObject> {
+  func bar<V>(v: V) where S == P14 {
+  }
+}
+
+@objc protocol P15: P14 { }
+
+class X13<S: P14> {
+  func bar<V>(v: V) where S == P15 {
+  }
+}
+

--- a/test/Generics/requirement_inference_objc.swift
+++ b/test/Generics/requirement_inference_objc.swift
@@ -6,14 +6,14 @@
 @objc protocol P14 { }
 
 class X12<S: AnyObject> {
-  func bar<V>(v: V) where S == P14 {
+  func bar<V>(v: V) where S == P14 { // expected-warning {{redundant constraint 'S' : 'AnyObject'}}
   }
 }
 
 @objc protocol P15: P14 { }
 
 class X13<S: P14> {
-  func bar<V>(v: V) where S == P15 {
+  func bar<V>(v: V) where S == P15 { // expected-warning {{redundant conformance constraint 'any P15' : 'P14'}}
   }
 }
 

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -158,7 +158,7 @@ protocol P {
 }
 
 struct S<A: P> {
-	init<Q: P>(_ q: Q) where Q.T == A {}
+	init<Q: P>(_ q: Q) where Q.T == A {} // expected-warning {{redundant conformance constraint 'A' : 'P'}}
 }
 
 // rdar://problem/19371678
@@ -177,7 +177,7 @@ struct SpecificAnimal<F:Food> : Animal {
     typealias EdibleFood=F
     let _eat:(_ f:F) -> ()
 
-    init<A:Animal>(_ selfie:A) where A.EdibleFood == F {
+    init<A:Animal>(_ selfie:A) where A.EdibleFood == F { // expected-warning {{redundant conformance constraint 'F' : 'Food'}}
         _eat = { selfie.eat($0) }
     }
     func eat(_ f:F) {

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' | %FileCheck %s
 
 struct S<T> {}
@@ -48,9 +48,8 @@ func nonGenericParam(x: Int) {}
 class G<T> {
   // CHECK: @_specialize(exported: false, kind: full, where T == Int)
   @_specialize(where T == Int)
-  @_specialize(where T == T) // expected-warning{{redundant same-type constraint 'T' == 'T'}}
-  // expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
-  // expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
+  @_specialize(where T == T) // expected-error{{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
+  // expected-note@-1 {{missing constraint for 'T' in '_specialize' attribute}}
   @_specialize(where T == S<T>)
   // expected-error@-1 {{cannot build rewrite system for generic signature; concrete nesting limit exceeded}}
   // expected-note@-2 {{failed rewrite rule is τ_0_0.[concrete: S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0}}
@@ -125,7 +124,6 @@ public func funcWithEmptySpecializeAttr<X: P, Y>(x: X, y: Y) {
 @_specialize(where X:_Trivial(8), Y == Int)
 @_specialize(where X == Int, Y == Int)
 @_specialize(where X == Int, X == Int) // expected-error{{too few generic parameters are specified in '_specialize' attribute (got 1, but expected 2)}} expected-note{{missing constraint for 'Y' in '_specialize' attribute}}
-// expected-warning@-1{{redundant same-type constraint 'X' == 'Int'}}
 @_specialize(where Y:_Trivial(32), X == Float)
 @_specialize(where X1 == Int, Y1 == Int) // expected-error{{cannot find type 'X1' in scope}} expected-error{{cannot find type 'Y1' in scope}} expected-error{{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 2)}} expected-note{{missing constraint for 'X' in '_specialize' attribute}} expected-note{{missing constraint for 'Y' in '_specialize' attribute}}
 public func funcWithTwoGenericParameters<X, Y>(x: X, y: Y) {
@@ -165,20 +163,17 @@ public func anotherFuncWithTwoGenericParameters<X: P, Y>(x: X, y: Y) {
 // expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
 // expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
 @_specialize(where T: C1) // expected-error{{only same-type and layout requirements are supported by '_specialize' attribute}}
-@_specialize(where Int: P) // expected-warning{{redundant conformance constraint 'Int' : 'P'}} expected-error{{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}} expected-note{{missing constraint for 'T' in '_specialize' attribute}}
+@_specialize(where Int: P) // expected-error{{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}} expected-note{{missing constraint for 'T' in '_specialize' attribute}}
 func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 }
 
 @_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject)
 // expected-error@-1{{no type for 'T' can satisfy both 'T : _RefCountedObject' and 'T : _Trivial(32)'}}
 // expected-error@-2{{no type for 'T' can satisfy both 'T : _Trivial(64)' and 'T : _Trivial(32)'}}
-// expected-warning@-3{{redundant constraint 'T' : '_Trivial'}}
-// expected-error@-4 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
-// expected-note@-5 {{missing constraint for 'T' in '_specialize' attribute}}
+// expected-error@-3 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
+// expected-note@-4 {{missing constraint for 'T' in '_specialize' attribute}}
 @_specialize(where T: _Trivial, T: _Trivial(64))
-// expected-warning@-1{{redundant constraint 'T' : '_Trivial'}}
 @_specialize(where T: _RefCountedObject, T: _NativeRefCountedObject)
-// expected-warning@-1{{redundant constraint 'T' : '_RefCountedObject'}}
 @_specialize(where Array<T> == Int) // expected-error{{generic signature requires types 'Array<T>' and 'Int' to be the same}}
 // expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
 // expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
@@ -191,9 +186,8 @@ public protocol Proto: class {
 }
 
 @_specialize(where T: _RefCountedObject)
-// expected-warning@-1 {{redundant constraint 'T' : '_RefCountedObject'}}
-// expected-error@-2 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
-// expected-note@-3 {{missing constraint for 'T' in '_specialize' attribute}}
+// expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
+// expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
 @_specialize(where T: _Trivial)
 // expected-error@-1{{no type for 'T' can satisfy both 'T : _NativeClass' and 'T : _Trivial'}}
 // expected-error@-2 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -143,7 +143,7 @@ class JustAClass: DoesNotImposeClassReq_1 {
   var property: String = ""
 }
 
-extension DoesNotImposeClassReq_1 where Self: JustAClass {
+extension DoesNotImposeClassReq_1 where Self: JustAClass { // expected-warning{{redundant conformance constraint 'JustAClass' : 'DoesNotImposeClassReq_1'}}
   var wrappingProperty1: String {
     get { return property }
     set { property = newValue } // Okay
@@ -244,7 +244,7 @@ class JustAClass1: DoesNotImposeClassReq_3 {
   var someProperty = 0
 }
 
-extension DoesNotImposeClassReq_3 where Self: JustAClass1 {
+extension DoesNotImposeClassReq_3 where Self: JustAClass1 { // expected-warning {{redundant conformance constraint 'JustAClass1' : 'DoesNotImposeClassReq_3'}}
   var anotherProperty1: Int {
     get { return someProperty }
     set { someProperty = newValue } // Okay


### PR DESCRIPTION
`InferredGenericSignatureRequest` creates `StructuralRequirement`s for the requirements of the generic signature that is passed to it (if one is).

Previously, it used invalid `SourceLoc`s for these requirements.  The result was that when errors that were emitted as a result of those `StructuralRequirement`s (during concrete type contraction), they would also have invalid `SourceLoc`s.  The effect was that those errors were ignored during `diagnoseRequirementErrors`.

Here, use the available loc for those requirements.

rdar://108963047
