### PR TITLE
[5.8] Relax FileCheck directives for `skip_clean_llbuild.test`

### DIFF
--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -74,7 +74,7 @@ class RoundTripTask(object):
                 logging.error(self.stderr.decode('utf-8', errors='replace'))
                 raise RuntimeError()
 
-        contents = ''.join(map(lambda l: l.decode('utf-8', errors='replace'),
+        contents = ''.join(map(lambda _: _.decode('utf-8', errors='replace'),
                                open(self.input_filename, 'rb').readlines()))
         stdout_contents = self.stdout.decode('utf-8', errors='replace')
 

--- a/validation-test/BuildSystem/skip_clean_llbuild.test
+++ b/validation-test/BuildSystem/skip_clean_llbuild.test
@@ -8,8 +8,8 @@
 # RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --skip-clean-llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-LLBUILD-CHECK %s
 
-# CLEAN-LLBUILD-CHECK: Cleaning the llbuild build directory
-# CLEAN-LLBUILD-CHECK-NEXT: rm -rf
+# CLEAN-LLBUILD-CHECK-DAG: Cleaning the llbuild build directory
+# CLEAN-LLBUILD-CHECK: rm -rf
 
 # SKIP-CLEAN-LLBUILD-CHECK-NOT: Cleaning the llbuild build directory
 # SKIP-CLEAN-LLBUILD-CHECK-NOT: rm -rf {{.*/llbuild-[^/]*}}


### PR DESCRIPTION
This is needed short term to allow the test to pass when running on Python 3.11 and later and avoid errors like

```
<stdin>:44:1: note: non-matching line after previous match is here
<string>:1: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
^
```

Long term we want to replace uses of the obsolete `pipes.quotes` function with `shlex.quotes`.

Piggyback a change in `round-trip-syntax-test` from #63237 to avoid Python linting errors.

Addresses rdar://109664710

(cherry picked from commit 1534925f2171f56640840b324855ea3800d2442b,
 #66062)