### PR TITLE
[IRGen] Support additional single payload enum cases in layout strings

### DIFF
--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -139,7 +139,8 @@ public:
     //   return fields[0];
     // }
 
-    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+        fields, T, getBestKnownAlignment().getValue(), *this);
   }
 
   llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const { return None; }
@@ -313,7 +314,8 @@ public:
     //   return fields[0];
     // }
 
-    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+        fields, T, getBestKnownAlignment().getValue(), *this);
   }
 
   llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const { return None; }

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1087,7 +1087,8 @@ class ClassExistentialTypeInfo final
           ScalarKind::TriviallyDestroyable));
     }
 
-    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(alignedGroup, T, getBestKnownAlignment().getValue());
+    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+        alignedGroup, T, getBestKnownAlignment().getValue(), *this);
   }
 
   /// Given an explosion with multiple pointer elements in them, pack them

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -416,7 +416,8 @@ namespace {
       //   return fields[0];
       // }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
@@ -765,7 +766,8 @@ namespace {
         return fields[0];
       }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
@@ -921,7 +923,8 @@ namespace {
         return fields[0];
       }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
@@ -999,7 +1002,8 @@ namespace {
       //   return fields[0];
       // }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const {
@@ -1090,7 +1094,8 @@ namespace {
       //   return fields[0];
       // }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     // We have an indirect schema.

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -297,7 +297,8 @@ namespace {
       // if (fields.size() == 1) {
       //   return fields[0];
       // }
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const {
@@ -348,7 +349,8 @@ namespace {
       //   return fields[0];
       // }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const {
@@ -422,7 +424,8 @@ namespace {
       //   return fields[0];
       // }
 
-      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(fields, T, getBestKnownAlignment().getValue());
+      return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(
+          fields, T, getBestKnownAlignment().getValue(), *this);
     }
 
     llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -43,6 +43,8 @@ enum class RefCountingKind : uint8_t {
   Existential = 0x0e,
   Resilient = 0x0f,
 
+  SinglePayloadEnumSimple = 0x10,
+
   Skip = 0x80,
   // We may use the MSB as flag that a count follows,
   // so all following values are reserved

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -276,6 +276,17 @@ struct InternalGeneric<T> {
     let y: Int
 }
 
+public enum SinglePayloadAnyObjectEnum {
+    case empty0
+    case empty1
+    case empty2
+    case empty3
+    case empty4
+    case empty5
+    case empty6
+    case nonEmpty(AnyObject)
+}
+
 public enum SinglePayloadEnum<T> {
     case empty
     case nonEmpty(T?)

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -276,7 +276,7 @@ struct InternalGeneric<T> {
     let y: Int
 }
 
-public enum SinglePayloadAnyObjectEnum {
+public enum SinglePayloadSimpleClassEnum {
     case empty0
     case empty1
     case empty2
@@ -284,7 +284,17 @@ public enum SinglePayloadAnyObjectEnum {
     case empty4
     case empty5
     case empty6
-    case nonEmpty(AnyObject)
+    case nonEmpty(SimpleClass)
+}
+
+public struct ContainsSinglePayloadSimpleClassEnum {
+    public let x: SinglePayloadSimpleClassEnum
+    public let y: AnyObject
+
+    public init(x: SinglePayloadSimpleClassEnum, y: AnyObject) {
+        self.x = x
+        self.y = y
+    }
 }
 
 public enum SinglePayloadEnum<T> {

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -257,16 +257,21 @@ func testExistentialReference() {
 
 testExistentialReference()
 
-func testSinglePayloadAnyObjectEnum() {
-    let ptr = UnsafeMutablePointer<SinglePayloadAnyObjectEnum>.allocate(capacity: 1)
+func testSinglePayloadSimpleClassEnum() {
+    let ptr = UnsafeMutablePointer<SinglePayloadSimpleClassEnum>.allocate(capacity: 1)
 
     do {
-        let x = SinglePayloadAnyObjectEnum.nonEmpty(SimpleClass(x: 23))
+        let x = SinglePayloadSimpleClassEnum.nonEmpty(SimpleClass(x: 23))
         testInit(ptr, to: x)
     }
 
     do {
-        let y = SinglePayloadAnyObjectEnum.nonEmpty(SimpleClass(x: 28))
+        // CHECK: Value: 23
+        if case .nonEmpty(let c) = ptr.pointee {
+            print("Value: \(c.x)")
+        }
+
+        let y = SinglePayloadSimpleClassEnum.nonEmpty(SimpleClass(x: 28))
 
         // CHECK: Before deinit
         print("Before deinit")
@@ -275,9 +280,13 @@ func testSinglePayloadAnyObjectEnum() {
         testAssign(ptr, from: y)
     }
 
+    // CHECK-NEXT: Value: 28
+    if case .nonEmpty(let c) = ptr.pointee {
+        print("Value: \(c.x)")
+    }
+
     // CHECK-NEXT: Before deinit
     print("Before deinit")
-
 
     // CHECK-NEXT: SimpleClass deinitialized!
     testDestroy(ptr)
@@ -285,7 +294,104 @@ func testSinglePayloadAnyObjectEnum() {
     ptr.deallocate()
 }
 
-testSinglePayloadAnyObjectEnum()
+testSinglePayloadSimpleClassEnum()
+
+func testSinglePayloadSimpleClassEnumEmpty() {
+    let ptr = UnsafeMutablePointer<SinglePayloadSimpleClassEnum>.allocate(capacity: 1)
+
+    do {
+        let x = SinglePayloadSimpleClassEnum.empty0
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = SinglePayloadSimpleClassEnum.empty1
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testSinglePayloadSimpleClassEnumEmpty()
+
+func testContainsSinglePayloadSimpleClassEnum() {
+    let ptr = UnsafeMutablePointer<ContainsSinglePayloadSimpleClassEnum>.allocate(capacity: 1)
+
+    do {
+        let x = ContainsSinglePayloadSimpleClassEnum(x: SinglePayloadSimpleClassEnum.nonEmpty(SimpleClass(x: 23)), y: TestClass())
+        testInit(ptr, to: x)
+    }
+
+    do {
+        // CHECK: Value: 23
+        if case .nonEmpty(let c) = ptr.pointee.x {
+            print("Value: \(c.x)")
+        }
+
+        let y = ContainsSinglePayloadSimpleClassEnum(x: SinglePayloadSimpleClassEnum.nonEmpty(SimpleClass(x: 28)), y: TestClass())
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: TestClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Value: 28
+    if case .nonEmpty(let c) = ptr.pointee.x {
+        print("Value: \(c.x)")
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    // CHECK-NEXT: TestClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testContainsSinglePayloadSimpleClassEnum()
+
+func testContainsSinglePayloadSimpleClassEnumEmpty() {
+    let ptr = UnsafeMutablePointer<ContainsSinglePayloadSimpleClassEnum>.allocate(capacity: 1)
+
+    do {
+        let x = ContainsSinglePayloadSimpleClassEnum(x: SinglePayloadSimpleClassEnum.empty0, y: TestClass())
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = ContainsSinglePayloadSimpleClassEnum(x: SinglePayloadSimpleClassEnum.empty1, y: TestClass())
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: TestClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: TestClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testContainsSinglePayloadSimpleClassEnumEmpty()
 
 func testMultiPayloadEnum() {
     let ptr = UnsafeMutablePointer<MultiPayloadEnumWrapper>.allocate(capacity: 1)

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -42,7 +42,7 @@ func testSimple() {
 
         // CHECK-NEXT: Before deinit
         print("Before deinit")
-        
+
         // CHECK-NEXT: SimpleClass deinitialized!
         testAssign(ptr, from: y)
     }
@@ -52,11 +52,11 @@ func testSimple() {
 
     // CHECK-NEXT: Before deinit
     print("Before deinit")
-        
+
 
     // CHECK-NEXT: SimpleClass deinitialized!
     testDestroy(ptr)
-    
+
     ptr.deallocate()
 }
 
@@ -85,9 +85,9 @@ func testWeakNative() {
 
     do {
         let ref = SimpleClass(x: 34)
-        
+
         withExtendedLifetime(ref) {
-            
+
             // CHECK-NEXT: SimpleClass deinitialized!
             testAssign(ptr, from: WeakNativeWrapper(x: ref))
 
@@ -131,7 +131,7 @@ func testUnownedNative() {
 
     do {
         let ref = SimpleClass(x: 34)
-        
+
         withExtendedLifetime(ref) {
             // CHECK-NEXT: SimpleClass deinitialized!
             testAssign(ptr, from: UnownedNativeWrapper(x: ref))
@@ -230,7 +230,7 @@ class ClassWithSomeClassProtocol: SomeClassProtocol {
 
 func testExistentialReference() {
     let ptr = UnsafeMutablePointer<ExistentialRefWrapper>.allocate(capacity: 1)
-    
+
     do {
         let x = ClassWithSomeClassProtocol()
         testInit(ptr, to: ExistentialRefWrapper(x: x))
@@ -257,6 +257,36 @@ func testExistentialReference() {
 
 testExistentialReference()
 
+func testSinglePayloadAnyObjectEnum() {
+    let ptr = UnsafeMutablePointer<SinglePayloadAnyObjectEnum>.allocate(capacity: 1)
+
+    do {
+        let x = SinglePayloadAnyObjectEnum.nonEmpty(SimpleClass(x: 23))
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = SinglePayloadAnyObjectEnum.nonEmpty(SimpleClass(x: 28))
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testSinglePayloadAnyObjectEnum()
+
 func testMultiPayloadEnum() {
     let ptr = UnsafeMutablePointer<MultiPayloadEnumWrapper>.allocate(capacity: 1)
 
@@ -270,7 +300,7 @@ func testMultiPayloadEnum() {
 
         // CHECK: Before deinit
         print("Before deinit")
-        
+
         // CHECK-NEXT: SimpleClass deinitialized!
         testAssign(ptr, from: y)
     }
@@ -482,7 +512,7 @@ func testUnownedObjc() {
 
     do {
         let ref = ObjcClass(x: 34)
-        
+
         withExtendedLifetime(ref) {
             // CHECK-macosx-NEXT: ObjcClass deinitialized!
             testAssign(ptr, from: UnownedObjcWrapper(x: ref))


### PR DESCRIPTION
rdar://105837101

Adds layout string support for single payload enums with simple (non-scattered) extra inhabitant patterns