### PR TITLE
Fix the new diagnostic formatter adding extra whitespace on Windows

### DIFF
--- a/test/diagnostics/Inputs/extra-newlines-2.swift
+++ b/test/diagnostics/Inputs/extra-newlines-2.swift
@@ -1,0 +1,2 @@
+// Intentionally blank.
+

--- a/test/diagnostics/extra-newlines.swift
+++ b/test/diagnostics/extra-newlines.swift
@@ -1,0 +1,22 @@
+// Check that there are no extra newlines in the driver diagnostics output due to
+// double LF -> CR LF conversions on child processes output on Windows.
+//
+// Compile more than one source files to trigger the use of the driver
+// task queue and child processes.
+
+// RUN: %line-directive %s %S/Inputs/extra-newlines-2.swift -- %swiftc_driver -c -diagnostic-style=swift -no-color-diagnostics %s %S/Inputs/extra-newlines-2.swift -module-name Foo 2>&1 | %FileCheck %s
+
+// UNSUPPORTED: swift_swift_parser
+
+// Check that there are no extra newlines between diagnostics lines
+
+// CHECK:      {{[=]+}} SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}extra-newlines.swift:[[#LINE:]]:5
+// CHECK-NEXT: [[#LINE-1]] | func foo(a: Int, b: Int) {
+// CHECK-NEXT: [[#LINE]]   |   a + b
+// CHECK-NEXT:             |   ~   ~
+// CHECK-NEXT:             |     ^ warning: result of operator '+' is unused
+// CHECK-NEXT: [[#LINE+1]] | }
+
+func foo(a: Int, b: Int) {
+  a + b
+}


### PR DESCRIPTION
The swift driver emits extra newlines because it applies the LF -> CRLF conversions again on the outpt from the child processes. Fix it by using the binary mode when outputting the output from the child processes.

Fixes: #64413
