### PR TITLE
Simplify _endian and _pointerBitWidth conditions

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -395,45 +395,17 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     return { UnsupportedOS, UnsupportedArch };
 
   // Set the "_endian" platform condition.
-  switch (Target.getArch()) {
-  default: llvm_unreachable("undefined architecture endianness");
-  case llvm::Triple::ArchType::arm:
-  case llvm::Triple::ArchType::thumb:
-  case llvm::Triple::ArchType::aarch64:
-  case llvm::Triple::ArchType::aarch64_32:
-  case llvm::Triple::ArchType::ppc64le:
-  case llvm::Triple::ArchType::wasm32:
-  case llvm::Triple::ArchType::x86:
-  case llvm::Triple::ArchType::x86_64:
-  case llvm::Triple::ArchType::riscv64:
+  if (Target.isLittleEndian()) {
     addPlatformConditionValue(PlatformConditionKind::Endianness, "little");
-    break;
-  case llvm::Triple::ArchType::ppc:
-  case llvm::Triple::ArchType::ppc64:
-  case llvm::Triple::ArchType::systemz:
+  } else {
     addPlatformConditionValue(PlatformConditionKind::Endianness, "big");
-    break;
   }
 
   // Set the "_pointerBitWidth" platform condition.
-  switch (Target.getArch()) {
-  default: llvm_unreachable("undefined architecture pointer bit width");
-  case llvm::Triple::ArchType::arm:
-  case llvm::Triple::ArchType::thumb:
-  case llvm::Triple::ArchType::aarch64_32:
-  case llvm::Triple::ArchType::ppc:
-  case llvm::Triple::ArchType::x86:
-  case llvm::Triple::ArchType::wasm32:
+  if (Target.isArch32Bit()) {
     addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_32");
-    break;
-  case llvm::Triple::ArchType::aarch64:
-  case llvm::Triple::ArchType::ppc64:
-  case llvm::Triple::ArchType::ppc64le:
-  case llvm::Triple::ArchType::x86_64:
-  case llvm::Triple::ArchType::systemz:
-  case llvm::Triple::ArchType::riscv64:
+  } else if (Target.isArch64Bit()) {
     addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");
-    break;
   }
 
   // Set the "runtime" platform condition.


### PR DESCRIPTION
Use the convenience predicates:

* [`bool Triple::isLittleEndian() const`](https://github.com/apple/llvm-project/blob/887d6ab12fa3123f61751d7438878bb4da492733/llvm/lib/TargetParser/Triple.cpp#L1740-L1791)

* [`bool Triple::isArch{32,64}Bit() const`](https://github.com/apple/llvm-project/blob/887d6ab12fa3123f61751d7438878bb4da492733/llvm/lib/TargetParser/Triple.cpp#L1390-L1474)