### PR TITLE
[ASTGen] Add experimental feature to use ASTGen in lieu of parsing types

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -282,6 +282,7 @@ void *MemberTypeRepr_create(void *ctx, void *baseComponent,
 void *GenericIdentTypeRepr_create(void *ctx, BridgedIdentifier name,
                                   void *nameLoc, BridgedArrayRef genericArgs,
                                   void *lAngle, void *rAngle);
+void *EmptyCompositionTypeRepr_create(void *ctx, void *anyLoc);
 void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types,
                                  void *firstTypeLoc);
 void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc,

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -274,6 +274,7 @@ void *MetatypeTypeRepr_create(void *ctx, void *baseType, void *typeLoc);
 void *ProtocolTypeRepr_create(void *ctx, void *baseType, void *protoLoc);
 void *AttributedTypeSpecifierRepr_create(
     void *ctx, void *base, BridgedAttributedTypeSpecifier specifier, void *specifierLoc);
+void *VarargTypeRepr_create(void *ctx, void *base, void *ellipsisLocPtr);
 void *PackExpansionTypeRepr_create(void *ctx, void *base, void *repeatLoc);
 void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                            void *rParenLoc);

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -112,6 +112,17 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : long {
   BridgedBuiltinExternalMacro
 } BridgedMacroDefinitionKind;
 
+/// Bridged parameter specifiers
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : long {
+  BridgedAttributedTypeSpecifierInOut,
+  BridgedAttributedTypeSpecifierBorrowing,
+  BridgedAttributedTypeSpecifierConsuming,
+  BridgedAttributedTypeSpecifierLegacyShared,
+  BridgedAttributedTypeSpecifierLegacyOwned,
+  BridgedAttributedTypeSpecifierConst,
+  BridgedAttributedTypeSpecifierIsolated,
+} BridgedAttributedTypeSpecifier;
+
 #ifdef __cplusplus
 extern "C" {
 
@@ -261,6 +272,8 @@ void *ImplicitlyUnwrappedOptionalTypeRepr_create(void *ctx, void *base,
                                                  void *exclamationLoc);
 void *MetatypeTypeRepr_create(void *ctx, void *baseType, void *typeLoc);
 void *ProtocolTypeRepr_create(void *ctx, void *baseType, void *protoLoc);
+void *AttributedTypeSpecifierRepr_create(
+    void *ctx, void *base, BridgedAttributedTypeSpecifier specifier, void *specifierLoc);
 void *PackExpansionTypeRepr_create(void *ctx, void *base, void *repeatLoc);
 void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                            void *rParenLoc);

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -123,6 +123,59 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : long
   BridgedAttributedTypeSpecifierIsolated,
 } BridgedAttributedTypeSpecifier;
 
+
+// Bridged type attribute kinds, which mirror TypeAttrKind exactly.
+typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : long {
+  BridgedTypeAttrKind_autoclosure,
+  BridgedTypeAttrKind_convention,
+  BridgedTypeAttrKind_noescape,
+  BridgedTypeAttrKind_escaping,
+  BridgedTypeAttrKind_differentiable,
+  BridgedTypeAttrKind_noDerivative,
+  BridgedTypeAttrKind_async,
+  BridgedTypeAttrKind_Sendable,
+  BridgedTypeAttrKind_unchecked,
+  BridgedTypeAttrKind__local,
+  BridgedTypeAttrKind__noMetadata,
+  BridgedTypeAttrKind__opaqueReturnTypeOf,
+  BridgedTypeAttrKind_block_storage,
+  BridgedTypeAttrKind_box,
+  BridgedTypeAttrKind_dynamic_self,
+  BridgedTypeAttrKind_sil_weak,
+  BridgedTypeAttrKind_sil_unowned,
+  BridgedTypeAttrKind_sil_unmanaged,
+  BridgedTypeAttrKind_error,
+  BridgedTypeAttrKind_out,
+  BridgedTypeAttrKind_direct,
+  BridgedTypeAttrKind_in,
+  BridgedTypeAttrKind_inout,
+  BridgedTypeAttrKind_inout_aliasable,
+  BridgedTypeAttrKind_in_guaranteed,
+  BridgedTypeAttrKind_in_constant,
+  BridgedTypeAttrKind_pack_owned,
+  BridgedTypeAttrKind_pack_guaranteed,
+  BridgedTypeAttrKind_pack_inout,
+  BridgedTypeAttrKind_pack_out,
+  BridgedTypeAttrKind_owned,
+  BridgedTypeAttrKind_unowned_inner_pointer,
+  BridgedTypeAttrKind_guaranteed,
+  BridgedTypeAttrKind_autoreleased,
+  BridgedTypeAttrKind_callee_owned,
+  BridgedTypeAttrKind_callee_guaranteed,
+  BridgedTypeAttrKind_objc_metatype,
+  BridgedTypeAttrKind_opened,
+  BridgedTypeAttrKind_pack_element,
+  BridgedTypeAttrKind_pseudogeneric,
+  BridgedTypeAttrKind_yields,
+  BridgedTypeAttrKind_yield_once,
+  BridgedTypeAttrKind_yield_many,
+  BridgedTypeAttrKind_captures_generics,
+  BridgedTypeAttrKind_moveOnly,
+  BridgedTypeAttrKind_thin,
+  BridgedTypeAttrKind_thick,
+  BridgedTypeAttrKind_Count
+} BridgedTypeAttrKind;
+
 #ifdef __cplusplus
 extern "C" {
 
@@ -272,6 +325,16 @@ void *ImplicitlyUnwrappedOptionalTypeRepr_create(void *ctx, void *base,
                                                  void *exclamationLoc);
 void *MetatypeTypeRepr_create(void *ctx, void *baseType, void *typeLoc);
 void *ProtocolTypeRepr_create(void *ctx, void *baseType, void *protoLoc);
+
+BridgedTypeAttrKind getBridgedTypeAttrKindFromString(
+    const unsigned char * _Nullable str, long len);
+
+typedef void *BridgedTypeAttributes;
+BridgedTypeAttributes BridgedTypeAttributes_create(void);
+void BridgedTypeAttributes_addSimpleAttr(
+    BridgedTypeAttributes typeAttributes, BridgedTypeAttrKind kind, void *atLoc, void *attrLoc);
+void *AttributedTypeRepr_create(void *ctx, void *base, BridgedTypeAttributes typeAttributes);
+
 void *AttributedTypeSpecifierRepr_create(
     void *ctx, void *base, BridgedAttributedTypeSpecifier specifier, void *specifierLoc);
 void *VarargTypeRepr_create(void *ctx, void *base, void *ellipsisLocPtr);

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -348,7 +348,7 @@ void *GenericIdentTypeRepr_create(void *ctx, BridgedIdentifier name,
                                   void *lAngle, void *rAngle);
 void *EmptyCompositionTypeRepr_create(void *ctx, void *anyLoc);
 void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types,
-                                 void *firstTypeLoc);
+                                 void *firstTypeLoc, void *firstAmpLoc);
 void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc,
                               void *_Nullable throwsLoc, void *arrowLoc,
                               void *returnType);

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -174,6 +174,10 @@ EXPERIMENTAL_FEATURE(ImplicitSome, false)
 /// corresponding syntax tree.
 EXPERIMENTAL_FEATURE(ParserASTGen, false)
 
+/// Use the syntax tree produced by the Swift (swift-syntax) parser for type
+/// parsing, using ASTGen to translate them into AST nodes.
+EXPERIMENTAL_FEATURE(ASTGenTypes, false)
+
 /// Parse using the Swift (swift-syntax) parser and use ASTGen to generate the
 /// corresponding syntax tree.
 EXPERIMENTAL_FEATURE(BuiltinMacros, false)

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1351,7 +1351,7 @@ public:
     if (!Context.LangOpts.hasFeature(Feature::ASTGenTypes))
       return nullptr;
 
-    auto exportedSourceFile = SF.exportedSourceFile;
+    auto exportedSourceFile = SF.getExportedSourceFile();
     if (!exportedSourceFile)
       return nullptr;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1366,10 +1366,11 @@ public:
       return nullptr;
     }
 
-    // Spin the lexer until we get to the ending location.
-    while (Tok.getLoc().getOpaquePointerValue() < endLocPtr &&
-           !Tok.is(tok::eof))
-      consumeToken();
+    // Reset the lexer to the ending location.
+    StringRef contents =
+        SourceMgr.extractText(SourceMgr.getRangeForBuffer(L->getBufferID()));
+    L->resetToOffset((const char *)endLocPtr - contents.data());
+    L->lex(Tok);
 
     return makeParserResult(astNode);
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3321,6 +3321,10 @@ static bool usesFeatureParserASTGen(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureASTGenTypes(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureBuiltinMacros(Decl *decl) {
   return false;
 }

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -119,6 +119,12 @@ void SwiftDiagnostic_finish(BridgedDiagnostic diagPtr) {
 BridgedIdentifier
 SwiftASTContext_getIdentifier(void *ctx, const unsigned char *_Nullable str,
                               long len) {
+  // If this was a back-ticked identifier, drop the back-ticks.
+  if (len >= 2 && str[0] == '`' && str[len-1] == '`') {
+    ++str;
+    len -= 2;
+  }
+
   return const_cast<void *>(
       static_cast<ASTContext *>(ctx)
           ->getIdentifier(

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -514,6 +514,13 @@ void *AttributedTypeSpecifierRepr_create(
   }
 }
 
+void *VarargTypeRepr_create(void *ctx, void *base, void *ellipsisLocPtr) {
+  ASTContext &Context = *static_cast<ASTContext *>(ctx);
+  SourceLoc ellipsisLoc = getSourceLocFromPointer(ellipsisLocPtr);
+  TypeRepr *baseType = (TypeRepr *)base;
+  return new (Context) VarargTypeRepr(baseType, ellipsisLoc);
+}
+
 void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                            void *rParenLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -484,6 +484,30 @@ void *PackExpansionTypeRepr_create(void *ctx, void *base, void *repeatLoc) {
       getSourceLocFromPointer(repeatLoc), (TypeRepr *)base);
 }
 
+void *AttributedTypeSpecifierRepr_create(
+    void *ctx, void *base, BridgedAttributedTypeSpecifier specifier, void *specifierLoc
+) {
+  ASTContext &Context = *static_cast<ASTContext *>(ctx);
+  SourceLoc loc = getSourceLocFromPointer(specifierLoc);
+  TypeRepr *baseType = (TypeRepr *)base;
+  switch (specifier) {
+  case BridgedAttributedTypeSpecifierInOut:
+    return new (Context) OwnershipTypeRepr(baseType, ParamSpecifier::InOut, loc);
+  case BridgedAttributedTypeSpecifierBorrowing:
+    return new (Context) OwnershipTypeRepr(baseType, ParamSpecifier::Borrowing, loc);
+  case BridgedAttributedTypeSpecifierConsuming:
+    return new (Context) OwnershipTypeRepr(baseType, ParamSpecifier::Consuming, loc);
+  case BridgedAttributedTypeSpecifierLegacyShared:
+    return new (Context) OwnershipTypeRepr(baseType, ParamSpecifier::LegacyShared, loc);
+  case BridgedAttributedTypeSpecifierLegacyOwned:
+    return new (Context) OwnershipTypeRepr(baseType, ParamSpecifier::LegacyOwned, loc);
+  case BridgedAttributedTypeSpecifierConst:
+    return new (Context) CompileTimeConstTypeRepr(baseType, loc);
+  case BridgedAttributedTypeSpecifierIsolated:
+    return new (Context) IsolatedTypeRepr(baseType, loc);
+  }
+}
+
 void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                            void *rParenLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -542,6 +542,12 @@ void *MemberTypeRepr_create(void *ctx, void *baseComponent,
                                 memberComponents);
 }
 
+void *EmptyCompositionTypeRepr_create(void *ctx, void *anyLocPtr) {
+  ASTContext &Context = *static_cast<ASTContext *>(ctx);
+  SourceLoc anyLoc = getSourceLocFromPointer(anyLocPtr);
+  return CompositionTypeRepr::createEmptyComposition(Context, anyLoc);
+}
+
 void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types,
                                  void *firstTypeLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -119,6 +119,9 @@ void SwiftDiagnostic_finish(BridgedDiagnostic diagPtr) {
 BridgedIdentifier
 SwiftASTContext_getIdentifier(void *ctx, const unsigned char *_Nullable str,
                               long len) {
+  if (len == 1 && str[0] == '_')
+    return BridgedIdentifier();
+
   // If this was a back-ticked identifier, drop the back-ticks.
   if (len >= 2 && str[0] == '`' && str[len-1] == '`') {
     ++str;

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -611,12 +611,15 @@ void *EmptyCompositionTypeRepr_create(void *ctx, void *anyLocPtr) {
   return CompositionTypeRepr::createEmptyComposition(Context, anyLoc);
 }
 
-void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types,
-                                 void *firstTypeLoc) {
+void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef typesPtr,
+                                 void *firstTypeLoc, void *firstAmpLocPtr) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   SourceLoc firstType = getSourceLocFromPointer(firstTypeLoc);
-  return CompositionTypeRepr::create(Context, getArrayRef<TypeRepr *>(types),
-                                     firstType, SourceRange{});
+  SourceLoc firstAmpLoc = getSourceLocFromPointer(firstAmpLocPtr);
+  auto types = getArrayRef<TypeRepr *>(typesPtr);
+  return CompositionTypeRepr::create(
+      Context, types, firstType,
+      SourceRange{firstAmpLoc, types.back()->getEndLoc()});
 }
 
 void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc,

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -637,7 +637,7 @@ func findSyntaxNodeInSourceFile<Node: SyntaxProtocol>(
     while let parentSyntax = resultSyntax.parent {
       guard let typedParent = parentSyntax.as(type),
             typedParent.position == resultSyntax.position else {
-        break;
+        break
       }
 
       resultSyntax = typedParent

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -633,8 +633,18 @@ func findSyntaxNodeInSourceFile<Node: SyntaxProtocol>(
   }
 
   // If we want the outermost node, keep looking.
+  // FIXME: This is VERY SPECIFIC to handling of types. We must be able to
+  // do better.
   if wantOutermost {
     while let parentSyntax = resultSyntax.parent {
+      // Look through type compositions.
+      if let compositionElement = parentSyntax.as(CompositionTypeElementSyntax.self),
+         let compositionList = compositionElement.parent?.as(CompositionTypeElementListSyntax.self),
+         let typedParent = compositionList.parent?.as(type) {
+        resultSyntax = typedParent
+        continue
+      }
+
       guard let typedParent = parentSyntax.as(type),
             typedParent.position == resultSyntax.position else {
         break

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -213,7 +213,13 @@ extension ASTGenVisitor {
         self.base.advanced(by: $0.position.utf8Offset).raw
       }
       let colonLoc = element.colon.map { self.base.advanced(by: $0.position.utf8Offset).raw }
-      let type = visit(element.type).rawValue
+
+      var type = visit(element.type).rawValue
+      if let ellipsis = element.ellipsis {
+        let ellipsisLoc = self.base.advanced(by: ellipsis.positionAfterSkippingLeadingTrivia.utf8Offset).raw
+        type = VarargTypeRepr_create(self.ctx, type, ellipsisLoc)
+      }
+
       let trailingCommaLoc = element.trailingComma.map {
         self.base.advanced(by: $0.position.utf8Offset).raw
       }

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -128,9 +128,11 @@ extension ASTGenVisitor {
     assert(node.elements.count > 1)
     let types = node.elements.map { visit($0.type) }.map { $0.rawValue }
     let firstTypeLoc = self.base.advanced(by: node.elements.first!.type.position.utf8Offset).raw
+    let firstAmpOffset = node.elements.first?.ampersand.map { $0.position.utf8Offset } ?? 0
+    let firstAmpLoc = self.base.advanced(by: firstAmpOffset).raw
     return .type(
       types.withBridgedArrayRef { types in
-        return CompositionTypeRepr_create(self.ctx, types, firstTypeLoc)
+        return CompositionTypeRepr_create(self.ctx, types, firstTypeLoc, firstAmpLoc)
       })
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -19,7 +19,7 @@ extension ASTGenVisitor {
     let rAngle = self.base.advanced(by: generics.rightAngleBracket.position.utf8Offset).raw
     return .type(
       generics.arguments.map({
-        self.visit($0.argumentType)
+        self.visit($0.argumentType).rawValue
       }).withBridgedArrayRef {
           genericArgs in
           GenericIdentTypeRepr_create(
@@ -46,7 +46,7 @@ extension ASTGenVisitor {
         let lAngle = self.base.advanced(by: generics.leftAngleBracket.position.utf8Offset).raw
         let rAngle = self.base.advanced(by: generics.rightAngleBracket.position.utf8Offset).raw
         reverseMemberComponents.append(
-          generics.arguments.map({ self.visit($0.argumentType) }).withBridgedArrayRef {
+          generics.arguments.map({ self.visit($0.argumentType).rawValue }).withBridgedArrayRef {
             genericArgs in
             GenericIdentTypeRepr_create(self.ctx, name, nameLoc, genericArgs, lAngle, rAngle)
           })

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -6,6 +6,11 @@ extension ASTGenVisitor {
   public func visit(_ node: SimpleTypeIdentifierSyntax) -> ASTNode {
     let loc = self.base.advanced(by: node.position.utf8Offset).raw
 
+    // If this is the bare 'Any' keyword, produce an empty composition type.
+    if node.name.tokenKind == .keyword(.Any) && node.genericArgumentClause == nil {
+      return .type(EmptyCompositionTypeRepr_create(self.ctx, loc))
+    }
+
     var text = node.name.text
     let id = text.withUTF8 { buf in
       return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -11,3 +11,13 @@ func test7(_ b: inout Bool) {
 struct X { struct `Protocol` { } }
 
 func test10(_: X.`Protocol`) { }
+
+func test11(_: Int...) { }
+func test11a() {
+  test11(1, 2, 3, 4, 5)
+}
+
+typealias VAFunc = (Int, Int...) -> Int
+func testVAFunc(a: Int, f: VAFunc) {
+  _ = f(a, a, a, a, a)
+}

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -3,6 +3,9 @@
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
 
+protocol P { }
+protocol Q { }
+typealias PQ = P & Q
 
 func test7(_ b: inout Bool) {
   b = true

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -31,3 +31,7 @@ func test12(_ producer: @escaping @autoclosure () -> Int) {
 func test12a(i: Int) {
   test12(i)
 }
+
+func test13(body: (_ value: Int) -> Void, i: Int) {
+  body(i)
+}

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -21,3 +21,10 @@ typealias VAFunc = (Int, Int...) -> Int
 func testVAFunc(a: Int, f: VAFunc) {
   _ = f(a, a, a, a, a)
 }
+
+func test12(_ producer: @escaping @autoclosure () -> Int) {
+  _ = producer()
+}
+func test12a(i: Int) {
+  test12(i)
+}

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -35,3 +35,7 @@ func test12a(i: Int) {
 func test13(body: (_ value: Int) -> Void, i: Int) {
   body(i)
 }
+
+func test14() {
+  _ = Array<Array<Array<Int>>>().count
+}

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ASTGenTypes
+
+// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
+
+func test7(_ b: inout Bool) {
+  b = true
+}
+
+struct X { struct `Protocol` { } }
+
+func test10(_: X.`Protocol`) { }

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -45,3 +45,5 @@ func test7(_ b: inout Bool) {
 
 func test8(_ i: _const Int) {
 }
+
+func test9(_ value: Any) { }

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature SwiftParser -enable-experimental-feature ParserASTGen)
+// RUN: %target-run-simple-swift(-enable-experimental-feature ASTGenTypes)
 
 // REQUIRES: executable_test
 
@@ -25,11 +26,11 @@ func test3(y: Int) -> Int {
   return x
 }
 
-func test4(_ b: Bool) -> Int {
-  if b { 0 } else { 1 }
+func test4(_ b: [Bool]) -> Int {
+  if b.isEmpty { 0 } else { 1 }
 }
 
-func test5(_ b: Bool) -> Int {
+func test5(_ b: Swift.Bool) -> Int {
   return if b { 0 } else { 1 }
 }
 

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -38,3 +38,10 @@ func test6(_ b: Bool) -> Int {
   let x = if b { 0 } else { 1 }
   return x
 }
+
+func test7(_ b: inout Bool) {
+  // b = true
+}
+
+func test8(_ i: _const Int) {
+}

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -3,7 +3,7 @@
 
 // REQUIRES: executable_test
 
-// -enable-experimental-feature requires and asserts build
+// -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
 
 func test1(x: Int, fn: (Int) -> Int) -> Int {


### PR DESCRIPTION
Introduce a new experimental feature `ASTGenTypes` that uses ASTGen to translate the Swift syntax tree (produced by the new Swift parser) into C++ `TypeRepr` nodes instead of having the C++ parser create the nodes.

The approach here is to intercept the C++ parser's `parseType` operation to find the Swift syntax node at the given position (where the lexer currently is) and have ASTGen translate that into the corresponding C++ AST node. Then, we spin the lexer forward to the token immediately following the end of the syntax node and continue parsing.

Introduce a collection of small fixes to the mapping of type syntax nodes into `TypeRepr`s:
* Fix crash due to generic arguments having the wrong pointer values (silly enums)
* Support specifiers like `inout`, `consuming`, and `isolated`
* Recognize `Any` and treat it as the empty composition type
* Handle back-ticked identifiers
* Handle variadic parameters in functions and function types
* Handle simple type attributes (this is *not* complete)
* Handle protocol composition types and provide correct source information
* Handle `_` identifier as the empty identifier

With all of these changes, a hacked compiler that enables this experimental flag all the time successfully handles 236 of 245 tests in `test/Sema`. 