### PR TITLE
[Profiler] Avoid quadratic search for coverage filename in WMO

### DIFF
--- a/test/Profiler/coverage_relative_path.swift
+++ b/test/Profiler/coverage_relative_path.swift
@@ -10,6 +10,6 @@
 //
 // ABSOLUTE: @__llvm_coverage_mapping = {{.*"\\02.*root[^/\\]*nested[/\\]*coverage_relative_path\.swift}}
 
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %/t/root=. -emit-ir %/t/root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %t/root=. -emit-ir %t/root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
 //
 // RELATIVE: @__llvm_coverage_mapping = {{.*"\\02.*\\01[^/]*\.[/\\]*nested[/\\]*coverage_relative_path\.swift}}

--- a/test/Profiler/coverage_relative_path_exec.swift
+++ b/test/Profiler/coverage_relative_path_exec.swift
@@ -4,15 +4,15 @@
 
 // This test is to make sure llvm-cov can deal with a coverage-prefix-map.
 
-// To make sure this test is resilient to directory changes, we create nested directories inside of the
-// temporary test directory and assert those exist, or don't exist, in the emitted ir
+// To make sure this test is resilient to directory changes, we create nested
+// directories inside of the temporary test directory.
 //
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/root/nested
 // RUN: echo "func coverage() {}" > %t/root/nested/coverage_relative_path.swift
 // RUN: cd %t/root
 
-// RUN: %target-build-swift -profile-generate -profile-coverage-mapping -Xfrontend -coverage-prefix-map -Xfrontend %/t/root=. -Xfrontend -disable-incremental-llvm-codegen -o %t/main %/t/root/nested/coverage_relative_path.swift
+// RUN: %target-build-swift -profile-generate -profile-coverage-mapping -Xfrontend -coverage-prefix-map -Xfrontend %t/root=. -Xfrontend -disable-incremental-llvm-codegen -o %t/main %t/root/nested/coverage_relative_path.swift
 
 // This unusual use of 'sh' allows the path of the profraw file to be
 // substituted by %target-run.
@@ -20,6 +20,8 @@
 // RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
 
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
-// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s
+// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck --check-prefix SHOW %s
+// RUN: %llvm-cov report %t/main -instr-profile=%t/default.profdata | %FileCheck --check-prefix REPORT %s
 
-// CHECK: func coverage
+// SHOW: func coverage
+// REPORT: coverage_relative_path.swift


### PR DESCRIPTION
Previously we were doing a `std::find` over the files for each coverage mapping, which would be quadratic for WMO. Switch to using a DenseMap instead.
