### PR TITLE
[CSSolver] Don't re-run solver to diagnose ambiguities

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -908,19 +908,25 @@ ConstraintSystem::solve(SyntacticElementTarget &target,
       return std::nullopt;
     }
 
-    case SolutionResult::Ambiguous:
-      // If salvaging produced an ambiguous result, it has already been
-      // diagnosed.
+    case SolutionResult::Ambiguous: {
       // If we have found an ambiguous solution in the first stage, salvaging
       // won't produce more solutions, so we can inform the solution callback
       // about the current ambiguous solutions straight away.
-      if (stage == 1 || Context.SolutionCallback) {
+      if (Context.SolutionCallback) {
         reportSolutionsToSolutionCallback(solution);
         solution.markAsDiagnosed();
         return std::nullopt;
       }
 
+      // If salvaging produced an ambiguous result, it has already been
+      // diagnosed.
+      if (stage == 1) {
+        solution.markAsDiagnosed();
+        return std::nullopt;
+      }
+
       LLVM_FALLTHROUGH;
+    }
 
     case SolutionResult::UndiagnosedError:
       if (stage == 1) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -925,6 +925,23 @@ ConstraintSystem::solve(SyntacticElementTarget &target,
         return std::nullopt;
       }
 
+      auto solutionsRef = std::move(solution).takeAmbiguousSolutions();
+      SmallVector<Solution, 4> ambiguity(
+          std::make_move_iterator(solutionsRef.begin()),
+          std::make_move_iterator(solutionsRef.end()));
+
+      {
+        SolverState state(*this, FreeTypeVariableBinding::Disallow);
+
+        // Constraint generator is allowed to introduce fixes to the
+        // contraint system.
+        if (diagnoseAmbiguityWithFixes(ambiguity) ||
+            diagnoseAmbiguity(ambiguity)) {
+          solution.markAsDiagnosed();
+          return std::nullopt;
+        }
+      }
+
       LLVM_FALLTHROUGH;
     }
 
@@ -1024,7 +1041,7 @@ bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
   // Filter deduced solutions, try to figure out if there is
   // a single best solution to use, if not explicitly disabled
   // by constraint system options.
-  filterSolutions(solutions);
+  filterSolutions(solutions, /*minimize=*/true);
 
   // We fail if there is no solution or the expression was too complex.
   return solutions.empty() || isTooComplex(solutions);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3361,28 +3361,37 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
     // FIXME: We would prefer to emit the name as written, but that information
     // is not sufficiently centralized in the AST.
     DeclNameRef name(getOverloadChoiceName(overload.choices));
+
+    // A location to attach ambiguity diagnostic to.
+    SourceLoc diagLoc;
+
+    // Some of the locations do not simplify all the way to anchor,
+    // for example - key path components and dynamic member references
+    // are not represented via ASTNode,
     auto anchor = simplifyLocatorToAnchor(overload.locator);
-    if (!anchor) {
-      // It's not clear that this is actually valid. Just use the overload's
-      // anchor for release builds, but assert so we can properly diagnose
-      // this case if it happens to be hit. Note that the overload will
-      // *always* be anchored, otherwise everything would be broken, ie. this
-      // assertion would be the least of our worries.
-      anchor = overload.locator->getAnchor();
-      assert(false && "locator could not be simplified to anchor");
+    if (anchor) {
+      diagLoc = getLoc(anchor);
+    } else if (auto keyPathComponent = overload.locator->getFirstElementAs<
+                                       LocatorPathElt::KeyPathComponent>()) {
+      auto *KPE = castToExpr<KeyPathExpr>(overload.locator->getAnchor());
+      diagLoc = KPE->getComponents()[keyPathComponent->getIndex()].getLoc();
+    } else {
+      diagLoc = getLoc(overload.locator->getAnchor());
     }
 
     // Emit the ambiguity diagnostic.
     auto &DE = getASTContext().Diags;
-    DE.diagnose(getLoc(anchor),
+    DE.diagnose(diagLoc,
                 name.isOperator() ? diag::ambiguous_operator_ref
                                   : diag::ambiguous_decl_ref,
                 name);
 
-    TrailingClosureAmbiguityFailure failure(solutions, anchor,
-                                            overload.choices);
-    if (failure.diagnoseAsNote())
-      return true;
+    if (anchor) {
+      TrailingClosureAmbiguityFailure failure(solutions, anchor,
+                                              overload.choices);
+      if (failure.diagnoseAsNote())
+        return true;
+    }
 
     // Emit candidates.  Use a SmallPtrSet to make sure only emit a particular
     // candidate once.  FIXME: Why is one candidate getting into the overload

--- a/test/expr/leading_dot/leading-dot+result-builders.swift
+++ b/test/expr/leading_dot/leading-dot+result-builders.swift
@@ -17,7 +17,9 @@ struct TupleBuilder<Context> {
 
 
 func test<B, V, T: P, U>(_: KeyPath<B, T>, _: V, @TupleBuilder<B> a: () -> U) where V == T.V, V: Equatable {}
+// expected-note@-1 {{found this candidate}}
 func test<B, V, T: P, U>(_: KeyPath<B, T>, _: V.V, @TupleBuilder<B> a: () -> U) where V == T.V, V: ExpressibleByNilLiteral, V.V: Equatable {}
+// expected-note@-1 {{found this candidate}}
 
 enum E: String, P, ExpressibleByNilLiteral {
   typealias V = Self
@@ -39,7 +41,6 @@ struct S : Element {
   init() { fatalError() }
 }
 
-// FIXME(diagnostics): This diagnostic is wrong. The problem is that `test` is ambiguous and should be diagnosed pre-salvage.
-test(\.value, .empty) { // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+test(\.value, .empty) { // expected-error {{ambiguous use of 'test(_:_:a:)'}}
   S()
 }

--- a/test/expr/leading_dot/salvage_leading_dot.swift
+++ b/test/expr/leading_dot/salvage_leading_dot.swift
@@ -1,12 +1,13 @@
 // RUN: %target-typecheck-verify-swift -solver-disable-crash-on-valid-salvage
-// RUN: not --crash %target-swift-frontend -typecheck %s -solver-enable-crash-on-valid-salvage
+// RUN: %target-swift-frontend -typecheck %s -solver-enable-crash-on-valid-salvage -verify
 
 struct S {
-  static func foo(_ s: S?) -> S? {s}
-  static func foo(_ s: S) -> S {s}
+  static func foo(_ s: S?) -> S? {s} // expected-note {{found this candidate}}
+  static func foo(_ s: S) -> S {s}   // expected-note {{found this candidate}}
 }
 
 public func test() {
-  let _: S? = .foo(S())
+  // Optional injection happens either at the argument or result of the chain.
+  let _: S? = .foo(S()) // expected-error {{ambiguous use of 'foo'}}
 }
 

--- a/test/expr/postfix/init/unqualified.swift
+++ b/test/expr/postfix/init/unqualified.swift
@@ -3,15 +3,15 @@
 // https://github.com/apple/swift/issues/43464
 
 class Aaron {
-  init(x: Int) {
+  init(x: Int) { // expected-note {{found this candidate}}
     func foo() {
       // Make sure we recover and assume 'self.init'.
       // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{11-11=self.}}
-      // expected-error@+1 {{failed to produce diagnostic for expression}}
+      // expected-error@+1 {{ambiguous use of 'init'}}
       _ = init
     }
   }
-  convenience init() {
+  convenience init() { // expected-note {{found this candidate}}
     // Make sure we recover and assume 'self.init'.
     // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{5-5=self.}}
     // expected-error@+1 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
@@ -23,7 +23,7 @@ class Aaron {
     func foo() { _ = init() }
   }
 
-  required init(y: Int) {}
+  required init(y: Int) {} // expected-note {{found this candidate}}
 
   static func aaronFn() {
     // Make sure we recover and assume 'self.init'.
@@ -40,7 +40,7 @@ class Aaron {
 }
 
 class Theodosia: Aaron {
-  init() {
+  init() { // expected-note {{found this candidate}}
     // Make sure we recover and assume 'super.init'.
     // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'super.'?}} {{5-5=super.}}
     // expected-error@+1 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
@@ -48,11 +48,11 @@ class Theodosia: Aaron {
 
     // Make sure we recover and assume 'self.init'.
     // expected-error@+2 {{initializer expression requires explicit access; did you mean to prepend it with 'self.'?}} {{22-22=self.}}
-    // expected-error@+1 {{failed to produce diagnostic for expression}}
+    // expected-error@+1 {{ambiguous use of 'init'}}
     func foo() { _ = init }
   }
 
-  required init(y: Int) {}
+  required init(y: Int) {} // expected-note {{found this candidate}}
 
   static func theodosiaFn() {
     // Make sure we recover and assume 'self.init'.

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-diagnoseAmbiguity-45e113.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-diagnoseAmbiguity-45e113.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::diagnoseAmbiguity(llvm::ArrayRef<swift::constraints::Solution>)","signatureAssert":"Assertion failed: (false && \"locator could not be simplified to anchor\"), function diagnoseAmbiguity","signatureNext":"ConstraintSystem::salvage"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a { eq = "" b "Self ecuador1 Self) > Bool {
     let getProperties = (
       \.eq as Self -> _

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-diagnoseAmbiguity-ffa220.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-diagnoseAmbiguity-ffa220.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"9d13c715","signature":"swift::constraints::ConstraintSystem::diagnoseAmbiguity(llvm::ArrayRef<swift::constraints::Solution>)","signatureAssert":"Assertion failed: (false && \"locator could not be simplified to anchor\"), function diagnoseAmbiguity","signatureNext":"ConstraintSystem::diagnoseAmbiguityWithFixes"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 class a {
   var
     b : Int


### PR DESCRIPTION
If ambiguity has been detected during normal solving,
let's diagnose that right away instead of re-running
the solver in diagnostic mode because it would produce
exactly the same set of solutions (all solutions with
fixes added in diagnostic mode would be filtered out
because they'd have worse scores).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
