### PR TITLE
Add the missing StrictConcurrency upcoming feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -108,6 +108,7 @@ UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
 UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(ExistentialAny, 335, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
+UPCOMING_FEATURE(StrictConcurrency, 337, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(VariadicGenerics, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3173,6 +3173,10 @@ static bool usesFeatureExistentialAny(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureStrictConcurrency(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureImportObjcForwardDeclarations(Decl *decl) {
   ClangNode clangNode = decl->getClangNode();
   if (!clangNode)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -909,6 +909,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   } else if (Args.hasArg(OPT_warn_concurrency)) {
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
+  } else if (Opts.hasFeature(Feature::StrictConcurrency)) {
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else {
     // Default to minimal checking in Swift 5.x.
     Opts.StrictConcurrencyLevel = StrictConcurrency::Minimal;

--- a/test/Concurrency/upcoming_feature_strictconcurrency.swift
+++ b/test/Concurrency/upcoming_feature_strictconcurrency.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature StrictConcurrency
+// REQUIRES: concurrency
+
+class C1 { } // expected-note{{class 'C1' does not conform to the 'Sendable' protocol}}
+class C2 { }
+
+@available(*, unavailable)
+extension C2: Sendable {} // expected-note{{conformance of 'C2' to 'Sendable' has been explicitly marked unavailable here}}
+
+protocol TestProtocol {
+  associatedtype Value: Sendable
+}
+
+struct Test1: TestProtocol { // expected-warning{{type 'Test1.Value' (aka 'C1') does not conform to the 'Sendable' protocol}}
+  typealias Value = C1
+}
+
+struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendable' is unavailable}}
+  // expected-note@-1{{in associated type 'Self.Value' (inferred as 'C2')}}
+  typealias Value = C2
+}


### PR DESCRIPTION
[SE-0362 § Proposals define their own feature identifier](https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md#proposals-define-their-own-feature-identifier) claims that an upcoming feature flag named `StrictConcurrency` exists and is equivalent to the `-strict-concurrency=complete` compiler flag. However, such a feature flag does not currently exist.

This is a problem for package maintainers attempting to add `Sendable` correctness to their own packages. Enabling full checking currently means either always building from the command line with `-Xswiftc -strict-concurrency=complete` setting manually specified or adding it to the `swiftSettings` for the appropriate target(s) in the package manifest. The former is easily forgotten, and the latter makes the package unusable as a dependency due to the use of "unsafe" flags. Allowing the use of `.enableUpcomingFeature("StrictConcurrency")` instead solves both issues.

As such, this PR adds the missing upcoming feature. As "unknown" upcoming feature names are silently ignored by the compiler, there are no backwards compatibility concerns.