### PR TITLE
[5.9][presets] Add presets for the SourceKit stress tester

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2803,6 +2803,31 @@ mixin-preset=source_compat_suite_linux_base
 debug
 no-assertions
 
+[preset: sourcekit_stress_test_mixin]
+swiftsyntax
+skstresstester
+install-skstresstester
+
+[preset: sourcekit_stress_test_macos_D]
+mixin-preset=
+    source_compat_suite_macos_D
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_DA]
+mixin-preset=
+    source_compat_suite_macos_DA
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_R]
+mixin-preset=
+    source_compat_suite_macos_R
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_RA]
+mixin-preset=
+    source_compat_suite_macos_RA
+    sourcekit_stress_test_mixin
+
 [preset: linux_lldb]
 lldb
 foundation


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/65706 to release/5.9.

---

* **Explanation**: The SourceKit stress tester had previously hard-coded a `build-script` invocation, which made it not pick up, e.g. the new driver. To switch it over to using presets, create them. 
* **Scope**: Adds a new build preset
* **Risk**: Zero, only adds a new build preset
* **Testing**: n/a/
* **Issue**: n/a
* **Reviewer**: @shahmishal 