### PR TITLE
[ObjcHeader] Fix objc header generation when pch is explicited passed

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -404,6 +404,9 @@ public:
   /// if we need to persist a PCH for later reuse.
   bool canReadPCH(StringRef PCHFilename);
 
+  /// Reads the original source file name from PCH.
+  std::string getOriginalSourceFile(StringRef PCHFilename);
+
   /// Makes a temporary replica of the ClangImporter's CompilerInstance, reads a
   /// module map into the replica and emits a PCM file for one of the modules it
   /// declares. Delegates to clang for everything except construction of the

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -616,6 +616,9 @@ public:
   /// file.
   SourceFile *getIDEInspectionFile() const;
 
+  /// Retrieve the printing path for bridging header.
+  std::string getBridgingHeaderPath() const;
+
 private:
   /// Set up the file system by loading and validating all VFS overlay YAML
   /// files. If the process of validating VFS files failed, or the overlay

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -913,6 +913,12 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   llvm_unreachable("unhandled result");
 }
 
+std::string ClangImporter::getOriginalSourceFile(StringRef PCHFilename) {
+  return clang::ASTReader::getOriginalSourceFile(
+      PCHFilename.str(), Impl.Instance->getFileManager(),
+      Impl.Instance->getPCHContainerReader(), Impl.Instance->getDiagnostics());
+}
+
 Optional<std::string>
 ClangImporter::getPCHFilename(const ClangImporterOptions &ImporterOptions,
                               StringRef SwiftPCHHash, bool &isExplicit) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -703,6 +703,26 @@ SourceFile *CompilerInstance::getIDEInspectionFile() const {
   return evaluateOrDefault(eval, IDEInspectionFileRequest{mod}, nullptr);
 }
 
+static inline bool isPCHFilenameExtension(StringRef path) {
+  return llvm::sys::path::extension(path)
+    .endswith(file_types::getExtension(file_types::TY_PCH));
+}
+
+std::string CompilerInstance::getBridgingHeaderPath() const {
+  const FrontendOptions &opts = Invocation.getFrontendOptions();
+  if (!isPCHFilenameExtension(opts.ImplicitObjCHeaderPath))
+    return opts.ImplicitObjCHeaderPath;
+
+  auto clangImporter =
+      static_cast<ClangImporter *>(getASTContext().getClangModuleLoader());
+
+  // No clang importer created. Report error?
+  if (!clangImporter)
+    return std::string();
+
+  return clangImporter->getOriginalSourceFile(opts.ImplicitObjCHeaderPath);
+}
+
 bool CompilerInstance::setUpInputs() {
   // Adds to InputSourceCodeBufferIDs, so may need to happen before the
   // per-input setup.

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -911,17 +911,14 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
 
   if ((!Context.hadError() || opts.AllowModuleWithCompilerErrors) &&
       opts.InputsAndOutputs.hasClangHeaderOutputPath()) {
-    std::string BridgingHeaderPathForPrint;
-    if (!opts.ImplicitObjCHeaderPath.empty()) {
+    std::string BridgingHeaderPathForPrint = Instance.getBridgingHeaderPath();
+    if (!BridgingHeaderPathForPrint.empty()) {
       if (opts.BridgingHeaderDirForPrint.has_value()) {
         // User specified preferred directory for including, use that dir.
         llvm::SmallString<32> Buffer(*opts.BridgingHeaderDirForPrint);
         llvm::sys::path::append(Buffer,
-          llvm::sys::path::filename(opts.ImplicitObjCHeaderPath));
+          llvm::sys::path::filename(BridgingHeaderPathForPrint));
         BridgingHeaderPathForPrint = (std::string)Buffer;
-      } else {
-        // By default, include the given bridging header path directly.
-        BridgingHeaderPathForPrint = opts.ImplicitObjCHeaderPath;
       }
     }
     hadAnyError |= printAsClangHeaderIfNeeded(

--- a/test/PrintAsObjC/Inputs/bridging_header-Bridging-Header.h
+++ b/test/PrintAsObjC/Inputs/bridging_header-Bridging-Header.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@protocol TestProto
+@property id strongProp;
+@end

--- a/test/PrintAsObjC/Inputs/custom-modules/bridging_header/bridging_header.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/bridging_header/bridging_header.h
@@ -1,0 +1,8 @@
+#import <Foundation.h>
+
+@interface ObjCClass : NSObject
+
+- (nullable id)swiftMethod;
+
+@end
+

--- a/test/PrintAsObjC/Inputs/custom-modules/module.map
+++ b/test/PrintAsObjC/Inputs/custom-modules/module.map
@@ -63,3 +63,8 @@ module objc_implementation {
   header "objc_implementation/objc_implementation.h"
   export *
 }
+
+module bridging_header {
+  header "bridging_header/bridging_header.h"
+  export *
+}

--- a/test/PrintAsObjC/bridging_header.swift
+++ b/test/PrintAsObjC/bridging_header.swift
@@ -1,0 +1,15 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-pch -o %t/bridging-header.pch %S/Inputs/bridging_header-Bridging-Header.h
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -import-objc-header %t/bridging-header.pch -import-underlying-module -o %t %s -disable-objc-attr-requires-foundation-module -emit-objc-header-path %t/bridging_header-Swift.h
+
+// RUN: %FileCheck %s --input-file %t/bridging_header-Swift.h
+
+// CHECK: bridging_header-Bridging-Header.h
+// CHECK-NOT: bridging-header.pch
+
+@objc class Test : NSObject, TestProto {
+  var strongProp: Any?
+}


### PR DESCRIPTION
When swift-frontend is explicitly passed the pch file as bridging header on command-line through `-import-objc-header`, it needs to print the original source file name if needed to the generated objc header.


<!-- What's in this pull request? -->
• Release: Swift 5.9
• Explanation: When swift-frontend is explicitly passed the pch file as bridging header on command-line through `-import-objc-header`, it needs to print the original source file name if needed to the generated objc header.
• Scope of Issue: When doing explicit module build, swift driver will explicit pass compiled PCH file to swift-frontend as bridging header. This can cause generated objc header from the swift module trying to include the compiled PCH file instead of bridging header source file.
• Origination: Explicit module build changes how bridging header pch file handling.
• Risk: Low. Only affects explicit module build. 
• Reviewed By: @artemcm @benlangmuir 

# Detailed description:

When importing bridging header, swift-frontend can take a compiled `.pch` file directly from command line option `-import-obcj-header` instead of the bridging header source file. But in the case when a objc header for the swift module needs to be generated with underlying module, the generated header needs to include bridging header by its path. Currently, the path is taken directly from the command-line option, regardless if it is header source file or a PCH file. This can result in the user trying to textual include a `pch` file and error out.

This problem exists for previous releases, but made more prominent for explicit module build as swift driver now utilize the function of passing `pch` directly. This can result in the projects that rely on generated objc header hitting the issue. The default implicit module build is not affected since it still gets the header source file.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
resolves: rdar://109411245

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
