### PR TITLE
[cxx-interop] Do not always treat types with user-declared copy constructor as safe

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6626,9 +6626,7 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
     return CxxRecordSemanticsKind::Iterator;
   }
   
-  if (!cxxDecl->hasUserDeclaredCopyConstructor() &&
-      !cxxDecl->hasUserDeclaredMoveConstructor() &&
-      hasPointerInSubobjects(cxxDecl)) {
+  if (hasPointerInSubobjects(cxxDecl)) {
     return CxxRecordSemanticsKind::UnsafePointerMember;
   }
 
@@ -6715,9 +6713,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return true;
         }
 
-        if (!cxxRecordReturnType->hasUserDeclaredCopyConstructor() &&
-            !cxxRecordReturnType->hasUserDeclaredMoveConstructor() &&
-            !hasOwnedValueAttr(cxxRecordReturnType) &&
+        if (!hasOwnedValueAttr(cxxRecordReturnType) &&
             hasPointerInSubobjects(cxxRecordReturnType)) {
           return false;
         }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3724,6 +3724,8 @@ namespace {
       auto loc = Impl.importSourceLoc(decl->getLocation());
       auto dc = Impl.importDeclContextOf(
           decl, importedName.getEffectiveContext());
+      if (!dc)
+        return nullptr;
 
       SmallVector<GenericTypeParamDecl *, 4> genericParams;
       for (auto &param : *decl->getTemplateParameters()) {

--- a/test/Interop/Cxx/stdlib/Inputs/std-pair.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-pair.h
@@ -23,3 +23,17 @@ using PairStructInt = std::pair<StructInPair, int>;
 inline PairStructInt getPairStructInt(int x) {
     return { { x * 2, -x}, x };
 }
+
+struct UnsafeStruct {
+    int *ptr;
+};
+
+struct __attribute__((swift_attr("import_iterator"))) Iterator {};
+
+using PairUnsafeStructInt = std::pair<UnsafeStruct, int>;
+using PairIteratorInt = std::pair<Iterator, int>;
+
+struct HasMethodThatReturnsUnsafePair {
+    PairUnsafeStructInt getUnsafePair() const { return {}; }
+    PairIteratorInt getIteratorPair() const { return {}; }
+};

--- a/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+import StdPair
+
+let u = HasMethodThatReturnsUnsafePair()
+u.getUnsafePair() // expected-error {{value of type 'HasMethodThatReturnsUnsafePair' has no member 'getUnsafePair'}}
+u.getIteratorPair() // expected-error {{value of type 'HasMethodThatReturnsUnsafePair' has no member 'getIteratorPair'}}


### PR DESCRIPTION
`std::set` defined `insert` method with a return type `std::pair<iterator, bool>`. This type is unsafe to use in Swift. However, it is currently treated as safe, and `insert` is not renamed to `__insertUnsafe`, because `std::pair` defines a copy constructor.

Let's not treat a user-declared copy constructor as a guarantee of safety.

rdar://109529750