### PR TITLE
MoveOnlyAddressChecker: Reintroduce debug info for variables after reassignment.

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -534,29 +534,6 @@ struct DebugVarCarryingInst : VarDeclCarryingInst {
   }
 };
 
-inline DebugVarCarryingInst DebugVarCarryingInst::getFromValue(SILValue value) {
-  if (auto *svi = dyn_cast<SingleValueInstruction>(value)) {
-    if (auto result = VarDeclCarryingInst(svi)) {
-      switch (result.getKind()) {
-      case VarDeclCarryingInst::Kind::Invalid:
-        llvm_unreachable("ShouldKind have never seen this");
-      case VarDeclCarryingInst::Kind::DebugValue:
-      case VarDeclCarryingInst::Kind::AllocStack:
-      case VarDeclCarryingInst::Kind::AllocBox:
-        return DebugVarCarryingInst(svi);
-      case VarDeclCarryingInst::Kind::GlobalAddr:
-      case VarDeclCarryingInst::Kind::RefElementAddr:
-        return DebugVarCarryingInst();
-      }
-    }
-  }
-
-  if (auto *use = getSingleDebugUse(value))
-    return DebugVarCarryingInst(use->getUser());
-
-  return DebugVarCarryingInst();
-}
-
 static_assert(sizeof(DebugVarCarryingInst) == sizeof(VarDeclCarryingInst) &&
                   alignof(DebugVarCarryingInst) == alignof(VarDeclCarryingInst),
               "Expected debug var carrying inst to have the same "

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -382,7 +382,25 @@ static bool isReinitToInitConvertibleInst(SILInstruction *memInst) {
   }
 }
 
-static void convertMemoryReinitToInitForm(SILInstruction *memInst) {
+static void insertDebugValueBefore(SILInstruction *insertPt,
+                                   DebugVarCarryingInst debugVar,
+                                   SILValue operand) {
+  if (!debugVar) {
+    return;
+  }
+  auto varInfo = debugVar.getVarInfo();
+  if (!varInfo) {
+    return;
+  }
+  SILBuilderWithScope debugInfoBuilder(insertPt);
+  debugInfoBuilder.setCurrentDebugScope(debugVar->getDebugScope());
+  debugInfoBuilder.createDebugValue(debugVar->getLoc(), operand,
+                                    *varInfo, false, true);
+}
+
+static void convertMemoryReinitToInitForm(SILInstruction *memInst,
+                                          DebugVarCarryingInst debugVar) {
+  SILValue dest;
   switch (memInst->getKind()) {
   default:
     llvm_unreachable("unsupported?!");
@@ -390,14 +408,21 @@ static void convertMemoryReinitToInitForm(SILInstruction *memInst) {
   case SILInstructionKind::CopyAddrInst: {
     auto *cai = cast<CopyAddrInst>(memInst);
     cai->setIsInitializationOfDest(IsInitialization_t::IsInitialization);
-    return;
+    dest = cai->getDest();
+    break;
   }
   case SILInstructionKind::StoreInst: {
     auto *si = cast<StoreInst>(memInst);
     si->setOwnershipQualifier(StoreOwnershipQualifier::Init);
-    return;
+    dest = si->getDest();
+    break;
   }
   }
+  
+  // Insert a new debug_value instruction after the reinitialization, so that
+  // the debugger knows that the variable is in a usable form again.
+  insertDebugValueBefore(memInst->getNextInstruction(), debugVar,
+                         stripAccessMarkers(dest));
 }
 
 static bool memInstMustConsume(Operand *memOper) {
@@ -1151,7 +1176,8 @@ struct MoveOnlyAddressCheckerPImpl {
                                 FieldSensitiveMultiDefPrunedLiveRange &liveness,
                                 FieldSensitivePrunedLivenessBoundary &boundary);
 
-  void rewriteUses(FieldSensitiveMultiDefPrunedLiveRange &liveness,
+  void rewriteUses(MarkMustCheckInst *markedValue,
+                   FieldSensitiveMultiDefPrunedLiveRange &liveness,
                    const FieldSensitivePrunedLivenessBoundary &boundary);
 
   void handleSingleBlockDestroy(SILInstruction *destroy, bool isReinit);
@@ -2210,17 +2236,9 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
     if (!debugVar) {
       return;
     }
-    auto varInfo = debugVar.getVarInfo();
-    if (!varInfo) {
-      return;
-    }
-    SILBuilderWithScope debugInfoBuilder(insertPt);
-    debugInfoBuilder.setCurrentDebugScope(debugVar->getDebugScope());
-    debugInfoBuilder.createDebugValue(
-        debugVar->getLoc(),
-        SILUndef::get(debugVar.getOperandForDebugValueClone()->getType(),
-                      insertPt->getModule()),
-        *varInfo, false, true);
+    insertDebugValueBefore(insertPt, debugVar,
+      SILUndef::get(debugVar.getOperandForDebugValueClone()->getType(),
+                    insertPt->getModule()));
   };
 
   for (auto &pair : boundary.getLastUsers()) {
@@ -2326,6 +2344,7 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
 }
 
 void MoveOnlyAddressCheckerPImpl::rewriteUses(
+    MarkMustCheckInst *markedValue,
     FieldSensitiveMultiDefPrunedLiveRange &liveness,
     const FieldSensitivePrunedLivenessBoundary &boundary) {
   LLVM_DEBUG(llvm::dbgs() << "MoveOnlyAddressChecker Rewrite Uses!\n");
@@ -2336,12 +2355,15 @@ void MoveOnlyAddressCheckerPImpl::rewriteUses(
     }
   }
 
+  auto debugVar = DebugVarCarryingInst::getFromValue(
+    stripAccessMarkers(markedValue->getOperand()));
+
   // Then convert all claimed reinits to inits.
   for (auto reinitPair : addressUseState.reinitInsts) {
     if (!isReinitToInitConvertibleInst(reinitPair.first))
       continue;
     if (!consumes.claimConsume(reinitPair.first, reinitPair.second))
-      convertMemoryReinitToInitForm(reinitPair.first);
+      convertMemoryReinitToInitForm(reinitPair.first, debugVar);
   }
 
   // Check all takes.
@@ -2524,7 +2546,7 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
   FieldSensitivePrunedLivenessBoundary boundary(liveness.getNumSubElements());
   liveness.computeBoundary(boundary);
   insertDestroysOnBoundary(markedAddress, liveness, boundary);
-  rewriteUses(liveness, boundary);
+  rewriteUses(markedAddress, liveness, boundary);
 
   return true;
 }

--- a/test/SILOptimizer/moveonly_debug_info_reinit.swift
+++ b/test/SILOptimizer/moveonly_debug_info_reinit.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -emit-sil -g %s | %FileCheck %s
+// RUN: %target-swift-frontend -DADDRESS_ONLY -emit-sil -g %s | %FileCheck %s
+
+struct Foo: ~Copyable {
+#if ADDRESS_ONLY
+    private var x: Any
+#else
+    private var x: Int
+#endif
+}
+
+@_silgen_name("use")
+func use(_: inout Foo)
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}3bar
+func bar(_ x: consuming Foo, y: consuming Foo, z: consuming Foo) {
+    // CHECK: [[X:%.*]] = alloc_stack{{.*}} $Foo, var, name "x"
+
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+    let _ = x
+
+    // CHECK: debug_value undef : $*Foo, var, name "y"
+    // CHECK: debug_value [[X]] : $*Foo, var, name "x"
+    x = y
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+    let _ = x
+
+    // CHECK: debug_value undef : $*Foo, var, name "z"
+    // CHECK: debug_value [[X]] : $*Foo, var, name "x"
+    x = z
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+}


### PR DESCRIPTION
After a value is consumed, we emit a `debug_value undef` to indicate that the variable value is no longer valid to the debugger. However, once a value is reassigned, it becomes valid again, so emit a `debug_value %original_address` to reassociate the variable with the valid memory location. rdar://109218404