### PR TITLE
[cherry-pick][release/5.9] [Build] Make sure lldb API tests run against newly built libcxx

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -289,6 +289,8 @@ skip-test-watchos-host
 
 # This is a mixin preset which builds and smoke-tests lldb.
 [preset: lldb-smoketest,tools=RA]
+# Build libcxx for tests
+libcxx
 # Build LLDB
 lldb
 
@@ -299,6 +301,8 @@ lldb-test-swift-only
 lldb-assertions
 
 [preset: lldb-pull-request]
+# Build libcxx for tests
+libcxx
 lldb
 lit-args=-v 
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1709,7 +1709,7 @@ for host in "${ALL_HOSTS[@]}"; do
             libcxx)
                 build_targets=(cxx)
                 cmake_options=(
-                    -DLLVM_ENABLE_RUNTIMES="libcxx" -DLIBCXX_INSTALL_LIBRARY=OFF
+                    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" -DLIBCXX_INSTALL_LIBRARY=OFF
                     "${cmake_options[@]}"
                     "${llvm_cmake_options[@]}"
                 )
@@ -2126,6 +2126,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 cmark_build_dir=$(build_directory ${host} cmark)
                 lldb_build_dir=$(build_directory ${host} lldb)
                 swift_build_dir=$(build_directory ${host} swift)
+                libcxx_build_dir=$(build_directory ${host} libcxx)
 
                 # Add any lldb extra cmake arguments here.
 
@@ -2205,6 +2206,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_ENABLE_LZMA=OFF
                     -DLLDB_ENABLE_LUA=OFF
                     -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
+                    -DLLDB_TEST_LIBCXX_ROOT_DIR:STRING="${libcxx_build_dir}"
                     -DLLDB_TEST_USER_ARGS="${DOTEST_ARGS}"
                 )
 
@@ -2648,10 +2650,6 @@ for host in "${ALL_HOSTS[@]}"; do
             fi
             with_pushd "${build_dir}" \
                 call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
-        fi
-
-        if [[ "${product}" == "libcxx" ]]; then
-            continue
         fi
 
         # Build.


### PR DESCRIPTION
Currently any buildbot that runs LLDB API tests does so against the system SDK. However, we explicitly need users to run the tests against a newly built libcxx. We recently added a new `LLDB_TEST_LIBCXX_ROOT_DIR` CMake variable to LLDB to allow standalone builds to point their tests to a custom libcxx directory.

This patch makes sure the relevant LLDB presets build libcxx and then sets above CMake variable.

(cherry picked from commit 0c974e0bf00fd4dcceb3c59e653338ecb1dbee5b)
