### PR TITLE
[5.9][Runtime] Use MetadataAllocator to allocate runtime instantiated layo…

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2729,8 +2729,8 @@ void swift::swift_initStructMetadataWithLayoutString(
   const size_t fixedLayoutStringSize = layoutStringHeaderSize +
                                        sizeof(uint64_t) * 2;
 
-  uint8_t *layoutStr = (uint8_t *)malloc(fixedLayoutStringSize +
-                                         refCountBytes);
+  uint8_t *layoutStr = (uint8_t *)MetadataAllocator(LayoutStringTag)
+      .Allocate(fixedLayoutStringSize + refCountBytes, alignof(uint8_t));
 
   *((size_t*)(layoutStr + sizeof(uint64_t))) = refCountBytes;
 

--- a/stdlib/public/runtime/MetadataAllocatorTags.def
+++ b/stdlib/public/runtime/MetadataAllocatorTags.def
@@ -48,5 +48,6 @@ TAG(ExtendedExistentialTypes, 22)
 TAG(ExtendedExistentialTypeShapes, 23)
 TAG(MetadataPack, 24)
 TAG(WitnessTablePack, 25)
+TAG(LayoutString, 26)
 
 #undef TAG


### PR DESCRIPTION
…ut strings (#66055)

5.9 cherry-pick of https://github.com/apple/swift/pull/66055

Explanation: This will create more visibility into layout string allocations when using swift-inspect.
Scope: Runtime instantiation of layout strings
Issue: rdar://109660582
Risk: Low. The feature is still experimental.
Testing: No new functionality was added, all existing tests still pass.
Reviewer: @mikeash 
