### PR TITLE
ReadOnlyGlobalVariables: don't convert external global vars to lets

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/ReadOnlyGlobalVariables.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/ReadOnlyGlobalVariables.swift
@@ -35,7 +35,8 @@ let readOnlyGlobalVariablesPass = ModulePass(name: "read-only-global-variables")
   }
 
   for g in moduleContext.globalVariables {
-    if !g.isPossiblyUsedExternally,
+    if !g.isAvailableExternally,
+       !g.isPossiblyUsedExternally,
        !g.isLet,
        !writtenGlobals.contains(g) {
       g.setIsLet(to: true, moduleContext)

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -35,6 +35,14 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
     return bridged.isPossiblyUsedExternally()
   }
 
+  /// True, if the linkage of the global indicates that it has a definition outside the
+  /// current compilation unit.
+  ///
+  /// For example, `public_external` linkage.
+  public var isAvailableExternally: Bool {
+    return bridged.isAvailableExternally()
+  }
+
   public var staticInitValue: SingleValueInstruction? {
     bridged.getStaticInitializerValue().instruction as? SingleValueInstruction
   }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -341,6 +341,10 @@ struct BridgedGlobalVar {
     return getGlobal()->isPossiblyUsedExternally();
   }
 
+  bool isAvailableExternally() const {
+    return swift::isAvailableExternally(getGlobal()->getLinkage());
+  }
+
   SWIFT_IMPORT_UNSAFE
   inline OptionalBridgedInstruction getStaticInitializerValue() const;
 

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -12,18 +12,16 @@
 import Module
 import ModuleTBD
 
-// CHECK-LABEL: sil_global public_external [let] @$s6Module0A6StructV22privateFunctionPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int{{$}}
+// CHECK-LABEL: sil_global public_external @$s6Module0A6StructV22privateFunctionPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int{{$}}
 
 public func callPublicFunctionPointer(_ x: Int) -> Int {
   return Module.ModuleStruct.publicFunctionPointer(x)
 }
 
 // CHECK-LABEL: sil @$s4Main25callPublicFunctionPointeryS2iF :
-// CHECK-NOT:     global_addr
-// CHECK-NOT:     apply
-// CHECK:         builtin "sadd
-// CHECK-NOT:     global_addr
-// CHECK-NOT:     apply
+// CHECK:         global_addr
+// CHECK:         load
+// CHECK:         apply
 // CHECK:       } // end sil function '$s4Main25callPublicFunctionPointeryS2iF'
 public func callPrivateFunctionPointer(_ x: Int) -> Int {
   return Module.ModuleStruct.privateFunctionPointer(x)

--- a/test/SILOptimizer/read_only_global_vars.sil
+++ b/test/SILOptimizer/read_only_global_vars.sil
@@ -23,6 +23,12 @@ sil_global @public_var : $Int32 = {
   %initval = struct $Int32 (%0 : $Builtin.Int32)
 }
 
+// CHECK-LABEL: sil_global public_external @external_var : $Int32 = {
+sil_global public_external @external_var : $Int32 = {
+  %0 = integer_literal $Builtin.Int32, 27
+  %initval = struct $Int32 (%0 : $Builtin.Int32)
+}
+
 sil @unknown_read_func : $@convention(thin) (@in Int32) -> ()
 
 sil @read_var : $@convention(thin) (@inout Int32) -> Int32 {


### PR DESCRIPTION
Because we don't know if external variables will be written

Fixes a miscompile
rdar://109476745
