### PR TITLE
Add and install a parent module map for Swift shims. NFC intended.

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -250,6 +250,16 @@ option(SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES
        "Use relative protocol witness tables"
        FALSE)
 
+if("${SWIFT_HOST_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
+  set(SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS_default TRUE)
+else()
+  set(SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS_default FALSE)
+endif()
+
+option(SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS
+       "Install a parent module map for Swift shims."
+       ${SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS_default})
+
 set(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH "" CACHE STRING
   "If set, provides a fixed path to the swift-backtrace binary.  This
    will disable dynamic determination of the path and will also disable

--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -63,6 +63,31 @@ foreach(input ${sources})
     list(APPEND outputs "${output_dir_static}/${input}")
   endif()
 endforeach()
+if (SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS)
+  # Copy the module map into the parent directory. Using "parent.modulemap"
+  # instead of putting "module.modulemap" into the parent module to avoid
+  # module redefinition conflicts with the toolchain.
+  add_custom_command(
+      OUTPUT "${output_dir}/../module.modulemap"
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/parent.modulemap"
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+        "${CMAKE_CURRENT_SOURCE_DIR}/parent.modulemap"
+        "${output_dir}/../module.modulemap"
+      COMMENT "Copying parent.modulemap to ${output_dir}")
+  list(APPEND outputs "${output_dir}/../module.modulemap")
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    add_custom_command(
+        OUTPUT "${output_dir_static}/../module.modulemap"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/parent.modulemap"
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/parent.modulemap"
+          "${output_dir_static}/../module.modulemap"
+        COMMENT "Copying parent.modulemap to ${output_dir_static}")
+    list(APPEND outputs "${output_dir_static}/../module.modulemap")
+  endif()
+endif()
 # Put the output dir itself last so that it isn't considered the primary output.
 list(APPEND outputs "${output_dir}")
 
@@ -173,17 +198,43 @@ if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
         COMMENT "Symlinking headers for bootstrapping0")
 
     add_dependencies(${target_name} copy_shim_headers)
+
+    if (SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS)
+      set(modulemap_target_name "symlink-modulemap-bootstrapping${bootstrapping}")
+      add_custom_command_target(unused_var
+          COMMAND
+            "${CMAKE_COMMAND}" "-E" "make_directory" "${outdir}"
+          COMMAND
+            "${CMAKE_COMMAND}" "-E" ${cmake_symlink_option}
+            "${output_dir}/../module.modulemap" "${outdir}/module.modulemap"
+
+          CUSTOM_TARGET_NAME ${modulemap_target_name}
+          OUTPUT "${outdir}/module.modulemap"
+          COMMENT "Symlinking shims modulemap for bootstrapping0")
+      add_dependencies(${modulemap_target_name} copy_shim_headers)
+      add_dependencies(${target_name} ${modulemap_target_name})
+    endif()
   endforeach()
 endif()
 
 swift_install_in_component(FILES ${sources}
                            DESTINATION "lib/swift/shims"
                            COMPONENT stdlib)
+if (SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS)
+  swift_install_in_component(FILES "${output_dir}/../module.modulemap"
+                             DESTINATION "lib/swift"
+                             COMPONENT stdlib)
+endif()
 
 if(SWIFT_BUILD_STATIC_STDLIB)
   swift_install_in_component(FILES ${sources}
                              DESTINATION "lib/swift_static/shims"
                              COMPONENT stdlib)
+  if (SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS)
+    swift_install_in_component(FILES "${output_dir_static}/../module.modulemap"
+                               DESTINATION "lib/swift_static"
+                               COMPONENT stdlib)
+  endif()
 endif()
 
 # Install Clang headers under the Swift library so that an installed Swift's

--- a/stdlib/public/SwiftShims/swift/shims/parent.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/parent.modulemap
@@ -1,0 +1,3 @@
+extern module SwiftShims             "shims/module.modulemap"
+extern module _SwiftConcurrencyShims "shims/module.modulemap"
+extern module SwiftOverlayShims      "shims/module.modulemap"


### PR DESCRIPTION
Header search path for Swift shims is "usr/lib/swift". Don't rely on clang looking for module maps in immediate subdirectories like "shims" but add a module map to "usr/lib/swift" sourcing "shims" modules.

rdar://106677321