### PR TITLE
[5.9] [Diags] Avoid emitting fix-its for generated code

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -344,8 +344,6 @@ Parser::parseSourceFileViaASTGen(SmallVectorImpl<ASTNode> &items,
                                  Optional<DiagnosticTransaction> &transaction,
                                  bool suppressDiagnostics) {
 #if SWIFT_SWIFT_PARSER
-  using ParsingFlags = SourceFile::ParsingFlags;
-  const auto parsingOpts = SF.getParsingOptions();
   const auto &langOpts = Context.LangOpts;
 
   // We only need to do parsing if we either have ASTGen enabled, or want the

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1293,6 +1293,25 @@ public struct DefineStructWithUnqualifiedLookupMacro: DeclarationMacro {
   }
 }
 
+public struct AddMemberWithFixIt: MemberMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax, Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    [
+      """
+      func foo() {
+        var x = 0
+        _ = x
+      }
+      """
+    ]
+  }
+}
+
 extension TupleExprElementListSyntax {
   /// Retrieve the first element with the given label.
   func first(labeled name: String) -> Element? {

--- a/test/Macros/macro_fixits.swift
+++ b/test/Macros/macro_fixits.swift
@@ -1,0 +1,26 @@
+// REQUIRES: swift_swift_parser
+
+// This test ensures we don't emit fix-its in generated code, such as macro
+// expansion buffers.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %host-build-swift -emit-library %S/Inputs/syntax_macro_definitions.swift -o %t/%target-library-name(MacroDefinition) -module-name MacroDefinition -swift-version 5 -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck %s -load-plugin-library %t/%target-library-name(MacroDefinition) -swift-version 5 -serialize-diagnostics-path %t/diags.dia -fixit-all -emit-fixits-path %t/fixits.json
+
+// RUN: %FileCheck %s --check-prefix FIXITS-JSON < %t/fixits.json
+
+// FIXITS-JSON:      [
+// FIXITS-JSON-NEXT: ]
+
+// RUN: c-index-test -read-diagnostics %t/diags.dia 2>&1 | %FileCheck -check-prefix DIAGS %s
+
+// DIAGS: warning: variable 'x' was never mutated; consider changing to 'let' constant
+// DIAGS-NEXT: Number FIXITs = 0
+
+@attached(member, names: arbitrary)
+public macro addMemberWithFixIt() = #externalMacro(module: "MacroDefinition", type: "AddMemberWithFixIt")
+
+@addMemberWithFixIt
+struct S {}

--- a/test/SourceKit/Macros/diags.swift
+++ b/test/SourceKit/Macros/diags.swift
@@ -16,6 +16,13 @@ func foo() {
 @Invalid
 struct Bad {}
 
+@attached(member, names: arbitrary)
+public macro addMemberWithFixIt() = #externalMacro(module: "MacroDefinition", type: "AddMemberWithFixIt")
+
+// Make sure we don't emit the fix-it for the member added by this macro.
+@addMemberWithFixIt
+struct S {}
+
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)

--- a/test/SourceKit/Macros/diags.swift.response
+++ b/test/SourceKit/Macros/diags.swift.response
@@ -44,6 +44,15 @@
         key.buffer_name: diags.swift
       },
       key.buffer_name: "@__swiftmacro_9MacroUser3Bad7InvalidfMp_.swift"
+    },
+    {
+      key.buffer_text: "func foo() {\n  var x = 0\n  _ = x\n}",
+      key.original_location: {
+        key.offset: 748,
+        key.length: 0,
+        key.buffer_name: diags.swift
+      },
+      key.buffer_name: "@__swiftmacro_9MacroUser1S18addMemberWithFixItfMm_.swift"
     }
   ],
   key.diagnostics: [
@@ -170,6 +179,30 @@
             {
               key.offset: 486,
               key.length: 13
+            }
+          ]
+        }
+      ]
+    },
+    {
+      key.line: 2,
+      key.column: 7,
+      key.filepath: "@__swiftmacro_9MacroUser1S18addMemberWithFixItfMm_.swift",
+      key.severity: source.diagnostic.severity.warning,
+      key.id: "variable_never_mutated",
+      key.description: "variable 'x' was never mutated; consider changing to 'let' constant",
+      key.diagnostics: [
+        {
+          key.line: 24,
+          key.column: 1,
+          key.filepath: diags.swift,
+          key.severity: source.diagnostic.severity.note,
+          key.id: "in_macro_expansion",
+          key.description: "in expansion of macro 'addMemberWithFixIt' here",
+          key.ranges: [
+            {
+              key.offset: 738,
+              key.length: 11
             }
           ]
         }


### PR DESCRIPTION
*5.9 cherry-pick of https://github.com/apple/swift/pull/66076*

- Explanation: Fixes diagnostics such that fix-its are not emitted for diagnostics in macro expansions, as they cannot be directly applied by the user.
- Scope: Affects diagnostics emitted in macro expansions.
- Issue: rdar://108231633
- Risk: Low, this just drops fix-its from diagnostics if they are emitted in a generated buffer.
- Testing: Added tests to the test suite
- Reviewer: Pavel Yaskevich