### PR TITLE
[cxx-interop] Instantiate return types before importing methods

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6416,7 +6416,9 @@ static bool hasIteratorAPIAttr(const clang::Decl *decl) {
 static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
   // Probably a class template that has not yet been specialized:
   if (!decl->getDefinition())
-    return false;
+    // If the definition is unknown, there is no way to determine if the type
+    // stores pointers. Stay on the safe side and assume that it does.
+    return true;
 
   auto checkType = [](clang::QualType t) {
     if (t->isPointerType())
@@ -6710,9 +6712,10 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return false;
         }
 
-        // Mark this as safe to help our diganostics down the road.
         if (!cxxRecordReturnType->getDefinition()) {
-          return true;
+          // This is a templated type that has not been instantiated yet. We do
+          // not know if it is safe. Assume that it isn't.
+          return false;
         }
 
         if (!cxxRecordReturnType->hasUserDeclaredCopyConstructor() &&

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -150,6 +150,17 @@ bool ClangImporter::Implementation::recordHasReferenceSemantics(
          });
 }
 
+bool ClangImporter::Implementation::instantiateClassTemplate(
+    const clang::ClassTemplateSpecializationDecl *decl) {
+  bool notInstantiated = getClangSema().InstantiateClassTemplateSpecialization(
+      decl->getLocation(),
+      const_cast<clang::ClassTemplateSpecializationDecl *>(decl),
+      clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+      /*Complain*/ false);
+  // If the template can't be instantiated, bail.
+  return !notInstantiated;
+}
+
 #ifndef NDEBUG
 static bool verifyNameMapping(MappedTypeNameKind NameMapping,
                               StringRef left, StringRef right) {
@@ -2835,13 +2846,9 @@ namespace {
       // return its definition afterwards.
       clang::Sema &clangSema = Impl.getClangSema();
       if (!decl->getDefinition()) {
-        bool notInstantiated = clangSema.InstantiateClassTemplateSpecialization(
-            decl->getLocation(),
-            const_cast<clang::ClassTemplateSpecializationDecl *>(decl),
-            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
-            /*Complain*/ false);
+        bool instantiated = Impl.instantiateClassTemplate(decl);
         // If the template can't be instantiated, bail.
-        if (notInstantiated)
+        if (!instantiated)
           return nullptr;
       }
       if (!clangSema.isCompleteType(
@@ -3512,6 +3519,27 @@ namespace {
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
+      // If the return type is a templated class, instantiate it. This must
+      // happen before we import the name of the method, as the name is affected
+      // by safety/unsafety of the return type. The safety detection logic
+      // (`IsSafeUseOfCxxDecl`) relies on the class being instantiated.
+      clang::QualType returnType = decl->getReturnType();
+      if (auto elaborated = dyn_cast<clang::ElaboratedType>(returnType))
+        returnType = elaborated->desugar();
+      if (auto templateInstType =
+              dyn_cast<clang::TemplateSpecializationType>(returnType)) {
+        if (auto templateInstDecl =
+                dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+                    templateInstType->getAsRecordDecl())) {
+          auto def = templateInstDecl->getDefinition();
+          if (!def) {
+            bool instantiated = Impl.instantiateClassTemplate(templateInstDecl);
+            if (!instantiated)
+              return nullptr;
+          }
+        }
+      }
+
       auto method = VisitFunctionDecl(decl);
       if (decl->isVirtual() && isa_and_nonnull<ValueDecl>(method)) {
         Impl.markUnavailable(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1795,6 +1795,9 @@ public:
   /// type into Swift.
   static bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
                                           ASTContext &ctx);
+
+  bool
+  instantiateClassTemplate(const clang::ClassTemplateSpecializationDecl *decl);
 };
 
 class ImportDiagnosticAdder {

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1933,6 +1933,31 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
     }
   }
 
+  if (auto methodDecl = dyn_cast<clang::CXXMethodDecl>(named)) {
+    clang::QualType returnType = methodDecl->getReturnType();
+    if (auto elaborated = dyn_cast<clang::ElaboratedType>(returnType))
+      returnType = elaborated->desugar();
+    // If the return type is a template instantiation, it is not possible to
+    // determine safety/unsafety of the method without instantiating the
+    // template. Let's add both safe and unsafe versions of the name to the
+    // lookup table.
+    if (isa<clang::TemplateSpecializationType>(returnType)) {
+      auto unsafeName = nameImporter.importName(methodDecl, currentVersion);
+      if (unsafeName) {
+        const DeclName &declName = unsafeName.getDeclName();
+        if (!declName.isSpecial()) {
+          StringRef id = declName.getBaseIdentifier().str();
+          if (id.starts_with("__") && id.ends_with("Unsafe")) {
+            StringRef safeId = id.drop_front(2).drop_back(6);
+            table.addEntry(
+                DeclBaseName(nameImporter.getContext().getIdentifier(safeId)),
+                named, unsafeName.getEffectiveContext());
+          }
+        }
+      }
+    }
+  }
+
   // Class template instantiations are imported lazily, however, the lookup
   // table must include their mangled name (__CxxTemplateInst...) to make it
   // possible to find these decls during deserialization. For any C++ typedef

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -213,4 +213,32 @@ struct HasMethodThatReturnsIteratorBox {
   IteratorBox getIteratorBox() const;
 };
 
+template <typename T>
+struct TemplatedPointerBox {
+  T *ptr;
+};
+
+struct HasMethodThatReturnsTemplatedPointerBox {
+  TemplatedPointerBox<int> getTemplatedPointerBox() const;
+};
+
+template <typename T>
+struct TemplatedBox {
+  T value;
+};
+
+struct HasMethodThatReturnsTemplatedBox {
+  TemplatedBox<int> getIntBox() const;
+  TemplatedBox<int *> getIntPtrBox() const;
+};
+
+template <typename T>
+struct __attribute__((swift_attr("import_iterator"))) TemplatedIterator {
+  T idx;
+};
+
+struct HasMethodThatReturnsTemplatedIterator {
+  TemplatedIterator<int *> getIterator() const;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_TYPE_CLASSIFICATION_H

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -35,3 +35,18 @@
 // CHECK:   func __getIteratorBoxUnsafe() -> IteratorBox
 // CHECK-SKIP-UNSAFE-NOT: func __getIteratorBoxUnsafe() -> IteratorBox
 // CHECK: }
+
+// CHECK: struct HasMethodThatReturnsTemplatedPointerBox {
+// CHECK:   func __getTemplatedPointerBoxUnsafe() -> TemplatedPointerBox<Int32>
+// CHECK-SKIP-UNSAFE-NOT: func __getTemplatedPointerBoxUnsafe() -> TemplatedPointerBox<Int32>
+// CHECK: }
+
+// CHECK: struct HasMethodThatReturnsTemplatedBox {
+// FIXME: This is unfortunate, we should be able to recognize that TemplatedBox<Int32> does not store any pointers as fields.
+// CHECK:   func __getIntBoxUnsafe() -> TemplatedBox<Int32>
+// CHECK:   func __getIntPtrBoxUnsafe()
+// CHECK: }
+
+// CHECK: struct HasMethodThatReturnsTemplatedIterator {
+// CHECK:   func __getIteratorUnsafe()
+// CHECK: }

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -42,8 +42,7 @@
 // CHECK: }
 
 // CHECK: struct HasMethodThatReturnsTemplatedBox {
-// FIXME: This is unfortunate, we should be able to recognize that TemplatedBox<Int32> does not store any pointers as fields.
-// CHECK:   func __getIntBoxUnsafe() -> TemplatedBox<Int32>
+// CHECK:   func getIntBox() -> TemplatedBox<Int32>
 // CHECK:   func __getIntPtrBoxUnsafe()
 // CHECK: }
 

--- a/test/Interop/Cxx/class/type-classification-typechecker.swift
+++ b/test/Interop/Cxx/class/type-classification-typechecker.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+
+import TypeClassification
+
+let x = HasMethodThatReturnsTemplatedBox()
+let box = x.getIntBox()
+let unsafeBox = x.__getIntBoxUnsafe() // expected-error {{value of type 'HasMethodThatReturnsTemplatedBox' has no member '__getIntBoxUnsafe'}}

--- a/test/Interop/Cxx/templates/Inputs/large-class-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/large-class-templates.h
@@ -28,17 +28,17 @@ struct ValExpr {
   using type = typename E::type;
   E expr;
   
-  ValExpr<SliceExpr<E, 1>> test1() { return {SliceExpr<E, 1>{expr}}; }
-  ValExpr<SliceExpr<E, 2>> test2() { return {SliceExpr<E, 2>{expr}}; }
-  ValExpr<SliceExpr<E, 3>> test3() { return {SliceExpr<E, 3>{expr}}; }
-  ValExpr<SliceExpr<E, 4>> test4() { return {SliceExpr<E, 4>{expr}}; }
-  ValExpr<SliceExpr<E, 5>> test5() { return {SliceExpr<E, 5>{expr}}; }
-  ValExpr<SliceExpr<E, 6>> test6() { return {SliceExpr<E, 6>{expr}}; }
-  ValExpr<SliceExpr<E, 7>> test7() { return {SliceExpr<E, 7>{expr}}; }
-  ValExpr<SliceExpr<E, 8>> test8() { return {SliceExpr<E, 8>{expr}}; }
-  ValExpr<SliceExpr<E, 9>> test9() { return {SliceExpr<E, 8>{expr}}; }
-  ValExpr<SliceExpr<E, 11>> test11() { return {SliceExpr<E, 11>{expr}}; }
-  ValExpr<SliceExpr<E, 12>> test12() { return {SliceExpr<E, 12>{expr}}; }
+  ValExpr<SliceExpr<E, 1>> test1() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 1>{expr}}; }
+  ValExpr<SliceExpr<E, 2>> test2() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 2>{expr}}; }
+  ValExpr<SliceExpr<E, 3>> test3() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 3>{expr}}; }
+  ValExpr<SliceExpr<E, 4>> test4() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 4>{expr}}; }
+  ValExpr<SliceExpr<E, 5>> test5() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 5>{expr}}; }
+  ValExpr<SliceExpr<E, 6>> test6() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 6>{expr}}; }
+  ValExpr<SliceExpr<E, 7>> test7() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 7>{expr}}; }
+  ValExpr<SliceExpr<E, 8>> test8() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 8>{expr}}; }
+  ValExpr<SliceExpr<E, 9>> test9() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 8>{expr}}; }
+  ValExpr<SliceExpr<E, 11>> test11() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 11>{expr}}; }
+  ValExpr<SliceExpr<E, 12>> test12() __attribute__((swift_attr("import_unsafe"))) { return {SliceExpr<E, 12>{expr}}; }
 };
 
 // This class template is exponentially slow to *fully* instantiate (and the


### PR DESCRIPTION
C++ methods that return types such as `std::vector<UnsafeType>` are currently treated as safe if the type was not explicitly instantiated via a using-decl or a typedef.

This happens because the type might not be instantiated when we (1) add the name to the lookup table and then (2) import the name of a method.

This change resolves both issues:
1. It is not possible to instantiate the return type during SwiftLookupTable initialization: the function might not be invoked from the Swift code that is being compiled, and in that case the return type might not be instantiatable. This is allowed in C++. To workaround this, we add both safe and unsafe method names to the lookup table. If the method is actually used from Swift, ClangImporter will later instantiate the return type and import the name considering safety/unsafety of the method.
2. Let's explicitly instantiate the return type of each method we import before importing its name.

rdar://107609381