### PR TITLE
[Distributed] Report error rather than crash no ad-hoc requirements are implemented

### DIFF
--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -51,6 +51,15 @@ bool DerivedConformance::canDeriveDistributedActor(
 bool DerivedConformance::canDeriveDistributedActorSystem(
     NominalTypeDecl *nominal, DeclContext *dc) {
   auto &C = nominal->getASTContext();
+
+  // Make sure ad-hoc requirements that we'll use in synthesis are present, before we try to use them.
+  // This leads to better error reporting because we already have errors happening (missing witnesses).
+  if (auto handlerType = getDistributedActorSystemResultHandlerType(nominal)) {
+    if (!C.getOnReturnOnDistributedTargetInvocationResultHandler(
+        handlerType->getAnyNominal()))
+      return false;
+  }
+
   return C.getLoadedModule(C.Id_Distributed);
 }
 

--- a/test/Distributed/distributed_imcomplete_system_dont_crash.swift
+++ b/test/Distributed/distributed_imcomplete_system_dont_crash.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+public final class CompletelyHollowActorSystem: DistributedActorSystem {
+  // expected-error@-1{{type 'CompletelyHollowActorSystem' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-error@-3{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-error@-5{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCallVoid'}}
+
+  public typealias ActorID = String
+  public typealias InvocationEncoder = Encoder
+  // expected-note@-1{{possibly intended match 'CompletelyHollowActorSystem.InvocationEncoder' (aka 'CompletelyHollowActorSystem.Encoder') does not conform to 'DistributedTargetInvocationEncoder'}}
+  public typealias InvocationDecoder = Decoder
+  // expected-note@-1{{possibly intended match 'CompletelyHollowActorSystem.InvocationDecoder' (aka 'CompletelyHollowActorSystem.Decoder') does not conform to 'DistributedTargetInvocationDecoder'}}
+
+  public typealias SerializationRequirement = Codable
+
+  public func actorReady<Act>(_ actor: Act) where Act : DistributedActor, ActorID == Act.ID {
+
+  }
+
+  public struct Encoder: InvocationEncoder {
+
+  }
+
+  public struct Decoder: InvocationDecoder {
+
+  }
+
+  public struct ResultHandler: DistributedTargetInvocationResultHandler {
+    // expected-error@-1{{type 'CompletelyHollowActorSystem.ResultHandler' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
+  }
+
+}


### PR DESCRIPTION
Ok this specific crash is because of a cascade of errors kind of... We don't get to emit errors about the NESTED type ResultHandler because the outer ActorSystem type already has errors. By not erroring about it, we attempt to synthesize bodies using it and fail on assertions looking for missing methods.

