### PR TITLE
add optimizations-on variants directly in the noncopyable tests

### DIFF
--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
+// this test takes a long time, so run this once with optimizations on.
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_bufferview.swift
+++ b/test/Interpreter/moveonly_bufferview.swift
@@ -1,14 +1,9 @@
-// TODO: re-enable the simplification passes once rdar://104875010 is fixed
-// RUN: %target-run-simple-swift(-Xllvm -sil-disable-pass=simplification) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: swift_test_mode_optimize_none
 
-// Until we get support for emitting value witnesses for deinits, do not run
-// this with optimizations.
-
-@_moveOnly
-public struct BufferView<T> {
+public struct BufferView<T>: ~Copyable {
     var ptr: UnsafeBufferPointer<T>
 
     var count: Int {

--- a/test/Interpreter/moveonly_computed_property_in_class.swift
+++ b/test/Interpreter/moveonly_computed_property_in_class.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
+
 // REQUIRES: executable_test
 @_moveOnly
 struct FileDescriptor {

--- a/test/Interpreter/moveonly_consuming_param.swift
+++ b/test/Interpreter/moveonly_consuming_param.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_discard.swift
+++ b/test/Interpreter/moveonly_discard.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
+// RUN: %target-run-simple-swift(-O -Xfrontend -enable-experimental-feature -Xfrontend MoveOnlyEnumDeinits -Xfrontend -sil-verify-all) | %FileCheck %s --implicit-check-not closing
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_escaping_capture_lifetimes.swift
+++ b/test/Interpreter/moveonly_escaping_capture_lifetimes.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only) | %FileCheck %s
+// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_escaping_definite_initialization.swift
+++ b/test/Interpreter/moveonly_escaping_definite_initialization.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/Interpreter/moveonly_field_in_class_reflection.swift
+++ b/test/Interpreter/moveonly_field_in_class_reflection.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -Xfrontend -enable-experimental-move-only)
 // REQUIRES: executable_test
 
 // Verify that iterating through the fields of an object whose class has

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck -check-prefix=SILGEN %s
 // RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature MoveOnlyEnumDeinits %s
 
 // Test that makes sure that throughout the pipeline we properly handle
 // conditional releases for trivial and non-trivial move only types.

--- a/test/SILGen/moveonly_enum_literal.swift
+++ b/test/SILGen/moveonly_enum_literal.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all %s
 
 // This test makes sure that we properly setup enums when we construct moveonly
 // enums from literals.

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -module-name moveonly_closure %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -module-name moveonly_closure -verify %s
 
+// FIXME: we should add -sil-verify-all to the below. rdar://109477976 (moveonly_escaping_closure.swift fails with -sil-verify-all)
+// RUN: %target-swift-emit-sil -O -enable-experimental-feature NoImplicitCopy -module-name moveonly_closure -verify %s
+
 @_moveOnly
 struct Empty {}
 

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/SILGen/moveonly_var.swift
+++ b/test/SILGen/moveonly_var.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
 
 //////////////////
 // Declarations //

--- a/test/SILGen/non_loadable_move_only.swift
+++ b/test/SILGen/non_loadable_move_only.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen -module-name=test -primary-file %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all %s
 
 @_moveOnly
 public struct GenericMoveOnly<T> {

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_class_inits_end_to_end.swift
+++ b/test/SILOptimizer/moveonly_class_inits_end_to_end.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -module-name moveonly_class_inits_end_to_end %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-sil -sil-verify-all > /dev/null
 
 // A test that makes sure end to end in a copyable class containing a
 // non-copyable type, in the init, we only have a single destroy_addr.
 
-@_moveOnly
-public struct MO {
+public struct MO: ~Copyable {
   var x: Int8 = 0
   deinit { print("destroyed MO") }
 }


### PR DESCRIPTION
To help cover our bases, this PR adds `-O` and `-sil-verify-all` flags to a handful of our noncopyable tests to ensure nothing is obviously wrong.