### PR TITLE
🍒[5.9][Distributed] Report error rather than crash no ad-hoc requirements are implemented

### DIFF
--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -51,6 +51,15 @@ bool DerivedConformance::canDeriveDistributedActor(
 bool DerivedConformance::canDeriveDistributedActorSystem(
     NominalTypeDecl *nominal, DeclContext *dc) {
   auto &C = nominal->getASTContext();
+
+  // Make sure ad-hoc requirements that we'll use in synthesis are present, before we try to use them.
+  // This leads to better error reporting because we already have errors happening (missing witnesses).
+  if (auto handlerType = getDistributedActorSystemResultHandlerType(nominal)) {
+    if (!C.getOnReturnOnDistributedTargetInvocationResultHandler(
+        handlerType->getAnyNominal()))
+      return false;
+  }
+
   return C.getLoadedModule(C.Id_Distributed);
 }
 

--- a/test/Distributed/distributed_imcomplete_system_dont_crash.swift
+++ b/test/Distributed/distributed_imcomplete_system_dont_crash.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+public final class CompletelyHollowActorSystem: DistributedActorSystem {
+  // expected-error@-1{{type 'CompletelyHollowActorSystem' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-error@-3{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-4{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-error@-5{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCallVoid'}}
+
+  public typealias ActorID = String
+  public typealias InvocationEncoder = Encoder
+  // expected-note@-1{{possibly intended match 'CompletelyHollowActorSystem.InvocationEncoder' (aka 'CompletelyHollowActorSystem.Encoder') does not conform to 'DistributedTargetInvocationEncoder'}}
+  public typealias InvocationDecoder = Decoder
+  // expected-note@-1{{possibly intended match 'CompletelyHollowActorSystem.InvocationDecoder' (aka 'CompletelyHollowActorSystem.Decoder') does not conform to 'DistributedTargetInvocationDecoder'}}
+
+  public typealias SerializationRequirement = Codable
+
+  public func actorReady<Act>(_ actor: Act) where Act : DistributedActor, ActorID == Act.ID {
+
+  }
+
+  public struct Encoder: InvocationEncoder {
+
+  }
+
+  public struct Decoder: InvocationDecoder {
+
+  }
+
+  public struct ResultHandler: DistributedTargetInvocationResultHandler {
+    // expected-error@-1{{type 'CompletelyHollowActorSystem.ResultHandler' does not conform to protocol 'DistributedTargetInvocationResultHandler'}}
+  }
+
+}


### PR DESCRIPTION
**Description:** A "very empty" implementation of a distributed actor system, which is missing all implementations of requirements fails to produce diagnostics but instead crashes on an assertion.

This is because we emit errors on the system, and don't proceed to visit nested types. By doing so, we didn't avoid synthesizing code which requires those not present ad-hoc requirements. Instead of emitting a diagnostic in the nested type we attempt to synthesize and hit assertions along the way. The solution is to check if we're able to synthesize or not more correctly.

**Risk:** Low, only prevents synthesis in a case where it would have crashed while doing synthesis before.
**Review by:** @DougGregor
**Testing:** CI testing
**Original PR:**  https://github.com/apple/swift/pull/66020
**Radar:** rdar://108995388