### PR TITLE
[5.9][Macro] Attributes for freestanding macro expansion

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2056,6 +2056,8 @@ ERROR(macro_expansion_expr_expected_macro_identifier,PointsToFirstBadToken,
       "expected a macro identifier for a pound literal expression", ())
 ERROR(macro_expansion_decl_expected_macro_identifier,PointsToFirstBadToken,
       "expected a macro identifier for a pound literal declaration", ())
+ERROR(extra_whitespace_macro_expansion_identifier,PointsToFirstBadToken,
+      "extraneous whitespace between '#' and macro name is not permitted", ())
 
 ERROR(macro_role_attr_expected_kind,PointsToFirstBadToken,
       "expected %select{a freestanding|an attached}0 macro role such as "

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -900,10 +900,14 @@ public:
   // Decl Parsing
 
   /// Returns true if parser is at the start of a Swift decl or decl-import.
-  bool isStartOfSwiftDecl(bool allowPoundIfAttributes = true);
+  bool isStartOfSwiftDecl(bool allowPoundIfAttributes = true,
+                          bool hadAttrsOrModifiers = false);
 
   /// Returns true if the parser is at the start of a SIL decl.
   bool isStartOfSILDecl();
+
+  /// Returns true if the parser is at a freestanding macro expansion.
+  bool isStartOfFreestandingMacroExpansion();
 
   /// Parse the top-level Swift items into the provided vector.
   ///

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1751,6 +1751,16 @@ public:
   DeclNameRef parseDeclNameRef(DeclNameLoc &loc, const Diagnostic &diag,
                                DeclNameOptions flags);
 
+  /// Parse macro expansion.
+  ///
+  ///   macro-expansion:
+  ///     '#' identifier generic-arguments? expr-paren? trailing-closure?
+  ParserStatus parseFreestandingMacroExpansion(
+      SourceLoc &poundLoc, DeclNameLoc &macroNameLoc, DeclNameRef &macroNameRef,
+      SourceLoc &leftAngleLoc, SmallVectorImpl<TypeRepr *> &genericArgs,
+      SourceLoc &rightAngleLoc, ArgumentList *&argList, bool isExprBasic,
+      const Diagnostic &diag);
+
   ParserResult<Expr> parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,
                                    Identifier PlaceholderId);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1482,7 +1482,7 @@ public:
   
   bool shouldSkip(Decl *D) {
     if (!Walker.shouldWalkMacroArgumentsAndExpansion().second &&
-        D->isInMacroExpansionInContext())
+        D->isInMacroExpansionInContext() && !Walker.Parent.isNull())
       return true;
 
     if (auto *VD = dyn_cast<VarDecl>(D)) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -856,7 +856,7 @@ OrigDeclAttrFilter::operator()(const DeclAttribute *Attr) const {
   auto declLoc = decl->getStartLoc();
   auto *mod = decl->getModuleContext();
   auto *declFile = mod->getSourceFileContainingLocation(declLoc);
-  auto *attrFile = mod->getSourceFileContainingLocation(Attr->AtLoc);
+  auto *attrFile = mod->getSourceFileContainingLocation(Attr->getLocation());
   if (!declFile || !attrFile)
     return Attr;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessRequests.h"
 #include "swift/AST/AccessScope.h"
@@ -10065,6 +10066,13 @@ void swift::simple_display(llvm::raw_ostream &out, const Decl *decl) {
       typeRepr->print(out);
     else
       ext->getSelfNominalTypeDecl()->dumpRef(out);
+  } else if (auto med = dyn_cast<MacroExpansionDecl>(decl)) {
+    out << '#' << med->getMacroName() << " in ";
+    printContext(out, med->getDeclContext());
+    if (med->getLoc().isValid()) {
+      out << '@';
+      med->getLoc().print(out, med->getASTContext().SourceMgr);
+    }
   } else {
     out << "(unknown decl)";
   }

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -32,5 +32,6 @@ add_pure_swift_host_library(swiftASTGen STATIC
     SwiftSyntax::SwiftParserDiagnostics
     SwiftSyntax::SwiftSyntax
     SwiftSyntax::SwiftSyntaxMacros
+    SwiftSyntax::SwiftSyntaxMacroExpansion
     swiftLLVMJSON
 )

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -37,10 +37,10 @@ let package = Package(
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax"),
         "swiftLLVMJSON"
       ],
       path: "Sources/ASTGen",
-      exclude: ["CMakeLists.txt"],
       swiftSettings: swiftSetttings
     ),
     .target(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ if (SWIFT_SWIFT_PARSER)
     SwiftOperators
     SwiftSyntaxBuilder
     SwiftSyntaxMacros
+    SwiftSyntaxMacroExpansion
     SwiftCompilerPluginMessageHandling
   )
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4927,8 +4927,9 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
   }
 
   // 'macro' name
-  if (Tok.isContextualKeyword("macro") && Tok2.is(tok::identifier))
-    return true;
+  if (Tok.isContextualKeyword("macro")) {
+    return Tok2.is(tok::identifier);
+  }
 
   if (Tok.isContextualKeyword("package")) {
     // If `case` is the next token after `return package` statement,
@@ -5013,16 +5014,20 @@ bool Parser::isStartOfSILDecl() {
 }
 
 bool Parser::isStartOfFreestandingMacroExpansion() {
-  // Check if "'#' <identifier>" without any whitespace between them.
+  // Check if "'#' <identifier>" where the identifier is on the sameline.
   if (!Tok.is(tok::pound))
     return false;
-  if (Tok.getRange().getEnd() != peekToken().getLoc())
+  const Token &Tok2 = peekToken();
+  if (Tok2.isAtStartOfLine())
     return false;
-  if (!peekToken().isAny(tok::identifier, tok::code_complete) &&
-      // allow keywords right after '#' so we can diagnose it when parsing.
-      !peekToken().isKeyword())
-    return false;
-  return true;
+
+  if (Tok2.isAny(tok::identifier, tok::code_complete))
+    return true;
+  if (Tok2.isKeyword()) {
+    // allow keywords right after '#' so we can diagnose it when parsing.
+    return Tok.getRange().getEnd() == Tok2.getLoc();
+  }
+  return false;
 }
 
 void Parser::consumeDecl(ParserPosition BeginParserPosition,
@@ -9789,47 +9794,18 @@ ParserResult<MacroDecl> Parser::parseDeclMacro(DeclAttributes &attributes) {
 ParserResult<MacroExpansionDecl>
 Parser::parseDeclMacroExpansion(ParseDeclOptions flags,
                                 DeclAttributes &attributes) {
-  SourceLoc poundLoc = consumeToken(tok::pound);
+  SourceLoc poundLoc;
   DeclNameLoc macroNameLoc;
-  DeclNameRef macroNameRef = parseDeclNameRef(
-      macroNameLoc, diag::macro_expansion_decl_expected_macro_identifier,
-      DeclNameOptions());
-  if (!macroNameRef)
-    return makeParserError();
-
-  ParserStatus status;
+  DeclNameRef macroNameRef;
   SourceLoc leftAngleLoc, rightAngleLoc;
-  SmallVector<TypeRepr *, 8> genericArgs;
-  if (canParseAsGenericArgumentList()) {
-    auto genericArgsStatus = parseGenericArguments(
-        genericArgs, leftAngleLoc, rightAngleLoc);
-    status |= genericArgsStatus;
-    if (genericArgsStatus.isErrorOrHasCompletion())
-      diagnose(leftAngleLoc, diag::while_parsing_as_left_angle_bracket);
-  }
-
+  SmallVector<TypeRepr *, 4> genericArgs;
   ArgumentList *argList = nullptr;
-  if (Tok.isFollowingLParen()) {
-    auto result = parseArgumentList(tok::l_paren, tok::r_paren,
-                                    /*isExprBasic*/ false,
-                                    /*allowTrailingClosure*/ true);
-    status |= result;
-    if (result.hasCodeCompletion())
-      return makeParserCodeCompletionResult<MacroExpansionDecl>();
-    argList = result.getPtrOrNull();
-  } else if (Tok.is(tok::l_brace)) {
-    SmallVector<Argument, 2> trailingClosures;
-    auto closuresStatus = parseTrailingClosures(/*isExprBasic*/ false,
-                                                macroNameLoc.getSourceRange(),
-                                                trailingClosures);
-    status |= closuresStatus;
-
-    if (!trailingClosures.empty()) {
-      argList = ArgumentList::createParsed(Context, SourceLoc(),
-                                           trailingClosures, SourceLoc(),
-                                           /*trailingClosureIdx*/ 0);
-    }
-  }
+  ParserStatus status = parseFreestandingMacroExpansion(
+      poundLoc, macroNameLoc, macroNameRef, leftAngleLoc, genericArgs,
+      rightAngleLoc, argList, /*isExprBasic=*/false,
+      diag::macro_expansion_decl_expected_macro_identifier);
+  if (!macroNameRef)
+    return status;
 
   auto *med = new (Context) MacroExpansionDecl(
       CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4768,7 +4768,8 @@ static void skipAttribute(Parser &P) {
   }
 }
 
-bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
+bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
+                                bool hadAttrsOrModifiers) {
   if (Tok.is(tok::at_sign) && peekToken().is(tok::kw_rethrows)) {
     // @rethrows does not follow the general rule of @<identifier> so
     // it is needed to short circuit this else there will be an infinite
@@ -4817,13 +4818,25 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
         (Tok.is(tok::pound_endif) && !allowPoundIfAttributes))
       return true;
 
-    return isStartOfSwiftDecl(allowPoundIfAttributes);
+    return isStartOfSwiftDecl(allowPoundIfAttributes,
+                              /*hadAttrsOrModifiers=*/true);
   }
 
-  if (Tok.is(tok::pound) && peekToken().is(tok::identifier)) {
-    // Macro expansions at the top level are declarations.
-    return !isInSILMode() && SF.Kind != SourceFileKind::Interface &&
-        CurDeclContext->isModuleScopeContext() && !allowTopLevelCode();
+  if (Tok.is(tok::pound)) {
+    if (isStartOfFreestandingMacroExpansion()) {
+      if (isInSILMode() || SF.Kind == SourceFileKind::Interface)
+        return false;
+
+      // Parse '#<identifier>' after attrs/modifiers as a macro expansion decl.
+      if (hadAttrsOrModifiers)
+        return true;
+
+      // Macro expansions at the top level of non-script file are declarations.
+      return CurDeclContext->isModuleScopeContext() && !allowTopLevelCode();
+    }
+
+    // Otherwise, prefer parsing it as an expression.
+    return false;
   }
 
   // Skip a #if that contains only attributes in all branches. These will be
@@ -4831,8 +4844,14 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
   if (Tok.is(tok::pound_if) && allowPoundIfAttributes) {
     BacktrackingScope backtrack(*this);
     bool sawAnyAttributes = false;
-    return skipIfConfigOfAttributes(sawAnyAttributes) &&
-        (Tok.is(tok::eof) || (sawAnyAttributes && isStartOfSwiftDecl()));
+    if (!skipIfConfigOfAttributes(sawAnyAttributes))
+      return false;
+    if (Tok.is(tok::eof))
+      return true;
+    if (!sawAnyAttributes)
+      return false;
+    return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/true,
+                              /*hadAttrsOrModifiers=*/true);
   }
 
   // If we have a decl modifying keyword, check if the next token is a valid
@@ -4854,13 +4873,15 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
           // If we found the start of a decl while trying to skip over the
           // paren, then we have something incomplete like 'private('. Return
           // true for better recovery.
-          if (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false))
+          if (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                                 /*hadAttrsOrModifiers=*/true))
             return true;
 
           skipSingle();
         }
       }
-      return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false);
+      return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                                /*hadAttrsOrModifiers=*/true);
     }
   }
 
@@ -4887,7 +4908,8 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
     consumeToken(tok::l_paren);
     consumeToken(tok::identifier);
     consumeToken(tok::r_paren);
-    return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false);
+    return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                              /*hadAttrsOrModifiers=*/true);
   }
 
   if (Tok.isContextualKeyword("actor")) {
@@ -4899,7 +4921,8 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
     // it's an actor declaration, otherwise, it isn't.
     do {
       consumeToken();
-    } while (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false));
+    } while (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                                /*hadAttrsOrModifiers=*/true));
     return Tok.is(tok::identifier);
   }
 
@@ -4942,12 +4965,14 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
           // If we found the start of a decl while trying to skip over the
           // paren, then we have something incomplete like 'package('. Return
           // true for better recovery.
-          if (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false))
+          if (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                                 /*hadAttrsOrModifiers=*/true))
             return true;
           skipSingle();
         }
       }
-      return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false);
+      return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                                /*hadAttrsOrModifiers=*/true);
     }
   }
 
@@ -4958,7 +4983,8 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
   // Otherwise, do a recursive parse.
   Parser::BacktrackingScope Backtrack(*this);
   consumeToken(tok::identifier);
-  return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false);
+  return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                            /*hadAttrsOrModifiers=*/true);
 }
 
 bool Parser::isStartOfSILDecl() {
@@ -4984,6 +5010,19 @@ bool Parser::isStartOfSILDecl() {
 #include "swift/AST/TokenKinds.def"
   }
   llvm_unreachable("Unhandled case in switch");
+}
+
+bool Parser::isStartOfFreestandingMacroExpansion() {
+  // Check if "'#' <identifier>" without any whitespace between them.
+  if (!Tok.is(tok::pound))
+    return false;
+  if (Tok.getRange().getEnd() != peekToken().getLoc())
+    return false;
+  if (!peekToken().isAny(tok::identifier, tok::code_complete) &&
+      // allow keywords right after '#' so we can diagnose it when parsing.
+      !peekToken().isKeyword())
+    return false;
+  return true;
 }
 
 void Parser::consumeDecl(ParserPosition BeginParserPosition,
@@ -5238,9 +5277,15 @@ Parser::parseDecl(ParseDeclOptions Flags,
     // Handled below.
     break;
   case tok::pound:
-    if (Tok.isAtStartOfLine() &&
-        peekToken().is(tok::code_complete) &&
-        Tok.getLoc().getAdvancedLoc(1) == peekToken().getLoc()) {
+    if (!isStartOfFreestandingMacroExpansion()) {
+      consumeToken(tok::pound);
+      diagnose(Tok.getLoc(),
+               diag::macro_expansion_decl_expected_macro_identifier);
+      DeclResult = makeParserError();
+      break;
+    }
+
+    if (peekToken().is(tok::code_complete)) {
       consumeToken();
       if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeAfterPoundDirective();
@@ -5252,6 +5297,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
 
     // Parse as a macro expansion.
     DeclResult = parseDeclMacroExpansion(Flags, Attributes);
+    StaticLoc = SourceLoc(); // Ignore 'static' on macro expansion
     break;
 
   case tok::pound_if:
@@ -9785,10 +9831,10 @@ Parser::parseDeclMacroExpansion(ParseDeclOptions flags,
     }
   }
 
-  return makeParserResult(
-      status,
-      new (Context) MacroExpansionDecl(
-        CurDeclContext, poundLoc, macroNameRef, macroNameLoc,
-        leftAngleLoc, Context.AllocateCopy(genericArgs), rightAngleLoc,
-        argList));
+  auto *med = new (Context) MacroExpansionDecl(
+      CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
+      Context.AllocateCopy(genericArgs), rightAngleLoc, argList);
+  med->getAttrs() = attributes;
+
+  return makeParserResult(status, med);
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1841,6 +1841,12 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   }
 
   case tok::pound:
+    if (!isStartOfFreestandingMacroExpansion()) {
+      consumeToken(tok::pound);
+      diagnose(Tok.getLoc(),
+               diag::macro_expansion_expr_expected_macro_identifier);
+      return makeParserError();
+    }
     if (peekToken().is(tok::code_complete) &&
         Tok.getLoc().getAdvancedLoc(1) == peekToken().getLoc()) {
       return parseExprPoundCodeCompletion(/*ParentKind*/None);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2269,6 +2269,71 @@ DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
   return DeclNameRef({ Context, baseName, argumentLabels });
 }
 
+ParserStatus Parser::parseFreestandingMacroExpansion(
+    SourceLoc &poundLoc, DeclNameLoc &macroNameLoc, DeclNameRef &macroNameRef,
+    SourceLoc &leftAngleLoc, SmallVectorImpl<TypeRepr *> &genericArgs,
+    SourceLoc &rightAngleLoc, ArgumentList *&argList, bool isExprBasic,
+    const Diagnostic &diag) {
+  SourceLoc poundEndLoc = Tok.getRange().getEnd();
+  poundLoc = consumeToken(tok::pound);
+
+  if (Tok.isAtStartOfLine()) {
+    // Diagnose and bail out if there's no macro name on the same line.
+    diagnose(poundEndLoc, diag);
+    return makeParserError();
+  }
+
+  bool hasWhitespaceBeforeName = poundEndLoc != Tok.getLoc();
+
+  // Diagnose and parse keyword right after `#`.
+  if (Tok.isKeyword() && !hasWhitespaceBeforeName) {
+    diagnose(Tok, diag::keyword_cant_be_identifier, Tok.getText());
+    diagnose(Tok, diag::backticks_to_escape)
+        .fixItReplace(Tok.getLoc(), "`" + Tok.getText().str() + "`");
+
+    // Let 'parseDeclNameRef' to parse this as an identifier.
+    Tok.setKind(tok::identifier);
+  }
+  macroNameRef = parseDeclNameRef(macroNameLoc, diag, DeclNameOptions());
+  if (!macroNameRef)
+    return makeParserError();
+
+  // Diagnose whitespace between '#' and the macro name, and continue parsing.
+  if (hasWhitespaceBeforeName) {
+    diagnose(poundEndLoc, diag::extra_whitespace_macro_expansion_identifier)
+        .fixItRemoveChars(poundEndLoc, macroNameLoc.getStartLoc());
+  }
+
+  ParserStatus status;
+  if (canParseAsGenericArgumentList()) {
+    auto genericArgsStatus =
+        parseGenericArguments(genericArgs, leftAngleLoc, rightAngleLoc);
+    status |= genericArgsStatus;
+    if (genericArgsStatus.isErrorOrHasCompletion())
+      diagnose(leftAngleLoc, diag::while_parsing_as_left_angle_bracket);
+  }
+
+  if (Tok.isFollowingLParen()) {
+    auto result = parseArgumentList(tok::l_paren, tok::r_paren, isExprBasic,
+                                    /*allowTrailingClosure*/ true);
+    status |= result;
+    argList = result.getPtrOrNull();
+  } else if (Tok.is(tok::l_brace)) {
+    SmallVector<Argument, 2> trailingClosures;
+    auto closuresStatus = parseTrailingClosures(
+        isExprBasic, macroNameLoc.getSourceRange(), trailingClosures);
+    status |= closuresStatus;
+
+    if (!trailingClosures.empty()) {
+      argList = ArgumentList::createParsed(Context, SourceLoc(),
+                                           trailingClosures, SourceLoc(),
+                                           /*trailingClosureIdx*/ 0);
+    }
+  }
+
+  return status;
+}
+
 ///   expr-identifier:
 ///     unqualified-decl-name generic-args?
 ParserResult<Expr> Parser::parseExprIdentifier() {
@@ -3376,45 +3441,18 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
 }
 
 ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
-  SourceLoc poundLoc = consumeToken(tok::pound);
+  SourceLoc poundLoc;
   DeclNameLoc macroNameLoc;
-  DeclNameRef macroNameRef = parseDeclNameRef(
-      macroNameLoc, diag::macro_expansion_expr_expected_macro_identifier,
-      DeclNameOptions());
-  if (!macroNameRef)
-    return makeParserError();
-
-  ParserStatus status;
+  DeclNameRef macroNameRef;
   SourceLoc leftAngleLoc, rightAngleLoc;
-  SmallVector<TypeRepr *, 8> genericArgs;
-  if (canParseAsGenericArgumentList()) {
-    auto genericArgsStatus = parseGenericArguments(
-        genericArgs, leftAngleLoc, rightAngleLoc);
-    status |= genericArgsStatus;
-    if (genericArgsStatus.isErrorOrHasCompletion())
-      diagnose(leftAngleLoc, diag::while_parsing_as_left_angle_bracket);
-  }
-
+  SmallVector<TypeRepr *, 4> genericArgs;
   ArgumentList *argList = nullptr;
-  if (Tok.isFollowingLParen()) {
-    auto result = parseArgumentList(tok::l_paren, tok::r_paren, isExprBasic,
-                                /*allowTrailingClosure*/ true);
-    argList = result.getPtrOrNull();
-    status |= result;
-  } else if (Tok.is(tok::l_brace) &&
-             isValidTrailingClosure(isExprBasic, *this)) {
-    SmallVector<Argument, 2> trailingClosures;
-    auto closureStatus = parseTrailingClosures(isExprBasic,
-                                               macroNameLoc.getSourceRange(),
-                                               trailingClosures);
-    status |= closureStatus;
-
-    if (!trailingClosures.empty()) {
-      argList = ArgumentList::createParsed(Context, SourceLoc(),
-                                           trailingClosures, SourceLoc(),
-                                           /*trailingClosureIdx*/ 0);
-    }
-  }
+  ParserStatus status = parseFreestandingMacroExpansion(
+      poundLoc, macroNameLoc, macroNameRef, leftAngleLoc, genericArgs,
+      rightAngleLoc, argList, isExprBasic,
+      diag::macro_expansion_expr_expected_macro_identifier);
+  if (!macroNameRef)
+    return status;
 
   return makeParserResult(
       status,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -473,6 +473,7 @@ public:
 
 private:
   MacroWalking getMacroWalkingBehavior() const override {
+    // Expansion buffers will have their type refinement contexts built lazily.
     return MacroWalking::Arguments;
   }
 
@@ -558,7 +559,7 @@ private:
   /// Returns a new context to be introduced for the declaration, or nullptr
   /// if no new context should be introduced.
   TypeRefinementContext *getNewContextForSignatureOfDecl(Decl *D) {
-    if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D))
+    if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D) && !isa<MacroExpansionDecl>(D))
       return nullptr;
 
     // Only introduce for an AbstractStorageDecl if it is not local. We
@@ -1430,7 +1431,9 @@ public:
   Optional<ASTNode> getInnermostMatchingNode() { return InnermostMatchingNode; }
 
   MacroWalking getMacroWalkingBehavior() const override {
-    return MacroWalking::ArgumentsAndExpansion;
+    // This is SourceRange based finder. 'SM.rangeContains()' fails anyway when
+    // crossing source buffers.
+    return MacroWalking::Arguments;
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -3244,7 +3247,8 @@ public:
   bool shouldWalkIntoTapExpression() override { return false; }
 
   MacroWalking getMacroWalkingBehavior() const override {
-    return MacroWalking::ArgumentsAndExpansion;
+    // Expanded source should be type checked and diagnosed separately.
+    return MacroWalking::Arguments;
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2058,6 +2058,10 @@ public:
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *MED) {
+    // TODO: Type check attributes.
+    // Type checking arguments should reflect the attributes.
+    // e.g. '@available(macOS 999) #Future { newAPIFrom999() }'.
+
     // Assign a discriminator.
     (void)MED->getDiscriminator();
     // Decls in expansion already visited as auxiliary decls.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2058,10 +2058,6 @@ public:
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *MED) {
-    // TODO: Type check attributes.
-    // Type checking arguments should reflect the attributes.
-    // e.g. '@available(macOS 999) #Future { newAPIFrom999() }'.
-
     // Assign a discriminator.
     (void)MED->getDiscriminator();
     // Decls in expansion already visited as auxiliary decls.

--- a/test/Macros/Inputs/top_level_freestanding_other.swift
+++ b/test/Macros/Inputs/top_level_freestanding_other.swift
@@ -11,9 +11,9 @@ var globalVar2 = { #stringify(1 + 1) }()
 func deprecated() -> Int { 0 }
 
 var globalVar3 = #stringify({ deprecated() })
-// expected-note@-1 2{{in expansion of macro 'stringify' here}}
+// expected-note@-1 {{in expansion of macro 'stringify' here}}
 // expected-warning@-2{{'deprecated()' is deprecated}}
 
 var globalVar4 = #stringify({ deprecated() })
-// expected-note@-1 2{{in expansion of macro 'stringify' here}}
+// expected-note@-1 {{in expansion of macro 'stringify' here}}
 // expected-warning@-2{{'deprecated()' is deprecated}}

--- a/test/Macros/macro_attribute_expansiondecl.swift
+++ b/test/Macros/macro_attribute_expansiondecl.swift
@@ -1,0 +1,99 @@
+// REQUIRES: swift_swift_parser, OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/src
+// RUN: mkdir -p %t/plugins
+
+// RUN: split-file %s %t/src
+
+//#-- Prepare the macro dylib plugin.
+// RUN: %host-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-library -o %t/plugins/%target-library-name(MacroDefinition) \
+// RUN:   -module-name MacroDefinition \
+// RUN:   %t/src/MacroDefinition.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   -enable-experimental-feature FreestandingMacros \
+// RUN:   -parse-as-library \
+// RUN:   -dump-macro-expansions \
+// RUN:   -plugin-path %t/plugins \
+// RUN:   %t/src/test.swift
+
+
+//--- MacroDefinition.swift
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct GlobalFuncAndVarMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["func globalFunc() {}", "var globalVar: Int { 1 }"]
+  }
+}
+
+public struct MemberFuncAndVarMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["func memberFunc() {}", "var memberVar: Int { 1 }"]
+  }
+}
+
+public struct LocalFuncAndVarMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["func LocalFunc() {}", "var LocalVar: Int { 1 }"]
+  }
+}
+
+//--- test.swift
+
+@freestanding(declaration, names: named(globalFunc), named(globalVar)) macro globalDecls() = #externalMacro(module: "MacroDefinition", type: "GlobalFuncAndVarMacro")
+@freestanding(declaration, names: named(memberFunc), named(memberVar)) macro memberDecls() = #externalMacro(module: "MacroDefinition", type: "MemberFuncAndVarMacro")
+@freestanding(declaration, names: named(localFunc), named(localVar)) macro localDecls() = #externalMacro(module: "MacroDefinition", type: "LocalFuncAndVarMacro")
+
+@available(SwiftStdlib 9999, *)
+#globalDecls
+
+func testGlobal() { // expected-note {{add @available attribute to enclosing global function}}
+  globalFunc() // expected-error {{'globalFunc()' is only available in macOS 9999 or newer}} expected-note {{add 'if #available' version check}}
+  // FIXME(109376568): Global variable introduced by macro expansion not found
+  _ = globalVar // expected-error {{cannot find 'globalVar' in scope}}
+}
+
+struct S {
+  @available(SwiftStdlib 9999, *)
+  #memberDecls
+}
+func testMember(value: S) { // expected-note 2 {{add @available attribute to enclosing global function}}
+  value.memberFunc() // expected-error {{'memberFunc()' is only available in macOS 9999 or newer}} expected-note {{add 'if #available' version check}}
+  _ = value.memberVar // expected-error {{'memberVar' is only available in macOS 9999 or newer}} expected-note {{add 'if #available' version check}}
+}
+
+struct T {
+  static #memberDecls
+}
+func testStatic() {
+  T.memberFunc() // OK
+  _ = T.memberVar // OK
+}
+
+func testLocal() {
+// FIXME(109376102): Local vars with freestanding macro is not supported yet.
+#if false
+  #localDecls
+  do {
+  }
+#endif
+}

--- a/test/Macros/macro_keywordname.swift
+++ b/test/Macros/macro_keywordname.swift
@@ -1,0 +1,61 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/src
+// RUN: mkdir -p %t/plugins
+// RUN: mkdir -p %t/lib
+
+// RUN: split-file %s %t/src
+
+//#-- Prepare the macro dylib plugin.
+// RUN: %host-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-library -o %t/plugins/%target-library-name(MacroDefinition) \
+// RUN:   -module-name MacroDefinition \
+// RUN:   %t/src/MacroDefinition.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath
+
+//#-- Prepare the macro library.
+// RUN: %target-swift-frontend \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-module -o %t/lib/MacroLib.swiftmodule \
+// RUN:   -module-name MacroLib \
+// RUN:   -plugin-path %t/plugins \
+// RUN:   %t/src/MacroLib.swift
+
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   -I %t/lib \
+// RUN:   -plugin-path %t/plugins \
+// RUN:   %t/src/test.swift
+
+//--- MacroDefinition.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct OneMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    return "1"
+  }
+}
+
+
+//--- MacroLib.swift
+@freestanding(expression) public macro `public`() -> Int = #externalMacro(module: "MacroDefinition", type: "OneMacro")
+@freestanding(expression) public macro `escaped`() -> Int = #externalMacro(module: "MacroDefinition", type: "OneMacro")
+@freestanding(expression) public macro normal() -> Int = #externalMacro(module: "MacroDefinition", type: "OneMacro")
+
+//--- test.swift
+import MacroLib
+@freestanding(expression) public macro `class`() -> Int = #externalMacro(module: "MacroDefinition", type: "OneMacro")
+
+func test() {
+  let _: Int = #public() // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}}
+  let _: Int = #`public`()
+  let _: Int = #escaped()
+  let _: Int = #`class`()
+  let _: Int = #normal()
+}

--- a/test/Macros/macro_self.swift
+++ b/test/Macros/macro_self.swift
@@ -9,11 +9,11 @@ func sync() {}
 macro Self() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro")
 
 func testSelfAsFreestandingMacro() {
-  _ = #self // expected-error {{expected a macro identifier for a pound literal expression}}
+  _ = #self // expected-error {{keyword 'self' cannot be used as an identifier here}} expected-note {{use backticks to escape it}}
 }
 
 func testCapitalSelfAsFreestandingMacro() {
-  _ = #Self // expected-error {{expected a macro identifier for a pound literal expression}}
+  _ = #Self // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{use backticks to escape it}}
 }
  
 func testSelfAsAttachedMacro() {

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -30,8 +30,8 @@ public struct S {
 // expected-error@+5{{operators must have one or two arguments}}
 // expected-error@+4{{member operator '/()' must have at least one argument of type 'S'}}
 // expected-error@+3{{expected '{' in body of function declaration}}
-// expected-error@+2 2 {{consecutive declarations on a line must be separated by ';}}
-// expected-error@+1 2 {{expected a macro identifier}}
+// expected-error@+2 {{consecutive declarations on a line must be separated by ';}}
+// expected-error@+1 {{expected a macro identifier}}
 / ###line 25 "line-directive.swift"
 }
 // expected-error@+1{{#line directive was renamed to #sourceLocation}}

--- a/test/Parse/macro_decl.swift
+++ b/test/Parse/macro_decl.swift
@@ -16,6 +16,11 @@ extension String {
 
   #memberwiseInit(flavor: .chocolate, haha: true) { "abc" }
 
+  @available(macOS 999, *)
+  public #memberwiseInit()
+
+  static internal #memberwiseInit
+
   struct Foo {
     #memberwiseInit
 
@@ -25,4 +30,19 @@ extension String {
 
   // expected-error @+1 {{expected a macro identifier for a pound literal declaration}}
   #()
+}
+
+@RandomAttr #someFunc
+
+public #someFunc
+
+#someFunc
+
+func test() {
+  @discardableResult #someFunc
+
+  dynamic #someFunc
+
+  @CustomAttr
+  isolated #someFunc
 }

--- a/test/Parse/macro_decl.swift
+++ b/test/Parse/macro_decl.swift
@@ -46,3 +46,11 @@ func test() {
   @CustomAttr
   isolated #someFunc
 }
+
+public # someFunc // expected-error {{extraneous whitespace between '#' and macro name is not permitted}} {{9-10=}}
+
+struct S {
+  # someFunc // expected-error {{extraneous whitespace between '#' and macro name is not permitted}} {{4-5=}}
+  #class // expected-error {{keyword 'class' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{4-9=`class`}} 
+  # struct Inner {} // expected-error {{expected a macro identifier for a pound literal declaration}} expected-error {{consecutive declarations on a line}}
+}

--- a/test/Parse/macro_expr.swift
+++ b/test/Parse/macro_expr.swift
@@ -35,3 +35,17 @@ _ = #another {
 
 // expected-error @+1 {{expected a macro identifier for a pound literal expression}}
 _ = #()
+
+do {
+  _ = # // expected-error {{expected a macro identifier for a pound literal expression}}
+  name()
+}
+do {
+  _ = # macro() // expected-error {{extraneous whitespace between '#' and macro name is not permitted}} {{8-9=}}
+}
+do {
+  _ = #public() // expected-error {{keyword 'public' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-14=`public`}}
+}
+do {
+  _ = # public() // expected-error {{expected a macro identifier for a pound literal expression}}
+}

--- a/test/Parse/object_literals.swift
+++ b/test/Parse/object_literals.swift
@@ -4,5 +4,4 @@ let _ = #notAPound // expected-error {{no macro named 'notAPound'}}
 let _ = #notAPound(1, 2) // expected-error {{no macro named 'notAPound'}}
 let _ = #Color // expected-error {{no macro named 'Color'}}
 
-let _ = [##] // expected-error 2 {{expected a macro identifier}} {{none}}
-// expected-error @-1 {{consecutive statements on a line must be separated by ';'}}
+let _ = [##] // expected-error {{expected a macro identifier}} {{none}}

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -52,7 +52,6 @@ infix operator aa--: A // expected-error {{'aa' is considered an identifier and 
 infix operator <<$$@< // expected-error {{'$$' is considered an identifier and must not appear within an operator name}}
 infix operator !!@aa // expected-error {{'@' is not allowed in operator names}}
 infix operator #++= // expected-error {{'#' is not allowed in operator names}}
-// expected-error@-1 {{expected a macro identifier}}
 infix operator ++=# // expected-error {{'#' is not allowed in operator names}}
 infix operator -># // expected-error {{'#' is not allowed in operator names}}
 
@@ -61,7 +60,6 @@ infix operator -># // expected-error {{'#' is not allowed in operator names}}
 infix operator =#=
 // expected-error@-1 {{'#' is not allowed in operator names}}
 // expected-error@-2 {{'=' must have consistent whitespace on both sides}}
-// expected-error@-3 {{expected a macro identifier}}
 
 infix operator +++=
 infix operator *** : A

--- a/test/Parse/raw_string_errors.swift
+++ b/test/Parse/raw_string_errors.swift
@@ -12,7 +12,7 @@ let _ = #"\##("invalid")"#
 let _ = ###"""invalid"######
 // expected-error@-1{{too many '#' characters in closing delimiter}}{{26-29=}}
 // expected-error@-2{{consecutive statements on a line must be separated by ';'}}
-// expected-error@-3 3 {{expected a macro identifier}}
+// expected-error@-3{{expected a macro identifier}}
 
 let _ = ####"invalid"###
 // expected-error@-1{{unterminated string literal}}
@@ -20,7 +20,7 @@ let _ = ####"invalid"###
 let _ = ###"invalid"######
 // expected-error@-1{{too many '#' characters in closing delimiter}}{{24-27=}}
 // expected-error@-2{{consecutive statements on a line must be separated by ';'}}
-// expected-error@-3 3 {{expected a macro identifier}}
+// expected-error@-3{{expected a macro identifier}}
 
 let _ = ##"""aa
   foobar

--- a/test/StringProcessing/Frontend/disable-flag.swift
+++ b/test/StringProcessing/Frontend/disable-flag.swift
@@ -9,6 +9,6 @@ _ = /x/
 // expected-error@-2 {{cannot find 'x' in scope}}
 // expected-error@-3 {{'/' is not a postfix unary operator}}
 
-_ = #/x/# // expected-error 2 {{expected a macro identifier}}
+_ = #/x/# // expected-error {{expected a macro identifier}}
 
 func foo(_ x: Regex<Substring>) {} // expected-error {{cannot find type 'Regex' in scope}}

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -34,7 +34,10 @@ func f1(_ a: Swift.Int) -> Swift.Void { print(a) }
 import func Swift.print
 
 // rdar://14418336
-#import something_nonexistent // expected-error {{expected a macro identifier}} expected-error {{no such module 'something_nonexistent'}}
+#import something_nonexistent
+// expected-error@-1 {{keyword 'import' cannot be used as an identifier here}} expected-note@-1 {{use backticks to escape it}}
+// expected-error@-2 {{no macro named 'import'}}
+// expected-error@-3 {{consecutive statements on a line}} expected-error@-3 {{cannot find 'something_nonexistent' in scope}}
 
 // Import specific decls
 import typealias Swift.Int

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -18,6 +18,7 @@ if (SWIFT_SWIFT_PARSER)
       $<TARGET_OBJECTS:_swiftCSwiftPluginServer>
     SWIFT_DEPENDENCIES
       SwiftSyntax::SwiftSyntaxMacros
+      SwiftSyntax::SwiftSyntaxMacroExpansion
       SwiftSyntax::SwiftCompilerPluginMessageHandling
       swiftLLVMJSON
   )


### PR DESCRIPTION
Cherry-pick #65815, #65882, #65932, #65959, and #65967 into `release/5.9`
* **Explanation**: Enable attributes and modifiers on macro expansion syntax. Attributes and modifiers on the expansion syntax are syntactically copied to the expanded declarations. Also, `@available` attributes are respected in the arguments of the expansion syntax e.g. `@available(macOS 99, *) #someMacro(someAPIfromMacOS_99())`.
* **Scope**: Freestanding macro expansion parsing and expansion. And availability check inside freestanding macro expansion and expanded declarations.
* **Risk**: Mid. The changes are relatively straightforward, but this touches broad area of the compiler and swift-syntax
* **Testing**: Added regression test cases
* **Issue**: rdar://107386648
* **Reviewers**: Alex Hoppen (@ahoppen), Ben Barham (@bnbarham), Doug Gregor (@DougGregor)