### PR TITLE
add missing %empty-directory in test

### DIFF
--- a/test/Distributed/distributed_actor_thunk_doesnt_leak_class_arguments.swift
+++ b/test/Distributed/distributed_actor_thunk_doesnt_leak_class_arguments.swift
@@ -1,3 +1,4 @@
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-swift-frontend -module-name no_to_arg_leaks -emit-irgen -disable-availability-checking -I %t 2>&1 %s | %IRGenFileCheck %s -check-prefix CHECK-%target-import-type
 


### PR DESCRIPTION
Discovered during the 5.9 cherry pick https://github.com/apple/swift/pull/65941 that we need to add this.
Tests passed on main without this but perhaps by accident, this should be more correct now.