### PR TITLE
Explicitly #include <errno.h>, avoid depending on implicit inclusion by other headers

### DIFF
--- a/include/swift/Threading/Impl/Darwin.h
+++ b/include/swift/Threading/Impl/Darwin.h
@@ -21,6 +21,12 @@
 #include <os/lock.h>
 #include <pthread.h>
 
+#if __has_include(<sys/errno.h>)
+#include <sys/errno.h>
+#else
+#include <errno.h>
+#endif
+
 #include "chrono_utils.h"
 
 #include "llvm/ADT/Optional.h"

--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -24,6 +24,12 @@
 #include <cstring>
 #include <string>
 
+#if __has_include(<sys/errno.h>)
+#include <sys/errno.h>
+#else
+#include <errno.h>
+#endif
+
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Win32.h"
 


### PR DESCRIPTION
Explicitly #include <errno.h>, avoid depending on implicit inclusion by other headers. The has_include complication is taken from Stubs.cpp because we apparently already support platforms that have errno at sys/errno.h or errno.h, but it's not consistent. 🤷 