### PR TITLE
[5.9] [Profiler] A couple of coverage fixes

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -191,6 +191,9 @@ public:
   /// Set the generated source information associated with a given buffer.
   void setGeneratedSourceInfo(unsigned bufferID, GeneratedSourceInfo);
 
+  /// Checks whether the given buffer has generated source information.
+  bool hasGeneratedSourceInfo(unsigned bufferID);
+
   /// Retrieve the generated source information for the given buffer.
   Optional<GeneratedSourceInfo> getGeneratedSourceInfo(unsigned bufferID) const;
 

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -394,6 +394,10 @@ void SourceManager::setGeneratedSourceInfo(
   }
 }
 
+bool SourceManager::hasGeneratedSourceInfo(unsigned bufferID) {
+  return GeneratedSourceInfos.count(bufferID);
+}
+
 Optional<GeneratedSourceInfo> SourceManager::getGeneratedSourceInfo(
     unsigned bufferID
 ) const {

--- a/test/Profiler/coverage_macros.swift
+++ b/test/Profiler/coverage_macros.swift
@@ -1,0 +1,49 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -emit-sil -emit-sorted-sil -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -module-name coverage_macros %s -load-plugin-library %t/%target-library-name(MacroDefinition) | %FileCheck %s --implicit-check-not sil_coverage_map
+// RUN: %target-swift-frontend -emit-ir -profile-generate -profile-coverage-mapping -load-plugin-library %t/%target-library-name(MacroDefinition) %s
+
+@attached(accessor)
+macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")
+
+@attached(
+  member,
+  names: named(`init`), named(Storage), named(storage), named(getStorage()), named(method)
+)
+macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+
+@freestanding(expression)
+macro nestedDeclInExpr() -> () -> Void = #externalMacro(module: "MacroDefinition", type: "NestedDeclInExprMacro")
+
+// Note we use implicit-check-not, so this test ensures we don't emit
+// coverage maps for the macro expansions.
+
+struct S1 {
+  // CHECK: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.x
+  var x: Int = 0
+
+  // CHECK: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S1.y
+  var y: Int = 0
+}
+
+@addMembers
+struct S2 {
+  // CHECK: sil_coverage_map{{.*}}variable initialization expression of coverage_macros.S2.(_storage
+  private var _storage = S1()
+
+  @accessViaStorage
+  var x: Int
+
+  // No coverage map for the initializer, as it gets subsumed.
+  @accessViaStorage
+  var y: Int = 17
+}
+
+// CHECK: sil_coverage_map{{.*}}s15coverage_macros3fooyyF
+func foo() {
+  _ = #nestedDeclInExpr()
+}

--- a/test/Profiler/coverage_relative_path.swift
+++ b/test/Profiler/coverage_relative_path.swift
@@ -1,15 +1,15 @@
 // To make sure this test is resilient to directory changes, we create nested directories inside of the
 // temporary test directory and assert those exist, or don't exist, in the emitted ir
 //
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/root/nested
 // RUN: echo "func coverage() {}" > %t/root/nested/coverage_relative_path.swift
 // RUN: cd %t/root
 
 // RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -emit-ir nested/coverage_relative_path.swift | %FileCheck -check-prefix=ABSOLUTE %s
 //
-// ABSOLUTE: @__llvm_coverage_mapping = {{.*"\\01.*root.*nested.*coverage_relative_path\.swift}}
+// ABSOLUTE: @__llvm_coverage_mapping = {{.*"\\02.*root[^/\\]*nested[/\\]*coverage_relative_path\.swift}}
 
 // RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %/t/root=. -emit-ir %/t/root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
 //
-// RELATIVE: @__llvm_coverage_mapping = {{.*"\\01[^/]*}}.{{/|\\}}nested{{.*coverage_relative_path\.swift}}
+// RELATIVE: @__llvm_coverage_mapping = {{.*"\\02.*\\01[^/]*\.[/\\]*nested[/\\]*coverage_relative_path\.swift}}

--- a/test/Profiler/coverage_relative_path.swift
+++ b/test/Profiler/coverage_relative_path.swift
@@ -10,6 +10,6 @@
 //
 // ABSOLUTE: @__llvm_coverage_mapping = {{.*"\\02.*root[^/\\]*nested[/\\]*coverage_relative_path\.swift}}
 
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %/t/root=. -emit-ir %/t/root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %t/root=. -emit-ir %t/root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
 //
 // RELATIVE: @__llvm_coverage_mapping = {{.*"\\02.*\\01[^/]*\.[/\\]*nested[/\\]*coverage_relative_path\.swift}}

--- a/test/Profiler/coverage_relative_path_exec.swift
+++ b/test/Profiler/coverage_relative_path_exec.swift
@@ -4,15 +4,15 @@
 
 // This test is to make sure llvm-cov can deal with a coverage-prefix-map.
 
-// To make sure this test is resilient to directory changes, we create nested directories inside of the
-// temporary test directory and assert those exist, or don't exist, in the emitted ir
+// To make sure this test is resilient to directory changes, we create nested
+// directories inside of the temporary test directory.
 //
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/root/nested
 // RUN: echo "func coverage() {}" > %t/root/nested/coverage_relative_path.swift
 // RUN: cd %t/root
 
-// RUN: %target-build-swift -profile-generate -profile-coverage-mapping -Xfrontend -coverage-prefix-map -Xfrontend %/t/root=. -Xfrontend -disable-incremental-llvm-codegen -o %t/main %/t/root/nested/coverage_relative_path.swift
+// RUN: %target-build-swift -profile-generate -profile-coverage-mapping -Xfrontend -coverage-prefix-map -Xfrontend %t/root=. -Xfrontend -disable-incremental-llvm-codegen -o %t/main %t/root/nested/coverage_relative_path.swift
 
 // This unusual use of 'sh' allows the path of the profraw file to be
 // substituted by %target-run.
@@ -20,6 +20,8 @@
 // RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
 
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
-// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s
+// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck --check-prefix SHOW %s
+// RUN: %llvm-cov report %t/main -instr-profile=%t/default.profdata | %FileCheck --check-prefix REPORT %s
 
-// CHECK: func coverage
+// SHOW: func coverage
+// REPORT: coverage_relative_path.swift

--- a/test/Profiler/coverage_relative_path_exec.swift
+++ b/test/Profiler/coverage_relative_path_exec.swift
@@ -1,0 +1,25 @@
+// REQUIRES: profile_runtime
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+// This test is to make sure llvm-cov can deal with a coverage-prefix-map.
+
+// To make sure this test is resilient to directory changes, we create nested directories inside of the
+// temporary test directory and assert those exist, or don't exist, in the emitted ir
+//
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/root/nested
+// RUN: echo "func coverage() {}" > %t/root/nested/coverage_relative_path.swift
+// RUN: cd %t/root
+
+// RUN: %target-build-swift -profile-generate -profile-coverage-mapping -Xfrontend -coverage-prefix-map -Xfrontend %/t/root=. -Xfrontend -disable-incremental-llvm-codegen -o %t/main %/t/root/nested/coverage_relative_path.swift
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-codesign %t/main
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
+// RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
+// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s
+
+// CHECK: func coverage


### PR DESCRIPTION
*5.9 cherry-pick of https://github.com/apple/swift/pull/66019 + https://github.com/apple/swift/pull/66053*

- Explanation: Fixes code coverage to not emit coverage maps for macro expansions for now, and fixes the filename emission to be consistent with version 6 of the coverage mapping format.
- Scope: Affects code coverage generation.
- Issue: rdar://109562235, https://github.com/apple/swift/issues/65964
- Risk: Low. The macro expansion change is very low risk, as it only excludes data from the coverage map. The filename change is also fairly low risk considering that it should only affect cases that use a coverage prefix map, and the previous behavior was completely broken.
- Testing: Added tests to the test suite
- Reviewer: Ben Barham