### PR TITLE
5.9: [IRGen] Cast dynamic alloca to appropriate type.

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2158,7 +2158,9 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
     HeapNonFixedOffsets offsets(IGF, layout);
     if (outType->isNoEscape()) {
       stackAddr = IGF.emitDynamicAlloca(
-          IGF.IGM.Int8Ty, layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize() , Alignment(16));
+          IGF.IGM.Int8Ty,
+          layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize(),
+          Alignment(16));
       stackAddr = stackAddr->withAddress(IGF.Builder.CreateElementBitCast(
           stackAddr->getAddress(), IGF.IGM.OpaqueTy));
       data = stackAddr->getAddress().getAddress();

--- a/validation-test/IRGen/rdar109540863.swift
+++ b/validation-test/IRGen/rdar109540863.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -disable-availability-checking -emit-ir | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// CHECK: define {{.*}}@callee
+@_silgen_name("callee")
+func callee<each T : P>(_ ts: repeat each T) async {
+  (repeat (each ts).foo())
+}
+
+// CHECK: define {{.*}}@caller
+@_silgen_name("caller")
+func caller<each T1 : P>(t1: repeat each T1) async {
+  await callee(S(), repeat each t1)
+}
+
+struct S : P {
+  func foo() {
+  }
+}
+protocol P {
+  func foo()
+}


### PR DESCRIPTION
Description: Stop emitting invalid LLVM IR when emitting pack metadata, witness tables, and values when stack allocating packs in async and coroutine code.

To allocate stack space for these packs, `emitDynamicAlloca` is called from `GenPack`.  The calling code expects the type of the returned `llvm::Value *` to be `Metadata **`/`WitnessTable **`.  In synchronous contexts, the value was indeed typed thus.  In asychronous contexts, however, it was typed `i8 **`.  Fix the callee to fulfill the callers' expectations by bit casting the value returned from `emitDynamicAlloca` to the type indicated by the caller.
Risk: Low.  There are only 9 callers of that function and of them the only callers (of which there are 3) that will see a change in behavior are in `GenPack`.  For the remaining 6, this change is NFC because no bitcast is inserted when the source (`i8 *`) and destination types are the same, and those all request `i8 *`.
Scope: Narrow.  Only affects variadic generic IR generation, and only changes its behavior in async and coroutine contexts.
Original PR: https://github.com/apple/swift/pull/66014
Reviewed By: Slava Pestov ( @slavapestov )
Testing: Added test case that previously triggered assertion failure.
Resolves: rdar://109540863
