### PR TITLE
[IRGen] Cast dynamic alloca to appropriate type.

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2158,7 +2158,9 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
     HeapNonFixedOffsets offsets(IGF, layout);
     if (outType->isNoEscape()) {
       stackAddr = IGF.emitDynamicAlloca(
-          IGF.IGM.Int8Ty, layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize() , Alignment(16));
+          IGF.IGM.Int8Ty,
+          layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize(),
+          Alignment(16));
       stackAddr = stackAddr->withAddress(IGF.Builder.CreateElementBitCast(
           stackAddr->getAddress(), IGF.IGM.OpaqueTy));
       data = stackAddr->getAddress().getAddress();

--- a/validation-test/IRGen/rdar109540863.swift
+++ b/validation-test/IRGen/rdar109540863.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -disable-availability-checking -emit-ir | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// CHECK: define {{.*}}@callee
+@_silgen_name("callee")
+func callee<each T : P>(_ ts: repeat each T) async {
+  (repeat (each ts).foo())
+}
+
+// CHECK: define {{.*}}@caller
+@_silgen_name("caller")
+func caller<each T1 : P>(t1: repeat each T1) async {
+  await callee(S(), repeat each t1)
+}
+
+struct S : P {
+  func foo() {
+  }
+}
+protocol P {
+  func foo()
+}


### PR DESCRIPTION
Fix the type of the `alloca` created by `GenPack` for type metadata and witness tables by fixing its callee, `emitDynamicAlloca` to always return a `StackAddress` whose `Address`' type is the one specified by the caller.

rdar://109540863