### PR TITLE
Relax FileCheck directives for `skip_clean_llbuild.test`

### DIFF
--- a/validation-test/BuildSystem/skip_clean_llbuild.test
+++ b/validation-test/BuildSystem/skip_clean_llbuild.test
@@ -8,8 +8,8 @@
 # RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --skip-clean-llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-LLBUILD-CHECK %s
 
-# CLEAN-LLBUILD-CHECK: Cleaning the llbuild build directory
-# CLEAN-LLBUILD-CHECK-NEXT: rm -rf
+# CLEAN-LLBUILD-CHECK-DAG: Cleaning the llbuild build directory
+# CLEAN-LLBUILD-CHECK: rm -rf
 
 # SKIP-CLEAN-LLBUILD-CHECK-NOT: Cleaning the llbuild build directory
 # SKIP-CLEAN-LLBUILD-CHECK-NOT: rm -rf {{.*/llbuild-[^/]*}}


### PR DESCRIPTION
This is needed short term to allow the test to pass when running on Python 3.11 and later and avoid errors like

```
<stdin>:44:1: note: non-matching line after previous match is here
<string>:1: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
^
```

Long term we want to replace uses of the obsolete `pipes.quotes` function with `shlex.quotes`.

Addresses rdar://109664710