### PR TITLE
[5.8] [stdlib] Fix String.reserveCapacity underallocation

### DIFF
--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -74,14 +74,28 @@ extension _StringGuts {
   // Grow to accommodate at least `n` code units
   @usableFromInline
   internal mutating func grow(_ n: Int) {
-    defer { self._invariantCheck() }
+    defer {
+      self._invariantCheck()
+      _internalInvariant(
+        self.uniqueNativeCapacity != nil && self.uniqueNativeCapacity! >= n)
+    }
 
     _internalInvariant(
       self.uniqueNativeCapacity == nil || self.uniqueNativeCapacity! < n)
 
+    // If unique and native, apply a 2x growth factor to avoid problematic
+    // performance when used in a loop. If one if those doesn't apply, we
+    // can just use the requested capacity (at least the current utf-8 count).
     // TODO: Don't do this! Growth should only happen for append...
-    let growthTarget = Swift.max(n, (self.uniqueNativeCapacity ?? 0) * 2)
+    let growthTarget: Int
+    if let capacity = self.uniqueNativeCapacity {
+      growthTarget = Swift.max(n, capacity * 2)
+    } else {
+      growthTarget = Swift.max(n, self.utf8Count)
+    }
 
+    // `isFastUTF8` is not the same as `isNative`. It can include small
+    // strings or foreign strings that provide contiguous UTF-8 access.
     if _fastPath(isFastUTF8) {
       let isASCII = self.isASCII
       let storage = self.withFastUTF8 {

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2380,7 +2380,8 @@ StringTests.test("String.CoW.reserveCapacity") {
   let preGrowCapacity = str.capacity
   
   // Growth shouldn't be linear
-  str.append(contentsOf: String(repeating: "z", count: 20))
+  let newElementCount = (preGrowCapacity - str.count) + 10
+  str.append(contentsOf: String(repeating: "z", count: newElementCount))
   expectGE(str.capacity, preGrowCapacity * 2)
   
   // Capacity can shrink when copying, but not below the count
@@ -2407,7 +2408,6 @@ StringTests.test("NSString.CoW.reserveCapacity") {
   var copy2 = str2
   copy2.append(contentsOf: String(repeating: "z", count: 10))
   expectGE(copy2.capacity, 30)
-  expectLT(copy2.capacity, 40)
 #endif
 }
 


### PR DESCRIPTION
This is a cherry pick of #65902 for the 5.8 branch.

When called on a string that is not uniquely referenced, `String.reserveCapacity(_:)` ignores the current capacity, using the passed-in capacity for the size of its new storage. This can result in an underallocation and write past the end of the new buffer.

This fix changes the new size calculation to use the current UTF-8 count as the minimum. Non-native or non-unique strings now allocate the requested capacity (or space enough for the current contents, if that's larger than what's requested).

rdar://109275875
Fixes #53483