### PR TITLE
Correctly print swift `Int` property as `NSUInteger` when it overrides an `NSUInteger` objc property.

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -959,6 +959,9 @@ private:
 
   /// Returns true if \p clangTy is the typedef for NSUInteger.
   bool isNSUInteger(clang::QualType clangTy) {
+    if (const auto* elaboratedTy = dyn_cast<clang::ElaboratedType>(clangTy)) {
+      clangTy = elaboratedTy->desugar();
+    }
     const auto *typedefTy = dyn_cast<clang::TypedefType>(clangTy);
     if (!typedefTy)
       return false;

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -49,8 +49,6 @@
 // CHECK-NEXT: - (nullable instancetype)initWithCoder:(NSCoder * _Nonnull){{[a-zA-Z]+}} OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 
-// REQUIRES: rdar102629628
-
 import Foundation
 
 

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -15,8 +15,6 @@
 
 // REQUIRES: objc_interop
 
-// REQUIRES: rdar102629628
-
 import OverrideBase
 // No errors from Clang until we get to the FixMe class.
 // CLANG-NOT: error


### PR DESCRIPTION
Noticed odd behavior around objc generated headers, a swift property of type `Int` was being printed as `NSInteger` even though it overrides an ObjC property of type `NSUInteger` . Tracked it down to a change in clang where it looks like clang is now providing `ElaboratedType` instead of an unwrapped `TypedefType` as the `QualType` of `ObjCPropertyDecl`.

isNSUInteger tries to cast `ElaboratedType` to `TypedefType`, this fails as they are different classes and returns false. Updated `isNSUInteger` to check if `clangTy` is an `ElaboratedType` and desugar it first, before checking if `clangTy` is a `TypedefType`. 

With this change we can re-enable the two disabled tests in PrintAsObjC as they are now passing again:
 * PrintAsObjC/availability-real-sdk
 * PrintAsObjC/override