### PR TITLE
[cherry-pick][release/5.9] [Build] Build libcxx on lldb ASAN/UBSAN bots

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -534,6 +534,8 @@ mixin-preset=buildbot_incremental_base
 
 build-subdir=buildbot_incremental_lldb_asan_ubsan
 
+# Standalone tests require newly built libcxx
+libcxx
 # Build a sanitized lldb. Don't build a sanitized clang/swift.
 lldb
 lldb-extra-cmake-args=-DLLVM_USE_SANITIZER=Address;Undefined


### PR DESCRIPTION
The preset for ubsan/asan buildbots include the
`buildbot_incremental_base` preset, which builds/runs tests. But the tests now require libcxx to be built since https://github.com/apple/swift/pull/66018

(cherry picked from commit 7893c8e69b25bab559f7942ae82387b47c4e1928)