### PR TITLE
[5.9] Fix covariant erasure for constrained existential

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -360,6 +360,8 @@ public:
   /// Determine whether the given dependent type is required to be a class.
   bool requiresClass(Type type) const;
 
+  Type getUpperBound(Type type, bool wantDependentUpperBound = false) const;
+
   /// Determine the superclass bound on the given dependent type.
   Type getSuperclassBound(Type type) const;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5579,12 +5579,7 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// variable and anything that depends on it to their non-dependent bounds.
 Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
                                          TypeVariableType *openedTypeVar,
-                                         TypePosition outermostPosition,
-                                         bool wantNonDependentBound = true);
-
-Type transformFn(Type type, Type existentialBaseType,
-                            TypePosition initialPos);
-
+                                         TypePosition outermostPosition);
 
 /// Returns true if a reference to a member on a given base type will apply
 /// its curried self parameter, assuming it has one.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5579,7 +5579,12 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// variable and anything that depends on it to their non-dependent bounds.
 Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
                                          TypeVariableType *openedTypeVar,
-                                         TypePosition outermostPosition);
+                                         TypePosition outermostPosition,
+                                         bool wantNonDependentBound = true);
+
+Type transformFn(Type type, Type existentialBaseType,
+                            TypePosition initialPos);
+
 
 /// Returns true if a reference to a member on a given base type will apply
 /// its curried self parameter, assuming it has one.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -631,23 +631,101 @@ Type GenericSignatureImpl::getNonDependentUpperBounds(Type type) const {
   bool hasExplicitAnyObject = requiresClass(type);
 
   llvm::SmallVector<Type, 2> types;
+
+  // Class Inheritence
+  // If the class contains a type parameter that cannot be reduced,
+  // try looking for a non-dependent superclass.
   if (Type superclass = getSuperclassBound(type)) {
-    // If the class contains a type parameter, try looking for a non-dependent
-    // superclass.
-    while (superclass && superclass->hasTypeParameter()) {
+    while (superclass &&
+           superclass->hasTypeParameter()) { // check if the current protocol
+                                             // has an associated type]
+      auto *boundgeneric = superclass->castTo<BoundGenericClassType>();
+
+      SmallVector<Type, 2> argTypes;
+
+      for (Type argTy : boundgeneric->getGenericArgs()) {
+        argTypes.push_back(getReducedType(argTy));
+      }
+
+      boundgeneric = BoundGenericClassType::get(
+          boundgeneric->getDecl(), boundgeneric->getParent(), argTypes);
+      if (!boundgeneric->hasDependentMember() &&
+          !boundgeneric->hasTypeParameter()) {
+        superclass = boundgeneric;
+        break;
+      }
       superclass = superclass->getSuperclass();
     }
-
     if (superclass) {
       types.push_back(superclass);
       hasExplicitAnyObject = false;
     }
   }
+  
+  // Protocol Inheritence
+  // If there is a reduced type, erase to it.
+  // Otherwise keep going until we hit a type that has unresolved components.
   for (auto *proto : getRequiredProtocols(type)) {
     if (proto->requiresClass())
       hasExplicitAnyObject = false;
+    
+    auto *baseType = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
 
-    types.push_back(proto->getDeclaredInterfaceType());
+    auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
+    if (!primaryAssocTypes.empty()) {
+      SmallVector<Type, 2> argTypes;
+
+      // Attempt to recover same-type requirements on primary associated types.
+      for (auto *assocType : primaryAssocTypes) {
+        // For each primary associated type A of P, compute the reduced type
+        // of T.[P]A.
+        auto *memberType = DependentMemberType::get(type, assocType);
+        auto reducedType = getReducedType(memberType);
+
+        // If the reduced type is at a lower depth than the root generic
+        // parameter of T, then it's constrained.
+        bool hasOuterGenericParam = false;
+        bool hasInnerGenericParam = false;
+        reducedType.visit([&](Type t) {
+          if (auto *paramTy = t->getAs<GenericTypeParamType>()) {
+            unsigned rootDepth = type->getRootGenericParam()->getDepth();
+            if (paramTy->getDepth() == rootDepth)
+              hasInnerGenericParam = true;
+            else {
+              assert(paramTy->getDepth() < rootDepth);
+              hasOuterGenericParam = true;
+            }
+          }
+        });
+
+        if (hasInnerGenericParam && hasOuterGenericParam) {
+          llvm::errs() << "Weird same-type requirements?\n";
+          llvm::errs() << "Interface type: " << type << "\n";
+          llvm::errs() << "Member type: " << memberType << "\n";
+          llvm::errs() << "Reduced member type: " << reducedType << "\n";
+          llvm::errs() << GenericSignature(this) << "\n";
+          abort();
+        }
+
+        if (!hasInnerGenericParam)
+          argTypes.push_back(reducedType);
+      }
+      // We should have either constrained all primary associated types,
+      // or none of them.
+      if (!argTypes.empty()) {
+        if (argTypes.size() != primaryAssocTypes.size()) {
+          llvm::errs() << "Not all primary associated types constrained?\n";
+          llvm::errs() << "Interface type: " << type << "\n";
+          llvm::errs() << GenericSignature(this) << "\n";
+          abort();
+        }
+
+        types.push_back(ParameterizedProtocolType::get(getASTContext(), baseType, argTypes));
+        continue;
+      }
+    }
+
+    types.push_back(baseType);
   }
 
   auto constraint = ProtocolCompositionType::get(
@@ -674,8 +752,20 @@ Type GenericSignatureImpl::getDependentUpperBounds(Type type) const {
   // FIXME: If the superclass bound is implied by one of our protocols, we
   // shouldn't add it to the constraint type.
   if (Type superclass = getSuperclassBound(type)) {
-    types.push_back(superclass);
     hasExplicitAnyObject = false;
+
+    if (auto *boundgeneric = superclass->getAs<BoundGenericClassType>()) {
+      SmallVector<Type, 2> argTypes;
+
+      for (Type argTy : boundgeneric->getGenericArgs()) {
+        argTypes.push_back(getReducedType(argTy));
+      }
+      boundgeneric = BoundGenericClassType::get(
+          boundgeneric->getDecl(), boundgeneric->getParent(), argTypes);
+      types.push_back(boundgeneric);
+    } else {
+      types.push_back(superclass);
+    }
   }
 
   for (auto proto : getRequiredProtocols(type)) {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -626,49 +626,39 @@ unsigned GenericSignatureImpl::getGenericParamOrdinal(
 }
 
 Type GenericSignatureImpl::getNonDependentUpperBounds(Type type) const {
+  return getUpperBound(type);
+}
+
+Type GenericSignatureImpl::getDependentUpperBounds(Type type) const {
+  return getUpperBound(type, /*wantDependentBound=*/true);
+}
+
+Type GenericSignatureImpl::getUpperBound(Type type,
+                                         bool wantDependentBound) const {
   assert(type->isTypeParameter());
 
   bool hasExplicitAnyObject = requiresClass(type);
 
   llvm::SmallVector<Type, 2> types;
 
-  // Class Inheritence
-  // If the class contains a type parameter that cannot be reduced,
-  // try looking for a non-dependent superclass.
   if (Type superclass = getSuperclassBound(type)) {
-    while (superclass &&
-           superclass->hasTypeParameter()) { // check if the current protocol
-                                             // has an associated type]
-      auto *boundgeneric = superclass->castTo<BoundGenericClassType>();
-
-      SmallVector<Type, 2> argTypes;
-
-      for (Type argTy : boundgeneric->getGenericArgs()) {
-        argTypes.push_back(getReducedType(argTy));
-      }
-
-      boundgeneric = BoundGenericClassType::get(
-          boundgeneric->getDecl(), boundgeneric->getParent(), argTypes);
-      if (!boundgeneric->hasDependentMember() &&
-          !boundgeneric->hasTypeParameter()) {
-        superclass = boundgeneric;
+    do {
+      superclass = getReducedType(superclass);
+      if (wantDependentBound || !superclass->hasTypeParameter()) {
         break;
       }
-      superclass = superclass->getSuperclass();
-    }
+    } while ((superclass = superclass->getSuperclass()));
+
     if (superclass) {
       types.push_back(superclass);
       hasExplicitAnyObject = false;
     }
   }
-  
-  // Protocol Inheritence
-  // If there is a reduced type, erase to it.
-  // Otherwise keep going until we hit a type that has unresolved components.
+
   for (auto *proto : getRequiredProtocols(type)) {
     if (proto->requiresClass())
       hasExplicitAnyObject = false;
-    
+
     auto *baseType = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
 
     auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
@@ -710,130 +700,26 @@ Type GenericSignatureImpl::getNonDependentUpperBounds(Type type) const {
         if (!hasInnerGenericParam)
           argTypes.push_back(reducedType);
       }
-      // We should have either constrained all primary associated types,
-      // or none of them.
-      if (!argTypes.empty()) {
-        if (argTypes.size() != primaryAssocTypes.size()) {
-          llvm::errs() << "Not all primary associated types constrained?\n";
-          llvm::errs() << "Interface type: " << type << "\n";
-          llvm::errs() << GenericSignature(this) << "\n";
-          abort();
-        }
 
+      // If we have constrained all primary associated types, create a
+      // parameterized protocol type. During code completion, we might call
+      // `getExistentialType` (which calls this method) on a generic parameter
+      // that doesn't have all parameters specified, e.g. to get a consise
+      // description of the parameter type to the following function.
+      //
+      // func foo<P: Publisher>(p: P) where P.Failure == Never
+      //
+      // In that case just add the base type in the default branch below.
+      if (argTypes.size() == primaryAssocTypes.size()) {
         types.push_back(ParameterizedProtocolType::get(getASTContext(), baseType, argTypes));
         continue;
       }
     }
-
     types.push_back(baseType);
   }
 
-  auto constraint = ProtocolCompositionType::get(
-      getASTContext(), types,
-      hasExplicitAnyObject);
-
-  if (!constraint->isConstraintType()) {
-    assert(constraint->getClassOrBoundGenericClass());
-    return constraint;
-  }
-
-  return ExistentialType::get(constraint);
-}
-
-Type GenericSignatureImpl::getDependentUpperBounds(Type type) const {
-  assert(type->isTypeParameter());
-
-  llvm::SmallVector<Type, 2> types;
-
-  auto &ctx = type->getASTContext();
-
-  bool hasExplicitAnyObject = requiresClass(type);
-
-  // FIXME: If the superclass bound is implied by one of our protocols, we
-  // shouldn't add it to the constraint type.
-  if (Type superclass = getSuperclassBound(type)) {
-    hasExplicitAnyObject = false;
-
-    if (auto *boundgeneric = superclass->getAs<BoundGenericClassType>()) {
-      SmallVector<Type, 2> argTypes;
-
-      for (Type argTy : boundgeneric->getGenericArgs()) {
-        argTypes.push_back(getReducedType(argTy));
-      }
-      boundgeneric = BoundGenericClassType::get(
-          boundgeneric->getDecl(), boundgeneric->getParent(), argTypes);
-      types.push_back(boundgeneric);
-    } else {
-      types.push_back(superclass);
-    }
-  }
-
-  for (auto proto : getRequiredProtocols(type)) {
-    if (proto->requiresClass())
-      hasExplicitAnyObject = false;
-
-    auto *baseType = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
-
-    auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
-    if (!primaryAssocTypes.empty()) {
-      SmallVector<Type, 2> argTypes;
-
-      // Attempt to recover same-type requirements on primary associated types.
-      for (auto *assocType : primaryAssocTypes) {
-        // For each primary associated type A of P, compute the reduced type
-        // of T.[P]A.
-        auto *memberType = DependentMemberType::get(type, assocType);
-        auto reducedType = getReducedType(memberType);
-
-        // If the reduced type is at a lower depth than the root generic
-        // parameter of T, then it's constrained.
-        bool hasOuterGenericParam = false;
-        bool hasInnerGenericParam = false;
-        reducedType.visit([&](Type t) {
-          if (auto *paramTy = t->getAs<GenericTypeParamType>()) {
-            unsigned rootDepth = type->getRootGenericParam()->getDepth();
-            if (paramTy->getDepth() == rootDepth)
-              hasInnerGenericParam = true;
-            else {
-              assert(paramTy->getDepth() < rootDepth);
-              hasOuterGenericParam = true;
-            }
-          }
-        });
-
-        if (hasInnerGenericParam && hasOuterGenericParam) {
-          llvm::errs() << "Weird same-type requirements?\n";
-          llvm::errs() << "Interface type: " << type << "\n";
-          llvm::errs() << "Member type: " << memberType << "\n";
-          llvm::errs() << "Reduced member type: " << reducedType << "\n";
-          llvm::errs() << GenericSignature(this) << "\n";
-          abort();
-        }
-
-        if (!hasInnerGenericParam)
-          argTypes.push_back(reducedType);
-      }
-
-      // We should have either constrained all primary associated types,
-      // or none of them.
-      if (!argTypes.empty()) {
-        if (argTypes.size() != primaryAssocTypes.size()) {
-          llvm::errs() << "Not all primary associated types constrained?\n";
-          llvm::errs() << "Interface type: " << type << "\n";
-          llvm::errs() << GenericSignature(this) << "\n";
-          abort();
-        }
-
-        types.push_back(ParameterizedProtocolType::get(ctx, baseType, argTypes));
-        continue;
-      }
-    }
-
-    types.push_back(baseType);
-  }
-
-  auto constraint = ProtocolCompositionType::get(
-     ctx, types, hasExplicitAnyObject);
+  auto constraint = ProtocolCompositionType::get(getASTContext(), types,
+                                                 hasExplicitAnyObject);
 
   if (!constraint->isConstraintType()) {
     assert(constraint->getClassOrBoundGenericClass());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8807,6 +8807,10 @@ bool MissingExplicitExistentialCoercion::fixItRequiresParens() const {
 
 void MissingExplicitExistentialCoercion::fixIt(
     InFlightDiagnostic &diagnostic) const {
+
+  if (ErasedResultType->hasDependentMember())
+    return;
+
   bool requiresParens = fixItRequiresParens();
 
   auto callRange = getSourceRange();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8808,7 +8808,7 @@ bool MissingExplicitExistentialCoercion::fixItRequiresParens() const {
 void MissingExplicitExistentialCoercion::fixIt(
     InFlightDiagnostic &diagnostic) const {
 
-  if (ErasedResultType->hasDependentMember())
+  if (ErasedResultType->hasTypeParameter())
     return;
 
   bool requiresParens = fixItRequiresParens();

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2496,13 +2496,27 @@ bool AddExplicitExistentialCoercion::isRequired(
         if (!existentialType)
           return Action::SkipChildren;
 
+        // let's grab the dependent upper bound here instead of nondependent
         auto erasedMemberTy = typeEraseOpenedExistentialReference(
-            Type(member), *existentialType, typeVar, TypePosition::Covariant);
+            Type(member), *existentialType, typeVar, TypePosition::Covariant,
+            false);
 
         // If result is an existential type and the base has `where` clauses
         // associated with its associated types, the call needs a coercion.
         if (erasedMemberTy->isExistentialType() &&
             hasConstrainedAssociatedTypes(member, *existentialType)) {
+          RequiresCoercion = true;
+          return Action::Stop;
+        }
+
+        if (erasedMemberTy->isExistentialType() &&
+            (erasedMemberTy->hasDependentMember() ||
+             erasedMemberTy->hasTypeParameter())) {
+          RequiresCoercion = true;
+          return Action::Stop;
+        }
+
+        if (erasedMemberTy->hasTypeVariable()) {
           RequiresCoercion = true;
           return Action::Stop;
         }
@@ -2554,6 +2568,7 @@ bool AddExplicitExistentialCoercion::isRequired(
         case RequirementKind::Layout: {
           if (isAnchoredOn(req.getFirstType(), member->getAssocType()))
             return true;
+          
           break;
         }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2496,10 +2496,8 @@ bool AddExplicitExistentialCoercion::isRequired(
         if (!existentialType)
           return Action::SkipChildren;
 
-        // let's grab the dependent upper bound here instead of nondependent
         auto erasedMemberTy = typeEraseOpenedExistentialReference(
-            Type(member), *existentialType, typeVar, TypePosition::Covariant,
-            false);
+            Type(member), *existentialType, typeVar, TypePosition::Covariant);
 
         // If result is an existential type and the base has `where` clauses
         // associated with its associated types, the call needs a coercion.
@@ -2510,13 +2508,7 @@ bool AddExplicitExistentialCoercion::isRequired(
         }
 
         if (erasedMemberTy->isExistentialType() &&
-            (erasedMemberTy->hasDependentMember() ||
-             erasedMemberTy->hasTypeParameter())) {
-          RequiresCoercion = true;
-          return Action::Stop;
-        }
-
-        if (erasedMemberTy->hasTypeVariable()) {
+             erasedMemberTy->hasTypeParameter()) {
           RequiresCoercion = true;
           return Action::Stop;
         }
@@ -2568,7 +2560,6 @@ bool AddExplicitExistentialCoercion::isRequired(
         case RequirementKind::Layout: {
           if (isAnchoredOn(req.getFirstType(), member->getAssocType()))
             return true;
-          
           break;
         }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12914,6 +12914,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
       // `as` coercion.
       if (AddExplicitExistentialCoercion::isRequired(
               *this, func2->getResult(), openedExistentials, locator)) {
+
         if (!shouldAttemptFixes())
           return SolutionKind::Error;
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -6,6 +6,10 @@ protocol P {
   associatedtype A: Q
 }
 
+protocol P1<A> {
+  associatedtype A
+}
+
 extension Int: P {
   typealias A = Double
 }
@@ -228,6 +232,7 @@ func testTakeValueAndClosure(p: any P) {
 protocol B {
   associatedtype C: P where C.A == Double
   associatedtype D: P
+  associatedtype E: P1 where E.A == Double
 }
 
 protocol D {
@@ -242,6 +247,7 @@ extension B {
 
 func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   func getC<T: B>(_: T) -> T.C { fatalError() }
+  func getE<T: B>(_: T) -> T.E { fatalError() }
   func getTuple<T: B>(_: T) -> (T, T.C) { fatalError() }
   func getNoError<T: B>(_: T) -> T.C.A { fatalError() }
   func getComplex<T: B>(_: T) -> ([(x: (a: T.C, b: Int), y: Int)], [Int: T.C]) { fatalError() }
@@ -252,11 +258,14 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
 
   _ = getC(v) // expected-error {{inferred result type 'any P' requires explicit coercion due to loss of generic requirements}} {{14-14=as any P}}
   _ = getC(v) as any P // Ok
-
+  
+  _ = getE(v) // expected-error {{inferred result type 'any P1<Double>' requires explicit coercion due to loss of generic requirements}} {{14-14=as any P1<Double>}}
+  _ = getE(v) as any P1<Double> // Ok
+  
   _ = getTuple(v) // expected-error {{inferred result type '(any B, any P)' requires explicit coercion due to loss of generic requirements}} {{18-18=as (any B, any P)}}
   _ = getTuple(v) as (any B, any P) // Ok
   // Ok because T.C.A == Double
-  _ = getNoError(v) // expected-error {{inferred result type '(any B).C.A' requires explicit coercion due to loss of generic requirements}}
+  _ = getNoError(v)
 
   _ = getComplex(v) // expected-error {{inferred result type '([(x: (a: any P, b: Int), y: Int)], [Int : any P])' requires explicit coercion due to loss of generic requirements}} {{20-20=as ([(x: (a: any P, b: Int), y: Int)], [Int : any P])}}
   _ = getComplex(v) as ([(x: (a: any P, b: Int), y: Int)], [Int : any P]) // Ok
@@ -306,39 +315,45 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   getP((v.getC() as any P))  // Ok - parens avoid opening suppression
 }
 
-// Generic Class Types
 class C1 {}
 class C2<T>: C1 {}
 
 // Test Associated Types
-protocol P1 {
+protocol P2 {
   associatedtype A
   associatedtype B: C2<A>
 
   func returnAssocTypeB() -> B
 }
 
-func testAssocReturn(p: any P1) { // should return C1
-  let _ = p.returnAssocTypeB() // expected-error {{inferred result type 'C1' requires explicit coercion due to loss of generic requirements}} {{29-29=as C1}}
+func testAssocReturn(p: any P2) {
+  let _ = p.returnAssocTypeB()  // returns C1
+}
+
+protocol Q2 : P2 where A == Int {}
+
+do {
+  let q: any Q2
+  let _ = q.returnAssocTypeB() // returns C1
 }
 
 // Test Primary Associated Types
-protocol P2<A> {
+protocol P3<A> {
   associatedtype A
   associatedtype B: C2<A>
 
   func returnAssocTypeB() -> B
 }
 
-func testAssocReturn(p: any P2<Int>) { // should return C2<A>
+func testAssocReturn(p: any P3<Int>) {
+  let _ = p.returnAssocTypeB() // returns C2<A>
+}
+
+func testAssocReturn(p: any P3<any P3<String>>) {
   let _ = p.returnAssocTypeB()
 }
 
-func testAssocReturn(p: any P2<any P2<String>>) {
-  let _ = p.returnAssocTypeB()
-}
-
-protocol P3<A> {
+protocol P4<A> {
   associatedtype A
   associatedtype B: C2<A>
 
@@ -346,11 +361,11 @@ protocol P3<A> {
   func returnAssocTypeCollection() -> any Collection<A>
 }
 
-// Confirm there is no way to access Primary Associated Type
-func testPrimaryAssocReturn(p: any P3<Int>) {
-  let _ = p.returnPrimaryAssocTypeA() //expected-error {{inferred result type '(any P3<Int>).A' requires explicit coercion due to loss of generic requirements}}
+ //Confirm there is no way to access Primary Associated Type directly
+func testPrimaryAssocReturn(p: any P4<Int>) {
+  let _ = p.returnPrimaryAssocTypeA()
 }
 
-func testPrimaryAssocCollection(p: any P3<Float>) {
+func testPrimaryAssocCollection(p: any P4<Float>) {
   let _: any Collection<Float> = p.returnAssocTypeCollection()
 }

--- a/test/SILGen/existential_member_accesses_self_assoctype.swift
+++ b/test/SILGen/existential_member_accesses_self_assoctype.swift
@@ -745,8 +745,49 @@ func testContravariantAssocMethod1Concrete(p3: any P3) {
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P3) Self, #P3.invariantAssocMethod1 : <Self where Self : P3> (Self) -> () -> GenericStruct<Self.A>
 // CHECK: [[RESULT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P3) Self>([[OPENED]]) : $@convention(witness_method: P3) <τ_0_0 where τ_0_0 : P3> (@in_guaranteed τ_0_0) -> GenericStruct<Bool>
 // CHECK: debug_value [[RESULT]] : $GenericStruct<Bool>, let, name "x"
+// CHECK: } // end sil function '$s42existential_member_accesses_self_assoctype33testInvariantAssocMethod1Concrete2p3yAA2P3_p_tF'
 func testInvariantAssocMethod1Concrete(p3: any P3) {
   let x = p3.invariantAssocMethod1()
+}
+
+// --------------------------------------------------------------------------------------------------------
+//  Covariant dependent member type erasure in concrete dependent member type as primary associated type
+// --------------------------------------------------------------------------------------------------------
+
+class C {}
+class GenericClass<T> {}
+class GenericSubClass<T> : C {}
+
+protocol P5<A>{
+  associatedtype A
+  associatedtype B : GenericClass<A>
+  associatedtype C : GenericSubClass<A>
+  
+  func returnAssocTypeB() -> B
+  
+  func returnAssocTypeC() -> C
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype30testCovariantAssocGenericClass2p5AA0iJ0CySiGAA2P5_pSi1AAaGPRts_XP_tF
+// CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P5<Int> to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P5<Int>) Self
+// CHECK: [[APPLY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P5<Int>) Self>([[OPENED]]) : $@convention(witness_method: P5) <τ_0_0 where τ_0_0 : P5> (@in_guaranteed τ_0_0) -> @owned τ_0_0.B
+// CHECK: [[UPCAST:%[0-9]+]] = upcast [[APPLY]] : $@opened([[OPENED_ID]], any P5<Int>) Self.B to $GenericClass<Int>
+// CHECK: return %{{[0-9]+}} : $GenericClass<Int>
+// CHECK: } // end sil function '$s42existential_member_accesses_self_assoctype30testCovariantAssocGenericClass2p5AA0iJ0CySiGAA2P5_pSi1AAaGPRts_XP_tF'
+func testCovariantAssocGenericClass(p5: any P5<Int>) -> GenericClass<Int> {
+  let x = p5.returnAssocTypeB()
+  return x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype33testCovariantAssocGenericSubClass2p5AA0ijK0CySbGAA2P5_pSb1AAaGPRts_XP_tF
+// CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P5<Bool> to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P5<Bool>) Self
+// CHECK: apply %3<@opened([[OPENED_ID]], any P5<Bool>) Self>([[OPENED]]) : $@convention(witness_method: P5) <τ_0_0 where τ_0_0 : P5> (@in_guaranteed τ_0_0) -> @owned τ_0_0.C
+// CHECK: [[UPCAST:%[0-9]+]] = upcast [[APPLY:%[0-9]+]] : $@opened([[OPENED_ID]], any P5<Bool>) Self.C to $GenericSubClass<Bool>
+// CHECK: return %{{[0-9]+}} : $GenericSubClass<Bool>
+// CHECK: } // end sil function '$s42existential_member_accesses_self_assoctype33testCovariantAssocGenericSubClass2p5AA0ijK0CySbGAA2P5_pSb1AAaGPRts_XP_tF'
+func testCovariantAssocGenericSubClass(p5: any P5<Bool>) -> GenericSubClass<Bool> {
+  let y = p5.returnAssocTypeC()
+  return y
 }
 
 // -----------------------------------------------------------------------------

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -637,6 +637,7 @@ do {
   let exist: any InvalidTypeParameters
 
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
+  // expected-error@-1 {{inferred result type '(any InvalidTypeParameters).A.A' requires explicit coercion due to loss of generic requirements}}
   exist.method2(false) // expected-error {{instance method 'method2' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method3(false, false) // expected-error {{instance method 'method3' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   // expected-error@-1 {{member 'method3' cannot be used on value of type 'any InvalidTypeParameters'; consider using a generic constraint instead}}
@@ -794,14 +795,14 @@ do {
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
-    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4
+    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4 // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
     ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.property4
 
     let _: any Class<Struct<Bool>.Inner> & ConcreteAssocTypes =
-      arg[
+      arg[ // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}
         subscript4: Struct<Bool>(), (any ConcreteAssocTypes).self, { true }
       ]
   }
@@ -918,12 +919,26 @@ do {
   let _: Class2Base = exist.method5()
   let _: any Class2Base & CovariantAssocTypeErasure = exist.method6()
   let _: any Class2Base & CovariantAssocTypeErasure = exist.method7()
-
   let _: Any? = exist.method8()
   let _: (AnyObject, Bool) = exist.method9()
   let _: any CovariantAssocTypeErasure.Type = exist.method10()
   let _: Array<Class2Base> = exist.method11()
   let _: Dictionary<String, Class2Base> = exist.method12()
+
+  let _ = exist.method1()
+  let _ = exist.method2()
+  let _ = exist.method3()
+  let _ = exist.method4()
+  let _ = exist.method5() // expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}{{24-24=as Class2Base}}
+  let _ = exist.method6()
+  let _ = exist.method7() // expected-error {{inferred result type 'any Class2Base & CovariantAssocTypeErasure' requires explicit coercion due to loss of generic requirements}}{{24-24=as any Class2Base & CovariantAssocTypeErasure}}
+  let _ = exist.method8()
+  let _ = exist.method9()
+  let _ = exist.method10()
+  let _ = exist.method11()
+  let _ = exist.method12() // expected-error {{inferred result type 'Dictionary<String, Class2Base>' requires explicit coercion due to loss of generic requirements}}{{25-25=as Dictionary<String, Class2Base>}}
+  
+
 }
 do {
   let exist: any CovariantAssocTypeErasureDerived

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -637,7 +637,6 @@ do {
   let exist: any InvalidTypeParameters
 
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
-  // expected-error@-1 {{inferred result type '(any InvalidTypeParameters).A.A' requires explicit coercion due to loss of generic requirements}}
   exist.method2(false) // expected-error {{instance method 'method2' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method3(false, false) // expected-error {{instance method 'method3' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   // expected-error@-1 {{member 'method3' cannot be used on value of type 'any InvalidTypeParameters'; consider using a generic constraint instead}}
@@ -795,14 +794,14 @@ do {
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
-    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4 // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}
+    ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.method4
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool
     ) -> any Class<Struct<Bool>.Inner> & ConcreteAssocTypes = arg.property4
 
     let _: any Class<Struct<Bool>.Inner> & ConcreteAssocTypes =
-      arg[ // expected-error {{inferred result type 'any Class<Struct<(any ConcreteAssocTypes).A7>.Inner> & ConcreteAssocTypes' requires explicit coercion due to loss of generic requirements}}
+      arg[
         subscript4: Struct<Bool>(), (any ConcreteAssocTypes).self, { true }
       ]
   }
@@ -929,16 +928,14 @@ do {
   let _ = exist.method2()
   let _ = exist.method3()
   let _ = exist.method4()
-  let _ = exist.method5() // expected-error {{inferred result type 'Class2Base' requires explicit coercion due to loss of generic requirements}}{{24-24=as Class2Base}}
+  let _ = exist.method5()
   let _ = exist.method6()
-  let _ = exist.method7() // expected-error {{inferred result type 'any Class2Base & CovariantAssocTypeErasure' requires explicit coercion due to loss of generic requirements}}{{24-24=as any Class2Base & CovariantAssocTypeErasure}}
+  let _ = exist.method7()
   let _ = exist.method8()
   let _ = exist.method9()
   let _ = exist.method10()
   let _ = exist.method11()
-  let _ = exist.method12() // expected-error {{inferred result type 'Dictionary<String, Class2Base>' requires explicit coercion due to loss of generic requirements}}{{25-25=as Dictionary<String, Class2Base>}}
-  
-
+  let _ = exist.method12()
 }
 do {
   let exist: any CovariantAssocTypeErasureDerived

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -91,3 +91,15 @@ func protocolCompositionNotSupported1(_: SomeProto & Sequence<Int>) {}
 
 func protocolCompositionNotSupported2(_: any SomeProto & Sequence<Int>) {}
 // expected-error@-1 {{non-protocol, non-class type 'Sequence<Int>' cannot be used within a protocol-constrained type}}
+
+func increment(_ n : any Collection<Float>) {
+  for value in n {
+      _ = value + 1
+  }
+}
+
+func genericIncrement<T: Numeric>(_ n : any Collection<T>) {
+  for value in n {
+    _ = value + 1
+  }
+}


### PR DESCRIPTION
* **Explanation**: Opened existentials should be erased to the dependent upper bound
if the dependent member can be reduced to a concrete type. This
allows the generic signature to support parameterized protocol types
and bound generic class types by producing a more specific constraint. 
* **Scope**: Narrow; effects existential parameterized protocol types
* **Risk**: Low, this adds support for opening existentials with parameterized protocol type
* **Reviewers**: @xedin 
* **Issue**: rdar://101343646 
* **Original pull request**: https://github.com/apple/swift/pull/65785