### PR TITLE
🍒[5.9][Distributed][Test] Avoid overlapping dump-ast which cause flaky test

### DIFF
--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -typecheck -dump-ast -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j1 -parse-as-library -typecheck -dump-ast -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2>&1 | %FileCheck %s --dump-input=always
 
 // REQUIRES: concurrency
 // REQUIRES: distributed


### PR DESCRIPTION
**Description:** This test being flaky on some configurations seems to be an output truncation issue in the dump-ast.

We start dumping the file of interest:

```
          (member_ref_expr implicit t
         (source_file "SOURCE_DIR/test/Distributed/Inputs/FakeDistributedActorSystems.swift"
```

but it's truncated suddenly and followed by a full dump of FakeDistributedActorSystems.swift. This means that the test does not get the output it needs to assert on.

The test does not need to -j2 which I suspect might have been the reason here

**Risk:** Low, this only lowers parallelism of compiling in a test to avoid overlapping dump-ast output. No logic changes.
**Review by:** @rjmccall 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/65994
**Radar:** rdar://109476130