### PR TITLE
[Diagnostics] Skip overloaded locations where all solutions have the same type

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5302,12 +5302,10 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 /// provided set.
 static unsigned countDistinctOverloads(ArrayRef<OverloadChoice> choices) {
   llvm::SmallPtrSet<void *, 4> uniqueChoices;
-  unsigned result = 0;
   for (auto choice : choices) {
-    if (uniqueChoices.insert(choice.getOpaqueChoiceSimple()).second)
-      ++result;
+    uniqueChoices.insert(choice.getOpaqueChoiceSimple());
   }
-  return result;
+  return uniqueChoices.size();
 }
 
 /// Determine the name of the overload in a set of overload choices.

--- a/test/Constraints/ambiguity_diagnostics.swift
+++ b/test/Constraints/ambiguity_diagnostics.swift
@@ -1,0 +1,50 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-availability-checking
+
+protocol View {
+}
+
+extension View {
+  func title<S>(_ title: S) -> some View where S : StringProtocol {
+    EmptyView()
+  }
+
+  func title(_ titleKey: LocalizedString) -> some View {
+    EmptyView()
+  }
+}
+
+extension View {
+  func background<T: ShapeStyle>(_: T) -> some View {
+    EmptyView()
+  }
+}
+
+struct EmptyView : View {}
+
+struct Text : View {
+  init(_: String) {}
+}
+
+protocol ShapeStyle {
+}
+
+struct AnyShapeStyle : ShapeStyle {}
+struct AnyGradient : ShapeStyle {}
+
+struct LocalizedString : ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral {
+  init(extendedGraphemeClusterLiteral value: String) {}
+  init(stringLiteral: String) {}
+}
+
+func test() {
+  func __findValue(_: String, fallback: LocalizedString) -> LocalizedString { fatalError() }
+  func __findValue<T: ExpressibleByStringLiteral>(_: String, fallback: T) -> T { fatalError() }
+  func __findValue<T: ExpressibleByExtendedGraphemeClusterLiteral>(_: String, fallback: T) -> T { fatalError() }
+
+  func ambiguitySource() -> AnyShapeStyle { fatalError() } // expected-note {{found this candidate}}
+  func ambiguitySource() -> AnyGradient { fatalError() }   // expected-note {{found this candidate}}
+
+  Text("Test")
+    .title(__findValue("someKey", fallback: "<unknown>"))
+    .background(ambiguitySource()) // expected-error {{ambiguous use of 'ambiguitySource()'}}
+}


### PR DESCRIPTION
If there are multiple overloads, let's skip locations that produce
the same type across all of the solutions, such location is most
likely a consequence of ambiguity and not its source.

Resolves: rdar://109245375

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
