### PR TITLE
[benchmark] add `removeAll(keepingCapacity: true)` benchmark for non-unique arrays

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SWIFT_BENCH_MODULES
     single-source/ArrayOfGenericRef
     single-source/ArrayOfPOD
     single-source/ArrayOfRef
+    single-source/ArrayRemoveAll
     single-source/ArraySetElement
     single-source/ArraySubscript
     single-source/BinaryFloatingPointConversionFromBinaryInteger

--- a/benchmark/single-source/ArrayRemoveAll.swift
+++ b/benchmark/single-source/ArrayRemoveAll.swift
@@ -5,13 +5,13 @@ import TestsUtils
 
 public let benchmarks = [
   BenchmarkInfo(
-    name: "ArrayRemoveAll_Class",
+    name: "Array.removeAll.keepingCapacity.Int",
     runFunction: run_ArrayRemoveAll_Class,
     tags: [.validation, .api, .Array],
     setUpFunction: { blackHole(inputArray_Class) }
   ),
   BenchmarkInfo(
-    name: "ArrayRemoveAll_Int",
+    name: "Array.removeAll.keepingCapacity.Object",
     runFunction: run_ArrayRemoveAll_Int,
     tags: [.validation, .api, .Array],
     setUpFunction: { blackHole(inputArray_Int) }

--- a/benchmark/single-source/ArrayRemoveAll.swift
+++ b/benchmark/single-source/ArrayRemoveAll.swift
@@ -18,6 +18,14 @@ public let benchmarks = [
   )
 ]
 
+class Slow {
+  public var num: Int
+
+  init(num: Int) {
+    self.num = num
+  }
+}
+
 let size_Int = 1_000_000
 let size_Class = 100_000
 
@@ -39,20 +47,6 @@ var inputArray_Class: [Slow]! = {
   return a
 }()
 
-class Slow {
-  public var num: Int
-    
-  init(num: Int) {
-    self.num = num
-  }
-}
-
-
-@inline(never)
-func verifyCapacity<T>(_ new: [T], orig: [T]) -> Bool {
-    return new.capacity == orig.capacity
-}
-
 @inline(never)
 func removeAll<T>(_ arr: [T]) -> [T] {
   var copy = arr
@@ -61,22 +55,19 @@ func removeAll<T>(_ arr: [T]) -> [T] {
 }
 
 @inline(never)
-func copyItem<T>(_ item: T) -> T {
-  return item
-}
-
-@inline(never)
 func run_ArrayRemoveAll_Class(_ n: Int) {
-  for _ in 1...n {
-    let copy = removeAll(inputArray_Class)
-    check(verifyCapacity(copy, orig: inputArray_Class))
+  var copy = removeAll(inputArray_Class);
+  for _ in 1..<n {
+    copy = removeAll(inputArray_Class)
   }
+  check(copy.capacity == inputArray_Class.capacity)
 }
 
 @inline(never)
 func run_ArrayRemoveAll_Int(_ n: Int) {
-  for _ in 1...n {
-    let copy = removeAll(inputArray_Int)
-    check(verifyCapacity(copy, orig: inputArray_Int))
+  var copy = removeAll(inputArray_Int);
+  for _ in 1..<n {
+    copy = removeAll(inputArray_Int)
   }
+  check(copy.capacity == inputArray_Int.capacity)
 }

--- a/benchmark/single-source/ArrayRemoveAll.swift
+++ b/benchmark/single-source/ArrayRemoveAll.swift
@@ -1,0 +1,82 @@
+// This test checks the performance of removeAll on a non-uniquely referenced array.
+import TestsUtils
+
+public let benchmarks = [
+  BenchmarkInfo(
+    name: "ArrayRemoveAll_Class",
+    runFunction: run_ArrayRemoveAll_Class,
+    tags: [.validation, .api, .Array],
+    setUpFunction: { blackHole(inputArray_Class) },
+    tearDownFunction: { inputArray_Class = nil }
+  ),
+  BenchmarkInfo(
+    name: "ArrayRemoveAll_Int",
+    runFunction: run_ArrayRemoveAll_Int,
+    tags: [.validation, .api, .Array],
+    setUpFunction: { blackHole(inputArray_Int) },
+    tearDownFunction: { inputArray_Int = nil }
+  )
+]
+
+let size_Int = 1_000_000
+let size_Class = 100_000
+
+var inputArray_Int: [Int]! = {
+  var a: [Int] = []
+  a.reserveCapacity(size_Int)
+  for i in 0 ..< size_Int {
+    a.append(i)
+  }
+  return a
+}()
+
+var inputArray_Class: [Slow]! = {
+  var a: [Slow] = []
+  a.reserveCapacity(size_Class)
+  for i in 0 ..< size_Class {
+    a.append(Slow(num: i))
+  }
+  return a
+}()
+
+class Slow {
+  public var num: Int
+    
+  init(num: Int) {
+    self.num = num
+  }
+}
+
+
+@inline(never)
+func verifyCapacity<T>(_ new: [T], orig: [T]) -> Bool {
+    return new.capacity == orig.capacity
+}
+
+@inline(never)
+func removeAll<T>(_ arr: [T]) -> [T] {
+  var copy = arr
+  copy.removeAll(keepingCapacity: true)
+  return copy
+}
+
+@inline(never)
+func copyItem<T>(_ item: T) -> T {
+  return item
+}
+
+@inline(never)
+func run_ArrayRemoveAll_Class(_ n: Int) {
+  for _ in 1...n {
+    let copy = removeAll(inputArray_Class)
+    check(verifyCapacity(copy, orig: inputArray_Class))
+  }
+}
+
+@inline(never)
+func run_ArrayRemoveAll_Int(_ n: Int) {
+  for _ in 1...n {
+    let copy = removeAll(inputArray_Int)
+    check(verifyCapacity(copy, orig: inputArray_Int))
+  }
+}

--- a/benchmark/single-source/ArrayRemoveAll.swift
+++ b/benchmark/single-source/ArrayRemoveAll.swift
@@ -1,4 +1,6 @@
-// This test checks the performance of removeAll on a non-uniquely referenced array.
+// This test checks the performance of removeAll
+// on a non-uniquely referenced array.
+
 import TestsUtils
 
 public let benchmarks = [
@@ -6,15 +8,13 @@ public let benchmarks = [
     name: "ArrayRemoveAll_Class",
     runFunction: run_ArrayRemoveAll_Class,
     tags: [.validation, .api, .Array],
-    setUpFunction: { blackHole(inputArray_Class) },
-    tearDownFunction: { inputArray_Class = nil }
+    setUpFunction: { blackHole(inputArray_Class) }
   ),
   BenchmarkInfo(
     name: "ArrayRemoveAll_Int",
     runFunction: run_ArrayRemoveAll_Int,
     tags: [.validation, .api, .Array],
-    setUpFunction: { blackHole(inputArray_Int) },
-    tearDownFunction: { inputArray_Int = nil }
+    setUpFunction: { blackHole(inputArray_Int) }
   )
 ]
 
@@ -26,26 +26,8 @@ class Slow {
   }
 }
 
-let size_Int = 1_000_000
-let size_Class = 100_000
-
-var inputArray_Int: [Int]! = {
-  var a: [Int] = []
-  a.reserveCapacity(size_Int)
-  for i in 0 ..< size_Int {
-    a.append(i)
-  }
-  return a
-}()
-
-var inputArray_Class: [Slow]! = {
-  var a: [Slow] = []
-  a.reserveCapacity(size_Class)
-  for i in 0 ..< size_Class {
-    a.append(Slow(num: i))
-  }
-  return a
-}()
+let inputArray_Int: [Int] = Array(0..<1_000_000)
+let inputArray_Class: [Slow] = (0..<100_000).map(Slow.init(num:))
 
 @inline(never)
 func removeAll<T>(_ arr: [T]) -> [T] {

--- a/benchmark/single-source/ArrayRemoveAll.swift
+++ b/benchmark/single-source/ArrayRemoveAll.swift
@@ -26,8 +26,8 @@ class Slow {
   }
 }
 
-let inputArray_Int: [Int] = Array(0..<1_000_000)
-let inputArray_Class: [Slow] = (0..<100_000).map(Slow.init(num:))
+let inputArray_Int: [Int] = Array(0..<500_000)
+let inputArray_Class: [Slow] = (0..<50_000).map(Slow.init(num:))
 
 @inline(never)
 func removeAll<T>(_ arr: [T]) -> [T] {

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -25,6 +25,7 @@ import ArrayOfGenericPOD
 import ArrayOfGenericRef
 import ArrayOfPOD
 import ArrayOfRef
+import ArrayRemoveAll
 import ArraySetElement
 import ArraySubscript
 import BinaryFloatingPointConversionFromBinaryInteger
@@ -217,6 +218,7 @@ register(ArrayOfGenericPOD.benchmarks)
 register(ArrayOfGenericRef.benchmarks)
 register(ArrayOfPOD.benchmarks)
 register(ArrayOfRef.benchmarks)
+register(ArrayRemoveAll.benchmarks)
 register(ArraySetElement.benchmarks)
 register(ArraySubscript.benchmarks)
 register(BinaryFloatingPointConversionFromBinaryInteger.benchmarks)


### PR DESCRIPTION
Add a benchmark for the issue described by #56321 (rdar://71809690), so that the actual fix (#66085) can be measured.