### PR TITLE
[5.9] Correctly print swift `Int` property as `NSUInteger` when it overrides an `NSUInteger` objc property.

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -959,6 +959,9 @@ private:
 
   /// Returns true if \p clangTy is the typedef for NSUInteger.
   bool isNSUInteger(clang::QualType clangTy) {
+    if (const auto* elaboratedTy = dyn_cast<clang::ElaboratedType>(clangTy)) {
+      clangTy = elaboratedTy->desugar();
+    }
     const auto *typedefTy = dyn_cast<clang::TypedefType>(clangTy);
     if (!typedefTy)
       return false;

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -49,8 +49,6 @@
 // CHECK-NEXT: - (nullable instancetype)initWithCoder:(NSCoder * _Nonnull){{[a-zA-Z]+}} OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 
-// REQUIRES: rdar102629628
-
 import Foundation
 
 

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -15,8 +15,6 @@
 
 // REQUIRES: objc_interop
 
-// REQUIRES: rdar102629628
-
 import OverrideBase
 // No errors from Clang until we get to the FixMe class.
 // CLANG-NOT: error


### PR DESCRIPTION
* **Explanation:** Clang rebranch started reporting certain types to be wrapped in `ElaboratedType` instead of the underlying `TypedefType`, which caused the logic to break for printing `NSUInteger` instead of `NSInteger` when a Swift `Int` method/property override an Obj-C decl that used `NSUInteger`.
* **Scope:** Narrow; affects the Obj-C header generated for a Swift class that subclasses another Obj-C class
* **Risk:** Low; this fixes a regression in the 5.9 branch after the rebranch
* **Reviewers:** @egorzhdan
* **Issue:** rdar://102629628
* **Original pull request:** https://github.com/apple/swift/pull/66011
