### PR TITLE
[5.9][Macros/Test] Plugin search order test is 'executable_test'

### DIFF
--- a/test/Macros/macro_plugin_searchorder.swift
+++ b/test/Macros/macro_plugin_searchorder.swift
@@ -1,5 +1,5 @@
 
-// REQUIRES: swift_swift_parser
+// REQUIRES: swift_swift_parser, executable_test
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
Cherry-pick #66024 into `release/5.9`

* **Explanation**: Fix test failure in non-`executable_test` environments. Since this test case requires `executable_test`, add it to `REQUIRES` entry
* **Scope**: One macro test case
* **Risk**: None. Unless I mis-spelled `executable_test` 
* **Issue**: rdar://109573140
* **Reviewer**: Ben Barham (@bnbarham)