### PR TITLE
[5.9][Runtime] Improve wording of deinit escape warning.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -819,8 +819,11 @@ void swift::swift_deallocClassInstance(HeapObject *object,
     auto descriptor = object->metadata->getTypeContextDescriptor();
 
     swift::fatalError(0,
-                      "Object %p of class %s deallocated with retain count %zd, "
-                      "reference may have escaped from deinit.\n",
+                      "Object %p of class %s deallocated with non-zero retain "
+                      "count %zd. This object's deinit, or something called "
+                      "from it, may have created a strong reference to self "
+                      "which outlived deinit, resulting in a dangling "
+                      "reference.\n",
                       object,
                       descriptor ? descriptor->Name.get() : "<unknown>",
                       retainCount);


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/65972 to `release/5.9`.

Describe in more detail how an object can end up with a non-zero refcount on deallocation, and the consequences.

rdar://109045333