### PR TITLE
Requestify ExportedSourceFile parsing

### DIFF
--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -116,6 +116,24 @@ public:
   readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
+/// Parse the ExportedSourceFile for a given SourceFile.
+class ExportedSourceFileRequest
+    : public SimpleRequest<ExportedSourceFileRequest,
+                           void *(const SourceFile *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  void *evaluate(Evaluator &evaluator, const SourceFile *SF) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 /// Parse the top-level items of a SourceFile.
 class ParseTopLevelDeclsRequest
     : public SimpleRequest<

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -28,3 +28,6 @@ SWIFT_REQUEST(Parse, ParseSourceFileRequest,
 SWIFT_REQUEST(Parse, ParseTopLevelDeclsRequest,
               ArrayRef<Decl *>(SourceFile *), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(Parse, ExportedSourceFileRequest,
+              void *(const SourceFile *), Cached,
+              NoLocationInfo)

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -91,9 +91,11 @@ public:
     /// files, as they get parsed multiple times.
     SuppressWarnings = 1 << 4,
 
-    /// Whether to disable the Swift Parser ASTGen
-    /// e.g. in dependency scanning, where an AST is not needed.
-    DisableSwiftParserASTGen = 1 << 5,
+    /// Ensure that the SwiftSyntax tree round trips correctly.
+    RoundTrip = 1 << 5,
+
+    /// Validate the new SwiftSyntax parser diagnostics.
+    ValidateNewParserDiagnostics = 1 << 6,
   };
   using ParsingOptions = OptionSet<ParsingFlags>;
 
@@ -262,6 +264,10 @@ public:
   /// code for it. Note this method returns \c false in WMO.
   bool isPrimary() const { return IsPrimary; }
 
+  /// Retrieve the \c ExportedSourceFile instance produced by ASTGen, which
+  /// includes the SourceFileSyntax node corresponding to this source file.
+  void *getExportedSourceFile() const;
+
   /// The list of local type declarations in the source file.
   llvm::SetVector<TypeDecl *> LocalTypeDecls;
 
@@ -333,10 +339,6 @@ public:
   /// Virtual file paths declared by \c #sourceLocation(file:) declarations in
   /// this source file.
   llvm::SmallVector<Located<StringRef>, 0> VirtualFilePaths;
-
-  /// The \c ExportedSourceFile instance produced by ASTGen, which includes
-  /// the SourceFileSyntax node corresponding to this source file.
-  void *exportedSourceFile = nullptr;
 
   /// Returns information about the file paths used for diagnostics and magic
   /// identifiers in this source file, including virtual filenames introduced by

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3687,6 +3687,10 @@ SourceFile::getDefaultParsingOptions(const LangOptions &langOpts) {
     opts |= ParsingFlags::DisablePoundIfEvaluation;
   if (langOpts.CollectParsedToken)
     opts |= ParsingFlags::CollectParsedTokens;
+  if (langOpts.hasFeature(Feature::ParserRoundTrip))
+    opts |= ParsingFlags::RoundTrip;
+  if (langOpts.hasFeature(Feature::ParserValidation))
+    opts |= ParsingFlags::ValidateNewParserDiagnostics;
   return opts;
 }
 
@@ -3760,6 +3764,11 @@ ArrayRef<ASTNode> SourceFile::getTopLevelItems() const {
 
 ArrayRef<Decl *> SourceFile::getHoistedDecls() const {
   return Hoisted;
+}
+
+void *SourceFile::getExportedSourceFile() const {
+  auto &eval = getASTContext().evaluator;
+  return evaluateOrDefault(eval, ExportedSourceFileRequest{this}, nullptr);
 }
 
 void SourceFile::addDeclWithRuntimeDiscoverableAttrs(ValueDecl *decl) {

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -419,11 +419,14 @@ UnifiedStatsReporter::noteCurrentProcessExitStatus(int status) {
 
 void
 UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
+  // NOTE: We do `Stat = 0` below to force LLVM to register the statistic,
+  // ensuring we print counters, even if 0.
   if (FrontendCounters) {
     auto &C = getFrontendCounters();
 #define FRONTEND_STATISTIC(TY, NAME)                            \
     do {                                                        \
       static Statistic Stat = {#TY, #NAME, #NAME};              \
+      Stat = 0;                                                 \
       Stat += (C).NAME;                                         \
     } while (0);
 #include "swift/Basic/Statistics.def"
@@ -434,6 +437,7 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
 #define DRIVER_STATISTIC(NAME)                                       \
     do {                                                             \
       static Statistic Stat = {"Driver", #NAME, #NAME};              \
+      Stat = 0;                                                      \
       Stat += (C).NAME;                                              \
     } while (0);
 #include "swift/Basic/Statistics.def"

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1115,6 +1115,8 @@ struct ParserUnit::Implementation {
         TypeCheckerOpts(TyOpts), SILOpts(silOpts), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
                              clangImporterOpts, symbolGraphOpts, SM, Diags)) {
+    registerParseRequestFunctions(Ctx.evaluator);
+
     auto parsingOpts = SourceFile::getDefaultParsingOptions(LangOpts);
     parsingOpts |= ParsingFlags::DisableDelayedBodies;
     parsingOpts |= ParsingFlags::DisablePoundIfEvaluation;

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -185,9 +185,9 @@ MacroDefinition MacroDefinitionRequest::evaluate(
   ptrdiff_t *replacements;
   ptrdiff_t numReplacements;
   auto checkResult = swift_ASTGen_checkMacroDefinition(
-      &ctx.Diags, sourceFile->exportedSourceFile, macro->getLoc().getOpaquePointerValue(),
-      &externalMacroNamePtr, &externalMacroNameLength,
-      &replacements, &numReplacements);
+      &ctx.Diags, sourceFile->getExportedSourceFile(),
+      macro->getLoc().getOpaquePointerValue(), &externalMacroNamePtr,
+      &externalMacroNameLength, &replacements, &numReplacements);
 
   // Clean up after the call.
   SWIFT_DEFER {
@@ -781,7 +781,7 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
     PrettyStackTraceExpr debugStack(ctx, "expanding macro", mee);
 
     // Builtin macros are handled via ASTGen.
-    auto astGenSourceFile = sourceFile->exportedSourceFile;
+    auto *astGenSourceFile = sourceFile->getExportedSourceFile();
     if (!astGenSourceFile)
       return None;
 
@@ -979,7 +979,7 @@ swift::expandFreestandingMacro(MacroExpansionDecl *med) {
     PrettyStackTraceDecl debugStack("expanding declaration macro", med);
 
     // Builtin macros are handled via ASTGen.
-    auto astGenSourceFile = sourceFile->exportedSourceFile;
+    auto *astGenSourceFile = sourceFile->getExportedSourceFile();
     if (!astGenSourceFile)
       return None;
 
@@ -1175,18 +1175,19 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
 #if SWIFT_SWIFT_PARSER
     PrettyStackTraceDecl debugStack("expanding attached macro", attachedTo);
 
-    auto astGenAttrSourceFile = attrSourceFile->exportedSourceFile;
+    auto *astGenAttrSourceFile = attrSourceFile->getExportedSourceFile();
     if (!astGenAttrSourceFile)
       return nullptr;
 
-    auto astGenDeclSourceFile = declSourceFile->exportedSourceFile;
+    auto *astGenDeclSourceFile = declSourceFile->getExportedSourceFile();
     if (!astGenDeclSourceFile)
       return nullptr;
 
     void *astGenParentDeclSourceFile = nullptr;
     const void *parentDeclLoc = nullptr;
     if (passParentContext) {
-      astGenParentDeclSourceFile = parentDeclSourceFile->exportedSourceFile;
+      astGenParentDeclSourceFile =
+          parentDeclSourceFile->getExportedSourceFile();
       if (!astGenParentDeclSourceFile)
         return nullptr;
 

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -167,10 +167,7 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
     unsigned bufferID = Ctx.SourceMgr.addNewSourceBuffer(std::move(interfaceBuf.get()));
     auto moduleDecl = ModuleDecl::create(realModuleName, Ctx);
 
-    // Dependency scanning does not require an AST, so disable Swift Parser
-    // ASTGen parsing completely.
     SourceFile::ParsingOptions parsingOpts;
-    parsingOpts |= SourceFile::ParsingFlags::DisableSwiftParserASTGen;
     auto sourceFile = new (Ctx) SourceFile(
         *moduleDecl, SourceFileKind::Interface, bufferID, parsingOpts);
     moduleDecl->addAuxiliaryFile(*sourceFile);

--- a/test/Macros/lazy_parsing.swift
+++ b/test/Macros/lazy_parsing.swift
@@ -1,0 +1,44 @@
+// REQUIRES: swift_swift_parser
+
+// This test ensures that we only attempt to parse the syntax tree of a
+// secondary file if the primary file needs it.
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/stats-no-lookup)
+// RUN: %empty-directory(%t/stats-lookup)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-no-lookup -primary-file %t/b.swift %t/a.swift
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -stats-output-dir %t/stats-lookup -primary-file %t/c.swift %t/a.swift
+
+// We use '<=' here instead of '==' to take account of the fact that in debug
+// builds we'll be doing round-trip checking, which will parse the syntax tree
+// for the primary.
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'ExportedSourceFileRequest <= 1' %t/stats-no-lookup
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'ExportedSourceFileRequest <= 2' %t/stats-lookup
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'ExportedSourceFileRequest == 1' %t/stats-no-lookup %t/stats-lookup
+
+//--- a.swift
+
+@attached(
+  member,
+  names: named(init), named(Storage), named(storage), named(getStorage()), named(method), named(init(other:))
+)
+macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+
+@addMembers
+struct S {}
+
+//--- b.swift
+
+// No lookup into S, so we don't need to evaluate any macros.
+func foo(_ x: S) {}
+
+//--- c.swift
+
+// A lookup into S, we need to parse the syntax tree.
+func foo(_ x: S) {
+  _ = x.getStorage()
+}

--- a/test/ScanDependencies/ensure_no_astgen.swift
+++ b/test/ScanDependencies/ensure_no_astgen.swift
@@ -1,0 +1,41 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/stats)
+// RUN: %empty-directory(%t/deps)
+// RUN: split-file %s %t
+// RUN: mv %t/Foo.swiftinterface %t/deps/
+
+// This test ensures we don't attempt to do syntax tree parsing for dependency
+// scanning.
+
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/a.swift %t/b.swift -I %t/deps -stats-output-dir %t/stats
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'ExportedSourceFileRequest == 0' %t/stats
+
+//--- Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo
+
+@attached(
+  member,
+  names: named(init), named(Storage), named(storage), named(getStorage()), named(method), named(init(other:))
+)
+public macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+
+@addMembers
+public struct S1 {}
+
+//--- a.swift
+
+import Foo
+
+@addMembers
+struct S2 {}
+
+//--- b.swift
+
+@freestanding(expression) macro myError(_ message: String) = #externalMacro(module: "MacroDefinition", type: "ErrorMacro")
+
+func foo(_ x: S) {
+  _ = x.getStorage()
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -775,7 +775,6 @@ public:
         CompInv.getTypeCheckerOptions(), CompInv.getSILOptions(),
         CompInv.getModuleName()));
 
-    registerParseRequestFunctions(Parser->getParser().Context.evaluator);
     registerTypeCheckerRequestFunctions(
         Parser->getParser().Context.evaluator);
     registerClangImporterRequestFunctions(Parser->getParser().Context.evaluator);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2007,7 +2007,6 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
         Invocation.getTypeCheckerOptions(), Invocation.getSILOptions(),
         Invocation.getModuleName());
 
-    registerParseRequestFunctions(Parser.getParser().Context.evaluator);
     registerTypeCheckerRequestFunctions(Parser.getParser().Context.evaluator);
     registerClangImporterRequestFunctions(Parser.getParser().Context.evaluator);
 
@@ -2236,7 +2235,6 @@ static int doStructureAnnotation(const CompilerInvocation &InitInvok,
                     Invocation.getTypeCheckerOptions(),
                     Invocation.getSILOptions(), Invocation.getModuleName());
 
-  registerParseRequestFunctions(Parser.getParser().Context.evaluator);
   registerTypeCheckerRequestFunctions(
       Parser.getParser().Context.evaluator);
   registerClangImporterRequestFunctions(Parser.getParser().Context.evaluator);


### PR DESCRIPTION
Avoid parsing the syntax tree up-front, and instead only parse it when required, which happens when either:

1. ASTGen parsing is enabled (currently disabled by default)
2. Round trip checking is enabled for a primary file (enabled by default in a debug build, except when dep scanning or doing an IDE operation)
3. We need to evaluate a macro in that file

This change therefore means that we now no longer need to parse the syntax tree for secondary files by default unless we specifically need to evaluate a macro in them (e.g if we need to lookup a member on a decl with an attached macro). And the same for primaries in release builds.

rdar://109283847