### PR TITLE
[5.9] MoveOnlyAddressChecker: Reintroduce debug info for variables after reassignment

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -534,29 +534,6 @@ struct DebugVarCarryingInst : VarDeclCarryingInst {
   }
 };
 
-inline DebugVarCarryingInst DebugVarCarryingInst::getFromValue(SILValue value) {
-  if (auto *svi = dyn_cast<SingleValueInstruction>(value)) {
-    if (auto result = VarDeclCarryingInst(svi)) {
-      switch (result.getKind()) {
-      case VarDeclCarryingInst::Kind::Invalid:
-        llvm_unreachable("ShouldKind have never seen this");
-      case VarDeclCarryingInst::Kind::DebugValue:
-      case VarDeclCarryingInst::Kind::AllocStack:
-      case VarDeclCarryingInst::Kind::AllocBox:
-        return DebugVarCarryingInst(svi);
-      case VarDeclCarryingInst::Kind::GlobalAddr:
-      case VarDeclCarryingInst::Kind::RefElementAddr:
-        return DebugVarCarryingInst();
-      }
-    }
-  }
-
-  if (auto *use = getSingleDebugUse(value))
-    return DebugVarCarryingInst(use->getUser());
-
-  return DebugVarCarryingInst();
-}
-
 static_assert(sizeof(DebugVarCarryingInst) == sizeof(VarDeclCarryingInst) &&
                   alignof(DebugVarCarryingInst) == alignof(VarDeclCarryingInst),
               "Expected debug var carrying inst to have the same "

--- a/test/SILOptimizer/moveonly_debug_info_reinit.swift
+++ b/test/SILOptimizer/moveonly_debug_info_reinit.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -emit-sil -g %s | %FileCheck %s
+// RUN: %target-swift-frontend -DADDRESS_ONLY -emit-sil -g %s | %FileCheck %s
+
+struct Foo: ~Copyable {
+#if ADDRESS_ONLY
+    private var x: Any
+#else
+    private var x: Int
+#endif
+}
+
+@_silgen_name("use")
+func use(_: inout Foo)
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}3bar
+func bar(_ x: consuming Foo, y: consuming Foo, z: consuming Foo) {
+    // CHECK: [[X:%.*]] = alloc_stack{{.*}} $Foo, var, name "x"
+
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+    let _ = x
+
+    // CHECK: debug_value undef : $*Foo, var, name "y"
+    // CHECK: debug_value [[X]] : $*Foo, var, name "x"
+    x = y
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+    let _ = x
+
+    // CHECK: debug_value undef : $*Foo, var, name "z"
+    // CHECK: debug_value [[X]] : $*Foo, var, name "x"
+    x = z
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+}


### PR DESCRIPTION
Issue: rdar://109218404
• Explanation: When a noncopyable binding's value is consumed, we mark the variable as absent in debug info so that the debugger does not attempt to show the expired value. This patch reintroduces the variable in cases where it's reassigned and becomes valid again.
• Scope of Issue: Improves debug info.
• Origination: Quality of implementation of debug info for the new noncopyable types feature.
• Risk: low -- improves debug info for a new feature. Should have no impact on existing code that doesn't adopt the noncopyable types feature.
• Reviewed By: @gottesmm 
• Automated Testing: Swift CI
