### PR TITLE
🍒[cxx-interop] Update help message for the driver flag

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -700,8 +700,7 @@ def enable_experimental_cxx_interop :
 def cxx_interoperability_mode :
   Joined<["-"], "cxx-interoperability-mode=">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
-  HelpText<"Enables C++ interoperability; requires compatbility version to be "
-  "specified.">;
+  HelpText<"Enables C++ interoperability; pass 'default' to enable or 'off' to disable">;
 
 def experimental_c_foreign_reference_types :
   Flag<["-"], "experimental-c-foreign-reference-types">,


### PR DESCRIPTION
**Explanation**: This makes the help message for `-cxx-interoperability-mode` flag up to date: it no longer requires passing an explicit version, as the C++ interop version is now tied to the language version.
**Scope**: Only changes the help message. No compiler functionality is affected.
**Risk**: Low, only affects the help message for a flag.


rdar://109524041
(cherry picked from commit 4e47aff5328bfbf503d7162d1683317c27ac22c1)