### PR TITLE
polish up the noncopyable diagnostics

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2805,7 +2805,7 @@ canonical SIL that the value was never copied and thus is a "move only value"
 even though the actual underlying wrapped type is copyable. As an example of
 this, consider the following Swift::
 
-  func doSomething(@_noImplicitCopy _ x: Klass) -> () { // expected-error {{'x' has guaranteed ownership but was consumed}}
+  func doSomething(@_noImplicitCopy _ x: Klass) -> () { // expected-error {{'x' is borrowed and cannot be consumed}}
     x.doSomething()
     let x2 = x // expected-note {{consuming use}}
     x2.doSomething()

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -248,7 +248,7 @@ ERROR(conforms_to_not_protocol,none,
       "%0 %1 referenced in protocol conformance '%2' is not a protocol", (DescriptiveDeclKind, ValueDecl *, StringRef))
 
 ERROR(move_only_requires_move_only,none,
-      "use of move-only C++ type '%0' requires -enable-experimental-move-only",
+      "use of noncopyable C++ type '%0' requires -enable-experimental-move-only",
       (StringRef))
 
 NOTE(unsupported_builtin_type, none, "built-in type '%0' not supported", (StringRef))

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -764,7 +764,7 @@ ERROR(sil_moveonlychecker_capture_consumed, none,
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
       "missing reinitialization of inout parameter '%0' after consume", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
-      "'%0' consumed by a use in a loop", (StringRef))
+      "'%0' consumed in a loop", (StringRef))
 
 ERROR(sil_moveonlychecker_use_after_partial_consume, none,
       "cannot use '%0' after partial consume", (StringRef))
@@ -774,28 +774,23 @@ ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed, none,
       (StringRef, bool))
 
 ERROR(sil_moveonlychecker_cannot_destructure_has_deinit, none,
-      "cannot partially consume '%0' since it has a user defined deinit",
+      "cannot partially consume '%0' when it has a deinitializer",
       (StringRef))
 
 NOTE(sil_moveonlychecker_partial_consume_here, none,
-     "partial consume here", ())
+     "partially consumed here", ())
 NOTE(sil_moveonlychecker_consuming_use_here, none,
-     "consuming use here", ())
+     "consumed here", ())
 NOTE(sil_moveonlychecker_other_consuming_use_here, none,
-     "other consuming use here", ())
+     "other consume here", ())
 NOTE(sil_moveonlychecker_two_consuming_uses_here, none,
-     "two consuming uses here", ())
+     "multiple consumes here", ())
 NOTE(sil_moveonlychecker_consuming_and_non_consuming_uses_here, none,
-     "consuming and non-consuming uses here", ())
+     "consumed and used here", ())
 NOTE(sil_moveonlychecker_consuming_closure_use_here, none,
-     "closure capture here", ())
-
-// TODO: a lot of these "non-consuming use" notes are just emitted to point out
-// an "invalid use after consume". I'd say most of them are for that.
-// In the other narrow cases where that's not quite right, we could go with
-// something vague like "use here"
+     "closure capturing '%0' here", (StringRef))
 NOTE(sil_moveonlychecker_nonconsuming_use_here, none,
-     "non-consuming use here", ())
+     "used here", ())
 
 NOTE(sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here, none,
      "consuming in loop use here", ())

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -762,7 +762,7 @@ ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
 ERROR(sil_moveonlychecker_capture_consumed_in_closure, none,
       "captured '%0' cannot be consumed within a closure", (StringRef))
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
-      "missing reinitialization of '%0' after consume", (StringRef))
+      "missing reinitialization of inout parameter '%0' after consume", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
       "'%0' consumed by a use in a loop", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -753,39 +753,26 @@ ERROR(sil_moveonlychecker_owned_value_consumed_and_used_at_same_time, none,
 ERROR(sil_moveonlychecker_value_used_after_consume, none,
       "'%0' used after consume", (StringRef))
 ERROR(sil_moveonlychecker_guaranteed_value_consumed, none,
-      "'%0' has guaranteed ownership but was consumed", (StringRef))
+      "'%0' is borrowed and cannot be consumed", (StringRef))
+
+// FIXME: this diagnostic shouldn't ever be emitted now. rdar://109742587 (closures may still try to consume captures, e.g., borrowed parameters)
 ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
-      "'%0' has guaranteed ownership but was consumed due to being captured by a closure", (StringRef))
-ERROR(sil_moveonlychecker_let_value_consumed_in_closure, none,
-      "'%0' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations", (StringRef))
+      "'%0' is borrowed and cannot be consumed by closure capture", (StringRef))
+
+ERROR(sil_moveonlychecker_capture_consumed_in_closure, none,
+      "captured '%0' cannot be consumed within a closure", (StringRef))
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
-      "'%0' consumed but not reinitialized before end of function", (StringRef))
-ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_closure, none,
-      "'%0' consumed in closure but not reinitialized before end of closure", (StringRef))
+      "missing reinitialization of '%0' after consume", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
       "'%0' consumed by a use in a loop", (StringRef))
-ERROR(sil_moveonlychecker_exclusivity_violation, none,
-      "'%0' has consuming use that cannot be eliminated due to a tight exclusivity scope", (StringRef))
-ERROR(sil_moveonlychecker_moveonly_field_consumed, none,
-      "'%0' has a move only field that was consumed before later uses", (StringRef))
 
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_let, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable class let field. One can only read from it",
-      (StringRef))
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_var, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it",
-      (StringRef))
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_global_var, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable global var. One can only read from it or assign to it",
-      (StringRef))
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_global_let, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable global let. One can only read from it",
-      (StringRef))
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it",
-      (StringRef))
-ERROR(sil_moveonlychecker_let_capture_consumed, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it", (StringRef))
+ERROR(sil_moveonlychecker_use_after_partial_consume, none,
+      "cannot use '%0' after partial consume", (StringRef))
+
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed, none,
+      "cannot consume noncopyable stored property '%0' %select{of a class|that is global}1",
+      (StringRef, bool))
+
 ERROR(sil_moveonlychecker_cannot_destructure_deinit_nominal_type_self, none,
       "Cannot partially consume '%0' since it has a user defined deinit",
       (StringRef))
@@ -793,8 +780,8 @@ ERROR(sil_moveonlychecker_cannot_destructure_deinit_nominal_type_field, none,
       "Cannot partially consume '%0' since it contains field '%1.%2' whose type %3 has a user defined deinit",
       (StringRef, StringRef, StringRef, DeclBaseName))
 
-NOTE(sil_moveonlychecker_moveonly_field_consumed_here, none,
-     "move only field consumed here", ())
+NOTE(sil_moveonlychecker_partial_consume_here, none,
+     "partial consume here", ())
 NOTE(sil_moveonlychecker_boundary_use, none,
      "boundary use here", ())
 NOTE(sil_moveonlychecker_consuming_use_here, none,
@@ -814,15 +801,6 @@ NOTE(sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here, none,
 NOTE(sil_moveonlychecker_deinit_here, none,
      "deinit declared here", ())
 
-ERROR(sil_moveonlychecker_not_understand_consumable_and_assignable, none,
-      "Usage of @noImplicitCopy that the move checker does not know how to "
-      "check!", ())
-ERROR(sil_moveonlychecker_not_understand_moveonly, none,
-      "Usage of a move only type that the move checker does not know how to "
-      "check!", ())
-ERROR(sil_moveonlychecker_missed_copy, none,
-      "copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug", ())
-
 // move kills copyable values checker diagnostics
 ERROR(sil_movekillscopyablevalue_value_consumed_more_than_once, none,
       "'%0' used after being consumed", (StringRef))
@@ -832,9 +810,21 @@ NOTE(sil_movekillscopyablevalue_use_here, none,
      "use here", ())
 NOTE(sil_movekillscopyablevalue_value_consumed_in_loop, none,
      "consume here would occur multiple times in loop", ())
+
+// errors involving noncopyables that are considered to be bugs in the compiler
+ERROR(sil_moveonlychecker_not_understand_consumable_and_assignable, none,
+      "usage of no-implicit-copy value that the compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug", ())
+ERROR(sil_moveonlychecker_not_understand_moveonly, none,
+      "usage of a noncopyable type that compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug"
+      "check!", ())
+ERROR(sil_moveonlychecker_bug_missed_copy, none,
+      "copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug", ())
+ERROR(sil_moveonlychecker_bug_exclusivity_violation, none,
+      "'%0' has an unexpected exclusivity violation. This is a compiler bug. Please file a bug with a small example of the bug", (StringRef))
 ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
-      "'consume' applied to value that the compiler does not support checking",
+      "'consume' applied to value that the compiler does not support. This is a compiler bug. Please file a bug with a small example of the bug",
       ())
+
 
 // Implicit inout-to-UnsafeRawPointer conversions
 WARNING(nontrivial_to_rawpointer_conversion,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -773,12 +773,9 @@ ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed, none,
       "cannot consume noncopyable stored property '%0' %select{of a class|that is global}1",
       (StringRef, bool))
 
-ERROR(sil_moveonlychecker_cannot_destructure_deinit_nominal_type_self, none,
-      "Cannot partially consume '%0' since it has a user defined deinit",
+ERROR(sil_moveonlychecker_cannot_destructure_has_deinit, none,
+      "cannot partially consume '%0' since it has a user defined deinit",
       (StringRef))
-ERROR(sil_moveonlychecker_cannot_destructure_deinit_nominal_type_field, none,
-      "Cannot partially consume '%0' since it contains field '%1.%2' whose type %3 has a user defined deinit",
-      (StringRef, StringRef, StringRef, DeclBaseName))
 
 NOTE(sil_moveonlychecker_partial_consume_here, none,
      "partial consume here", ())

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -779,8 +779,6 @@ ERROR(sil_moveonlychecker_cannot_destructure_has_deinit, none,
 
 NOTE(sil_moveonlychecker_partial_consume_here, none,
      "partial consume here", ())
-NOTE(sil_moveonlychecker_boundary_use, none,
-     "boundary use here", ())
 NOTE(sil_moveonlychecker_consuming_use_here, none,
      "consuming use here", ())
 NOTE(sil_moveonlychecker_other_consuming_use_here, none,
@@ -791,8 +789,14 @@ NOTE(sil_moveonlychecker_consuming_and_non_consuming_uses_here, none,
      "consuming and non-consuming uses here", ())
 NOTE(sil_moveonlychecker_consuming_closure_use_here, none,
      "closure capture here", ())
+
+// TODO: a lot of these "non-consuming use" notes are just emitted to point out
+// an "invalid use after consume". I'd say most of them are for that.
+// In the other narrow cases where that's not quite right, we could go with
+// something vague like "use here"
 NOTE(sil_moveonlychecker_nonconsuming_use_here, none,
      "non-consuming use here", ())
+
 NOTE(sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here, none,
      "consuming in loop use here", ())
 NOTE(sil_moveonlychecker_deinit_here, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -745,77 +745,65 @@ NOTE(discard_nontrivial_implicit_storage_note,none,
      "type %0 implicitly contains %1 which cannot be trivially destroyed",
      (Type, Type))
 
-// move only checker diagnostics
-ERROR(sil_moveonlychecker_owned_value_consumed_more_than_once, none,
+
+/// Move Checking / Noncopyable types diagnostics
+
+ERROR(sil_movechecking_owned_value_consumed_more_than_once, none,
       "'%0' consumed more than once", (StringRef))
-ERROR(sil_moveonlychecker_owned_value_consumed_and_used_at_same_time, none,
+ERROR(sil_movechecking_owned_value_consumed_and_used_at_same_time, none,
       "'%0' consumed and used at the same time", (StringRef))
-ERROR(sil_moveonlychecker_value_used_after_consume, none,
+ERROR(sil_movechecking_value_used_after_consume, none,
       "'%0' used after consume", (StringRef))
-ERROR(sil_moveonlychecker_guaranteed_value_consumed, none,
+ERROR(sil_movechecking_guaranteed_value_consumed, none,
       "'%0' is borrowed and cannot be consumed", (StringRef))
 
 // FIXME: this diagnostic shouldn't ever be emitted now. rdar://109742587 (closures may still try to consume captures, e.g., borrowed parameters)
-ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
+ERROR(sil_movechecking_guaranteed_value_captured_by_closure, none,
       "'%0' is borrowed and cannot be consumed by closure capture", (StringRef))
 
-ERROR(sil_moveonlychecker_capture_consumed, none,
+ERROR(sil_movechecking_capture_consumed, none,
       "noncopyable '%0' cannot be consumed when captured by a closure", (StringRef))
-ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
+ERROR(sil_movechecking_inout_not_reinitialized_before_end_of_function, none,
       "missing reinitialization of inout parameter '%0' after consume", (StringRef))
-ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
+ERROR(sil_movechecking_value_consumed_in_a_loop, none,
       "'%0' consumed in a loop", (StringRef))
-
-ERROR(sil_moveonlychecker_use_after_partial_consume, none,
+ERROR(sil_movechecking_use_after_partial_consume, none,
       "cannot use '%0' after partial consume", (StringRef))
-
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed, none,
+ERROR(sil_movechecking_notconsumable_but_assignable_was_consumed, none,
       "cannot consume noncopyable stored property '%0' %select{of a class|that is global}1",
       (StringRef, bool))
-
-ERROR(sil_moveonlychecker_cannot_destructure_has_deinit, none,
+ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
       "cannot partially consume '%0' when it has a deinitializer",
       (StringRef))
 
-NOTE(sil_moveonlychecker_partial_consume_here, none,
+NOTE(sil_movechecking_partial_consume_here, none,
      "partially consumed here", ())
-NOTE(sil_moveonlychecker_consuming_use_here, none,
+NOTE(sil_movechecking_consuming_use_here, none,
      "consumed here", ())
-NOTE(sil_moveonlychecker_other_consuming_use_here, none,
+NOTE(sil_movechecking_other_consuming_use_here, none,
      "other consume here", ())
-NOTE(sil_moveonlychecker_two_consuming_uses_here, none,
+NOTE(sil_movechecking_two_consuming_uses_here, none,
      "multiple consumes here", ())
-NOTE(sil_moveonlychecker_consuming_and_non_consuming_uses_here, none,
+NOTE(sil_movechecking_consuming_and_non_consuming_uses_here, none,
      "consumed and used here", ())
-NOTE(sil_moveonlychecker_consuming_closure_use_here, none,
+NOTE(sil_movechecking_consuming_closure_use_here, none,
      "closure capturing '%0' here", (StringRef))
-NOTE(sil_moveonlychecker_nonconsuming_use_here, none,
+NOTE(sil_movechecking_nonconsuming_use_here, none,
      "used here", ())
-
-NOTE(sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here, none,
-     "consuming in loop use here", ())
-NOTE(sil_moveonlychecker_deinit_here, none,
-     "deinit declared here", ())
-
-// move kills copyable values checker diagnostics
-ERROR(sil_movekillscopyablevalue_value_consumed_more_than_once, none,
-      "'%0' used after being consumed", (StringRef))
-NOTE(sil_movekillscopyablevalue_move_here, none,
-     "consume here", ())
-NOTE(sil_movekillscopyablevalue_use_here, none,
-     "use here", ())
-NOTE(sil_movekillscopyablevalue_value_consumed_in_loop, none,
-     "consume here would occur multiple times in loop", ())
+NOTE(sil_movechecking_consumed_in_loop_here, none,
+     "consumed in loop here", ())
+NOTE(sil_movechecking_deinit_here, none,
+     "deinitializer declared here", ())
 
 // errors involving noncopyables that are considered to be bugs in the compiler
-ERROR(sil_moveonlychecker_not_understand_consumable_and_assignable, none,
+ERROR(sil_movechecking_not_understand_consumable_and_assignable, none,
       "usage of no-implicit-copy value that the compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug", ())
-ERROR(sil_moveonlychecker_not_understand_moveonly, none,
+ERROR(sil_movechecking_not_understand_moveonly, none,
       "usage of a noncopyable type that compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug"
       "check!", ())
-ERROR(sil_moveonlychecker_bug_missed_copy, none,
+ERROR(sil_movechecking_bug_missed_copy, none,
       "copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug", ())
-ERROR(sil_moveonlychecker_bug_exclusivity_violation, none,
+ERROR(sil_movechecking_bug_exclusivity_violation, none,
       "'%0' has an unexpected exclusivity violation. This is a compiler bug. Please file a bug with a small example of the bug", (StringRef))
 ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
       "'consume' applied to value that the compiler does not support. This is a compiler bug. Please file a bug with a small example of the bug",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -759,8 +759,8 @@ ERROR(sil_moveonlychecker_guaranteed_value_consumed, none,
 ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
       "'%0' is borrowed and cannot be consumed by closure capture", (StringRef))
 
-ERROR(sil_moveonlychecker_capture_consumed_in_closure, none,
-      "captured '%0' cannot be consumed within a closure", (StringRef))
+ERROR(sil_moveonlychecker_capture_consumed, none,
+      "noncopyable '%0' cannot be consumed when captured by a closure", (StringRef))
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
       "missing reinitialization of inout parameter '%0' after consume", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -780,8 +780,8 @@ NOTE(sil_movechecking_partial_consume_here, none,
      "partially consumed here", ())
 NOTE(sil_movechecking_consuming_use_here, none,
      "consumed here", ())
-NOTE(sil_movechecking_other_consuming_use_here, none,
-     "other consume here", ())
+NOTE(sil_movechecking_consumed_again_here, none,
+     "consumed again here", ())
 NOTE(sil_movechecking_two_consuming_uses_here, none,
      "multiple consumes here", ())
 NOTE(sil_movechecking_consuming_and_non_consuming_uses_here, none,
@@ -799,8 +799,7 @@ NOTE(sil_movechecking_deinit_here, none,
 ERROR(sil_movechecking_not_understand_consumable_and_assignable, none,
       "usage of no-implicit-copy value that the compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug", ())
 ERROR(sil_movechecking_not_understand_moveonly, none,
-      "usage of a noncopyable type that compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug"
-      "check!", ())
+      "usage of a noncopyable type that compiler can't verify. This is a compiler bug. Please file a bug with a small example of the bug", ())
 ERROR(sil_movechecking_bug_missed_copy, none,
       "copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug", ())
 ERROR(sil_movechecking_bug_exclusivity_violation, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1718,7 +1718,7 @@ ERROR(expose_enum_case_tuple_to_cxx,none,
 ERROR(expose_protocol_to_cxx_unsupported,none,
       "protocol %0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_move_only_to_cxx,none,
-      "move-only %0 %1 can not yet be represented in C++", (DescriptiveDeclKind, ValueDecl *))
+      "noncopyable %0 %1 can not yet be represented in C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(unexposed_other_decl_in_cxx,none,
       "%0 %1 is not yet exposed to C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(unsupported_other_decl_in_cxx,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6930,30 +6930,6 @@ ERROR(wrap_invalid_attr_added_by_access_note, none,
 
 #undef WHICH_ACCESS_NOTE
 
-// Move Only diagnostics
-
-ERROR(experimental_moveonly_feature_can_only_be_used_when_enabled,
-      none, "Can not use feature when experimental move only is disabled! Pass"
-      " the frontend flag -enable-experimental-move-only to swift to enable "
-      "the usage of this language feature", ())
-ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
-      none, "'@_noImplicitCopy' attribute can only be applied to local lets and params", ())
-ERROR(noimplicitcopy_attr_invalid_in_generic_context,
-      none, "'@_noImplicitCopy' attribute cannot be applied to entities in generic contexts", ())
-ERROR(moveonly_generics, none, "move-only type %0 cannot be used with generics yet", (Type))
-ERROR(moveonly_effectful_getter,none,
-      "%0 of move-only type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
-ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
-      "'@_noImplicitCopy' has no effect when applied to a move only type", ())
-ERROR(moveonly_enums_do_not_support_indirect,none,
-      "move-only enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
-ERROR(moveonly_cast,none,
-      "move-only types cannot be conditionally cast", ())
-ERROR(moveonly_failable_init,none,
-      "move-only types cannot have failable initializers yet", ())
-ERROR(moveonly_objc_enum_banned, none,
-      "@objc enums cannot be marked as move-only", ())
-
 //------------------------------------------------------------------------------
 // MARK: Type inference from default expressions
 //------------------------------------------------------------------------------
@@ -7010,21 +6986,6 @@ ERROR(concurrency_task_to_thread_model_global_actor,none,
 ERROR(concurrency_task_to_thread_model_global_actor_annotation,none,
       "annotating a type with a global actor %0 is not permitted within %1",
       (TypeRepr*, StringRef))
-
-ERROR(moveOnly_not_allowed_here,none,
-      "'moveOnly' only applies to structs or enums", ())
-ERROR(consume_expression_not_passed_lvalue,none,
-      "'consume' can only be applied to lvalues", ())
-ERROR(borrow_expression_not_passed_lvalue,none,
-      "'borrow' can only be applied to lvalues", ())
-ERROR(copy_expression_not_passed_lvalue,none,
-      "'copy' can only be applied to lvalues", ())
-ERROR(copy_expression_cannot_be_used_with_noncopyable_types,none,
-      "'copy' cannot be applied to noncopyable types", ())
-
-ERROR(moveOnly_requires_lexical_lifetimes,none,
-      "noncopyable types require lexical borrow scopes "
-      "(add -enable-lexical-borrow-scopes=true)", ())
 
 //------------------------------------------------------------------------------
 // MARK: #_hasSymbol
@@ -7158,31 +7119,68 @@ NOTE(macro_expand_circular_reference_unnamed_through, none,
      "circular reference expanding %0 macros", (StringRef))
 
 //------------------------------------------------------------------------------
-// MARK: Move Only Errors
+// MARK: Noncopyable Types Diagnostics
 //------------------------------------------------------------------------------
 
-ERROR(moveonly_copyable_type_that_contains_moveonly_type, none,
-      "%0 %1 cannot contain a move-only type without also being move-only",
+ERROR(noncopyable_within_copyable, none,
+      "%0 %1 cannot contain a noncopyable type without also being noncopyable",
       (DescriptiveDeclKind, DeclName))
-NOTE(moveonly_copyable_type_that_contains_moveonly_type_location, none,
-     "contained move-only %0 '%1.%2'",
+NOTE(noncopyable_within_copyable_location, none,
+     "contained noncopyable %0 '%1.%2'",
      (DescriptiveDeclKind, StringRef, StringRef))
-ERROR(moveonly_cannot_conform_to_type, none,
-     "move-only %0 %1 cannot conform to %2",
+ERROR(noncopyable_cannot_conform_to_type, none,
+     "noncopyable %0 %1 cannot conform to %2",
      (DescriptiveDeclKind, DeclName, Type))
-ERROR(moveonly_parameter_missing_ownership, none,
+ERROR(noncopyable_parameter_requires_ownership, none,
       "noncopyable parameter must specify its ownership", ())
-ERROR(moveonly_parameter_subscript_unsupported, none,
+ERROR(noncopyable_parameter_subscript_unsupported, none,
       "subscripts cannot have noncopyable parameters yet", ())
-NOTE(moveonly_parameter_ownership_suggestion, none,
+NOTE(noncopyable_parameter_ownership_suggestion, none,
       "add '%0' %1", (StringRef, StringRef))
 ERROR(ownership_specifier_copyable,none,
-      "Copyable types cannot be 'consuming' or 'borrowing' yet", ())
+      "copyable types cannot be 'consuming' or 'borrowing' yet", ())
 ERROR(self_ownership_specifier_copyable,none,
-      "%0 is not yet valid on %1s in a Copyable type",
+      "%0 is not yet valid on %1s of a copyable type",
       (SelfAccessKind, DescriptiveDeclKind))
 ERROR(ownership_specifier_nonescaping_closure,none,
       "'%0' cannot be applied to nonescaping closure", (StringRef))
+ERROR(noncopyable_generics, none, "noncopyable type %0 cannot be used with generics yet", (Type))
+ERROR(noncopyable_effectful_getter,none,
+      "%0 of noncopyable type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
+ERROR(noncopyable_enums_do_not_support_indirect,none,
+      "noncopyable enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
+ERROR(noncopyable_cast,none,
+      "noncopyable types cannot be conditionally cast", ())
+ERROR(noncopyable_failable_init,none,
+      "noncopyable types cannot have failable initializers yet", ())
+ERROR(noncopyable_objc_enum, none,
+      "noncopyable enums cannot be marked '@objc'", ())
+ERROR(moveOnly_not_allowed_here,none,
+      "'@_moveOnly' attribute is only valid on structs or enums", ())
+ERROR(consume_expression_not_passed_lvalue,none,
+      "'consume' can only be applied to a local binding ('let', 'var', or parameter)", ())
+ERROR(borrow_expression_not_passed_lvalue,none,
+      "'borrow' can only be applied to a local binding ('let', 'var', or parameter)", ())
+ERROR(copy_expression_not_passed_lvalue,none,
+      "'copy' can only be applied to a local binding ('let', 'var', or parameter)", ())
+ERROR(copy_expression_cannot_be_used_with_noncopyable_types,none,
+      "'copy' cannot be applied to noncopyable types", ())
+
+ERROR(moveOnly_requires_lexical_lifetimes,none,
+      "noncopyable types require lexical borrow scopes "
+      "(add -enable-lexical-borrow-scopes=true)", ())
+
+// Experimental noncopyable feature diagnostics:
+ERROR(experimental_moveonly_feature_can_only_be_used_when_enabled,
+      none, "Can not use feature when experimental move only is disabled! Pass"
+            " the frontend flag -enable-experimental-move-only to swift to enable "
+            "the usage of this language feature", ())
+ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
+      none, "'@_noImplicitCopy' attribute can only be applied to local lets and params", ())
+ERROR(noimplicitcopy_attr_invalid_in_generic_context,
+      none, "'@_noImplicitCopy' attribute cannot be applied to entities in generic contexts", ())
+ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
+      "'@_noImplicitCopy' has no effect when applied to a noncopyable type", ())
 
 //------------------------------------------------------------------------------
 // MARK: Runtime discoverable attributes (@runtimeMetadata)

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1655,18 +1655,18 @@ bool DataflowState::process(
         auto &astContext = fn->getASTContext();
         {
           auto diag =
-              diag::sil_movekillscopyablevalue_value_consumed_more_than_once;
+              diag::sil_movechecking_value_used_after_consume;
           StringRef name = getDebugVarName(address);
           diagnose(astContext, getSourceLocFromValue(address), diag, name);
         }
 
         {
-          auto diag = diag::sil_movekillscopyablevalue_move_here;
+          auto diag = diag::sil_movechecking_consuming_use_here;
           diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
         }
 
         {
-          auto diag = diag::sil_movekillscopyablevalue_use_here;
+          auto diag = diag::sil_movechecking_nonconsuming_use_here;
           diagnose(astContext, iter->second->getLoc().getSourceLoc(), diag);
         }
 
@@ -1685,18 +1685,18 @@ bool DataflowState::process(
           auto &astContext = fn->getASTContext();
           {
             auto diag =
-                diag::sil_movekillscopyablevalue_value_consumed_more_than_once;
+                diag::sil_movechecking_value_used_after_consume;
             StringRef name = getDebugVarName(address);
             diagnose(astContext, getSourceLocFromValue(address), diag, name);
           }
 
           {
-            auto diag = diag::sil_movekillscopyablevalue_move_here;
+            auto diag = diag::sil_movechecking_consuming_use_here;
             diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
           }
 
           {
-            auto diag = diag::sil_movekillscopyablevalue_use_here;
+            auto diag = diag::sil_movechecking_nonconsuming_use_here;
             for (auto *user : iter->second->pairedUseInsts) {
               diagnose(astContext, user->getLoc().getSourceLoc(), diag);
             }
@@ -2114,16 +2114,16 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
     auto &astCtx = mvi->getFunction()->getASTContext();
     {
       auto diag =
-          diag::sil_movekillscopyablevalue_value_consumed_more_than_once;
+          diag::sil_movechecking_value_used_after_consume;
       StringRef name = getDebugVarName(address);
       diagnose(astCtx, getSourceLocFromValue(address), diag, name);
     }
 
-    auto diag = diag::sil_movekillscopyablevalue_move_here;
+    auto diag = diag::sil_movechecking_consuming_use_here;
     diagnose(astCtx, mvi->getLoc().getSourceLoc(), diag);
 
     {
-      auto diag = diag::sil_movekillscopyablevalue_use_here;
+      auto diag = diag::sil_movechecking_nonconsuming_use_here;
       for (auto *user : interestingClosureUsers) {
         diagnose(astCtx, user->getLoc().getSourceLoc(), diag);
       }
@@ -2155,18 +2155,18 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
     auto &astCtx = mvi->getFunction()->getASTContext();
     {
       auto diag =
-          diag::sil_movekillscopyablevalue_value_consumed_more_than_once;
+          diag::sil_movechecking_value_used_after_consume;
       StringRef name = getDebugVarName(address);
       diagnose(astCtx, getSourceLocFromValue(address), diag, name);
     }
 
     {
-      auto diag = diag::sil_movekillscopyablevalue_move_here;
+      auto diag = diag::sil_movechecking_consuming_use_here;
       diagnose(astCtx, mvi->getLoc().getSourceLoc(), diag);
     }
 
     {
-      auto diag = diag::sil_movekillscopyablevalue_use_here;
+      auto diag = diag::sil_movechecking_nonconsuming_use_here;
       diagnose(astCtx, interestingUser->getLoc().getSourceLoc(), diag);
     }
 

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -248,10 +248,10 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
 
   // First we emit the main error and then the note on where the move was.
   diagnose(astContext, getSourceLocFromValue(borrowedValue),
-           diag::sil_movekillscopyablevalue_value_consumed_more_than_once,
+           diag::sil_movechecking_value_used_after_consume,
            borrowedValueName);
   diagnose(astContext, mvi->getLoc().getSourceLoc(),
-           diag::sil_movekillscopyablevalue_move_here);
+           diag::sil_movechecking_consuming_use_here);
 
   // Then we do a bit of work to figure out where /all/ of the later uses than
   // mvi are so we can emit notes to the user telling them this is a problem
@@ -282,7 +282,7 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
       case PrunedLiveness::LifetimeEndingUse:
         LLVM_DEBUG(llvm::dbgs() << "Emitting note for in block use: " << inst);
         diagnose(astContext, inst.getLoc().getSourceLoc(),
-                 diag::sil_movekillscopyablevalue_use_here);
+                 diag::sil_movechecking_nonconsuming_use_here);
         break;
       }
     }
@@ -341,7 +341,7 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
           LLVM_DEBUG(llvm::dbgs()
                      << "(3) Emitting diagnostic for user: " << inst);
           diagnose(astContext, inst.getLoc().getSourceLoc(),
-                   diag::sil_movekillscopyablevalue_use_here);
+                   diag::sil_movechecking_nonconsuming_use_here);
           break;
         }
       }
@@ -367,7 +367,7 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
         LLVM_DEBUG(llvm::dbgs()
                    << "(1) Emitting diagnostic for user: " << inst);
         diagnose(astContext, inst.getLoc().getSourceLoc(),
-                 diag::sil_movekillscopyablevalue_use_here);
+                 diag::sil_movechecking_nonconsuming_use_here);
         continue;
       }
 
@@ -378,7 +378,7 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
           // carry dataflow violation.
           if (mvi == &inst) {
             diagnose(astContext, inst.getLoc().getSourceLoc(),
-                     diag::sil_movekillscopyablevalue_value_consumed_in_loop);
+                     diag::sil_movechecking_consumed_in_loop_here);
             continue;
           }
           // We ignore consuming uses that are destroy_value since in our model
@@ -389,7 +389,7 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
           LLVM_DEBUG(llvm::dbgs()
                      << "(2) Emitting diagnostic for user: " << inst);
           diagnose(astContext, inst.getLoc().getSourceLoc(),
-                   diag::sil_movekillscopyablevalue_use_here);
+                   diag::sil_movechecking_nonconsuming_use_here);
         }
       }
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -563,7 +563,7 @@ void DiagnosticEmitter::emitObjectDestructureNeededWithinBorrowBoundary(
                      [&](unsigned index) { return pair.second.test(index); })) {
       LLVM_DEBUG(llvm::dbgs()
                  << "    Destructure Boundary Use: " << *pair.first);
-      diagnose(astContext, pair.first, diag::sil_moveonlychecker_boundary_use);
+      diagnose(astContext, pair.first, diag::sil_moveonlychecker_nonconsuming_use_here);
     }
   }
   registerDiagnosticEmitted(markedValue);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -221,7 +221,7 @@ void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
           lookThroughCopyValueInsts(markedValue->getOperand()))) {
     if (fArg->isClosureCapture()) {
       diagnose(astContext, markedValue,
-               diag::sil_moveonlychecker_capture_consumed_in_closure,
+               diag::sil_moveonlychecker_capture_consumed,
                varName);
       emitObjectDiagnosticsForGuaranteedUses(
           true /*ignore partial apply uses*/);
@@ -650,7 +650,7 @@ void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
   // remaining cases must be a closure capture.
   diagnose(markedValue->getModule().getASTContext(),
            markedValue,
-           diag::sil_moveonlychecker_capture_consumed_in_closure,
+           diag::sil_moveonlychecker_capture_consumed,
            varName);
   registerDiagnosticEmitted(markedValue);
 }
@@ -666,7 +666,7 @@ void DiagnosticEmitter::emitPromotedBoxArgumentError(
   // diagnose consume of capture within a closure
   diagnose(astContext,
            arg->getDecl()->getLoc(),
-           diag::sil_moveonlychecker_capture_consumed_in_closure,
+           diag::sil_moveonlychecker_capture_consumed,
            varName);
 
   // Now for each consuming use that needs a copy...

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -176,10 +176,10 @@ void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
   if (markedValue->getType().isMoveOnlyWrapped()) {
     diagnose(
         fn->getASTContext(), markedValue,
-        diag::sil_moveonlychecker_not_understand_consumable_and_assignable);
+        diag::sil_movechecking_not_understand_consumable_and_assignable);
   } else {
     diagnose(fn->getASTContext(), markedValue,
-             diag::sil_moveonlychecker_not_understand_moveonly);
+             diag::sil_movechecking_not_understand_moveonly);
   }
   registerDiagnosticEmitted(markedValue);
   emittedCheckerDoesntUnderstandDiagnostic = true;
@@ -187,7 +187,7 @@ void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
 
 void DiagnosticEmitter::emitCheckedMissedCopyError(SILInstruction *copyInst) {
   diagnose(copyInst->getFunction()->getASTContext(), copyInst,
-           diag::sil_moveonlychecker_bug_missed_copy);
+           diag::sil_movechecking_bug_missed_copy);
 }
 
 //===----------------------------------------------------------------------===//
@@ -203,7 +203,7 @@ void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
   // See if we have any closure capture uses and emit a better diagnostic.
   if (getCanonicalizer().hasPartialApplyConsumingUse()) {
     diagnose(astContext, markedValue,
-             diag::sil_moveonlychecker_guaranteed_value_captured_by_closure,
+             diag::sil_movechecking_guaranteed_value_captured_by_closure,
              varName);
     emitObjectDiagnosticsForPartialApplyUses(varName);
     registerDiagnosticEmitted(markedValue);
@@ -221,7 +221,7 @@ void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
           lookThroughCopyValueInsts(markedValue->getOperand()))) {
     if (fArg->isClosureCapture()) {
       diagnose(astContext, markedValue,
-               diag::sil_moveonlychecker_capture_consumed,
+               diag::sil_movechecking_capture_consumed,
                varName);
       emitObjectDiagnosticsForGuaranteedUses(
           true /*ignore partial apply uses*/);
@@ -231,7 +231,7 @@ void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
   }
 
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_guaranteed_value_consumed, varName);
+           diag::sil_movechecking_guaranteed_value_consumed, varName);
 
   emitObjectDiagnosticsForGuaranteedUses(true /*ignore partial apply uses*/);
 }
@@ -280,23 +280,23 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
       if (consumingUserSet.contains(&*ii)) {
         foundSingleBlockError = true;
         diagnose(astContext, markedValue,
-                 diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
+                 diag::sil_movechecking_owned_value_consumed_more_than_once,
                  varName);
         diagnose(astContext, user,
-                 diag::sil_moveonlychecker_consuming_use_here);
+                 diag::sil_movechecking_consuming_use_here);
         diagnose(astContext, &*ii,
-                 diag::sil_moveonlychecker_other_consuming_use_here);
+                 diag::sil_movechecking_other_consuming_use_here);
         break;
       }
 
       if (nonConsumingUserSet.contains(&*ii)) {
         foundSingleBlockError = true;
         diagnose(astContext, markedValue,
-                 diag::sil_moveonlychecker_value_used_after_consume, varName);
+                 diag::sil_movechecking_value_used_after_consume, varName);
         diagnose(astContext, user,
-                 diag::sil_moveonlychecker_consuming_use_here);
+                 diag::sil_movechecking_consuming_use_here);
         diagnose(astContext, &*ii,
-                 diag::sil_moveonlychecker_nonconsuming_use_here);
+                 diag::sil_movechecking_nonconsuming_use_here);
         break;
       }
     }
@@ -315,9 +315,9 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
       // such a case, we found a consuming use within a loop.
       if (nextBlock == user->getParent()) {
         diagnose(astContext, markedValue,
-                 diag::sil_moveonlychecker_value_consumed_in_a_loop, varName);
+                 diag::sil_movechecking_value_consumed_in_a_loop, varName);
         auto d =
-            diag::sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here;
+            diag::sil_movechecking_consumed_in_loop_here;
         diagnose(astContext, user, d);
         break;
       }
@@ -328,12 +328,12 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
           // We found it... emit the error and break.
           diagnose(
               astContext, markedValue,
-              diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
+              diag::sil_movechecking_owned_value_consumed_more_than_once,
               varName);
           diagnose(astContext, user,
-                   diag::sil_moveonlychecker_consuming_use_here);
+                   diag::sil_movechecking_consuming_use_here);
           diagnose(astContext, iter->second,
-                   diag::sil_moveonlychecker_other_consuming_use_here);
+                   diag::sil_movechecking_other_consuming_use_here);
           break;
         }
       }
@@ -343,11 +343,11 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
         if (iter != nonConsumingBlockToUserMap.end()) {
           // We found it... emit the error and break.
           diagnose(astContext, markedValue,
-                   diag::sil_moveonlychecker_value_used_after_consume, varName);
+                   diag::sil_movechecking_value_used_after_consume, varName);
           diagnose(astContext, user,
-                   diag::sil_moveonlychecker_consuming_use_here);
+                   diag::sil_movechecking_consuming_use_here);
           diagnose(astContext, iter->second,
-                   diag::sil_moveonlychecker_nonconsuming_use_here);
+                   diag::sil_movechecking_nonconsuming_use_here);
           break;
         }
       }
@@ -368,14 +368,14 @@ void DiagnosticEmitter::emitObjectDiagnosticsForGuaranteedUses(
     if (ignorePartialApplyUses && isa<PartialApplyInst>(consumingUser))
       continue;
     diagnose(astContext, consumingUser,
-             diag::sil_moveonlychecker_consuming_use_here);
+             diag::sil_movechecking_consuming_use_here);
   }
 
   for (auto *user : getCanonicalizer().consumingBoundaryUsers) {
     if (ignorePartialApplyUses && isa<PartialApplyInst>(user))
       continue;
 
-    diagnose(astContext, user, diag::sil_moveonlychecker_consuming_use_here);
+    diagnose(astContext, user, diag::sil_movechecking_consuming_use_here);
   }
 }
 
@@ -388,7 +388,7 @@ void DiagnosticEmitter::emitObjectDiagnosticsForPartialApplyUses(
       continue;
     diagnose(astContext,
              user,
-             diag::sil_moveonlychecker_consuming_closure_use_here,
+             diag::sil_movechecking_consuming_closure_use_here,
              capturedVarName);
   }
 
@@ -398,7 +398,7 @@ void DiagnosticEmitter::emitObjectDiagnosticsForPartialApplyUses(
 
     diagnose(astContext,
              user,
-             diag::sil_moveonlychecker_consuming_closure_use_here,
+             diag::sil_movechecking_consuming_closure_use_here,
              capturedVarName);
   }
 }
@@ -422,9 +422,9 @@ void DiagnosticEmitter::emitAddressExclusivityHazardDiagnostic(
   LLVM_DEBUG(llvm::dbgs() << "    Consuming use: " << *consumingUser);
 
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_bug_exclusivity_violation, varName);
+           diag::sil_movechecking_bug_exclusivity_violation, varName);
   diagnose(astContext, consumingUser,
-           diag::sil_moveonlychecker_consuming_use_here);
+           diag::sil_movechecking_consuming_use_here);
 }
 
 void DiagnosticEmitter::emitAddressDiagnostic(MarkMustCheckInst *markedValue,
@@ -451,9 +451,9 @@ void DiagnosticEmitter::emitAddressDiagnostic(MarkMustCheckInst *markedValue,
   // had a loop. Give a better diagnostic.
   if (lastLiveUser == violatingUser) {
     diagnose(astContext, markedValue,
-             diag::sil_moveonlychecker_value_consumed_in_a_loop, varName);
+             diag::sil_movechecking_value_consumed_in_a_loop, varName);
     diagnose(astContext, violatingUser,
-             diag::sil_moveonlychecker_consuming_use_here);
+             diag::sil_movechecking_consuming_use_here);
     return;
   }
 
@@ -461,32 +461,32 @@ void DiagnosticEmitter::emitAddressDiagnostic(MarkMustCheckInst *markedValue,
     diagnose(
         astContext, markedValue,
         diag::
-            sil_moveonlychecker_inout_not_reinitialized_before_end_of_function,
+            sil_movechecking_inout_not_reinitialized_before_end_of_function,
         varName);
     diagnose(astContext, violatingUser,
-             diag::sil_moveonlychecker_consuming_use_here);
+             diag::sil_movechecking_consuming_use_here);
     return;
   }
 
   // First if we are consuming emit an error for no implicit copy semantics.
   if (isUseConsuming) {
     diagnose(astContext, markedValue,
-             diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
+             diag::sil_movechecking_owned_value_consumed_more_than_once,
              varName);
     diagnose(astContext, violatingUser,
-             diag::sil_moveonlychecker_consuming_use_here);
+             diag::sil_movechecking_consuming_use_here);
     diagnose(astContext, lastLiveUser,
-             diag::sil_moveonlychecker_consuming_use_here);
+             diag::sil_movechecking_consuming_use_here);
     return;
   }
 
   // Otherwise, use the "used after consuming use" error.
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_value_used_after_consume, varName);
+           diag::sil_movechecking_value_used_after_consume, varName);
   diagnose(astContext, violatingUser,
-           diag::sil_moveonlychecker_consuming_use_here);
+           diag::sil_movechecking_consuming_use_here);
   diagnose(astContext, lastLiveUser,
-           diag::sil_moveonlychecker_nonconsuming_use_here);
+           diag::sil_movechecking_nonconsuming_use_here);
 }
 
 void DiagnosticEmitter::emitInOutEndOfFunctionDiagnostic(
@@ -512,10 +512,10 @@ void DiagnosticEmitter::emitInOutEndOfFunctionDiagnostic(
   // consuming message:
   diagnose(
       astContext, markedValue,
-      diag::sil_moveonlychecker_inout_not_reinitialized_before_end_of_function,
+      diag::sil_movechecking_inout_not_reinitialized_before_end_of_function,
       varName);
   diagnose(astContext, violatingUser,
-           diag::sil_moveonlychecker_consuming_use_here);
+           diag::sil_movechecking_consuming_use_here);
 }
 
 void DiagnosticEmitter::emitAddressDiagnosticNoCopy(
@@ -534,9 +534,9 @@ void DiagnosticEmitter::emitAddressDiagnosticNoCopy(
   // Otherwise, we need to do no implicit copy semantics. If our last use was
   // consuming message:
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_guaranteed_value_consumed, varName);
+           diag::sil_movechecking_guaranteed_value_consumed, varName);
   diagnose(astContext, consumingUser,
-           diag::sil_moveonlychecker_consuming_use_here);
+           diag::sil_movechecking_consuming_use_here);
   registerDiagnosticEmitted(markedValue);
 }
 
@@ -557,9 +557,9 @@ void DiagnosticEmitter::emitObjectDestructureNeededWithinBorrowBoundary(
                           << *destructureNeedingUser);
 
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_use_after_partial_consume, varName);
+           diag::sil_movechecking_use_after_partial_consume, varName);
   diagnose(astContext, destructureNeedingUser,
-           diag::sil_moveonlychecker_partial_consume_here);
+           diag::sil_movechecking_partial_consume_here);
 
   // Only emit errors for last users that overlap with our needed destructure
   // bits.
@@ -568,7 +568,7 @@ void DiagnosticEmitter::emitObjectDestructureNeededWithinBorrowBoundary(
                      [&](unsigned index) { return pair.second.test(index); })) {
       LLVM_DEBUG(llvm::dbgs()
                  << "    Destructure Boundary Use: " << *pair.first);
-      diagnose(astContext, pair.first, diag::sil_moveonlychecker_nonconsuming_use_here);
+      diagnose(astContext, pair.first, diag::sil_movechecking_nonconsuming_use_here);
     }
   }
   registerDiagnosticEmitted(markedValue);
@@ -592,10 +592,10 @@ void DiagnosticEmitter::emitObjectInstConsumesValueTwice(
   SmallString<64> varName;
   getVariableNameForValue(markedValue, varName);
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
+           diag::sil_movechecking_owned_value_consumed_more_than_once,
            varName);
   diagnose(astContext, firstUse->getUser(),
-           diag::sil_moveonlychecker_two_consuming_uses_here);
+           diag::sil_movechecking_two_consuming_uses_here);
   registerDiagnosticEmitted(markedValue);
 }
 
@@ -618,10 +618,10 @@ void DiagnosticEmitter::emitObjectInstConsumesAndUsesValue(
   SmallString<64> varName;
   getVariableNameForValue(markedValue, varName);
   diagnose(astContext, markedValue,
-           diag::sil_moveonlychecker_owned_value_consumed_and_used_at_same_time,
+           diag::sil_movechecking_owned_value_consumed_and_used_at_same_time,
            varName);
   diagnose(astContext, consumingUse->getUser(),
-           diag::sil_moveonlychecker_consuming_and_non_consuming_uses_here);
+           diag::sil_movechecking_consuming_and_non_consuming_uses_here);
   registerDiagnosticEmitted(markedValue);
 }
 
@@ -636,7 +636,7 @@ void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
   if (isa<RefElementAddrInst>(operand)) {
     diagnose(markedValue->getModule().getASTContext(),
              markedValue,
-             diag::sil_moveonlychecker_notconsumable_but_assignable_was_consumed,
+             diag::sil_movechecking_notconsumable_but_assignable_was_consumed,
              varName, /*isGlobal=*/false);
     registerDiagnosticEmitted(markedValue);
     return;
@@ -646,7 +646,7 @@ void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
   if (isa<GlobalAddrInst>(operand)) {
     diagnose(markedValue->getModule().getASTContext(),
              markedValue,
-             diag::sil_moveonlychecker_notconsumable_but_assignable_was_consumed,
+             diag::sil_movechecking_notconsumable_but_assignable_was_consumed,
              varName, /*isGlobal=*/true);
     registerDiagnosticEmitted(markedValue);
     return;
@@ -655,7 +655,7 @@ void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
   // remaining cases must be a closure capture.
   diagnose(markedValue->getModule().getASTContext(),
            markedValue,
-           diag::sil_moveonlychecker_capture_consumed,
+           diag::sil_movechecking_capture_consumed,
            varName);
   registerDiagnosticEmitted(markedValue);
 }
@@ -671,16 +671,16 @@ void DiagnosticEmitter::emitPromotedBoxArgumentError(
   // diagnose consume of capture within a closure
   diagnose(astContext,
            arg->getDecl()->getLoc(),
-           diag::sil_moveonlychecker_capture_consumed,
+           diag::sil_movechecking_capture_consumed,
            varName);
 
   // Now for each consuming use that needs a copy...
   for (auto *user : getCanonicalizer().consumingUsesNeedingCopy) {
-    diagnose(astContext, user, diag::sil_moveonlychecker_consuming_use_here);
+    diagnose(astContext, user, diag::sil_movechecking_consuming_use_here);
   }
 
   for (auto *user : getCanonicalizer().consumingBoundaryUsers) {
-    diagnose(astContext, user, diag::sil_moveonlychecker_consuming_use_here);
+    diagnose(astContext, user, diag::sil_movechecking_consuming_use_here);
   }
 }
 
@@ -697,12 +697,12 @@ void DiagnosticEmitter::emitCannotDestructureDeinitNominalError(
 
   diagnose(
       astContext, consumingUser,
-      diag::sil_moveonlychecker_cannot_destructure_has_deinit,
+      diag::sil_movechecking_cannot_destructure_has_deinit,
       varName);
   registerDiagnosticEmitted(markedValue);
 
   // point to the deinit if we know where it is.
   if (auto deinitLoc =
       deinitedNominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
-    astContext.Diags.diagnose(deinitLoc, diag::sil_moveonlychecker_deinit_here);
+    astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
 }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -285,7 +285,7 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
         diagnose(astContext, user,
                  diag::sil_movechecking_consuming_use_here);
         diagnose(astContext, &*ii,
-                 diag::sil_movechecking_other_consuming_use_here);
+                 diag::sil_movechecking_consumed_again_here);
         break;
       }
 
@@ -333,7 +333,7 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
           diagnose(astContext, user,
                    diag::sil_movechecking_consuming_use_here);
           diagnose(astContext, iter->second,
-                   diag::sil_movechecking_other_consuming_use_here);
+                   diag::sil_movechecking_consumed_again_here);
           break;
         }
       }
@@ -476,7 +476,7 @@ void DiagnosticEmitter::emitAddressDiagnostic(MarkMustCheckInst *markedValue,
     diagnose(astContext, violatingUser,
              diag::sil_movechecking_consuming_use_here);
     diagnose(astContext, lastLiveUser,
-             diag::sil_movechecking_consuming_use_here);
+             diag::sil_movechecking_consumed_again_here);
     return;
   }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -205,7 +205,7 @@ void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
     diagnose(astContext, markedValue,
              diag::sil_moveonlychecker_guaranteed_value_captured_by_closure,
              varName);
-    emitObjectDiagnosticsForPartialApplyUses();
+    emitObjectDiagnosticsForPartialApplyUses(varName);
     registerDiagnosticEmitted(markedValue);
   }
 
@@ -379,22 +379,27 @@ void DiagnosticEmitter::emitObjectDiagnosticsForGuaranteedUses(
   }
 }
 
-void DiagnosticEmitter::emitObjectDiagnosticsForPartialApplyUses() const {
+void DiagnosticEmitter::emitObjectDiagnosticsForPartialApplyUses(
+    StringRef capturedVarName) const {
   auto &astContext = fn->getASTContext();
 
   for (auto *user : getCanonicalizer().consumingUsesNeedingCopy) {
     if (!isa<PartialApplyInst>(user))
       continue;
-    diagnose(astContext, user,
-             diag::sil_moveonlychecker_consuming_closure_use_here);
+    diagnose(astContext,
+             user,
+             diag::sil_moveonlychecker_consuming_closure_use_here,
+             capturedVarName);
   }
 
   for (auto *user : getCanonicalizer().consumingBoundaryUsers) {
     if (!isa<PartialApplyInst>(user))
       continue;
 
-    diagnose(astContext, user,
-             diag::sil_moveonlychecker_consuming_closure_use_here);
+    diagnose(astContext,
+             user,
+             diag::sil_moveonlychecker_consuming_closure_use_here,
+             capturedVarName);
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -166,7 +166,7 @@ private:
   /// the caller processed it correctly. false, then we continue to process it.
   void
   emitObjectDiagnosticsForGuaranteedUses(bool ignorePartialApply = false) const;
-  void emitObjectDiagnosticsForPartialApplyUses() const;
+  void emitObjectDiagnosticsForPartialApplyUses(StringRef capturedVarName) const;
 
   void registerDiagnosticEmitted(MarkMustCheckInst *value) {
     ++diagnosticCount;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6129,7 +6129,7 @@ bool NotCompileTimeConstFailure::diagnoseAsError() {
 }
 
 bool NotCopyableFailure::diagnoseAsError() {
-  emitDiagnostic(diag::moveonly_generics, noncopyableTy);
+  emitDiagnostic(diag::noncopyable_generics, noncopyableTy);
   return true;
 }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -388,7 +388,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       if (castType->isPureMoveOnly()) {
         // can't cast anything to move-only; there should be no valid ones.
-        Ctx.Diags.diagnose(cast->getLoc(), diag::moveonly_cast);
+        Ctx.Diags.diagnose(cast->getLoc(), diag::noncopyable_cast);
         return;
       }
 
@@ -398,7 +398,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       if (auto fromType = cast->getSubExpr()->getType()) {
         if (fromType->isPureMoveOnly()) {
           // can't cast move-only to anything.
-          Ctx.Diags.diagnose(cast->getLoc(), diag::moveonly_cast);
+          Ctx.Diags.diagnose(cast->getLoc(), diag::noncopyable_cast);
           return;
         }
       }
@@ -6208,13 +6208,13 @@ void swift::diagnoseCopyableTypeContainingMoveOnlyType(
     if (auto *eltDecl = topFieldToError.dyn_cast<EnumElementDecl *>()) {
       DE.diagnoseWithNotes(
           copyableNominalType->diagnose(
-              diag::moveonly_copyable_type_that_contains_moveonly_type,
+              diag::noncopyable_within_copyable,
               copyableNominalType->getDescriptiveKind(),
               copyableNominalType->getBaseName()),
           [&]() {
             eltDecl->diagnose(
                 diag::
-                    moveonly_copyable_type_that_contains_moveonly_type_location,
+                    noncopyable_within_copyable_location,
                 fieldKind, parentName.userFacingName(),
                 fieldName.userFacingName());
           });
@@ -6224,12 +6224,12 @@ void swift::diagnoseCopyableTypeContainingMoveOnlyType(
     auto *varDecl = topFieldToError.get<VarDecl *>();
     DE.diagnoseWithNotes(
         copyableNominalType->diagnose(
-            diag::moveonly_copyable_type_that_contains_moveonly_type,
+            diag::noncopyable_within_copyable,
             copyableNominalType->getDescriptiveKind(),
             copyableNominalType->getBaseName()),
         [&]() {
           varDecl->diagnose(
-              diag::moveonly_copyable_type_that_contains_moveonly_type_location,
+              diag::noncopyable_within_copyable_location,
               fieldKind, parentName.userFacingName(),
               fieldName.userFacingName());
         });

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2609,7 +2609,7 @@ public:
     //
 
     if (ED->isObjC() && ED->isMoveOnly()) {
-      ED->diagnose(diag::moveonly_objc_enum_banned);
+      ED->diagnose(diag::noncopyable_objc_enum);
     }
     // FIXME(kavon): see if these can be integrated into other parts of Sema
     diagnoseCopyableTypeContainingMoveOnlyType(ED);
@@ -2625,11 +2625,11 @@ public:
     // indirect cases.
     if (ED->getAttrs().hasAttribute<MoveOnlyAttr>()) {
       if (ED->isIndirect())
-        ED->diagnose(diag::moveonly_enums_do_not_support_indirect,
+        ED->diagnose(diag::noncopyable_enums_do_not_support_indirect,
                      ED->getBaseIdentifier());
       for (auto *elt : ED->getAllElements()) {
         if (elt->isIndirect()) {
-          elt->diagnose(diag::moveonly_enums_do_not_support_indirect,
+          elt->diagnose(diag::noncopyable_enums_do_not_support_indirect,
                         ED->getBaseIdentifier());
         }
       }
@@ -2797,7 +2797,7 @@ public:
 
     auto &ctx = moveonlyType->getASTContext();
     ctx.Diags.diagnose(loc,
-                       diag::moveonly_cannot_conform_to_type,
+                       diag::noncopyable_cannot_conform_to_type,
                        moveonlyType->getDescriptiveKind(),
                        moveonlyType->getBaseName(),
                        type);
@@ -3646,7 +3646,7 @@ public:
     if (CD->isFailable()) {
       if (auto *nom = CD->getDeclContext()->getSelfNominalTypeDecl()) {
         if (nom->isMoveOnly()) {
-          CD->diagnose(diag::moveonly_failable_init);
+          CD->diagnose(diag::noncopyable_failable_init);
         }
       }
     }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -616,17 +616,6 @@ IsSetterMutatingRequest::evaluate(Evaluator &evaluator,
   llvm_unreachable("bad storage kind");
 }
 
-/*
- // An accessor that uses borrowed ownership cannot have effects, as the
-   // coroutine accessor doesn't support `async` or `throws`
-   if (auto accessor = dyn_cast<AccessorDecl>(FD)) {
-     if (accessor->hasThrows() || accessor->hasAsync())
-       if (accessor->)
-       if (accessor->getResultInterfaceType()->isPureMoveOnly())
-         accessor->diagnose(diag::moveonly_effectful_getter);
-   }
- */
-
 OpaqueReadOwnership
 OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
                                      AbstractStorageDecl *storage) const {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -629,7 +629,7 @@ OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
     if (auto *getter = storage->getEffectfulGetAccessor()) {
       switch (kind) {
       case DiagKind::NoncopyableType:
-        getter->diagnose(diag::moveonly_effectful_getter,
+        getter->diagnose(diag::noncopyable_effectful_getter,
                          getter->getDescriptiveKind());
         break;
       case DiagKind::BorrowedAttr:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1006,7 +1006,7 @@ static bool didDiagnoseMoveOnlyGenericArgs(ASTContext &ctx,
     if (!t->isPureMoveOnly())
       continue;
 
-    ctx.Diags.diagnose(loc, diag::moveonly_generics, t);
+    ctx.Diags.diagnose(loc, diag::noncopyable_generics, t);
     didEmitDiag = true;
   }
 
@@ -2278,7 +2278,7 @@ bool TypeResolver::diagnoseInvalidPlaceHolder(OpaqueReturnTypeRepr *repr) {
 /// returns true if an error diagnostic was emitted
 bool TypeResolver::diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy) {
   if (genericArgTy->isPureMoveOnly()) {
-    diagnoseInvalid(repr, repr->getLoc(), diag::moveonly_generics,
+    diagnoseInvalid(repr, repr->getLoc(), diag::noncopyable_generics,
                     genericArgTy);
     return true;
   }
@@ -2319,21 +2319,21 @@ bool TypeResolver::diagnoseMoveOnlyMissingOwnership(
   // decls, give a tailored error message saying you simply can't use a
   // noncopyable type here.
   if (options.hasBase(TypeResolverContext::SubscriptDecl)) {
-    diagnose(repr->getLoc(), diag::moveonly_parameter_subscript_unsupported);
+    diagnose(repr->getLoc(), diag::noncopyable_parameter_subscript_unsupported);
   } else {
     // general error diagnostic
     diagnose(repr->getLoc(),
-             diag::moveonly_parameter_missing_ownership);
+             diag::noncopyable_parameter_requires_ownership);
 
-    diagnose(repr->getLoc(), diag::moveonly_parameter_ownership_suggestion,
+    diagnose(repr->getLoc(), diag::noncopyable_parameter_ownership_suggestion,
              "borrowing", "for an immutable reference")
         .fixItInsert(repr->getStartLoc(), "borrowing ");
 
-    diagnose(repr->getLoc(), diag::moveonly_parameter_ownership_suggestion,
+    diagnose(repr->getLoc(), diag::noncopyable_parameter_ownership_suggestion,
              "inout", "for a mutable reference")
         .fixItInsert(repr->getStartLoc(), "inout ");
 
-    diagnose(repr->getLoc(), diag::moveonly_parameter_ownership_suggestion,
+    diagnose(repr->getLoc(), diag::noncopyable_parameter_ownership_suggestion,
              "consuming", "to take the value from the caller")
         .fixItInsert(repr->getStartLoc(), "consuming ");
   }

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -61,185 +61,185 @@ var globalMO: MO = MO()
 
 // some top-level tests
 let _: MO = globalMO
-takeGeneric(globalMO) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+takeGeneric(globalMO) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
 
 
 
 func testAny() {
-  let _: Any = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  takeAny(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Any = MO() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeAny(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 }
 
 func testBasic(_ mo: borrowing MO) {
   takeConcrete(globalMO)
   takeConcrete(MO())
 
-  takeGeneric(globalMO) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  takeGeneric(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  takeGeneric(mo) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeGeneric(globalMO) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeGeneric(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeGeneric(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeAny(mo) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  print(mo) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  _ = "\(mo)" // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: String = String(describing: mo) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeAny(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  print(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = "\(mo)" // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: String = String(describing: mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
   takeGeneric { () -> Int? in mo.x }
   genericVarArg(5)
-  genericVarArg(mo) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  genericVarArg(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeGeneric( (mo, 5) ) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  takeGenericSendable((mo, mo)) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  takeGeneric( (mo, 5) ) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeGenericSendable((mo, mo)) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
 
   let singleton : (MO) = (mo)
-  takeGeneric(singleton) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeGeneric(singleton) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeAny((mo)) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  takeAny((mo, mo)) // expected-error {{move-only type '(MO, MO)' cannot be used with generics yet}}
+  takeAny((mo)) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeAny((mo, mo)) // expected-error {{noncopyable type '(MO, MO)' cannot be used with generics yet}}
 }
 
 func checkBasicBoxes() {
   let mo = MO()
 
-  let vb = ValBox(consume mo) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  let vb = ValBox(consume mo) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
   _ = vb.get()
   _ = vb.val
 
-  let rb = RefBox(MO())  // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  let rb = RefBox(MO())  // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
   _ = rb.get()
   _ = rb.val
 
-  let vb2: ValBox<MO> = .init(MO())  // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let vb2: ValBox<MO> = .init(MO())  // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 }
 
 func checkExistential() {
-  takeAnyBox( // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-      RefBox(MO())) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  takeAnyBox( // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+      RefBox(MO())) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeAnyBox( // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-      ValBox(globalMO)) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
-
-  takeAnyBoxErased(
-      RefBox(MO())) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  takeAnyBox( // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+      ValBox(globalMO)) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
 
   takeAnyBoxErased(
-      ValBox(globalMO)) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+      RefBox(MO())) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
+
+  takeAnyBoxErased(
+      ValBox(globalMO)) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
 }
 
 func checkMethodCalls() {
-  let tg: NotStoredGenerically<MO> = NotStoredGenerically() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let tg: NotStoredGenerically<MO> = NotStoredGenerically() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   tg.take(MO())
   tg.give()
 
-  let _: Maybe<MO> = .none // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _ = Maybe<MO>.just(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: Maybe<MO> = .just(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  takeMaybe(.just(MO())) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  let _: Maybe<MO> = .none // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _ = Maybe<MO>.just(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Maybe<MO> = .just(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeMaybe(.just(MO())) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeMaybe(true ? .none : .just(MO())) // expected-error 3{{move-only type 'MO' cannot be used with generics yet}}
+  takeMaybe(true ? .none : .just(MO())) // expected-error 3{{noncopyable type 'MO' cannot be used with generics yet}}
 }
 
 func checkCasting(_ b: any Box, _ mo: borrowing MO, _ a: Any) {
   // casting dynamically is allowed, but should always fail since you can't
   // construct such a type.
-  let box = b as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let box = b as! ValBox<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   let dup = box
 
   let _: MO = dup.get()
   let _: MO = dup.val
 
-  let _: Any = MO.self // expected-error {{move-only type 'MO.Type' cannot be used with generics yet}}
-  let _: AnyObject = MO.self // expected-error {{move-only type 'MO.Type' cannot be used with generics yet}}
-  let _ = MO.self as Any // expected-error {{move-only type 'MO.Type' cannot be used with generics yet}}
+  let _: Any = MO.self // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
+  let _: AnyObject = MO.self // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
+  let _ = MO.self as Any // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
   let _ = MO.self is Any // expected-warning {{cast from 'MO.Type' to unrelated type 'Any' always fails}}
 
-  let _: Sendable = (MO(), MO()) // expected-error {{move-only type '(MO, MO)' cannot be used with generics yet}}
-  let _: Sendable = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Sendable = (MO(), MO()) // expected-error {{noncopyable type '(MO, MO)' cannot be used with generics yet}}
+  let _: Sendable = MO() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   let _: _Copyable = mo // expected-error {{'_Copyable' is unavailable}}
-                        // expected-error@-1 {{move-only type 'MO' cannot be used with generics yet}}
-  let _: AnyObject = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: Any = mo // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+                        // expected-error@-1 {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: AnyObject = MO() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Any = mo // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  _ = MO() as P // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  _ = MO() as any P // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  _ = MO() as Any // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = MO() as P // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = MO() as any P // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = MO() as Any // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   _ = MO() as MO
-  _ = MO() as AnyObject // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = MO() as AnyObject // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   _ = 5 as MO // expected-error {{cannot convert value of type 'Int' to type 'MO' in coercion}}
   _ = a as MO // expected-error {{cannot convert value of type 'Any' to type 'MO' in coercion}}
   _ = b as MO // expected-error {{cannot convert value of type 'any Box' to type 'MO' in coercion}}
 
   _ = MO() is AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() is AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() is Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() is P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() is MO // expected-warning {{'is' test is always true}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   _ = 5 is MO // expected-warning {{cast from 'Int' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = a is MO // expected-warning {{cast from 'Any' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = b is MO // expected-warning {{cast from 'any Box' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   _ = MO() as! AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as! AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as! Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as! P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as! MO // expected-warning {{forced cast of 'MO' to same type has no effect}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   _ = 5 as! MO // expected-warning {{cast from 'Int' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = a as! MO // expected-warning {{cast from 'Any' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = b as! MO // expected-warning {{cast from 'any Box' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   _ = MO() as? AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as? AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as? Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as? P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = MO() as? MO // expected-warning {{conditional cast from 'MO' to 'MO' always succeeds}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   _ = 5 as? MO // expected-warning {{cast from 'Int' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = a as? MO // expected-warning {{cast from 'Any' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   _ = b as? MO // expected-warning {{cast from 'any Box' to unrelated type 'MO' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
 }
 
 func checkStdlibTypes(_ mo: borrowing MO) {
-  let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
       [MO(), MO()]
-  let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
       []
-  let _: [String: MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: [String: MO] = // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
       ["hello" : MO()]  // expected-error{{tuples with noncopyable elements are not supported}}
 
   // i think this one's only caught b/c of the 'Any' change
-  _ = [MO()] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = [MO()] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  let _: Array<MO> = .init() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  _ = [MO]() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Array<MO> = .init() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = [MO]() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  let s: String = "hello \(mo)" // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let s: String = "hello \(mo)" // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 }
 
 func copyableExistentials(_ a: Any, _ e1: Error, _ e2: any Error, _ ah: AnyHashable) {
@@ -280,5 +280,5 @@ func doBadMetatypeStuff<T>(_ t: T) {
   }
 }
 func tryToDoBadMetatypeStuff() {
-  doBadMetatypeStuff(MO.self) // expected-error {{move-only type 'MO.Type' cannot be used with generics yet}}
+  doBadMetatypeStuff(MO.self) // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
 }

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-types-in-cxx.swift
@@ -12,19 +12,17 @@ public func takesVoid(_ x: ()) {}
 
 // CHECK:     takeFloat
 
-@_moveOnly
-public enum MoveOnlyEnum {
+public enum MoveOnlyEnum: ~Copyable {
     case a
 }
 
-// CHECK: class MoveOnlyEnum { } SWIFT_UNAVAILABLE_MSG("move-only enum 'MoveOnlyEnum' can not yet be represented in C++");
+// CHECK: class MoveOnlyEnum { } SWIFT_UNAVAILABLE_MSG("noncopyable enum 'MoveOnlyEnum' can not yet be represented in C++");
 
-@_moveOnly
-public struct MoveOnlyStruct {
+public struct MoveOnlyStruct: ~Copyable {
     let x: Int
 }
 
-// CHECK: class MoveOnlyStruct { } SWIFT_UNAVAILABLE_MSG("move-only struct 'MoveOnlyStruct' can not yet be represented in C++");
+// CHECK: class MoveOnlyStruct { } SWIFT_UNAVAILABLE_MSG("noncopyable struct 'MoveOnlyStruct' can not yet be represented in C++");
 
 public protocol TestProtocol {}
 

--- a/test/Parse/copy_expr.swift
+++ b/test/Parse/copy_expr.swift
@@ -76,9 +76,9 @@ struct Foo {
 
     func copyPropertyWrapper() {
         // Make sure that we can parse.
-        _ = copy wrapperTest // expected-error {{'copy' can only be applied to lvalues}}
-        _ = copy _wrapperTest // expected-error {{'copy' can only be applied to lvalues}}
-        _ = copy $wrapperTest // expected-error {{'copy' can only be applied to lvalues}}
+        _ = copy wrapperTest // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
+        _ = copy _wrapperTest // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
+        _ = copy $wrapperTest // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
     }
 }
 

--- a/test/Parse/move_expr.swift
+++ b/test/Parse/move_expr.swift
@@ -76,9 +76,9 @@ struct Foo {
 
     func consumePropertyWrapper() {
         // should still parse, even if it doesn't semantically work out
-        _ = consume wrapperTest // expected-error{{can only be applied to lvalues}}
-        _ = consume _wrapperTest // expected-error{{can only be applied to lvalues}}
-        _ = consume $wrapperTest // expected-error{{can only be applied to lvalues}}
+        _ = consume wrapperTest // expected-error{{can only be applied to a local binding ('let', 'var', or parameter)}}
+        _ = consume _wrapperTest // expected-error{{can only be applied to a local binding ('let', 'var', or parameter)}}
+        _ = consume $wrapperTest // expected-error{{can only be applied to a local binding ('let', 'var', or parameter)}}
     }
 }
 

--- a/test/Parse/move_func_decl.swift
+++ b/test/Parse/move_func_decl.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking
 
-// rdar://100872195 (error: 'move' can only be applied to lvalues , error: Can not use feature when experimental move only is disabled!)
+// rdar://100872195 (error: 'move' can only be applied to a local binding ('let', 'var', or parameter) , error: Can not use feature when experimental move only is disabled!)
 //
 // Identifiers with a single underscore are not reserved for use by the language implementation. It is perfectly valid for a library to define its own '_move'.
 // The contextual consume keyword should only be parse when it is followed by an lvalue, so should *not* conflict with user-defined '_move' functions.

--- a/test/Parse/ownership_modifiers.swift
+++ b/test/Parse/ownership_modifiers.swift
@@ -18,13 +18,13 @@ func worst(x: (borrowing consuming Foo) -> ()) {} // expected-error{{at most one
 
 func zim(x: borrowing) {}
 func zang(x: consuming) {}
-func zung(x: borrowing consuming) {} // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
-func zip(x: consuming borrowing) {}  // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func zung(x: borrowing consuming) {} // expected-error{{copyable types cannot be 'consuming' or 'borrowing' yet}}
+func zip(x: consuming borrowing) {}  // expected-error{{copyable types cannot be 'consuming' or 'borrowing' yet}}
 func zap(x: (borrowing, consuming) -> ()) {}
-func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {} // expected-error 2{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func zoop(x: (borrowing consuming, consuming borrowing) -> ()) {} // expected-error 2{{copyable types cannot be 'consuming' or 'borrowing' yet}}
 
-func worster(x: borrowing borrowing borrowing) {} // expected-error{{at most one}} // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
-func worstest(x: (borrowing borrowing borrowing) -> ()) {} // expected-error{{at most one}} // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func worster(x: borrowing borrowing borrowing) {} // expected-error{{at most one}} // expected-error{{copyable types cannot be 'consuming' or 'borrowing' yet}}
+func worstest(x: (borrowing borrowing borrowing) -> ()) {} // expected-error{{at most one}} // expected-error{{copyable types cannot be 'consuming' or 'borrowing' yet}}
 
 // Parameter specifier names are regular identifiers in other positions,
 // including argument labels.
@@ -61,15 +61,15 @@ struct MethodModifiers: ~Copyable {
 }
 
 
-func chalk(_ a: consuming String, // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
-           _ b: borrowing [Int], // expected-error{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func chalk(_ a: consuming String, // expected-error{{copyable types cannot be 'consuming' or 'borrowing' yet}}
+           _ b: borrowing [Int], // expected-error{{copyable types cannot be 'consuming' or 'borrowing' yet}}
            _ c: __shared [String],
            _ d: __owned Int?)
            {}
 
 struct Stepping {
-    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
-    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods of a copyable type}}
+    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods of a copyable type}}
   mutating func change() {}
   var ex: Int {
     __consuming get { 0 }
@@ -77,16 +77,16 @@ struct Stepping {
 }
 
 class Clapping {
-    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
-    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods of a copyable type}}
+    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods of a copyable type}}
   var ex: Int {
     __consuming get { 0 }
   }
 }
 
 protocol Popping {
-    consuming func perform() // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
-    borrowing func doIt() // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+    consuming func perform() // expected-error {{'consuming' is not yet valid on instance methods of a copyable type}}
+    borrowing func doIt() // expected-error {{'borrowing' is not yet valid on instance methods of a copyable type}}
   mutating func change()
   var ex: Int {
     __consuming get
@@ -94,8 +94,8 @@ protocol Popping {
 }
 
 enum Exercising {
-    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods in a Copyable type}}
-    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods in a Copyable type}}
+    consuming func perform() {} // expected-error {{'consuming' is not yet valid on instance methods of a copyable type}}
+    borrowing func doIt() {} // expected-error {{'borrowing' is not yet valid on instance methods of a copyable type}}
   mutating func change() {}
   var ex: Int {
     __consuming get { 0 }
@@ -103,7 +103,7 @@ enum Exercising {
 }
 
 func consumingClosure1(_ f: consuming () -> ()) { } // expected-error {{'consuming' cannot be applied to nonescaping closure}}
-func consumingClosure2(_ f: consuming @escaping () -> ()) { } // expected-error {{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func consumingClosure2(_ f: consuming @escaping () -> ()) { } // expected-error {{copyable types cannot be 'consuming' or 'borrowing' yet}}
 
-func borrowingClosure1(_ f: borrowing () -> ()) { } // expected-error {{Copyable types cannot be 'consuming' or 'borrowing' yet}}
-func borrowingClosure2(_ f: borrowing @escaping () -> ()) { } // expected-error {{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+func borrowingClosure1(_ f: borrowing () -> ()) { } // expected-error {{copyable types cannot be 'consuming' or 'borrowing' yet}}
+func borrowingClosure2(_ f: borrowing @escaping () -> ()) { } // expected-error {{copyable types cannot be 'consuming' or 'borrowing' yet}}

--- a/test/Parse/without_copyable.swift
+++ b/test/Parse/without_copyable.swift
@@ -6,7 +6,7 @@ struct S: ~U, // expected-error {{can only suppress 'Copyable'}}
               // expected-error@-1 {{inheritance from non-protocol type 'U'}}
           ~Copyable {}
 
-struct U: // expected-error {{move-only struct 'U' cannot conform to 'Sando'}}
+struct U: // expected-error {{noncopyable struct 'U' cannot conform to 'Sando'}}
           // expected-error@-1 {{type 'U' does not conform to protocol 'Sando'}}
           ~Copyable,
           Sando,

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -72,9 +72,9 @@ func testGlobalClosureCaptureVar() {
     x = SingleElt()
     globalClosureCaptureVar = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1:29 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2:26 {{conflicting access is here}}
     }
@@ -135,15 +135,15 @@ func testLocalLetClosureCaptureVar() {
     x = SingleElt()
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-note {{consuming use here}}
-        consumeVal(x) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
         borrowConsumeVal(x, x)
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
-        // expected-note @-3 {{non-consuming use here}}
-        // expected-note @-4 {{non-consuming use here}}
-        // expected-note @-5 {{consuming use here}}
+        // expected-note @-3 {{used here}}
+        // expected-note @-4 {{used here}}
+        // expected-note @-5 {{consumed here}}
     }
     f()
 }
@@ -195,9 +195,9 @@ func testLocalVarClosureCaptureVar() {
     x = SingleElt()
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -256,9 +256,9 @@ func testInOutVarClosureCaptureVar(_ f: inout () -> ()) {
     x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -322,9 +322,9 @@ func testConsumingEscapeClosureCaptureVar(_ f: consuming @escaping () -> ()) {
     x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -375,9 +375,9 @@ func testGlobalClosureCaptureLet() {
     let x = SingleElt()
     globalClosureCaptureLet = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     globalClosureCaptureLet()
 }
@@ -419,14 +419,14 @@ func testGlobalClosureCaptureLet() {
 // CHECK: } // end sil function '$s16moveonly_closure026testLocalLetClosureCaptureE0yyFyycfU_'
 func testLocalLetClosureCaptureLet() {
     let x = SingleElt()
-    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
-    // expected-error @-3 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
+    // expected-error @-3 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-note {{consuming use here}}
-        consumeVal(x) // expected-note {{consuming use here}}
-        borrowConsumeVal(x, x) // expected-note {{consuming use here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        borrowConsumeVal(x, x) // expected-note {{consumed here}}
     }
     f()
 }
@@ -467,9 +467,9 @@ func testLocalVarClosureCaptureLet() {
     let x = SingleElt()
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     f = {}
     f()
@@ -515,9 +515,9 @@ func testInOutVarClosureCaptureLet(_ f: inout () -> ()) {
     let x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -568,9 +568,9 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
     let x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -877,9 +877,9 @@ var globalClosureCaptureConsuming: () -> () = {}
 func testGlobalClosureCaptureConsuming(_ x: consuming SingleElt) {
     globalClosureCaptureConsuming = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1:29 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2:26 {{conflicting access is here}}
     }
@@ -938,14 +938,14 @@ func testLocalLetClosureCaptureConsuming(_ x: consuming SingleElt) {
     // expected-error @-3 {{'x' used after consume}}
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-note {{consuming use here}}
-        consumeVal(x) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
-        borrowConsumeVal(x, x) // expected-note {{non-consuming use here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
+        borrowConsumeVal(x, x) // expected-note {{used here}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
-        // expected-note @-3 {{consuming use here}}
-        // expected-note @-4 {{non-consuming use here}}
+        // expected-note @-3 {{consumed here}}
+        // expected-note @-4 {{used here}}
     }
     f()
 }
@@ -953,9 +953,9 @@ func testLocalLetClosureCaptureConsuming(_ x: consuming SingleElt) {
 func testLocalLetClosureCaptureConsuming2(_ x: consuming SingleElt) -> (() -> ()) {
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -1009,9 +1009,9 @@ func testLocalLetClosureCaptureConsuming2(_ x: consuming SingleElt) -> (() -> ()
 func testLocalVarClosureCaptureConsuming(_ x: consuming SingleElt) {
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -1074,9 +1074,9 @@ func testLocalVarClosureCaptureConsuming(_ x: consuming SingleElt) {
 func testConsumingEscapeClosureCaptureConsuming(_ f: consuming @escaping () -> (), _ x: consuming SingleElt) {
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -1126,9 +1126,9 @@ var globalClosureCaptureOwned: () -> () = {}
 func testGlobalClosureCaptureOwned(_ x: __owned SingleElt) {
     globalClosureCaptureOwned = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     globalClosureCaptureOwned()
 }
@@ -1169,14 +1169,14 @@ func testGlobalClosureCaptureOwned(_ x: __owned SingleElt) {
 // CHECK:   apply {{%.*}}([[LOADED_READ]], [[LOADED_TAKE]])
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalLetClosureCaptureOwnedyyAA9SingleEltVnFyycfU_'
 func testLocalLetClosureCaptureOwned(_ x: __owned SingleElt) {
-    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
-    // expected-error @-3 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
+    // expected-error @-3 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-note {{consuming use here}}
-        consumeVal(x) // expected-note {{consuming use here}}
-        borrowConsumeVal(x, x) // expected-note {{consuming use here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        consumeVal(x) // expected-note {{consumed here}}
+        borrowConsumeVal(x, x) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1216,9 +1216,9 @@ func testLocalLetClosureCaptureOwned(_ x: __owned SingleElt) {
 func testLocalVarClosureCaptureOwned(_ x: __owned SingleElt) {
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     f = {}
     f()
@@ -1263,9 +1263,9 @@ func testLocalVarClosureCaptureOwned(_ x: __owned SingleElt) {
 func testInOutVarClosureCaptureOwned(_ f: inout () -> (), _ x: __owned SingleElt) {
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -1316,9 +1316,9 @@ func testConsumingEscapeClosureCaptureOwned(_ f: consuming @escaping () -> (),
                                             _ x: __owned SingleElt) {
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
-        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
+        borrowConsumeVal(x, x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -1340,7 +1340,7 @@ struct ClosureHolder {
 }
 
 func closureCoroutineAssignmentLetBorrowingArgument(_ e: borrowing Empty) { // expected-error {{'e' is borrowed and cannot be consumed by closure capture}}
-    let f: () -> () = { // expected-note {{capture here}}
+    let f: () -> () = { // expected-note {{closure capturing 'e' here}}
         _ = e
     }
     var c = ClosureHolder()
@@ -1357,7 +1357,7 @@ func closureCoroutineAssignmentLetConsumingArgument(_ e: __owned Empty) {
 
 func closureCoroutineAssignmentVarConsumingArgument(_ e: consuming Empty) {
     let f: () -> () = {
-        _ = e // expected-error {{captured 'e' cannot be consumed within a closure}}
+        _ = e // expected-error {{noncopyable 'e' cannot be consumed when captured by a closure}}
     }
     var c = ClosureHolder()
     c.fCoroutine = f
@@ -1376,7 +1376,7 @@ func closureCoroutineAssignmentVarBinding() {
     var e = Empty()
     e = Empty()
     let f: () -> () = {
-        _ = e // expected-error {{captured 'e' cannot be consumed within a closure}}
+        _ = e // expected-error {{noncopyable 'e' cannot be consumed when captured by a closure}}
     }
     var c = ClosureHolder()
     c.fCoroutine = f

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -72,9 +72,9 @@ func testGlobalClosureCaptureVar() {
     x = SingleElt()
     globalClosureCaptureVar = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1:29 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2:26 {{conflicting access is here}}
     }
@@ -195,9 +195,9 @@ func testLocalVarClosureCaptureVar() {
     x = SingleElt()
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -256,9 +256,9 @@ func testInOutVarClosureCaptureVar(_ f: inout () -> ()) {
     x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -322,9 +322,9 @@ func testConsumingEscapeClosureCaptureVar(_ f: consuming @escaping () -> ()) {
     x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -375,9 +375,9 @@ func testGlobalClosureCaptureLet() {
     let x = SingleElt()
     globalClosureCaptureLet = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     globalClosureCaptureLet()
 }
@@ -419,9 +419,9 @@ func testGlobalClosureCaptureLet() {
 // CHECK: } // end sil function '$s16moveonly_closure026testLocalLetClosureCaptureE0yyFyycfU_'
 func testLocalLetClosureCaptureLet() {
     let x = SingleElt()
-    // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-3 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-3 {{captured 'x' cannot be consumed within a closure}}
     let f = {
         borrowVal(x)
         consumeVal(x) // expected-note {{consuming use here}}
@@ -467,9 +467,9 @@ func testLocalVarClosureCaptureLet() {
     let x = SingleElt()
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     f = {}
     f()
@@ -515,9 +515,9 @@ func testInOutVarClosureCaptureLet(_ f: inout () -> ()) {
     let x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     f()
 }
@@ -568,9 +568,9 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
     let x = SingleElt()
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     f()
 }
@@ -877,9 +877,9 @@ var globalClosureCaptureConsuming: () -> () = {}
 func testGlobalClosureCaptureConsuming(_ x: consuming SingleElt) {
     globalClosureCaptureConsuming = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1:29 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2:26 {{conflicting access is here}}
     }
@@ -953,9 +953,9 @@ func testLocalLetClosureCaptureConsuming(_ x: consuming SingleElt) {
 func testLocalLetClosureCaptureConsuming2(_ x: consuming SingleElt) -> (() -> ()) {
     let f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -1009,9 +1009,9 @@ func testLocalLetClosureCaptureConsuming2(_ x: consuming SingleElt) -> (() -> ()
 func testLocalVarClosureCaptureConsuming(_ x: consuming SingleElt) {
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -1074,9 +1074,9 @@ func testLocalVarClosureCaptureConsuming(_ x: consuming SingleElt) {
 func testConsumingEscapeClosureCaptureConsuming(_ f: consuming @escaping () -> (), _ x: consuming SingleElt) {
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
     }
@@ -1126,9 +1126,9 @@ var globalClosureCaptureOwned: () -> () = {}
 func testGlobalClosureCaptureOwned(_ x: __owned SingleElt) {
     globalClosureCaptureOwned = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     globalClosureCaptureOwned()
 }
@@ -1169,9 +1169,9 @@ func testGlobalClosureCaptureOwned(_ x: __owned SingleElt) {
 // CHECK:   apply {{%.*}}([[LOADED_READ]], [[LOADED_TAKE]])
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalLetClosureCaptureOwnedyyAA9SingleEltVnFyycfU_'
 func testLocalLetClosureCaptureOwned(_ x: __owned SingleElt) {
-    // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-3 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-3 {{captured 'x' cannot be consumed within a closure}}
     let f = {
         borrowVal(x)
         consumeVal(x) // expected-note {{consuming use here}}
@@ -1216,9 +1216,9 @@ func testLocalLetClosureCaptureOwned(_ x: __owned SingleElt) {
 func testLocalVarClosureCaptureOwned(_ x: __owned SingleElt) {
     var f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     f = {}
     f()
@@ -1263,9 +1263,9 @@ func testLocalVarClosureCaptureOwned(_ x: __owned SingleElt) {
 func testInOutVarClosureCaptureOwned(_ f: inout () -> (), _ x: __owned SingleElt) {
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     f()
 }
@@ -1316,9 +1316,9 @@ func testConsumingEscapeClosureCaptureOwned(_ f: consuming @escaping () -> (),
                                             _ x: __owned SingleElt) {
     f = {
         borrowVal(x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        borrowConsumeVal(x, x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        borrowConsumeVal(x, x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     f()
 }
@@ -1339,7 +1339,7 @@ struct ClosureHolder {
     }
 }
 
-func closureCoroutineAssignmentLetBorrowingArgument(_ e: borrowing Empty) { // expected-error {{'e' has guaranteed ownership but was consumed due to being captured by a closure}}
+func closureCoroutineAssignmentLetBorrowingArgument(_ e: borrowing Empty) { // expected-error {{'e' is borrowed and cannot be consumed by closure capture}}
     let f: () -> () = { // expected-note {{capture here}}
         _ = e
     }
@@ -1357,7 +1357,7 @@ func closureCoroutineAssignmentLetConsumingArgument(_ e: __owned Empty) {
 
 func closureCoroutineAssignmentVarConsumingArgument(_ e: consuming Empty) {
     let f: () -> () = {
-        _ = e // expected-error {{'e' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        _ = e // expected-error {{captured 'e' cannot be consumed within a closure}}
     }
     var c = ClosureHolder()
     c.fCoroutine = f
@@ -1376,7 +1376,7 @@ func closureCoroutineAssignmentVarBinding() {
     var e = Empty()
     e = Empty()
     let f: () -> () = {
-        _ = e // expected-error {{'e' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        _ = e // expected-error {{captured 'e' cannot be consumed within a closure}}
     }
     var c = ClosureHolder()
     c.fCoroutine = f

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -137,7 +137,7 @@ func testLocalLetClosureCaptureVar() {
         borrowVal(x)
         consumeVal(x) // expected-note {{consumed here}}
         consumeVal(x) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
         borrowConsumeVal(x, x)
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}
@@ -940,7 +940,7 @@ func testLocalLetClosureCaptureConsuming(_ x: consuming SingleElt) {
         borrowVal(x)
         consumeVal(x) // expected-note {{consumed here}}
         consumeVal(x) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
         borrowConsumeVal(x, x) // expected-note {{used here}}
         // expected-error @-1 {{overlapping accesses, but deinitialization requires exclusive access}}
         // expected-note @-2 {{conflicting access is here}}

--- a/test/SILOptimizer/consume_operator_kills_copyable_addresses.sil
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addresses.sil
@@ -14,19 +14,19 @@ sil hidden [ossa] @$s4test3fooyyAA5KlassCnF : $@convention(thin) (@owned Klass) 
 bb0(%0 : @owned $Klass):
   %1 = begin_borrow [lexical] %0 : $Klass
   debug_value %1 : $Klass, let, name "k", argno 1
-  %3 = alloc_stack [lexical] $Klass, var, name "k2" // expected-error {{'k2' used after being consumed}}
+  %3 = alloc_stack [lexical] $Klass, var, name "k2" // expected-error {{'k2' used after consume}}
   %4 = copy_value %1 : $Klass
   %5 = move_value [allows_diagnostics] %4 : $Klass
   store %5 to [init] %3 : $*Klass
   %7 = begin_access [modify] [static] %3 : $*Klass
   %8 = alloc_stack $Klass
-  mark_unresolved_move_addr %7 to %8 : $*Klass // expected-note {{consume here}}
+  mark_unresolved_move_addr %7 to %8 : $*Klass // expected-note {{consumed here}}
   %10 = load [copy] %8 : $*Klass
   destroy_addr %8 : $*Klass
   end_access %7 : $*Klass
   %13 = begin_access [modify] [static] %3 : $*Klass
   %14 = function_ref @useTwice : $@convention(thin) (@guaranteed Klass, @inout Klass) -> ()
-  %15 = apply %14(%10, %13) : $@convention(thin) (@guaranteed Klass, @inout Klass) -> () // expected-note {{use here}}
+  %15 = apply %14(%10, %13) : $@convention(thin) (@guaranteed Klass, @inout Klass) -> () // expected-note {{used here}}
   end_access %13 : $*Klass
   destroy_value %10 : $Klass
   dealloc_stack %8 : $*Klass

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
@@ -26,16 +26,16 @@ func nonConsumingUse<T>(_ k: T) {}
 //
 
 public func simpleLinearUse<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
-    nonConsumingUse(y) // expected-note {{use here}}
+    let y = x // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
+    nonConsumingUse(y) // expected-note {{used here}}
 }
 
 // We just emit an error today for the first error in a block.
 public func simpleLinearUse2<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
-    nonConsumingUse(y) // expected-note {{use here}}
+    let y = x // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
+    nonConsumingUse(y) // expected-note {{used here}}
     nonConsumingUse(y)
 }
 
@@ -49,10 +49,10 @@ public func conditionalUse1<T>(_ x: T) {
 }
 
 public func loopUse1<T>(_ x: T) {
-    let y = x  // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
+    let y = x  // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        nonConsumingUse(y) // expected-note {{use here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     }
 }
 
@@ -61,9 +61,9 @@ public func loopUse1<T>(_ x: T) {
 //
 
 public func simpleLinearConsumingUse<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
-    consumingUse(y) // expected-note {{use here}}
+    let y = x // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
+    consumingUse(y) // expected-note {{used here}}
 }
 
 public func conditionalUseOk1<T>(_ x: T) {
@@ -78,10 +78,10 @@ public func conditionalUseOk1<T>(_ x: T) {
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUse<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
+    let y = x // expected-error {{'y' used after consume}}
     if booleanValue {
-        let _ = consume y // expected-note {{consume here}}
-        consumingUse(y) // expected-note {{use here}}
+        let _ = consume y // expected-note {{consumed here}}
+        consumingUse(y) // expected-note {{used here}}
     } else {
         // We shouldn't get any diagnostic on this use.
         consumingUse(y)
@@ -93,25 +93,25 @@ public func conditionalBadConsumingUse<T>(_ x: T) {
 }
 
 public func conditionalBadConsumingUse2<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
+    let y = x // expected-error {{'y' used after consume}}
     if booleanValue {
-        let _ = consume y // expected-note {{consume here}}
+        let _ = consume y // expected-note {{consumed here}}
     } else {
         // We shouldn't get any diagnostic on this use.
         consumingUse(y)
     }
 
-    consumingUse(y) // expected-note {{use here}}
+    consumingUse(y) // expected-note {{used here}}
 }
 
 
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUseLoop<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
+    let y = x // expected-error {{'y' used after consume}}
     if booleanValue {
-        let _ = consume y // expected-note {{consume here}}
-        consumingUse(y) // expected-note {{use here}}
+        let _ = consume y // expected-note {{consumed here}}
+        consumingUse(y) // expected-note {{used here}}
     } else {
         // We shouldn't get any diagnostic on this use.
         consumingUse(y)
@@ -129,16 +129,16 @@ public func conditionalBadConsumingUseLoop<T>(_ x: T) {
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUseLoop2<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being consumed}}
+    let y = x // expected-error {{'y' used after consume}}
     if booleanValue {
-        let _ = consume y // expected-note {{consume here}}
+        let _ = consume y // expected-note {{consumed here}}
     } else {
         // We shouldn't get any diagnostic on this use.
         consumingUse(y)
     }
 
     for _ in 0..<1024 {
-        consumingUse(y) // expected-note {{use here}}
+        consumingUse(y) // expected-note {{used here}}
     }
 }
 
@@ -154,51 +154,51 @@ public func simpleMoveOfOwnedParameter<T>(_ x: __owned T) -> () {
     let _ = consume x
 }
 
-public func errorSimpleMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let _ = consume x // expected-note {{use here}}
+public func errorSimpleMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let _ = consume x // expected-note {{used here}}
 }
 
-public func errorSimple2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let _ = consumingUse(x) // expected-note {{use here}}
+public func errorSimple2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let _ = consumingUse(x) // expected-note {{used here}}
 }
 
 // TODO: I wonder if we could do better for the 2nd error. At least we tell the
 // user it is due to the loop.
-public func errorLoopMultipleMove<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-                                                      // expected-error @-1 {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoopMultipleMove<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+                                                      // expected-error @-1 {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        let _ = consume x // expected-note {{consume here}}
-                         // expected-note @-1 {{use here}}
-                         // expected-note @-2 {{use here}}
+        let _ = consume x // expected-note {{consumed here}}
+                         // expected-note @-1 {{used here}}
+                         // expected-note @-2 {{used here}}
     }
 }
 
-public func errorLoopMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoopMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumingUse(x) // expected-note {{use here}}
+        consumingUse(x) // expected-note {{used here}}
     }
 }
 
-public func errorLoop2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoop2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        nonConsumingUse(x) // expected-note {{use here}}
+        nonConsumingUse(x) // expected-note {{used here}}
     }
 }
 
-public func errorSimple2MoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let _ = nonConsumingUse(x) // expected-note {{use here}}
+public func errorSimple2MoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let _ = nonConsumingUse(x) // expected-note {{used here}}
 }
 
-public func errorLoopMoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoopMoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        nonConsumingUse(x) // expected-note {{use here}}
+        nonConsumingUse(x) // expected-note {{used here}}
     }
 }
 
@@ -207,9 +207,9 @@ public func errorLoopMoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // exp
 ////////////////////////
 
 public func patternMatchIfCaseLet<T>(_ x: T?) {
-    if case let .some(y) = x { // expected-error {{'y' used after being consumed}}
-        let _ = consume y // expected-note {{consume here}}
-        nonConsumingUse(y) // expected-note {{use here}}
+    if case let .some(y) = x { // expected-error {{'y' used after consume}}
+        let _ = consume y // expected-note {{consumed here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     }
 }
 
@@ -217,28 +217,28 @@ public func patternMatchSwitchLet<T>(_ x: T?) {
     switch x {
     case .none:
         break
-    case .some(let y): // expected-error {{'y' used after being consumed}}
-        let _ = consume y // expected-note {{consume here}}
-        nonConsumingUse(y) // expected-note {{use here}}
+    case .some(let y): // expected-error {{'y' used after consume}}
+        let _ = consume y // expected-note {{consumed here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     }
 }
 
 public func patternMatchSwitchLet2<T>(_ x: (T?, T?)?) {
     switch x {
-    case .some((.some(let y), _)): // expected-error {{'y' used after being consumed}}
-        let _ = consume y // expected-note {{consume here}}
-        nonConsumingUse(y) // expected-note {{use here}}
+    case .some((.some(let y), _)): // expected-error {{'y' used after consume}}
+        let _ = consume y // expected-note {{consumed here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     default:
         break
     }
 }
 
-public func patternMatchSwitchLet3<T>(_ x: __owned (T?, T?)?) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    switch x { // expected-note {{use here}}
-    case .some((.some(_), .some(let z))): // expected-error {{'z' used after being consumed}}
-        let _ = consume z // expected-note {{consume here}}
-        nonConsumingUse(z) // expected-note {{use here}}
+public func patternMatchSwitchLet3<T>(_ x: __owned (T?, T?)?) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    switch x { // expected-note {{used here}}
+    case .some((.some(_), .some(let z))): // expected-error {{'z' used after consume}}
+        let _ = consume z // expected-note {{consumed here}}
+        nonConsumingUse(z) // expected-note {{used here}}
     default:
         break
     }
@@ -258,10 +258,10 @@ public struct Pair<T> {
 // have invalidated a part of pair. We can be less restrictive in the future.
 //
 // TODO: Why are we emitting two uses here.
-public func performMoveOnOneEltOfPair<T>(_ p: __owned Pair<T>) { // expected-error {{'p' used after being consumed}}
+public func performMoveOnOneEltOfPair<T>(_ p: __owned Pair<T>) { // expected-error {{'p' used after consume}}
     let _ = p.z // Make sure we don't crash when we access a trivial value from Pair.
-    let _ = consume p // expected-note {{consume here}}
-    nonConsumingUse(p.y) // expected-note {{use here}}
+    let _ = consume p // expected-note {{consumed here}}
+    nonConsumingUse(p.y) // expected-note {{used here}}
 }
 
 public class TPair<T> {
@@ -280,24 +280,24 @@ public func multipleVarsWithSubsequentBorrows<T : Equatable>(_ p: T) -> Bool {
 // Cast Tests //
 ////////////////
 
-public func castTest0<T : SubP1>(_ x: __owned T) -> P { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    return x as P // expected-note {{use here}}
+public func castTest0<T : SubP1>(_ x: __owned T) -> P { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    return x as P // expected-note {{used here}}
 }
 
-public func castTest1<T : P>(_ x: __owned T) -> SubP2 { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    return x as! SubP2 // expected-note {{use here}}
+public func castTest1<T : P>(_ x: __owned T) -> SubP2 { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    return x as! SubP2 // expected-note {{used here}}
 }
 
-public func castTest2<T : P>(_ x: __owned T) -> SubP1? { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    return x as? SubP1 // expected-note {{use here}}
+public func castTest2<T : P>(_ x: __owned T) -> SubP1? { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    return x as? SubP1 // expected-note {{used here}}
 }
 
-public func castTestSwitch1<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    switch x { // expected-note {{use here}}
+public func castTestSwitch1<T : P>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    switch x { // expected-note {{used here}}
     case let k as SubP1:
         print(k)
     default:
@@ -305,9 +305,9 @@ public func castTestSwitch1<T : P>(_ x: __owned T) { // expected-error {{'x' use
     }
 }
 
-public func castTestSwitch2<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    switch x { // expected-note {{use here}}
+public func castTestSwitch2<T : P>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    switch x { // expected-note {{used here}}
     case let k as SubP1:
         print(k)
     case let k as SubP2:
@@ -317,11 +317,11 @@ public func castTestSwitch2<T : P>(_ x: __owned T) { // expected-error {{'x' use
     }
 }
 
-public func castTestSwitchInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func castTestSwitchInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        switch x { // expected-note {{use here}}
+        switch x { // expected-note {{used here}}
         case let k as SubP1:
             print(k)
         default:
@@ -330,19 +330,19 @@ public func castTestSwitchInLoop<T : P>(_ x: __owned T) { // expected-error {{'x
     }
 }
 
-public func castTestIfLet<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    if case let k as SubP1 = x { // expected-note {{use here}}
+public func castTestIfLet<T : P>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    if case let k as SubP1 = x { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
     }
 }
 
-public func castTestIfLetInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func castTestIfLetInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        if case let k as SubP1 = x { // expected-note {{use here}}
+        if case let k as SubP1 = x { // expected-note {{used here}}
             print(k)
         } else {
             print("no")
@@ -355,9 +355,9 @@ public enum EnumWithKlass {
     case klass(P)
 }
 
-public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    if case let .klass(k as SubP1) = x { // expected-note {{use here}}
+public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    if case let .klass(k as SubP1) = x { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
@@ -369,9 +369,9 @@ public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x
 /////////////////////////
 
 // Emit a better error here. At least we properly error.
-public func partialApplyTest<T>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let f = { // expected-note {{use here}}
+public func partialApplyTest<T>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let f = { // expected-note {{used here}}
         nonConsumingUse(x)
     }
     f()
@@ -382,9 +382,9 @@ public func partialApplyTest<T>(_ x: __owned T) { // expected-error {{'x' used a
 /////////////////
 
 // TODO: Emit an error in the defer.
-public func deferTest<T>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    defer { // expected-note {{use here}}
+public func deferTest<T>(_ x: __owned T) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    defer { // expected-note {{used here}}
         nonConsumingUse(x)
     }
     print("do Something")

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
@@ -147,7 +147,7 @@ public func conditionalBadConsumingUseLoop2<T>(_ x: T) {
 
 // This is ok, no uses after.
 public func simpleMoveOfParameter<T>(_ x: T) -> () {
-    let _ = consume x // expected-error {{'consume' applied to value that the compiler does not support checking}}
+    let _ = consume x // expected-error {{'consume' applied to value that the compiler does not support}}
 }
 
 public func simpleMoveOfOwnedParameter<T>(_ x: __owned T) -> () {

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
@@ -42,9 +42,9 @@ public func performMoveOnVarSingleBlock<T>(_ p: T) {
 }
 
 public func performMoveOnVarSingleBlockError<T>(_ p: T) {
-    var x = p // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    nonConsumingUse(x) // expected-note {{use here}}
+    var x = p // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    nonConsumingUse(x) // expected-note {{used here}}
     x = p
     nonConsumingUse(x)
 }
@@ -66,10 +66,10 @@ public func performMoveOnVarMultiBlock<T>(_ p: T) {
 }
 
 public func performMoveOnVarMultiBlockError1<T>(_ p: T) {
-    var x = p // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+    var x = p // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
 
-    nonConsumingUse(x) // expected-note {{use here}}
+    nonConsumingUse(x) // expected-note {{used here}}
 
     while booleanValue {
         print("true")
@@ -90,14 +90,14 @@ public func performMoveOnVarMultiBlockError1<T>(_ p: T) {
 }
 
 public func performMoveOnVarMultiBlockError2<T>(_ p: T) {
-    var x = p // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+    var x = p // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
 
     while booleanValue {
         print("true")
     }
 
-    nonConsumingUse(x) // expected-note {{use here}}
+    nonConsumingUse(x) // expected-note {{used here}}
 
     while booleanValue {
         print("true")
@@ -110,10 +110,10 @@ public func performMoveOnVarMultiBlockError2<T>(_ p: T) {
     nonConsumingUse(x)
 }
 
-public func performMoveOnInOut<T>(_ p: inout T) { // expected-error {{'p' used after being consumed}}
-    let buf = consume p // expected-note {{consume here}}
+public func performMoveOnInOut<T>(_ p: inout T) { // expected-error {{'p' used after consume}}
+    let buf = consume p // expected-note {{consumed here}}
     let _ = buf
-} // expected-note {{use here}}
+} // expected-note {{used here}}
 
 public func performMoveOnInOut2<T>(_ p: inout T, _ p2: T) {
     let buf = consume p
@@ -130,10 +130,10 @@ struct S<T> {
         self = .init(buffer: maybeNewB)
     }
 
-    mutating func appendError() { // expected-error {{'self' used after being consumed}}
-        let b = (consume self).buffer // expected-note {{consume here}}
+    mutating func appendError() { // expected-error {{'self' used after consume}}
+        let b = (consume self).buffer // expected-note {{consumed here}}
         let _ = b
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 
     mutating func appendThrowingNoError1(_ f: () throws -> ()) throws {
         let b = (consume self).buffer
@@ -168,49 +168,49 @@ struct S<T> {
         }
     }
 
-    mutating func appendThrowingError0(_ f: () throws -> ()) throws { // expected-error {{'self' used after being consumed}}
-        let b = (consume self).buffer // expected-note {{consume here}}
+    mutating func appendThrowingError0(_ f: () throws -> ()) throws { // expected-error {{'self' used after consume}}
+        let b = (consume self).buffer // expected-note {{consumed here}}
         let maybeNewB = exchangeUse(b)
-        try f() // expected-note {{use here}}
+        try f() // expected-note {{used here}}
         self = .init(buffer: maybeNewB)
     }
 
 
-    mutating func appendThrowingError1(_ f: () throws -> ()) throws { // expected-error {{'self' used after being consumed}}
-        let b = (consume self).buffer // expected-note {{consume here}}
+    mutating func appendThrowingError1(_ f: () throws -> ()) throws { // expected-error {{'self' used after consume}}
+        let b = (consume self).buffer // expected-note {{consumed here}}
         let maybeNewB = exchangeUse(b)
         let _ = maybeNewB
-        try f() // expected-note {{use here}}
+        try f() // expected-note {{used here}}
     }
 
-    mutating func appendThrowingError2(_ f: () throws -> ()) { // expected-error {{'self' used after being consumed}}
+    mutating func appendThrowingError2(_ f: () throws -> ()) { // expected-error {{'self' used after consume}}
         do {
-            let b = (consume self).buffer // expected-note {{consume here}}
+            let b = (consume self).buffer // expected-note {{consumed here}}
             let _ = b
             try f()
         } catch {
             self = .init(buffer: nil)
         }
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 
-    mutating func appendThrowingError3(_ f: () throws -> ()) { // expected-error {{'self' used after being consumed}}
+    mutating func appendThrowingError3(_ f: () throws -> ()) { // expected-error {{'self' used after consume}}
         do {
-            let b = (consume self).buffer // expected-note {{consume here}}
+            let b = (consume self).buffer // expected-note {{consumed here}}
             try f()
             let maybeNewB = exchangeUse(b)
             self = .init(buffer: maybeNewB)
         } catch {
         }
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 
-    mutating func appendThrowingError4(_ f: () throws -> ()) { // expected-error {{'self' used after being consumed}}
+    mutating func appendThrowingError4(_ f: () throws -> ()) { // expected-error {{'self' used after consume}}
         do {
-            let b = (consume self).buffer // expected-note {{consume here}}
+            let b = (consume self).buffer // expected-note {{consumed here}}
             let _ = b
             try f()
         } catch {
         }
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 }
 
 /////////////////
@@ -266,21 +266,21 @@ extension DeferTestProtocol {
     }
 
     // We do not support moving within a defer right now.
-    mutating func deferTestFail2() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail2() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
-            nonConsumingUse(k) // expected-note {{use here}}
+            nonConsumingUse(k) // expected-note {{used here}}
             self = selfType.getP()
         }
         print("123")
     }
 
 
-    mutating func deferTestFail3() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail3() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
-        nonConsumingUse(k) // expected-note {{use here}}
+        let _ = (consume self) // expected-note {{consumed here}}
+        nonConsumingUse(k) // expected-note {{used here}}
         defer {
             nonConsumingUse(k)
             self = selfType.getP()
@@ -288,20 +288,20 @@ extension DeferTestProtocol {
         print("123")
     }
 
-    mutating func deferTestFail4() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail4() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
-            consumingUse(k) // expected-note {{use here}}
+            consumingUse(k) // expected-note {{used here}}
             self = selfType.getP()
         }
         print("123")
     }
 
     // TODO: We should definitely be erroring on consuming use I think.
-    mutating func deferTestFail5() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail5() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         for _ in 0..<1024 {
             defer {
                 consumingUse(k)
@@ -310,14 +310,14 @@ extension DeferTestProtocol {
             print("foo bar")
         }
         print("123")
-    }  // expected-note {{use here}}
+    }  // expected-note {{used here}}
 
     // TODO: We should be erroring on nonConsumingUse rather than the end of
     // scope use.
     //
-    mutating func deferTestFail6() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail6() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         for _ in 0..<1024 {
             defer {
                 nonConsumingUse(k)
@@ -326,14 +326,14 @@ extension DeferTestProtocol {
             print("foo bar")
         }
         print("123")
-    }  // expected-note {{use here}}
+    }  // expected-note {{used here}}
 
-    mutating func deferTestFail7() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail7() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
         for _ in 0..<1024 {
-            let _ = (consume self) // expected-note {{consume here}}
+            let _ = (consume self) // expected-note {{consumed here}}
             defer {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
                 self = selfType.getP()
             }
             print("foo bar")
@@ -341,24 +341,24 @@ extension DeferTestProtocol {
         print("123")
     }
 
-    mutating func deferTestFail8() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail8() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
             if booleanValue {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = selfType.getP()
         }
         print("foo bar")
     }
 
-    mutating func deferTestFail9() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail9() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
             if booleanValue {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             } else {
                 nonConsumingUse(k)
             }
@@ -367,21 +367,21 @@ extension DeferTestProtocol {
         print("foo bar")
     }
 
-    mutating func deferTestFail10() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail10() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
             for _ in 0..<1024 {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = selfType.getP()
         }
         print("foo bar")
     }
 
-    mutating func deferTestFail11() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail11() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
-        let _ = (consume self) // expected-note {{consume here}}
+        let _ = (consume self) // expected-note {{consumed here}}
         if booleanValue {
             print("creating blocks")
         } else {
@@ -389,25 +389,25 @@ extension DeferTestProtocol {
         }
         defer {
             for _ in 0..<1024 {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = selfType.getP()
         }
         print("foo bar")
     }
 
-    mutating func deferTestFail12() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail12() { // expected-error {{'self' used after consume}}
         let selfType = type(of: self)
         if booleanValue {
             print("creating blocks")
         } else {
-            let _ = (consume self) // expected-note {{consume here}}
+            let _ = (consume self) // expected-note {{consumed here}}
             print("creating blocks2")
         }
 
         defer {
             for _ in 0..<1024 {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = selfType.getP()
         }
@@ -451,31 +451,31 @@ extension DeferTestProtocol {
 ////////////////
 
 public func castTest0<T : SubP1>(_ x: __owned T) -> P {
-    var x2 = x  // expected-error {{'x2' used after being consumed}}
+    var x2 = x  // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    return x2 as P // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    return x2 as P // expected-note {{used here}}
 }
 
 public func castTest1<T : P>(_ x: __owned T) -> SubP1 {
-    var x2 = x  // expected-error {{'x2' used after being consumed}}
+    var x2 = x  // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    return x2 as! SubP1 // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    return x2 as! SubP1 // expected-note {{used here}}
 }
 
 public func castTest2<T : P>(_ x: __owned T) -> SubP1? {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    return x2 as? SubP1 // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    return x2 as? SubP1 // expected-note {{used here}}
 }
 
 public func castTestSwitch1<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    switch x2 {  // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    switch x2 {  // expected-note {{used here}}
     case let k as SubP1:
         print(k)
     default:
@@ -484,10 +484,10 @@ public func castTestSwitch1<T : P>(_ x : __owned T) {
 }
 
 public func castTestSwitch2<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    switch x2 { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    switch x2 { // expected-note {{used here}}
     case let k as SubP1:
         print(k)
     case let k as SubP2:
@@ -498,12 +498,12 @@ public func castTestSwitch2<T : P>(_ x : __owned T) {
 }
 
 public func castTestSwitchInLoop<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
+    let _ = consume x2 // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        switch x2 { // expected-note {{use here}}
+        switch x2 { // expected-note {{used here}}
         case let k as SubP1:
             print(k)
         default:
@@ -513,10 +513,10 @@ public func castTestSwitchInLoop<T : P>(_ x : __owned T) {
 }
 
 public func castTestIfLet<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    if case let k as SubP1 = x2 { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    if case let k as SubP1 = x2 { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
@@ -524,11 +524,11 @@ public func castTestIfLet<T : P>(_ x : __owned T) {
 }
 
 public func castTestIfLetInLoop<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
+    let _ = consume x2 // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        if case let k as SubP1 = x2 { // expected-note {{use here}}
+        if case let k as SubP1 = x2 { // expected-note {{used here}}
             print(k)
         } else {
             print("no")
@@ -542,10 +542,10 @@ public enum EnumWithP<T> {
 }
 
 public func castTestIfLet2<T : P>(_ x : __owned EnumWithP<T>) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    if case let .klass(k as SubP1) = x2 { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    if case let .klass(k as SubP1) = x2 { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
@@ -557,17 +557,17 @@ public func castTestIfLet2<T : P>(_ x : __owned EnumWithP<T>) {
 ///////////////
 
 public func castAccess<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    let _ = x2.k // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    let _ = x2.k // expected-note {{used here}}
 }
 
 public func castAccess2<T : P>(_ x : __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    let _ = x2.k.getOtherKlass() // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    let _ = x2.k.getOtherKlass() // expected-note {{used here}}
 }
 
 /////////////////////////
@@ -575,10 +575,10 @@ public func castAccess2<T : P>(_ x : __owned T) {
 /////////////////////////
 
 public func nonEscapingpartialApplyTest<T : P>(_ x: __owned T) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    let f = { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    let f = { // expected-note {{used here}}
         print(x2)
     }
     f()
@@ -661,15 +661,15 @@ func multipleCapture1<T : P>(_ k: T) -> () {
 
 func multipleCapture2<T : P>(_ k: T) -> () {
     let kType = type(of: k)
-    var k2 = k // expected-error {{'k2' used after being consumed}}
+    var k2 = k // expected-error {{'k2' used after consume}}
     k2 = k
     var k3 = k
-    let _ = consume k2 // expected-note {{consume here}}
+    let _ = consume k2 // expected-note {{consumed here}}
     let _ = consume k3
     var k4 = k
     k4 = k
     defer {
-        print(k2) // expected-note {{use here}}
+        print(k2) // expected-note {{used here}}
         print(k4)
         k3 = kType.getP()
     }
@@ -707,10 +707,10 @@ func useValueAndInOut<T>(_ x: T, _ y: inout T) {}
 func useValueAndInOut<T>(_ x: inout T, _ y: T) {}
 
 func inoutAndUseTest<T>(_ x: T) {
-    var y = x // expected-error {{'y' used after being consumed}}
-              // expected-error @-1 {{'y' used after being consumed}}
-    useValueAndInOut(consume y, &y) // expected-note {{use here}}
-                                  // expected-note @-1 {{consume here}}
-    useValueAndInOut(&y, consume y) // expected-note {{use here}}
-                                  // expected-note @-1 {{consume here}}
+    var y = x // expected-error {{'y' used after consume}}
+              // expected-error @-1 {{'y' used after consume}}
+    useValueAndInOut(consume y, &y) // expected-note {{used here}}
+                                  // expected-note @-1 {{consumed here}}
+    useValueAndInOut(&y, consume y) // expected-note {{used here}}
+                                  // expected-note @-1 {{consumed here}}
 }

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
@@ -260,7 +260,7 @@ extension DeferTestProtocol {
         let _ = (consume self)
         defer {
             self = selfType.getP()
-            let _ = (consume self) // expected-error {{'consume' applied to value that the compiler does not support checking}}
+            let _ = (consume self) // expected-error {{'consume' applied to value that the compiler does not support}}
         }
         print("123")
     }
@@ -588,7 +588,7 @@ public func nonEscapingpartialApplyTest<T : P>(_ x: __owned T) {
 public func partialApplyTest<T : P>(_ x: __owned T) -> () -> () {
     var x2 = x
     x2 = x
-    let _ = consume x2 // expected-error {{'consume' applied to value that the compiler does not support checking}}
+    let _ = consume x2 // expected-error {{'consume' applied to value that the compiler does not support}}
     let f = {
         print(x2)
     }
@@ -694,7 +694,7 @@ func reinitInPieces1<T : P>(_ k: ProtPair<T>) {
     var k2 = k
     k2 = k
 
-    let _ = consume k2 // expected-error {{'consume' applied to value that the compiler does not support checking}}
+    let _ = consume k2 // expected-error {{'consume' applied to value that the compiler does not support}}
     k2.lhs = selfType.getP()
     k2.rhs = selfType.getP()
 }

--- a/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
@@ -319,7 +319,7 @@ extension KlassWrapper {
         let _ = (consume self)
         defer {
             self = KlassWrapper(k: Klass())
-            let _ = (consume self) // expected-error {{'consume' applied to value that the compiler does not support checking}}
+            let _ = (consume self) // expected-error {{'consume' applied to value that the compiler does not support}}
         }
         print("123")
     }
@@ -725,7 +725,7 @@ func reinitInPieces1(_ k: KlassPair) {
     var k2 = k
     k2 = k
 
-    let _ = consume k2 // expected-error {{'consume' applied to value that the compiler does not support checking}}
+    let _ = consume k2 // expected-error {{'consume' applied to value that the compiler does not support}}
     k2.lhs = Klass()
     k2.rhs = Klass()
 }

--- a/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
@@ -36,9 +36,9 @@ public func performMoveOnVarSingleBlock(_ p: Klass) {
 }
 
 public func performMoveOnVarSingleBlockError(_ p: Klass) {
-    var x = p // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    nonConsumingUse(x) // expected-note {{use here}}
+    var x = p // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    nonConsumingUse(x) // expected-note {{used here}}
     x = p
     nonConsumingUse(x)
 }
@@ -60,10 +60,10 @@ public func performMoveOnVarMultiBlock(_ p: Klass) {
 }
 
 public func performMoveOnVarMultiBlockError1(_ p: Klass) {
-    var x = p // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+    var x = p // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
 
-    nonConsumingUse(x) // expected-note {{use here}}
+    nonConsumingUse(x) // expected-note {{used here}}
 
     while booleanValue {
         print("true")
@@ -84,14 +84,14 @@ public func performMoveOnVarMultiBlockError1(_ p: Klass) {
 }
 
 public func performMoveOnVarMultiBlockError2(_ p: Klass) {
-    var x = p // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+    var x = p // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
 
     while booleanValue {
         print("true")
     }
 
-    nonConsumingUse(x) // expected-note {{use here}}
+    nonConsumingUse(x) // expected-note {{used here}}
 
     while booleanValue {
         print("true")
@@ -120,12 +120,12 @@ public func performMoveConditionalReinitialization(_ p: Klass) {
 }
 
 public func performMoveConditionalReinitialization2(_ p: Klass) {
-    var x = p // expected-error {{'x' used after being consumed}}
+    var x = p // expected-error {{'x' used after consume}}
 
     if booleanValue {
         nonConsumingUse(x)
-        let _ = consume x // expected-note {{consume here}}
-        nonConsumingUse(x) // expected-note {{use here}}
+        let _ = consume x // expected-note {{consumed here}}
+        nonConsumingUse(x) // expected-note {{used here}}
         x = p
         nonConsumingUse(x)
     } else {
@@ -136,18 +136,18 @@ public func performMoveConditionalReinitialization2(_ p: Klass) {
 }
 
 public func performMoveConditionalReinitialization3(_ p: Klass, _ p2: Klass, _ p3: Klass) {
-    var x = p // expected-error {{'x' used after being consumed}}
-              // expected-error @-1 {{'x' used after being consumed}}
+    var x = p // expected-error {{'x' used after consume}}
+              // expected-error @-1 {{'x' used after consume}}
 
     if booleanValue {
         nonConsumingUse(x)
-        let _ = consume x   // expected-note {{consume here}}
-        nonConsumingUse(x) // expected-note {{use here}}
+        let _ = consume x   // expected-note {{consumed here}}
+        nonConsumingUse(x) // expected-note {{used here}}
         nonConsumingUse(x) // We only emit for the first one.
         x = p2
         nonConsumingUse(x)
-        let _ = consume x   // expected-note {{consume here}}
-        nonConsumingUse(x) // expected-note {{use here}}
+        let _ = consume x   // expected-note {{consumed here}}
+        nonConsumingUse(x) // expected-note {{used here}}
     } else {
         nonConsumingUse(x)
     }
@@ -158,12 +158,12 @@ public func performMoveConditionalReinitialization3(_ p: Klass, _ p2: Klass, _ p
 // Even though the examples below are for lets, since the let is not initially
 // defined it comes out like a var.
 public func performMoveOnLaterDefinedInit(_ p: Klass) {
-    let x: Klass // expected-error {{'x' used after being consumed}}
+    let x: Klass // expected-error {{'x' used after consume}}
     do {
         x = p
     }
-    let _ = consume x // expected-note {{consume here}}
-    nonConsumingUse(x) // expected-note {{use here}}
+    let _ = consume x // expected-note {{consumed here}}
+    nonConsumingUse(x) // expected-note {{used here}}
 }
 
 public func performMoveOnLaterDefinedInit2(_ p: Klass) {
@@ -175,10 +175,10 @@ public func performMoveOnLaterDefinedInit2(_ p: Klass) {
     let _ = consume x
 }
 
-public func performMoveOnInOut(_ p: inout Klass) { // expected-error {{'p' used after being consumed}}
-    let buf = consume p // expected-note {{consume here}}
+public func performMoveOnInOut(_ p: inout Klass) { // expected-error {{'p' used after consume}}
+    let buf = consume p // expected-note {{consumed here}}
     let _ = buf
-} // expected-note {{use here}}
+} // expected-note {{used here}}
 
 public func performMoveOnInOut2(_ p: inout Klass, _ p2: Klass) {
     let buf = consume p
@@ -196,10 +196,10 @@ struct S {
         self = .init(buffer: maybeNewB)
     }
 
-    mutating func appendError() { // expected-error {{'self' used after being consumed}}
-        let b = (consume self).buffer // expected-note {{consume here}}
+    mutating func appendError() { // expected-error {{'self' used after consume}}
+        let b = (consume self).buffer // expected-note {{consumed here}}
         let _ = b
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 
     mutating func appendThrowingNoError1(_ f: () throws -> ()) throws {
         let b = (consume self).buffer!
@@ -234,49 +234,49 @@ struct S {
         }
     }
 
-    mutating func appendThrowingError0(_ f: () throws -> ()) throws { // expected-error {{'self' used after being consumed}}
-        let b = (consume self).buffer! // expected-note {{consume here}}
+    mutating func appendThrowingError0(_ f: () throws -> ()) throws { // expected-error {{'self' used after consume}}
+        let b = (consume self).buffer! // expected-note {{consumed here}}
         let maybeNewB = exchangeUse(b)
-        try f() // expected-note {{use here}}
+        try f() // expected-note {{used here}}
         self = .init(buffer: maybeNewB)
     }
 
 
-    mutating func appendThrowingError1(_ f: () throws -> ()) throws { // expected-error {{'self' used after being consumed}}
-        let b = (consume self).buffer! // expected-note {{consume here}}
+    mutating func appendThrowingError1(_ f: () throws -> ()) throws { // expected-error {{'self' used after consume}}
+        let b = (consume self).buffer! // expected-note {{consumed here}}
         let maybeNewB = exchangeUse(b)
         let _ = maybeNewB
-        try f() // expected-note {{use here}}
+        try f() // expected-note {{used here}}
     }
 
-    mutating func appendThrowingError2(_ f: () throws -> ()) { // expected-error {{'self' used after being consumed}}
+    mutating func appendThrowingError2(_ f: () throws -> ()) { // expected-error {{'self' used after consume}}
         do {
-            let b = (consume self).buffer // expected-note {{consume here}}
+            let b = (consume self).buffer // expected-note {{consumed here}}
             let _ = b
             try f()
         } catch {
             self = .init(buffer: nil)
         }
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 
-    mutating func appendThrowingError3(_ f: () throws -> ()) { // expected-error {{'self' used after being consumed}}
+    mutating func appendThrowingError3(_ f: () throws -> ()) { // expected-error {{'self' used after consume}}
         do {
-            let b = (consume self).buffer! // expected-note {{consume here}}
+            let b = (consume self).buffer! // expected-note {{consumed here}}
             try f()
             let maybeNewB = exchangeUse(b)
             self = .init(buffer: maybeNewB)
         } catch {
         }
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 
-    mutating func appendThrowingError4(_ f: () throws -> ()) { // expected-error {{'self' used after being consumed}}
+    mutating func appendThrowingError4(_ f: () throws -> ()) { // expected-error {{'self' used after consume}}
         do {
-            let b = (consume self).buffer // expected-note {{consume here}}
+            let b = (consume self).buffer // expected-note {{consumed here}}
             let _ = b
             try f()
         } catch {
         }
-    } // expected-note {{use here}}
+    } // expected-note {{used here}}
 }
 
 /////////////////
@@ -325,19 +325,19 @@ extension KlassWrapper {
     }
 
     // We do not support moving within a defer right now.
-    mutating func deferTestFail2() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail2() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
-            nonConsumingUse(k) // expected-note {{use here}}
+            nonConsumingUse(k) // expected-note {{used here}}
             self = KlassWrapper(k: Klass())
         }
         print("123")
     }
 
 
-    mutating func deferTestFail3() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
-        nonConsumingUse(k) // expected-note {{use here}}
+    mutating func deferTestFail3() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
+        nonConsumingUse(k) // expected-note {{used here}}
         defer {
             nonConsumingUse(k)
             self = KlassWrapper(k: Klass())
@@ -345,18 +345,18 @@ extension KlassWrapper {
         print("123")
     }
 
-    mutating func deferTestFail4() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail4() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
-            consumingUse(k) // expected-note {{use here}}
+            consumingUse(k) // expected-note {{used here}}
             self = KlassWrapper(k: Klass())
         }
         print("123")
     }
 
     // TODO: We should definitely be erroring on consuming use I think.
-    mutating func deferTestFail5() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail5() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         for _ in 0..<1024 {
             defer {
                 consumingUse(k)
@@ -365,13 +365,13 @@ extension KlassWrapper {
             print("foo bar")
         }
         print("123")
-    }  // expected-note {{use here}}
+    }  // expected-note {{used here}}
 
     // TODO: We should be erroring on nonConsumingUse rather than the end of
     // scope use.
     //
-    mutating func deferTestFail6() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail6() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         for _ in 0..<1024 {
             defer {
                 nonConsumingUse(k)
@@ -380,13 +380,13 @@ extension KlassWrapper {
             print("foo bar")
         }
         print("123")
-    }  // expected-note {{use here}}
+    }  // expected-note {{used here}}
 
-    mutating func deferTestFail7() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail7() { // expected-error {{'self' used after consume}}
         for _ in 0..<1024 {
-            let _ = (consume self) // expected-note {{consume here}}
+            let _ = (consume self) // expected-note {{consumed here}}
             defer {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
                 self = KlassWrapper(k: Klass())
             }
             print("foo bar")
@@ -394,22 +394,22 @@ extension KlassWrapper {
         print("123")
     }
 
-    mutating func deferTestFail8() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail8() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
             if booleanValue {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = KlassWrapper(k: Klass())
         }
         print("foo bar")
     }
 
-    mutating func deferTestFail9() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail9() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
             if booleanValue {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             } else {
                 nonConsumingUse(k)
             }
@@ -418,19 +418,19 @@ extension KlassWrapper {
         print("foo bar")
     }
 
-    mutating func deferTestFail10() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail10() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         defer {
             for _ in 0..<1024 {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = KlassWrapper(k: Klass())
         }
         print("foo bar")
     }
 
-    mutating func deferTestFail11() { // expected-error {{'self' used after being consumed}}
-        let _ = (consume self) // expected-note {{consume here}}
+    mutating func deferTestFail11() { // expected-error {{'self' used after consume}}
+        let _ = (consume self) // expected-note {{consumed here}}
         if booleanValue {
             print("creating blocks")
         } else {
@@ -438,24 +438,24 @@ extension KlassWrapper {
         }
         defer {
             for _ in 0..<1024 {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = KlassWrapper(k: Klass())
         }
         print("foo bar")
     }
 
-    mutating func deferTestFail12() { // expected-error {{'self' used after being consumed}}
+    mutating func deferTestFail12() { // expected-error {{'self' used after consume}}
         if booleanValue {
             print("creating blocks")
         } else {
-            let _ = (consume self) // expected-note {{consume here}}
+            let _ = (consume self) // expected-note {{consumed here}}
             print("creating blocks2")
         }
 
         defer {
             for _ in 0..<1024 {
-                nonConsumingUse(k) // expected-note {{use here}}
+                nonConsumingUse(k) // expected-note {{used here}}
             }
             self = KlassWrapper(k: Klass())
         }
@@ -497,31 +497,31 @@ extension KlassWrapper {
 ////////////////
 
 public func castTest0(_ x: __owned SubKlass1) -> Klass {
-    var x2 = x  // expected-error {{'x2' used after being consumed}}
+    var x2 = x  // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    return x2 as Klass // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    return x2 as Klass // expected-note {{used here}}
 }
 
 public func castTest1(_ x: __owned Klass) -> SubKlass1 {
-    var x2 = x  // expected-error {{'x2' used after being consumed}}
+    var x2 = x  // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    return x2 as! SubKlass1 // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    return x2 as! SubKlass1 // expected-note {{used here}}
 }
 
 public func castTest2(_ x: __owned Klass) -> SubKlass1? {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    return x2 as? SubKlass1 // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    return x2 as? SubKlass1 // expected-note {{used here}}
 }
 
 public func castTestSwitch1(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    switch x2 {  // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    switch x2 {  // expected-note {{used here}}
     case let k as SubKlass1:
         print(k)
     default:
@@ -530,10 +530,10 @@ public func castTestSwitch1(_ x : __owned Klass) {
 }
 
 public func castTestSwitch2(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    switch x2 { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    switch x2 { // expected-note {{used here}}
     case let k as SubKlass1:
         print(k)
     case let k as SubKlass2:
@@ -544,12 +544,12 @@ public func castTestSwitch2(_ x : __owned Klass) {
 }
 
 public func castTestSwitchInLoop(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
+    let _ = consume x2 // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        switch x2 { // expected-note {{use here}}
+        switch x2 { // expected-note {{used here}}
         case let k as SubKlass1:
             print(k)
         default:
@@ -559,10 +559,10 @@ public func castTestSwitchInLoop(_ x : __owned Klass) {
 }
 
 public func castTestIfLet(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    if case let k as SubKlass1 = x2 { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    if case let k as SubKlass1 = x2 { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
@@ -570,11 +570,11 @@ public func castTestIfLet(_ x : __owned Klass) {
 }
 
 public func castTestIfLetInLoop(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
+    let _ = consume x2 // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        if case let k as SubKlass1 = x2 { // expected-note {{use here}}
+        if case let k as SubKlass1 = x2 { // expected-note {{used here}}
             print(k)
         } else {
             print("no")
@@ -588,10 +588,10 @@ public enum EnumWithKlass {
 }
 
 public func castTestIfLet2(_ x : __owned EnumWithKlass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    if case let .klass(k as SubKlass1) = x2 { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    if case let .klass(k as SubKlass1) = x2 { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
@@ -603,17 +603,17 @@ public func castTestIfLet2(_ x : __owned EnumWithKlass) {
 ///////////////
 
 public func castAccess(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    let _ = x2.k // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    let _ = x2.k // expected-note {{used here}}
 }
 
 public func castAccess2(_ x : __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    let _ = x2.k!.getOtherKlass() // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    let _ = x2.k!.getOtherKlass() // expected-note {{used here}}
 }
 
 /////////////////////////
@@ -622,10 +622,10 @@ public func castAccess2(_ x : __owned Klass) {
 
 // Emit a better error here. At least we properly error.
 public func partialApplyTest(_ x: __owned Klass) {
-    var x2 = x // expected-error {{'x2' used after being consumed}}
+    var x2 = x // expected-error {{'x2' used after consume}}
     x2 = x
-    let _ = consume x2 // expected-note {{consume here}}
-    let f = { // expected-note {{use here}}
+    let _ = consume x2 // expected-note {{consumed here}}
+    let f = { // expected-note {{used here}}
         print(x2)
     }
     f()
@@ -693,15 +693,15 @@ func multipleCapture1(_ k: Klass) -> () {
 }
 
 func multipleCapture2(_ k: Klass) -> () {
-    var k2 = k // expected-error {{'k2' used after being consumed}}
+    var k2 = k // expected-error {{'k2' used after consume}}
     k2 = k
     var k3 = k
-    let _ = consume k2 // expected-note {{consume here}}
+    let _ = consume k2 // expected-note {{consumed here}}
     let _ = consume k3
     var k4 = k
     k4 = k
     defer {
-        print(k2) // expected-note {{use here}}
+        print(k2) // expected-note {{used here}}
         print(k4)
         k3 = Klass()
     }
@@ -738,10 +738,10 @@ func useValueAndInOut(_ x: Klass, _ y: inout Klass) {}
 func useValueAndInOut(_ x: inout Klass, _ y: Klass) {}
 
 func inoutAndUseTest(_ x: Klass) {
-    var y = x // expected-error {{'y' used after being consumed}}
-              // expected-error @-1 {{'y' used after being consumed}}
-    useValueAndInOut(consume y, &y) // expected-note {{use here}}
-                                  // expected-note @-1 {{consume here}}
-    useValueAndInOut(&y, consume y) // expected-note {{use here}}
-                                  // expected-note @-1 {{consume here}}
+    var y = x // expected-error {{'y' used after consume}}
+              // expected-error @-1 {{'y' used after consume}}
+    useValueAndInOut(consume y, &y) // expected-note {{used here}}
+                                  // expected-note @-1 {{consumed here}}
+    useValueAndInOut(&y, consume y) // expected-note {{used here}}
+                                  // expected-note @-1 {{consumed here}}
 }

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.sil
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.sil
@@ -22,10 +22,10 @@ case some(T)
 sil [ossa] @useInLoopWithDestroyOutOfLoop : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   debug_value %0 : $Klass, let, name "x", argno 1
-  %2 = begin_borrow [lexical] %0 : $Klass // expected-error {{'y' used after being consumed}}
+  %2 = begin_borrow [lexical] %0 : $Klass // expected-error {{'y' used after consume}}
   debug_value %2 : $Klass, let, name "y"
   %4 = copy_value %2 : $Klass
-  %5 = move_value [allows_diagnostics] %4 : $Klass // expected-note {{consume here}}
+  %5 = move_value [allows_diagnostics] %4 : $Klass // expected-note {{consumed here}}
   destroy_value %5 : $Klass
   br bb1
 
@@ -34,7 +34,7 @@ bb1:
 
 bb2(%58 : $Int):
   %59 = copy_value %2 : $Klass
-  %60 = begin_borrow [lexical] %59 : $Klass // expected-note {{use here}}
+  %60 = begin_borrow [lexical] %59 : $Klass // expected-note {{used here}}
   debug_value %60 : $Klass, let, name "m"
   end_borrow %60 : $Klass
   destroy_value %59 : $Klass

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -23,9 +23,9 @@ func nonConsumingUse(_ k: Klass) {}
 //
 
 public func simpleLinearUse(_ x: __owned Klass) {
-    let y = x // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
-    nonConsumingUse(y) // expected-note {{use here}}
+    let y = x // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
+    nonConsumingUse(y) // expected-note {{used here}}
 }
 
 public func conditionalUse1(_ x: Klass) {
@@ -38,10 +38,10 @@ public func conditionalUse1(_ x: Klass) {
 }
 
 public func loopUse1(_ x: Klass) {
-    let y = x  // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
+    let y = x  // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        nonConsumingUse(y) // expected-note {{use here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     }
 }
 
@@ -50,9 +50,9 @@ public func loopUse1(_ x: Klass) {
 //
 
 public func simpleLinearUseAssignment(_ x: __owned Klass) {
-    let y = x // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
-    let m = y // expected-note {{use here}}
+    let y = x // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
+    let m = y // expected-note {{used here}}
     let _ = m
 }
 
@@ -67,10 +67,10 @@ public func conditionalUse1Assignment(_ x: Klass) {
 }
 
 public func loopUse1Assignment(_ x: Klass) {
-    let y = x  // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
+    let y = x  // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        let m = y // expected-note {{use here}}
+        let m = y // expected-note {{used here}}
         let _ = m
     }
 }
@@ -80,9 +80,9 @@ public func loopUse1Assignment(_ x: Klass) {
 //
 
 public func simpleLinearConsumingUse(_ x: Klass) {
-    let y = x // expected-error {{'y' used after being consumed}}
-    let _ = consume y // expected-note {{consume here}}
-    consumingUse(y) // expected-note {{use here}}
+    let y = x // expected-error {{'y' used after consume}}
+    let _ = consume y // expected-note {{consumed here}}
+    consumingUse(y) // expected-note {{used here}}
 }
 
 public func conditionalUseOk1(_ x: Klass) {
@@ -97,9 +97,9 @@ public func conditionalUseOk1(_ x: Klass) {
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUse(_ x: Klass) {
-    let y = x // expected-error {{'y' used after being consumed}}
+    let y = x // expected-error {{'y' used after consume}}
     if booleanValue {
-        let _ = consume y // expected-note {{consume here}}
+        let _ = consume y // expected-note {{consumed here}}
         // TODO: We should be able to also emit a note on the line
         // below. Without this the user will have to compile multiple times to
         // work through the errors. But this makes it simpler to implement a
@@ -111,16 +111,16 @@ public func conditionalBadConsumingUse(_ x: Klass) {
     }
 
     // But this one and the first consumingUse should get a diagnostic.
-    consumingUse(y) // expected-note {{use here}}
+    consumingUse(y) // expected-note {{used here}}
 }
 
 
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUseLoop(_ x: Klass) {
-    let y = x // expected-error {{'y' used after being consumed}}
+    let y = x // expected-error {{'y' used after consume}}
     if booleanValue {
-        let _ = consume y // expected-note {{consume here}}
+        let _ = consume y // expected-note {{consumed here}}
         // TODO: We should be able to also emit a note on the line
         // below. Without this the user will have to compile multiple times to
         // work through the errors. But this makes it simpler to implement a
@@ -133,7 +133,7 @@ public func conditionalBadConsumingUseLoop(_ x: Klass) {
 
     // But this one and the first consumingUse should get a diagnostic.
     for _ in 0..<1024 {
-        consumingUse(y) // expected-note {{use here}}
+        consumingUse(y) // expected-note {{used here}}
     }
 }
 
@@ -144,58 +144,58 @@ public func simpleMoveOfParameter(_ x: __owned Klass) -> () {
     let _ = consume x
 }
 
-public func errorSimpleMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let _ = consume x // expected-note {{use here}}
+public func errorSimpleMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let _ = consume x // expected-note {{used here}}
 }
 
-public func errorSimple2MoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let _ = consumingUse(x) // expected-note {{use here}}
+public func errorSimple2MoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let _ = consumingUse(x) // expected-note {{used here}}
 }
 
 // TODO: I wonder if we could do better for the 2nd error. At least we tell the
 // user it is due to the loop.
-public func errorLoopMultipleMove(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-                                                      // expected-error @-1 {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoopMultipleMove(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+                                                      // expected-error @-1 {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        let _ = consume x // expected-note {{consume here}}
-                         // expected-note @-1 {{consume here would occur multiple times in loop}}
-                         // expected-note @-2 {{use here}}
+        let _ = consume x // expected-note {{consumed here}}
+                         // expected-note @-1 {{consumed in loop here}}
+                         // expected-note @-2 {{used here}}
     }
 }
 
-public func errorLoopMultipleMove1(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
+public func errorLoopMultipleMove1(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
     for _ in 0..<1024 {
-        let _ = consume x // expected-note {{consume here}}
-                         // expected-note @-1 {{consume here would occur multiple times in loop}}
+        let _ = consume x // expected-note {{consumed here}}
+                         // expected-note @-1 {{consumed in loop here}}
     }
 }
 
-public func errorLoopMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoopMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumingUse(x) // expected-note {{use here}}
+        consumingUse(x) // expected-note {{used here}}
     }
 }
 
-public func errorLoop2MoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoop2MoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        nonConsumingUse(x) // expected-note {{use here}}
+        nonConsumingUse(x) // expected-note {{used here}}
     }
 }
 
-public func errorSimple2MoveOfParameterNonConsume(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let _ = nonConsumingUse(x) // expected-note {{use here}}
+public func errorSimple2MoveOfParameterNonConsume(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let _ = nonConsumingUse(x) // expected-note {{used here}}
 }
 
-public func errorLoopMoveOfParameterNonConsume(_ x: __owned Klass) -> () { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func errorLoopMoveOfParameterNonConsume(_ x: __owned Klass) -> () { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        nonConsumingUse(x) // expected-note {{use here}}
+        nonConsumingUse(x) // expected-note {{used here}}
     }
 }
 
@@ -204,9 +204,9 @@ public func errorLoopMoveOfParameterNonConsume(_ x: __owned Klass) -> () { // ex
 ////////////////////////
 
 public func patternMatchIfCaseLet(_ x: __owned Klass?) {
-    if case let .some(y) = x { // expected-error {{'y' used after being consumed}}
-        let _ = consume y // expected-note {{consume here}}
-        nonConsumingUse(y) // expected-note {{use here}}
+    if case let .some(y) = x { // expected-error {{'y' used after consume}}
+        let _ = consume y // expected-note {{consumed here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     }
 }
 
@@ -214,31 +214,31 @@ public func patternMatchSwitchLet(_ x: __owned Klass?) {
     switch x {
     case .none:
         break
-    case .some(let y): // expected-error {{'y' used after being consumed}}
-        let _ = consume y // expected-note {{consume here}}
-        nonConsumingUse(y) // expected-note {{use here}}
+    case .some(let y): // expected-error {{'y' used after consume}}
+        let _ = consume y // expected-note {{consumed here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     }
 }
 
 public func patternMatchSwitchLet2(_ x: __owned (Klass?, Klass?)?) {
     switch x {
-    case .some((.some(let y), _)): // expected-error {{'y' used after being consumed}}
-        let _ = consume y // expected-note {{consume here}}
-        nonConsumingUse(y) // expected-note {{use here}}
+    case .some((.some(let y), _)): // expected-error {{'y' used after consume}}
+        let _ = consume y // expected-note {{consumed here}}
+        nonConsumingUse(y) // expected-note {{used here}}
     default:
         break
     }
 }
 
-public func patternMatchSwitchLet3(_ x: __owned (Klass?, Klass?)?) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func patternMatchSwitchLet3(_ x: __owned (Klass?, Klass?)?) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     switch x {
-    case .some((.some(_), .some(let z))): // expected-error {{'z' used after being consumed}}
-        let _ = consume z // expected-note {{consume here}}
-        nonConsumingUse(z) // expected-note {{use here}}
+    case .some((.some(_), .some(let z))): // expected-error {{'z' used after consume}}
+        let _ = consume z // expected-note {{consumed here}}
+        nonConsumingUse(z) // expected-note {{used here}}
     default:
         break
-    } // expected-note {{use here}} expected-note {{use here}}
+    } // expected-note {{used here}} expected-note {{used here}}
 }
 
 ////////////////
@@ -278,33 +278,33 @@ public func multipleVarsWithSubsequentBorrows() -> Bool {
 // Cast Tests //
 ////////////////
 
-public func castTest0(_ x: __owned SubKlass1) -> Klass { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    return x as Klass // expected-note {{use here}}
+public func castTest0(_ x: __owned SubKlass1) -> Klass { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    return x as Klass // expected-note {{used here}}
 }
 
-public func castTest1(_ x: __owned Klass) -> SubKlass1 { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    return x as! SubKlass1 // expected-note {{use here}}
+public func castTest1(_ x: __owned Klass) -> SubKlass1 { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    return x as! SubKlass1 // expected-note {{used here}}
 }
 
-public func castTest2(_ x: __owned Klass) -> SubKlass1? { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    return x as? SubKlass1 // expected-note {{use here}}
+public func castTest2(_ x: __owned Klass) -> SubKlass1? { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    return x as? SubKlass1 // expected-note {{used here}}
 }
 
-public func castTestSwitch1(_ x : __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func castTestSwitch1(_ x : __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     switch x {
     case let k as SubKlass1:
         print(k)
     default:
         print("Nope")
-    } // expected-note {{use here}} expected-note {{use here}}
+    } // expected-note {{used here}} expected-note {{used here}}
 }
 
-public func castTestSwitch2(_ x : __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func castTestSwitch2(_ x : __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     switch x {
     case let k as SubKlass1:
         print(k)
@@ -312,11 +312,11 @@ public func castTestSwitch2(_ x : __owned Klass) { // expected-error {{'x' used 
         print(k)
     default:
         print("Nope")
-    } // expected-note {{use here}} expected-note {{use here}} expected-note {{use here}}
+    } // expected-note {{used here}} expected-note {{used here}} expected-note {{used here}}
 }
 
-public func castTestSwitchInLoop(_ x : __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func castTestSwitchInLoop(_ x : __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
         switch x {
@@ -328,19 +328,19 @@ public func castTestSwitchInLoop(_ x : __owned Klass) { // expected-error {{'x' 
     }
 }
 
-public func castTestIfLet(_ x : __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    if case let k as SubKlass1 = x { // expected-note {{use here}}
+public func castTestIfLet(_ x : __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    if case let k as SubKlass1 = x { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
     }
 }
 
-public func castTestIfLetInLoop(_ x : __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
+public func castTestIfLetInLoop(_ x : __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        if case let k as SubKlass1 = x { // expected-note {{use here}}
+        if case let k as SubKlass1 = x { // expected-note {{used here}}
             print(k)
         } else {
             print("no")
@@ -353,9 +353,9 @@ public enum EnumWithKlass {
     case klass(Klass)
 }
 
-public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    if case let .klass(k as SubKlass1) = x { // expected-note {{use here}}
+public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    if case let .klass(k as SubKlass1) = x { // expected-note {{used here}}
         print(k)
     } else {
         print("no")
@@ -367,9 +367,9 @@ public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x
 /////////////////////////
 
 // Emit a better error here. At least we properly error.
-public func partialApplyTest(_ x: __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    let f = { // expected-note {{use here}}
+public func partialApplyTest(_ x: __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    let f = { // expected-note {{used here}}
         print(x)
     }
     f()
@@ -383,9 +383,9 @@ public func partialApplyTest(_ x: __owned Klass) { // expected-error {{'x' used 
 //
 // NOTE: This will require adding knowledge about captured defer arguments for
 // values. This at least prevents the error from happening.
-public func deferTest(_ x: __owned Klass) { // expected-error {{'x' used after being consumed}}
-    let _ = consume x // expected-note {{consume here}}
-    defer { // expected-note {{use here}}
+public func deferTest(_ x: __owned Klass) { // expected-error {{'x' used after consume}}
+    let _ = consume x // expected-note {{consumed here}}
+    defer { // expected-note {{used here}}
         nonConsumingUse(x)
     }
     print("do Something")

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -260,11 +260,11 @@ let myLetGlobal = Klass()
 var myVarGlobal = Klass()
 
 public func performMoveOnVarGlobalError() {
-    let _ = consume myVarGlobal // expected-error {{'consume' applied to value that the compiler does not support checking}}
+    let _ = consume myVarGlobal // expected-error {{'consume' applied to value that the compiler does not support}}
 }
 
 public func performMoveOnLetGlobalError() {
-    let _ = consume myVarGlobal // expected-error {{'consume' applied to value that the compiler does not support checking}}
+    let _ = consume myVarGlobal // expected-error {{'consume' applied to value that the compiler does not support}}
 }
 
 public func multipleVarsWithSubsequentBorrows() -> Bool {

--- a/test/SILOptimizer/definite_init_moveonly_controlflowdep_init.sil
+++ b/test/SILOptimizer/definite_init_moveonly_controlflowdep_init.sil
@@ -119,7 +119,7 @@ bb3:
   %23 = apply %22(%21) : $@convention(thin) (@guaranteed S) -> ()
   destroy_value %21 : $S
   %25 = mark_must_check [assignable_but_not_consumable] %3 : $*S
-  // expected-error @-1 {{'s' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+  // expected-error @-1 {{captured 's' cannot be consumed within a closure}}
   %26 = load [take] %25 : $*S
   %27 = function_ref @consumeVal : $@convention(thin) (@owned S) -> ()
   %28 = apply %27(%26) : $@convention(thin) (@owned S) -> ()

--- a/test/SILOptimizer/definite_init_moveonly_controlflowdep_init.sil
+++ b/test/SILOptimizer/definite_init_moveonly_controlflowdep_init.sil
@@ -119,7 +119,7 @@ bb3:
   %23 = apply %22(%21) : $@convention(thin) (@guaranteed S) -> ()
   destroy_value %21 : $S
   %25 = mark_must_check [assignable_but_not_consumable] %3 : $*S
-  // expected-error @-1 {{captured 's' cannot be consumed within a closure}}
+  // expected-error @-1 {{noncopyable 's' cannot be consumed when captured by a closure}}
   %26 = load [take] %25 : $*S
   %27 = function_ref @consumeVal : $@convention(thin) (@owned S) -> ()
   %28 = apply %27(%26) : $@convention(thin) (@owned S) -> ()

--- a/test/SILOptimizer/move_only_checker_addressonly_fail.swift
+++ b/test/SILOptimizer/move_only_checker_addressonly_fail.swift
@@ -16,6 +16,6 @@ func test1<T>(_ x: T) {
     //
     // An earlier change, I believe made it so that SILGen did not emit these
     // unchecked_addr_cast.
-    consumeValue(x2) // expected-error {{Usage of @noImplicitCopy that the move checker does not know how to check!}}
-    consumeValue(x2) // expected-error {{Usage of @noImplicitCopy that the move checker does not know how to check!}}
+    consumeValue(x2) // expected-error {{usage of no-implicit-copy value that the compiler can't verify.}}
+    consumeValue(x2) // expected-error {{usage of no-implicit-copy value that the compiler can't verify.}}
 }

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -64,7 +64,7 @@ struct DeinitStruct : ~Copyable {
   var fourth: (MoveOnlyKlass, MoveOnlyKlass)
   var fifth: MoveOnlyKlass
 
-  deinit {} // expected-note 10{{deinit declared here}}
+  deinit {} // expected-note 10{{deinitializer declared here}}
 }
 
 func testConsumeCopyable(_ x: consuming DeinitStruct) {

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -64,17 +64,7 @@ struct DeinitStruct : ~Copyable {
   var fourth: (MoveOnlyKlass, MoveOnlyKlass)
   var fifth: MoveOnlyKlass
 
-  deinit {}
-  // expected-note @-1 {{deinit declared here}}
-  // expected-note @-2 {{deinit declared here}}
-  // expected-note @-3 {{deinit declared here}}
-  // expected-note @-4 {{deinit declared here}}
-  // expected-note @-5 {{deinit declared here}}
-  // expected-note @-6 {{deinit declared here}}
-  // expected-note @-7 {{deinit declared here}}
-  // expected-note @-8 {{deinit declared here}}
-  // expected-note @-9 {{deinit declared here}}
-  // expected-note @-10 {{deinit declared here}}
+  deinit {} // expected-note 10{{deinit declared here}}
 }
 
 func testConsumeCopyable(_ x: consuming DeinitStruct) {
@@ -84,24 +74,24 @@ func testConsumeCopyable(_ x: consuming DeinitStruct) {
 }
 
 func testConsumeNonCopyable1(_ x: consuming DeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it has a user defined deinit}}
-    consume(x.third.rhs) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    consume(x.third.rhs)
 }
 
 func testConsumeNonCopyable2(_ x: consuming DeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it has a user defined deinit}}
-    consume(x.fourth.0) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    consume(x.fourth.0)
 }
 
 func testConsumeNonCopyable3(_ x: consuming DeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it has a user defined deinit}}
-    consume(x.fourth.1) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    consume(x.fourth.1)
 }
 
 
 func testConsumeNonCopyable4(_ x: consuming DeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it has a user defined deinit}}
-    consume(x.fifth) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    consume(x.fifth)
 }
 
 
@@ -129,35 +119,35 @@ func testStructContainDeinitStructConsumeCopyable1(_ x: consuming StructContainD
 }
 
 
-func testStructContainStructContainDeinitStructConsumeNonCopyable1(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.first' whose type 'DeinitStruct' has a user defined deinit}}
-    consume(x.first.third.rhs) // expected-note {{consuming use here}}
+func testStructContainStructContainDeinitStructConsumeNonCopyable1(_ xyz: consuming StructContainDeinitStruct) {
+    // expected-error @+1 {{cannot partially consume 'xyz.first' since it has a user defined deinit}}
+    consume(xyz.first.third.rhs)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable1a(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.second.0' whose type 'DeinitStruct' has a user defined deinit}}
-    consume(x.second.0.third.rhs) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x.second.0' since it has a user defined deinit}}
+    consume(x.second.0.third.rhs)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable2(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.first' whose type 'DeinitStruct' has a user defined deinit}}
-    consume(x.first.fourth.0) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x.first' since it has a user defined deinit}}
+    consume(x.first.fourth.0)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable2a(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.second.1' whose type 'DeinitStruct' has a user defined deinit}}
-    consume(x.second.1.fourth.0) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x.second.1' since it has a user defined deinit}}
+    consume(x.second.1.fourth.0)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable3(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.first' whose type 'DeinitStruct' has a user defined deinit}}
-    consume(x.first.fourth.1) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x.first' since it has a user defined deinit}}
+    consume(x.first.fourth.1)
 }
 
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable4(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.first' whose type 'DeinitStruct' has a user defined deinit}}
-    consume(x.first.fifth) // expected-note {{consuming use here}}
+    // expected-error @+1 {{cannot partially consume 'x.first' since it has a user defined deinit}}
+    consume(x.first.fifth)
 }
 
 ////////////////////////
@@ -169,12 +159,7 @@ struct AddressOnlyDeinitStruct<T : P> : ~Copyable {
   var moveOnly = SingleIntContainingStruct()
   var moveOnlyPair = MoveOnlyPair()
 
-  deinit {}
-  // expected-note @-1 {{deinit declared here}}
-  // expected-note @-2 {{deinit declared here}}
-  // expected-note @-3 {{deinit declared here}}
-  // expected-note @-4 {{deinit declared here}}
-  // expected-note @-5 {{deinit declared here}}
+  deinit {} // expected-note 5{{deinitializer declared here}}
 }
 
 func consume<T : P>(_ x: consuming AddressOnlyDeinitStruct<T>) {}
@@ -187,10 +172,8 @@ func testAddressOnlyCanConsumeEntireType<T : P>(_ x: consuming AddressOnlyDeinit
 }
 
 func testAddressOnlyCannotPartialConsume<T : P>(_ x: consuming AddressOnlyDeinitStruct<T>) {
-  // expected-error @-1 {{Cannot partially consume 'x' since it has a user defined deinit}}
-  // expected-error @-2 {{Cannot partially consume 'x' since it has a user defined deinit}}
-  consume(x.moveOnly) // expected-note {{consuming use here}}
-  consume(x.moveOnlyPair.first) // expected-note {{consuming use here}}
+  consume(x.moveOnly) // expected-error {{cannot partially consume 'x' when it has a deinitializer}}
+  consume(x.moveOnlyPair.first) // expected-error {{cannot partially consume 'x' when it has a deinitializer}}
   consume(x.copyable)
 }
 
@@ -199,17 +182,14 @@ struct AddressOnlyContainingDeinitStruct<T : P> : ~Copyable {
 }
 
 func testAddressOnlyCannotPartialConsumeEvenIfSingleElt<T : P>(_ x: consuming AddressOnlyContainingDeinitStruct<T>) {
-  // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.a' whose type 'AddressOnlyDeinitStruct' has a user defined deinit}}
-
   // We do not error here since we can partially consume x, but not x.a
   consume(x.a)
-  consume(x.a.moveOnlyPair) // expected-note {{consuming use here}}
+  consume(x.a.moveOnlyPair) // expected-error {{cannot partially consume 'x.a' when it has a deinitializer}}
 }
 
 struct AddressOnlyContainingDeinitSingleField<T : P> : ~Copyable {
   var moveOnly = SingleIntContainingStruct()
-  deinit {}
-  // expected-note @-1 {{deinit declared here}}
+  deinit {} // expected-note {{deinitializer declared here}}
 }
 
 struct AddressOnlyContainingDeinitStruct3<T : P> : ~Copyable {
@@ -219,11 +199,9 @@ struct AddressOnlyContainingDeinitStruct3<T : P> : ~Copyable {
 func consume<T : P>(_ x: consuming AddressOnlyContainingDeinitSingleField<T>) {}
 
 func testAddressOnlyCannotPartialConsumeEvenIfSingleElt<T : P>(_ x: consuming AddressOnlyContainingDeinitStruct3<T>) {
-  // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.a' whose type 'AddressOnlyContainingDeinitSingleField' has a user defined deinit}}
-
   // We do not error here since we can partially consume x, but not x.a
   consume(x.a)
-  consume(x.a.moveOnly) // expected-note {{consuming use here}}
+  consume(x.a.moveOnly) // expected-error {{cannot partially consume 'x.a' when it has a deinitializer}}
 }
 
 
@@ -235,9 +213,7 @@ struct AddressOnlyContainingDeinitStructPair<T : P> : ~Copyable {
 // Make sure that if the deinit is in an intermediate element of the path that
 // we still handle it appropriately.
 func testAddressOnlyDeinitInMiddlePath<T : P>(_ x: consuming AddressOnlyContainingDeinitStructPair<T>) {
-  // expected-error @-1 {{Cannot partially consume 'x' since it contains field 'x.first' whose type 'AddressOnlyDeinitStruct' has a user defined deinit}}
-  // expected-error @-2 {{Cannot partially consume 'x' since it contains field 'x.first' whose type 'AddressOnlyDeinitStruct' has a user defined deinit}}
-  consume(x.first.moveOnly) // expected-note {{consuming use here}}
-  consume(x.first.moveOnlyPair.first) // expected-note {{consuming use here}}
+  consume(x.first.moveOnly) // expected-error {{cannot partially consume 'x.first' when it has a deinitializer}}
+  consume(x.first.moveOnlyPair.first) // expected-error {{cannot partially consume 'x.first' when it has a deinitializer}}
   consume(x.first.copyable)
 }

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -74,23 +74,23 @@ func testConsumeCopyable(_ x: consuming DeinitStruct) {
 }
 
 func testConsumeNonCopyable1(_ x: consuming DeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x' when it has a deinitializer}}
     consume(x.third.rhs)
 }
 
 func testConsumeNonCopyable2(_ x: consuming DeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x' when it has a deinitializer}}
     consume(x.fourth.0)
 }
 
 func testConsumeNonCopyable3(_ x: consuming DeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x' when it has a deinitializer}}
     consume(x.fourth.1)
 }
 
 
 func testConsumeNonCopyable4(_ x: consuming DeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x' when it has a deinitializer}}
     consume(x.fifth)
 }
 
@@ -120,33 +120,33 @@ func testStructContainDeinitStructConsumeCopyable1(_ x: consuming StructContainD
 
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable1(_ xyz: consuming StructContainDeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'xyz.first' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'xyz.first' when it has a deinitializer}}
     consume(xyz.first.third.rhs)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable1a(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x.second.0' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x.second.0' when it has a deinitializer}}
     consume(x.second.0.third.rhs)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable2(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x.first' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x.first' when it has a deinitializer}}
     consume(x.first.fourth.0)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable2a(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x.second.1' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x.second.1' when it has a deinitializer}}
     consume(x.second.1.fourth.0)
 }
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable3(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x.first' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x.first' when it has a deinitializer}}
     consume(x.first.fourth.1)
 }
 
 
 func testStructContainStructContainDeinitStructConsumeNonCopyable4(_ x: consuming StructContainDeinitStruct) {
-    // expected-error @+1 {{cannot partially consume 'x.first' since it has a user defined deinit}}
+    // expected-error @+1 {{cannot partially consume 'x.first' when it has a deinitializer}}
     consume(x.first.fifth)
 }
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -103,7 +103,7 @@ bb0(%0 : $Int):
   end_access %8 : $*AggStruct
   %12 = begin_access [read] [static] %3 : $*AggStruct
   %13 = struct_element_addr %12 : $*AggStruct, #AggStruct.lhs
-  %14 = load [copy] %13 : $*Klass // expected-note {{consuming use here}}
+  %14 = load [copy] %13 : $*Klass // expected-note {{consumed here}}
   end_access %12 : $*AggStruct
   %16 = move_value [lexical] %14 : $Klass
   %17 = mark_must_check [consumable_and_assignable] %16 : $Klass
@@ -112,7 +112,7 @@ bb0(%0 : $Int):
   %20 = move_value %19 : $Klass
   destroy_value %20 : $Klass
   destroy_value %17 : $Klass
-  %23 = load [copy] %3 : $*AggStruct // expected-note {{consuming use here}}
+  %23 = load [copy] %3 : $*AggStruct // expected-note {{consumed here}}
   destroy_addr %3 : $*AggStruct
   dealloc_stack %2 : $*AggStruct
   return %23 : $AggStruct
@@ -123,14 +123,14 @@ bb0(%arg : @owned $AggStruct):
   %0 = alloc_stack [lexical] $AggStruct, var, name "x2"
   %1 = mark_must_check [consumable_and_assignable] %0 : $*AggStruct
   // expected-error @-1 {{'x2' consumed more than once}}
-  // expected-error @-2 {{'x2' consumed by a use in a loop}}
+  // expected-error @-2 {{'x2' consumed in a loop}}
   %9 = begin_access [modify] [static] %1 : $*AggStruct
   store %arg to [init] %9 : $*AggStruct
   end_access %9 : $*AggStruct
   %12 = begin_access [read] [static] %1 : $*AggStruct
   %13 = struct_element_addr %12 : $*AggStruct, #AggStruct.pair
   %14 = struct_element_addr %13 : $*KlassPair, #KlassPair.lhs
-  %15 = load [copy] %14 : $*Klass // expected-note {{consuming use here}}
+  %15 = load [copy] %14 : $*Klass // expected-note {{consumed here}}
   end_access %12 : $*AggStruct
   %17 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %18 = apply %17(%15) : $@convention(thin) (@owned Klass) -> ()
@@ -144,8 +144,8 @@ bb2(%55 : $Int):
   %57 = struct_element_addr %56 : $*AggStruct, #AggStruct.pair
   %58 = struct_element_addr %57 : $*KlassPair, #KlassPair.lhs
   %59 = load [copy] %58 : $*Klass
-  // expected-note @-1 {{consuming use here}}
-  // expected-note @-2 {{consuming use here}}
+  // expected-note @-1 {{consumed here}}
+  // expected-note @-2 {{consumed here}}
   end_access %56 : $*AggStruct
   %61 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %62 = apply %61(%59) : $@convention(thin) (@owned Klass) -> ()
@@ -208,13 +208,13 @@ bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
   end_access %12 : $*NonTrivialStruct
   %19 = begin_access [read] [static] %1 : $*NonTrivialStruct
   %20 = struct_element_addr %19 : $*NonTrivialStruct, #NonTrivialStruct.k
-  %21 = load [copy] %20 : $*Klass // expected-note {{consuming use here}}
+  %21 = load [copy] %20 : $*Klass // expected-note {{consumed here}}
   end_access %19 : $*NonTrivialStruct
   %23 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %24 = apply %23(%21) : $@convention(thin) (@owned Klass) -> ()
   %25 = begin_access [read] [static] %1 : $*NonTrivialStruct
   %26 = struct_element_addr %25 : $*NonTrivialStruct, #NonTrivialStruct.k
-  %27 = load [copy] %26 : $*Klass // expected-note {{consuming use here}}
+  %27 = load [copy] %26 : $*Klass // expected-note {{consumed here}}
   end_access %25 : $*NonTrivialStruct
   %29 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %30 = apply %29(%27) : $@convention(thin) (@owned Klass) -> ()
@@ -257,7 +257,7 @@ bb0(%0 : @owned $NonTrivialStruct):
   %4 = mark_must_check [consumable_and_assignable] %3 : $*NonTrivialStruct // expected-error {{'x2' consumed more than once}}
   store %1 to [init] %4 : $*NonTrivialStruct
   %6 = function_ref @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
-  %7 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %7 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consumed here}}
   %8 = partial_apply [callee_guaranteed] %6(%7) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
   %9 = begin_borrow [lexical] %8 : $@callee_guaranteed () -> ()
   debug_value %9 : $@callee_guaranteed () -> (), let, name "f"
@@ -266,7 +266,7 @@ bb0(%0 : @owned $NonTrivialStruct):
   destroy_value %11 : $@callee_guaranteed () -> ()
   %14 = alloc_stack $NonTrivialStruct, let, name "x3"
   %15 = mark_must_check [consumable_and_assignable] %14 : $*NonTrivialStruct
-  %16 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %16 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consumed here}}
   store %16 to [init] %15 : $*NonTrivialStruct
   %18 = load [copy] %15 : $*NonTrivialStruct
   %19 = move_value %18 : $NonTrivialStruct
@@ -289,10 +289,10 @@ bb0(%0 : @owned $NonTrivialStruct):
   %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct // expected-error {{'x' used after consume}}
   store %0 to [init] %2 : $*NonTrivialStruct
   %4 = load_borrow %2 : $*NonTrivialStruct
-  %5 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %5 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %6 = function_ref @borrow_and_consume : $@convention(thin) (@guaranteed NonTrivialStruct, @owned NonTrivialStruct) -> ()
   %7 = apply %6(%4, %5) : $@convention(thin) (@guaranteed NonTrivialStruct, @owned NonTrivialStruct) -> ()
-  end_borrow %4 : $NonTrivialStruct // expected-note {{non-consuming use here}}
+  end_borrow %4 : $NonTrivialStruct // expected-note {{used here}}
   destroy_addr %2 : $*NonTrivialStruct
   dealloc_stack %1 : $*NonTrivialStruct
   %11 = tuple ()
@@ -309,12 +309,12 @@ bb0(%0 : $*Klass):
   %3 = alloc_stack [lexical] $Klass, var, name "y2"
   %4 = mark_must_check [consumable_and_assignable] %3 : $*Klass
   %5 = begin_access [read] [static] %1 : $*Klass
-  copy_addr %5 to [init] %4 : $*Klass // expected-note {{consuming use here}}
+  copy_addr %5 to [init] %4 : $*Klass // expected-note {{consumed here}}
   end_access %5 : $*Klass
   %8 = begin_access [read] [static] %1 : $*Klass
   %9 = load [copy] %8 : $*Klass
-  // expected-note @-1 {{consuming use here}}
-  // expected-note @-2 {{consuming use here}}
+  // expected-note @-1 {{consumed here}}
+  // expected-note @-2 {{consumed here}}
   end_access %8 : $*Klass
   %11 = begin_access [modify] [static] %4 : $*Klass
   store %9 to [assign] %11 : $*Klass
@@ -407,9 +407,9 @@ bb0(%0 : @owned $NonTrivialStruct):
 
   %8 = function_ref @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
   (%9, %10) = begin_apply %8(%6) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
-  %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %12 = apply %7(%11) : $@convention(thin) (@owned NonTrivialStruct) -> ()
-  end_apply %10 // expected-note {{non-consuming use here}}
+  end_apply %10 // expected-note {{used here}}
   destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_addr %2 : $*NonTrivialStruct
   dealloc_stack %1 : $*NonTrivialStruct
@@ -431,9 +431,9 @@ bb0(%0 : @owned $NonTrivialStruct):
 
   %8 = function_ref @coroutine_callee_uses_partial_apply : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
   (%9, %10) = begin_apply %8(%6) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
-  %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %12 = apply %7(%11) : $@convention(thin) (@owned NonTrivialStruct) -> ()
-  abort_apply %10 // expected-note {{non-consuming use here}}
+  abort_apply %10 // expected-note {{used here}}
   destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_addr %2 : $*NonTrivialStruct
   dealloc_stack %1 : $*NonTrivialStruct
@@ -489,15 +489,15 @@ bb0(%0 : @owned $NonTrivialStruct):
   cond_br undef, bb1, bb2
 
 bb1:
-  %12 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %12 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %13 = apply %7(%12) : $@convention(thin) (@owned NonTrivialStruct) -> ()
-  abort_apply %10 // expected-note {{non-consuming use here}}
+  abort_apply %10 // expected-note {{used here}}
   br bb3
 
 bb2:
-  %16 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %16 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %17 = apply %7(%16) : $@convention(thin) (@owned NonTrivialStruct) -> ()
-  end_apply %10 // expected-note {{non-consuming use here}}
+  end_apply %10 // expected-note {{used here}}
   br bb3
 
 bb3:

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -112,7 +112,7 @@ bb0(%0 : $Int):
   %20 = move_value %19 : $Klass
   destroy_value %20 : $Klass
   destroy_value %17 : $Klass
-  %23 = load [copy] %3 : $*AggStruct // expected-note {{consumed here}}
+  %23 = load [copy] %3 : $*AggStruct // expected-note {{consumed again here}}
   destroy_addr %3 : $*AggStruct
   dealloc_stack %2 : $*AggStruct
   return %23 : $AggStruct
@@ -145,7 +145,7 @@ bb2(%55 : $Int):
   %58 = struct_element_addr %57 : $*KlassPair, #KlassPair.lhs
   %59 = load [copy] %58 : $*Klass
   // expected-note @-1 {{consumed here}}
-  // expected-note @-2 {{consumed here}}
+  // expected-note @-2 {{consumed again here}}
   end_access %56 : $*AggStruct
   %61 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %62 = apply %61(%59) : $@convention(thin) (@owned Klass) -> ()
@@ -214,7 +214,7 @@ bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
   %24 = apply %23(%21) : $@convention(thin) (@owned Klass) -> ()
   %25 = begin_access [read] [static] %1 : $*NonTrivialStruct
   %26 = struct_element_addr %25 : $*NonTrivialStruct, #NonTrivialStruct.k
-  %27 = load [copy] %26 : $*Klass // expected-note {{consumed here}}
+  %27 = load [copy] %26 : $*Klass // expected-note {{consumed again here}}
   end_access %25 : $*NonTrivialStruct
   %29 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %30 = apply %29(%27) : $@convention(thin) (@owned Klass) -> ()
@@ -266,7 +266,7 @@ bb0(%0 : @owned $NonTrivialStruct):
   destroy_value %11 : $@callee_guaranteed () -> ()
   %14 = alloc_stack $NonTrivialStruct, let, name "x3"
   %15 = mark_must_check [consumable_and_assignable] %14 : $*NonTrivialStruct
-  %16 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consumed here}}
+  %16 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consumed again here}}
   store %16 to [init] %15 : $*NonTrivialStruct
   %18 = load [copy] %15 : $*NonTrivialStruct
   %19 = move_value %18 : $NonTrivialStruct
@@ -314,7 +314,7 @@ bb0(%0 : $*Klass):
   %8 = begin_access [read] [static] %1 : $*Klass
   %9 = load [copy] %8 : $*Klass
   // expected-note @-1 {{consumed here}}
-  // expected-note @-2 {{consumed here}}
+  // expected-note @-2 {{consumed again here}}
   end_access %8 : $*Klass
   %11 = begin_access [modify] [static] %4 : $*Klass
   store %9 to [assign] %11 : $*Klass

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -304,7 +304,7 @@ sil [ossa] @classSimpleChainArgTest : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = mark_must_check [consumable_and_assignable] %0 : $*Klass
   // expected-error @-1 {{'x2' consumed more than once}}
-  // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+  // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
   debug_value %1 : $*Klass, var, name "x2", argno 1, expr op_deref
   %3 = alloc_stack [lexical] $Klass, var, name "y2"
   %4 = mark_must_check [consumable_and_assignable] %3 : $*Klass

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -359,7 +359,7 @@ bb0(%0 : @closureCapture @guaranteed $<τ_0_0 where τ_0_0 : P> { var AddressOnl
   end_access %12 : $*AddressOnlyGeneric<T>
   %17 = begin_access [deinit] [dynamic] %1 : $*AddressOnlyGeneric<T>
   %18 = mark_must_check [assignable_but_not_consumable] %17 : $*AddressOnlyGeneric<T>
-  // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+  // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
   %19 = function_ref @addressOnlyGenericConsume : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
   %20 = apply %19<T>(%18) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
   end_access %17 : $*AddressOnlyGeneric<T>

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -304,7 +304,7 @@ sil [ossa] @classSimpleChainArgTest : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = mark_must_check [consumable_and_assignable] %0 : $*Klass
   // expected-error @-1 {{'x2' consumed more than once}}
-  // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+  // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
   debug_value %1 : $*Klass, var, name "x2", argno 1, expr op_deref
   %3 = alloc_stack [lexical] $Klass, var, name "y2"
   %4 = mark_must_check [consumable_and_assignable] %3 : $*Klass
@@ -359,7 +359,7 @@ bb0(%0 : @closureCapture @guaranteed $<τ_0_0 where τ_0_0 : P> { var AddressOnl
   end_access %12 : $*AddressOnlyGeneric<T>
   %17 = begin_access [deinit] [dynamic] %1 : $*AddressOnlyGeneric<T>
   %18 = mark_must_check [assignable_but_not_consumable] %17 : $*AddressOnlyGeneric<T>
-  // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+  // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
   %19 = function_ref @addressOnlyGenericConsume : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
   %20 = apply %19<T>(%18) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in AddressOnlyGeneric<τ_0_0>) -> ()
   end_access %17 : $*AddressOnlyGeneric<T>

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -137,7 +137,7 @@ public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x'
     x2 = x // expected-note {{consumed here}}
     let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consumed here}}
+    let k3 = x2 // expected-note {{consumed again here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -147,7 +147,7 @@ public func classSimpleChainArgTest(_ x2: inout Klass) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consumed here}}
     y2 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -189,7 +189,7 @@ public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expect
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                   // expected-note @-1 {{consumed here}}
+                   // expected-note @-1 {{consumed again here}}
 }
 
 public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expected-error {{'x2' used after consume}}
@@ -207,7 +207,7 @@ public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x'
     x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
@@ -215,7 +215,7 @@ public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{mis
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                   // expected-note @-1 {{consumed here}}
+                   // expected-note @-1 {{consumed again here}}
 }
 
 public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -223,14 +223,14 @@ public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' i
                 // expected-note @-1 {{consumed here}}
     x2 = Klass()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                     // expected-note @-1 {{consumed here}}
+                     // expected-note @-1 {{consumed again here}}
 }
 
 public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -284,7 +284,7 @@ public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' i
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -307,7 +307,7 @@ public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2'
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
     x2 = Klass()
@@ -318,7 +318,7 @@ public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is
                // expected-note @-1 {{consumed here}}
     x2 = Klass()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -327,7 +327,7 @@ public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' c
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     x3 = Klass()
     consumeVal(x3)
 }
@@ -337,7 +337,7 @@ public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is
                // expected-note @-1 {{consumed here}}
     x2 = Klass()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -345,7 +345,7 @@ public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' c
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -376,7 +376,7 @@ public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is
                // expected-note @-1 {{consumed here}}
     x2 = Klass()
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -384,7 +384,7 @@ public func classAssignToVar4Arg(_ x2: inout Klass) { // expected-error {{'x2' c
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2)   // expected-note {{consumed here}}
-                // expected-note @-1 {{consumed here}}
+                // expected-note @-1 {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -528,7 +528,7 @@ public func finalClassUseAfterConsume() {
     x2 = FinalKlass()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
@@ -536,21 +536,21 @@ public func finalClassUseAfterConsumeArg(_ x2: inout FinalKlass) { // expected-e
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-              // expected-note @-1 {{consumed here}}
+              // expected-note @-1 {{consumed again here}}
 }
 
 public func finalClassDoubleConsume() {
     var x2 = FinalKlass()  // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassDoubleConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                  // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}    
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                          // expected-note @-1 {{consumed here}}
+                          // expected-note @-1 {{consumed again here}}
 }
 
 public func finalClassLoopConsume() {
@@ -595,7 +595,7 @@ public func finalClassDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                                // expected-note @-1 {{consumed here}}
+                                // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -618,7 +618,7 @@ public func finalClassDiamondInLoopArg2(_ x2: inout FinalKlass) { // expected-er
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                                // expected-note @-1 {{consumed here}}
+                                // expected-note @-1 {{consumed again here}}
       }
     }
 
@@ -629,7 +629,7 @@ public func finalClassAssignToVar1() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
@@ -639,7 +639,7 @@ public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
@@ -648,7 +648,7 @@ public func finalClassAssignToVar2() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -657,7 +657,7 @@ public func finalClassAssignToVar2Arg(_ x2: inout FinalKlass) {
     // expected-error @-2 {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -680,7 +680,7 @@ public func finalClassAssignToVar4() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -689,7 +689,7 @@ public func finalClassAssignToVar4Arg(_ x2: inout FinalKlass) {
     // expected-error @-2 {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-              // expected-note @-1 {{consumed here}}
+              // expected-note @-1 {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -780,7 +780,7 @@ public struct AggStruct {
     init(myInit: Int) { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: Int) {
@@ -798,7 +798,7 @@ public struct AggStruct {
         self.center = myInit3
         let x = self.lhs // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     init(myInit4: Int) {
         self.init()
@@ -830,7 +830,7 @@ public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consumed here}}
     y2 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -864,7 +864,7 @@ public func aggStructUseAfterConsume() {
     x2 = AggStruct()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
@@ -873,14 +873,14 @@ public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-              // expected-note @-1 {{consumed here}}
+              // expected-note @-1 {{consumed again here}}
 }
 
 public func aggStructDoubleConsume() {
     var x2 = AggStruct()  // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
@@ -888,7 +888,7 @@ public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggStructLoopConsume() {
@@ -935,7 +935,7 @@ public func aggStructDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -975,7 +975,7 @@ public func aggStructConsumeField() {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1011,7 +1011,7 @@ public func aggStructConsumeGrandField() {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1047,7 +1047,7 @@ public struct AggGenericStruct<T> {
     init(myInit: UnsafeRawPointer) { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: UnsafeRawPointer) {
@@ -1065,7 +1065,7 @@ public struct AggGenericStruct<T> {
         self.rhs = myInit3
         let x = self.lhs // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     init(myInit4: UnsafeRawPointer) {
         self.init()
@@ -1127,7 +1127,7 @@ public func aggGenericStructUseAfterConsume() {
     x2 = AggGenericStruct<CopyableKlass>()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
@@ -1136,14 +1136,14 @@ public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<Copy
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}x
+    // expected-note @-1 {{consumed again here}}x
 }
 
 public func aggGenericStructDoubleConsume() {
     var x2 = AggGenericStruct<CopyableKlass>()  // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
@@ -1151,7 +1151,7 @@ public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<Copyab
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume() {
@@ -1197,7 +1197,7 @@ public func aggGenericStructDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1237,7 +1237,7 @@ public func aggGenericStructConsumeField() {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1273,7 +1273,7 @@ public func aggGenericStructConsumeGrandField() {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1283,7 +1283,7 @@ public func aggGenericStructConsumeGrandField2() {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
     }
-    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
@@ -1342,7 +1342,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
     x2 = AggGenericStruct<T>()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
@@ -1351,14 +1351,14 @@ public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
@@ -1366,7 +1366,7 @@ public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>)
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
@@ -1412,7 +1412,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1452,7 +1452,7 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1488,7 +1488,7 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1556,7 +1556,7 @@ public func enumUseAfterConsume() {
     x2 = EnumTy.klass(Klass())
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
@@ -1565,14 +1565,14 @@ public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func enumDoubleConsume() {
     var x2 = EnumTy.klass(Klass())  // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
@@ -1580,7 +1580,7 @@ public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed more than once}} 
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func enumLoopConsume() {
@@ -1627,7 +1627,7 @@ public func enumDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1648,7 +1648,7 @@ public func enumAssignToVar1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
@@ -1659,7 +1659,7 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
                                                             
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
@@ -1668,7 +1668,7 @@ public func enumAssignToVar2() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -1677,7 +1677,7 @@ public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed more than once}} 
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-     // expected-note @-1 {{consumed here}}
+     // expected-note @-1 {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -1700,7 +1700,7 @@ public func enumAssignToVar4() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -1709,7 +1709,7 @@ public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -1744,7 +1744,7 @@ public func enumPatternMatchIfLet1() {
     if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1756,7 +1756,7 @@ public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
         borrowVal(x)
     }
     if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1885,7 +1885,7 @@ public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGener
     x2 = x // expected-note {{consumed here}}
     let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consumed here}}
+    let k3 = x2 // expected-note {{consumed again here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -1895,7 +1895,7 @@ public func addressOnlyGenericSimpleChainArgTest<T>(_ x2: inout AddressOnlyGener
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consumed here}}
     y2 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1903,7 +1903,7 @@ public func addressOnlyGenericSimpleChainArgTest<T>(_ x2: inout AddressOnlyGener
 public func addressOnlyGenericSimpleChainConsumingArgTest<T>(_ x2: consuming AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
     var y2 = x2 // expected-note {{consumed here}}
-    y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1949,7 +1949,7 @@ public func addressOnlyGenericMultipleNonConsumingUseArgTest3<T>(_ x2: inout Add
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                   // expected-note @-1 {{consumed here}}
+                   // expected-note @-1 {{consumed again here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseArgTest4<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' used after consume}}
@@ -1978,7 +1978,7 @@ public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest3<T>(_ x2: 
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest4<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' used after consume}}
@@ -1997,7 +1997,7 @@ public func addressOnlyGenericUseAfterConsume<T>(_ x: borrowing AddressOnlyGener
     x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
@@ -2005,14 +2005,14 @@ public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGener
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                   // expected-note @-1 {{consumed here}}
+                   // expected-note @-1 {{consumed again here}}
 }
 
 public func addressOnlyGenericUseAfterConsumeArg2<T>(_ x2: consuming AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -2020,20 +2020,20 @@ public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric
                 // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyGenericDoubleConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                     // expected-note @-1 {{consumed here}}
+                     // expected-note @-1 {{consumed again here}}
 }
 
 public func addressOnlyGenericDoubleConsumeArg2<T>(_ x2: consuming AddressOnlyGeneric<T>) {
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyGenericLoopConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -2102,7 +2102,7 @@ public func addressOnlyGenericDiamondInLoop<T>(_ x: borrowing AddressOnlyGeneric
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2125,7 +2125,7 @@ public func addressOnlyGenericDiamondInLoopArg2<T>(_ x2: inout AddressOnlyGeneri
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
     x2 = AddressOnlyGeneric<T>()
@@ -2140,7 +2140,7 @@ public func addressOnlyGenericDiamondInLoopArg3<T>(_ x2: consuming AddressOnlyGe
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2152,7 +2152,7 @@ public func addressOnlyGenericDiamondInLoopArg4<T>(_ x2: consuming AddressOnlyGe
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
     x2 = AddressOnlyGeneric<T>()
@@ -2165,7 +2165,7 @@ public func addressOnlyGenericAssignToVar1<T>(_ x: borrowing AddressOnlyGeneric<
                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -2174,14 +2174,14 @@ public func addressOnlyGenericAssignToVar1Arg<T>(_ x2: inout AddressOnlyGeneric<
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     x3 = AddressOnlyGeneric<T>()
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar1Arg2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = AddressOnlyGeneric<T>()
     consumeVal(x3)
 }
@@ -2191,7 +2191,7 @@ public func addressOnlyGenericAssignToVar2<T>(_ x: borrowing AddressOnlyGeneric<
                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -2199,13 +2199,13 @@ public func addressOnlyGenericAssignToVar2Arg<T>(_ x2: inout AddressOnlyGeneric<
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     borrowVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar2Arg2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -2238,7 +2238,7 @@ public func addressOnlyGenericAssignToVar4<T>(_ x: borrowing AddressOnlyGeneric<
                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -2246,13 +2246,13 @@ public func addressOnlyGenericAssignToVar4Arg<T>(_ x2: inout AddressOnlyGeneric<
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2)   // expected-note {{consumed here}}
-                // expected-note @-1 {{consumed here}}
+                // expected-note @-1 {{consumed again here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar4Arg2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2)   // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -2351,7 +2351,7 @@ public func addressOnlyGenericAccessConsumeField2<T>(_ x: borrowing AddressOnlyG
     consumeVal(x2.moveOnly) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.moveOnly) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2374,7 +2374,7 @@ public func addressOnlyGenericAccessConsumeGrandField2<T>(_ x: borrowing Address
     consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2420,7 +2420,7 @@ public func addressOnlyGenericAccessConsumeFieldArg4<T>(_ x2: consuming AddressO
 
     for _ in 0..<1024 {
         consumeVal(x2.moveOnly) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2464,7 +2464,7 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg4<T>(_ x2: consuming Add
 
     for _ in 0..<1024 {
         consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2526,7 +2526,7 @@ public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtoco
     x2 = x // expected-note {{consumed here}}
     let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consumed here}}
+    let k3 = x2 // expected-note {{consumed again here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -2536,7 +2536,7 @@ public func addressOnlyProtocolSimpleChainArgTest(_ x2: inout AddressOnlyProtoco
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consumed here}}
     y2 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -2544,7 +2544,7 @@ public func addressOnlyProtocolSimpleChainArgTest(_ x2: inout AddressOnlyProtoco
 public func addressOnlyProtocolSimpleChainConsumingArgTest(_ x2: consuming AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
     var y2 = x2 // expected-note {{consumed here}}
-    y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -2590,7 +2590,7 @@ public func addressOnlyProtocolMultipleNonConsumingUseArgTest3(_ x2: inout Addre
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                   // expected-note @-1 {{consumed here}}
+                   // expected-note @-1 {{consumed again here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseArgTest4(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' used after consume}}
@@ -2619,7 +2619,7 @@ public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest3(_ x2: co
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest4(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' used after consume}}
@@ -2638,7 +2638,7 @@ public func addressOnlyProtocolUseAfterConsume(_ x: borrowing AddressOnlyProtoco
     x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
@@ -2646,14 +2646,14 @@ public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtoco
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                   // expected-note @-1 {{consumed here}}
+                   // expected-note @-1 {{consumed again here}}
 }
 
 public func addressOnlyProtocolUseAfterConsumeArg2(_ x2: consuming AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -2661,20 +2661,20 @@ public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol)
                 // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyProtocolDoubleConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-                     // expected-note @-1 {{consumed here}}
+                     // expected-note @-1 {{consumed again here}}
 }
 
 public func addressOnlyProtocolDoubleConsumeArg2(_ x2: consuming AddressOnlyProtocol) {
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func addressOnlyProtocolLoopConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -2743,7 +2743,7 @@ public func addressOnlyProtocolDiamondInLoop(_ x: borrowing AddressOnlyProtocol)
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2766,7 +2766,7 @@ public func addressOnlyProtocolDiamondInLoopArg2(_ x2: inout AddressOnlyProtocol
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
     x2 = AddressOnlyProtocol()
@@ -2781,7 +2781,7 @@ public func addressOnlyProtocolDiamondInLoopArg3(_ x2: consuming AddressOnlyProt
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2793,7 +2793,7 @@ public func addressOnlyProtocolDiamondInLoopArg4(_ x2: consuming AddressOnlyProt
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-                           // expected-note @-1 {{consumed here}}
+                           // expected-note @-1 {{consumed again here}}
       }
     }
     x2 = AddressOnlyProtocol()
@@ -2806,7 +2806,7 @@ public func addressOnlyProtocolAssignToVar1(_ x: borrowing AddressOnlyProtocol) 
                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -2815,14 +2815,14 @@ public func addressOnlyProtocolAssignToVar1Arg(_ x2: inout AddressOnlyProtocol) 
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     x3 = AddressOnlyProtocol()
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar1Arg2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = AddressOnlyProtocol()
     consumeVal(x3)
 }
@@ -2832,7 +2832,7 @@ public func addressOnlyProtocolAssignToVar2(_ x: borrowing AddressOnlyProtocol) 
                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -2840,13 +2840,13 @@ public func addressOnlyProtocolAssignToVar2Arg(_ x2: inout AddressOnlyProtocol) 
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
     borrowVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar2Arg2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -2879,7 +2879,7 @@ public func addressOnlyProtocolAssignToVar4(_ x: borrowing AddressOnlyProtocol) 
                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -2887,13 +2887,13 @@ public func addressOnlyProtocolAssignToVar4Arg(_ x2: inout AddressOnlyProtocol) 
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2)   // expected-note {{consumed here}}
-                // expected-note @-1 {{consumed here}}
+                // expected-note @-1 {{consumed again here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar4Arg2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2)   // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -2992,7 +2992,7 @@ public func addressOnlyProtocolAccessConsumeField2(_ x: borrowing AddressOnlyPro
     consumeVal(x2.moveOnly) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.moveOnly) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -3028,7 +3028,7 @@ public func addressOnlyProtocolAccessConsumeFieldArg4(_ x2: consuming AddressOnl
 
     for _ in 0..<1024 {
         consumeVal(x2.moveOnly) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -3052,7 +3052,7 @@ public func closureLetClassUseAfterConsume1() {
         x2 = Klass()
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -3063,7 +3063,7 @@ public func closureLetClassUseAfterConsume2() {
         x2 = Klass()
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -3076,7 +3076,7 @@ public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f(&argX)
 }
@@ -3090,7 +3090,7 @@ public func closureLetCaptureClassUseAfterConsume() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
 }
@@ -3114,11 +3114,11 @@ public func closureLetCaptureClassUseAfterConsumeError() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
     consumeVal(x2) // expected-note {{consumed here}}
-    let x3 = x2 // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed again here}}
     x2 = Klass()
     let _ = x3
 }
@@ -3164,7 +3164,7 @@ public func closureVarClassUseAfterConsume1() {
         x2 = Klass()
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -3176,7 +3176,7 @@ public func closureVarClassUseAfterConsume2() {
         x2 = Klass()
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -3190,7 +3190,7 @@ public func closureVarClassUseAfterConsumeArg(_ argX: inout Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f(&argX)
 }
@@ -3262,7 +3262,7 @@ public func deferCaptureClassUseAfterConsume() {
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2)
         // expected-note @-1 {{consumed here}}
-        // expected-note @-2 {{consumed here}}
+        // expected-note @-2 {{consumed again here}}
     }
     consumeVal(x2) // expected-note {{consumed here}}
 }
@@ -3277,7 +3277,7 @@ public func deferCaptureClassUseAfterConsume2() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
@@ -3291,7 +3291,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     print("foo")
 }
@@ -3307,7 +3307,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume() {
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -3326,7 +3326,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2() {
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -3345,7 +3345,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3() {
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -3364,7 +3364,7 @@ public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) 
             // expected-note @-1 {{consumed here}}
             consumeVal(x2) // expected-note {{captured here}}
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -3384,7 +3384,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume() {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -3400,7 +3400,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume2() {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -3444,7 +3444,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3463,7 +3463,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3484,7 +3484,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3530,7 +3530,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3562,7 +3562,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3722,12 +3722,12 @@ func moveOperatorTest(_ k: __owned Klass) {
     let k3 = consume k2 // expected-note {{consumed here}}
     let _ = consume k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
     _ = k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
     let _ = k2
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let _ = k3
 }
 
@@ -3740,12 +3740,12 @@ func moveOperatorTest2(_ k: consuming Klass) {
     let k3 = consume k2 // expected-note {{consumed here}}
     let _ = consume k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
     _ = k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
     let _ = k2
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let _ = k3
 }
 
@@ -3767,21 +3767,21 @@ func blackHoleKlassTestCase(_ k: __owned Klass) {
     // expected-error @-3 {{'k2' consumed more than once}}
     // expected-error @-4 {{'k2' consumed more than once}}
     let _ = k2 // expected-note {{consumed here}}
-    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed again here}}
 
     k2 = Klass()
     var _ = k2 // expected-note {{consumed here}}
     var _ = k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
 
     _ = k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
 
     // TODO: Why do we not also get 2 errors here?
     _ = k2
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 func blackHoleKlassTestCase2(_ k: consuming Klass) {
@@ -3791,21 +3791,21 @@ func blackHoleKlassTestCase2(_ k: consuming Klass) {
     // expected-error @-3 {{'k2' consumed more than once}}
     // expected-error @-4 {{'k2' consumed more than once}}
     let _ = k2 // expected-note {{consumed here}}
-    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed again here}}
 
     k2 = Klass()
     var _ = k2 // expected-note {{consumed here}}
     var _ = k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
 
     _ = k2
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
 
     // TODO: Why do we not also get 2 errors here?
     _ = k2
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 ///////////////////////////////////////
@@ -4013,7 +4013,7 @@ func sameCallSiteTestConsumeTwice(_ k: inout Klass) { // expected-error {{'k' co
     func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
     consumeKlassTwice(k, k) // expected-error {{overlapping accesses to 'k', but deinitialization requires exclusive access}}
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
     // expected-note @-3 {{conflicting access is here}}
     k = Klass()
 }
@@ -4205,7 +4205,7 @@ func testEmptyStruct() {
   func testArg2a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
     consume(x) // expected-note {{consumed here}}
-    consume(x) // expected-note {{consumed here}}
+    consume(x) // expected-note {{consumed again here}}
   }
 
   func testArg2b(_ x: consuming EmptyStruct) {
@@ -4222,7 +4222,7 @@ func testEmptyStruct() {
   func testArg3a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
     let _ = x // expected-note {{consumed here}}
-    let _ = x // expected-note {{consumed here}}
+    let _ = x // expected-note {{consumed again here}}
   }
 
   func testArg4(_ x: consuming EmptyStruct) {
@@ -4232,7 +4232,7 @@ func testEmptyStruct() {
   func testArg4a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
     _ = x // expected-note {{consumed here}}
-    _ = x // expected-note {{consumed here}}
+    _ = x // expected-note {{consumed again here}}
   }
 
   func testArg4b(_ x: consuming EmptyStruct) {
@@ -4240,8 +4240,8 @@ func testEmptyStruct() {
     // expected-error @-2 {{'x' consumed more than once}}
     _ = x // expected-note {{consumed here}}
     _ = x // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
-    let _ = x // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
+    let _ = x // expected-note {{consumed again here}}
   }
 
   func testArg5(_ x: consuming EmptyStruct) {
@@ -4260,7 +4260,7 @@ func testEmptyStruct() {
   func testArg7a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
     x.doSomething3() // expected-note {{consumed here}}
-    x.doSomething3() // expected-note {{consumed here}}
+    x.doSomething3() // expected-note {{consumed again here}}
   }
 }
 
@@ -4311,7 +4311,7 @@ func testStructContainingEmptyStruct() {
   func testArg7a(_ x: consuming StructContainingEmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
     x.x.doSomething3() // expected-note {{consumed here}}
-    x.x.doSomething3() // expected-note {{consumed here}}
+    x.x.doSomething3() // expected-note {{consumed again here}}
   }
 }
 
@@ -4373,7 +4373,7 @@ func testStructContainingTwoEmptyStruct() {
     // expected-error @-1 {{'x' consumed more than once}}
     x.x.doSomething3() // expected-note {{consumed here}}
     x.y.doSomething3()
-    x.x.doSomething3() // expected-note {{consumed here}}
+    x.x.doSomething3() // expected-note {{consumed again here}}
   }
 }
 
@@ -4405,7 +4405,7 @@ func testMyEnum() {
 
   func test1a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
     if case let .first(y) = x { // expected-note {{consumed here}}
-      _ = consume x // expected-note {{consumed here}}
+      _ = consume x // expected-note {{consumed again here}}
       _ = y
     }
   }
@@ -4414,7 +4414,7 @@ func testMyEnum() {
     if case let .first(y) = x { // expected-note {{consumed here}}
       _ = y
     }
-    _ = consume x // expected-note {{consumed here}}
+    _ = consume x // expected-note {{consumed again here}}
   }
 
   func test2(_ x: consuming MyEnum) {
@@ -4425,7 +4425,7 @@ func testMyEnum() {
 
   func test2a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
     if case let .third(.first(y)) = x { // expected-note {{consumed here}}
-      _ = consume x // expected-note {{consumed here}}
+      _ = consume x // expected-note {{consumed again here}}
       _ = y
     }
   }
@@ -4434,7 +4434,7 @@ func testMyEnum() {
     if case let .third(.first(y)) = x { // expected-note {{consumed here}}
       _ = y
     }
-    _ = consume x // expected-note {{consumed here}}
+    _ = consume x // expected-note {{consumed again here}}
   }
 
   func test2c(_ x: consuming MyEnum) { // expected-error {{'x' used after consume}}
@@ -4462,7 +4462,7 @@ func testMyEnum() {
     default:
       break
     }
-    _ = consume x // expected-note {{consumed here}}
+    _ = consume x // expected-note {{consumed again here}}
   }
 
   func test4(_ x: consuming MyEnum) {
@@ -4483,6 +4483,6 @@ func testMyEnum() {
     default:
       break
     }
-    _ = consume x // expected-note {{consumed here}}
+    _ = consume x // expected-note {{consumed again here}}
   }
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3143,11 +3143,11 @@ func closureLetStoreClosureInVariableIsEscape() {
 
     let f = {
         borrowVal(s)
-        consumeVal(s) // expected-error {{captured 's' cannot be consumed within a closure}}
+        consumeVal(s) // expected-error {{noncopyable 's' cannot be consumed when captured by a closure}}
     }
     let c = StoreClosure(f: f)
     _ = c
-    consumeVal(s) // expected-error {{captured 's' cannot be consumed within a closure}}
+    consumeVal(s) // expected-error {{noncopyable 's' cannot be consumed when captured by a closure}}
 }
 
 /////////////////////////////
@@ -3202,8 +3202,8 @@ public func closureVarCaptureClassUseAfterConsume() {
     var f = {}
     f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3214,7 +3214,7 @@ public func closureVarCaptureClassUseAfterConsume2() {
     var f = {}
     f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3225,12 +3225,12 @@ public func closureVarCaptureClassUseAfterConsumeError() {
     var f = {}
     f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     x2 = Klass()
     let _ = x3
 }
@@ -3458,7 +3458,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
     x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3479,7 +3479,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
     // expected-note @-1 {{consuming use here}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3489,11 +3489,11 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
@@ -3508,7 +3508,7 @@ public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         defer {
@@ -3539,7 +3539,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
 
 // TODO: MG
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         defer {
@@ -3550,7 +3550,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3567,7 +3567,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 ///////////////////////////////////////////
@@ -3582,11 +3582,11 @@ public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3601,14 +3601,14 @@ public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
@@ -3623,19 +3623,19 @@ public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
 public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
@@ -3657,8 +3657,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3671,8 +3671,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3685,13 +3685,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3700,13 +3700,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 /////////////////////////////
@@ -4106,14 +4106,14 @@ func inoutCaptureTest() -> (() -> ()) {
 
     borrowVal(x)
     consumeVal(x)
-    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     x = NonTrivialStruct()
 
     let g = {
         x = NonTrivialStruct()
         useInOut(&x)
         consumeVal(x)
-        // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+        // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     g()
 
@@ -4130,13 +4130,13 @@ func inoutCaptureTestAddressOnlyGeneric<T : P>(_ t: T.Type) -> (() -> ()) {
     }
 
     borrowVal(x)
-    consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+    consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     x = AddressOnlyGeneric<T>()
 
     let g = {
         x = AddressOnlyGeneric<T>()
         useInOut(&x)
-        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
+        consumeVal(x) // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     }
     g()
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -132,12 +132,12 @@ public struct AddressOnlyProtocol {
 /////////////////
 
 public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
                // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = x // expected-note {{consuming use here}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    x2 = x // expected-note {{consumed here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consuming use here}}
+    let k3 = x2 // expected-note {{consumed here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -145,16 +145,16 @@ public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x'
 public func classSimpleChainArgTest(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
 
 public func classSimpleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -163,8 +163,8 @@ public func classSimpleNonConsumingUseArgTest(_ x2: inout Klass) {
 }
 
 public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -173,90 +173,90 @@ public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected
 public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classMultipleNonConsumingUseArgTest2(_ x2: inout Klass) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
 }
 
 public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                   // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                   // expected-note @-1 {{consumed here}}
 }
 
 public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x2 = Klass()
 }
 
 
 public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                   // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                   // expected-note @-1 {{consumed here}}
 }
 
 public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
     x2 = Klass()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                     // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                     // expected-note @-1 {{consumed here}}
 }
 
 public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    var x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     x2 = Klass()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func classLoopConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func classLoopConsumeArg2(_ x2: inout Klass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func classLoopConsumeArg2(_ x2: inout Klass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     x2 = Klass()
 }
 
 public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = Klass()
     if boolValue {
         consumeVal(x2)
@@ -268,23 +268,23 @@ public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borr
 public func classDiamondArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                  // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = x // expected-error {{'x2' consumed in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
-               // expected-note @-2 {{consuming use here}}
+               // expected-note @-2 {{consumed here}}
     x2 = Klass()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -293,21 +293,21 @@ public func classDiamondInLoopArg(_ x2: inout Klass) { // expected-error {{missi
                                                        // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
-public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2' consumed in a loop}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
     x2 = Klass()
@@ -315,84 +315,84 @@ public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2'
 
 public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = Klass()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     x3 = Klass()
     consumeVal(x3)
 }
 
 public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = Klass()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     borrowVal(x3)
 }
 
 public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = Klass()
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar3Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = Klass()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2)   // expected-note {{consuming use here}}
-                // expected-note @-1 {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed here}}
+                // expected-note @-1 {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar5() {
     var x2 = Klass() // expected-error {{'x2' used after consume}}
     x2 = Klass()
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = Klass()
     consumeVal(x3)
 }
@@ -400,23 +400,23 @@ public func classAssignToVar5() {
 public func classAssignToVar5Arg(_ x: borrowing Klass, _ x2: inout Klass) {
     // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar5Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
     x2 = Klass()
 }
 
 public func classAccessAccessField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = Klass()
     borrowVal(x2.k)
     for _ in 0..<1024 {
@@ -431,7 +431,7 @@ public func classAccessAccessFieldArg(_ x2: inout Klass) {
 }
 
 public func classAccessConsumeField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = Klass()
     // Since a class is a reference type, we do not emit an error here.
     consumeVal(x2.k)
@@ -455,7 +455,7 @@ public func classAccessConsumeFieldArg(_ x2: inout Klass) {
 
 extension Klass {
     func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
     }
 }
@@ -473,7 +473,7 @@ public func finalClassSimpleChainTest() {
 }
 
 public func finalClassSimpleChainTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -520,50 +520,50 @@ public func finalClassMultipleNonConsumingUseTest() {
 public func finalClassMultipleNonConsumingUseTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsume() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-              // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+              // expected-note @-1 {{consumed here}}
 }
 
 public func finalClassDoubleConsume() {
     var x2 = FinalKlass()  // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                  // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}    
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                          // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                          // expected-note @-1 {{consumed here}}
 }
 
 public func finalClassLoopConsume() {
-    var x2 = FinalKlass() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = FinalKlass() // expected-error {{'x2' consumed in a loop}}
     x2 = FinalKlass()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func finalClassLoopConsumeArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -580,22 +580,22 @@ public func finalClassDiamond() {
 public func finalClassDiamondArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                            // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func finalClassDiamondInLoop() {
-    var x2 = FinalKlass() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = FinalKlass() // expected-error {{'x2' consumed in a loop}}
                           // expected-error @-1 {{'x2' consumed more than once}}
     x2 = FinalKlass()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                                // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                                // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -604,21 +604,21 @@ public func finalClassDiamondInLoopArg(_ x2: inout FinalKlass) { // expected-err
                                                                  // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
-public func finalClassDiamondInLoopArg2(_ x2: inout FinalKlass) { // expected-error {{consumed by a use in a loop}}
+public func finalClassDiamondInLoopArg2(_ x2: inout FinalKlass) { // expected-error {{consumed in a loop}}
                                                                   // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                                // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                                // expected-note @-1 {{consumed here}}
       }
     }
 
@@ -628,8 +628,8 @@ public func finalClassDiamondInLoopArg2(_ x2: inout FinalKlass) { // expected-er
 public func finalClassAssignToVar1() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
@@ -637,9 +637,9 @@ public func finalClassAssignToVar1() {
 public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
@@ -647,17 +647,17 @@ public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
 public func finalClassAssignToVar2() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func finalClassAssignToVar2Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     borrowVal(x3)
 }
 
@@ -671,7 +671,7 @@ public func finalClassAssignToVar3() {
 
 public func finalClassAssignToVar3Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
@@ -679,40 +679,40 @@ public func finalClassAssignToVar3Arg(_ x2: inout FinalKlass) {
 public func finalClassAssignToVar4() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar4Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-              // expected-note @-1 {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+              // expected-note @-1 {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5() {
     var x2 = FinalKlass() // expected-error {{'x2' used after consume}}
     x2 = FinalKlass()
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5Arg2(_ x2: inout FinalKlass) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = FinalKlass()
     consumeVal(x3)
 }
@@ -778,9 +778,9 @@ public struct AggStruct {
     //
     // TODO: Improve error message!
     init(myInit: Int) { // expected-error {{'self' consumed more than once}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: Int) {
@@ -796,9 +796,9 @@ public struct AggStruct {
     init(myInit3: Int) { // expected-error {{'self' consumed more than once}}
         self.init()
         self.center = myInit3
-        let x = self.lhs // expected-note {{consuming use here}}
+        let x = self.lhs // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     init(myInit4: Int) {
         self.init()
@@ -828,9 +828,9 @@ public func aggStructSimpleChainTest() {
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -856,52 +856,52 @@ public func aggStructMultipleNonConsumingUseTest() {
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsume() {
     var x2 = AggStruct() // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-              // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+              // expected-note @-1 {{consumed here}}
 }
 
 public func aggStructDoubleConsume() {
     var x2 = AggStruct()  // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggStructLoopConsume() {
-    var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggStruct() // expected-error {{'x2' consumed in a loop}}
     x2 = AggStruct()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -919,23 +919,23 @@ public func aggStructDiamondArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructDiamondInLoop() {
     var x2 = AggStruct()
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = AggStruct()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -945,9 +945,9 @@ public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -969,22 +969,22 @@ public func aggStructAccessFieldArg(_ x2: inout AggStruct) {
 }
 
 public func aggStructConsumeField() {
-    var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggStruct() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -1005,22 +1005,22 @@ public func aggStructAccessGrandFieldArg(_ x2: inout AggStruct) {
 }
 
 public func aggStructConsumeGrandField() {
-    var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggStruct() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -1045,9 +1045,9 @@ public struct AggGenericStruct<T> {
     //
     // TODO: Improve error message!
     init(myInit: UnsafeRawPointer) { // expected-error {{'self' consumed more than once}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: UnsafeRawPointer) {
@@ -1063,9 +1063,9 @@ public struct AggGenericStruct<T> {
     init(myInit3: UnsafeRawPointer) { // expected-error {{'self' consumed more than once}}
         self.init()
         self.rhs = myInit3
-        let x = self.lhs // expected-note {{consuming use here}}
+        let x = self.lhs // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     init(myInit4: UnsafeRawPointer) {
         self.init()
@@ -1093,7 +1093,7 @@ public func aggGenericStructSimpleChainTest() {
 }
 
 public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1119,52 +1119,52 @@ public func aggGenericStructMultipleNonConsumingUseTest() {
 public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsume() {
     var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}x
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}x
 }
 
 public func aggGenericStructDoubleConsume() {
     var x2 = AggGenericStruct<CopyableKlass>()  // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume() {
-    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed in a loop}}
     x2 = AggGenericStruct<CopyableKlass>()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1182,22 +1182,22 @@ public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<CopyableKlas
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamondInLoop() {
-    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1207,9 +1207,9 @@ public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<Copyab
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -1231,22 +1231,22 @@ public func aggGenericStructAccessFieldArg(_ x2: inout AggGenericStruct<Copyable
 }
 
 public func aggGenericStructConsumeField() {
-    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -1267,31 +1267,31 @@ public func aggGenericStructAccessGrandFieldArg(_ x2: inout AggGenericStruct<Cop
 }
 
 public func aggGenericStructConsumeGrandField() {
-    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandField2() {
     var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<CopyableKlass>()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
     }
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -1308,7 +1308,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1334,52 +1334,52 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
-    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed in a loop}}
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1397,22 +1397,22 @@ public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1422,9 +1422,9 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>)
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -1446,22 +1446,22 @@ public func aggGenericStructAccessFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
 }
 
 public func aggGenericStructConsumeField<T>(_ x: T.Type) {
-    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -1482,22 +1482,22 @@ public func aggGenericStructAccessGrandFieldArg<T>(_ x2: inout AggGenericStruct<
 }
 
 public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
-    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -1522,7 +1522,7 @@ public func enumSimpleChainTest() {
 }
 
 public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1548,52 +1548,52 @@ public func enumMultipleNonConsumingUseTest() {
 public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsume() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func enumDoubleConsume() {
     var x2 = EnumTy.klass(Klass())  // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func enumLoopConsume() {
-    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed in a loop}}
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1611,23 +1611,23 @@ public func enumDiamondArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumDiamondInLoop() {
     var x2 = EnumTy.klass(Klass())
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1637,9 +1637,9 @@ public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -1647,8 +1647,8 @@ public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
 public func enumAssignToVar1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
@@ -1657,9 +1657,9 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
                                                             
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
@@ -1667,17 +1667,17 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
 public func enumAssignToVar2() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-     // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+     // expected-note @-1 {{consumed here}}
     borrowVal(x3)
 }
 
@@ -1691,7 +1691,7 @@ public func enumAssignToVar3() {
 
 public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
@@ -1699,40 +1699,40 @@ public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missin
 public func enumAssignToVar4() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = EnumTy.klass(Klass())
     consumeVal(x3)
 }
@@ -1741,10 +1741,10 @@ public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{missi
 public func enumPatternMatchIfLet1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
@@ -1752,20 +1752,20 @@ public func enumPatternMatchIfLet1() {
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet2() {
-    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed in a loop}}
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1773,7 +1773,7 @@ public func enumPatternMatchIfLet2() {
 
 public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1782,17 +1782,17 @@ public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{
 public func enumPatternMatchSwitch1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         borrowVal(x2)
@@ -1813,7 +1813,7 @@ public func enumPatternMatchSwitch2() {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
     case .int:
@@ -1825,9 +1825,9 @@ public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {
 public func enumPatternMatchSwitch2WhereClause() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -1837,7 +1837,7 @@ public func enumPatternMatchSwitch2WhereClause() {
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -1863,7 +1863,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where boolValue:
         borrowVal(k)
@@ -1880,12 +1880,12 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expe
 
 public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
                // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = x // expected-note {{consuming use here}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    x2 = x // expected-note {{consumed here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consuming use here}}
+    let k3 = x2 // expected-note {{consumed here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -1893,17 +1893,17 @@ public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGener
 public func addressOnlyGenericSimpleChainArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
 
 public func addressOnlyGenericSimpleChainConsumingArgTest<T>(_ x2: consuming AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1911,8 +1911,8 @@ public func addressOnlyGenericSimpleChainConsumingArgTest<T>(_ x2: consuming Add
 public func addressOnlyGenericSimpleNonConsumingUseTest<T>(_ x: borrowing AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -1923,8 +1923,8 @@ public func addressOnlyGenericSimpleNonConsumingUseArgTest<T>(_ x2: inout Addres
 public func addressOnlyGenericMultipleNonConsumingUseTest<T>(_ x: borrowing AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -1933,30 +1933,30 @@ public func addressOnlyGenericMultipleNonConsumingUseTest<T>(_ x: borrowing Addr
 public func addressOnlyGenericMultipleNonConsumingUseArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseArgTest2<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseArgTest3<T>(_ x2: inout AddressOnlyGeneric<T>) {  // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                   // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                   // expected-note @-1 {{consumed here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseArgTest4<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x2 = AddressOnlyGeneric<T>()
 }
 
@@ -1969,23 +1969,23 @@ public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest<T>(_ x2: c
 public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest3<T>(_ x2: consuming AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest4<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x2 = AddressOnlyGeneric<T>()
 }
 
@@ -1993,80 +1993,80 @@ public func addressOnlyGenericUseAfterConsume<T>(_ x: borrowing AddressOnlyGener
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                   // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                   // expected-note @-1 {{consumed here}}
 }
 
 public func addressOnlyGenericUseAfterConsumeArg2<T>(_ x2: consuming AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyGenericDoubleConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                     // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                     // expected-note @-1 {{consumed here}}
 }
 
 public func addressOnlyGenericDoubleConsumeArg2<T>(_ x2: consuming AddressOnlyGeneric<T>) {
                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyGenericLoopConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    var x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func addressOnlyGenericLoopConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func addressOnlyGenericLoopConsumeArg2<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyGenericLoopConsumeArg2<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     x2 = AddressOnlyGeneric<T>()
 }
 
-public func addressOnlyGenericLoopConsumeArg3<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyGenericLoopConsumeArg3<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     x2 = AddressOnlyGeneric<T>()
 }
 
 public func addressOnlyGenericDiamond<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     if boolValue {
         consumeVal(x2)
@@ -2078,9 +2078,9 @@ public func addressOnlyGenericDiamond<T>(_ x: borrowing AddressOnlyGeneric<T>) {
 public func addressOnlyGenericDiamondArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                  // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -2093,16 +2093,16 @@ public func addressOnlyGenericDiamondArg2<T>(_ x2: consuming AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericDiamondInLoop<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = x // expected-error {{'x2' consumed in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
-               // expected-note @-2 {{consuming use here}}
+               // expected-note @-2 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -2111,48 +2111,48 @@ public func addressOnlyGenericDiamondInLoopArg<T>(_ x2: inout AddressOnlyGeneric
                                                        // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
-public func addressOnlyGenericDiamondInLoopArg2<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyGenericDiamondInLoopArg2<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed in a loop}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
     x2 = AddressOnlyGeneric<T>()
 }
 
 public func addressOnlyGenericDiamondInLoopArg3<T>(_ x2: consuming AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
 
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
-public func addressOnlyGenericDiamondInLoopArg4<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyGenericDiamondInLoopArg4<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed in a loop}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
     x2 = AddressOnlyGeneric<T>()
@@ -2162,105 +2162,105 @@ public func addressOnlyGenericAssignToVar1<T>(_ x: borrowing AddressOnlyGeneric<
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar1Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     x3 = AddressOnlyGeneric<T>()
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar1Arg2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = AddressOnlyGeneric<T>()
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar2Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     borrowVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar2Arg2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar3<T>(_ x: borrowing AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar3Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar3Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar4<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar4Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2)   // expected-note {{consuming use here}}
-                // expected-note @-1 {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed here}}
+                // expected-note @-1 {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar4Arg2<T>(_ x2: consuming AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2)   // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar5<T : P>(_ ty: T.Type) {
     var x2 = AddressOnlyGeneric<T>() // expected-error {{'x2' used after consume}}
     x2 = AddressOnlyGeneric<T>()
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = AddressOnlyGeneric<T>()
     consumeVal(x3)
 }
@@ -2268,17 +2268,17 @@ public func addressOnlyGenericAssignToVar5<T : P>(_ ty: T.Type) {
 public func addressOnlyGenericAssignToVar5Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyGenericAssignToVar5Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
     x2 = AddressOnlyGeneric<T>()
 }
@@ -2287,7 +2287,7 @@ public func addressOnlyGenericAssignToVar5Arg2<T>(_ x: borrowing AddressOnlyGene
 // that a use of a copy_addr that is copyable is not a consuming use. I will
 // remove them when I fix it in the next commit.
 public func addressOnlyGenericAccessAccessField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     borrowVal(x2.copyable)
     for _ in 0..<1024 {
@@ -2296,7 +2296,7 @@ public func addressOnlyGenericAccessAccessField<T>(_ x: borrowing AddressOnlyGen
 }
 
 public func addressOnlyGenericAccessAccessField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
     borrowVal(x2.moveOnly)
     for _ in 0..<1024 {
@@ -2333,7 +2333,7 @@ public func addressOnlyGenericAccessAccessFieldArg4<T>(_ x2: consuming AddressOn
 }
 
 public func addressOnlyGenericAccessConsumeField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
 
     consumeVal(x2.copyable)
@@ -2343,20 +2343,20 @@ public func addressOnlyGenericAccessConsumeField<T>(_ x: borrowing AddressOnlyGe
 }
 
 public func addressOnlyGenericAccessConsumeField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    var x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = AddressOnlyGeneric<T>()
 
-    consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.moveOnly) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func addressOnlyGenericAccessConsumeGrandField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
 
     consumeVal(x2.copyable.name)
@@ -2366,20 +2366,20 @@ public func addressOnlyGenericAccessConsumeGrandField<T>(_ x: borrowing AddressO
 }
 
 public func addressOnlyGenericAccessConsumeGrandField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     x2 = AddressOnlyGeneric<T>()
 
-    consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func addressOnlyGenericAccessConsumeGrandField2a<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyGeneric<T>()
 
     consumeVal(x2.moveOnly.copyableK)
@@ -2398,10 +2398,10 @@ public func addressOnlyGenericAccessConsumeFieldArg<T>(_ x2: inout AddressOnlyGe
 public func addressOnlyGenericAccessConsumeFieldArg2<T>(_ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly) // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+        consumeVal(x2.moveOnly) // expected-note {{consumed here}}
     }
 }
 
@@ -2414,13 +2414,13 @@ public func addressOnlyGenericAccessConsumeFieldArg3<T>(_ x2: consuming AddressO
 }
 
 public func addressOnlyGenericAccessConsumeFieldArg4<T>(_ x2: consuming AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly) // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.moveOnly) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
@@ -2434,10 +2434,10 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg<T>(_ x2: inout AddressO
 public func addressOnlyGenericAccessConsumeGrandFieldArg2<T>(_ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
+        consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
     }
 }
 
@@ -2458,13 +2458,13 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg3<T>(_ x2: consuming Add
 }
 
 public func addressOnlyGenericAccessConsumeGrandFieldArg4<T>(_ x2: consuming AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.moveOnly.k) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
@@ -2478,12 +2478,12 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg4a<T>(_ x2: consuming Ad
 
 extension AddressOnlyGeneric {
     func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
     }
 
     mutating func testNoUseSelf2() { // expected-error {{missing reinitialization of inout parameter 'self' after consume}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
     }
 }
@@ -2521,12 +2521,12 @@ struct AddressOnlyGenericInit<T : P> {
 
 public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
                // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = x // expected-note {{consuming use here}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    x2 = x // expected-note {{consumed here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consuming use here}}
+    let k3 = x2 // expected-note {{consumed here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -2534,17 +2534,17 @@ public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtoco
 public func addressOnlyProtocolSimpleChainArgTest(_ x2: inout AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
 
 public func addressOnlyProtocolSimpleChainConsumingArgTest(_ x2: consuming AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -2552,8 +2552,8 @@ public func addressOnlyProtocolSimpleChainConsumingArgTest(_ x2: consuming Addre
 public func addressOnlyProtocolSimpleNonConsumingUseTest(_ x: borrowing AddressOnlyProtocol) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -2564,8 +2564,8 @@ public func addressOnlyProtocolSimpleNonConsumingUseArgTest(_ x2: inout AddressO
 public func addressOnlyProtocolMultipleNonConsumingUseTest(_ x: borrowing AddressOnlyProtocol) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -2574,30 +2574,30 @@ public func addressOnlyProtocolMultipleNonConsumingUseTest(_ x: borrowing Addres
 public func addressOnlyProtocolMultipleNonConsumingUseArgTest(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseArgTest2(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseArgTest3(_ x2: inout AddressOnlyProtocol) {  // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                   // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                   // expected-note @-1 {{consumed here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseArgTest4(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x2 = AddressOnlyProtocol()
 }
 
@@ -2610,23 +2610,23 @@ public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest(_ x2: con
 public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest3(_ x2: consuming AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest4(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x2 = AddressOnlyProtocol()
 }
 
@@ -2634,80 +2634,80 @@ public func addressOnlyProtocolUseAfterConsume(_ x: borrowing AddressOnlyProtoco
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    x2 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                   // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                   // expected-note @-1 {{consumed here}}
 }
 
 public func addressOnlyProtocolUseAfterConsumeArg2(_ x2: consuming AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyProtocolDoubleConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-                     // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+                     // expected-note @-1 {{consumed here}}
 }
 
 public func addressOnlyProtocolDoubleConsumeArg2(_ x2: consuming AddressOnlyProtocol) {
                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func addressOnlyProtocolLoopConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    var x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func addressOnlyProtocolLoopConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func addressOnlyProtocolLoopConsumeArg2(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyProtocolLoopConsumeArg2(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     x2 = AddressOnlyProtocol()
 }
 
-public func addressOnlyProtocolLoopConsumeArg3(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyProtocolLoopConsumeArg3(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     x2 = AddressOnlyProtocol()
 }
 
 public func addressOnlyProtocolDiamond(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyProtocol()
     if boolValue {
         consumeVal(x2)
@@ -2719,9 +2719,9 @@ public func addressOnlyProtocolDiamond(_ x: borrowing AddressOnlyProtocol) { // 
 public func addressOnlyProtocolDiamondArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                  // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -2734,16 +2734,16 @@ public func addressOnlyProtocolDiamondArg2(_ x2: consuming AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolDiamondInLoop(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = x // expected-error {{'x2' consumed in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
-               // expected-note @-2 {{consuming use here}}
+               // expected-note @-2 {{consumed here}}
     x2 = AddressOnlyProtocol()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -2752,48 +2752,48 @@ public func addressOnlyProtocolDiamondInLoopArg(_ x2: inout AddressOnlyProtocol)
                                                        // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
-public func addressOnlyProtocolDiamondInLoopArg2(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyProtocolDiamondInLoopArg2(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed in a loop}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
     x2 = AddressOnlyProtocol()
 }
 
 public func addressOnlyProtocolDiamondInLoopArg3(_ x2: consuming AddressOnlyProtocol) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
 
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
-public func addressOnlyProtocolDiamondInLoopArg4(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed by a use in a loop}}
+public func addressOnlyProtocolDiamondInLoopArg4(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed in a loop}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-                           // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+                           // expected-note @-1 {{consumed here}}
       }
     }
     x2 = AddressOnlyProtocol()
@@ -2803,105 +2803,105 @@ public func addressOnlyProtocolAssignToVar1(_ x: borrowing AddressOnlyProtocol) 
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar1Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     x3 = AddressOnlyProtocol()
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar1Arg2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = AddressOnlyProtocol()
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar2Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
     borrowVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar2Arg2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar3(_ x: borrowing AddressOnlyProtocol) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyProtocol()
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar3Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar3Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar4(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     x2 = AddressOnlyProtocol()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar4Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2)   // expected-note {{consuming use here}}
-                // expected-note @-1 {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed here}}
+                // expected-note @-1 {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar4Arg2(_ x2: consuming AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2)   // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2)   // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar5<T : P>(_ ty: T.Type) {
     var x2 = AddressOnlyProtocol() // expected-error {{'x2' used after consume}}
     x2 = AddressOnlyProtocol()
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = AddressOnlyProtocol()
     consumeVal(x3)
 }
@@ -2909,17 +2909,17 @@ public func addressOnlyProtocolAssignToVar5<T : P>(_ ty: T.Type) {
 public func addressOnlyProtocolAssignToVar5Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func addressOnlyProtocolAssignToVar5Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
     x2 = AddressOnlyProtocol()
 }
@@ -2928,7 +2928,7 @@ public func addressOnlyProtocolAssignToVar5Arg2(_ x: borrowing AddressOnlyProtoc
 // that a use of a copy_addr that is copyable is not a consuming use. I will
 // remove them when I fix it in the next commit.
 public func addressOnlyProtocolAccessAccessField(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyProtocol()
     borrowVal(x2.copyable)
     for _ in 0..<1024 {
@@ -2937,7 +2937,7 @@ public func addressOnlyProtocolAccessAccessField(_ x: borrowing AddressOnlyProto
 }
 
 public func addressOnlyProtocolAccessAccessField2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyProtocol()
     borrowVal(x2.moveOnly)
     for _ in 0..<1024 {
@@ -2974,7 +2974,7 @@ public func addressOnlyProtocolAccessAccessFieldArg4(_ x2: consuming AddressOnly
 }
 
 public func addressOnlyProtocolAccessConsumeField(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     x2 = AddressOnlyProtocol()
 
     consumeVal(x2.copyable)
@@ -2984,15 +2984,15 @@ public func addressOnlyProtocolAccessConsumeField(_ x: borrowing AddressOnlyProt
 }
 
 public func addressOnlyProtocolAccessConsumeField2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    var x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = AddressOnlyProtocol()
 
-    consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.moveOnly) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
@@ -3006,10 +3006,10 @@ public func addressOnlyProtocolAccessConsumeFieldArg(_ x2: inout AddressOnlyProt
 public func addressOnlyProtocolAccessConsumeFieldArg2(_ x2: inout AddressOnlyProtocol) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly) // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+        consumeVal(x2.moveOnly) // expected-note {{consumed here}}
     }
 }
 
@@ -3022,19 +3022,19 @@ public func addressOnlyProtocolAccessConsumeFieldArg3(_ x2: consuming AddressOnl
 }
 
 public func addressOnlyProtocolAccessConsumeFieldArg4(_ x2: consuming AddressOnlyProtocol) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
+    consumeVal(x2.moveOnly) // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.moveOnly) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 extension AddressOnlyProtocol {
     func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
     }
 }
@@ -3051,8 +3051,8 @@ public func closureLetClassUseAfterConsume1() {
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -3062,8 +3062,8 @@ public func closureLetClassUseAfterConsume2() {
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -3074,9 +3074,9 @@ public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
         // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f(&argX)
 }
@@ -3088,9 +3088,9 @@ public func closureLetCaptureClassUseAfterConsume() {
     x2 = Klass()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
 }
@@ -3100,7 +3100,7 @@ public func closureLetCaptureClassUseAfterConsume2() {
     x2 = Klass()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -3112,13 +3112,13 @@ public func closureLetCaptureClassUseAfterConsumeError() {
     x2 = Klass()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
     x2 = Klass()
     let _ = x3
 }
@@ -3163,8 +3163,8 @@ public func closureVarClassUseAfterConsume1() {
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -3175,8 +3175,8 @@ public func closureVarClassUseAfterConsume2() {
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -3188,9 +3188,9 @@ public func closureVarClassUseAfterConsumeArg(_ argX: inout Klass) {
         // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f(&argX)
 }
@@ -3257,14 +3257,14 @@ public func deferCaptureClassUseAfterConsume() {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2)
-        // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
+        // expected-note @-2 {{consumed here}}
     }
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func deferCaptureClassUseAfterConsume2() {
@@ -3273,13 +3273,13 @@ public func deferCaptureClassUseAfterConsume2() {
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = Klass()
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
@@ -3289,9 +3289,9 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     borrowVal(x2)
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     print("foo")
 }
@@ -3304,10 +3304,10 @@ public func closureLetAndDeferCaptureClassUseAfterConsume() {
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -3320,13 +3320,13 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2() {
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
-        defer { // expected-note {{non-consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        defer { // expected-note {{used here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -3339,13 +3339,13 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = { 
-        consumeVal(x2) // expected-note {{consuming use here}}
-        defer { // expected-note {{non-consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        defer { // expected-note {{used here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -3361,10 +3361,10 @@ public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) 
         defer { // expected-note {{captured indirectly by this call}}
             borrowVal(x2) // expected-note {{captured here}}
             consumeVal(x2) // expected-note {{captured here}}
-            // expected-note @-1 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
             consumeVal(x2) // expected-note {{captured here}}
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -3382,9 +3382,9 @@ public func closureLetAndClosureCaptureClassUseAfterConsume() {
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -3398,9 +3398,9 @@ public func closureLetAndClosureCaptureClassUseAfterConsume2() {
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -3437,14 +3437,14 @@ public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass
 public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
-    x2 = x // expected-note {{consuming use here}}
+    x2 = x // expected-note {{consumed here}}
     var f = {}
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3455,15 +3455,15 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
     var x2 = Klass()
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    x2 = x // expected-note {{consuming use here}}
+    x2 = x // expected-note {{consumed here}}
     var f = {}
     f = {
         consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3476,15 +3476,15 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     var f = {}
     f = {
         consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3496,11 +3496,11 @@ public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
-    f = {// expected-note {{closure capture here}}
+    f = {// expected-note {{closure capturing 'x2' here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3513,8 +3513,8 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3528,9 +3528,9 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3544,8 +3544,8 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3560,9 +3560,9 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3576,7 +3576,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
 
 public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
-    x2 = x // expected-note {{consuming use here}}
+    x2 = x // expected-note {{consumed here}}
     var f = {}
     f = {
         var g = {}
@@ -3594,7 +3594,7 @@ public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
 public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     var f = {}
     f = {
@@ -3614,9 +3614,9 @@ public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
 
 public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     var f = {}
     f = {
@@ -3639,12 +3639,12 @@ public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing K
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
-    f = {// expected-note {{closure capture here}}
+    f = {// expected-note {{closure capturing 'x2' here}}
         var g = {}
-        g = {// expected-note {{closure capture here}}
+        g = {// expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3719,15 +3719,15 @@ func moveOperatorTest(_ k: __owned Klass) {
     // expected-error @-2 {{'k2' consumed more than once}}
     // expected-error @-3 {{'k2' consumed more than once}}
     k2 = Klass()
-    let k3 = consume k2 // expected-note {{consuming use here}}
+    let k3 = consume k2 // expected-note {{consumed here}}
     let _ = consume k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
     _ = k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
     let _ = k2
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     let _ = k3
 }
 
@@ -3737,15 +3737,15 @@ func moveOperatorTest2(_ k: consuming Klass) {
     // expected-error @-2 {{'k2' consumed more than once}}
     // expected-error @-3 {{'k2' consumed more than once}}
     k2 = Klass()
-    let k3 = consume k2 // expected-note {{consuming use here}}
+    let k3 = consume k2 // expected-note {{consumed here}}
     let _ = consume k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
     _ = k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
     let _ = k2
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     let _ = k3
 }
 
@@ -3766,22 +3766,22 @@ func blackHoleKlassTestCase(_ k: __owned Klass) {
     // expected-error @-2 {{'k2' consumed more than once}}
     // expected-error @-3 {{'k2' consumed more than once}}
     // expected-error @-4 {{'k2' consumed more than once}}
-    let _ = k2 // expected-note {{consuming use here}}
-    let _ = k2 // expected-note {{consuming use here}}
+    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed here}}
 
     k2 = Klass()
-    var _ = k2 // expected-note {{consuming use here}}
+    var _ = k2 // expected-note {{consumed here}}
     var _ = k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 
     _ = k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 
     // TODO: Why do we not also get 2 errors here?
     _ = k2
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 func blackHoleKlassTestCase2(_ k: consuming Klass) {
@@ -3790,22 +3790,22 @@ func blackHoleKlassTestCase2(_ k: consuming Klass) {
     // expected-error @-2 {{'k2' consumed more than once}}
     // expected-error @-3 {{'k2' consumed more than once}}
     // expected-error @-4 {{'k2' consumed more than once}}
-    let _ = k2 // expected-note {{consuming use here}}
-    let _ = k2 // expected-note {{consuming use here}}
+    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed here}}
 
     k2 = Klass()
-    var _ = k2 // expected-note {{consuming use here}}
+    var _ = k2 // expected-note {{consumed here}}
     var _ = k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 
     _ = k2
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 
     // TODO: Why do we not also get 2 errors here?
     _ = k2
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 ///////////////////////////////////////
@@ -3926,13 +3926,13 @@ func fieldSensitiveTestReinitFieldMultiBlock1() {
 func fieldSensitiveTestReinitFieldMultiBlock2() {
     var a = NonTrivialStruct() // expected-error {{'a' used after consume}}
     a = NonTrivialStruct()
-    consumeVal(a.k) // expected-note {{consuming use here}}
+    consumeVal(a.k) // expected-note {{consumed here}}
 
     if boolValue {
         a.k = Klass()
     }
 
-    borrowVal(a.k) // expected-note {{non-consuming use here}}
+    borrowVal(a.k) // expected-note {{used here}}
 }
 
 func fieldSensitiveTestReinitFieldMultiBlock3() {
@@ -3968,13 +3968,13 @@ func fieldSensitiveTestReinitFieldMultiBlock4() {
 func fieldSensitiveTestReinitEnumMultiBlock() {
     var e = NonTrivialEnum.first // expected-error {{'e' used after consume}}
     e = NonTrivialEnum.second(Klass())
-    switch e { // expected-note {{consuming use here}}
+    switch e { // expected-note {{consumed here}}
     case .second:
         e = NonTrivialEnum.third(NonTrivialStruct())
     default:
         break
     }
-    borrowVal(e) // expected-note {{non-consuming use here}}
+    borrowVal(e) // expected-note {{used here}}
 }
 
 func fieldSensitiveTestReinitEnumMultiBlock1() {
@@ -4012,8 +4012,8 @@ func fieldSensitiveTestReinitEnumMultiBlock2() {
 func sameCallSiteTestConsumeTwice(_ k: inout Klass) { // expected-error {{'k' consumed more than once}}
     func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
     consumeKlassTwice(k, k) // expected-error {{overlapping accesses to 'k', but deinitialization requires exclusive access}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
     // expected-note @-3 {{conflicting access is here}}
     k = Klass()
 }
@@ -4021,8 +4021,8 @@ func sameCallSiteTestConsumeTwice(_ k: inout Klass) { // expected-error {{'k' co
 func sameCallSiteConsumeAndUse(_ k: inout Klass) { // expected-error {{'k' used after consume}}
     func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: borrowing Klass) {}
     consumeKlassAndUseKlass(k, k) // expected-error {{overlapping accesses to 'k', but deinitialization requires exclusive access}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{non-consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{used here}}
     // expected-note @-3 {{conflicting access is here}}
     k = Klass()
 }
@@ -4030,8 +4030,8 @@ func sameCallSiteConsumeAndUse(_ k: inout Klass) { // expected-error {{'k' used 
 func inoutAndConsumingUse(_ k: inout Klass) { // expected-error {{'k' used after consume}}
     func consumeKlassAndInoutUseKlass(_ k: __owned Klass, _ k2: inout Klass) {}
     consumeKlassAndInoutUseKlass(k, &k) // expected-error {{overlapping accesses to 'k', but deinitialization requires exclusive access}}
-    // expected-note @-1 {{non-consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{used here}}
+    // expected-note @-2 {{consumed here}}
     // expected-note @-3 {{conflicting access is here}}
 }
 
@@ -4151,14 +4151,14 @@ func borrowAndConsumeAtSameTime(_: borrowing NonTrivialStruct, consume _: __owne
 
 func borrowAndConsumeAtSameTimeTest(x: __owned NonTrivialStruct) { // expected-error {{'x' used after consume}}
     borrowAndConsumeAtSameTime(x, consume: x)
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{non-consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{used here}}
 }
 
 func borrowAndConsumeAtSameTimeTest2(x: consuming NonTrivialStruct) { // expected-error {{'x' used after consume}}
     borrowAndConsumeAtSameTime(x, consume: x)
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{non-consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{used here}}
     // expected-error @-3 {{overlapping accesses to 'x', but deinitialization requires exclusive access}}
     // expected-note @-4 {{conflicting access is here}}
 }
@@ -4204,15 +4204,15 @@ func testEmptyStruct() {
 
   func testArg2a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
-    consume(x) // expected-note {{consuming use here}}
-    consume(x) // expected-note {{consuming use here}}
+    consume(x) // expected-note {{consumed here}}
+    consume(x) // expected-note {{consumed here}}
   }
 
   func testArg2b(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' used after consume}}
     borrow(x)
-    consume(x) // expected-note {{consuming use here}}
-    borrow(x) // expected-note {{non-consuming use here}}
+    consume(x) // expected-note {{consumed here}}
+    borrow(x) // expected-note {{used here}}
   }
 
   func testArg3(_ x: consuming EmptyStruct) {
@@ -4221,8 +4221,8 @@ func testEmptyStruct() {
 
   func testArg3a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
-    let _ = x // expected-note {{consuming use here}}
-    let _ = x // expected-note {{consuming use here}}
+    let _ = x // expected-note {{consumed here}}
+    let _ = x // expected-note {{consumed here}}
   }
 
   func testArg4(_ x: consuming EmptyStruct) {
@@ -4231,17 +4231,17 @@ func testEmptyStruct() {
 
   func testArg4a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
-    _ = x // expected-note {{consuming use here}}
-    _ = x // expected-note {{consuming use here}}
+    _ = x // expected-note {{consumed here}}
+    _ = x // expected-note {{consumed here}}
   }
 
   func testArg4b(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
     // expected-error @-2 {{'x' consumed more than once}}
-    _ = x // expected-note {{consuming use here}}
-    _ = x // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
-    let _ = x // expected-note {{consuming use here}}
+    _ = x // expected-note {{consumed here}}
+    _ = x // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
+    let _ = x // expected-note {{consumed here}}
   }
 
   func testArg5(_ x: consuming EmptyStruct) {
@@ -4259,8 +4259,8 @@ func testEmptyStruct() {
 
   func testArg7a(_ x: consuming EmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
-    x.doSomething3() // expected-note {{consuming use here}}
-    x.doSomething3() // expected-note {{consuming use here}}
+    x.doSomething3() // expected-note {{consumed here}}
+    x.doSomething3() // expected-note {{consumed here}}
   }
 }
 
@@ -4310,8 +4310,8 @@ func testStructContainingEmptyStruct() {
 
   func testArg7a(_ x: consuming StructContainingEmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
-    x.x.doSomething3() // expected-note {{consuming use here}}
-    x.x.doSomething3() // expected-note {{consuming use here}}
+    x.x.doSomething3() // expected-note {{consumed here}}
+    x.x.doSomething3() // expected-note {{consumed here}}
   }
 }
 
@@ -4371,9 +4371,9 @@ func testStructContainingTwoEmptyStruct() {
 
   func testArg10(_ x: consuming StructContainingTwoEmptyStruct) {
     // expected-error @-1 {{'x' consumed more than once}}
-    x.x.doSomething3() // expected-note {{consuming use here}}
+    x.x.doSomething3() // expected-note {{consumed here}}
     x.y.doSomething3()
-    x.x.doSomething3() // expected-note {{consuming use here}}
+    x.x.doSomething3() // expected-note {{consumed here}}
   }
 }
 
@@ -4404,17 +4404,17 @@ func testMyEnum() {
   }
 
   func test1a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .first(y) = x { // expected-note {{consuming use here}}
-      _ = consume x // expected-note {{consuming use here}}
+    if case let .first(y) = x { // expected-note {{consumed here}}
+      _ = consume x // expected-note {{consumed here}}
       _ = y
     }
   }
 
   func test1b(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .first(y) = x { // expected-note {{consuming use here}}
+    if case let .first(y) = x { // expected-note {{consumed here}}
       _ = y
     }
-    _ = consume x // expected-note {{consuming use here}}
+    _ = consume x // expected-note {{consumed here}}
   }
 
   func test2(_ x: consuming MyEnum) {
@@ -4424,24 +4424,24 @@ func testMyEnum() {
   }
 
   func test2a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .third(.first(y)) = x { // expected-note {{consuming use here}}
-      _ = consume x // expected-note {{consuming use here}}
+    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
+      _ = consume x // expected-note {{consumed here}}
       _ = y
     }
   }
 
   func test2b(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .third(.first(y)) = x { // expected-note {{consuming use here}}
+    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
       _ = y
     }
-    _ = consume x // expected-note {{consuming use here}}
+    _ = consume x // expected-note {{consumed here}}
   }
 
   func test2c(_ x: consuming MyEnum) { // expected-error {{'x' used after consume}}
-    if case let .third(.first(y)) = x { // expected-note {{consuming use here}}
+    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
       _ = y
     }
-    borrow(x) // expected-note {{non-consuming use here}}
+    borrow(x) // expected-note {{used here}}
   }
 
   func test3(_ x: consuming MyEnum) {
@@ -4455,14 +4455,14 @@ func testMyEnum() {
   }
 
   func test3a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    switch x { // expected-note {{consuming use here}}
+    switch x { // expected-note {{consumed here}}
     case let .first(y):
       _ = y
       break
     default:
       break
     }
-    _ = consume x // expected-note {{consuming use here}}
+    _ = consume x // expected-note {{consumed here}}
   }
 
   func test4(_ x: consuming MyEnum) {
@@ -4476,13 +4476,13 @@ func testMyEnum() {
   }
 
   func test4a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    switch x { // expected-note {{consuming use here}}
+    switch x { // expected-note {{consumed here}}
     case let .third(.first(y)):
       _ = y
       break
     default:
       break
     }
-    _ = consume x // expected-note {{consuming use here}}
+    _ = consume x // expected-note {{consumed here}}
   }
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -144,7 +144,7 @@ public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x'
 
 public func classSimpleChainArgTest(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -170,7 +170,7 @@ public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected
     consumeVal(x2)
 }
 
-public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -183,7 +183,7 @@ public func classMultipleNonConsumingUseArgTest2(_ x2: inout Klass) { // expecte
     borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
-public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
@@ -210,7 +210,7 @@ public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x'
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -226,7 +226,7 @@ public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' i
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -242,7 +242,7 @@ public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is 
     }
 }
 
-public func classLoopConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classLoopConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -265,8 +265,8 @@ public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borr
     }
 }
 
-public func classDiamondArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func classDiamondArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                 // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -289,8 +289,8 @@ public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' i
     }
 }
 
-public func classDiamondInLoopArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                       // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func classDiamondInLoopArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -324,7 +324,7 @@ public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is
 }
 
 public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -342,7 +342,7 @@ public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is
 }
 
 public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -357,14 +357,14 @@ public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' is
     consumeVal(x3)
 }
 
-public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar3Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func classAssignToVar3Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -381,7 +381,7 @@ public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is
 }
 
 public func classAssignToVar4Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
@@ -472,7 +472,7 @@ public func finalClassSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func finalClassSimpleChainTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func finalClassSimpleChainTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -517,7 +517,7 @@ public func finalClassMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func finalClassMultipleNonConsumingUseTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -532,7 +532,7 @@ public func finalClassUseAfterConsume() {
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
-                                                                   // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                                   // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -547,7 +547,7 @@ public func finalClassDoubleConsume() {
 }
 
 public func finalClassDoubleConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
-                                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}    
+                                                                 // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}    
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
                           // expected-note @-1 {{consuming use here}}
@@ -561,7 +561,7 @@ public func finalClassLoopConsume() {
     }
 }
 
-public func finalClassLoopConsumeArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func finalClassLoopConsumeArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -577,8 +577,8 @@ public func finalClassDiamond() {
     }
 }
 
-public func finalClassDiamondArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                           // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func finalClassDiamondArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                           // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -600,8 +600,8 @@ public func finalClassDiamondInLoop() {
     }
 }
 
-public func finalClassDiamondInLoopArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func finalClassDiamondInLoopArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                                 // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -636,7 +636,7 @@ public func finalClassAssignToVar1() {
 
 public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -653,7 +653,7 @@ public func finalClassAssignToVar2() {
 }
 
 public func finalClassAssignToVar2Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -670,7 +670,7 @@ public func finalClassAssignToVar3() {
 }
 
 public func finalClassAssignToVar3Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
     consumeVal(x3)
@@ -685,7 +685,7 @@ public func finalClassAssignToVar4() {
 }
 
 public func finalClassAssignToVar4Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -711,7 +711,7 @@ public func finalClassAssignToVar5Arg(_ x2: inout FinalKlass) {
 }
 
 public func finalClassAssignToVar5Arg2(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
     consumeVal(x3)
@@ -827,7 +827,7 @@ public func aggStructSimpleChainTest() {
 
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -853,7 +853,7 @@ public func aggStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -869,7 +869,7 @@ public func aggStructUseAfterConsume() {
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -884,7 +884,7 @@ public func aggStructDoubleConsume() {
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -899,7 +899,7 @@ public func aggStructLoopConsume() {
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -916,8 +916,8 @@ public func aggStructDiamond() {
 }
 
 public func aggStructDiamondArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -941,8 +941,8 @@ public func aggStructDiamondInLoop() {
 }
 
 public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -980,8 +980,8 @@ public func aggStructConsumeField() {
 }
 
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1016,8 +1016,8 @@ public func aggStructConsumeGrandField() {
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1092,7 +1092,7 @@ public func aggGenericStructSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1116,7 +1116,7 @@ public func aggGenericStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1131,7 +1131,7 @@ public func aggGenericStructUseAfterConsume() {
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1147,7 +1147,7 @@ public func aggGenericStructDoubleConsume() {
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1162,7 +1162,7 @@ public func aggGenericStructLoopConsume() {
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1179,8 +1179,8 @@ public func aggGenericStructDiamond() {
 }
 
 public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1203,8 +1203,8 @@ public func aggGenericStructDiamondInLoop() {
 }
 
 public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1242,8 +1242,8 @@ public func aggGenericStructConsumeField() {
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1287,8 +1287,8 @@ public func aggGenericStructConsumeGrandField2() {
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1307,7 +1307,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1331,7 +1331,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1346,7 +1346,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1362,7 +1362,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1377,7 +1377,7 @@ public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1394,8 +1394,8 @@ public func aggGenericStructDiamond<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1418,8 +1418,8 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1457,8 +1457,8 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1493,8 +1493,8 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1521,7 +1521,7 @@ public func enumSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1545,7 +1545,7 @@ public func enumMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1560,7 +1560,7 @@ public func enumUseAfterConsume() {
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1576,7 +1576,7 @@ public func enumDoubleConsume() {
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1591,7 +1591,7 @@ public func enumLoopConsume() {
     }
 }
 
-public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1608,8 +1608,8 @@ public func enumDiamond() {
 }
 
 public func enumDiamondArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1633,8 +1633,8 @@ public func enumDiamondInLoop() {
 }
 
 public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1654,7 +1654,7 @@ public func enumAssignToVar1() {
 }
 
 public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1673,7 +1673,7 @@ public func enumAssignToVar2() {
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -1689,7 +1689,7 @@ public func enumAssignToVar3() {
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
@@ -1705,7 +1705,7 @@ public func enumAssignToVar4() {
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1730,7 +1730,7 @@ public func enumAssignToVar5Arg(_ x2: inout EnumTy) {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
@@ -1750,7 +1750,7 @@ public func enumPatternMatchIfLet1() {
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x)
@@ -1771,7 +1771,7 @@ public func enumPatternMatchIfLet2() {
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1791,7 +1791,7 @@ public func enumPatternMatchSwitch1() {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1812,7 +1812,7 @@ public func enumPatternMatchSwitch2() {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1836,7 +1836,7 @@ public func enumPatternMatchSwitch2WhereClause() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
@@ -1862,7 +1862,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where boolValue:
@@ -1892,7 +1892,7 @@ public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGener
 
 public func addressOnlyGenericSimpleChainArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -1930,7 +1930,7 @@ public func addressOnlyGenericMultipleNonConsumingUseTest<T>(_ x: borrowing Addr
     consumeVal(x2)
 }
 
-public func addressOnlyGenericMultipleNonConsumingUseArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericMultipleNonConsumingUseArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1943,7 +1943,7 @@ public func addressOnlyGenericMultipleNonConsumingUseArgTest2<T>(_ x2: inout Add
     borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
-public func addressOnlyGenericMultipleNonConsumingUseArgTest3<T>(_ x2: inout AddressOnlyGeneric<T>) {  // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericMultipleNonConsumingUseArgTest3<T>(_ x2: inout AddressOnlyGeneric<T>) {  // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
@@ -2000,7 +2000,7 @@ public func addressOnlyGenericUseAfterConsume<T>(_ x: borrowing AddressOnlyGener
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2023,7 +2023,7 @@ public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyGenericDoubleConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericDoubleConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2045,7 +2045,7 @@ public func addressOnlyGenericLoopConsume<T>(_ x: borrowing AddressOnlyGeneric<T
     }
 }
 
-public func addressOnlyGenericLoopConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericLoopConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -2075,8 +2075,8 @@ public func addressOnlyGenericDiamond<T>(_ x: borrowing AddressOnlyGeneric<T>) {
     }
 }
 
-public func addressOnlyGenericDiamondArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericDiamondArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                 // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -2107,8 +2107,8 @@ public func addressOnlyGenericDiamondInLoop<T>(_ x: borrowing AddressOnlyGeneric
     }
 }
 
-public func addressOnlyGenericDiamondInLoopArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                       // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericDiamondInLoopArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -2171,7 +2171,7 @@ public func addressOnlyGenericAssignToVar1<T>(_ x: borrowing AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericAssignToVar1Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2196,7 +2196,7 @@ public func addressOnlyGenericAssignToVar2<T>(_ x: borrowing AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericAssignToVar2Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2219,14 +2219,14 @@ public func addressOnlyGenericAssignToVar3<T>(_ x: borrowing AddressOnlyGeneric<
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar3Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericAssignToVar3Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar3Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyGenericAssignToVar3Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -2243,7 +2243,7 @@ public func addressOnlyGenericAssignToVar4<T>(_ x: borrowing AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericAssignToVar4Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
@@ -2396,8 +2396,8 @@ public func addressOnlyGenericAccessConsumeFieldArg<T>(_ x2: inout AddressOnlyGe
 }
 
 public func addressOnlyGenericAccessConsumeFieldArg2<T>(_ x2: inout AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
 
     for _ in 0..<1024 {
@@ -2432,8 +2432,8 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg<T>(_ x2: inout AddressO
 }
 
 public func addressOnlyGenericAccessConsumeGrandFieldArg2<T>(_ x2: inout AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
 
     for _ in 0..<1024 {
@@ -2482,7 +2482,7 @@ extension AddressOnlyGeneric {
         let _ = x
     }
 
-    mutating func testNoUseSelf2() { // expected-error {{missing reinitialization of 'self' after consume}}
+    mutating func testNoUseSelf2() { // expected-error {{missing reinitialization of inout parameter 'self' after consume}}
         let x = self // expected-note {{consuming use here}}
         let _ = x
     }
@@ -2533,7 +2533,7 @@ public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtoco
 
 public func addressOnlyProtocolSimpleChainArgTest(_ x2: inout AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -2571,7 +2571,7 @@ public func addressOnlyProtocolMultipleNonConsumingUseTest(_ x: borrowing Addres
     consumeVal(x2)
 }
 
-public func addressOnlyProtocolMultipleNonConsumingUseArgTest(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolMultipleNonConsumingUseArgTest(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2584,7 +2584,7 @@ public func addressOnlyProtocolMultipleNonConsumingUseArgTest2(_ x2: inout Addre
     borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
-public func addressOnlyProtocolMultipleNonConsumingUseArgTest3(_ x2: inout AddressOnlyProtocol) {  // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolMultipleNonConsumingUseArgTest3(_ x2: inout AddressOnlyProtocol) {  // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
@@ -2641,7 +2641,7 @@ public func addressOnlyProtocolUseAfterConsume(_ x: borrowing AddressOnlyProtoco
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2664,7 +2664,7 @@ public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol)
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyProtocolDoubleConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolDoubleConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2686,7 +2686,7 @@ public func addressOnlyProtocolLoopConsume(_ x: borrowing AddressOnlyProtocol) {
     }
 }
 
-public func addressOnlyProtocolLoopConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolLoopConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -2716,8 +2716,8 @@ public func addressOnlyProtocolDiamond(_ x: borrowing AddressOnlyProtocol) { // 
     }
 }
 
-public func addressOnlyProtocolDiamondArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolDiamondArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                 // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -2748,8 +2748,8 @@ public func addressOnlyProtocolDiamondInLoop(_ x: borrowing AddressOnlyProtocol)
     }
 }
 
-public func addressOnlyProtocolDiamondInLoopArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
-                                                       // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolDiamondInLoopArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
+                                                       // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -2812,7 +2812,7 @@ public func addressOnlyProtocolAssignToVar1(_ x: borrowing AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolAssignToVar1Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2837,7 +2837,7 @@ public func addressOnlyProtocolAssignToVar2(_ x: borrowing AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolAssignToVar2Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2860,14 +2860,14 @@ public func addressOnlyProtocolAssignToVar3(_ x: borrowing AddressOnlyProtocol) 
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar3Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolAssignToVar3Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar3Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func addressOnlyProtocolAssignToVar3Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                                    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -2884,7 +2884,7 @@ public func addressOnlyProtocolAssignToVar4(_ x: borrowing AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolAssignToVar4Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+                                                      // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
@@ -3004,8 +3004,8 @@ public func addressOnlyProtocolAccessConsumeFieldArg(_ x2: inout AddressOnlyProt
 }
 
 public func addressOnlyProtocolAccessConsumeFieldArg2(_ x2: inout AddressOnlyProtocol) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
 
     for _ in 0..<1024 {
@@ -3071,7 +3071,7 @@ public func closureLetClassUseAfterConsume2() {
 public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
     // TODO: Fix this
     let f = { (_ x2: inout Klass) in
-        // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+        // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -3083,7 +3083,7 @@ public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
 
 // We do not support captures of vars by closures today.
 public func closureLetCaptureClassUseAfterConsume() {
-    var x2 = Klass() // expected-error {{missing reinitialization of 'x2' after consume}}
+    var x2 = Klass() // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -3096,7 +3096,7 @@ public func closureLetCaptureClassUseAfterConsume() {
 }
 
 public func closureLetCaptureClassUseAfterConsume2() {
-    var x2 = Klass() // expected-error {{missing reinitialization of 'x2' after consume}}
+    var x2 = Klass() // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = Klass()
     let f = {
         borrowVal(x2)
@@ -3106,7 +3106,7 @@ public func closureLetCaptureClassUseAfterConsume2() {
 }
 
 public func closureLetCaptureClassUseAfterConsumeError() {
-    var x2 = Klass() // expected-error {{missing reinitialization of 'x2' after consume}}
+    var x2 = Klass() // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
@@ -3185,7 +3185,7 @@ public func closureVarClassUseAfterConsumeArg(_ argX: inout Klass) {
     // TODO: Fix this
     var f = { (_ x2: inout Klass) in}
     f = { (_ x2: inout Klass) in
-        // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+        // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -3254,7 +3254,7 @@ public func closureVarCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 public func deferCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' used after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
     defer { // expected-note {{non-consuming use here}}
@@ -3269,7 +3269,7 @@ public func deferCaptureClassUseAfterConsume() {
 
 public func deferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = Klass()
@@ -3284,7 +3284,7 @@ public func deferCaptureClassUseAfterConsume2() {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     defer {
@@ -3298,7 +3298,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume() {
     var x2 = Klass()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -3316,7 +3316,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume() {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume2() {
     var x2 = Klass() // expected-error {{'x2' used after consume}}
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -3335,7 +3335,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2() {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume3() {
     var x2 = Klass() // expected-error {{'x2' used after consume}}
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = { 
@@ -3354,7 +3354,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3() {
 }
 
 public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -3377,7 +3377,7 @@ public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) 
 
 public func closureLetAndClosureCaptureClassUseAfterConsume() {
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = Klass()
     let f = {
         let g = {
@@ -3393,7 +3393,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume() {
 
 public func closureLetAndClosureCaptureClassUseAfterConsume2() {
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = Klass()
     let f = {
         let g = {
@@ -3436,7 +3436,7 @@ public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass
 
 public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = {
@@ -3453,7 +3453,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
 
 public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = x // expected-note {{consuming use here}}
     var f = {}
@@ -3474,7 +3474,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = x
     // expected-note @-1 {{consuming use here}}
     var f = {}
@@ -3522,7 +3522,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     var f = {}
     f = {
@@ -3555,7 +3555,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var f = {}
     f = {
         defer {

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -131,7 +131,7 @@ public struct AddressOnlyProtocol {
 // Class Tests //
 /////////////////
 
-public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
                // expected-error @-1 {{'x2' consumed more than once}}
     x2 = x // expected-note {{consuming use here}}
@@ -144,7 +144,7 @@ public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x'
 
 public func classSimpleChainArgTest(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -152,7 +152,7 @@ public func classSimpleChainArgTest(_ x2: inout Klass) {
     borrowVal(k2)
 }
 
-public func classSimpleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -162,7 +162,7 @@ public func classSimpleNonConsumingUseArgTest(_ x2: inout Klass) {
     borrowVal(x2)
 }
 
-public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -170,7 +170,7 @@ public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected
     consumeVal(x2)
 }
 
-public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -183,7 +183,7 @@ public func classMultipleNonConsumingUseArgTest2(_ x2: inout Klass) { // expecte
     borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
-public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expected-error {{missing reinitialization of 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
@@ -201,7 +201,7 @@ public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expecte
 }
 
 
-public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
@@ -210,7 +210,7 @@ public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x'
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -218,7 +218,7 @@ public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{'x2
                    // expected-note @-1 {{consuming use here}}
 }
 
-public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -226,14 +226,14 @@ public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' h
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
                      // expected-note @-1 {{consuming use here}}
 }
 
-public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -242,7 +242,7 @@ public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' has
     }
 }
 
-public func classLoopConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classLoopConsumeArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -255,7 +255,7 @@ public func classLoopConsumeArg2(_ x2: inout Klass) { // expected-error {{'x2' c
     x2 = Klass()
 }
 
-public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     if boolValue {
@@ -265,8 +265,8 @@ public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' has gua
     }
 }
 
-public func classDiamondArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                 // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func classDiamondArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -274,7 +274,7 @@ public func classDiamondArg(_ x2: inout Klass) { // expected-error {{'x2' consum
     }
 }
 
-public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
                // expected-note @-2 {{consuming use here}}
@@ -289,8 +289,8 @@ public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' h
     }
 }
 
-public func classDiamondInLoopArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                       // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func classDiamondInLoopArg(_ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                       // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -313,7 +313,7 @@ public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2'
     x2 = Klass()
 }
 
-public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -324,7 +324,7 @@ public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' ha
 }
 
 public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -332,7 +332,7 @@ public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' c
     consumeVal(x3)
 }
 
-public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -342,14 +342,14 @@ public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' ha
 }
 
 public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
     borrowVal(x3)
 }
 
-public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     var x3 = x2
@@ -357,21 +357,21 @@ public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar3Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                                   // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                                   // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -381,7 +381,7 @@ public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' ha
 }
 
 public func classAssignToVar4Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
@@ -399,14 +399,14 @@ public func classAssignToVar5() {
 
 public func classAssignToVar5Arg(_ x: borrowing Klass, _ x2: inout Klass) {
     // expected-error @-1 {{'x2' used after consume}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar5Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar5Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -415,7 +415,7 @@ public func classAssignToVar5Arg2(_ x: borrowing Klass, _ x2: inout Klass) { // 
     x2 = Klass()
 }
 
-public func classAccessAccessField(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessAccessField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     borrowVal(x2.k)
@@ -430,31 +430,31 @@ public func classAccessAccessFieldArg(_ x2: inout Klass) {
     }
 }
 
-public func classAccessConsumeField(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessConsumeField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     // Since a class is a reference type, we do not emit an error here.
     consumeVal(x2.k)
-    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
         consumeVal(x2.k)
-        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func classAccessConsumeFieldArg(_ x2: inout Klass) {
     // Since a class is a reference type, we do not emit an error here.
     consumeVal(x2.k)
-    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
 
     for _ in 0..<1024 {
         consumeVal(x2.k)
-        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 extension Klass {
-    func testNoUseSelf() { // expected-error {{'self' has guaranteed ownership but was consumed}}
+    func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
         let x = self // expected-note {{consuming use here}}
         let _ = x
     }
@@ -472,7 +472,7 @@ public func finalClassSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func finalClassSimpleChainTestArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func finalClassSimpleChainTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -517,7 +517,7 @@ public func finalClassMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTestArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func finalClassMultipleNonConsumingUseTestArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -532,7 +532,7 @@ public func finalClassUseAfterConsume() {
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
-                                                                   // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                                   // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -547,7 +547,7 @@ public func finalClassDoubleConsume() {
 }
 
 public func finalClassDoubleConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
-                                                                 // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}    
+                                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}    
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
                           // expected-note @-1 {{consuming use here}}
@@ -561,7 +561,7 @@ public func finalClassLoopConsume() {
     }
 }
 
-public func finalClassLoopConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func finalClassLoopConsumeArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -577,8 +577,8 @@ public func finalClassDiamond() {
     }
 }
 
-public func finalClassDiamondArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                           // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func finalClassDiamondArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                           // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -600,8 +600,8 @@ public func finalClassDiamondInLoop() {
     }
 }
 
-public func finalClassDiamondInLoopArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                                 // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func finalClassDiamondInLoopArg(_ x2: inout FinalKlass) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -636,7 +636,7 @@ public func finalClassAssignToVar1() {
 
 public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -653,7 +653,7 @@ public func finalClassAssignToVar2() {
 }
 
 public func finalClassAssignToVar2Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -670,7 +670,7 @@ public func finalClassAssignToVar3() {
 }
 
 public func finalClassAssignToVar3Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
     consumeVal(x3)
@@ -685,7 +685,7 @@ public func finalClassAssignToVar4() {
 }
 
 public func finalClassAssignToVar4Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -711,7 +711,7 @@ public func finalClassAssignToVar5Arg(_ x2: inout FinalKlass) {
 }
 
 public func finalClassAssignToVar5Arg2(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
     consumeVal(x3)
@@ -738,19 +738,19 @@ public func finalClassConsumeField() {
     x2 = FinalKlass()
 
     consumeVal(x2.k)
-    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
         consumeVal(x2.k)
-        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: inout FinalKlass) {
     consumeVal(x2.k)
-    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
         consumeVal(x2.k)
-        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        // expected-error @-1 {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
@@ -827,7 +827,7 @@ public func aggStructSimpleChainTest() {
 
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -853,7 +853,7 @@ public func aggStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -869,7 +869,7 @@ public func aggStructUseAfterConsume() {
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -884,7 +884,7 @@ public func aggStructDoubleConsume() {
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -899,7 +899,7 @@ public func aggStructLoopConsume() {
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -916,8 +916,8 @@ public func aggStructDiamond() {
 }
 
 public func aggStructDiamondArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -941,8 +941,8 @@ public func aggStructDiamondInLoop() {
 }
 
 public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -980,8 +980,8 @@ public func aggStructConsumeField() {
 }
 
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1016,8 +1016,8 @@ public func aggStructConsumeGrandField() {
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1092,7 +1092,7 @@ public func aggGenericStructSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1116,7 +1116,7 @@ public func aggGenericStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1131,7 +1131,7 @@ public func aggGenericStructUseAfterConsume() {
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1147,7 +1147,7 @@ public func aggGenericStructDoubleConsume() {
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1162,7 +1162,7 @@ public func aggGenericStructLoopConsume() {
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1179,8 +1179,8 @@ public func aggGenericStructDiamond() {
 }
 
 public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1203,8 +1203,8 @@ public func aggGenericStructDiamondInLoop() {
 }
 
 public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1242,8 +1242,8 @@ public func aggGenericStructConsumeField() {
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1287,8 +1287,8 @@ public func aggGenericStructConsumeGrandField2() {
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1307,7 +1307,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1331,7 +1331,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1346,7 +1346,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1362,7 +1362,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1377,7 +1377,7 @@ public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1394,8 +1394,8 @@ public func aggGenericStructDiamond<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1418,8 +1418,8 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1457,8 +1457,8 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1493,8 +1493,8 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1521,7 +1521,7 @@ public func enumSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1545,7 +1545,7 @@ public func enumMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1560,7 +1560,7 @@ public func enumUseAfterConsume() {
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1576,7 +1576,7 @@ public func enumDoubleConsume() {
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1591,7 +1591,7 @@ public func enumLoopConsume() {
     }
 }
 
-public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1608,8 +1608,8 @@ public func enumDiamond() {
 }
 
 public func enumDiamondArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1633,8 +1633,8 @@ public func enumDiamondInLoop() {
 }
 
 public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1654,7 +1654,7 @@ public func enumAssignToVar1() {
 }
 
 public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1673,7 +1673,7 @@ public func enumAssignToVar2() {
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -1689,7 +1689,7 @@ public func enumAssignToVar3() {
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
@@ -1705,7 +1705,7 @@ public func enumAssignToVar4() {
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1730,7 +1730,7 @@ public func enumAssignToVar5Arg(_ x2: inout EnumTy) {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
@@ -1750,7 +1750,7 @@ public func enumPatternMatchIfLet1() {
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x)
@@ -1771,7 +1771,7 @@ public func enumPatternMatchIfLet2() {
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1791,7 +1791,7 @@ public func enumPatternMatchSwitch1() {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1812,7 +1812,7 @@ public func enumPatternMatchSwitch2() {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1836,7 +1836,7 @@ public func enumPatternMatchSwitch2WhereClause() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
@@ -1862,7 +1862,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where boolValue:
@@ -1878,8 +1878,8 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expe
 // Address Only Generic Tests //
 ////////////////////////////////
 
-public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
                // expected-error @-1 {{'x2' consumed more than once}}
     x2 = x // expected-note {{consuming use here}}
@@ -1892,7 +1892,7 @@ public func addressOnlyGenericSimpleChainTest<T>(_ x: borrowing AddressOnlyGener
 
 public func addressOnlyGenericSimpleChainArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -1909,8 +1909,8 @@ public func addressOnlyGenericSimpleChainConsumingArgTest<T>(_ x2: consuming Add
 }
 
 public func addressOnlyGenericSimpleNonConsumingUseTest<T>(_ x: borrowing AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -1921,8 +1921,8 @@ public func addressOnlyGenericSimpleNonConsumingUseArgTest<T>(_ x2: inout Addres
 }
 
 public func addressOnlyGenericMultipleNonConsumingUseTest<T>(_ x: borrowing AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -1930,7 +1930,7 @@ public func addressOnlyGenericMultipleNonConsumingUseTest<T>(_ x: borrowing Addr
     consumeVal(x2)
 }
 
-public func addressOnlyGenericMultipleNonConsumingUseArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericMultipleNonConsumingUseArgTest<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1943,7 +1943,7 @@ public func addressOnlyGenericMultipleNonConsumingUseArgTest2<T>(_ x2: inout Add
     borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
-public func addressOnlyGenericMultipleNonConsumingUseArgTest3<T>(_ x2: inout AddressOnlyGeneric<T>) {  // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericMultipleNonConsumingUseArgTest3<T>(_ x2: inout AddressOnlyGeneric<T>) {  // expected-error {{missing reinitialization of 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
@@ -1990,8 +1990,8 @@ public func addressOnlyGenericMultipleNonConsumingUseConsumingArgTest4<T>(_ x2: 
 }
 
 public func addressOnlyGenericUseAfterConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
@@ -2000,7 +2000,7 @@ public func addressOnlyGenericUseAfterConsume<T>(_ x: borrowing AddressOnlyGener
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericUseAfterConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2015,7 +2015,7 @@ public func addressOnlyGenericUseAfterConsumeArg2<T>(_ x2: consuming AddressOnly
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
@@ -2023,7 +2023,7 @@ public func addressOnlyGenericDoubleConsume<T>(_ x: borrowing AddressOnlyGeneric
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyGenericDoubleConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericDoubleConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2036,7 +2036,7 @@ public func addressOnlyGenericDoubleConsumeArg2<T>(_ x2: consuming AddressOnlyGe
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyGenericLoopConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericLoopConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
@@ -2045,7 +2045,7 @@ public func addressOnlyGenericLoopConsume<T>(_ x: borrowing AddressOnlyGeneric<T
     }
 }
 
-public func addressOnlyGenericLoopConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericLoopConsumeArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -2065,7 +2065,7 @@ public func addressOnlyGenericLoopConsumeArg3<T>(_ x2: consuming AddressOnlyGene
     x2 = AddressOnlyGeneric<T>()
 }
 
-public func addressOnlyGenericDiamond<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericDiamond<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
     if boolValue {
@@ -2075,8 +2075,8 @@ public func addressOnlyGenericDiamond<T>(_ x: borrowing AddressOnlyGeneric<T>) {
     }
 }
 
-public func addressOnlyGenericDiamondArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                 // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericDiamondArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -2092,7 +2092,7 @@ public func addressOnlyGenericDiamondArg2<T>(_ x2: consuming AddressOnlyGeneric<
     }
 }
 
-public func addressOnlyGenericDiamondInLoop<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericDiamondInLoop<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
                // expected-note @-2 {{consuming use here}}
@@ -2107,8 +2107,8 @@ public func addressOnlyGenericDiamondInLoop<T>(_ x: borrowing AddressOnlyGeneric
     }
 }
 
-public func addressOnlyGenericDiamondInLoopArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                       // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyGenericDiamondInLoopArg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                       // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -2159,8 +2159,8 @@ public func addressOnlyGenericDiamondInLoopArg4<T>(_ x2: consuming AddressOnlyGe
 }
 
 public func addressOnlyGenericAssignToVar1<T>(_ x: borrowing AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
@@ -2171,7 +2171,7 @@ public func addressOnlyGenericAssignToVar1<T>(_ x: borrowing AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericAssignToVar1Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2186,7 +2186,7 @@ public func addressOnlyGenericAssignToVar1Arg2<T>(_ x2: consuming AddressOnlyGen
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAssignToVar2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
@@ -2196,7 +2196,7 @@ public func addressOnlyGenericAssignToVar2<T>(_ x: borrowing AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericAssignToVar2Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2210,8 +2210,8 @@ public func addressOnlyGenericAssignToVar2Arg2<T>(_ x2: consuming AddressOnlyGen
 }
 
 public func addressOnlyGenericAssignToVar3<T>(_ x: borrowing AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
     var x3 = x2
@@ -2219,21 +2219,21 @@ public func addressOnlyGenericAssignToVar3<T>(_ x: borrowing AddressOnlyGeneric<
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar3Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAssignToVar3Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar3Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                                   // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAssignToVar3Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                                   // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar4<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAssignToVar4<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
@@ -2243,7 +2243,7 @@ public func addressOnlyGenericAssignToVar4<T>(_ x: borrowing AddressOnlyGeneric<
 }
 
 public func addressOnlyGenericAssignToVar4Arg<T>(_ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
@@ -2267,14 +2267,14 @@ public func addressOnlyGenericAssignToVar5<T : P>(_ ty: T.Type) {
 
 public func addressOnlyGenericAssignToVar5Arg<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) {
     // expected-error @-1 {{'x2' used after consume}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyGenericAssignToVar5Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAssignToVar5Arg2<T>(_ x: borrowing AddressOnlyGeneric<T>, _ x2: inout AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -2286,7 +2286,7 @@ public func addressOnlyGenericAssignToVar5Arg2<T>(_ x: borrowing AddressOnlyGene
 // MG: We are calling these consuming uses since I have not taught the checker
 // that a use of a copy_addr that is copyable is not a consuming use. I will
 // remove them when I fix it in the next commit.
-public func addressOnlyGenericAccessAccessField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessAccessField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
     borrowVal(x2.copyable)
@@ -2295,7 +2295,7 @@ public func addressOnlyGenericAccessAccessField<T>(_ x: borrowing AddressOnlyGen
     }
 }
 
-public func addressOnlyGenericAccessAccessField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessAccessField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
     borrowVal(x2.moveOnly)
@@ -2332,7 +2332,7 @@ public func addressOnlyGenericAccessAccessFieldArg4<T>(_ x2: consuming AddressOn
     }
 }
 
-public func addressOnlyGenericAccessConsumeField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessConsumeField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
 
@@ -2342,7 +2342,7 @@ public func addressOnlyGenericAccessConsumeField<T>(_ x: borrowing AddressOnlyGe
     }
 }
 
-public func addressOnlyGenericAccessConsumeField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessConsumeField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -2355,7 +2355,7 @@ public func addressOnlyGenericAccessConsumeField2<T>(_ x: borrowing AddressOnlyG
     }
 }
 
-public func addressOnlyGenericAccessConsumeGrandField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessConsumeGrandField<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
 
@@ -2365,7 +2365,7 @@ public func addressOnlyGenericAccessConsumeGrandField<T>(_ x: borrowing AddressO
     }
 }
 
-public func addressOnlyGenericAccessConsumeGrandField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessConsumeGrandField2<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -2378,7 +2378,7 @@ public func addressOnlyGenericAccessConsumeGrandField2<T>(_ x: borrowing Address
     }
 }
 
-public func addressOnlyGenericAccessConsumeGrandField2a<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyGenericAccessConsumeGrandField2a<T>(_ x: borrowing AddressOnlyGeneric<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyGeneric<T>()
 
@@ -2396,8 +2396,8 @@ public func addressOnlyGenericAccessConsumeFieldArg<T>(_ x2: inout AddressOnlyGe
 }
 
 public func addressOnlyGenericAccessConsumeFieldArg2<T>(_ x2: inout AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
 
     for _ in 0..<1024 {
@@ -2432,8 +2432,8 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg<T>(_ x2: inout AddressO
 }
 
 public func addressOnlyGenericAccessConsumeGrandFieldArg2<T>(_ x2: inout AddressOnlyGeneric<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.moveOnly.k) // expected-note {{consuming use here}}
 
     for _ in 0..<1024 {
@@ -2477,12 +2477,12 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg4a<T>(_ x2: consuming Ad
 }
 
 extension AddressOnlyGeneric {
-    func testNoUseSelf() { // expected-error {{'self' has guaranteed ownership but was consumed}}
+    func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
         let x = self // expected-note {{consuming use here}}
         let _ = x
     }
 
-    mutating func testNoUseSelf2() { // expected-error {{'self' consumed but not reinitialized before end of function}}
+    mutating func testNoUseSelf2() { // expected-error {{missing reinitialization of 'self' after consume}}
         let x = self // expected-note {{consuming use here}}
         let _ = x
     }
@@ -2519,8 +2519,8 @@ struct AddressOnlyGenericInit<T : P> {
 // Address Only Protocol //
 ///////////////////////////
 
-public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
                // expected-error @-1 {{'x2' consumed more than once}}
     x2 = x // expected-note {{consuming use here}}
@@ -2533,7 +2533,7 @@ public func addressOnlyProtocolSimpleChainTest(_ x: borrowing AddressOnlyProtoco
 
 public func addressOnlyProtocolSimpleChainArgTest(_ x2: inout AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -2550,8 +2550,8 @@ public func addressOnlyProtocolSimpleChainConsumingArgTest(_ x2: consuming Addre
 }
 
 public func addressOnlyProtocolSimpleNonConsumingUseTest(_ x: borrowing AddressOnlyProtocol) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -2562,8 +2562,8 @@ public func addressOnlyProtocolSimpleNonConsumingUseArgTest(_ x2: inout AddressO
 }
 
 public func addressOnlyProtocolMultipleNonConsumingUseTest(_ x: borrowing AddressOnlyProtocol) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -2571,7 +2571,7 @@ public func addressOnlyProtocolMultipleNonConsumingUseTest(_ x: borrowing Addres
     consumeVal(x2)
 }
 
-public func addressOnlyProtocolMultipleNonConsumingUseArgTest(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolMultipleNonConsumingUseArgTest(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2584,7 +2584,7 @@ public func addressOnlyProtocolMultipleNonConsumingUseArgTest2(_ x2: inout Addre
     borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
-public func addressOnlyProtocolMultipleNonConsumingUseArgTest3(_ x2: inout AddressOnlyProtocol) {  // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolMultipleNonConsumingUseArgTest3(_ x2: inout AddressOnlyProtocol) {  // expected-error {{missing reinitialization of 'x2' after consume}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     borrowVal(x2)
@@ -2631,8 +2631,8 @@ public func addressOnlyProtocolMultipleNonConsumingUseConsumingArgTest4(_ x2: co
 }
 
 public func addressOnlyProtocolUseAfterConsume(_ x: borrowing AddressOnlyProtocol) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
@@ -2641,7 +2641,7 @@ public func addressOnlyProtocolUseAfterConsume(_ x: borrowing AddressOnlyProtoco
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolUseAfterConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2656,7 +2656,7 @@ public func addressOnlyProtocolUseAfterConsumeArg2(_ x2: consuming AddressOnlyPr
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyProtocol()
@@ -2664,7 +2664,7 @@ public func addressOnlyProtocolDoubleConsume(_ x: borrowing AddressOnlyProtocol)
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyProtocolDoubleConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolDoubleConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2677,7 +2677,7 @@ public func addressOnlyProtocolDoubleConsumeArg2(_ x2: consuming AddressOnlyProt
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func addressOnlyProtocolLoopConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolLoopConsume(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyProtocol()
@@ -2686,7 +2686,7 @@ public func addressOnlyProtocolLoopConsume(_ x: borrowing AddressOnlyProtocol) {
     }
 }
 
-public func addressOnlyProtocolLoopConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolLoopConsumeArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -2706,7 +2706,7 @@ public func addressOnlyProtocolLoopConsumeArg3(_ x2: consuming AddressOnlyProtoc
     x2 = AddressOnlyProtocol()
 }
 
-public func addressOnlyProtocolDiamond(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolDiamond(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyProtocol()
     if boolValue {
@@ -2716,8 +2716,8 @@ public func addressOnlyProtocolDiamond(_ x: borrowing AddressOnlyProtocol) { // 
     }
 }
 
-public func addressOnlyProtocolDiamondArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                 // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolDiamondArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                 // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -2733,7 +2733,7 @@ public func addressOnlyProtocolDiamondArg2(_ x2: consuming AddressOnlyProtocol) 
     }
 }
 
-public func addressOnlyProtocolDiamondInLoop(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolDiamondInLoop(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
                // expected-note @-2 {{consuming use here}}
@@ -2748,8 +2748,8 @@ public func addressOnlyProtocolDiamondInLoop(_ x: borrowing AddressOnlyProtocol)
     }
 }
 
-public func addressOnlyProtocolDiamondInLoopArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                       // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+public func addressOnlyProtocolDiamondInLoopArg(_ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                       // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -2800,8 +2800,8 @@ public func addressOnlyProtocolDiamondInLoopArg4(_ x2: consuming AddressOnlyProt
 }
 
 public func addressOnlyProtocolAssignToVar1(_ x: borrowing AddressOnlyProtocol) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyProtocol()
@@ -2812,7 +2812,7 @@ public func addressOnlyProtocolAssignToVar1(_ x: borrowing AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolAssignToVar1Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2827,7 +2827,7 @@ public func addressOnlyProtocolAssignToVar1Arg2(_ x2: consuming AddressOnlyProto
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAssignToVar2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyProtocol()
@@ -2837,7 +2837,7 @@ public func addressOnlyProtocolAssignToVar2(_ x: borrowing AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolAssignToVar2Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
@@ -2851,8 +2851,8 @@ public func addressOnlyProtocolAssignToVar2Arg2(_ x2: consuming AddressOnlyProto
 }
 
 public func addressOnlyProtocolAssignToVar3(_ x: borrowing AddressOnlyProtocol) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyProtocol()
     var x3 = x2
@@ -2860,21 +2860,21 @@ public func addressOnlyProtocolAssignToVar3(_ x: borrowing AddressOnlyProtocol) 
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar3Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAssignToVar3Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar3Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-                                                                   // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAssignToVar3Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{missing reinitialization of 'x2' after consume}}
+                                                                   // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar4(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAssignToVar4(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = AddressOnlyProtocol()
@@ -2884,7 +2884,7 @@ public func addressOnlyProtocolAssignToVar4(_ x: borrowing AddressOnlyProtocol) 
 }
 
 public func addressOnlyProtocolAssignToVar4Arg(_ x2: inout AddressOnlyProtocol) { // expected-error {{'x2' consumed more than once}}
-                                                      // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+                                                      // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
@@ -2908,14 +2908,14 @@ public func addressOnlyProtocolAssignToVar5<T : P>(_ ty: T.Type) {
 
 public func addressOnlyProtocolAssignToVar5Arg(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) {
     // expected-error @-1 {{'x2' used after consume}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func addressOnlyProtocolAssignToVar5Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAssignToVar5Arg2(_ x: borrowing AddressOnlyProtocol, _ x2: inout AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -2927,7 +2927,7 @@ public func addressOnlyProtocolAssignToVar5Arg2(_ x: borrowing AddressOnlyProtoc
 // MG: We are calling these consuming uses since I have not taught the checker
 // that a use of a copy_addr that is copyable is not a consuming use. I will
 // remove them when I fix it in the next commit.
-public func addressOnlyProtocolAccessAccessField(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAccessAccessField(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyProtocol()
     borrowVal(x2.copyable)
@@ -2936,7 +2936,7 @@ public func addressOnlyProtocolAccessAccessField(_ x: borrowing AddressOnlyProto
     }
 }
 
-public func addressOnlyProtocolAccessAccessField2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAccessAccessField2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyProtocol()
     borrowVal(x2.moveOnly)
@@ -2973,7 +2973,7 @@ public func addressOnlyProtocolAccessAccessFieldArg4(_ x2: consuming AddressOnly
     }
 }
 
-public func addressOnlyProtocolAccessConsumeField(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAccessConsumeField(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = AddressOnlyProtocol()
 
@@ -2983,7 +2983,7 @@ public func addressOnlyProtocolAccessConsumeField(_ x: borrowing AddressOnlyProt
     }
 }
 
-public func addressOnlyProtocolAccessConsumeField2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func addressOnlyProtocolAccessConsumeField2(_ x: borrowing AddressOnlyProtocol) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -3004,8 +3004,8 @@ public func addressOnlyProtocolAccessConsumeFieldArg(_ x2: inout AddressOnlyProt
 }
 
 public func addressOnlyProtocolAccessConsumeFieldArg2(_ x2: inout AddressOnlyProtocol) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.moveOnly) // expected-note {{consuming use here}}
 
     for _ in 0..<1024 {
@@ -3033,7 +3033,7 @@ public func addressOnlyProtocolAccessConsumeFieldArg4(_ x2: consuming AddressOnl
 }
 
 extension AddressOnlyProtocol {
-    func testNoUseSelf() { // expected-error {{'self' has guaranteed ownership but was consumed}}
+    func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
         let x = self // expected-note {{consuming use here}}
         let _ = x
     }
@@ -3071,7 +3071,7 @@ public func closureLetClassUseAfterConsume2() {
 public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
     // TODO: Fix this
     let f = { (_ x2: inout Klass) in
-        // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+        // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -3083,7 +3083,7 @@ public func closureLetClassUseAfterConsumeArg(_ argX: inout Klass) {
 
 // We do not support captures of vars by closures today.
 public func closureLetCaptureClassUseAfterConsume() {
-    var x2 = Klass() // expected-error {{'x2' consumed in closure but not reinitialized before end of closure}}
+    var x2 = Klass() // expected-error {{missing reinitialization of 'x2' after consume}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -3096,7 +3096,7 @@ public func closureLetCaptureClassUseAfterConsume() {
 }
 
 public func closureLetCaptureClassUseAfterConsume2() {
-    var x2 = Klass() // expected-error {{'x2' consumed in closure but not reinitialized before end of closure}}
+    var x2 = Klass() // expected-error {{missing reinitialization of 'x2' after consume}}
     x2 = Klass()
     let f = {
         borrowVal(x2)
@@ -3106,7 +3106,7 @@ public func closureLetCaptureClassUseAfterConsume2() {
 }
 
 public func closureLetCaptureClassUseAfterConsumeError() {
-    var x2 = Klass() // expected-error {{'x2' consumed in closure but not reinitialized before end of closure}}
+    var x2 = Klass() // expected-error {{missing reinitialization of 'x2' after consume}}
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
@@ -3143,11 +3143,11 @@ func closureLetStoreClosureInVariableIsEscape() {
 
     let f = {
         borrowVal(s)
-        consumeVal(s) // expected-error {{'s' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(s) // expected-error {{captured 's' cannot be consumed within a closure}}
     }
     let c = StoreClosure(f: f)
     _ = c
-    consumeVal(s) // expected-error {{'s' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(s) // expected-error {{captured 's' cannot be consumed within a closure}}
 }
 
 /////////////////////////////
@@ -3185,7 +3185,7 @@ public func closureVarClassUseAfterConsumeArg(_ argX: inout Klass) {
     // TODO: Fix this
     var f = { (_ x2: inout Klass) in}
     f = { (_ x2: inout Klass) in
-        // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+        // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -3202,8 +3202,8 @@ public func closureVarCaptureClassUseAfterConsume() {
     var f = {}
     f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
@@ -3214,7 +3214,7 @@ public func closureVarCaptureClassUseAfterConsume2() {
     var f = {}
     f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
@@ -3225,12 +3225,12 @@ public func closureVarCaptureClassUseAfterConsumeError() {
     var f = {}
     f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     x2 = Klass()
     let _ = x3
 }
@@ -3254,7 +3254,7 @@ public func closureVarCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 public func deferCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' used after consume}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
     defer { // expected-note {{non-consuming use here}}
@@ -3269,7 +3269,7 @@ public func deferCaptureClassUseAfterConsume() {
 
 public func deferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = Klass()
@@ -3284,7 +3284,7 @@ public func deferCaptureClassUseAfterConsume2() {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     defer {
@@ -3298,7 +3298,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -3316,7 +3316,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume() {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume2() {
     var x2 = Klass() // expected-error {{'x2' used after consume}}
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -3335,7 +3335,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2() {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume3() {
     var x2 = Klass() // expected-error {{'x2' used after consume}}
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = { 
@@ -3354,7 +3354,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3() {
 }
 
 public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -3377,7 +3377,7 @@ public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) 
 
 public func closureLetAndClosureCaptureClassUseAfterConsume() {
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     x2 = Klass()
     let f = {
         let g = {
@@ -3393,7 +3393,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume() {
 
 public func closureLetAndClosureCaptureClassUseAfterConsume2() {
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     x2 = Klass()
     let f = {
         let g = {
@@ -3434,9 +3434,9 @@ public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass
 // MARK: Defer and Var Closure //
 /////////////////////////////////
 
-public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = {
@@ -3451,14 +3451,14 @@ public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
     f()
 }
 
-public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3471,15 +3471,15 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 }
 
 // TODO: MG
-public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     x2 = x
     // expected-note @-1 {{consuming use here}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3489,12 +3489,12 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
         defer {
@@ -3508,7 +3508,7 @@ public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     var f = {}
     f = {
         defer {
@@ -3522,7 +3522,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     var f = {}
     f = {
@@ -3539,7 +3539,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
 
 // TODO: MG
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     var f = {}
     f = {
         defer {
@@ -3550,12 +3550,12 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var f = {}
     f = {
         defer {
@@ -3567,14 +3567,14 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 ///////////////////////////////////////////
 // MARK: Multiple Levels of Var Closures //
 ///////////////////////////////////////////
 
-public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
     x2 = x // expected-note {{consuming use here}}
     var f = {}
@@ -3582,16 +3582,16 @@ public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
 
-public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = Klass()
     x2 = x
     // expected-note @-1 {{consuming use here}}
@@ -3601,18 +3601,18 @@ public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
-public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
     // expected-note @-1 {{consuming use here}}
     x2 = x
@@ -3623,21 +3623,21 @@ public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
 public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
         var g = {}
@@ -3657,8 +3657,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3671,8 +3671,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3685,13 +3685,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3700,13 +3700,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 /////////////////////////////
@@ -4050,12 +4050,12 @@ func copyableKlassWithMoveOnlyFieldBorrowValue(_ x: CopyableKlassWithMoveOnlyFie
 
 func copyableKlassWithMoveOnlyFieldConsumeValue(_ x: CopyableKlassWithMoveOnlyField) {
     consumeVal(x.moveOnlyVarStruct)
-    // expected-error @-1 {{'x.moveOnlyVarStruct' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
-    consumeVal(x.moveOnlyVarStruct.nonTrivialStruct2) // expected-error {{'x.moveOnlyVarStruct' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    // expected-error @-1 {{cannot consume noncopyable stored property 'x.moveOnlyVarStruct' of a class}}
+    consumeVal(x.moveOnlyVarStruct.nonTrivialStruct2) // expected-error {{cannot consume noncopyable stored property 'x.moveOnlyVarStruct' of a class}}
     // TODO: We should place a note on x. We need to make the diagnostic part of
     // this a little smarter.
-    consumeVal(x.moveOnlyLetStruct) // expected-error {{'x.moveOnlyLetStruct' was consumed but it is illegal to consume a noncopyable class let field. One can only read from it}}
-    consumeVal(x.moveOnlyLetStruct.nonTrivialStruct2) // expected-error {{'x.moveOnlyLetStruct' was consumed but it is illegal to consume a noncopyable class let field. One can only read from it}}
+    consumeVal(x.moveOnlyLetStruct) // expected-error {{cannot consume noncopyable stored property 'x.moveOnlyLetStruct' of a class}}
+    consumeVal(x.moveOnlyLetStruct.nonTrivialStruct2) // expected-error {{cannot consume noncopyable stored property 'x.moveOnlyLetStruct' of a class}}
 }
 
 func copyableKlassWithMoveOnlyFieldAssignValue(_ x: CopyableKlassWithMoveOnlyField) {
@@ -4078,12 +4078,12 @@ func moveOnlyGlobalBorrowValue() {
 }
 
 func moveOnlyGlobalConsumeValue() {
-    consumeVal(varGlobal) // expected-error {{'varGlobal' was consumed but it is illegal to consume a noncopyable global var. One can only read from it or assign to it}}
+    consumeVal(varGlobal) // expected-error {{cannot consume noncopyable stored property 'varGlobal' that is global}}
     // TODO: Fix error to say that it is from nonTrivialStruct2
-    consumeVal(varGlobal.nonTrivialStruct2) // expected-error {{'varGlobal' was consumed but it is illegal to consume a noncopyable global var. One can only read from it or assign to it}}
-    consumeVal(letGlobal) // expected-error {{'letGlobal' was consumed but it is illegal to consume a noncopyable global let. One can only read from it}}
+    consumeVal(varGlobal.nonTrivialStruct2) // expected-error {{cannot consume noncopyable stored property 'varGlobal' that is global}}
+    consumeVal(letGlobal) // expected-error {{cannot consume noncopyable stored property 'letGlobal' that is global}}
     // TODO: Fix error to say that it is from nonTrivialStruct2
-    consumeVal(letGlobal.nonTrivialStruct2) // expected-error {{'letGlobal' was consumed but it is illegal to consume a noncopyable global let. One can only read from it}}
+    consumeVal(letGlobal.nonTrivialStruct2) // expected-error {{cannot consume noncopyable stored property 'letGlobal' that is global}}
 }
 
 func moveOnlyGlobalAssignValue() {
@@ -4106,14 +4106,14 @@ func inoutCaptureTest() -> (() -> ()) {
 
     borrowVal(x)
     consumeVal(x)
-    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
     x = NonTrivialStruct()
 
     let g = {
         x = NonTrivialStruct()
         useInOut(&x)
         consumeVal(x)
-        // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
     }
     g()
 
@@ -4130,13 +4130,13 @@ func inoutCaptureTestAddressOnlyGeneric<T : P>(_ t: T.Type) -> (() -> ()) {
     }
 
     borrowVal(x)
-    consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     x = AddressOnlyGeneric<T>()
 
     let g = {
         x = AddressOnlyGeneric<T>()
         useInOut(&x)
-        consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x) // expected-error {{captured 'x' cannot be consumed within a closure}}
     }
     g()
 

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
@@ -78,7 +78,7 @@ bb0(%0 : @guaranteed $AggStruct2):
   destroy_value %2 : $AggStruct2
   %9 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
   apply %9(%7) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
-  apply %9(%7a) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{boundary use here}}
+  apply %9(%7a) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{non-consuming use here}}
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
@@ -63,7 +63,7 @@ sil @klass_use : $@convention(thin) (@guaranteed Klass) -> ()
 sil [ossa] @test_access_single_child_field_consume : $@convention(method) (@guaranteed AggStruct2) -> () {
 bb0(%0 : @guaranteed $AggStruct2):
   %1 = copy_value %0 : $AggStruct2
-  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct2 // expected-error {{'self' has a move only field that was consumed before later uses}}
+  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct2 // expected-error {{cannot use 'self' after partial consume}}
   debug_value %2 : $AggStruct2, let, name "self", argno 1, implicit
   %4 = begin_borrow %2 : $AggStruct2
   %5 = struct_extract %4 : $AggStruct2, #AggStruct2.pair
@@ -77,7 +77,7 @@ bb0(%0 : @guaranteed $AggStruct2):
   end_borrow %4a : $AggStruct2
   destroy_value %2 : $AggStruct2
   %9 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
-  apply %9(%7) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{consuming use here}}
+  apply %9(%7) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
   apply %9(%7a) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{boundary use here}}
   %9999 = tuple()
   return %9999 : $()
@@ -134,14 +134,14 @@ bb0(%0 : @owned $AggStruct2):
   %4 = copy_value %2 : $AggStruct2
   %5 = move_value [lexical] %4 : $AggStruct2
   %6 = mark_must_check [consumable_and_assignable] %5 : $AggStruct2
-  // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-  // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+  // expected-error @-1 {{cannot use 'x2' after partial consume}}
+  // expected-error @-2 {{cannot use 'x2' after partial consume}}
   debug_value %6 : $AggStruct2, let, name "x2"
   %8 = begin_borrow %6 : $AggStruct2
   %9 = struct_extract %8 : $AggStruct2, #AggStruct2.lhs
   %10 = copy_value %9 : $MoveOnlyKlass
   %11 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
-  %12 = apply %11(%10) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{consuming use here}}
+  %12 = apply %11(%10) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
   end_borrow %8 : $AggStruct2
   br bb1
 
@@ -153,7 +153,7 @@ bb2:
   %52 = struct_extract %51 : $AggStruct2, #AggStruct2.lhs
   %53 = copy_value %52 : $MoveOnlyKlass
   %54 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
-  %55 = apply %54(%53) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{consuming use here}}
+  %55 = apply %54(%53) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
   end_borrow %51 : $AggStruct2
   br bb1
 

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
@@ -77,8 +77,8 @@ bb0(%0 : @guaranteed $AggStruct2):
   end_borrow %4a : $AggStruct2
   destroy_value %2 : $AggStruct2
   %9 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
-  apply %9(%7) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
-  apply %9(%7a) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{non-consuming use here}}
+  apply %9(%7) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partially consumed here}}
+  apply %9(%7a) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{used here}}
   %9999 = tuple()
   return %9999 : $()
 }
@@ -99,7 +99,7 @@ bb0(%0 : @guaranteed $AggStruct2):
   %7a = copy_value %6a : $MoveOnlyKlass
   end_borrow %4a : $AggStruct2
   destroy_value %2 : $AggStruct2
-  %8 = struct $KlassPair2(%7 : $MoveOnlyKlass, %7a : $MoveOnlyKlass) // expected-note {{two consuming uses here}}
+  %8 = struct $KlassPair2(%7 : $MoveOnlyKlass, %7a : $MoveOnlyKlass) // expected-note {{multiple consumes here}}
   return %8 : $KlassPair2
 }
 
@@ -120,7 +120,7 @@ bb0(%0 : @guaranteed $AggStruct2):
   end_borrow %4a : $AggStruct2
   destroy_value %2 : $AggStruct2
   %8 = function_ref @moveonlyklass_consume_use : $@convention(thin) (@owned MoveOnlyKlass, @guaranteed MoveOnlyKlass) -> ()
-  apply %8(%7, %7a) : $@convention(thin) (@owned MoveOnlyKlass, @guaranteed MoveOnlyKlass) -> () // expected-note {{consuming and non-consuming uses here}}
+  apply %8(%7, %7a) : $@convention(thin) (@owned MoveOnlyKlass, @guaranteed MoveOnlyKlass) -> () // expected-note {{consumed and used here}}
   destroy_value %7a : $MoveOnlyKlass
   %9999 = tuple()
   return %9999 : $()
@@ -141,7 +141,7 @@ bb0(%0 : @owned $AggStruct2):
   %9 = struct_extract %8 : $AggStruct2, #AggStruct2.lhs
   %10 = copy_value %9 : $MoveOnlyKlass
   %11 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
-  %12 = apply %11(%10) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
+  %12 = apply %11(%10) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partially consumed here}}
   end_borrow %8 : $AggStruct2
   br bb1
 
@@ -153,7 +153,7 @@ bb2:
   %52 = struct_extract %51 : $AggStruct2, #AggStruct2.lhs
   %53 = copy_value %52 : $MoveOnlyKlass
   %54 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
-  %55 = apply %54(%53) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partial consume here}}
+  %55 = apply %54(%53) : $@convention(thin) (@owned MoveOnlyKlass) -> () // expected-note {{partially consumed here}}
   end_borrow %51 : $AggStruct2
   br bb1
 

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -13,22 +13,22 @@ struct MoveOnlyStruct {
         // expected-error @-1 {{'self' consumed more than once}}
         // expected-error @-2 {{'self' consumed more than once}}
         // expected-error @-3 {{'self' consumed more than once}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         _ = x
         var y = MoveOnlyStruct() // expected-error {{'y' consumed more than once}}
         y = self
-        // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
+        // expected-note @-2 {{other consume here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         // expected-warning @-6 {{function call causes an infinite recursion}}
         _ = y
-        // expected-note @-1 {{consuming use here}}
-        let z = y // expected-note {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
+        let z = y // expected-note {{consumed here}}
         let _ = z
-        globalMoveOnlyStruct = self // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
-    } // expected-note {{consuming use here}}
+        globalMoveOnlyStruct = self // expected-note {{consumed here}}
+        // expected-note @-1 {{other consume here}}
+    } // expected-note {{other consume here}}
 }
 
 @_moveOnly
@@ -40,16 +40,16 @@ enum MoveOnlyEnum {
         // expected-error @-1 {{'self' consumed more than once}}
         // expected-error @-2 {{'self' consumed more than once}}
         // expected-error @-3 {{'self' consumed more than once}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         _ = x
         var y = MoveOnlyEnum.lhs(Klass())
-        y = self // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        y = self // expected-note {{consumed here}}
+        // expected-note @-1 {{other consume here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         // expected-warning @-5 {{function call causes an infinite recursion}}
         _ = y 
-        globalMoveOnlyEnum = self // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
-    } // expected-note {{consuming use here}}
+        globalMoveOnlyEnum = self // expected-note {{consumed here}}
+        // expected-note @-1 {{other consume here}}
+    } // expected-note {{other consume here}}
 }

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -18,17 +18,17 @@ struct MoveOnlyStruct {
         var y = MoveOnlyStruct() // expected-error {{'y' consumed more than once}}
         y = self
         // expected-note @-1 {{consumed here}}
-        // expected-note @-2 {{other consume here}}
+        // expected-note @-2 {{consumed again here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         // expected-warning @-6 {{function call causes an infinite recursion}}
         _ = y
         // expected-note @-1 {{consumed here}}
-        let z = y // expected-note {{consumed here}}
+        let z = y // expected-note {{consumed again here}}
         let _ = z
         globalMoveOnlyStruct = self // expected-note {{consumed here}}
-        // expected-note @-1 {{other consume here}}
-    } // expected-note {{other consume here}}
+        // expected-note @-1 {{consumed again here}}
+    } // expected-note {{consumed again here}}
 }
 
 @_moveOnly
@@ -44,12 +44,12 @@ enum MoveOnlyEnum {
         _ = x
         var y = MoveOnlyEnum.lhs(Klass())
         y = self // expected-note {{consumed here}}
-        // expected-note @-1 {{other consume here}}
+        // expected-note @-1 {{consumed again here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         // expected-warning @-5 {{function call causes an infinite recursion}}
         _ = y 
         globalMoveOnlyEnum = self // expected-note {{consumed here}}
-        // expected-note @-1 {{other consume here}}
-    } // expected-note {{other consume here}}
+        // expected-note @-1 {{consumed again here}}
+    } // expected-note {{consumed again here}}
 }

--- a/test/SILOptimizer/moveonly_discard.swift
+++ b/test/SILOptimizer/moveonly_discard.swift
@@ -21,8 +21,8 @@ struct GoodFileDescriptor {
 
   deinit { // expected-error {{'self' consumed more than once}}
     // FIXME: this is suppose to be valid. rdar://106044273
-    close() // expected-note {{consuming use here}}
-  } // expected-note {{other consuming use here}}
+    close() // expected-note {{consumed here}}
+  } // expected-note {{other consume here}}
 }
 
 @_moveOnly
@@ -33,23 +33,23 @@ struct BadFileDescriptor {
 
   var rawFileDescriptor: Int {
     __consuming get { // expected-error {{'self' consumed more than once}}
-      discard self    // expected-note {{consuming use here}}
-      return self.rawFileDescriptor  // expected-note {{consuming use here}}
+      discard self    // expected-note {{consumed here}}
+      return self.rawFileDescriptor  // expected-note {{consumed here}}
                                      // expected-warning@-1 {{function call causes an infinite recursion}}
     }
   }
 
   __consuming func closeBoring(_ b: Bool) -> Int { // expected-error {{'self' consumed more than once}}
     if b {
-      discard self // expected-note {{consuming use here}}
+      discard self // expected-note {{consumed here}}
     }
-    return rawFileDescriptor // expected-note {{consuming use here}}
+    return rawFileDescriptor // expected-note {{consumed here}}
   }
 
   __consuming func closeRepeatedly(_ n: Int) -> Int { // expected-error {{'self' used after consume}}
     for _ in 0..<n {
-      posix_close(_fd) // expected-note {{non-consuming use here}}
-      discard self     // expected-note {{consuming use here}}
+      posix_close(_fd) // expected-note {{used here}}
+      discard self     // expected-note {{consumed here}}
     }
     return 0
   }
@@ -74,19 +74,19 @@ final class Wallet {
       discard()
       self = .within(existingWallet)
     }
-    discard(forever: true) // expected-note {{consuming use here}}
-  } // expected-note {{consuming use here}}
+    discard(forever: true) // expected-note {{consumed here}}
+  } // expected-note {{consumed here}}
 
-  __consuming func discard(forever: Bool) { // expected-error {{'self' consumed by a use in a loop}}
+  __consuming func discard(forever: Bool) { // expected-error {{'self' consumed in a loop}}
     while forever {
-      discard self // expected-note {{consuming use here}}
+      discard self // expected-note {{consumed here}}
     }
   }
 
   __consuming func inspect() { // expected-error {{'self' consumed more than once}}
-    switch self { // expected-note {{consuming use here}}
+    switch self { // expected-note {{consumed here}}
     case .green, .yellow, .red:
-      discard self // expected-note {{consuming use here}}
+      discard self // expected-note {{consumed here}}
     default:
       return
     }

--- a/test/SILOptimizer/moveonly_discard.swift
+++ b/test/SILOptimizer/moveonly_discard.swift
@@ -22,7 +22,7 @@ struct GoodFileDescriptor {
   deinit { // expected-error {{'self' consumed more than once}}
     // FIXME: this is suppose to be valid. rdar://106044273
     close() // expected-note {{consumed here}}
-  } // expected-note {{other consume here}}
+  } // expected-note {{consumed again here}}
 }
 
 @_moveOnly
@@ -34,7 +34,7 @@ struct BadFileDescriptor {
   var rawFileDescriptor: Int {
     __consuming get { // expected-error {{'self' consumed more than once}}
       discard self    // expected-note {{consumed here}}
-      return self.rawFileDescriptor  // expected-note {{consumed here}}
+      return self.rawFileDescriptor  // expected-note {{consumed again here}}
                                      // expected-warning@-1 {{function call causes an infinite recursion}}
     }
   }
@@ -43,7 +43,7 @@ struct BadFileDescriptor {
     if b {
       discard self // expected-note {{consumed here}}
     }
-    return rawFileDescriptor // expected-note {{consumed here}}
+    return rawFileDescriptor // expected-note {{consumed again here}}
   }
 
   __consuming func closeRepeatedly(_ n: Int) -> Int { // expected-error {{'self' used after consume}}
@@ -75,7 +75,7 @@ final class Wallet {
       self = .within(existingWallet)
     }
     discard(forever: true) // expected-note {{consumed here}}
-  } // expected-note {{consumed here}}
+  } // expected-note {{consumed again here}}
 
   __consuming func discard(forever: Bool) { // expected-error {{'self' consumed in a loop}}
     while forever {
@@ -86,7 +86,7 @@ final class Wallet {
   __consuming func inspect() { // expected-error {{'self' consumed more than once}}
     switch self { // expected-note {{consumed here}}
     case .green, .yellow, .red:
-      discard self // expected-note {{consumed here}}
+      discard self // expected-note {{consumed again here}}
     default:
       return
     }

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -77,12 +77,12 @@ func c2(x: consuming M) {
     consume(x)
 }
 
-func d(x: __owned M) { // expected-error {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+func d(x: __owned M) { // expected-error {{captured 'x' cannot be consumed within a closure}}
     clodger({ consume(x) })
     // expected-note @-1 {{consuming use here}}
 }
 
-func d2(x: consuming M) { // expected-error {{'x' consumed in closure but not reinitialized before end of closure}}
+func d2(x: consuming M) { // expected-error {{missing reinitialization of 'x' after consume}}
     clodger({ consume(x) })
     // expected-note @-1 {{consuming use here}}
 }
@@ -129,7 +129,7 @@ func k(x: borrowing M) {
 }
 
 
-func l(x: inout M) { // expected-error {{'x' consumed in closure but not reinitialized before end of closure}}
+func l(x: inout M) { // expected-error {{missing reinitialization of 'x' after consume}}
     clodger({ consume(x) }) // expected-note {{consuming use here}}
 }
 

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -50,8 +50,8 @@ func a(x: borrowing M) {
 
 func b(x: __owned M) { // expected-error {{'x' used after consume}}
     clodger({ borrow(x) }, consume: x)
-    // expected-note @-1:25 {{non-consuming use here}}
-    // expected-note @-2:37 {{consuming use here}}
+    // expected-note @-1:25 {{used here}}
+    // expected-note @-2:37 {{consumed here}}
 }
 
 // We have a use after free here since we treat the passing of borrow to clodger
@@ -60,9 +60,9 @@ func b(x: __owned M) { // expected-error {{'x' used after consume}}
 func b2(x: consuming M) {
     // expected-error @-1 {{'x' used after consume}}
     clodger({ borrow(x) }, // expected-note {{conflicting access is here}}
-            // expected-note @-1 {{non-consuming use here}}
+            // expected-note @-1 {{used here}}
             consume: x) // expected-error {{overlapping accesses to 'x', but deinitialization requires exclusive access}}
-            // expected-note @-1 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
 }
 
 func c(x: __owned M) {
@@ -79,12 +79,12 @@ func c2(x: consuming M) {
 
 func d(x: __owned M) { // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     clodger({ consume(x) })
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 func d2(x: consuming M) { // expected-error {{missing reinitialization of inout parameter 'x' after consume}}
     clodger({ consume(x) })
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 func e(x: inout M) {
@@ -106,9 +106,9 @@ func g(x: inout M) {
 
 func h(x: inout M) { // expected-error {{'x' used after consume}}
     clodger({ mutate(&x) }, // expected-note {{conflicting access is here}}
-            // expected-note @-1 {{non-consuming use here}}
+            // expected-note @-1 {{used here}}
             consume: x) // expected-error {{overlapping accesses to 'x', but deinitialization requires exclusive access}}}
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     x = M()
 }
 
@@ -130,17 +130,17 @@ func k(x: borrowing M) {
 
 
 func l(x: inout M) { // expected-error {{missing reinitialization of inout parameter 'x' after consume}}
-    clodger({ consume(x) }) // expected-note {{consuming use here}}
+    clodger({ consume(x) }) // expected-note {{consumed here}}
 }
 
 func m(x: inout M) { // expected-error {{'x' used after consume}}
-    consume(x) // expected-note {{consuming use here}}
-    clodger({ borrow(x) }) // expected-note {{non-consuming use here}}
+    consume(x) // expected-note {{consumed here}}
+    clodger({ borrow(x) }) // expected-note {{used here}}
 }
 
 func n(x: inout M) { // expected-error {{'x' used after consume}}
-    consume(x) // expected-note {{consuming use here}}
-    clodger({ // expected-note {{non-consuming use here}}
+    consume(x) // expected-note {{consumed here}}
+    clodger({ // expected-note {{used here}}
         mutate(&x)
     })
 }

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -82,7 +82,7 @@ func d(x: __owned M) { // expected-error {{captured 'x' cannot be consumed withi
     // expected-note @-1 {{consuming use here}}
 }
 
-func d2(x: consuming M) { // expected-error {{missing reinitialization of 'x' after consume}}
+func d2(x: consuming M) { // expected-error {{missing reinitialization of inout parameter 'x' after consume}}
     clodger({ consume(x) })
     // expected-note @-1 {{consuming use here}}
 }
@@ -129,7 +129,7 @@ func k(x: borrowing M) {
 }
 
 
-func l(x: inout M) { // expected-error {{missing reinitialization of 'x' after consume}}
+func l(x: inout M) { // expected-error {{missing reinitialization of inout parameter 'x' after consume}}
     clodger({ consume(x) }) // expected-note {{consuming use here}}
 }
 

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -77,7 +77,7 @@ func c2(x: consuming M) {
     consume(x)
 }
 
-func d(x: __owned M) { // expected-error {{captured 'x' cannot be consumed within a closure}}
+func d(x: __owned M) { // expected-error {{noncopyable 'x' cannot be consumed when captured by a closure}}
     clodger({ consume(x) })
     // expected-note @-1 {{consuming use here}}
 }

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -47,7 +47,7 @@ public final class FinalKlass {
 // Class Tests //
 /////////////////
 
-public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
                // expected-error @-1 {{'x2' consumed more than once}}
     let y2 = x2 // expected-note {{consuming use here}}
@@ -57,7 +57,7 @@ public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x'
     borrowVal(k2)
 }
 
-public func classSimpleChainArgTest(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classSimpleChainArgTest(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -75,7 +75,7 @@ public func classSimpleChainOwnedArgTest2(_ x2: consuming Klass) {
     borrowVal(k2)
 }
 
-public func classSimpleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -92,14 +92,14 @@ public func classSimpleNonConsumingUseOwnedArgTest2(_ x2: consuming Klass) {
     borrowVal(x2)
 }
 
-public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func classMultipleNonConsumingUseArgTest(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseArgTest(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -117,7 +117,7 @@ public func classMultipleNonConsumingUseOwnedArgTest2(_ x2: consuming Klass) {
     consumeVal(x2)
 }
 
-public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -125,7 +125,7 @@ public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x'
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classUseAfterConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classUseAfterConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -143,14 +143,14 @@ public func classUseAfterConsumeOwnedArg2(_ x2: consuming Klass) { // expected-e
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDoubleConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -165,7 +165,7 @@ public func classDoubleConsumeOwnedArg2(_ x2: consuming Klass) { // expected-err
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -173,7 +173,7 @@ public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' has
     }
 }
 
-public func classLoopConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classLoopConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -191,7 +191,7 @@ public func classLoopConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error
     }
 }
 
-public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -200,7 +200,7 @@ public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' has gua
     }
 }
 
-public func classDiamondArg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDiamondArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -224,7 +224,7 @@ public func classDiamondOwnedArg2(_ x2: consuming Klass) {
     }
 }
 
-public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -238,7 +238,7 @@ public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' h
     }
 }
 
-public func classDiamondInLoopArg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDiamondInLoopArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -272,7 +272,7 @@ public func classDiamondInLoopOwnedArg2(_ x2: consuming Klass) { // expected-err
     }
 }
 
-public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -281,8 +281,8 @@ public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func classAssignToVar1Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar1Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -293,7 +293,7 @@ public func classAssignToVar1Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { 
 // load forwarding. We may need to make predictable mem opts more conservative
 // with move only var.
 public func classAssignToVar1OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -301,14 +301,14 @@ public func classAssignToVar1OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass)
 }
 
 public func classAssignToVar1OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -316,7 +316,7 @@ public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' ha
     borrowVal(x3)
 }
 
-public func classAssignToVar2Arg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar2Arg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -335,7 +335,7 @@ public func classAssignToVar2OwnedArg2(_ x2: consuming Klass) { // expected-erro
 }
 
 // NOTE: consumeVal(x3) should not be marked.
-public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
@@ -343,26 +343,26 @@ public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' ha
 }
 
 // NOTE: consumeVal(x3) is a bug.
-public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar3OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar3OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -370,7 +370,7 @@ public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func classAssignToVar4Arg(_ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar4Arg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -388,7 +388,7 @@ public func classAssignToVar4OwnedArg2(_ x2: consuming Klass) { // expected-erro
     consumeVal(x3)
 }
 
-public func classAssignToVar5(_ x: borrowing Klass) {  // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar5(_ x: borrowing Klass) {  // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
     // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -397,8 +397,8 @@ public func classAssignToVar5(_ x: borrowing Klass) {  // expected-error {{'x' h
     consumeVal(x3)
 }
 
-public func classAssignToVar5Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar5Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2)
     x3 = x // expected-note {{consuming use here}}
@@ -406,7 +406,7 @@ public func classAssignToVar5Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { 
 }
 
 public func classAssignToVar5OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
-                                                                         // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -414,14 +414,14 @@ public func classAssignToVar5OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass)
 }
 
 public func classAssignToVar5OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x2' used after consume}}
-                                                                         // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAccessAccessField(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessAccessField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.k)
     for _ in 0..<1024 {
@@ -450,37 +450,37 @@ public func classAccessAccessFieldOwnedArg2(_ x2: consuming Klass) {
     }
 }
 
-public func classAccessConsumeField(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessConsumeField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func classAccessConsumeFieldArg(_ x2: borrowing Klass) {
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func classAccessConsumeFieldOwnedArg(_ x2: __owned Klass) {
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func classAccessConsumeFieldOwnedArg2(_ x2: consuming Klass) {
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 extension Klass {
-    func testNoUseSelf() { // expected-error {{'self' has guaranteed ownership but was consumed}}
+    func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
         let x = self // expected-note {{consuming use here}}
         let _ = x
     }
@@ -490,14 +490,14 @@ extension Klass {
 // Final Class //
 /////////////////
 
-public func finalClassSimpleChainTest(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassSimpleChainTest(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func finalClassSimpleChainTestArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassSimpleChainTestArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -515,7 +515,7 @@ public func finalClassSimpleChainTestOwnedArg2(_ x2: consuming FinalKlass) {
     borrowVal(k2)
 }
 
-public func finalClassSimpleNonConsumingUseTest(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassSimpleNonConsumingUseTest(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -532,14 +532,14 @@ public func finalClassSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming FinalKl
     borrowVal(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTest(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassMultipleNonConsumingUseTest(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTestArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassMultipleNonConsumingUseTestArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -557,7 +557,7 @@ public func finalClassMultipleNonConsumingUseTestownedArg2(_ x2: consuming Final
     consumeVal(x2)
 }
 
-public func finalClassUseAfterConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassUseAfterConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -565,7 +565,7 @@ public func finalClassUseAfterConsume(_ x: borrowing FinalKlass) { // expected-e
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassUseAfterConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassUseAfterConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -583,14 +583,14 @@ public func finalClassUseAfterConsumeOwnedArg2(_ x2: consuming FinalKlass) { // 
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassDoubleConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassDoubleConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassDoubleConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDoubleConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -605,7 +605,7 @@ public func finalClassDoubleConsumeownedArg2(_ x2: consuming FinalKlass) { // ex
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassLoopConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassLoopConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -613,7 +613,7 @@ public func finalClassLoopConsume(_ x: borrowing FinalKlass) { // expected-error
     }
 }
 
-public func finalClassLoopConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassLoopConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -631,7 +631,7 @@ public func finalClassLoopConsumeOwnedArg2(_ x2: consuming FinalKlass) { // expe
     }
 }
 
-public func finalClassDiamond(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassDiamond(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -640,7 +640,7 @@ public func finalClassDiamond(_ x: borrowing FinalKlass) { // expected-error {{'
     }
 }
 
-public func finalClassDiamondArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDiamondArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -664,7 +664,7 @@ public func finalClassDiamondOwnedArg2(_ x2: consuming FinalKlass) {
     }
 }
 
-public func finalClassDiamondInLoop(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassDiamondInLoop(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -678,7 +678,7 @@ public func finalClassDiamondInLoop(_ x: borrowing FinalKlass) { // expected-err
     }
 }
 
-public func finalClassDiamondInLoopArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDiamondInLoopArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -712,7 +712,7 @@ public func finalClassDiamondInLoopOwnedArg2(_ x2: consuming FinalKlass) { // ex
     }
 }
 
-public func finalClassAssignToVar1(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar1(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -721,8 +721,8 @@ public func finalClassAssignToVar1(_ x: borrowing FinalKlass) { // expected-erro
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar1Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar1Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -730,7 +730,7 @@ public func finalClassAssignToVar1Arg(_ x: borrowing FinalKlass, _ x2: borrowing
 }
 
 public func finalClassAssignToVar1OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-                                                                                        // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                                        // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -738,14 +738,14 @@ public func finalClassAssignToVar1OwnedArg(_ x: borrowing FinalKlass, _ x2: __ow
 }
 
 public func finalClassAssignToVar1OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
-                                                                                        // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                                        // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar2(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar2(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -753,7 +753,7 @@ public func finalClassAssignToVar2(_ x: borrowing FinalKlass) { // expected-erro
     borrowVal(x3)
 }
 
-public func finalClassAssignToVar2Arg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar2Arg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -771,33 +771,33 @@ public func finalClassAssignToVar2OwnedArg2(_ x2: consuming FinalKlass) { // exp
     borrowVal(x3)
 }
 
-public func finalClassAssignToVar3(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar3Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar3OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar3OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar4(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar4(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -805,7 +805,7 @@ public func finalClassAssignToVar4(_ x: borrowing FinalKlass) { // expected-erro
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar4Arg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar4Arg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -823,7 +823,7 @@ public func finalClassAssignToVar4OwnedArg2(_ x2: consuming FinalKlass) { // exp
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar5(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar5(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -832,8 +832,8 @@ public func finalClassAssignToVar5(_ x: borrowing FinalKlass) { // expected-erro
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar5Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar5Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2)
     x3 = x // expected-note {{consuming use here}}
@@ -841,7 +841,7 @@ public func finalClassAssignToVar5Arg(_ x: borrowing FinalKlass, _ x2: borrowing
 }
 
 public func finalClassAssignToVar5OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' used after consume}}
-                                                                                        // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                                        // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -849,14 +849,14 @@ public func finalClassAssignToVar5OwnedArg(_ x: borrowing FinalKlass, _ x2: __ow
 }
 
 public func finalClassAssignToVar5OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x2' used after consume}}
-                                                                                        // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                                        // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAccessField(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAccessField(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.k)
     for _ in 0..<1024 {
@@ -885,36 +885,36 @@ public func finalClassAccessFieldOwnedArg2(_ x2: consuming FinalKlass) {
     }
 }
 
-public func finalClassConsumeField(_ x: borrowing FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassConsumeField(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: borrowing FinalKlass) {
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: __owned FinalKlass) {
     // No diagnostic here since class is a reference type and we are not copying
     // the class, we are copying its field.
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
 public func finalClassConsumeFieldArg2(_ x2: consuming FinalKlass) {
     // No diagnostic here since class is a reference type and we are not copying
     // the class, we are copying its field.
-    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+    consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
-        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+        consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     }
 }
 
@@ -936,14 +936,14 @@ public struct AggStruct {
     var pair: KlassPair
 }
 
-public func aggStructSimpleChainTest(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggStructSimpleChainTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -961,7 +961,7 @@ public func aggStructSimpleChainTestOwnedArg2(_ x2: consuming AggStruct) {
     borrowVal(k2)
 }
 
-public func aggStructSimpleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -978,14 +978,14 @@ public func aggStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStruc
     borrowVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1003,7 +1003,7 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStr
     consumeVal(x2)
 }
 
-public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1011,7 +1011,7 @@ public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-err
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1029,14 +1029,14 @@ public func aggStructUseAfterConsumeOwnedArg2(_ x2: consuming AggStruct) { // ex
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1051,7 +1051,7 @@ public func aggStructDoubleConsumeOwnedArg2(_ x2: consuming AggStruct) { // expe
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1059,7 +1059,7 @@ public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1077,7 +1077,7 @@ public func aggStructLoopConsumeOwnedArg2(_ x2: consuming AggStruct) { // expect
     }
 }
 
-public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1086,7 +1086,7 @@ public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x'
     }
 }
 
-public func aggStructDiamondArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1110,7 +1110,7 @@ public func aggStructDiamondOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1124,7 +1124,7 @@ public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error
     }
 }
 
-public func aggStructDiamondInLoopArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoopArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1158,7 +1158,7 @@ public func aggStructDiamondInLoopOwnedArg2(_ x2: consuming AggStruct) { // expe
     }
 }
 
-public func aggStructAccessField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1187,7 +1187,7 @@ public func aggStructAccessFieldOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -1199,11 +1199,11 @@ public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error 
 }
 
 public func aggStructConsumeFieldArg(_ x2: borrowing AggStruct) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x2' after partial consume}}
+    // expected-error @-2 {{cannot use 'x2' after partial consume}}
+    consumeVal(x2.lhs) // expected-note {{partial consume here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{partial consume here}}
     }
 }
 
@@ -1227,7 +1227,7 @@ public func aggStructConsumeFieldOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructAccessGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -1256,7 +1256,7 @@ public func aggStructAccessGrandFieldOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -1268,11 +1268,11 @@ public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-e
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: borrowing AggStruct) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x2' after partial consume}}
+    // expected-error @-2 {{cannot use 'x2' after partial consume}}
+    consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
     }
 }
 
@@ -1371,14 +1371,14 @@ public struct AggGenericStruct<T> { // FIXME: for better test coverage this shou
     var pair: KlassPair
 }
 
-public func aggGenericStructSimpleChainTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1396,7 +1396,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2(_ x2: consuming AggGenericS
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -1413,14 +1413,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming A
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1438,7 +1438,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1446,7 +1446,7 @@ public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<Stri
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1464,14 +1464,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg2(_ x2: consuming AggGenericS
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1486,7 +1486,7 @@ public func aggGenericStructDoubleConsumeOwnedArg2(_ x2: consuming AggGenericStr
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1494,7 +1494,7 @@ public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<String>)
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1512,7 +1512,7 @@ public func aggGenericStructLoopConsumeOwnedArg2(_ x2: consuming AggGenericStruc
     }
 }
 
-public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1521,7 +1521,7 @@ public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<String>) { /
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1545,7 +1545,7 @@ public func aggGenericStructDiamondOwnedArg2(_ x2: consuming AggGenericStruct<St
     }
 }
 
-public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1559,7 +1559,7 @@ public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<String
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1593,7 +1593,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2(_ x2: consuming AggGenericStr
     }
 }
 
-public func aggGenericStructAccessField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1622,7 +1622,7 @@ public func aggGenericStructAccessFieldOwnedArg2(_ x2: consuming AggGenericStruc
     }
 }
 
-public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -1634,11 +1634,11 @@ public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<String>
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: borrowing AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x2' after partial consume}}
+    // expected-error @-2 {{cannot use 'x2' after partial consume}}
+    consumeVal(x2.lhs) // expected-note {{partial consume here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{partial consume here}}
     }
 }
 
@@ -1662,7 +1662,7 @@ public func aggGenericStructConsumeFieldOwnedArg2(_ x2: consuming AggGenericStru
     }
 }
 
-public func aggGenericStructAccessGrandField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -1691,7 +1691,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg2(_ x2: consuming AggGeneric
     }
 }
 
-public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -1703,11 +1703,11 @@ public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<St
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: borrowing AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x2' after partial consume}}
+    // expected-error @-2 {{cannot use 'x2' after partial consume}}
+    consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
     }
 }
 
@@ -1735,14 +1735,14 @@ public func aggGenericStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggGeneri
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructSimpleChainTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1760,7 +1760,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2<T>(_ x2: consuming AggGener
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -1777,14 +1777,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2<T>(_ x2: consumin
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { //expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1802,7 +1802,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2<T>(_ x2: consum
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1810,7 +1810,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1828,14 +1828,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg2<T>(_ x2: consuming AggGener
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1850,7 +1850,7 @@ public func aggGenericStructDoubleConsumeOwnedArg2<T>(_ x2: consuming AggGeneric
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1858,7 +1858,7 @@ public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1876,7 +1876,7 @@ public func aggGenericStructLoopConsumeOwnedArg2<T>(_ x2: consuming AggGenericSt
     }
 }
 
-public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1885,7 +1885,7 @@ public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // 
     }
 }
 
-public func aggGenericStructDiamondArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1909,7 +1909,7 @@ public func aggGenericStructDiamondOwnedArg2<T>(_ x2: consuming AggGenericStruct
     }
 }
 
-public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1923,7 +1923,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>)
     }
 }
 
-public func aggGenericStructDiamondInLoopArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1957,7 +1957,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2<T>(_ x2: consuming AggGeneric
     }
 }
 
-public func aggGenericStructAccessField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1986,7 +1986,7 @@ public func aggGenericStructAccessFieldOwnedArg2<T>(_ x2: consuming AggGenericSt
     }
 }
 
-public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -1998,11 +1998,11 @@ public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) 
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: borrowing AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x2' after partial consume}}
+    // expected-error @-2 {{cannot use 'x2' after partial consume}}
+    consumeVal(x2.lhs) // expected-note {{partial consume here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{partial consume here}}
     }
 }
 
@@ -2026,7 +2026,7 @@ public func aggGenericStructConsumeFieldOwnedArg2<T>(_ x2: consuming AggGenericS
     }
 }
 
-public func aggGenericStructAccessGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -2055,7 +2055,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg2<T>(_ x2: consuming AggGene
     }
 }
 
-public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed by a use in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -2067,11 +2067,11 @@ public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: borrowing AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x2' after partial consume}}
+    // expected-error @-2 {{cannot use 'x2' after partial consume}}
+    consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
     }
 }
 
@@ -2107,14 +2107,14 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumSimpleChainTest(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -2132,7 +2132,7 @@ public func enumSimpleChainTestOwnedArg2(_ x2: consuming EnumTy) {
     borrowVal(k2)
 }
 
-public func enumSimpleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -2149,14 +2149,14 @@ public func enumSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
     borrowVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2174,7 +2174,7 @@ public func enumMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
     consumeVal(x2)
 }
 
-public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -2182,7 +2182,7 @@ public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x'
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -2200,14 +2200,14 @@ public func enumUseAfterConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-e
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -2222,7 +2222,7 @@ public func enumDoubleConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-err
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -2230,7 +2230,7 @@ public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has
     }
 }
 
-public func enumLoopConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumLoopConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -2248,7 +2248,7 @@ public func enumLoopConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error
     }
 }
 
-public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -2257,7 +2257,7 @@ public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' has gua
     }
 }
 
-public func enumDiamondArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -2281,7 +2281,7 @@ public func enumDiamondOwnedArg2(_ x2: consuming EnumTy) {
     }
 }
 
-public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -2295,7 +2295,7 @@ public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' h
     }
 }
 
-public func enumDiamondInLoopArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoopArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -2329,7 +2329,7 @@ public func enumDiamondInLoopOwnedArg2(_ x2: consuming EnumTy) { // expected-err
     }
 }
 
-public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -2338,8 +2338,8 @@ public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -2347,7 +2347,7 @@ public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) {
 }
 
 public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -2355,14 +2355,14 @@ public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy
 }
 
 public func enumAssignToVar1OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -2370,7 +2370,7 @@ public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     borrowVal(x3)
 }
 
-public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -2388,33 +2388,33 @@ public func enumAssignToVar2OwnedArg2(_ x2: consuming EnumTy) { // expected-erro
     borrowVal(x3)
 }
 
-public func enumAssignToVar3(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -2422,7 +2422,7 @@ public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -2440,7 +2440,7 @@ public func enumAssignToVar4OwnedArg2(_ x2: consuming EnumTy) { // expected-erro
     consumeVal(x3)
 }
 
-public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -2449,8 +2449,8 @@ public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2)
     x3 = x // expected-note {{consuming use here}}
@@ -2458,7 +2458,7 @@ public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) {
 }
 
 public func enumAssignToVar5OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -2466,14 +2466,14 @@ public func enumAssignToVar5OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy
 }
 
 public func enumAssignToVar5OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
@@ -2484,7 +2484,7 @@ public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{
     }
 }
 
-public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x)
     }
@@ -2511,7 +2511,7 @@ public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expecte
     }
 }
 
-public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -2521,7 +2521,7 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -2545,7 +2545,7 @@ public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expecte
     }
 }
 
-public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -2557,7 +2557,7 @@ public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -2589,7 +2589,7 @@ public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expect
     }
 }
 
-public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k):
@@ -2599,7 +2599,7 @@ public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -2627,7 +2627,7 @@ public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
 }
 
 // QOI: We can do better here. We should also flag x2
-public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -2641,7 +2641,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expec
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
@@ -2677,7 +2677,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) 
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k)
@@ -2690,7 +2690,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expe
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where boolValue:
@@ -2731,8 +2731,8 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 /////////////////////////////
 
 public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
     let f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consuming use here}}
@@ -2744,7 +2744,7 @@ public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
 }
 
 public func closureLetClassUseAfterConsume2(_ argX: borrowing Klass) {
-    let f = { (_ x: borrowing Klass) in // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let f = { (_ x: borrowing Klass) in // expected-error {{'x' is borrowed and cannot be consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
                    // expected-note @-1 {{consuming use here}}
         borrowVal(x2)
@@ -2755,7 +2755,7 @@ public func closureLetClassUseAfterConsume2(_ argX: borrowing Klass) {
 }
 
 public func closureLetClassUseAfterConsumeArg(_ argX: borrowing Klass) {
-    let f = { (_ x2: borrowing Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    let f = { (_ x2: borrowing Klass) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2764,8 +2764,8 @@ public func closureLetClassUseAfterConsumeArg(_ argX: borrowing Klass) {
 }
 
 public func closureLetCaptureClassUseAfterConsume(_ x: consuming Klass) {
-    let x2 = x // expected-error {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    let x2 = x // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2774,10 +2774,10 @@ public func closureLetCaptureClassUseAfterConsume(_ x: consuming Klass) {
     f()
 }
 
-public func closureLetCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}} 
     x2 = x  // expected-note {{consuming use here}}
 
     let f = {
@@ -2802,7 +2802,7 @@ public func closureLetCaptureClassUseAfterConsume2(_ x2: inout Klass) {
 // TODO: We are considering this to be an escaping use.
 public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     func useClosure(_ x: () -> ()) {}
 
     useClosure {
@@ -2814,10 +2814,10 @@ public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
 }
 
 
-public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2829,8 +2829,8 @@ public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { /
 }
 
 public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2840,8 +2840,8 @@ public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
 }
 
 public func closureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2852,7 +2852,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
 
 public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}} 
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2863,8 +2863,8 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass
 }
 
 public func closureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2878,7 +2878,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) 
 public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    // expected-error @-3 {{missing reinitialization of 'x2' after consume}} 
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2897,8 +2897,8 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
 /////////////////////////////
 
 public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
     var f = {}
     f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
@@ -2912,7 +2912,7 @@ public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
 
 public func closureVarClassUseAfterConsume2(_ argX: borrowing Klass) {
     var f = {(_ x: borrowing Klass) in }
-    f = { (_ x: borrowing Klass) in // expected-error {{'x' has guaranteed ownership but was consumed}}
+    f = { (_ x: borrowing Klass) in // expected-error {{'x' is borrowed and cannot be consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consuming use here}}
         borrowVal(x2)
@@ -2924,7 +2924,7 @@ public func closureVarClassUseAfterConsume2(_ argX: borrowing Klass) {
 
 public func closureVarClassUseAfterConsumeArg(_ argX: borrowing Klass) {
     var f = {(_ x2: borrowing Klass) in}
-    f = { (_ x2: borrowing Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    f = { (_ x2: borrowing Klass) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2932,26 +2932,26 @@ public func closureVarClassUseAfterConsumeArg(_ argX: borrowing Klass) {
     f(argX)
 }
 
-public func closureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
 
-public func closureVarCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x  // expected-note {{consuming use here}}
 
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
@@ -2980,7 +2980,7 @@ public func closureVarCaptureClassUseAfterConsume3(_ x2: inout Klass) {
 
 public func closureVarCaptureClassUseAfterConsume4(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     func useClosure(_ x: () -> ()) {}
 
     useClosure {
@@ -2992,22 +2992,22 @@ public func closureVarCaptureClassUseAfterConsume4(_ x2: inout Klass) {
 }
 
 
-public func closureVarCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     let _ = x3
 }
 
 public func closureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = { // expected-note {{closure capture here}}
         borrowVal(x2)
@@ -3021,8 +3021,8 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
@@ -3031,8 +3031,8 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
@@ -3041,11 +3041,11 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) 
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     let _ = x3
 }
 
@@ -3053,12 +3053,12 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     x2 = Klass()
     let _ = x3
 }
@@ -3067,9 +3067,9 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
 // MARK: Defer Tests //
 ///////////////////////
 
-public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     defer {
         borrowVal(x2)
         // TODO: Defer can only run once, so this error shouldn't occur.
@@ -3079,10 +3079,10 @@ public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected
     consumeVal(x) // expected-note {{consuming use here}}
 }
 
-public func deferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     // expected-error @-3 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -3094,7 +3094,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expecte
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     borrowVal(x2)
     defer {
         borrowVal(x2)
@@ -3105,7 +3105,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -3115,7 +3115,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     defer {
         borrowVal(x2)
@@ -3127,7 +3127,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     // expected-error @-2 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -3138,7 +3138,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
@@ -3154,9 +3154,9 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
 // MARK: Defer and Let Closure //
 /////////////////////////////////
 
-public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3168,11 +3168,11 @@ public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
     f()
 }
 
-public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     // TODO: This is wrong
-    let x2 = x // expected-error {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    let x2 = x // expected-error {{captured 'x2' cannot be consumed within a closure}}
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -3186,11 +3186,11 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 }
 
 // TODO: MG
-public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-3 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -3205,8 +3205,8 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
 }
 
 public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         defer {
             borrowVal(x2)
@@ -3219,7 +3219,7 @@ public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
 }
 
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3232,7 +3232,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
 }
 
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         defer {
@@ -3248,7 +3248,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
 
 // TODO: MG
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3263,7 +3263,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
 
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3281,10 +3281,10 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
 // MARK: Multiple Levels of Let Closures //
 ///////////////////////////////////////////
 
-public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -3296,11 +3296,11 @@ public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
     f()
 }
 
-public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-3 {{captured 'x2' cannot be consumed within a closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
 
     let f = {
@@ -3317,11 +3317,11 @@ public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
     _ = x3
 }
 
-public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-4 {{'x2' consumed more than once}}
     x2 = x
     // expected-note @-1 {{consuming use here}}
@@ -3342,9 +3342,9 @@ public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
 }
 
 public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         let g = { // expected-note {{closure capture here}}
             borrowVal(x2)
@@ -3357,8 +3357,8 @@ public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing K
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -3372,7 +3372,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}} 
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}} 
     let f = {
         let g = {
             borrowVal(x2)
@@ -3386,8 +3386,8 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -3401,7 +3401,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         let g = {
@@ -3417,7 +3417,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     let f = {
@@ -3438,9 +3438,9 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consu
 // MARK: Defer and Var Closure //
 /////////////////////////////////
 
-public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     var f = {}
     f = {
         defer {
@@ -3453,12 +3453,12 @@ public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
     f()
 }
 
-public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
+    let x2 = x // expected-error {{captured 'x2' cannot be consumed within a closure}}
     // expected-note @-1 {{consuming use here}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3470,13 +3470,13 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 }
 
 // TODO: MG
-public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3485,12 +3485,12 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
         defer {
@@ -3504,7 +3504,7 @@ public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     var f = {}
     f = {
         defer {
@@ -3518,7 +3518,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     var f = {}
     f = {
@@ -3535,7 +3535,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
 
 // TODO: MG
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     var f = {}
     f = {
         defer {
@@ -3546,12 +3546,12 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var f = {}
     f = {
         defer {
@@ -3563,30 +3563,30 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 ///////////////////////////////////////////
 // MARK: Multiple Levels of Var Closures //
 ///////////////////////////////////////////
 
-public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = {
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
 
-public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
 
@@ -3595,18 +3595,18 @@ public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
-public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
     // expected-note @-1 {{consuming use here}}
     x2 = x
@@ -3617,21 +3617,21 @@ public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
 public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
         var g = {}
@@ -3651,8 +3651,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3665,8 +3665,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3679,13 +3679,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3694,35 +3694,35 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 /////////////////////////////////
 // MARK: Var and Let Functions //
 /////////////////////////////////
 
-public func closureVarAndClosureLetCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureLetCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var f = {}
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
 
-public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
 
@@ -3730,18 +3730,18 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing K
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
-public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
     // expected-note @-1 {{consuming use here}}
     x2 = x
@@ -3751,21 +3751,21 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing K
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
 public func closureVarAndClosureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
 let g = {// expected-note {{closure capture here}}
@@ -3783,8 +3783,8 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __o
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3796,8 +3796,8 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: co
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3809,13 +3809,13 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3823,31 +3823,31 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: co
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
-public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let f = {
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
 }
 
-public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
 
@@ -3856,21 +3856,21 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing K
             var g = {}
             g = {
                 borrowVal(x2)
-                consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-                consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+                consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+                consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
             }
             g()
         }
         h()
-        consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
-public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
     // expected-note @-1 {{consuming use here}}
     x2 = x
@@ -3880,21 +3880,21 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing K
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-    let x3 = x2 // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
     _ = x3
 }
 
 public func closureLetAndClosureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = {// expected-note {{closure capture here}}
         var g = {}
         g = {// expected-note {{closure capture here}}
@@ -3912,8 +3912,8 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume(_ x2: __o
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3925,8 +3925,8 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume2(_ x2: co
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
@@ -3938,13 +3938,13 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume3(_ x2: __
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3952,13 +3952,13 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: co
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
-            consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
 }
 
 ///////////////////////////////////
@@ -4098,12 +4098,12 @@ func testEmptyStruct() {
   }
 
   func testGuaranteedArg2(_ x: borrowing EmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     consume(x) // expected-note {{consuming use here}}
   }
 
   func testGuaranteedArg3(_ x: borrowing EmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let _ = x // expected-note {{consuming use here}}
   }
 
@@ -4112,7 +4112,7 @@ func testEmptyStruct() {
   }
 
   func testGuaranteedArg5(_ x: borrowing EmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let y = x // expected-note {{consuming use here}}
     _ = y
   }
@@ -4122,12 +4122,12 @@ func testEmptyStruct() {
   }
 
   func testGuaranteedArg7(_ x: borrowing EmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     x.doSomething3() // expected-note {{consuming use here}}
   }
 
   func testGuaranteedArg7a(_ x: borrowing EmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     x.doSomething3() // expected-note {{consuming use here}}
     x.doSomething3() // expected-note {{consuming use here}}
   }
@@ -4153,12 +4153,12 @@ func testStructContainingEmptyStruct() {
   }
 
   func testGuaranteedArg2(_ x: borrowing StructContainingEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     consume(x) // expected-note {{consuming use here}}
   }
 
   func testGuaranteedArg3(_ x: borrowing StructContainingEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let _ = x // expected-note {{consuming use here}}
   }
 
@@ -4167,7 +4167,7 @@ func testStructContainingEmptyStruct() {
   }
 
   func testGuaranteedArg5(_ x: borrowing StructContainingEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let y = x // expected-note {{consuming use here}}
     _ = y
   }
@@ -4177,13 +4177,13 @@ func testStructContainingEmptyStruct() {
   }
 
   func testGuaranteedArg7(_ x: borrowing StructContainingEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     x.x.doSomething3() // expected-note {{consuming use here}}
   }
 
   func testGuaranteedArg7a(_ x: borrowing StructContainingEmptyStruct) {
-    // expected-error @-1 {{'x' has a move only field that was consumed before later uses}}
-    x.x.doSomething3() // expected-note {{consuming use here}}
+    // expected-error @-1 {{cannot use 'x' after partial consume}}
+    x.x.doSomething3() // expected-note {{partial consume here}}
     x.x.doSomething3() // expected-note {{boundary use here}}
   }
 }
@@ -4209,12 +4209,12 @@ func testStructContainingTwoEmptyStruct() {
   }
 
   func testGuaranteedArg2(_ x: borrowing StructContainingTwoEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     consume(x) // expected-note {{consuming use here}}
   }
 
   func testGuaranteedArg3(_ x: borrowing StructContainingTwoEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let _ = x // expected-note {{consuming use here}}
   }
 
@@ -4223,7 +4223,7 @@ func testStructContainingTwoEmptyStruct() {
   }
 
   func testGuaranteedArg5(_ x: borrowing StructContainingTwoEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let y = x // expected-note {{consuming use here}}
     _ = y
   }
@@ -4233,12 +4233,12 @@ func testStructContainingTwoEmptyStruct() {
   }
 
   func testGuaranteedArg7(_ x: borrowing StructContainingTwoEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     x.x.doSomething3() // expected-note {{consuming use here}}
   }
 
   func testGuaranteedArg8(_ x: borrowing StructContainingTwoEmptyStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     x.y.doSomething3() // expected-note {{consuming use here}}
   }
 }
@@ -4261,13 +4261,13 @@ case third(MyEnum2)
 }
 
 func testMyEnum() {
-  func test1(_ x: borrowing MyEnum) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+  func test1(_ x: borrowing MyEnum) { // expected-error {{'x' is borrowed and cannot be consumed}}
     if case let .first(y) = x { // expected-note {{consuming use here}}
       _ = y
     }
   }
 
-  func test2(_ x: borrowing MyEnum) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+  func test2(_ x: borrowing MyEnum) { // expected-error {{'x' is borrowed and cannot be consumed}}
     if case let .third(.first(y)) = x { // expected-note {{consuming use here}}
       _ = y
     }

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2732,7 +2732,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 
 public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     let f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consuming use here}}
@@ -2764,8 +2764,8 @@ public func closureLetClassUseAfterConsumeArg(_ argX: borrowing Klass) {
 }
 
 public func closureLetCaptureClassUseAfterConsume(_ x: consuming Klass) {
-    let x2 = x // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    let x2 = x // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2816,8 +2816,8 @@ public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
 
 public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2829,7 +2829,7 @@ public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { /
 }
 
 public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         borrowVal(x2)
@@ -2840,8 +2840,8 @@ public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
 }
 
 public func closureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2863,8 +2863,8 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass
 }
 
 public func closureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2898,7 +2898,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
 
 public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    // expected-error @-2 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     var f = {}
     f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
@@ -2937,8 +2937,8 @@ public func closureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // exp
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -2950,8 +2950,8 @@ public func closureVarCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // ex
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -2997,16 +2997,16 @@ public func closureVarCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { /
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let _ = x3
 }
 
 public func closureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = { // expected-note {{closure capture here}}
@@ -3021,8 +3021,8 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3031,8 +3031,8 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3041,11 +3041,11 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) 
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let _ = x3
 }
 
@@ -3053,12 +3053,12 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
     var f = {}
     f = { 
         borrowVal(x2)
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     x2 = Klass()
     let _ = x3
 }
@@ -3069,7 +3069,7 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
 
 public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
         // TODO: Defer can only run once, so this error shouldn't occur.
@@ -3082,7 +3082,7 @@ public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected
 public func deferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -3094,7 +3094,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expecte
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     borrowVal(x2)
     defer {
         borrowVal(x2)
@@ -3105,7 +3105,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -3127,7 +3127,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -3156,7 +3156,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
 
 public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3170,9 +3170,9 @@ public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
 
 public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     // TODO: This is wrong
-    let x2 = x // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x2 = x // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -3189,8 +3189,8 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-3 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-3 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -3205,7 +3205,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
 }
 
 public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         defer {
@@ -3219,7 +3219,7 @@ public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
 }
 
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3248,7 +3248,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
 
 // TODO: MG
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3283,8 +3283,8 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
 
 public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -3299,8 +3299,8 @@ public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
 public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-3 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-3 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
 
     let f = {
@@ -3342,7 +3342,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
 }
 
 public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
@@ -3357,8 +3357,8 @@ public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing K
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -3386,8 +3386,8 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -3440,7 +3440,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consu
 
 public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         defer {
@@ -3454,11 +3454,11 @@ public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
 }
 
 public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    let x2 = x // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-note @-1 {{consuming use here}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3473,10 +3473,10 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -3485,11 +3485,11 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
     f = {// expected-note {{closure capture here}}
@@ -3504,7 +3504,7 @@ public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         defer {
@@ -3535,7 +3535,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
 
 // TODO: MG
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         defer {
@@ -3546,7 +3546,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3563,7 +3563,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
         print("foo")
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 ///////////////////////////////////////////
@@ -3577,11 +3577,11 @@ public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3595,14 +3595,14 @@ public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
@@ -3617,19 +3617,19 @@ public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
 public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
@@ -3651,8 +3651,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3665,8 +3665,8 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3679,13 +3679,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3694,13 +3694,13 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 /////////////////////////////////
@@ -3713,11 +3713,11 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume(_ x: borrowing Kl
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3730,14 +3730,14 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing K
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
@@ -3751,19 +3751,19 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing K
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
 public func closureVarAndClosureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
@@ -3783,8 +3783,8 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __o
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3796,8 +3796,8 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: co
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3809,13 +3809,13 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3823,13 +3823,13 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: co
     f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -3838,11 +3838,11 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Kl
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
 }
@@ -3856,17 +3856,17 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing K
             var g = {}
             g = {
                 borrowVal(x2)
-                consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-                consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+                consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+                consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
             }
             g()
         }
         h()
-        consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+        consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
@@ -3880,19 +3880,19 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing K
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-    let x3 = x2 // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    let x3 = x2 // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     _ = x3
 }
 
 public func closureLetAndClosureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = {// expected-note {{closure capture here}}
@@ -3912,8 +3912,8 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume(_ x2: __o
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3925,8 +3925,8 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume2(_ x2: co
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
@@ -3938,13 +3938,13 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume3(_ x2: __
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
@@ -3952,13 +3952,13 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: co
         var g = {}
         g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
-            consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+            consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-error {{captured 'x2' cannot be consumed within a closure}}
+    consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
 }
 
 ///////////////////////////////////

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2777,7 +2777,7 @@ public func closureLetCaptureClassUseAfterConsume(_ x: consuming Klass) {
 public func closureLetCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}} 
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}} 
     x2 = x  // expected-note {{consuming use here}}
 
     let f = {
@@ -2802,7 +2802,7 @@ public func closureLetCaptureClassUseAfterConsume2(_ x2: inout Klass) {
 // TODO: We are considering this to be an escaping use.
 public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     func useClosure(_ x: () -> ()) {}
 
     useClosure {
@@ -2852,7 +2852,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
 
 public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}} 
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}} 
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2878,7 +2878,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) 
 public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{missing reinitialization of 'x2' after consume}} 
+    // expected-error @-3 {{missing reinitialization of inout parameter 'x2' after consume}} 
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2980,7 +2980,7 @@ public func closureVarCaptureClassUseAfterConsume3(_ x2: inout Klass) {
 
 public func closureVarCaptureClassUseAfterConsume4(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     func useClosure(_ x: () -> ()) {}
 
     useClosure {
@@ -3115,7 +3115,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     defer {
         borrowVal(x2)
@@ -3138,7 +3138,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
@@ -3232,7 +3232,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
 }
 
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         defer {
@@ -3263,7 +3263,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
 
 public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     let f = {
         defer {
             borrowVal(x2)
@@ -3321,7 +3321,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
     var x2 = x
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-3 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-4 {{'x2' consumed more than once}}
     x2 = x
     // expected-note @-1 {{consuming use here}}
@@ -3372,7 +3372,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}} 
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}} 
     let f = {
         let g = {
             borrowVal(x2)
@@ -3401,7 +3401,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         let g = {
@@ -3417,7 +3417,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
 }
 
 public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     let f = {
@@ -3518,7 +3518,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
 }
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     var f = {}
     f = {
@@ -3551,7 +3551,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
 
 public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var f = {}
     f = {
         defer {

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -48,17 +48,17 @@ public final class FinalKlass {
 /////////////////
 
 public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
                // expected-error @-1 {{'x2' consumed more than once}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consuming use here}}
+    let k3 = x2 // expected-note {{consumed here}}
     let _ = k3
     borrowVal(k2)
 }
 
 public func classSimpleChainArgTest(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -76,7 +76,7 @@ public func classSimpleChainOwnedArgTest2(_ x2: consuming Klass) {
 }
 
 public func classSimpleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -93,7 +93,7 @@ public func classSimpleNonConsumingUseOwnedArgTest2(_ x2: consuming Klass) {
 }
 
 public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -102,7 +102,7 @@ public func classMultipleNonConsumingUseTest(_ x: borrowing Klass) { // expected
 public func classMultipleNonConsumingUseArgTest(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classMultipleNonConsumingUseOwnedArgTest(_ x2: __owned Klass) {
@@ -119,80 +119,80 @@ public func classMultipleNonConsumingUseOwnedArgTest2(_ x2: consuming Klass) {
 
 public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classUseAfterConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classUseAfterConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classUseAfterConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func classLoopConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func classLoopConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func classLoopConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func classLoopConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func classLoopConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -202,9 +202,9 @@ public func classDiamond(_ x: borrowing Klass) { // expected-error {{'x' is borr
 
 public func classDiamondArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -225,15 +225,15 @@ public func classDiamondOwnedArg2(_ x2: consuming Klass) {
 }
 
 public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-    // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -241,51 +241,51 @@ public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' i
 public func classDiamondInLoopArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func classDiamondInLoopOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func classDiamondInLoopOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar1Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                 // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
@@ -294,135 +294,135 @@ public func classAssignToVar1Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { 
 // with move only var.
 public func classAssignToVar1OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar1OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func classAssignToVar2Arg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func classAssignToVar2OwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func classAssignToVar2OwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 // NOTE: consumeVal(x3) should not be marked.
 public func classAssignToVar3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 // NOTE: consumeVal(x3) is a bug.
 public func classAssignToVar3Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar3OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar3OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4Arg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4OwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4OwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar5(_ x: borrowing Klass) {  // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-    // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar5Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     borrowVal(x2)
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar5OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar5OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x2' used after consume}}
                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func classAccessAccessField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.k)
     for _ in 0..<1024 {
         borrowVal(x2.k)
@@ -451,7 +451,7 @@ public func classAccessAccessFieldOwnedArg2(_ x2: consuming Klass) {
 }
 
 public func classAccessConsumeField(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
@@ -481,7 +481,7 @@ public func classAccessConsumeFieldOwnedArg2(_ x2: consuming Klass) {
 
 extension Klass {
     func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
     }
 }
@@ -491,14 +491,14 @@ extension Klass {
 /////////////////
 
 public func finalClassSimpleChainTest(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func finalClassSimpleChainTestArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -516,7 +516,7 @@ public func finalClassSimpleChainTestOwnedArg2(_ x2: consuming FinalKlass) {
 }
 
 public func finalClassSimpleNonConsumingUseTest(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -533,7 +533,7 @@ public func finalClassSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming FinalKl
 }
 
 public func finalClassMultipleNonConsumingUseTest(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -542,7 +542,7 @@ public func finalClassMultipleNonConsumingUseTest(_ x: borrowing FinalKlass) { /
 public func finalClassMultipleNonConsumingUseTestArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassMultipleNonConsumingUseTestownedArg(_ x2: __owned FinalKlass) {
@@ -559,80 +559,80 @@ public func finalClassMultipleNonConsumingUseTestownedArg2(_ x2: consuming Final
 
 public func finalClassUseAfterConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsumeOwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsumeOwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsumeownedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsumeownedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassLoopConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func finalClassLoopConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func finalClassLoopConsumeOwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func finalClassLoopConsumeOwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func finalClassLoopConsumeOwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func finalClassLoopConsumeOwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func finalClassDiamond(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -642,9 +642,9 @@ public func finalClassDiamond(_ x: borrowing FinalKlass) { // expected-error {{'
 
 public func finalClassDiamondArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -666,14 +666,14 @@ public func finalClassDiamondOwnedArg2(_ x2: consuming FinalKlass) {
 
 public func finalClassDiamondInLoop(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -681,183 +681,183 @@ public func finalClassDiamondInLoop(_ x: borrowing FinalKlass) { // expected-err
 public func finalClassDiamondInLoopArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func finalClassDiamondInLoopOwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func finalClassDiamondInLoopOwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func finalClassAssignToVar1(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar1Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar1OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar1OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar2(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func finalClassAssignToVar2Arg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func finalClassAssignToVar2OwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func finalClassAssignToVar2OwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func finalClassAssignToVar3(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar3Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar3OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar3OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar4(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar4Arg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar4OwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar4OwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5Arg(_ x: borrowing FinalKlass, _ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                                            // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     borrowVal(x2)
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' used after consume}}
                                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar5OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x2' used after consume}}
                                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func finalClassAccessField(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.k)
     for _ in 0..<1024 {
         borrowVal(x2.k)
@@ -886,7 +886,7 @@ public func finalClassAccessFieldOwnedArg2(_ x2: consuming FinalKlass) {
 }
 
 public func finalClassConsumeField(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-error {{cannot consume noncopyable stored property 'x2.k' of a class}}
@@ -937,14 +937,14 @@ public struct AggStruct {
 }
 
 public func aggStructSimpleChainTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func aggStructSimpleChainTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -962,7 +962,7 @@ public func aggStructSimpleChainTestOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructSimpleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -979,7 +979,7 @@ public func aggStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStruc
 }
 
 public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -988,7 +988,7 @@ public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // 
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct) {
@@ -1005,80 +1005,80 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStr
 
 public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggStructLoopConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggStructLoopConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -1088,9 +1088,9 @@ public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x'
 
 public func aggStructDiamondArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1112,14 +1112,14 @@ public func aggStructDiamondOwnedArg2(_ x2: consuming AggStruct) {
 
 public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1127,39 +1127,39 @@ public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error
 public func aggStructDiamondInLoopArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggStructDiamondInLoopOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggStructAccessField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -1188,47 +1188,47 @@ public func aggStructAccessFieldOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    let x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeFieldArg(_ x2: borrowing AggStruct) {
     // expected-error @-1 {{cannot use 'x2' after partial consume}}
     // expected-error @-2 {{cannot use 'x2' after partial consume}}
-    consumeVal(x2.lhs) // expected-note {{partial consume here}}
+    consumeVal(x2.lhs) // expected-note {{partially consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{partial consume here}}
+        consumeVal(x2.lhs) // expected-note {{partially consumed here}}
     }
 }
 
 public func aggStructConsumeFieldOwnedArg(_ x2: __owned AggStruct) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeFieldOwnedArg2(_ x2: consuming AggStruct) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructAccessGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -1257,42 +1257,42 @@ public func aggStructAccessGrandFieldOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    let x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: borrowing AggStruct) {
     // expected-error @-1 {{cannot use 'x2' after partial consume}}
     // expected-error @-2 {{cannot use 'x2' after partial consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
+    consumeVal(x2.pair.lhs) // expected-note {{partially consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
+        consumeVal(x2.pair.lhs) // expected-note {{partially consumed here}}
     }
 }
 
 public func aggStructConsumeGrandFieldOwnedArg(_ x2: __owned AggStruct) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggStruct) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
@@ -1319,9 +1319,9 @@ public func aggStructConsumeFieldError(_ x2: __owned AggStruct) {
     if boolValue {
         consumeVal(x2.lhs)
     } else {
-        consumeVal(x2.pair.rhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.rhs) // expected-note {{consumed here}}
     }
-    borrowVal(x2.pair) // expected-note {{non-consuming use here}}
+    borrowVal(x2.pair) // expected-note {{used here}}
 }
 
 public func aggStructConsumeFieldError2(_ x2: consuming AggStruct) {
@@ -1329,35 +1329,35 @@ public func aggStructConsumeFieldError2(_ x2: consuming AggStruct) {
     if boolValue {
         consumeVal(x2.lhs)
     } else {
-        consumeVal(x2.pair.rhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.rhs) // expected-note {{consumed here}}
     }
-    borrowVal(x2.pair) // expected-note {{non-consuming use here}}
+    borrowVal(x2.pair) // expected-note {{used here}}
 }
 
 public func aggStructConsumeFieldError3(_ x2: __owned AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if boolValue {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2.pair.rhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.rhs) // expected-note {{consumed here}}
     }
     consumeVal(x2)
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 }
 
 public func aggStructConsumeFieldError4(_ x2: __owned AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if boolValue {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2.pair.rhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.rhs) // expected-note {{consumed here}}
     }
     consumeVal(x2)
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 }
 
 //////////////////////////////
@@ -1372,14 +1372,14 @@ public struct AggGenericStruct<T> { // FIXME: for better test coverage this shou
 }
 
 public func aggGenericStructSimpleChainTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1397,7 +1397,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2(_ x2: consuming AggGenericS
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -1414,7 +1414,7 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming A
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -1423,7 +1423,7 @@ public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGeneri
 public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggGenericStruct<String>) {
@@ -1440,80 +1440,80 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming
 
 public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -1523,9 +1523,9 @@ public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<String>) { /
 
 public func aggGenericStructDiamondArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1547,14 +1547,14 @@ public func aggGenericStructDiamondOwnedArg2(_ x2: consuming AggGenericStruct<St
 
 public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1562,39 +1562,39 @@ public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<String
 public func aggGenericStructDiamondInLoopArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructAccessField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -1623,47 +1623,47 @@ public func aggGenericStructAccessFieldOwnedArg2(_ x2: consuming AggGenericStruc
 }
 
 public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    let x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: borrowing AggGenericStruct<String>) {
     // expected-error @-1 {{cannot use 'x2' after partial consume}}
     // expected-error @-2 {{cannot use 'x2' after partial consume}}
-    consumeVal(x2.lhs) // expected-note {{partial consume here}}
+    consumeVal(x2.lhs) // expected-note {{partially consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{partial consume here}}
+        consumeVal(x2.lhs) // expected-note {{partially consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldOwnedArg2(_ x2: consuming AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructAccessGrandField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -1692,42 +1692,42 @@ public func aggGenericStructAccessGrandFieldOwnedArg2(_ x2: consuming AggGeneric
 }
 
 public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    let x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: borrowing AggGenericStruct<String>) {
     // expected-error @-1 {{cannot use 'x2' after partial consume}}
     // expected-error @-2 {{cannot use 'x2' after partial consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
+    consumeVal(x2.pair.lhs) // expected-note {{partially consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
+        consumeVal(x2.pair.lhs) // expected-note {{partially consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
@@ -1736,14 +1736,14 @@ public func aggGenericStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggGeneri
 ////////////////////////////////////////////////////////////
 
 public func aggGenericStructSimpleChainTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1761,7 +1761,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2<T>(_ x2: consuming AggGener
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -1778,7 +1778,7 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2<T>(_ x2: consumin
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -1787,7 +1787,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGen
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { //expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
@@ -1804,80 +1804,80 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2<T>(_ x2: consum
 
 public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -1887,9 +1887,9 @@ public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // 
 
 public func aggGenericStructDiamondArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1911,14 +1911,14 @@ public func aggGenericStructDiamondOwnedArg2<T>(_ x2: consuming AggGenericStruct
 
 public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1926,39 +1926,39 @@ public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>)
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructAccessField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -1987,47 +1987,47 @@ public func aggGenericStructAccessFieldOwnedArg2<T>(_ x2: consuming AggGenericSt
 }
 
 public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    let x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: borrowing AggGenericStruct<T>) {
     // expected-error @-1 {{cannot use 'x2' after partial consume}}
     // expected-error @-2 {{cannot use 'x2' after partial consume}}
-    consumeVal(x2.lhs) // expected-note {{partial consume here}}
+    consumeVal(x2.lhs) // expected-note {{partially consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{partial consume here}}
+        consumeVal(x2.lhs) // expected-note {{partially consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructAccessGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -2056,42 +2056,42 @@ public func aggGenericStructAccessGrandFieldOwnedArg2<T>(_ x2: consuming AggGene
 }
 
 public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    let x2 = x // expected-note {{consumed here}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: borrowing AggGenericStruct<T>) {
     // expected-error @-1 {{cannot use 'x2' after partial consume}}
     // expected-error @-2 {{cannot use 'x2' after partial consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
+    consumeVal(x2.pair.lhs) // expected-note {{partially consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{partial consume here}}
+        consumeVal(x2.pair.lhs) // expected-note {{partially consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
@@ -2108,14 +2108,14 @@ public enum EnumTy {
 }
 
 public func enumSimpleChainTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func enumSimpleChainTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -2133,7 +2133,7 @@ public func enumSimpleChainTestOwnedArg2(_ x2: consuming EnumTy) {
 }
 
 public func enumSimpleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -2150,7 +2150,7 @@ public func enumSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
 }
 
 public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -2159,7 +2159,7 @@ public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected
 public func enumMultipleNonConsumingUseTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumMultipleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
@@ -2176,80 +2176,80 @@ public func enumMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
 
 public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func enumLoopConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumLoopConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -2259,9 +2259,9 @@ public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' is borr
 
 public func enumDiamondArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -2283,14 +2283,14 @@ public func enumDiamondOwnedArg2(_ x2: consuming EnumTy) {
 
 public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -2298,224 +2298,224 @@ public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' i
 public func enumDiamondInLoopArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func enumDiamondInLoopOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                              // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar1OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar3(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar3Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                              // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar3OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar3OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                              // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     borrowVal(x2)
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -2523,23 +2523,23 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
 
 public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -2547,18 +2547,18 @@ public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expecte
 
 public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    switch x2 { // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -2570,27 +2570,27 @@ public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-err
 }
 
 public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     switch x2 {
     case let .klass(k):
         borrowVal(k)
@@ -2600,7 +2600,7 @@ public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -2629,10 +2629,10 @@ public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
 // QOI: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    switch x2 { // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -2642,7 +2642,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expec
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -2654,9 +2654,9 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // e
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -2666,9 +2666,9 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -2678,7 +2678,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) 
 }
 
 public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     switch x2 {
     case let .klass(k)
            where boolValue:
@@ -2691,7 +2691,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expe
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -2733,12 +2733,12 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
-    let f = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x' here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
-        // expected-note @-1 {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -2746,10 +2746,10 @@ public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
 public func closureLetClassUseAfterConsume2(_ argX: borrowing Klass) {
     let f = { (_ x: borrowing Klass) in // expected-error {{'x' is borrowed and cannot be consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
-                   // expected-note @-1 {{consuming use here}}
+                   // expected-note @-1 {{consumed here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
@@ -2757,8 +2757,8 @@ public func closureLetClassUseAfterConsume2(_ argX: borrowing Klass) {
 public func closureLetClassUseAfterConsumeArg(_ argX: borrowing Klass) {
     let f = { (_ x2: borrowing Klass) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
@@ -2768,23 +2768,23 @@ public func closureLetCaptureClassUseAfterConsume(_ x: consuming Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
 
 public func closureLetCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}} 
-    x2 = x  // expected-note {{consuming use here}}
+    x2 = x  // expected-note {{consumed here}}
 
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
 }
@@ -2807,21 +2807,21 @@ public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
 
     useClosure {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 
 public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
     let x3 = x2
@@ -2831,10 +2831,10 @@ public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { /
 public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    let f = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x2' here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -2844,8 +2844,8 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -2855,9 +2855,9 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}} 
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
 }
@@ -2867,8 +2867,8 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) 
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
     let x3 = x2
@@ -2881,13 +2881,13 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
     // expected-error @-3 {{missing reinitialization of inout parameter 'x2' after consume}} 
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     x2 = Klass()
     let _ = x3
 }
@@ -2900,12 +2900,12 @@ public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     var f = {}
-    f = { // expected-note {{closure capture here}}
+    f = { // expected-note {{closure capturing 'x' here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
-        // expected-note @-1 {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -2914,10 +2914,10 @@ public func closureVarClassUseAfterConsume2(_ argX: borrowing Klass) {
     var f = {(_ x: borrowing Klass) in }
     f = { (_ x: borrowing Klass) in // expected-error {{'x' is borrowed and cannot be consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
-        // expected-note @-1 {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
@@ -2926,14 +2926,14 @@ public func closureVarClassUseAfterConsumeArg(_ argX: borrowing Klass) {
     var f = {(_ x2: borrowing Klass) in}
     f = { (_ x2: borrowing Klass) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
 
 public func closureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var f = {}
     f = { 
         borrowVal(x2)
@@ -2944,8 +2944,8 @@ public func closureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // exp
 }
 
 public func closureVarCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    var x2 = x // expected-note {{consuming use here}}
-    x2 = x  // expected-note {{consuming use here}}
+    var x2 = x // expected-note {{consumed here}}
+    x2 = x  // expected-note {{consumed here}}
 
     var f = {}
     f = { 
@@ -2985,15 +2985,15 @@ public func closureVarCaptureClassUseAfterConsume4(_ x2: inout Klass) {
 
     useClosure {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 
 public func closureVarCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var f = {}
     f = { 
         borrowVal(x2)
@@ -3009,10 +3009,10 @@ public func closureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
-    f = { // expected-note {{closure capture here}}
+    f = { // expected-note {{closure capturing 'x2' here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -3068,28 +3068,28 @@ public func closureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
 ///////////////////////
 
 public func deferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
         // TODO: Defer can only run once, so this error shouldn't occur.
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
-    consumeVal(x) // expected-note {{consuming use here}}
+    consumeVal(x) // expected-note {{consumed here}}
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
@@ -3098,8 +3098,8 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     borrowVal(x2)
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     print("foo")
 }
@@ -3108,8 +3108,8 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     print("foo")
 }
@@ -3119,9 +3119,9 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
     // expected-error @-2 {{'x2' consumed more than once}}
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     print("foo")
 }
@@ -3129,25 +3129,25 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
 public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 /////////////////////////////////
@@ -3155,13 +3155,13 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
 /////////////////////////////////
 
 public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3171,14 +3171,14 @@ public func closureLetAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
 public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     // TODO: This is wrong
     let x2 = x // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3188,15 +3188,15 @@ public func closureLetAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 // TODO: MG
 public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3207,11 +3207,11 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
 public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    let f = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x2' here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3223,8 +3223,8 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3237,9 +3237,9 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3252,8 +3252,8 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3267,9 +3267,9 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3282,14 +3282,14 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
 ///////////////////////////////////////////
 
 public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3298,7 +3298,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
 
 public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
@@ -3306,38 +3306,38 @@ public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
     _ = x3
 }
 
 public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-4 {{'x2' consumed more than once}}
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
     _ = x3
 }
 
@@ -3345,11 +3345,11 @@ public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing K
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    let f = { // expected-note {{closure capture here}}
-        let g = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x2' here}}
+        let g = { // expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3362,8 +3362,8 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owne
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3376,9 +3376,9 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -3391,8 +3391,8 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __own
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3406,9 +3406,9 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -3423,15 +3423,15 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consu
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    f() // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    f() // expected-note {{used here}}
 }
 
 /////////////////////////////////
@@ -3439,14 +3439,14 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consu
 /////////////////////////////////
 
 public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3455,14 +3455,14 @@ public func closureVarAndDeferCaptureClassUseAfterConsume(_ x: borrowing Klass) 
 
 public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     var f = {}
     f = {
         consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3472,15 +3472,15 @@ public func closureVarAndDeferCaptureClassUseAfterConsume2(_ x: borrowing Klass)
 // TODO: MG
 public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     var f = {}
     f = {
         consumeVal(x2) // expected-error {{noncopyable 'x2' cannot be consumed when captured by a closure}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3492,11 +3492,11 @@ public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Kla
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
-    f = {// expected-note {{closure capture here}}
+    f = {// expected-note {{closure capturing 'x2' here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3509,8 +3509,8 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned 
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3524,9 +3524,9 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3540,8 +3540,8 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         print("foo")
     }
@@ -3556,9 +3556,9 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
     f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         print("foo")
     }
@@ -3571,7 +3571,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
 ///////////////////////////////////////////
 
 public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var f = {}
     f = {
         var g = {}
@@ -3588,7 +3588,7 @@ public func closureVarAndClosureCaptureClassUseAfterConsume(_ x: borrowing Klass
 
 public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     var f = {}
     f = {
@@ -3608,9 +3608,9 @@ public func closureVarAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
 
 public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     var f = {}
     f = {
@@ -3633,12 +3633,12 @@ public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing K
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
-    f = {// expected-note {{closure capture here}}
+    f = {// expected-note {{closure capturing 'x2' here}}
         var g = {}
-        g = {// expected-note {{closure capture here}}
+        g = {// expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3708,7 +3708,7 @@ public func closureVarAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
 /////////////////////////////////
 
 public func closureVarAndClosureLetCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var f = {}
     f = {
         let g = {
@@ -3724,7 +3724,7 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume(_ x: borrowing Kl
 
 public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     var f = {}
     f = {
@@ -3743,9 +3743,9 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume2(_ x: borrowing K
 
 public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     var f = {}
     f = {
@@ -3767,11 +3767,11 @@ public func closureVarAndClosureLetCaptureClassArgUseAfterConsume(_ x2: borrowin
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     var f = {}
-    f = {// expected-note {{closure capture here}}
-let g = {// expected-note {{closure capture here}}
+    f = {// expected-note {{closure capturing 'x2' here}}
+let g = {// expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3833,7 +3833,7 @@ public func closureVarAndClosureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: co
 }
 
 public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let f = {
         var g = {}
         g = {
@@ -3849,7 +3849,7 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume(_ x: borrowing Kl
 
 public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     let f = {
         let h = {
@@ -3872,9 +3872,9 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume2(_ x: borrowing K
 
 public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 
     let f = {
         var g = {}
@@ -3895,12 +3895,12 @@ public func closureLetAndClosureVarCaptureClassArgUseAfterConsume(_ x2: borrowin
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    let f = {// expected-note {{closure capture here}}
+    let f = {// expected-note {{closure capturing 'x2' here}}
         var g = {}
-        g = {// expected-note {{closure capture here}}
+        g = {// expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -3967,15 +3967,15 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: co
 
 func moveOperatorTest(_ k: __owned Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
-    let k3 = consume k2 // expected-note {{consuming use here}}
-    let _ = consume k2 // expected-note {{consuming use here}}
+    let k3 = consume k2 // expected-note {{consumed here}}
+    let _ = consume k2 // expected-note {{consumed here}}
     let _ = k3
 }
 
 func moveOperatorTest2(_ k: consuming Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
-    let k3 = consume k2 // expected-note {{consuming use here}}
-    let _ = consume k2 // expected-note {{consuming use here}}
+    let k3 = consume k2 // expected-note {{consumed here}}
+    let _ = consume k2 // expected-note {{consumed here}}
     let _ = k3
 }
 
@@ -3985,14 +3985,14 @@ func moveOperatorTest2(_ k: consuming Klass) {
 
 func blackHoleTestCase(_ k: __owned Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
-    let _ = k2 // expected-note {{consuming use here}}
-    let _ = k2 // expected-note {{consuming use here}}
+    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed here}}
 }
 
 func blackHoleTestCase2(_ k: consuming Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
-    let _ = k2 // expected-note {{consuming use here}}
-    let _ = k2 // expected-note {{consuming use here}}
+    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed here}}
 }
 
 ////////////////////////////////////////////
@@ -4002,15 +4002,15 @@ func blackHoleTestCase2(_ k: consuming Klass) {
 func sameCallSiteTestConsumeTwice(_ k: __owned Klass) { // expected-error {{'k' consumed more than once}}
     func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
     consumeKlassTwice(k, k)
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{consumed here}}
 }
 
 func sameCallSiteConsumeAndUse(_ k: __owned Klass) { // expected-error {{'k' used after consume}}
     func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: borrowing Klass) {}
     consumeKlassAndUseKlass(k, k)
-    // expected-note @-1 {{consuming use here}}
-    // expected-note @-2 {{non-consuming use here}}
+    // expected-note @-1 {{consumed here}}
+    // expected-note @-2 {{used here}}
 }
 
 ////////////////////////////////
@@ -4099,12 +4099,12 @@ func testEmptyStruct() {
 
   func testGuaranteedArg2(_ x: borrowing EmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    consume(x) // expected-note {{consuming use here}}
+    consume(x) // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg3(_ x: borrowing EmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let _ = x // expected-note {{consuming use here}}
+    let _ = x // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg4(_ x: borrowing EmptyStruct) {
@@ -4113,7 +4113,7 @@ func testEmptyStruct() {
 
   func testGuaranteedArg5(_ x: borrowing EmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let y = x // expected-note {{consuming use here}}
+    let y = x // expected-note {{consumed here}}
     _ = y
   }
 
@@ -4123,13 +4123,13 @@ func testEmptyStruct() {
 
   func testGuaranteedArg7(_ x: borrowing EmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    x.doSomething3() // expected-note {{consuming use here}}
+    x.doSomething3() // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg7a(_ x: borrowing EmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    x.doSomething3() // expected-note {{consuming use here}}
-    x.doSomething3() // expected-note {{consuming use here}}
+    x.doSomething3() // expected-note {{consumed here}}
+    x.doSomething3() // expected-note {{consumed here}}
   }
 }
 
@@ -4154,12 +4154,12 @@ func testStructContainingEmptyStruct() {
 
   func testGuaranteedArg2(_ x: borrowing StructContainingEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    consume(x) // expected-note {{consuming use here}}
+    consume(x) // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg3(_ x: borrowing StructContainingEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let _ = x // expected-note {{consuming use here}}
+    let _ = x // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg4(_ x: borrowing StructContainingEmptyStruct) {
@@ -4168,7 +4168,7 @@ func testStructContainingEmptyStruct() {
 
   func testGuaranteedArg5(_ x: borrowing StructContainingEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let y = x // expected-note {{consuming use here}}
+    let y = x // expected-note {{consumed here}}
     _ = y
   }
 
@@ -4178,13 +4178,13 @@ func testStructContainingEmptyStruct() {
 
   func testGuaranteedArg7(_ x: borrowing StructContainingEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    x.x.doSomething3() // expected-note {{consuming use here}}
+    x.x.doSomething3() // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg7a(_ x: borrowing StructContainingEmptyStruct) {
     // expected-error @-1 {{cannot use 'x' after partial consume}}
-    x.x.doSomething3() // expected-note {{partial consume here}}
-    x.x.doSomething3() // expected-note {{non-consuming use here}}
+    x.x.doSomething3() // expected-note {{partially consumed here}}
+    x.x.doSomething3() // expected-note {{used here}}
   }
 }
 
@@ -4210,12 +4210,12 @@ func testStructContainingTwoEmptyStruct() {
 
   func testGuaranteedArg2(_ x: borrowing StructContainingTwoEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    consume(x) // expected-note {{consuming use here}}
+    consume(x) // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg3(_ x: borrowing StructContainingTwoEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let _ = x // expected-note {{consuming use here}}
+    let _ = x // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg4(_ x: borrowing StructContainingTwoEmptyStruct) {
@@ -4224,7 +4224,7 @@ func testStructContainingTwoEmptyStruct() {
 
   func testGuaranteedArg5(_ x: borrowing StructContainingTwoEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let y = x // expected-note {{consuming use here}}
+    let y = x // expected-note {{consumed here}}
     _ = y
   }
 
@@ -4234,12 +4234,12 @@ func testStructContainingTwoEmptyStruct() {
 
   func testGuaranteedArg7(_ x: borrowing StructContainingTwoEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    x.x.doSomething3() // expected-note {{consuming use here}}
+    x.x.doSomething3() // expected-note {{consumed here}}
   }
 
   func testGuaranteedArg8(_ x: borrowing StructContainingTwoEmptyStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    x.y.doSomething3() // expected-note {{consuming use here}}
+    x.y.doSomething3() // expected-note {{consumed here}}
   }
 }
 
@@ -4262,13 +4262,13 @@ case third(MyEnum2)
 
 func testMyEnum() {
   func test1(_ x: borrowing MyEnum) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    if case let .first(y) = x { // expected-note {{consuming use here}}
+    if case let .first(y) = x { // expected-note {{consumed here}}
       _ = y
     }
   }
 
   func test2(_ x: borrowing MyEnum) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    if case let .third(.first(y)) = x { // expected-note {{consuming use here}}
+    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
       _ = y
     }
   }

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -52,7 +52,7 @@ public func classSimpleChainTest(_ x: borrowing Klass) { // expected-error {{'x'
                // expected-error @-1 {{'x2' consumed more than once}}
     let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
-    let k3 = x2 // expected-note {{consumed here}}
+    let k3 = x2 // expected-note {{consumed again here}}
     let _ = k3
     borrowVal(k2)
 }
@@ -122,7 +122,7 @@ public func classUseAfterConsume(_ x: borrowing Klass) { // expected-error {{'x'
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classUseAfterConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -134,20 +134,20 @@ public func classUseAfterConsumeArg(_ x2: borrowing Klass) { // expected-error {
 public func classUseAfterConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classUseAfterConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classDoubleConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classDoubleConsumeArg(_ x2: borrowing Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -157,12 +157,12 @@ public func classDoubleConsumeArg(_ x2: borrowing Klass) { // expected-error {{'
 
 public func classDoubleConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classDoubleConsumeOwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func classLoopConsume(_ x: borrowing Klass) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -233,7 +233,7 @@ public func classDiamondInLoop(_ x: borrowing Klass) { // expected-error {{'x' i
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -255,7 +255,7 @@ public func classDiamondInLoopOwnedArg(_ x2: __owned Klass) { // expected-error 
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -267,7 +267,7 @@ public func classDiamondInLoopOwnedArg2(_ x2: consuming Klass) { // expected-err
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -276,7 +276,7 @@ public func classAssignToVar1(_ x: borrowing Klass) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -295,7 +295,7 @@ public func classAssignToVar1Arg(_ x: borrowing Klass, _ x2: borrowing Klass) { 
 public func classAssignToVar1OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -303,7 +303,7 @@ public func classAssignToVar1OwnedArg(_ x: borrowing Klass, _ x2: __owned Klass)
 public func classAssignToVar1OwnedArg2(_ x: borrowing Klass, _ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -312,7 +312,7 @@ public func classAssignToVar2(_ x: borrowing Klass) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -324,13 +324,13 @@ public func classAssignToVar2Arg(_ x2: borrowing Klass) { // expected-error {{'x
 
 public func classAssignToVar2OwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
 public func classAssignToVar2OwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -366,7 +366,7 @@ public func classAssignToVar4(_ x: borrowing Klass) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -378,13 +378,13 @@ public func classAssignToVar4Arg(_ x2: borrowing Klass) { // expected-error {{'x
 
 public func classAssignToVar4OwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
 public func classAssignToVar4OwnedArg2(_ x2: consuming Klass) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -562,7 +562,7 @@ public func finalClassUseAfterConsume(_ x: borrowing FinalKlass) { // expected-e
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -574,20 +574,20 @@ public func finalClassUseAfterConsumeArg(_ x2: borrowing FinalKlass) { // expect
 public func finalClassUseAfterConsumeOwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassUseAfterConsumeOwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassDoubleConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassDoubleConsumeArg(_ x2: borrowing FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -597,12 +597,12 @@ public func finalClassDoubleConsumeArg(_ x2: borrowing FinalKlass) { // expected
 
 public func finalClassDoubleConsumeownedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassDoubleConsumeownedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassLoopConsume(_ x: borrowing FinalKlass) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -673,7 +673,7 @@ public func finalClassDiamondInLoop(_ x: borrowing FinalKlass) { // expected-err
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -695,7 +695,7 @@ public func finalClassDiamondInLoopOwnedArg(_ x2: __owned FinalKlass) { // expec
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -707,7 +707,7 @@ public func finalClassDiamondInLoopOwnedArg2(_ x2: consuming FinalKlass) { // ex
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -716,7 +716,7 @@ public func finalClassAssignToVar1(_ x: borrowing FinalKlass) { // expected-erro
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -732,7 +732,7 @@ public func finalClassAssignToVar1Arg(_ x: borrowing FinalKlass, _ x2: borrowing
 public func finalClassAssignToVar1OwnedArg(_ x: borrowing FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -740,7 +740,7 @@ public func finalClassAssignToVar1OwnedArg(_ x: borrowing FinalKlass, _ x2: __ow
 public func finalClassAssignToVar1OwnedArg2(_ x: borrowing FinalKlass, _ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                                         // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -749,7 +749,7 @@ public func finalClassAssignToVar2(_ x: borrowing FinalKlass) { // expected-erro
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -761,13 +761,13 @@ public func finalClassAssignToVar2Arg(_ x2: borrowing FinalKlass) { // expected-
 
 public func finalClassAssignToVar2OwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
 public func finalClassAssignToVar2OwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -801,7 +801,7 @@ public func finalClassAssignToVar4(_ x: borrowing FinalKlass) { // expected-erro
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -813,13 +813,13 @@ public func finalClassAssignToVar4Arg(_ x2: borrowing FinalKlass) { // expected-
 
 public func finalClassAssignToVar4OwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
 public func finalClassAssignToVar4OwnedArg2(_ x2: consuming FinalKlass) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -1008,7 +1008,7 @@ public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-err
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1020,20 +1020,20 @@ public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected
 public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1043,12 +1043,12 @@ public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-e
 
 public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -1119,7 +1119,7 @@ public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1141,7 +1141,7 @@ public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expecte
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1153,7 +1153,7 @@ public func aggStructDiamondInLoopOwnedArg2(_ x2: consuming AggStruct) { // expe
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1194,7 +1194,7 @@ public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error 
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1213,7 +1213,7 @@ public func aggStructConsumeFieldOwnedArg(_ x2: __owned AggStruct) {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1223,7 +1223,7 @@ public func aggStructConsumeFieldOwnedArg2(_ x2: consuming AggStruct) {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1263,7 +1263,7 @@ public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-e
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1282,7 +1282,7 @@ public func aggStructConsumeGrandFieldOwnedArg(_ x2: __owned AggStruct) {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1292,7 +1292,7 @@ public func aggStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggStruct) {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1343,8 +1343,8 @@ public func aggStructConsumeFieldError3(_ x2: __owned AggStruct) {
         consumeVal(x2.pair.rhs) // expected-note {{consumed here}}
     }
     consumeVal(x2)
-    // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
+    // expected-note @-2 {{consumed again here}}
 }
 
 public func aggStructConsumeFieldError4(_ x2: __owned AggStruct) {
@@ -1356,8 +1356,8 @@ public func aggStructConsumeFieldError4(_ x2: __owned AggStruct) {
         consumeVal(x2.pair.rhs) // expected-note {{consumed here}}
     }
     consumeVal(x2)
-    // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
+    // expected-note @-2 {{consumed again here}}
 }
 
 //////////////////////////////
@@ -1443,7 +1443,7 @@ public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<Stri
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1455,20 +1455,20 @@ public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<
 public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<String>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1478,12 +1478,12 @@ public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<St
 
 public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2(_ x2: consuming AggGenericStruct<String>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<String>) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -1554,7 +1554,7 @@ public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<String
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1576,7 +1576,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1588,7 +1588,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2(_ x2: consuming AggGenericStr
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1629,7 +1629,7 @@ public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<String>
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1648,7 +1648,7 @@ public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1658,7 +1658,7 @@ public func aggGenericStructConsumeFieldOwnedArg2(_ x2: consuming AggGenericStru
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1698,7 +1698,7 @@ public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<St
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1717,7 +1717,7 @@ public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericSt
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1727,7 +1727,7 @@ public func aggGenericStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggGeneri
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -1807,7 +1807,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1819,20 +1819,20 @@ public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStru
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1842,12 +1842,12 @@ public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -1918,7 +1918,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>)
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1940,7 +1940,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStr
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1952,7 +1952,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2<T>(_ x2: consuming AggGeneric
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1993,7 +1993,7 @@ public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) 
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2012,7 +2012,7 @@ public func aggGenericStructConsumeFieldOwnedArg<T>(_ x2: __owned AggGenericStru
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2022,7 +2022,7 @@ public func aggGenericStructConsumeFieldOwnedArg2<T>(_ x2: consuming AggGenericS
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2062,7 +2062,7 @@ public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2081,7 +2081,7 @@ public func aggGenericStructConsumeGrandFieldOwnedArg<T>(_ x2: __owned AggGeneri
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2091,7 +2091,7 @@ public func aggGenericStructConsumeGrandFieldOwnedArg2<T>(_ x2: consuming AggGen
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2179,7 +2179,7 @@ public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x'
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -2191,20 +2191,20 @@ public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {
 public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -2214,12 +2214,12 @@ public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'
 
 public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -2290,7 +2290,7 @@ public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' i
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2312,7 +2312,7 @@ public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error 
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2324,7 +2324,7 @@ public func enumDiamondInLoopOwnedArg2(_ x2: consuming EnumTy) { // expected-err
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -2333,7 +2333,7 @@ public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -2349,7 +2349,7 @@ public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) {
 public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -2357,7 +2357,7 @@ public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy
 public func enumAssignToVar1OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -2366,7 +2366,7 @@ public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -2378,13 +2378,13 @@ public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x
 
 public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -2418,7 +2418,7 @@ public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -2430,13 +2430,13 @@ public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x
 
 public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -2479,7 +2479,7 @@ public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -2497,7 +2497,7 @@ public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-e
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -2506,7 +2506,7 @@ public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expecte
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -2738,7 +2738,7 @@ public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
         // expected-note @-1 {{consumed here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -2749,7 +2749,7 @@ public func closureLetClassUseAfterConsume2(_ argX: borrowing Klass) {
                    // expected-note @-1 {{consumed here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f(argX)
 }
@@ -2784,7 +2784,7 @@ public func closureLetCaptureClassUseAfterConsume1(_ x: borrowing Klass) { // ex
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
 }
@@ -2809,7 +2809,7 @@ public func closureLetCaptureClassUseAfterConsume3(_ x2: inout Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -2857,7 +2857,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
 }
@@ -2883,11 +2883,11 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     x2 = Klass()
     let _ = x3
 }
@@ -2905,7 +2905,7 @@ public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
         // expected-note @-1 {{consumed here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -2917,7 +2917,7 @@ public func closureVarClassUseAfterConsume2(_ argX: borrowing Klass) {
         // expected-note @-1 {{consumed here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f(argX)
 }
@@ -2987,7 +2987,7 @@ public func closureVarCaptureClassUseAfterConsume4(_ x2: inout Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -3121,7 +3121,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     print("foo")
 }
@@ -3145,7 +3145,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     consumeVal(x2) // expected-note {{consumed here}}
 }
@@ -3239,7 +3239,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3269,7 +3269,7 @@ public func closureLetAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3313,7 +3313,7 @@ public func closureLetAndClosureCaptureClassUseAfterConsume2(_ x: borrowing Klas
     }
     f()
     consumeVal(x2) // expected-note {{consumed here}}
-    let x3 = x2 // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed again here}}
     _ = x3
 }
 
@@ -3331,13 +3331,13 @@ public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
     f()
     consumeVal(x2) // expected-note {{consumed here}}
-    let x3 = x2 // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed again here}}
     _ = x3
 }
 
@@ -3378,7 +3378,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consu
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -3408,7 +3408,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: consu
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -3425,7 +3425,7 @@ public func closureLetAndClosureCaptureClassOwnedArgUseAfterConsume5(_ x2: consu
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -3526,7 +3526,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consumi
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3558,7 +3558,7 @@ public func closureVarAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consumi
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         print("foo")
     }
@@ -3968,14 +3968,14 @@ public func closureLetAndClosureVarCaptureClassOwnedArgUseAfterConsume4(_ x2: co
 func moveOperatorTest(_ k: __owned Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
     let k3 = consume k2 // expected-note {{consumed here}}
-    let _ = consume k2 // expected-note {{consumed here}}
+    let _ = consume k2 // expected-note {{consumed again here}}
     let _ = k3
 }
 
 func moveOperatorTest2(_ k: consuming Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
     let k3 = consume k2 // expected-note {{consumed here}}
-    let _ = consume k2 // expected-note {{consumed here}}
+    let _ = consume k2 // expected-note {{consumed again here}}
     let _ = k3
 }
 
@@ -3986,13 +3986,13 @@ func moveOperatorTest2(_ k: consuming Klass) {
 func blackHoleTestCase(_ k: __owned Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
     let _ = k2 // expected-note {{consumed here}}
-    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed again here}}
 }
 
 func blackHoleTestCase2(_ k: consuming Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
     let _ = k2 // expected-note {{consumed here}}
-    let _ = k2 // expected-note {{consumed here}}
+    let _ = k2 // expected-note {{consumed again here}}
 }
 
 ////////////////////////////////////////////
@@ -4003,7 +4003,7 @@ func sameCallSiteTestConsumeTwice(_ k: __owned Klass) { // expected-error {{'k' 
     func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
     consumeKlassTwice(k, k)
     // expected-note @-1 {{consumed here}}
-    // expected-note @-2 {{consumed here}}
+    // expected-note @-2 {{consumed again here}}
 }
 
 func sameCallSiteConsumeAndUse(_ k: __owned Klass) { // expected-error {{'k' used after consume}}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -4184,7 +4184,7 @@ func testStructContainingEmptyStruct() {
   func testGuaranteedArg7a(_ x: borrowing StructContainingEmptyStruct) {
     // expected-error @-1 {{cannot use 'x' after partial consume}}
     x.x.doSomething3() // expected-note {{partial consume here}}
-    x.x.doSomething3() // expected-note {{boundary use here}}
+    x.x.doSomething3() // expected-note {{non-consuming use here}}
   }
 }
 

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -69,7 +69,7 @@ public struct AggStruct {
     init(myInit: Int) { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: Int) {
@@ -87,7 +87,7 @@ public struct AggStruct {
         self.center = myInit3
         let x = self.pair // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     init(myInit4: Int) {
         self.init()
@@ -119,7 +119,7 @@ public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consumed here}}
     y2 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -153,7 +153,7 @@ public func aggStructUseAfterConsume() {
     x2 = AggStruct()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
@@ -162,14 +162,14 @@ public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-              // expected-note @-1 {{consumed here}}
+              // expected-note @-1 {{consumed again here}}
 }
 
 public func aggStructDoubleConsume() {
     var x2 = AggStruct()  // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
@@ -177,7 +177,7 @@ public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggStructLoopConsume() {
@@ -224,7 +224,7 @@ public func aggStructDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -264,7 +264,7 @@ public func aggStructConsumeField() {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -300,7 +300,7 @@ public func aggStructConsumeGrandField() {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -334,7 +334,7 @@ public struct AggGenericStruct<T> { // FIXME: this generic parameter should prob
     init(myInit: UnsafeRawPointer) { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: UnsafeRawPointer) {
@@ -352,7 +352,7 @@ public struct AggGenericStruct<T> { // FIXME: this generic parameter should prob
         self.rhs = myInit3
         let x = self.lhs // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consumed here}}
+    } // expected-note {{consumed again here}}
 
     init(myInit4: UnsafeRawPointer) {
         self.init()
@@ -414,7 +414,7 @@ public func aggGenericStructUseAfterConsume() {
     x2 = AggGenericStruct<String>()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<String>) {
@@ -423,14 +423,14 @@ public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<Stri
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}x
+    // expected-note @-1 {{consumed again here}}x
 }
 
 public func aggGenericStructDoubleConsume() {
     var x2 = AggGenericStruct<String>()  // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<String>) {
@@ -438,7 +438,7 @@ public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<String
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume() {
@@ -484,7 +484,7 @@ public func aggGenericStructDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -524,7 +524,7 @@ public func aggGenericStructConsumeField() {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -560,7 +560,7 @@ public func aggGenericStructConsumeGrandField() {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -570,7 +570,7 @@ public func aggGenericStructConsumeGrandField2() {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
     }
-    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<String>) {
@@ -629,7 +629,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
     x2 = AggGenericStruct<T>()
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
@@ -638,14 +638,14 @@ public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
@@ -653,7 +653,7 @@ public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>)
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
@@ -699,7 +699,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -739,7 +739,7 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
     consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -775,7 +775,7 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
     consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
 }
 
@@ -843,7 +843,7 @@ public func enumUseAfterConsume() {
     x2 = EnumTy.klass(NonTrivialStruct())
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
@@ -852,14 +852,14 @@ public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func enumDoubleConsume() {
     var x2 = EnumTy.klass(NonTrivialStruct())  // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
@@ -867,7 +867,7 @@ public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed more than once}} 
     consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func enumLoopConsume() {
@@ -914,7 +914,7 @@ public func enumDiamondInLoop() {
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -935,7 +935,7 @@ public func enumAssignToVar1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
@@ -946,7 +946,7 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
                                                             
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
@@ -955,7 +955,7 @@ public func enumAssignToVar2() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -964,7 +964,7 @@ public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed more than once}} 
     var x3 = x2 // expected-note {{consumed here}}
     x3 = x2 // expected-note {{consumed here}}
-     // expected-note @-1 {{consumed here}}
+     // expected-note @-1 {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -987,7 +987,7 @@ public func enumAssignToVar4() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -996,7 +996,7 @@ public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -1023,7 +1023,7 @@ public func enumPatternMatchIfLet1() {
     if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1035,7 +1035,7 @@ public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
         borrowVal(x)
     }
     if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1168,7 +1168,7 @@ public func closureClassUseAfterConsume1() {
         x2 = NonTrivialStruct()
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -1179,7 +1179,7 @@ public func closureClassUseAfterConsume2() {
         x2 = NonTrivialStruct()
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -1192,7 +1192,7 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f(&argX)
 }
@@ -1207,7 +1207,7 @@ public func closureCaptureClassUseAfterConsume() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
 }
@@ -1224,15 +1224,15 @@ public func closureCaptureClassUseAfterConsumeError() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
     let x3 = x2 // expected-note {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
     var x4 = x2 // expected-note {{consumed here}}
-    // expected-note @-1 {{consumed here}}
-    x4 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
+    x4 = x2 // expected-note {{consumed again here}}
     _ = x4
     let _ = x3
 }
@@ -1259,7 +1259,7 @@ public func deferCaptureClassUseAfterConsume() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     consumeVal(x2) // expected-note {{consumed here}}
 }
@@ -1274,7 +1274,7 @@ public func deferCaptureClassUseAfterConsume2() {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
@@ -1288,7 +1288,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     print("foo")
 }
@@ -1304,7 +1304,7 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -1324,7 +1324,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -1344,7 +1344,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -1363,7 +1363,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
             // expected-note @-1 {{consumed here}}
             consumeVal(x2) // expected-note {{captured here}}
             // expected-note @-1 {{consumed here}}
-            // expected-note @-2 {{consumed here}}
+            // expected-note @-2 {{consumed again here}}
         }
         print("foo")
     }
@@ -1380,7 +1380,7 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -1397,7 +1397,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }
@@ -1416,7 +1416,7 @@ public func closureAndClosureCaptureClassUseAfterConsume3() {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -116,7 +116,7 @@ public func aggStructSimpleChainTest() {
 
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -142,7 +142,7 @@ public func aggStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -158,7 +158,7 @@ public func aggStructUseAfterConsume() {
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -173,7 +173,7 @@ public func aggStructDoubleConsume() {
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -188,7 +188,7 @@ public func aggStructLoopConsume() {
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -205,8 +205,8 @@ public func aggStructDiamond() {
 }
 
 public func aggStructDiamondArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -230,8 +230,8 @@ public func aggStructDiamondInLoop() {
 }
 
 public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -269,8 +269,8 @@ public func aggStructConsumeField() {
 }
 
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -305,8 +305,8 @@ public func aggStructConsumeGrandField() {
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -379,7 +379,7 @@ public func aggGenericStructSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -403,7 +403,7 @@ public func aggGenericStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -418,7 +418,7 @@ public func aggGenericStructUseAfterConsume() {
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -434,7 +434,7 @@ public func aggGenericStructDoubleConsume() {
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -449,7 +449,7 @@ public func aggGenericStructLoopConsume() {
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -466,8 +466,8 @@ public func aggGenericStructDiamond() {
 }
 
 public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -490,8 +490,8 @@ public func aggGenericStructDiamondInLoop() {
 }
 
 public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -529,8 +529,8 @@ public func aggGenericStructConsumeField() {
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -574,8 +574,8 @@ public func aggGenericStructConsumeGrandField2() {
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -594,7 +594,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -618,7 +618,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -633,7 +633,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -649,7 +649,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -664,7 +664,7 @@ public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -681,8 +681,8 @@ public func aggGenericStructDiamond<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -705,8 +705,8 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -744,8 +744,8 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -780,8 +780,8 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -808,7 +808,7 @@ public func enumSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -832,7 +832,7 @@ public func enumMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -847,7 +847,7 @@ public func enumUseAfterConsume() {
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -863,7 +863,7 @@ public func enumDoubleConsume() {
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -878,7 +878,7 @@ public func enumLoopConsume() {
     }
 }
 
-public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -895,8 +895,8 @@ public func enumDiamond() {
 }
 
 public func enumDiamondArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -920,8 +920,8 @@ public func enumDiamondInLoop() {
 }
 
 public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -941,7 +941,7 @@ public func enumAssignToVar1() {
 }
 
 public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
@@ -960,7 +960,7 @@ public func enumAssignToVar2() {
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -976,7 +976,7 @@ public func enumAssignToVar3() {
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
@@ -992,7 +992,7 @@ public func enumAssignToVar4() {
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1029,7 +1029,7 @@ public func enumPatternMatchIfLet1() {
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x)
@@ -1050,7 +1050,7 @@ public func enumPatternMatchIfLet2() {
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1073,7 +1073,7 @@ public func enumPatternMatchSwitch1() {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1096,7 +1096,7 @@ public func enumPatternMatchSwitch2() {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1120,7 +1120,7 @@ public func enumPatternMatchSwitch2WhereClause() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
@@ -1146,7 +1146,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where boolValue:
@@ -1187,7 +1187,7 @@ public func closureClassUseAfterConsume2() {
 public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
     // TODO: Fix this
     let f = { (_ x2: inout NonTrivialStruct) in
-        // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+        // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1200,7 +1200,7 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
 // We do not support captures of vars by closures today.
 public func closureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
@@ -1216,7 +1216,7 @@ public func closureCaptureClassUseAfterConsumeError() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-3 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
@@ -1251,7 +1251,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) 
 // TODO: Improve error msg here to make it clear the use is due to the defer.
 public func deferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1266,7 +1266,7 @@ public func deferCaptureClassUseAfterConsume() {
 
 public func deferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1281,7 +1281,7 @@ public func deferCaptureClassUseAfterConsume2() {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     defer {
@@ -1295,7 +1295,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
 
 public func closureAndDeferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
@@ -1313,7 +1313,7 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
 
 public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1333,7 +1333,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
 
 public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1353,7 +1353,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -1373,7 +1373,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
@@ -1390,7 +1390,7 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
@@ -1408,7 +1408,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 public func closureAndClosureCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -116,7 +116,7 @@ public func aggStructSimpleChainTest() {
 
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     var y2 = x2 // expected-note {{consuming use here}}
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
@@ -142,7 +142,7 @@ public func aggStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -158,7 +158,7 @@ public func aggStructUseAfterConsume() {
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -173,7 +173,7 @@ public func aggStructDoubleConsume() {
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -188,7 +188,7 @@ public func aggStructLoopConsume() {
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -205,8 +205,8 @@ public func aggStructDiamond() {
 }
 
 public func aggStructDiamondArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -230,8 +230,8 @@ public func aggStructDiamondInLoop() {
 }
 
 public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -269,8 +269,8 @@ public func aggStructConsumeField() {
 }
 
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -305,8 +305,8 @@ public func aggStructConsumeGrandField() {
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -379,7 +379,7 @@ public func aggGenericStructSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -403,7 +403,7 @@ public func aggGenericStructMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -418,7 +418,7 @@ public func aggGenericStructUseAfterConsume() {
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -434,7 +434,7 @@ public func aggGenericStructDoubleConsume() {
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -449,7 +449,7 @@ public func aggGenericStructLoopConsume() {
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -466,8 +466,8 @@ public func aggGenericStructDiamond() {
 }
 
 public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -490,8 +490,8 @@ public func aggGenericStructDiamondInLoop() {
 }
 
 public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -529,8 +529,8 @@ public func aggGenericStructConsumeField() {
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -574,8 +574,8 @@ public func aggGenericStructConsumeGrandField2() {
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -594,7 +594,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -618,7 +618,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -633,7 +633,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -649,7 +649,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -664,7 +664,7 @@ public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -681,8 +681,8 @@ public func aggGenericStructDiamond<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -705,8 +705,8 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -744,8 +744,8 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -780,8 +780,8 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -808,7 +808,7 @@ public func enumSimpleChainTest() {
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -832,7 +832,7 @@ public func enumMultipleNonConsumingUseTest() {
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -847,7 +847,7 @@ public func enumUseAfterConsume() {
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -863,7 +863,7 @@ public func enumDoubleConsume() {
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -878,7 +878,7 @@ public func enumLoopConsume() {
     }
 }
 
-public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -895,8 +895,8 @@ public func enumDiamond() {
 }
 
 public func enumDiamondArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -920,8 +920,8 @@ public func enumDiamondInLoop() {
 }
 
 public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -941,7 +941,7 @@ public func enumAssignToVar1() {
 }
 
 public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
@@ -960,7 +960,7 @@ public func enumAssignToVar2() {
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -976,7 +976,7 @@ public func enumAssignToVar3() {
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
@@ -992,7 +992,7 @@ public func enumAssignToVar4() {
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1029,7 +1029,7 @@ public func enumPatternMatchIfLet1() {
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x)
@@ -1050,7 +1050,7 @@ public func enumPatternMatchIfLet2() {
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1073,7 +1073,7 @@ public func enumPatternMatchSwitch1() {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1096,7 +1096,7 @@ public func enumPatternMatchSwitch2() {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
         borrowVal(k)
@@ -1120,7 +1120,7 @@ public func enumPatternMatchSwitch2WhereClause() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
@@ -1146,7 +1146,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of 'x2' after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where boolValue:
@@ -1187,7 +1187,7 @@ public func closureClassUseAfterConsume2() {
 public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
     // TODO: Fix this
     let f = { (_ x2: inout NonTrivialStruct) in
-        // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+        // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1200,7 +1200,7 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
 // We do not support captures of vars by closures today.
 public func closureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
@@ -1216,7 +1216,7 @@ public func closureCaptureClassUseAfterConsumeError() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
@@ -1251,7 +1251,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) 
 // TODO: Improve error msg here to make it clear the use is due to the defer.
 public func deferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1266,7 +1266,7 @@ public func deferCaptureClassUseAfterConsume() {
 
 public func deferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1281,7 +1281,7 @@ public func deferCaptureClassUseAfterConsume2() {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
     defer {
@@ -1295,7 +1295,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
 
 public func closureAndDeferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
@@ -1313,7 +1313,7 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
 
 public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1333,7 +1333,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
 
 public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
@@ -1353,7 +1353,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -1373,7 +1373,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
@@ -1390,7 +1390,7 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
@@ -1408,7 +1408,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 public func closureAndClosureCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -67,9 +67,9 @@ public struct AggStruct {
     //
     // TODO: Improve error message!
     init(myInit: Int) { // expected-error {{'self' consumed more than once}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: Int) {
@@ -85,9 +85,9 @@ public struct AggStruct {
     init(myInit3: Int) { // expected-error {{'self' consumed more than once}}
         self.init()
         self.center = myInit3
-        let x = self.pair // expected-note {{consuming use here}}
+        let x = self.pair // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     init(myInit4: Int) {
         self.init()
@@ -117,9 +117,9 @@ public func aggStructSimpleChainTest() {
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    var y2 = x2 // expected-note {{consuming use here}}
-    y2 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var y2 = x2 // expected-note {{consumed here}}
+    y2 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -145,52 +145,52 @@ public func aggStructMultipleNonConsumingUseTest() {
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsume() {
     var x2 = AggStruct() // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-              // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+              // expected-note @-1 {{consumed here}}
 }
 
 public func aggStructDoubleConsume() {
     var x2 = AggStruct()  // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggStructLoopConsume() {
-    var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggStruct() // expected-error {{'x2' consumed in a loop}}
     x2 = AggStruct()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -208,23 +208,23 @@ public func aggStructDiamondArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructDiamondInLoop() {
     var x2 = AggStruct()
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = AggStruct()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -234,9 +234,9 @@ public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -258,22 +258,22 @@ public func aggStructAccessFieldArg(_ x2: inout AggStruct) {
 }
 
 public func aggStructConsumeField() {
-    var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggStruct() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -294,22 +294,22 @@ public func aggStructAccessGrandFieldArg(_ x2: inout AggStruct) {
 }
 
 public func aggStructConsumeGrandField() {
-    var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggStruct() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -332,9 +332,9 @@ public struct AggGenericStruct<T> { // FIXME: this generic parameter should prob
     //
     // TODO: Improve error message!
     init(myInit: UnsafeRawPointer) { // expected-error {{'self' consumed more than once}}
-        let x = self // expected-note {{consuming use here}}
+        let x = self // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     // Make sure we can reinitialize successfully.
     init(myInit2: UnsafeRawPointer) {
@@ -350,9 +350,9 @@ public struct AggGenericStruct<T> { // FIXME: this generic parameter should prob
     init(myInit3: UnsafeRawPointer) { // expected-error {{'self' consumed more than once}}
         self.init()
         self.rhs = myInit3
-        let x = self.lhs // expected-note {{consuming use here}}
+        let x = self.lhs // expected-note {{consumed here}}
         let _ = x
-    } // expected-note {{consuming use here}}
+    } // expected-note {{consumed here}}
 
     init(myInit4: UnsafeRawPointer) {
         self.init()
@@ -380,7 +380,7 @@ public func aggGenericStructSimpleChainTest() {
 }
 
 public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -406,52 +406,52 @@ public func aggGenericStructMultipleNonConsumingUseTest() {
 public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsume() {
     var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}x
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}x
 }
 
 public func aggGenericStructDoubleConsume() {
     var x2 = AggGenericStruct<String>()  // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume() {
-    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed in a loop}}
     x2 = AggGenericStruct<String>()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -469,22 +469,22 @@ public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamondInLoop() {
-    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -494,9 +494,9 @@ public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<String
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -518,22 +518,22 @@ public func aggGenericStructAccessFieldArg(_ x2: inout AggGenericStruct<String>)
 }
 
 public func aggGenericStructConsumeField() {
-    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -554,31 +554,31 @@ public func aggGenericStructAccessGrandFieldArg(_ x2: inout AggGenericStruct<Str
 }
 
 public func aggGenericStructConsumeGrandField() {
-    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandField2() {
     var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<String>()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
     }
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -595,7 +595,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -621,52 +621,52 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
-    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed in a loop}}
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -684,22 +684,22 @@ public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -709,9 +709,9 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>)
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -733,22 +733,22 @@ public func aggGenericStructAccessFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
 }
 
 public func aggGenericStructConsumeField<T>(_ x: T.Type) {
-    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -769,22 +769,22 @@ public func aggGenericStructAccessGrandFieldArg<T>(_ x2: inout AggGenericStruct<
 }
 
 public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
-    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
-    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consumed here}}
     }
 }
 
@@ -809,7 +809,7 @@ public func enumSimpleChainTest() {
 }
 
 public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -835,52 +835,52 @@ public func enumMultipleNonConsumingUseTest() {
 public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsume() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func enumDoubleConsume() {
     var x2 = EnumTy.klass(NonTrivialStruct())  // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func enumLoopConsume() {
-    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed in a loop}}
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -898,23 +898,23 @@ public func enumDiamondArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumDiamondInLoop() {
     var x2 = EnumTy.klass(NonTrivialStruct())
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -924,9 +924,9 @@ public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
@@ -934,8 +934,8 @@ public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
 public func enumAssignToVar1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
@@ -944,9 +944,9 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
                                                             
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
@@ -954,17 +954,17 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
 public func enumAssignToVar2() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-     // expected-note @-1 {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+     // expected-note @-1 {{consumed here}}
     borrowVal(x3)
 }
 
@@ -978,7 +978,7 @@ public func enumAssignToVar3() {
 
 public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
                                                             
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
@@ -986,33 +986,33 @@ public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{missin
 public func enumAssignToVar4() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x2: inout EnumTy) { // expected-error {{'x2' used after consume}}
                                                             
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
     x3 = EnumTy.klass(NonTrivialStruct())
     consumeVal(x3)
 }
@@ -1020,10 +1020,10 @@ public func enumAssignToVar5Arg(_ x2: inout EnumTy) { // expected-error {{'x2' u
 public func enumPatternMatchIfLet1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
@@ -1031,20 +1031,20 @@ public func enumPatternMatchIfLet1() {
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet2() {
-    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed in a loop}}
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1052,7 +1052,7 @@ public func enumPatternMatchIfLet2() {
 
 public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1062,19 +1062,19 @@ public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{
 public func enumPatternMatchSwitch1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -1097,7 +1097,7 @@ public func enumPatternMatchSwitch2() {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
     case .int:
@@ -1109,9 +1109,9 @@ public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {
 public func enumPatternMatchSwitch2WhereClause() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -1121,7 +1121,7 @@ public func enumPatternMatchSwitch2WhereClause() {
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -1147,7 +1147,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where boolValue:
         borrowVal(k)
@@ -1167,8 +1167,8 @@ public func closureClassUseAfterConsume1() {
         var x2 = NonTrivialStruct() // expected-error {{'x2' consumed more than once}}
         x2 = NonTrivialStruct()
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1178,8 +1178,8 @@ public func closureClassUseAfterConsume2() {
         var x2 = NonTrivialStruct() // expected-error {{'x2' consumed more than once}}
         x2 = NonTrivialStruct()
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1190,9 +1190,9 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
         // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
         // expected-error @-2 {{'x2' consumed more than once}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f(&argX)
 }
@@ -1205,9 +1205,9 @@ public func closureCaptureClassUseAfterConsume() {
     x2 = NonTrivialStruct()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
 }
@@ -1222,17 +1222,17 @@ public func closureCaptureClassUseAfterConsumeError() {
     x2 = NonTrivialStruct()
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
-    var x4 = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
-    x4 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
+    var x4 = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
+    x4 = x2 // expected-note {{consumed here}}
     _ = x4
     let _ = x3
 }
@@ -1255,13 +1255,13 @@ public func deferCaptureClassUseAfterConsume() {
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func deferCaptureClassUseAfterConsume2() {
@@ -1270,13 +1270,13 @@ public func deferCaptureClassUseAfterConsume2() {
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
-    defer { //  expected-note {{non-consuming use here}}
+    defer { //  expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
@@ -1286,9 +1286,9 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     borrowVal(x2)
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     print("foo")
 }
@@ -1301,10 +1301,10 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -1318,13 +1318,13 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
-        defer { // expected-note {{non-consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        defer { // expected-note {{used here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -1338,13 +1338,13 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
-        defer { // expected-note {{non-consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        defer { // expected-note {{used here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2)
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -1360,10 +1360,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
         defer { // expected-note {{captured indirectly by this call}}
             borrowVal(x2) // expected-note {{captured here}}
             consumeVal(x2) // expected-note {{captured here}}
-            // expected-note @-1 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
             consumeVal(x2) // expected-note {{captured here}}
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
+            // expected-note @-1 {{consumed here}}
+            // expected-note @-2 {{consumed here}}
         }
         print("foo")
     }
@@ -1378,9 +1378,9 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -1395,9 +1395,9 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -1414,15 +1414,15 @@ public func closureAndClosureCaptureClassUseAfterConsume3() {
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
     f()
-    consumeVal(x2) // expected-note {{consuming use here}}
-    f() // expected-note {{non-consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    f() // expected-note {{used here}}
 }
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -58,14 +58,14 @@ public struct AggStruct {
     var pair: MOIntPair
 }
 
-public func aggStructSimpleChainTest(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggStructSimpleChainTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -83,7 +83,7 @@ public func aggStructSimpleChainTestOwnedArg2(_ x2: consuming AggStruct) {
     borrowVal(k2)
 }
 
-public func aggStructSimpleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -100,14 +100,14 @@ public func aggStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStruc
     borrowVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -125,7 +125,7 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStr
     consumeVal(x2)
 }
 
-public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -133,7 +133,7 @@ public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-err
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -151,14 +151,14 @@ public func aggStructUseAfterConsumeOwnedArg2(_ x2: consuming AggStruct) { // ex
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -173,7 +173,7 @@ public func aggStructDoubleConsumeOwnedArg2(_ x2: consuming AggStruct) { // expe
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -181,7 +181,7 @@ public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -199,7 +199,7 @@ public func aggStructLoopConsumeOwnedArg2(_ x2: consuming AggStruct) { // expect
     }
 }
 
-public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -208,7 +208,7 @@ public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x'
     }
 }
 
-public func aggStructDiamondArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -232,7 +232,7 @@ public func aggStructDiamondOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -246,7 +246,7 @@ public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error
     }
 }
 
-public func aggStructDiamondInLoopArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoopArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -280,7 +280,7 @@ public func aggStructDiamondInLoopOwnedArg2(_ x2: consuming AggStruct) { // expe
     }
 }
 
-public func aggStructAccessField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -309,7 +309,7 @@ public func aggStructAccessFieldOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
@@ -339,7 +339,7 @@ public func aggStructConsumeFieldOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructAccessGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -368,7 +368,7 @@ public func aggStructAccessGrandFieldOwnedArg2(_ x2: consuming AggStruct) {
     }
 }
 
-public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -409,14 +409,14 @@ public struct AggGenericStruct<T> {
     var pair: MOIntPair
 }
 
-public func aggGenericStructSimpleChainTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -434,7 +434,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2(_ x2: consuming AggGenericS
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -451,14 +451,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming A
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -476,7 +476,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -484,7 +484,7 @@ public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<Copy
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -502,14 +502,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg2(_ x2: consuming AggGenericS
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -524,7 +524,7 @@ public func aggGenericStructDoubleConsumeOwnedArg2(_ x2: consuming AggGenericStr
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -532,7 +532,7 @@ public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<Copyable
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -550,7 +550,7 @@ public func aggGenericStructLoopConsumeOwnedArg2(_ x2: consuming AggGenericStruc
     }
 }
 
-public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -559,7 +559,7 @@ public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<CopyableKlas
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -583,7 +583,7 @@ public func aggGenericStructDiamondOwnedArg2(_ x2: consuming AggGenericStruct<Co
     }
 }
 
-public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -597,7 +597,7 @@ public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<Copyab
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -631,7 +631,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2(_ x2: consuming AggGenericStr
     }
 }
 
-public func aggGenericStructAccessField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -660,7 +660,7 @@ public func aggGenericStructAccessFieldOwnedArg2(_ x2: consuming AggGenericStruc
     }
 }
 
-public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
@@ -689,7 +689,7 @@ public func aggGenericStructConsumeFieldOwnedArg2(_ x2: consuming AggGenericStru
     }
 }
 
-public func aggGenericStructAccessGrandField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -718,7 +718,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg2(_ x2: consuming AggGeneric
     }
 }
 
-public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -751,14 +751,14 @@ public func aggGenericStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggGeneri
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructSimpleChainTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -776,7 +776,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2<T>(_ x2: consuming AggGener
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -793,14 +793,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2<T>(_ x2: consumin
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { //expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -818,7 +818,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2<T>(_ x2: consum
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -826,7 +826,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -844,14 +844,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg2<T>(_ x2: consuming AggGener
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -866,7 +866,7 @@ public func aggGenericStructDoubleConsumeOwnedArg2<T>(_ x2: consuming AggGeneric
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -874,7 +874,7 @@ public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -892,7 +892,7 @@ public func aggGenericStructLoopConsumeOwnedArg2<T>(_ x2: consuming AggGenericSt
     }
 }
 
-public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -901,7 +901,7 @@ public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // 
     }
 }
 
-public func aggGenericStructDiamondArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -925,7 +925,7 @@ public func aggGenericStructDiamondOwnedArg2<T>(_ x2: consuming AggGenericStruct
     }
 }
 
-public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -939,7 +939,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>)
     }
 }
 
-public func aggGenericStructDiamondInLoopArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -973,7 +973,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2<T>(_ x2: consuming AggGeneric
     }
 }
 
-public func aggGenericStructAccessField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1002,7 +1002,7 @@ public func aggGenericStructAccessFieldOwnedArg2<T>(_ x2: consuming AggGenericSt
     }
 }
 
-public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1031,7 +1031,7 @@ public func aggGenericStructConsumeFieldOwnedArg2<T>(_ x2: consuming AggGenericS
     }
 }
 
-public func aggGenericStructAccessGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -1060,7 +1060,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg2<T>(_ x2: consuming AggGene
     }
 }
 
-public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -1101,14 +1101,14 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumSimpleChainTest(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1126,7 +1126,7 @@ public func enumSimpleChainTestOwnedArg2(_ x2: consuming EnumTy) {
     borrowVal(k2)
 }
 
-public func enumSimpleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
@@ -1143,14 +1143,14 @@ public func enumSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
     borrowVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1168,7 +1168,7 @@ public func enumMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
     consumeVal(x2)
 }
 
-public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1176,7 +1176,7 @@ public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x'
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1194,14 +1194,14 @@ public func enumUseAfterConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-e
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1216,7 +1216,7 @@ public func enumDoubleConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-err
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1224,7 +1224,7 @@ public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' has
     }
 }
 
-public func enumLoopConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumLoopConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1242,7 +1242,7 @@ public func enumLoopConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error
     }
 }
 
-public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1251,7 +1251,7 @@ public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' has gua
     }
 }
 
-public func enumDiamondArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1275,7 +1275,7 @@ public func enumDiamondOwnedArg2(_ x2: consuming EnumTy) {
     }
 }
 
-public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1289,7 +1289,7 @@ public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' h
     }
 }
 
-public func enumDiamondInLoopArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoopArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1323,7 +1323,7 @@ public func enumDiamondInLoopOwnedArg2(_ x2: consuming EnumTy) { // expected-err
     }
 }
 
-public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1332,8 +1332,8 @@ public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -1341,7 +1341,7 @@ public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) {
 }
 
 public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -1349,14 +1349,14 @@ public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy
 }
 
 public func enumAssignToVar1OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1364,7 +1364,7 @@ public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     borrowVal(x3)
 }
 
-public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -1382,33 +1382,33 @@ public func enumAssignToVar2OwnedArg2(_ x2: consuming EnumTy) { // expected-erro
     borrowVal(x3)
 }
 
-public func enumAssignToVar3(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1416,7 +1416,7 @@ public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -1434,7 +1434,7 @@ public func enumAssignToVar4OwnedArg2(_ x2: consuming EnumTy) { // expected-erro
     consumeVal(x3)
 }
 
-public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1443,8 +1443,8 @@ public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+                                                             // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
@@ -1454,7 +1454,7 @@ public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) {
 }
 
 public func enumAssignToVar5OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -1462,14 +1462,14 @@ public func enumAssignToVar5OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy
 }
 
 public func enumAssignToVar5OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+                                                                          // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
@@ -1480,7 +1480,7 @@ public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{
     }
 }
 
-public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x.i)
     }
@@ -1507,7 +1507,7 @@ public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expecte
     }
 }
 
-public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1517,7 +1517,7 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1541,7 +1541,7 @@ public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expecte
     }
 }
 
-public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -1553,7 +1553,7 @@ public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -1585,7 +1585,7 @@ public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expect
     }
 }
 
-public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k):
@@ -1595,7 +1595,7 @@ public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -1623,7 +1623,7 @@ public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
 }
 
 // TODO: We can do better here. We should also flag x2
-public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -1637,7 +1637,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expec
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
@@ -1673,7 +1673,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) 
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k)
@@ -1686,7 +1686,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expe
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where boolValue:
@@ -1727,8 +1727,8 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 /////////////////////////////
 
 public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consuming use here}}
@@ -1740,7 +1740,7 @@ public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
 }
 
 public func closureClassUseAfterConsume2(_ argX: borrowing NonTrivialStruct) {
-    let f = { (_ x: borrowing NonTrivialStruct) in // expected-error {{'x' has guaranteed ownership but was consumed}}
+    let f = { (_ x: borrowing NonTrivialStruct) in // expected-error {{'x' is borrowed and cannot be consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
                    // expected-note @-1 {{consuming use here}}
         borrowVal(x2)
@@ -1752,7 +1752,7 @@ public func closureClassUseAfterConsume2(_ argX: borrowing NonTrivialStruct) {
 
 public func closureClassUseAfterConsumeArg(_ argX: borrowing NonTrivialStruct) {
     // TODO: Fix this
-    let f = { (_ x2: borrowing NonTrivialStruct) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    let f = { (_ x2: borrowing NonTrivialStruct) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1760,10 +1760,10 @@ public func closureClassUseAfterConsumeArg(_ argX: borrowing NonTrivialStruct) {
     f(argX)
 }
 
-public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     
     let f = {
         borrowVal(x2)
@@ -1773,10 +1773,10 @@ public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) 
     f()
 }
 
-public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1788,8 +1788,8 @@ public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStr
 }
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1799,8 +1799,8 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStru
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1810,7 +1810,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialS
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         borrowVal(x2)
@@ -1822,8 +1822,8 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivi
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1835,7 +1835,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivial
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
     let f = {
@@ -1850,9 +1850,9 @@ public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivi
     let _ = x3
 }
 
-public func deferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1861,10 +1861,10 @@ public func deferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { 
     consumeVal(x) // expected-note {{consuming use here}}
 }
 
-public func deferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     // expected-error @-3 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -1876,7 +1876,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     borrowVal(x2)
     defer {
         borrowVal(x2)
@@ -1887,7 +1887,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1898,7 +1898,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStr
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1909,7 +1909,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivial
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     // expected-error @-2 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -1920,7 +1920,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialSt
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' used after consume}}
     // expected-error @-3 {{'x2' consumed more than once}}
     defer { // expected-note {{non-consuming use here}}
@@ -1933,9 +1933,9 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivial
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -1947,10 +1947,10 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivial
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -1963,11 +1963,11 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivia
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-3 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -1981,8 +1981,8 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivia
     consumeVal(x2)
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = { // expected-note {{closure capture here}}
         defer {
             borrowVal(x2)
@@ -1995,7 +1995,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTri
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -2008,7 +2008,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         defer {
@@ -2023,7 +2023,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming 
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -2037,7 +2037,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned No
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         defer {
@@ -2052,10 +2052,10 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
     consumeVal(x2)
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2067,10 +2067,10 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivi
     f()
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2085,9 +2085,9 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTriv
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         let g = { // expected-note {{closure capture here}}
             borrowVal(x2)
@@ -2100,8 +2100,8 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonT
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2115,7 +2115,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2129,8 +2129,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consumin
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2144,8 +2144,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned 
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
     let f = {
         let g = {
             borrowVal(x2)

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1810,7 +1810,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialS
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         borrowVal(x2)
@@ -1835,7 +1835,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivial
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
     let f = {
@@ -1898,7 +1898,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStr
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1920,7 +1920,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialSt
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' used after consume}}
     // expected-error @-3 {{'x2' consumed more than once}}
     defer { // expected-note {{non-consuming use here}}
@@ -2008,7 +2008,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         defer {
@@ -2037,7 +2037,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned No
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
-    // expected-error @-1 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         defer {
@@ -2115,7 +2115,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{missing reinitialization of 'x2' after consume}}
+    // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     let f = {
         let g = {
             borrowVal(x2)

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -59,14 +59,14 @@ public struct AggStruct {
 }
 
 public func aggStructSimpleChainTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func aggStructSimpleChainTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -84,7 +84,7 @@ public func aggStructSimpleChainTestOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructSimpleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -101,7 +101,7 @@ public func aggStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStruc
 }
 
 public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -110,7 +110,7 @@ public func aggStructMultipleNonConsumingUseTest(_ x: borrowing AggStruct) { // 
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct) {
@@ -127,80 +127,80 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming AggStr
 
 public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggStructLoopConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggStructLoopConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -210,9 +210,9 @@ public func aggStructDiamond(_ x: borrowing AggStruct) { // expected-error {{'x'
 
 public func aggStructDiamondArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -234,14 +234,14 @@ public func aggStructDiamondOwnedArg2(_ x2: consuming AggStruct) {
 
 public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -249,39 +249,39 @@ public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error
 public func aggStructDiamondInLoopArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggStructDiamondInLoopOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggStructAccessField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -310,7 +310,7 @@ public func aggStructAccessFieldOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructConsumeField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.lhs)
@@ -340,7 +340,7 @@ public func aggStructConsumeFieldOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructAccessGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -369,7 +369,7 @@ public func aggStructAccessGrandFieldOwnedArg2(_ x2: consuming AggStruct) {
 }
 
 public func aggStructConsumeGrandField(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs)
@@ -410,14 +410,14 @@ public struct AggGenericStruct<T> {
 }
 
 public func aggGenericStructSimpleChainTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -435,7 +435,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2(_ x2: consuming AggGenericS
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -452,7 +452,7 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming A
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -461,7 +461,7 @@ public func aggGenericStructMultipleNonConsumingUseTest(_ x: borrowing AggGeneri
 public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
@@ -478,80 +478,80 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming
 
 public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -561,9 +561,9 @@ public func aggGenericStructDiamond(_ x: borrowing AggGenericStruct<CopyableKlas
 
 public func aggGenericStructDiamondArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -585,14 +585,14 @@ public func aggGenericStructDiamondOwnedArg2(_ x2: consuming AggGenericStruct<Co
 
 public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -600,39 +600,39 @@ public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<Copyab
 public func aggGenericStructDiamondInLoopArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructAccessField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -661,7 +661,7 @@ public func aggGenericStructAccessFieldOwnedArg2(_ x2: consuming AggGenericStruc
 }
 
 public func aggGenericStructConsumeField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.lhs)
@@ -690,7 +690,7 @@ public func aggGenericStructConsumeFieldOwnedArg2(_ x2: consuming AggGenericStru
 }
 
 public func aggGenericStructAccessGrandField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -719,7 +719,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg2(_ x2: consuming AggGeneric
 }
 
 public func aggGenericStructConsumeGrandField(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs)
@@ -752,14 +752,14 @@ public func aggGenericStructConsumeGrandFieldOwnedArg2(_ x2: consuming AggGeneri
 ////////////////////////////////////////////////////////////
 
 public func aggGenericStructSimpleChainTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -777,7 +777,7 @@ public func aggGenericStructSimpleChainTestOwnedArg2<T>(_ x2: consuming AggGener
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -794,7 +794,7 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg2<T>(_ x2: consumin
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -803,7 +803,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: borrowing AggGen
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: borrowing AggGenericStruct<T>) { //expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
@@ -820,80 +820,80 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg2<T>(_ x2: consum
 
 public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -903,9 +903,9 @@ public func aggGenericStructDiamond<T>(_ x: borrowing AggGenericStruct<T>) { // 
 
 public func aggGenericStructDiamondArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -927,14 +927,14 @@ public func aggGenericStructDiamondOwnedArg2<T>(_ x2: consuming AggGenericStruct
 
 public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -942,39 +942,39 @@ public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>)
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructAccessField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -1003,7 +1003,7 @@ public func aggGenericStructAccessFieldOwnedArg2<T>(_ x2: consuming AggGenericSt
 }
 
 public func aggGenericStructConsumeField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.lhs)
@@ -1032,7 +1032,7 @@ public func aggGenericStructConsumeFieldOwnedArg2<T>(_ x2: consuming AggGenericS
 }
 
 public func aggGenericStructAccessGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -1061,7 +1061,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg2<T>(_ x2: consuming AggGene
 }
 
 public func aggGenericStructConsumeGrandField<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs)
@@ -1102,14 +1102,14 @@ public enum EnumTy {
 }
 
 public func enumSimpleChainTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
 public func enumSimpleChainTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     borrowVal(k2)
 }
@@ -1127,7 +1127,7 @@ public func enumSimpleChainTestOwnedArg2(_ x2: consuming EnumTy) {
 }
 
 public func enumSimpleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
 }
 
@@ -1144,7 +1144,7 @@ public func enumSimpleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
 }
 
 public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
@@ -1153,7 +1153,7 @@ public func enumMultipleNonConsumingUseTest(_ x: borrowing EnumTy) { // expected
 public func enumMultipleNonConsumingUseTestArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumMultipleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
@@ -1170,80 +1170,80 @@ public func enumMultipleNonConsumingUseTestOwnedArg2(_ x2: consuming EnumTy) {
 
 public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
-                // expected-note @-1 {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+                // expected-note @-1 {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    consumeVal(x2) // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
-public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}};
+        consumeVal(x2) // expected-note {{consumed here}};
     }
 }
 
-public func enumLoopConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumLoopConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}};
+        consumeVal(x2) // expected-note {{consumed here}};
     }
 }
 
 public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     if boolValue {
         consumeVal(x2)
     } else {
@@ -1253,9 +1253,9 @@ public func enumDiamond(_ x: borrowing EnumTy) { // expected-error {{'x' is borr
 
 public func enumDiamondArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     } else {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1277,14 +1277,14 @@ public func enumDiamondOwnedArg2(_ x2: consuming EnumTy) {
 
 public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-note @-1 {{consumed here}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
@@ -1292,226 +1292,226 @@ public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' i
 public func enumDiamondInLoopArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func enumDiamondInLoopOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming use here}}
+          consumeVal(x2) // expected-note {{consumed here}}
+          // expected-note @-1 {{consumed here}}
       }
     }
 }
 
 public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                              // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar1OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar3(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar3Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                              // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar3OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar3OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     var x3 = x2
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
                                                              // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
     borrowVal(x2)
-    x3 = x // expected-note {{consuming use here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar5OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    borrowVal(x2) // expected-note {{non-consuming use here}}
-    x3 = x // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    borrowVal(x2) // expected-note {{used here}}
+    x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
 
 public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
-               // expected-note @-1 {{consuming use here}}
+    let x2 = x // expected-error {{'x2' consumed in a loop}}
+               // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1519,23 +1519,23 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
 
 public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1543,18 +1543,18 @@ public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expecte
 
 public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    switch x2 { // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -1566,27 +1566,27 @@ public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-err
 }
 
 public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
-        borrowVal(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     switch x2 {
     case let .klass(k):
         borrowVal(k)
@@ -1596,7 +1596,7 @@ public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -1625,10 +1625,10 @@ public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
 // TODO: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
-               // expected-note @-1 {{consuming use here}}
-    switch x2 { // expected-note {{consuming use here}}
+               // expected-note @-1 {{consumed here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -1638,7 +1638,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expec
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -1650,9 +1650,9 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // e
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -1662,9 +1662,9 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
     case .int:
         break
@@ -1674,7 +1674,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) 
 }
 
 public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     switch x2 {
     case let .klass(k)
            where boolValue:
@@ -1687,7 +1687,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expe
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -1729,12 +1729,12 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
     // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed by closure capture}}
-    let f = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x' here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
-        // expected-note @-1 {{consuming use here}}
+        // expected-note @-1 {{consumed here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1742,10 +1742,10 @@ public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
 public func closureClassUseAfterConsume2(_ argX: borrowing NonTrivialStruct) {
     let f = { (_ x: borrowing NonTrivialStruct) in // expected-error {{'x' is borrowed and cannot be consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
-                   // expected-note @-1 {{consuming use here}}
+                   // expected-note @-1 {{consumed here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
@@ -1754,33 +1754,33 @@ public func closureClassUseAfterConsumeArg(_ argX: borrowing NonTrivialStruct) {
     // TODO: Fix this
     let f = { (_ x2: borrowing NonTrivialStruct) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
 
 public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
     let x3 = x2
@@ -1790,10 +1790,10 @@ public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStr
 public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    let f = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x2' here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1803,8 +1803,8 @@ public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialS
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1814,9 +1814,9 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivi
     // expected-error @-2 {{'x2' consumed more than once}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
 }
@@ -1826,8 +1826,8 @@ public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivial
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     f()
     let x3 = x2
@@ -1840,38 +1840,38 @@ public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivi
     // expected-error @-3 {{'x2' consumed more than once}}
     let f = {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     f()
-    let x3 = x2 // expected-note {{consuming use here}}
-    consumeVal(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed here}}
     let _ = x3
 }
 
 public func deferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
-    consumeVal(x) // expected-note {{consuming use here}}
+    consumeVal(x) // expected-note {{consumed here}}
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
@@ -1880,8 +1880,8 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct
     borrowVal(x2)
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     consumeVal("foo")
 }
@@ -1890,8 +1890,8 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStr
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
     consumeVal("foo")
 }
@@ -1901,9 +1901,9 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivial
     // expected-error @-2 {{missing reinitialization of inout parameter 'x2' after consume}}
     defer {
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
     consumeVal("foo")
 }
@@ -1911,36 +1911,36 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivial
 public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
     }
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivialStruct) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' used after consume}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         borrowVal(x2)
-        consumeVal(x2) // expected-note {{consuming use here}}
-        consumeVal(x2) // expected-note {{consuming use here}}
-        // expected-note @-1 {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed here}}
+        // expected-note @-1 {{consumed here}}
     }
-    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consumed here}}
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -1948,15 +1948,15 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivial
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -1965,15 +1965,15 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivia
 
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consumed here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -1983,11 +1983,11 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivia
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    let f = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x2' here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -1999,8 +1999,8 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -2013,9 +2013,9 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming 
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -2027,8 +2027,8 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned No
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -2042,9 +2042,9 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         consumeVal("foo")
     }
@@ -2053,14 +2053,14 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -2068,14 +2068,14 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivi
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let x2 = x // expected-note {{consuming use here}}
+    let x2 = x // expected-note {{consumed here}}
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -2088,11 +2088,11 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonT
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    let f = { // expected-note {{closure capture here}}
-        let g = { // expected-note {{closure capture here}}
+    let f = { // expected-note {{closure capturing 'x2' here}}
+        let g = { // expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -2105,8 +2105,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -2119,9 +2119,9 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consumin
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
-            // expected-note @-1 {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            // expected-note @-1 {{consumed here}}
         }
         g()
     }
@@ -2134,8 +2134,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned 
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }
@@ -2149,8 +2149,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: __owned 
     let f = {
         let g = {
             borrowVal(x2)
-            consumeVal(x2) // expected-note {{consuming use here}}
-            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consumed here}}
+            consumeVal(x2) // expected-note {{consumed here}}
         }
         g()
     }

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1727,7 +1727,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 /////////////////////////////
 
 public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
@@ -1762,8 +1762,8 @@ public func closureClassUseAfterConsumeArg(_ argX: borrowing NonTrivialStruct) {
 
 public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     
     let f = {
         borrowVal(x2)
@@ -1775,8 +1775,8 @@ public func closureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) 
 
 public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1788,7 +1788,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStr
 }
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
         borrowVal(x2)
@@ -1799,8 +1799,8 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStru
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1822,8 +1822,8 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivi
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1852,7 +1852,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivi
 
 public func deferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1864,7 +1864,7 @@ public func deferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { 
 public func deferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-3 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -1876,7 +1876,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     borrowVal(x2)
     defer {
         borrowVal(x2)
@@ -1887,7 +1887,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     defer {
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1909,7 +1909,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivial
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' used after consume}}
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -1935,7 +1935,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivial
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -1949,8 +1949,8 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: borrowing NonTrivial
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -1966,8 +1966,8 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: borrowing NonTrivia
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-3 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-3 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         consumeVal(x2) // expected-note {{consuming use here}}
         defer {
@@ -1982,7 +1982,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivia
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = { // expected-note {{closure capture here}}
         defer {
             borrowVal(x2)
@@ -1995,7 +1995,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTri
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -2023,7 +2023,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming 
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         defer {
             borrowVal(x2)
@@ -2054,8 +2054,8 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2069,8 +2069,8 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: borrowing NonTrivi
 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTrivialStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2085,7 +2085,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTriv
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
     // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
     let f = { // expected-note {{closure capture here}}
@@ -2100,8 +2100,8 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonT
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2129,8 +2129,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consumin
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)
@@ -2144,8 +2144,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume3(_ x2: __owned 
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume4(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{captured 'x2' cannot be consumed within a closure}}
-    // expected-error @-2 {{captured 'x2' cannot be consumed within a closure}}
+    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = {
         let g = {
             borrowVal(x2)

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -130,7 +130,7 @@ public func aggStructUseAfterConsume(_ x: borrowing AggStruct) { // expected-err
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -142,20 +142,20 @@ public func aggStructUseAfterConsumeArg(_ x2: borrowing AggStruct) { // expected
 public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -165,12 +165,12 @@ public func aggStructDoubleConsumeArg(_ x2: borrowing AggStruct) { // expected-e
 
 public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg2(_ x2: consuming AggStruct) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructLoopConsume(_ x: borrowing AggStruct) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -241,7 +241,7 @@ public func aggStructDiamondInLoop(_ x: borrowing AggStruct) { // expected-error
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -263,7 +263,7 @@ public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expecte
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -275,7 +275,7 @@ public func aggStructDiamondInLoopOwnedArg2(_ x2: consuming AggStruct) { // expe
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -481,7 +481,7 @@ public func aggGenericStructUseAfterConsume(_ x: borrowing AggGenericStruct<Copy
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -493,20 +493,20 @@ public func aggGenericStructUseAfterConsumeArg(_ x2: borrowing AggGenericStruct<
 public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -516,12 +516,12 @@ public func aggGenericStructDoubleConsumeArg(_ x2: borrowing AggGenericStruct<Co
 
 public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2(_ x2: consuming AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume(_ x: borrowing AggGenericStruct<CopyableKlass>) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -592,7 +592,7 @@ public func aggGenericStructDiamondInLoop(_ x: borrowing AggGenericStruct<Copyab
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -614,7 +614,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -626,7 +626,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2(_ x2: consuming AggGenericStr
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -823,7 +823,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: borrowing AggGenericStruct<T
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -835,20 +835,20 @@ public func aggGenericStructUseAfterConsumeArg<T>(_ x2: borrowing AggGenericStru
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -858,12 +858,12 @@ public func aggGenericStructDoubleConsumeArg<T>(_ x2: borrowing AggGenericStruct
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg2<T>(_ x2: consuming AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: borrowing AggGenericStruct<T>) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -934,7 +934,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: borrowing AggGenericStruct<T>)
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -956,7 +956,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStr
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -968,7 +968,7 @@ public func aggGenericStructDiamondInLoopOwnedArg2<T>(_ x2: consuming AggGeneric
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1173,7 +1173,7 @@ public func enumUseAfterConsume(_ x: borrowing EnumTy) { // expected-error {{'x'
                // expected-note @-1 {{consumed here}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1185,20 +1185,20 @@ public func enumUseAfterConsumeArg(_ x2: borrowing EnumTy) { // expected-error {
 public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consumed here}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1208,12 +1208,12 @@ public func enumDoubleConsumeArg(_ x2: borrowing EnumTy) { // expected-error {{'
 
 public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     consumeVal(x2) // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
 }
 
 public func enumLoopConsume(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
@@ -1284,7 +1284,7 @@ public func enumDiamondInLoop(_ x: borrowing EnumTy) { // expected-error {{'x' i
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1306,7 +1306,7 @@ public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error 
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1318,7 +1318,7 @@ public func enumDiamondInLoopOwnedArg2(_ x2: consuming EnumTy) { // expected-err
           consumeVal(x2) // expected-note {{consumed here}}
       } else {
           consumeVal(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
       }
     }
 }
@@ -1327,7 +1327,7 @@ public func enumAssignToVar1(_ x: borrowing EnumTy) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -1343,7 +1343,7 @@ public func enumAssignToVar1Arg(_ x: borrowing EnumTy, _ x2: borrowing EnumTy) {
 public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -1351,7 +1351,7 @@ public func enumAssignToVar1OwnedArg(_ x: borrowing EnumTy, _ x2: __owned EnumTy
 public func enumAssignToVar1OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x // expected-note {{consumed here}}
     consumeVal(x3)
 }
@@ -1360,7 +1360,7 @@ public func enumAssignToVar2(_ x: borrowing EnumTy) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -1372,13 +1372,13 @@ public func enumAssignToVar2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x
 
 public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     borrowVal(x3)
 }
 
@@ -1412,7 +1412,7 @@ public func enumAssignToVar4(_ x: borrowing EnumTy) { // expected-error {{'x' is
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -1424,13 +1424,13 @@ public func enumAssignToVar4Arg(_ x2: borrowing EnumTy) { // expected-error {{'x
 
 public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     consumeVal(x3)
 }
 
@@ -1475,7 +1475,7 @@ public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x.i)
     }
 }
@@ -1493,7 +1493,7 @@ public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-e
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1502,7 +1502,7 @@ public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expecte
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1734,7 +1734,7 @@ public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
         // expected-note @-1 {{consumed here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -1745,7 +1745,7 @@ public func closureClassUseAfterConsume2(_ argX: borrowing NonTrivialStruct) {
                    // expected-note @-1 {{consumed here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
-        consumeVal(x2) // expected-note {{consumed here}}
+        consumeVal(x2) // expected-note {{consumed again here}}
     }
     f(argX)
 }
@@ -1816,7 +1816,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivi
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
 }
@@ -1842,11 +1842,11 @@ public func closureCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivi
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     f()
     let x3 = x2 // expected-note {{consumed here}}
-    consumeVal(x2) // expected-note {{consumed here}}
+    consumeVal(x2) // expected-note {{consumed again here}}
     let _ = x3
 }
 
@@ -1903,7 +1903,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming NonTrivial
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     consumeVal("foo")
 }
@@ -1927,7 +1927,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming NonTrivial
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
         consumeVal(x2) // expected-note {{consumed here}}
-        // expected-note @-1 {{consumed here}}
+        // expected-note @-1 {{consumed again here}}
     }
     consumeVal(x2) // expected-note {{consumed here}}
 }
@@ -2015,7 +2015,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: consuming 
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         consumeVal("foo")
     }
@@ -2044,7 +2044,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming 
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         consumeVal("foo")
     }
@@ -2121,7 +2121,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: consumin
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consumed here}}
             consumeVal(x2) // expected-note {{consumed here}}
-            // expected-note @-1 {{consumed here}}
+            // expected-note @-1 {{consumed again here}}
         }
         g()
     }

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -25,7 +25,7 @@ public func classSimpleChainTest(_ x: Klass) {
 }
 
 public func classSimpleChainArgTest(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     classUseMoveOnlyWithoutEscaping(k2)
 }
@@ -59,7 +59,7 @@ public func classMultipleNonConsumingUseTest(_ x: Klass) {
 public func classMultipleNonConsumingUseArgTest(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     classUseMoveOnlyWithoutEscaping(x2)
     classUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func classMultipleNonConsumingUseOwnedArgTest(@_noImplicitCopy _ x2: __owned Klass) {
@@ -71,40 +71,40 @@ public func classMultipleNonConsumingUseOwnedArgTest(@_noImplicitCopy _ x2: __ow
 public func classUseAfterConsume(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     classUseMoveOnlyWithoutEscaping(x2)
-    classConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func classUseAfterConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     classUseMoveOnlyWithoutEscaping(x2)
-    classConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func classUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     classUseMoveOnlyWithoutEscaping(x2)
-    classConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsume(_ x: Klass) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    classConsume(x2) // expected-note {{consuming use here}}
-    classConsume(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
+    classConsume(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    classConsume(x2) // expected-note {{consuming use here}}
-    classConsume(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
+    classConsume(x2) // expected-note {{consumed here}}
 }
 
 public func classDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    classConsume(x2) // expected-note {{consuming use here}}
-    classConsume(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
+    classConsume(x2) // expected-note {{consumed here}}
 }
 
 public func classLoopConsume(_ x: Klass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         classConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -112,11 +112,11 @@ public func classLoopConsume(_ x: Klass) {
 
 public func classLoopConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consumed here}}
     }
 }
 
-public func classLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func classLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         classConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -133,9 +133,9 @@ public func classDiamond(_ x: Klass) {
 
 public func classDiamondArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        classConsume(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consumed here}}
     } else {
-        classConsume(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -149,12 +149,12 @@ public func classDiamondOwnedArg(@_noImplicitCopy _ x2: __owned Klass) {
 
 public func classDiamondInLoop(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          classConsume(x2) // expected-note {{consuming use here}}
+          classConsume(x2) // expected-note {{consumed here}}
       } else {
-          classConsume(x2) // expected-note {{consuming use here}}
+          classConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -163,20 +163,20 @@ public func classDiamondInLoop(_ x: Klass) {
 public func classDiamondInLoopArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          classConsume(x2) // expected-note {{consuming use here}}
+          classConsume(x2) // expected-note {{consumed here}}
       } else {
-          classConsume(x2) // expected-note {{consuming use here}}
+          classConsume(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func classDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          classConsume(x2) // expected-note {{consuming use here}}
+          classConsume(x2) // expected-note {{consumed here}}
       } else {
-          classConsume(x2) // expected-note {{consuming use here}}
+          classConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -184,42 +184,42 @@ public func classDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { /
 
 public func classAssignToVar1(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func classAssignToVar1Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func classAssignToVar1OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func classAssignToVar2(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     classUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func classAssignToVar2Arg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     classUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func classAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     classUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -231,7 +231,7 @@ public func classAssignToVar3(_ x: Klass) {
 }
 
 public func classAssignToVar3Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
@@ -244,33 +244,33 @@ public func classAssignToVar3OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned
 
 public func classAssignToVar4(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func classAssignToVar4Arg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func classAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func classAssignToVar5(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
 
 public func classAssignToVar5Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
     classUseMoveOnlyWithoutEscaping(x2)
@@ -279,8 +279,8 @@ public func classAssignToVar5Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // 
 }
 
 public func classAssignToVar5OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
@@ -349,7 +349,7 @@ public func finalClassSimpleChainTest(_ x: FinalKlass) {
 }
 
 public func finalClassSimpleChainTestArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     finalClassUseMoveOnlyWithoutEscaping(k2)
 }
@@ -383,7 +383,7 @@ public func finalClassMultipleNonConsumingUseTest(_ x: FinalKlass) {
 public func finalClassMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
     finalClassUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassMultipleNonConsumingUseTestownedArg(@_noImplicitCopy _ x2: __owned FinalKlass) {
@@ -395,40 +395,40 @@ public func finalClassMultipleNonConsumingUseTestownedArg(@_noImplicitCopy _ x2:
 public func finalClassUseAfterConsume(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsume(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassDoubleConsumeownedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
+    finalClassConsume(x2) // expected-note {{consumed here}}
 }
 
 public func finalClassLoopConsume(_ x: FinalKlass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         finalClassConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -436,11 +436,11 @@ public func finalClassLoopConsume(_ x: FinalKlass) {
 
 public func finalClassLoopConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        finalClassConsume(x2) // expected-note {{consumed here}}
     }
 }
 
-public func finalClassLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed by a use in a loop}}
+public func finalClassLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         finalClassConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -457,9 +457,9 @@ public func finalClassDiamond(_ x: FinalKlass) {
 
 public func finalClassDiamondArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        finalClassConsume(x2) // expected-note {{consumed here}}
     } else {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        finalClassConsume(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -473,12 +473,12 @@ public func finalClassDiamondOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass)
 
 public func finalClassDiamondInLoop(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          finalClassConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -487,20 +487,20 @@ public func finalClassDiamondInLoop(_ x: FinalKlass) {
 public func finalClassDiamondInLoopArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          finalClassConsume(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func finalClassDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          finalClassConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -508,42 +508,42 @@ public func finalClassDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Final
 
 public func finalClassAssignToVar1(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func finalClassAssignToVar1Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func finalClassAssignToVar1OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func finalClassAssignToVar2(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     finalClassUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func finalClassAssignToVar2Arg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     finalClassUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func finalClassAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     finalClassUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -555,7 +555,7 @@ public func finalClassAssignToVar3(_ x: FinalKlass) {
 }
 
 public func finalClassAssignToVar3Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
@@ -568,33 +568,33 @@ public func finalClassAssignToVar3OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x
 
 public func finalClassAssignToVar4(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func finalClassAssignToVar4Arg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func finalClassAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func finalClassAssignToVar5(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
 
 public func finalClassAssignToVar5Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
     finalClassUseMoveOnlyWithoutEscaping(x2)
@@ -603,8 +603,8 @@ public func finalClassAssignToVar5Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: Fi
 }
 
 public func finalClassAssignToVar5OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
@@ -689,7 +689,7 @@ public func aggStructSimpleChainTest(_ x: AggStruct) {
 }
 
 public func aggStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     aggStructUseMoveOnlyWithoutEscaping(k2)
 }
@@ -723,7 +723,7 @@ public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) {
 public func aggStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
@@ -735,40 +735,40 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: 
 public func aggStructUseAfterConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
+    aggStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         aggStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -776,11 +776,11 @@ public func aggStructLoopConsume(_ x: AggStruct) {
 
 public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        aggStructConsume(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         aggStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -797,9 +797,9 @@ public func aggStructDiamond(_ x: AggStruct) {
 
 public func aggStructDiamondArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        aggStructConsume(x2) // expected-note {{consumed here}}
     } else {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        aggStructConsume(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -813,12 +813,12 @@ public func aggStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
 
 public func aggStructDiamondInLoop(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          aggStructConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -827,20 +827,20 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
 public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          aggStructConsume(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          aggStructConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -959,7 +959,7 @@ public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<Klass>) {
 }
 
 public func aggGenericStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
@@ -993,7 +993,7 @@ public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<Kl
 public func aggGenericStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) {
@@ -1005,40 +1005,40 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy
 public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -1046,11 +1046,11 @@ public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
 
 public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -1067,9 +1067,9 @@ public func aggGenericStructDiamond(_ x: AggGenericStruct<Klass>) {
 
 public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1083,12 +1083,12 @@ public func aggGenericStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggGe
 
 public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -1097,20 +1097,20 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
 public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -1223,7 +1223,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) {
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
@@ -1257,7 +1257,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { //expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) {
@@ -1269,40 +1269,40 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(@_noImplicitC
 public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -1310,11 +1310,11 @@ public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
 
 public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -1331,9 +1331,9 @@ public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) {
 
 public func aggGenericStructDiamondArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1347,12 +1347,12 @@ public func aggGenericStructDiamondOwnedArg<T>(@_noImplicitCopy _ x2: __owned Ag
 
 public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -1361,20 +1361,20 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
 public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -1495,7 +1495,7 @@ public func enumSimpleChainTest(_ x: EnumTy) {
 }
 
 public func enumSimpleChainTestArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     enumUseMoveOnlyWithoutEscaping(k2)
 }
@@ -1529,7 +1529,7 @@ public func enumMultipleNonConsumingUseTest(_ x: EnumTy) {
 public func enumMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     enumUseMoveOnlyWithoutEscaping(x2)
     enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func enumMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) {
@@ -1541,40 +1541,40 @@ public func enumMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __own
 public func enumUseAfterConsume(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    enumConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    enumConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func enumUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    enumConsume(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsume(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    enumConsume(x2) // expected-note {{consumed here}}
+    enumConsume(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    enumConsume(x2) // expected-note {{consumed here}}
+    enumConsume(x2) // expected-note {{consumed here}}
 }
 
 public func enumDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    enumConsume(x2) // expected-note {{consumed here}}
+    enumConsume(x2) // expected-note {{consumed here}}
 }
 
 public func enumLoopConsume(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         enumConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -1582,11 +1582,11 @@ public func enumLoopConsume(_ x: EnumTy) {
 
 public func enumLoopConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        enumConsume(x2) // expected-note {{consumed here}}
     }
 }
 
-public func enumLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         enumConsume(x2) // expected-note {{consuming in loop use here}}
     }
@@ -1603,9 +1603,9 @@ public func enumDiamond(_ x: EnumTy) {
 
 public func enumDiamondArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        enumConsume(x2) // expected-note {{consumed here}}
     } else {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        enumConsume(x2) // expected-note {{consumed here}}
     }
 }
 
@@ -1619,12 +1619,12 @@ public func enumDiamondOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) {
 
 public func enumDiamondInLoop(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          enumConsume(x2) // expected-note {{consumed here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          enumConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -1633,20 +1633,20 @@ public func enumDiamondInLoop(_ x: EnumTy) {
 public func enumDiamondInLoopArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          enumConsume(x2) // expected-note {{consumed here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          enumConsume(x2) // expected-note {{consumed here}}
       }
     }
 }
 
 public func enumDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          enumConsume(x2) // expected-note {{consumed here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          enumConsume(x2) // expected-note {{consumed here}}
           // expected-note @-1 {{consuming in loop use here}}
       }
     }
@@ -1654,42 +1654,42 @@ public func enumDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { /
 
 public func enumAssignToVar1(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func enumAssignToVar1Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func enumAssignToVar1OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func enumAssignToVar2(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     enumUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func enumAssignToVar2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     enumUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func enumAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     enumUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -1701,7 +1701,7 @@ public func enumAssignToVar3(_ x: EnumTy) {
 }
 
 public func enumAssignToVar3Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
@@ -1714,33 +1714,33 @@ public func enumAssignToVar3OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned
 
 public func enumAssignToVar4(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func enumAssignToVar4Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func enumAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func enumAssignToVar5(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
 
 public func enumAssignToVar5Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
     enumUseMoveOnlyWithoutEscaping(x2)
@@ -1749,42 +1749,42 @@ public func enumAssignToVar5Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { //
 }
 
 public func enumAssignToVar5OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
 
 public func enumPatternMatchIfLet1(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
 }
 
 public func enumPatternMatchIfLet1Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consuming use here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
 }
 
 public func enumPatternMatchIfLet2(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
             classUseMoveOnlyWithoutEscaping(x)
@@ -1794,13 +1794,13 @@ public func enumPatternMatchIfLet2(_ x: EnumTy) {
 
 public func enumPatternMatchIfLet2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
             classUseMoveOnlyWithoutEscaping(x)
         }
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
+public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
             classUseMoveOnlyWithoutEscaping(x)
@@ -1811,17 +1811,17 @@ public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy
 // This is wrong.
 public func enumPatternMatchSwitch1(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
-        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     case .int:
         break
     }
 }
 
 public func enumPatternMatchSwitch1Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
         // This should be flagged as the use after free use. We are atleast
@@ -1833,10 +1833,10 @@ public func enumPatternMatchSwitch1Arg(@_noImplicitCopy _ x2: EnumTy) { // expec
 }
 
 public func enumPatternMatchSwitch1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
-        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     case .int:
         break
     }
@@ -1853,7 +1853,7 @@ public func enumPatternMatchSwitch2(_ x: EnumTy) {
 }
 
 public func enumPatternMatchSwitch2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
     case .int:
@@ -1873,9 +1873,9 @@ public func enumPatternMatchSwitch2OwnedArg(@_noImplicitCopy _ x2: __owned EnumT
 // QOI: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         classUseMoveOnlyWithoutEscaping(k)
     case .int:
         break
@@ -1885,7 +1885,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) {
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething():
         classUseMoveOnlyWithoutEscaping(k)
@@ -1897,9 +1897,9 @@ public func enumPatternMatchSwitch2WhereClauseArg(@_noImplicitCopy _ x2: EnumTy)
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use here}}
+           where x2.doSomething(): // expected-note {{used here}}
         classUseMoveOnlyWithoutEscaping(k)
     case .int:
         break
@@ -1922,7 +1922,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) {
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consuming use here}}
+    switch x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where boolValue:
         classUseMoveOnlyWithoutEscaping(k)
@@ -1953,8 +1953,8 @@ public func closureClassUseAfterConsume1(_ x: Klass) {
     let f = {
         @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consumed here}}
+        print(x2) // expected-note {{consumed here}}
     }
     f()
 }
@@ -1963,8 +1963,8 @@ public func closureClassUseAfterConsume2(_ argX: Klass) {
     let f = { (_ x: Klass) in
         @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consumed here}}
+        print(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
@@ -1973,8 +1973,8 @@ public func closureClassUseAfterConsumeArg(_ argX: Klass) {
     // TODO: Fix this
     let f = { (@_noImplicitCopy _ x2: Klass) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consumed here}}
+        print(x2) // expected-note {{consumed here}}
     }
     f(argX)
 }
@@ -1991,18 +1991,18 @@ public func closureCaptureClassUseAfterConsume(_ x: Klass) {
 
 public func closureCaptureClassUseAfterConsumeError(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)
     }
     f()
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
 public func closureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)
@@ -2020,13 +2020,13 @@ public func closureCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)
     }
     f()
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
@@ -2042,12 +2042,12 @@ public func deferCaptureClassUseAfterConsume(_ x: Klass) {
 
 public func deferCaptureClassUseAfterConsume2(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)
     }
-    let x3 = x2 // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
     let _ = x3
 }
 
@@ -2071,12 +2071,12 @@ public func deferCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __ow
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
-    defer { // expected-note {{non-consuming use here}}
+    defer { // expected-note {{used here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)
     }
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) {
@@ -2108,7 +2108,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) {
 
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         classConsume(x2)
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -2118,11 +2118,11 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) {
         print("foo")
     }
     f()
-    classConsume(x2) // expected-note {{consuming use here}}
+    classConsume(x2) // expected-note {{consumed here}}
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
@@ -2146,7 +2146,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy 
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
@@ -2155,7 +2155,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy
         print("foo")
     }
     f()
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) {
@@ -2173,7 +2173,7 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) {
 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
@@ -2182,12 +2182,12 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) {
         g()
     }
     f()
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
@@ -2211,7 +2211,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(@_noImplicitCop
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    let f = { // expected-note {{consuming use here}}
+    let f = { // expected-note {{consumed here}}
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
@@ -2220,7 +2220,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCo
         g()
     }
     f()
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 /////////////////////////////
@@ -2229,7 +2229,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCo
 
 func moveOperatorTest(_ k: __owned Klass) {
     @_noImplicitCopy let k2 = k // expected-error {{'k2' consumed more than once}}
-    @_noImplicitCopy let k3 = consume k2 // expected-note {{consuming use here}}
-    let _ = consume k2 // expected-note {{consuming use here}}
+    @_noImplicitCopy let k3 = consume k2 // expected-note {{consumed here}}
+    let _ = consume k2 // expected-note {{consumed here}}
     let _ = k3
 }

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -72,7 +72,7 @@ public func classUseAfterConsume(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     classUseMoveOnlyWithoutEscaping(x2)
     classConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func classUseAfterConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -84,13 +84,13 @@ public func classUseAfterConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-
 public func classUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     classUseMoveOnlyWithoutEscaping(x2)
     classConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func classDoubleConsume(_ x: Klass) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     classConsume(x2) // expected-note {{consumed here}}
-    classConsume(x2) // expected-note {{consumed here}}
+    classConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func classDoubleConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -100,7 +100,7 @@ public func classDoubleConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-er
 
 public func classDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     classConsume(x2) // expected-note {{consumed here}}
-    classConsume(x2) // expected-note {{consumed here}}
+    classConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func classLoopConsume(_ x: Klass) {
@@ -154,7 +154,7 @@ public func classDiamondInLoop(_ x: Klass) {
       if boolValue {
           classConsume(x2) // expected-note {{consumed here}}
       } else {
-          classConsume(x2) // expected-note {{consumed here}}
+          classConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -176,7 +176,7 @@ public func classDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { /
       if boolValue {
           classConsume(x2) // expected-note {{consumed here}}
       } else {
-          classConsume(x2) // expected-note {{consumed here}}
+          classConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -185,7 +185,7 @@ public func classDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { /
 public func classAssignToVar1(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -199,7 +199,7 @@ public func classAssignToVar1Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // 
 
 public func classAssignToVar1OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -207,7 +207,7 @@ public func classAssignToVar1OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned
 public func classAssignToVar2(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     classUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -219,7 +219,7 @@ public func classAssignToVar2Arg(@_noImplicitCopy _ x2: Klass) { // expected-err
 
 public func classAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     classUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -245,7 +245,7 @@ public func classAssignToVar3OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned
 public func classAssignToVar4(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -257,7 +257,7 @@ public func classAssignToVar4Arg(@_noImplicitCopy _ x2: Klass) { // expected-err
 
 public func classAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -396,7 +396,7 @@ public func finalClassUseAfterConsume(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
     finalClassConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassUseAfterConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -408,13 +408,13 @@ public func finalClassUseAfterConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { //
 public func finalClassUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
     finalClassConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassDoubleConsume(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     finalClassConsume(x2) // expected-note {{consumed here}}
-    finalClassConsume(x2) // expected-note {{consumed here}}
+    finalClassConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassDoubleConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -424,7 +424,7 @@ public func finalClassDoubleConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // e
 
 public func finalClassDoubleConsumeownedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     finalClassConsume(x2) // expected-note {{consumed here}}
-    finalClassConsume(x2) // expected-note {{consumed here}}
+    finalClassConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func finalClassLoopConsume(_ x: FinalKlass) {
@@ -478,7 +478,7 @@ public func finalClassDiamondInLoop(_ x: FinalKlass) {
       if boolValue {
           finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consumed here}}
+          finalClassConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -500,7 +500,7 @@ public func finalClassDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Final
       if boolValue {
           finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consumed here}}
+          finalClassConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -509,7 +509,7 @@ public func finalClassDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Final
 public func finalClassAssignToVar1(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -523,7 +523,7 @@ public func finalClassAssignToVar1Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: Fi
 
 public func finalClassAssignToVar1OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -531,7 +531,7 @@ public func finalClassAssignToVar1OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x
 public func finalClassAssignToVar2(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     finalClassUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -543,7 +543,7 @@ public func finalClassAssignToVar2Arg(@_noImplicitCopy _ x2: FinalKlass) { // ex
 
 public func finalClassAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     finalClassUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -569,7 +569,7 @@ public func finalClassAssignToVar3OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x
 public func finalClassAssignToVar4(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -581,7 +581,7 @@ public func finalClassAssignToVar4Arg(@_noImplicitCopy _ x2: FinalKlass) { // ex
 
 public func finalClassAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -736,7 +736,7 @@ public func aggStructUseAfterConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -748,13 +748,13 @@ public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // e
 public func aggStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     aggStructConsume(x2) // expected-note {{consumed here}}
-    aggStructConsume(x2) // expected-note {{consumed here}}
+    aggStructConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -764,7 +764,7 @@ public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // exp
 
 public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     aggStructConsume(x2) // expected-note {{consumed here}}
-    aggStructConsume(x2) // expected-note {{consumed here}}
+    aggStructConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) {
@@ -818,7 +818,7 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
       if boolValue {
           aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consumed here}}
+          aggStructConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -840,7 +840,7 @@ public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
       if boolValue {
           aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consumed here}}
+          aggStructConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1006,7 +1006,7 @@ public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1018,13 +1018,13 @@ public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGeneric
 public func aggGenericStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1034,7 +1034,7 @@ public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericSt
 
 public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
@@ -1088,7 +1088,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consumed here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1110,7 +1110,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consumed here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1270,7 +1270,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1282,13 +1282,13 @@ public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGene
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1298,7 +1298,7 @@ public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGeneri
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     aggGenericStructConsume(x2) // expected-note {{consumed here}}
-    aggGenericStructConsume(x2) // expected-note {{consumed here}}
+    aggGenericStructConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
@@ -1352,7 +1352,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consumed here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1374,7 +1374,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __ow
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consumed here}}
+          aggGenericStructConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1542,7 +1542,7 @@ public func enumUseAfterConsume(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     enumUseMoveOnlyWithoutEscaping(x2)
     enumConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func enumUseAfterConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1554,13 +1554,13 @@ public func enumUseAfterConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-
 public func enumUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     enumUseMoveOnlyWithoutEscaping(x2)
     enumConsume(x2) // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsume(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     enumConsume(x2) // expected-note {{consumed here}}
-    enumConsume(x2) // expected-note {{consumed here}}
+    enumConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func enumDoubleConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -1570,7 +1570,7 @@ public func enumDoubleConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-er
 
 public func enumDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     enumConsume(x2) // expected-note {{consumed here}}
-    enumConsume(x2) // expected-note {{consumed here}}
+    enumConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func enumLoopConsume(_ x: EnumTy) {
@@ -1624,7 +1624,7 @@ public func enumDiamondInLoop(_ x: EnumTy) {
       if boolValue {
           enumConsume(x2) // expected-note {{consumed here}}
       } else {
-          enumConsume(x2) // expected-note {{consumed here}}
+          enumConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1646,7 +1646,7 @@ public func enumDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { /
       if boolValue {
           enumConsume(x2) // expected-note {{consumed here}}
       } else {
-          enumConsume(x2) // expected-note {{consumed here}}
+          enumConsume(x2) // expected-note {{consumed again here}}
           // expected-note @-1 {{consumed in loop here}}
       }
     }
@@ -1655,7 +1655,7 @@ public func enumDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { /
 public func enumAssignToVar1(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -1669,7 +1669,7 @@ public func enumAssignToVar1Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { //
 
 public func enumAssignToVar1OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -1677,7 +1677,7 @@ public func enumAssignToVar1OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned
 public func enumAssignToVar2(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     enumUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -1689,7 +1689,7 @@ public func enumAssignToVar2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-err
 
 public func enumAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     enumUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -1715,7 +1715,7 @@ public func enumAssignToVar3OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned
 public func enumAssignToVar4(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -1727,7 +1727,7 @@ public func enumAssignToVar4Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-err
 
 public func enumAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -1760,7 +1760,7 @@ public func enumPatternMatchIfLet1(_ x: EnumTy) {
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
 }
@@ -1778,7 +1778,7 @@ public func enumPatternMatchIfLet1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy
     if case let .klass(x) = x2 { // expected-note {{consumed here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
 }
@@ -1954,7 +1954,7 @@ public func closureClassUseAfterConsume1(_ x: Klass) {
         @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consumed here}}
-        print(x2) // expected-note {{consumed here}}
+        print(x2) // expected-note {{consumed again here}}
     }
     f()
 }
@@ -1964,7 +1964,7 @@ public func closureClassUseAfterConsume2(_ argX: Klass) {
         @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consumed here}}
-        print(x2) // expected-note {{consumed here}}
+        print(x2) // expected-note {{consumed again here}}
     }
     f(argX)
 }
@@ -1997,7 +1997,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: Klass) {
         print(x2)
     }
     f()
-    let x3 = x2 // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed again here}}
     let _ = x3
 }
 
@@ -2026,7 +2026,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: _
         print(x2)
     }
     f()
-    let x3 = x2 // expected-note {{consumed here}}
+    let x3 = x2 // expected-note {{consumed again here}}
     let _ = x3
 }
 
@@ -2118,7 +2118,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) {
         print("foo")
     }
     f()
-    classConsume(x2) // expected-note {{consumed here}}
+    classConsume(x2) // expected-note {{consumed again here}}
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -2155,7 +2155,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy
         print("foo")
     }
     f()
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) {
@@ -2182,7 +2182,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) {
         g()
     }
     f()
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 
@@ -2220,7 +2220,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCo
         g()
     }
     f()
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 /////////////////////////////
@@ -2230,6 +2230,6 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCo
 func moveOperatorTest(_ k: __owned Klass) {
     @_noImplicitCopy let k2 = k // expected-error {{'k2' consumed more than once}}
     @_noImplicitCopy let k3 = consume k2 // expected-note {{consumed here}}
-    let _ = consume k2 // expected-note {{consumed here}}
+    let _ = consume k2 // expected-note {{consumed again here}}
     let _ = k3
 }

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -106,7 +106,7 @@ public func classDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { /
 public func classLoopConsume(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming in loop use here}}
+        classConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -118,7 +118,7 @@ public func classLoopConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-erro
 
 public func classLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming in loop use here}}
+        classConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -155,7 +155,7 @@ public func classDiamondInLoop(_ x: Klass) {
           classConsume(x2) // expected-note {{consumed here}}
       } else {
           classConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -177,7 +177,7 @@ public func classDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { /
           classConsume(x2) // expected-note {{consumed here}}
       } else {
           classConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -430,7 +430,7 @@ public func finalClassDoubleConsumeownedArg(@_noImplicitCopy _ x2: __owned Final
 public func finalClassLoopConsume(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming in loop use here}}
+        finalClassConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -442,7 +442,7 @@ public func finalClassLoopConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // exp
 
 public func finalClassLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming in loop use here}}
+        finalClassConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -479,7 +479,7 @@ public func finalClassDiamondInLoop(_ x: FinalKlass) {
           finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
           finalClassConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -501,7 +501,7 @@ public func finalClassDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Final
           finalClassConsume(x2) // expected-note {{consumed here}}
       } else {
           finalClassConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -770,7 +770,7 @@ public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
 public func aggStructLoopConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming in loop use here}}
+        aggStructConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -782,7 +782,7 @@ public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expec
 
 public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming in loop use here}}
+        aggStructConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -819,7 +819,7 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
           aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
           aggStructConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -841,7 +841,7 @@ public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
           aggStructConsume(x2) // expected-note {{consumed here}}
       } else {
           aggStructConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1040,7 +1040,7 @@ public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -1052,7 +1052,7 @@ public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStru
 
 public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -1089,7 +1089,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1111,7 +1111,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1304,7 +1304,7 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __ow
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -1316,7 +1316,7 @@ public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericS
 
 public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
+        aggGenericStructConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -1353,7 +1353,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1375,7 +1375,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __ow
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1576,7 +1576,7 @@ public func enumDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { /
 public func enumLoopConsume(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming in loop use here}}
+        enumConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -1588,7 +1588,7 @@ public func enumLoopConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-erro
 
 public func enumLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming in loop use here}}
+        enumConsume(x2) // expected-note {{consumed in loop here}}
     }
 }
 
@@ -1625,7 +1625,7 @@ public func enumDiamondInLoop(_ x: EnumTy) {
           enumConsume(x2) // expected-note {{consumed here}}
       } else {
           enumConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1647,7 +1647,7 @@ public func enumDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { /
           enumConsume(x2) // expected-note {{consumed here}}
       } else {
           enumConsume(x2) // expected-note {{consumed here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consumed in loop here}}
       }
     }
 }
@@ -1786,7 +1786,7 @@ public func enumPatternMatchIfLet1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy
 public func enumPatternMatchIfLet2(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed in loop here}}
             classUseMoveOnlyWithoutEscaping(x)
         }
     }
@@ -1802,7 +1802,7 @@ public func enumPatternMatchIfLet2Arg(@_noImplicitCopy _ x2: EnumTy) { // expect
 
 public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consumed in loop here}}
             classUseMoveOnlyWithoutEscaping(x)
         }
     }

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -24,7 +24,7 @@ public func classSimpleChainTest(_ x: Klass) {
     classUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func classSimpleChainArgTest(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classSimpleChainArgTest(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     classUseMoveOnlyWithoutEscaping(k2)
@@ -56,7 +56,7 @@ public func classMultipleNonConsumingUseTest(_ x: Klass) {
     print(x2)
 }
 
-public func classMultipleNonConsumingUseArgTest(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseArgTest(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     classUseMoveOnlyWithoutEscaping(x2)
     classUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -75,7 +75,7 @@ public func classUseAfterConsume(_ x: Klass) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func classUseAfterConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classUseAfterConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     classUseMoveOnlyWithoutEscaping(x2)
     classConsume(x2) // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
@@ -93,7 +93,7 @@ public func classDoubleConsume(_ x: Klass) {
     classConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDoubleConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     classConsume(x2) // expected-note {{consuming use here}}
     classConsume(x2) // expected-note {{consuming use here}}
 }
@@ -110,7 +110,7 @@ public func classLoopConsume(_ x: Klass) {
     }
 }
 
-public func classLoopConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classLoopConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         classConsume(x2) // expected-note {{consuming use here}}
     }
@@ -131,7 +131,7 @@ public func classDiamond(_ x: Klass) {
     }
 }
 
-public func classDiamondArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDiamondArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         classConsume(x2) // expected-note {{consuming use here}}
     } else {
@@ -160,7 +160,7 @@ public func classDiamondInLoop(_ x: Klass) {
     }
 }
 
-public func classDiamondInLoopArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDiamondInLoopArg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           classConsume(x2) // expected-note {{consuming use here}}
@@ -190,7 +190,7 @@ public func classAssignToVar1(_ x: Klass) {
     print(x3)
 }
 
-public func classAssignToVar1Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar1Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x
@@ -211,7 +211,7 @@ public func classAssignToVar2(_ x: Klass) {
     classUseMoveOnlyWithoutEscaping(x3)
 }
 
-public func classAssignToVar2Arg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar2Arg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     classUseMoveOnlyWithoutEscaping(x3)
@@ -230,7 +230,7 @@ public func classAssignToVar3(_ x: Klass) {
     print(x3)
 }
 
-public func classAssignToVar3Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar3Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x
     print(x3)
@@ -249,7 +249,7 @@ public func classAssignToVar4(_ x: Klass) {
     print(x3)
 }
 
-public func classAssignToVar4Arg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar4Arg(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
     print(x3)
@@ -269,7 +269,7 @@ public func classAssignToVar5(_ x: Klass) {
     print(x3)
 }
 
-public func classAssignToVar5Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar5Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
@@ -348,7 +348,7 @@ public func finalClassSimpleChainTest(_ x: FinalKlass) {
     finalClassUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func finalClassSimpleChainTestArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassSimpleChainTestArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     finalClassUseMoveOnlyWithoutEscaping(k2)
@@ -380,7 +380,7 @@ public func finalClassMultipleNonConsumingUseTest(_ x: FinalKlass) {
     print(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
     finalClassUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -399,7 +399,7 @@ public func finalClassUseAfterConsume(_ x: FinalKlass) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassUseAfterConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassUseAfterConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     finalClassUseMoveOnlyWithoutEscaping(x2)
     finalClassConsume(x2) // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
@@ -417,7 +417,7 @@ public func finalClassDoubleConsume(_ x: FinalKlass) {
     finalClassConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassDoubleConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDoubleConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     finalClassConsume(x2) // expected-note {{consuming use here}}
     finalClassConsume(x2) // expected-note {{consuming use here}}
 }
@@ -434,7 +434,7 @@ public func finalClassLoopConsume(_ x: FinalKlass) {
     }
 }
 
-public func finalClassLoopConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassLoopConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         finalClassConsume(x2) // expected-note {{consuming use here}}
     }
@@ -455,7 +455,7 @@ public func finalClassDiamond(_ x: FinalKlass) {
     }
 }
 
-public func finalClassDiamondArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDiamondArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         finalClassConsume(x2) // expected-note {{consuming use here}}
     } else {
@@ -484,7 +484,7 @@ public func finalClassDiamondInLoop(_ x: FinalKlass) {
     }
 }
 
-public func finalClassDiamondInLoopArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDiamondInLoopArg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           finalClassConsume(x2) // expected-note {{consuming use here}}
@@ -514,7 +514,7 @@ public func finalClassAssignToVar1(_ x: FinalKlass) {
     print(x3)
 }
 
-public func finalClassAssignToVar1Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar1Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x
@@ -535,7 +535,7 @@ public func finalClassAssignToVar2(_ x: FinalKlass) {
     finalClassUseMoveOnlyWithoutEscaping(x3)
 }
 
-public func finalClassAssignToVar2Arg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar2Arg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     finalClassUseMoveOnlyWithoutEscaping(x3)
@@ -554,7 +554,7 @@ public func finalClassAssignToVar3(_ x: FinalKlass) {
     print(x3)
 }
 
-public func finalClassAssignToVar3Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x
     print(x3)
@@ -573,7 +573,7 @@ public func finalClassAssignToVar4(_ x: FinalKlass) {
     print(x3)
 }
 
-public func finalClassAssignToVar4Arg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar4Arg(@_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
     print(x3)
@@ -593,7 +593,7 @@ public func finalClassAssignToVar5(_ x: FinalKlass) {
     print(x3)
 }
 
-public func finalClassAssignToVar5Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar5Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: FinalKlass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
@@ -688,7 +688,7 @@ public func aggStructSimpleChainTest(_ x: AggStruct) {
     aggStructUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func aggStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     aggStructUseMoveOnlyWithoutEscaping(k2)
@@ -720,7 +720,7 @@ public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) {
     print(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -739,7 +739,7 @@ public func aggStructUseAfterConsume(_ x: AggStruct) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructConsume(x2) // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
@@ -757,7 +757,7 @@ public func aggStructDoubleConsume(_ x: AggStruct) {
     aggStructConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructConsume(x2) // expected-note {{consuming use here}}
     aggStructConsume(x2) // expected-note {{consuming use here}}
 }
@@ -774,7 +774,7 @@ public func aggStructLoopConsume(_ x: AggStruct) {
     }
 }
 
-public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         aggStructConsume(x2) // expected-note {{consuming use here}}
     }
@@ -795,7 +795,7 @@ public func aggStructDiamond(_ x: AggStruct) {
     }
 }
 
-public func aggStructDiamondArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         aggStructConsume(x2) // expected-note {{consuming use here}}
     } else {
@@ -824,7 +824,7 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
     }
 }
 
-public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           aggStructConsume(x2) // expected-note {{consuming use here}}
@@ -958,7 +958,7 @@ public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<Klass>) {
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
@@ -990,7 +990,7 @@ public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<Kl
     print(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -1009,7 +1009,7 @@ public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Klass>) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
@@ -1027,7 +1027,7 @@ public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Klass>) {
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
 }
@@ -1044,7 +1044,7 @@ public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     }
@@ -1065,7 +1065,7 @@ public func aggGenericStructDiamond(_ x: AggGenericStruct<Klass>) {
     }
 }
 
-public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     } else {
@@ -1094,7 +1094,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
@@ -1222,7 +1222,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) {
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
@@ -1254,7 +1254,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct
     print(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { //expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -1273,7 +1273,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
@@ -1291,7 +1291,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     aggGenericStructConsume(x2) // expected-note {{consuming use here}}
 }
@@ -1308,7 +1308,7 @@ public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     }
@@ -1329,7 +1329,7 @@ public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructDiamondArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         aggGenericStructConsume(x2) // expected-note {{consuming use here}}
     } else {
@@ -1358,7 +1358,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
@@ -1494,7 +1494,7 @@ public func enumSimpleChainTest(_ x: EnumTy) {
     enumUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func enumSimpleChainTestArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTestArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     enumUseMoveOnlyWithoutEscaping(k2)
@@ -1526,7 +1526,7 @@ public func enumMultipleNonConsumingUseTest(_ x: EnumTy) {
     print(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     enumUseMoveOnlyWithoutEscaping(x2)
     enumUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -1545,7 +1545,7 @@ public func enumUseAfterConsume(_ x: EnumTy) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func enumUseAfterConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     enumUseMoveOnlyWithoutEscaping(x2)
     enumConsume(x2) // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
@@ -1563,7 +1563,7 @@ public func enumDoubleConsume(_ x: EnumTy) {
     enumConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDoubleConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     enumConsume(x2) // expected-note {{consuming use here}}
     enumConsume(x2) // expected-note {{consuming use here}}
 }
@@ -1580,7 +1580,7 @@ public func enumLoopConsume(_ x: EnumTy) {
     }
 }
 
-public func enumLoopConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumLoopConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         enumConsume(x2) // expected-note {{consuming use here}}
     }
@@ -1601,7 +1601,7 @@ public func enumDiamond(_ x: EnumTy) {
     }
 }
 
-public func enumDiamondArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         enumConsume(x2) // expected-note {{consuming use here}}
     } else {
@@ -1630,7 +1630,7 @@ public func enumDiamondInLoop(_ x: EnumTy) {
     }
 }
 
-public func enumDiamondInLoopArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoopArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           enumConsume(x2) // expected-note {{consuming use here}}
@@ -1660,7 +1660,7 @@ public func enumAssignToVar1(_ x: EnumTy) {
     print(x3)
 }
 
-public func enumAssignToVar1Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x
@@ -1681,7 +1681,7 @@ public func enumAssignToVar2(_ x: EnumTy) {
     enumUseMoveOnlyWithoutEscaping(x3)
 }
 
-public func enumAssignToVar2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     enumUseMoveOnlyWithoutEscaping(x3)
@@ -1700,7 +1700,7 @@ public func enumAssignToVar3(_ x: EnumTy) {
     print(x3)
 }
 
-public func enumAssignToVar3Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x
     print(x3)
@@ -1719,7 +1719,7 @@ public func enumAssignToVar4(_ x: EnumTy) {
     print(x3)
 }
 
-public func enumAssignToVar4Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
     print(x3)
@@ -1739,7 +1739,7 @@ public func enumAssignToVar5(_ x: EnumTy) {
     print(x3)
 }
 
-public func enumAssignToVar5Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
@@ -1765,7 +1765,7 @@ public func enumPatternMatchIfLet1(_ x: EnumTy) {
     }
 }
 
-public func enumPatternMatchIfLet1Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
         classUseMoveOnlyWithoutEscaping(x)
     }
@@ -1792,7 +1792,7 @@ public func enumPatternMatchIfLet2(_ x: EnumTy) {
     }
 }
 
-public func enumPatternMatchIfLet2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             classUseMoveOnlyWithoutEscaping(x)
@@ -1820,7 +1820,7 @@ public func enumPatternMatchSwitch1(_ x: EnumTy) {
     }
 }
 
-public func enumPatternMatchSwitch1Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
@@ -1852,7 +1852,7 @@ public func enumPatternMatchSwitch2(_ x: EnumTy) {
     }
 }
 
-public func enumPatternMatchSwitch2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
@@ -1884,7 +1884,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClauseArg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
@@ -1921,7 +1921,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) {
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2Arg(@_noImplicitCopy _ x2: EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where boolValue:
@@ -1971,7 +1971,7 @@ public func closureClassUseAfterConsume2(_ argX: Klass) {
 
 public func closureClassUseAfterConsumeArg(_ argX: Klass) {
     // TODO: Fix this
-    let f = { (@_noImplicitCopy _ x2: Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    let f = { (@_noImplicitCopy _ x2: Klass) in // expected-error {{'x2' is borrowed and cannot be consumed}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use here}}
         print(x2) // expected-note {{consuming use here}}
@@ -2001,7 +2001,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: Klass) {
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func closureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let f = { // expected-note {{consuming use here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
@@ -2121,7 +2121,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) {
     classConsume(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let f = { // expected-note {{consuming use here}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -2186,7 +2186,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) {
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassArgUseAfterConsume(@_noImplicitCopy _ x2: Klass) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let f = { // expected-note {{consuming use here}}
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)

--- a/test/SILOptimizer/noimplicitcopy_trivial.swift
+++ b/test/SILOptimizer/noimplicitcopy_trivial.swift
@@ -107,7 +107,7 @@ public func trivialDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial)
 public func trivialLoopConsume(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming in loop use here}}
+        let y = x2 // expected-note {{consumed in loop here}}
         let _ = y
     }
 }
@@ -121,7 +121,7 @@ public func trivialLoopConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-
 
 public func trivialLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming in loop use here}}
+        let y = x2 // expected-note {{consumed in loop here}}
         let _ = y
     }
 }
@@ -165,7 +165,7 @@ public func trivialDiamondInLoop(_ x: Trivial) {
           let y = x2 // expected-note {{consumed here}}
           let _ = y
       } else {
-          let z = x2 // expected-note {{consuming in loop use here}}
+          let z = x2 // expected-note {{consumed in loop here}}
           // expected-note @-1 {{consumed here}}
           let _ = z
       }
@@ -192,7 +192,7 @@ public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial)
           let y = x2 // expected-note {{consumed here}}
           let _ = y
       } else {
-          let z = x2 // expected-note {{consuming in loop use here}}
+          let z = x2 // expected-note {{consumed in loop here}}
           // expected-note @-1 {{consumed here}}
           let _ = z
       }
@@ -445,7 +445,7 @@ public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
 public func aggStructLoopConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming in loop use here}}
+        let y = x2 // expected-note {{consumed in loop here}}
         let _ = y
     }
 }
@@ -459,7 +459,7 @@ public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expec
 
 public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming in loop use here}}
+        let y = x2 // expected-note {{consumed in loop here}}
         let _ = y
     }
 }
@@ -678,7 +678,7 @@ public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let y = x2  // expected-note {{consuming in loop use here}}
+        let y = x2  // expected-note {{consumed in loop here}}
         let _ = y
     }
 }
@@ -692,7 +692,7 @@ public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStru
 
 public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let y = x2  // expected-note {{consuming in loop use here}}
+        let y = x2  // expected-note {{consumed in loop here}}
         let _ = y
     }
 }
@@ -740,7 +740,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Trivial>) {
             let _ = y
         } else {
             let y = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consuming in loop use here}}
+            // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
     }
@@ -767,7 +767,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned
             let _ = y
         } else {
             let y = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consuming in loop use here}}
+            // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
     }
@@ -905,7 +905,7 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __ow
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let z = x2 // expected-note {{consuming in loop use here}}
+        let z = x2 // expected-note {{consumed in loop here}}
         let _ = z
     }
 }
@@ -919,7 +919,7 @@ public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericS
 
 public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        let z = x2 // expected-note {{consuming in loop use here}}
+        let z = x2 // expected-note {{consumed in loop here}}
         let _ = z
     }
 }
@@ -964,7 +964,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
             let _ = z
         } else {
             let y = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consuming in loop use here}}
+            // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
     }
@@ -991,7 +991,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __ow
             let _ = z
         } else {
             let y = x2 // expected-note {{consumed here}}
-            // expected-note @-1 {{consuming in loop use here}}
+            // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
     }

--- a/test/SILOptimizer/noimplicitcopy_trivial.swift
+++ b/test/SILOptimizer/noimplicitcopy_trivial.swift
@@ -19,7 +19,7 @@ public func trivialSimpleChainTest(_ x: Trivial) {
 }
 
 public func trivialSimpleChainTestArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     trivialUseMoveOnlyWithoutEscaping(k2)
 }
@@ -40,7 +40,7 @@ public func trivialMultipleNonConsumingUseTest(_ x: Trivial) {
 public func trivialMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     trivialUseMoveOnlyWithoutEscaping(x2)
     trivialUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func trivialMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
@@ -53,59 +53,59 @@ public func trivialUseAfterConsume(_ x: Trivial) {
     @_noImplicitCopy let x2 = x
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
-    let z = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let _ = y
     let _ = z
     print(x2)
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func trivialUseAfterConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y = x2 // expected-note {{consuming use here}}
-    let z = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = y
     let _ = z
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func trivialUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
-    let z = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let _ = y
     let _ = z
     print(x2)
-    // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consumed here}}
 }
 
 public func trivialDoubleConsume(_ x: Trivial) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
-    let z = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = y
     let _ = z
 }
 
 public func trivialDoubleConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y = x2 // expected-note {{consuming use here}}
-    let z = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = y
     let _ = z
 }
 
 public func trivialDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
-    let z = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = y
     let _ = z
 }
 
 public func trivialLoopConsume(_ x: Trivial) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
@@ -114,12 +114,12 @@ public func trivialLoopConsume(_ x: Trivial) {
 
 public func trivialLoopConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
     }
 }
 
-public func trivialLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed by a use in a loop}}
+public func trivialLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
@@ -139,10 +139,10 @@ public func trivialDiamond(_ x: Trivial) {
 
 public func trivialDiamondArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
     } else {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consumed here}}
         let _ = z
     }
 }
@@ -159,14 +159,14 @@ public func trivialDiamondOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
 
 public func trivialDiamondInLoop(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          let y = x2 // expected-note {{consuming use here}}
+          let y = x2 // expected-note {{consumed here}}
           let _ = y
       } else {
           let z = x2 // expected-note {{consuming in loop use here}}
-          // expected-note @-1 {{consuming use here}}
+          // expected-note @-1 {{consumed here}}
           let _ = z
       }
     }
@@ -175,10 +175,10 @@ public func trivialDiamondInLoop(_ x: Trivial) {
 public func trivialDiamondInLoopArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          let y = x2 // expected-note {{consuming use here}}
+          let y = x2 // expected-note {{consumed here}}
           let _ = y
       } else {
-          let z = x2 // expected-note {{consuming use here}}
+          let z = x2 // expected-note {{consumed here}}
           let _ = z
       }
     }
@@ -186,14 +186,14 @@ public func trivialDiamondInLoopArg(@_noImplicitCopy _ x2: Trivial) { // expecte
 
 public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
       if boolValue {
-          let y = x2 // expected-note {{consuming use here}}
+          let y = x2 // expected-note {{consumed here}}
           let _ = y
       } else {
           let z = x2 // expected-note {{consuming in loop use here}}
-          // expected-note @-1 {{consuming use here}}
+          // expected-note @-1 {{consumed here}}
           let _ = z
       }
     }
@@ -201,42 +201,42 @@ public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial)
 
 public func trivialAssignToVar1(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func trivialAssignToVar1Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func trivialAssignToVar1OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
 
 public func trivialAssignToVar2(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     trivialUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func trivialAssignToVar2Arg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     trivialUseMoveOnlyWithoutEscaping(x3)
 }
 
 public func trivialAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed here}}
     trivialUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -248,7 +248,7 @@ public func trivialAssignToVar3(_ x: Trivial) {
 }
 
 public func trivialAssignToVar3Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     x3 = x
     print(x3)
 }
@@ -261,41 +261,41 @@ public func trivialAssignToVar3OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __o
 
 public func trivialAssignToVar4(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func trivialAssignToVar4Arg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func trivialAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
-    let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    let x3 = x2 // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed here}}
     print(x3)
 }
 
 public func trivialAssignToVar5(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    trivialUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    trivialUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
 
 public func trivialAssignToVar5Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    var x3 = x2 // expected-note {{consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
     trivialUseMoveOnlyWithoutEscaping(x2)
     x3 = x
     print(x3)
 }
 
 public func trivialAssignToVar5OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' used after consume}}
-    var x3 = x2 // expected-note {{consuming use here}}
-    trivialUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    var x3 = x2 // expected-note {{consumed here}}
+    trivialUseMoveOnlyWithoutEscaping(x2) // expected-note {{used here}}
     x3 = x
     print(x3)
 }
@@ -345,7 +345,7 @@ public func aggStructSimpleChainTest(_ x: AggStruct) {
 }
 
 public func aggStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     aggStructUseMoveOnlyWithoutEscaping(k2)
 }
@@ -379,7 +379,7 @@ public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) {
 public func aggStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
@@ -392,58 +392,58 @@ public func aggStructUseAfterConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let _ = z
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 
 public func aggStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
-    // expected-note @-1 {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
+    // expected-note @-1 {{consumed here}}
     let _ = z
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggStructDoubleConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
@@ -452,12 +452,12 @@ public func aggStructLoopConsume(_ x: AggStruct) {
 
 public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
@@ -477,10 +477,10 @@ public func aggStructDiamond(_ x: AggStruct) {
 
 public func aggStructDiamondArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
     } else {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
     }
 }
@@ -500,13 +500,13 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
     // expected-error @-1 {{'x2' used after consume}}
     for _ in 0..<1024 {
         if boolValue {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
-            aggStructConsume(x2) // expected-note {{non-consuming use here}}
+            aggStructConsume(x2) // expected-note {{used here}}
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
-            aggStructConsume(x2) // expected-note {{non-consuming use here}}
+            aggStructConsume(x2) // expected-note {{used here}}
         }
     }
 }
@@ -514,12 +514,12 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
 public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if boolValue {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
 
             aggStructConsume(x2)
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
             aggStructConsume(x2)
         }
@@ -530,13 +530,13 @@ public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
     // expected-error @-1 {{'x2' used after consume}}
     for _ in 0..<1024 {
         if boolValue {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
-            aggStructConsume(x2) // expected-note {{non-consuming use here}}
+            aggStructConsume(x2) // expected-note {{used here}}
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
-            aggStructConsume(x2) // expected-note {{non-consuming use here}}
+            aggStructConsume(x2) // expected-note {{used here}}
         }
     }
 }
@@ -585,7 +585,7 @@ public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<Trivial>) {
 }
 
 public func aggGenericStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
@@ -619,7 +619,7 @@ public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<Tr
 public func aggGenericStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) {
@@ -631,52 +631,52 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy
 public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    let y = x2  // expected-note {{consuming use here}}
+    let y = x2  // expected-note {{consumed here}}
     let _ = y
-    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{used here}}
     print(x2)
 }
 
 public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    let y = x2  // expected-note {{consuming use here}}
+    let y = x2  // expected-note {{consumed here}}
     let _ = y
     aggGenericStructConsume(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' used after consume}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    let y = x2  // expected-note {{consuming use here}}
+    let y = x2  // expected-note {{consumed here}}
     let _ = y
-    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{used here}}
     print(x2)
 }
 
 public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    let y = x2  // expected-note {{consuming use here}}
+    let y = x2  // expected-note {{consumed here}}
     let _ = y
-    let z = x2  // expected-note {{consuming use here}}
+    let z = x2  // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y = x2  // expected-note {{consuming use here}}
+    let y = x2  // expected-note {{consumed here}}
     let _ = y
-    let z = x2  // expected-note {{consuming use here}}
+    let z = x2  // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed more than once}}
-    let y = x2  // expected-note {{consuming use here}}
+    let y = x2  // expected-note {{consumed here}}
     let _ = y
-    let z = x2  // expected-note {{consuming use here}}
+    let z = x2  // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Trivial>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let y = x2  // expected-note {{consuming in loop use here}}
         let _ = y
@@ -685,12 +685,12 @@ public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Trivial>) {
 
 public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        let y = x2  // expected-note {{consuming use here}}
+        let y = x2  // expected-note {{consumed here}}
         let _ = y
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let y = x2  // expected-note {{consuming in loop use here}}
         let _ = y
@@ -700,9 +700,9 @@ public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned A
 public func aggGenericStructDiamond(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     if boolValue {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
-        aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{used here}}
     } else {
         let z = x2
         let _ = z
@@ -711,20 +711,20 @@ public func aggGenericStructDiamond(_ x: AggGenericStruct<Trivial>) {
 
 public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
         aggGenericStructConsume(x2)
     } else {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consumed here}}
         let _ = z
     }
 }
 
 public func aggGenericStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' used after consume}}
     if boolValue {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consumed here}}
         let _ = y
-        aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{used here}}
     } else {
         let z = x2
         let _ = z
@@ -733,13 +733,13 @@ public func aggGenericStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggGe
 
 public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         if boolValue {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
@@ -749,10 +749,10 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Trivial>) {
 public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if boolValue {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
         }
     }
@@ -760,13 +760,13 @@ public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericSt
 
 public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         if boolValue {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
@@ -812,7 +812,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) {
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y2 = x2 // expected-note {{consuming use here}}
+    let y2 = x2 // expected-note {{consumed here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
@@ -846,7 +846,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) {
@@ -858,52 +858,52 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(@_noImplicitC
 public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{used here}}
     print(x2)
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
     aggGenericStructConsume(x2)
-    print(x2) // expected-note {{consuming use here}}
+    print(x2) // expected-note {{consumed here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' used after consume}} 
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{used here}}
     print(x2)
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    let y = x2 // expected-note {{consuming use here}}
+    let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consuming use here}}
+    let z = x2 // expected-note {{consumed here}}
     let _ = z
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let z = x2 // expected-note {{consuming in loop use here}}
         let _ = z
@@ -912,12 +912,12 @@ public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
 
 public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consumed here}}
         let _ = z
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         let z = x2 // expected-note {{consuming in loop use here}}
         let _ = z
@@ -937,10 +937,10 @@ public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) {
 
 public func aggGenericStructDiamondArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consumed here}}
         let _ = z
     } else {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consumed here}}
         let _ = z
     }
 }
@@ -957,13 +957,13 @@ public func aggGenericStructDiamondOwnedArg<T>(@_noImplicitCopy _ x2: __owned Ag
 
 public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-1 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         if boolValue {
-            let z = x2 // expected-note {{consuming use here}}
+            let z = x2 // expected-note {{consumed here}}
             let _ = z
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
@@ -973,10 +973,10 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
 public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if boolValue {
-            let z = x2 // expected-note {{consuming use here}}
+            let z = x2 // expected-note {{consumed here}}
             let _ = z
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             let _ = y
         }
     }
@@ -984,13 +984,13 @@ public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGeneri
 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
         if boolValue {
-            let z = x2 // expected-note {{consuming use here}}
+            let z = x2 // expected-note {{consumed here}}
             let _ = z
         } else {
-            let y = x2 // expected-note {{consuming use here}}
+            let y = x2 // expected-note {{consumed here}}
             // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
@@ -1024,13 +1024,13 @@ public func aggGenericStructAccessFieldOwnedArg<T>(@_noImplicitCopy _ x2: __owne
 ///////////////////
 
 public func noImplicitCopyArgReturn(@_noImplicitCopy _ x: Trivial) -> Trivial { // expected-error {{'x' is borrowed and cannot be consumed}}
-    return x // expected-note {{consuming use here}}
+    return x // expected-note {{consumed here}}
 }
 
 public func noImplicitCopyArgReturnWithAssign(@_noImplicitCopy _ x: Trivial) -> Trivial { // expected-error {{'x' is borrowed and cannot be consumed}}
-    let y = x // expected-note {{consuming use here}}
+    let y = x // expected-note {{consumed here}}
     print(y)
-    return x // expected-note {{consuming use here}}
+    return x // expected-note {{consumed here}}
 }
 
 public func noImplicitCopyReturn(_ x: Int) -> Int {
@@ -1040,7 +1040,7 @@ public func noImplicitCopyReturn(_ x: Int) -> Int {
 
 public func noImplicitCopyReturnUse(_ x: Int) -> Int {
     @_noImplicitCopy let y = x // expected-error {{'y' consumed more than once}}
-    let z = y // expected-note {{consuming use here}}
+    let z = y // expected-note {{consumed here}}
     let _ = z
-    return y // expected-note {{consuming use here}}
+    return y // expected-note {{consumed here}}
 }

--- a/test/SILOptimizer/noimplicitcopy_trivial.swift
+++ b/test/SILOptimizer/noimplicitcopy_trivial.swift
@@ -18,7 +18,7 @@ public func trivialSimpleChainTest(_ x: Trivial) {
     trivialUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func trivialSimpleChainTestArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialSimpleChainTestArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     trivialUseMoveOnlyWithoutEscaping(k2)
@@ -37,7 +37,7 @@ public func trivialMultipleNonConsumingUseTest(_ x: Trivial) {
     print(x2)
 }
 
-public func trivialMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     trivialUseMoveOnlyWithoutEscaping(x2)
     trivialUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -62,7 +62,7 @@ public func trivialUseAfterConsume(_ x: Trivial) {
     // expected-note @-1 {{consuming use here}}
 }
 
-public func trivialUseAfterConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialUseAfterConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y = x2 // expected-note {{consuming use here}}
     let z = x2 // expected-note {{consuming use here}}
     let _ = y
@@ -90,7 +90,7 @@ public func trivialDoubleConsume(_ x: Trivial) {
     let _ = z
 }
 
-public func trivialDoubleConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialDoubleConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y = x2 // expected-note {{consuming use here}}
     let z = x2 // expected-note {{consuming use here}}
     let _ = y
@@ -112,7 +112,7 @@ public func trivialLoopConsume(_ x: Trivial) {
     }
 }
 
-public func trivialLoopConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialLoopConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
@@ -137,7 +137,7 @@ public func trivialDiamond(_ x: Trivial) {
     }
 }
 
-public func trivialDiamondArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialDiamondArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
@@ -172,7 +172,7 @@ public func trivialDiamondInLoop(_ x: Trivial) {
     }
 }
 
-public func trivialDiamondInLoopArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialDiamondInLoopArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
       if boolValue {
           let y = x2 // expected-note {{consuming use here}}
@@ -207,7 +207,7 @@ public func trivialAssignToVar1(_ x: Trivial) {
     print(x3)
 }
 
-public func trivialAssignToVar1Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialAssignToVar1Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x
@@ -228,7 +228,7 @@ public func trivialAssignToVar2(_ x: Trivial) {
     trivialUseMoveOnlyWithoutEscaping(x3)
 }
 
-public func trivialAssignToVar2Arg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialAssignToVar2Arg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     trivialUseMoveOnlyWithoutEscaping(x3)
@@ -247,7 +247,7 @@ public func trivialAssignToVar3(_ x: Trivial) {
     print(x3)
 }
 
-public func trivialAssignToVar3Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialAssignToVar3Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x
     print(x3)
@@ -266,7 +266,7 @@ public func trivialAssignToVar4(_ x: Trivial) {
     print(x3)
 }
 
-public func trivialAssignToVar4Arg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialAssignToVar4Arg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     print(x2) // expected-note {{consuming use here}}
     print(x3)
@@ -286,7 +286,7 @@ public func trivialAssignToVar5(_ x: Trivial) {
     print(x3)
 }
 
-public func trivialAssignToVar5Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func trivialAssignToVar5Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     trivialUseMoveOnlyWithoutEscaping(x2)
     x3 = x
@@ -344,7 +344,7 @@ public func aggStructSimpleChainTest(_ x: AggStruct) {
     aggStructUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func aggStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     aggStructUseMoveOnlyWithoutEscaping(k2)
@@ -376,7 +376,7 @@ public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) {
     print(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggStructUseMoveOnlyWithoutEscaping(x2)
     aggStructUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -400,7 +400,7 @@ public func aggStructUseAfterConsume(_ x: AggStruct) {
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
     let z = x2 // expected-note {{consuming use here}}
@@ -428,7 +428,7 @@ public func aggStructDoubleConsume(_ x: AggStruct) {
     let _ = z
 }
 
-public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
     let z = x2 // expected-note {{consuming use here}}
@@ -450,7 +450,7 @@ public func aggStructLoopConsume(_ x: AggStruct) {
     }
 }
 
-public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
@@ -475,7 +475,7 @@ public func aggStructDiamond(_ x: AggStruct) {
     }
 }
 
-public func aggStructDiamondArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
@@ -511,7 +511,7 @@ public func aggStructDiamondInLoop(_ x: AggStruct) {
     }
 }
 
-public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if boolValue {
             let y = x2 // expected-note {{consuming use here}}
@@ -584,7 +584,7 @@ public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<Trivial>) {
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
@@ -616,7 +616,7 @@ public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<Tr
     print(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -637,7 +637,7 @@ public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Trivial>) {
     print(x2)
 }
 
-public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     let y = x2  // expected-note {{consuming use here}}
     let _ = y
@@ -661,7 +661,7 @@ public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Trivial>) {
     let _ = z
 }
 
-public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y = x2  // expected-note {{consuming use here}}
     let _ = y
     let z = x2  // expected-note {{consuming use here}}
@@ -683,7 +683,7 @@ public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Trivial>) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         let y = x2  // expected-note {{consuming use here}}
         let _ = y
@@ -709,7 +709,7 @@ public func aggGenericStructDiamond(_ x: AggGenericStruct<Trivial>) {
     }
 }
 
-public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
@@ -746,7 +746,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Trivial>) {
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if boolValue {
             let y = x2 // expected-note {{consuming use here}}
@@ -811,7 +811,7 @@ public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) {
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     aggGenericStructUseMoveOnlyWithoutEscaping(k2)
@@ -843,7 +843,7 @@ public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct
     print(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     print(x2) // expected-note {{consuming use here}}
@@ -864,7 +864,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
     print(x2)
 }
 
-public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
@@ -888,7 +888,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
     let _ = z
 }
 
-public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
     let z = x2 // expected-note {{consuming use here}}
@@ -910,7 +910,7 @@ public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         let z = x2 // expected-note {{consuming use here}}
         let _ = z
@@ -935,7 +935,7 @@ public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructDiamondArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     if boolValue {
         let z = x2 // expected-note {{consuming use here}}
         let _ = z
@@ -970,7 +970,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
     }
 }
 
-public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
         if boolValue {
             let z = x2 // expected-note {{consuming use here}}
@@ -1023,11 +1023,11 @@ public func aggGenericStructAccessFieldOwnedArg<T>(@_noImplicitCopy _ x2: __owne
 // Return Values //
 ///////////////////
 
-public func noImplicitCopyArgReturn(@_noImplicitCopy _ x: Trivial) -> Trivial { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func noImplicitCopyArgReturn(@_noImplicitCopy _ x: Trivial) -> Trivial { // expected-error {{'x' is borrowed and cannot be consumed}}
     return x // expected-note {{consuming use here}}
 }
 
-public func noImplicitCopyArgReturnWithAssign(@_noImplicitCopy _ x: Trivial) -> Trivial { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func noImplicitCopyArgReturnWithAssign(@_noImplicitCopy _ x: Trivial) -> Trivial { // expected-error {{'x' is borrowed and cannot be consumed}}
     let y = x // expected-note {{consuming use here}}
     print(y)
     return x // expected-note {{consuming use here}}

--- a/test/SILOptimizer/noimplicitcopy_trivial.swift
+++ b/test/SILOptimizer/noimplicitcopy_trivial.swift
@@ -54,12 +54,12 @@ public func trivialUseAfterConsume(_ x: Trivial) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     // expected-note @-1 {{consumed here}}
     let _ = y
     let _ = z
     print(x2)
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func trivialUseAfterConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -74,18 +74,18 @@ public func trivialUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivia
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     // expected-note @-1 {{consumed here}}
     let _ = y
     let _ = z
     print(x2)
-    // expected-note @-1 {{consumed here}}
+    // expected-note @-1 {{consumed again here}}
 }
 
 public func trivialDoubleConsume(_ x: Trivial) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     let _ = y
     let _ = z
 }
@@ -99,7 +99,7 @@ public func trivialDoubleConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expecte
 
 public func trivialDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     let _ = y
     let _ = z
 }
@@ -166,7 +166,7 @@ public func trivialDiamondInLoop(_ x: Trivial) {
           let _ = y
       } else {
           let z = x2 // expected-note {{consumed in loop here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
           let _ = z
       }
     }
@@ -193,7 +193,7 @@ public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial)
           let _ = y
       } else {
           let z = x2 // expected-note {{consumed in loop here}}
-          // expected-note @-1 {{consumed here}}
+          // expected-note @-1 {{consumed again here}}
           let _ = z
       }
     }
@@ -202,7 +202,7 @@ public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial)
 public func trivialAssignToVar1(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -216,7 +216,7 @@ public func trivialAssignToVar1Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial)
 
 public func trivialAssignToVar1OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     x3 = x
     print(x3)
 }
@@ -224,7 +224,7 @@ public func trivialAssignToVar1OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __o
 public func trivialAssignToVar2(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     trivialUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -236,7 +236,7 @@ public func trivialAssignToVar2Arg(@_noImplicitCopy _ x2: Trivial) { // expected
 
 public func trivialAssignToVar2OwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consumed here}}
-    x3 = x2 // expected-note {{consumed here}}
+    x3 = x2 // expected-note {{consumed again here}}
     trivialUseMoveOnlyWithoutEscaping(x3)
 }
 
@@ -262,7 +262,7 @@ public func trivialAssignToVar3OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __o
 public func trivialAssignToVar4(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -274,7 +274,7 @@ public func trivialAssignToVar4Arg(@_noImplicitCopy _ x2: Trivial) { // expected
 
 public func trivialAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consumed here}}
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
     print(x3)
 }
 
@@ -394,10 +394,10 @@ public func aggStructUseAfterConsume(_ x: AggStruct) {
     // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     // expected-note @-1 {{consumed here}}
     let _ = z
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
@@ -414,17 +414,17 @@ public func aggStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggS
     // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     // expected-note @-1 {{consumed here}}
     let _ = z
-    print(x2) // expected-note {{consumed here}}
+    print(x2) // expected-note {{consumed again here}}
 }
 
 public func aggStructDoubleConsume(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     let _ = z
 }
 
@@ -438,7 +438,7 @@ public func aggStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // exp
 public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     let _ = z
 }
 
@@ -657,7 +657,7 @@ public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     let y = x2  // expected-note {{consumed here}}
     let _ = y
-    let z = x2  // expected-note {{consumed here}}
+    let z = x2  // expected-note {{consumed again here}}
     let _ = z
 }
 
@@ -671,7 +671,7 @@ public func aggGenericStructDoubleConsumeArg(@_noImplicitCopy _ x2: AggGenericSt
 public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed more than once}}
     let y = x2  // expected-note {{consumed here}}
     let _ = y
-    let z = x2  // expected-note {{consumed here}}
+    let z = x2  // expected-note {{consumed again here}}
     let _ = z
 }
 
@@ -739,7 +739,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Trivial>) {
             let y = x2 // expected-note {{consumed here}}
             let _ = y
         } else {
-            let y = x2 // expected-note {{consumed here}}
+            let y = x2 // expected-note {{consumed again here}}
             // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
@@ -766,7 +766,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned
             let y = x2 // expected-note {{consumed here}}
             let _ = y
         } else {
-            let y = x2 // expected-note {{consumed here}}
+            let y = x2 // expected-note {{consumed again here}}
             // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
@@ -884,7 +884,7 @@ public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     let _ = z
 }
 
@@ -898,7 +898,7 @@ public func aggGenericStructDoubleConsumeArg<T>(@_noImplicitCopy _ x2: AggGeneri
 public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consumed here}}
     let _ = y
-    let z = x2 // expected-note {{consumed here}}
+    let z = x2 // expected-note {{consumed again here}}
     let _ = z
 }
 
@@ -963,7 +963,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
             let z = x2 // expected-note {{consumed here}}
             let _ = z
         } else {
-            let y = x2 // expected-note {{consumed here}}
+            let y = x2 // expected-note {{consumed again here}}
             // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
@@ -990,7 +990,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __ow
             let z = x2 // expected-note {{consumed here}}
             let _ = z
         } else {
-            let y = x2 // expected-note {{consumed here}}
+            let y = x2 // expected-note {{consumed again here}}
             // expected-note @-1 {{consumed in loop here}}
             let _ = y
         }
@@ -1042,5 +1042,5 @@ public func noImplicitCopyReturnUse(_ x: Int) -> Int {
     @_noImplicitCopy let y = x // expected-error {{'y' consumed more than once}}
     let z = y // expected-note {{consumed here}}
     let _ = z
-    return y // expected-note {{consumed here}}
+    return y // expected-note {{consumed again here}}
 }

--- a/test/Sema/borrow_expr.swift
+++ b/test/Sema/borrow_expr.swift
@@ -43,7 +43,7 @@ func testExprFailureLet() {
     // Next line is parsed as move(t) + t
     let _ = _borrow t + t
     // Next line is parsed as move(t+t)
-    let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to lvalues}}
+    let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testExprFailureVar() {
@@ -52,7 +52,7 @@ func testExprFailureVar() {
     // Next line is parsed as move(t) + t
     let _ = _borrow t + t
     // Next line is parsed as move(t+t)
-    let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to lvalues}}
+    let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func letAddressOnly<T>(_ v: T) {
@@ -83,5 +83,5 @@ func testLetClassAccessField() {
 func testVarClassAccessField() {
     var t = Klass()
     t = Klass()
-    let _ = _borrow t.k // expected-error {{'borrow' can only be applied to lvalues}}
+    let _ = _borrow t.k // expected-error {{'borrow' can only be applied to a local binding ('let', 'var', or parameter)}}
 }

--- a/test/Sema/copy_expr.swift
+++ b/test/Sema/copy_expr.swift
@@ -45,29 +45,29 @@ struct StructWithField {
 
 func testLetStructAccessField() {
   let t = StructWithField()
-  let _ = copy t.k // expected-error {{'copy' can only be applied to lvalues}}
+  let _ = copy t.k // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testLetStructAccessComputedField() {
     let t = StructWithField()
-    let _ = copy t.computedK  // expected-error {{'copy' can only be applied to lvalues}}
+    let _ = copy t.computedK  // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testVarStructAccessField() {
     var t = StructWithField()
     t = StructWithField()
-    let _ = copy t.k // expected-error {{'copy' can only be applied to lvalues}}
+    let _ = copy t.k // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testLetClassAccessField() {
     let t = Klass()
-    let _ = copy t.k  // expected-error {{'copy' can only be applied to lvalues}}
+    let _ = copy t.k  // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testVarClassAccessField() {
     var t = Klass()
     t = Klass()
-    let _ = copy t.k // expected-error {{'copy' can only be applied to lvalues}}
+    let _ = copy t.k // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 struct MoveOnly : ~Copyable {}
@@ -88,7 +88,7 @@ func testCopyResultImmutable() {
 
   var t = Test()
   t.mutatingTest()
-  copy t.borrowingTest() // expected-error {{'copy' can only be applied to lvalues}}
+  copy t.borrowingTest() // expected-error {{'copy' can only be applied to a local binding ('let', 'var', or parameter)}}
   (copy t).borrowingTest()
   (copy t).consumingTest()
   (copy t).mutatingTest() // expected-error {{cannot use mutating member on immutable value of type 'Test'}}

--- a/test/Sema/copyable.swift
+++ b/test/Sema/copyable.swift
@@ -9,7 +9,7 @@ typealias WhatIfIQualify = Swift._Copyable // expected-error {{'_Copyable' is un
 class C: _Copyable {} // expected-error {{'_Copyable' is unavailable}}
 
 @_moveOnly struct MOStruct: _Copyable {}
-// expected-error@-1 {{move-only struct 'MOStruct' cannot conform to '_Copyable'}}
+// expected-error@-1 {{noncopyable struct 'MOStruct' cannot conform to '_Copyable'}}
 // expected-error@-2 {{'_Copyable' is unavailable}}
 
 

--- a/test/Sema/copyable_constraint.swift
+++ b/test/Sema/copyable_constraint.swift
@@ -11,4 +11,4 @@ func nextTime<T>(_ t: T) {}
 
 @_moveOnly struct MO {}
 
-nextTime(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+nextTime(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}

--- a/test/Sema/move_expr.swift
+++ b/test/Sema/move_expr.swift
@@ -44,24 +44,24 @@ struct StructWithField {
 
 func testLetStructAccessField() {
     let t = StructWithField()
-    let _ = consume t.k  // expected-error {{'consume' can only be applied to lvalues}}
+    let _ = consume t.k  // expected-error {{'consume' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testVarStructAccessField() {
     var t = StructWithField()
     t = StructWithField()
-    let _ = consume t.k // expected-error {{'consume' can only be applied to lvalues}}
+    let _ = consume t.k // expected-error {{'consume' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testLetClassAccessField() {
     let t = Klass()
-    let _ = consume t.k  // expected-error {{'consume' can only be applied to lvalues}}
+    let _ = consume t.k  // expected-error {{'consume' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testVarClassAccessField() {
     var t = Klass()
     t = Klass()
-    let _ = consume t.k // expected-error {{'consume' can only be applied to lvalues}}
+    let _ = consume t.k // expected-error {{'consume' can only be applied to a local binding ('let', 'var', or parameter)}}
 }
 
 func testConsumeResultImmutable() {
@@ -76,7 +76,7 @@ func testConsumeResultImmutable() {
 
   var t = Test()
   t.mutatingTest()
-  consume t.borrowingTest() // expected-error {{'consume' can only be applied to lvalues}}
+  consume t.borrowingTest() // expected-error {{'consume' can only be applied to a local binding ('let', 'var', or parameter)}}
   (consume t).borrowingTest()
   (consume t).consumingTest()
   (consume t).mutatingTest() // expected-error {{cannot use mutating member on immutable value of type 'Test'}}

--- a/test/Sema/moveonly_decl_attr.swift
+++ b/test/Sema/moveonly_decl_attr.swift
@@ -2,7 +2,7 @@
 
 import Swift
 
-@_moveOnly class C { // expected-error {{'moveOnly' only applies to structs or enums}}{{1-12=}}
+@_moveOnly class C { // expected-error {{'@_moveOnly' attribute is only valid on structs or enums}}{{1-12=}}
     @_moveOnly // expected-error {{'@_moveOnly' attribute cannot be applied to this declaration}}
     func foo() {}
 }
@@ -21,6 +21,6 @@ enum E {
 
 @_moveOnly let l = C()  // expected-error {{'@_moveOnly' attribute cannot be applied to this declaration}}
 
-@_moveOnly protocol P {} // expected-error {{'moveOnly' only applies to structs or enums}}{{1-12=}}
-@_moveOnly actor A {} // expected-error {{'moveOnly' only applies to structs or enums}}{{1-12=}}
+@_moveOnly protocol P {} // expected-error {{'@_moveOnly' attribute is only valid on structs or enums}}{{1-12=}}
+@_moveOnly actor A {} // expected-error {{'@_moveOnly' attribute is only valid on structs or enums}}{{1-12=}}
 @_moveOnly extension C {} // expected-error {{'@_moveOnly' attribute cannot be applied to this declaration}}{{1-12=}}

--- a/test/Sema/moveonly_experimental.swift
+++ b/test/Sema/moveonly_experimental.swift
@@ -4,7 +4,7 @@
 
 struct SomeValue {}
 
-@_moveOnly class NoncopyableClass {} // expected-error {{'moveOnly' only applies to structs or enums}}
+@_moveOnly class NoncopyableClass {} // expected-error {{'@_moveOnly' attribute is only valid on structs or enums}}
 
 func checkOldConsumeName() {
   let x = SomeValue()

--- a/test/Sema/moveonly_illegal_types.swift
+++ b/test/Sema/moveonly_illegal_types.swift
@@ -47,33 +47,33 @@ struct CerebralValley<T> {
 // --- now some tests ---
 // ----------------------
 
-func basic_vararg(_ va: MO...) {} // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+func basic_vararg(_ va: MO...) {} // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
 func illegalTypes<T>(_ t: T) {
-  let _: Array<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: Maybe<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: Dictionary<MO, String> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: [MO] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: [String : MO] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: [MO : MO] // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
-  let _: [MO : T] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Array<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Maybe<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Dictionary<MO, String> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [MO] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [String : MO] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [MO : MO] // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [MO : T] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  _ = t as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = t as! ValBox<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  let _: Optional<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: MO? // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: MO?? // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: MO! // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: MO?! // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Optional<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: MO? // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: MO?? // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: MO! // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: MO?! // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
   let _: Klass & MO // expected-error {{non-protocol, non-class type 'MO' cannot be used within a protocol-constrained type}}
   let _: any MO // expected-error {{'any' has no effect on concrete type 'MO'}}
   let _: any GenericMO<T> // expected-error {{'any' has no effect on concrete type 'GenericMO<T>'}}
 
-  let _: CerebralValley<MO>.TechBro // expected-error {{move-only type 'MO' cannot be used with generics yet}}
-  let _: CerebralValley<Int>.GenericBro<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: CerebralValley<MO>.TechBro // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: CerebralValley<Int>.GenericBro<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  let _: GenericMO<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: GenericMO<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 }
 
 func illegalInExpr() {

--- a/test/Sema/moveonly_indirect_enum.swift
+++ b/test/Sema/moveonly_indirect_enum.swift
@@ -17,7 +17,7 @@ enum E1 {
 }
 
 @_moveOnly
-indirect enum E2 { // expected-error {{move-only enum 'E2' cannot be marked indirect or have indirect cases yet}}
+indirect enum E2 { // expected-error {{noncopyable enum 'E2' cannot be marked indirect or have indirect cases yet}}
     case first
     case second(S)
 }
@@ -25,5 +25,5 @@ indirect enum E2 { // expected-error {{move-only enum 'E2' cannot be marked indi
 @_moveOnly
 enum E3 {
     case first
-    indirect case second(S) // expected-error {{move-only enum 'E3' cannot be marked indirect or have indirect cases yet}}
+    indirect case second(S) // expected-error {{noncopyable enum 'E3' cannot be marked indirect or have indirect cases yet}}
 }

--- a/test/Sema/moveonly_objc_enum.swift
+++ b/test/Sema/moveonly_objc_enum.swift
@@ -5,13 +5,13 @@
 // Validate that we can't mark an objc enum as move only.
 
 @_moveOnly
-@objc enum Foo : Int { // expected-error {{@objc enums cannot be marked as move-only}}
+@objc enum Foo : Int { // expected-error {{noncopyable enums cannot be marked '@objc'}}
   case X, Y, Z
   deinit {} // expected-error {{deinitializers cannot be declared on an @objc enum type}}
 }
 
 @_moveOnly
-@objc enum Foo2 : Int { // expected-error {{@objc enums cannot be marked as move-only}}
+@objc enum Foo2 : Int { // expected-error {{noncopyable enums cannot be marked '@objc'}}
   case X, Y, Z
 }
 

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -6,48 +6,48 @@ class CopyableKlass {}
 
 @_moveOnly
 class MoveOnlyKlass {
-    init?() {} // expected-error {{move-only types cannot have failable initializers yet}}
+    init?() {} // expected-error {{noncopyable types cannot have failable initializers yet}}
 }
 
 @_moveOnly
 class MoveOnlyStruct {
-    init?(one: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
-    init!(two: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
+    init?(one: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init!(two: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
 }
 
 class C {
     var copyable: CopyableKlass? = nil
-    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 @_moveOnly
 class CMoveOnly {
     var copyable: CopyableKlass? = nil
-    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
-struct OptionalGrandField<T> { // expected-error {{generic struct 'OptionalGrandField' cannot contain a move-only type without also being move-only}}
+struct OptionalGrandField<T> { // expected-error {{generic struct 'OptionalGrandField' cannot contain a noncopyable type without also being noncopyable}}
     var moveOnly3: T?
-    var moveOnly2: MoveOnlyKlass // expected-note {{contained move-only property 'OptionalGrandField.moveOnly2'}}
+    var moveOnly2: MoveOnlyKlass // expected-note {{contained noncopyable property 'OptionalGrandField.moveOnly2'}}
 }
 
 struct S0 {
-    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnly4: OptionalGrandField<MoveOnlyStruct> // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnly4: OptionalGrandField<MoveOnlyStruct> // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 struct SCopyable {
     var copyable: CopyableKlass
 }
 
-struct S { // expected-error {{struct 'S' cannot contain a move-only type without also being move-only}}
+struct S { // expected-error {{struct 'S' cannot contain a noncopyable type without also being noncopyable}}
     var copyable: CopyableKlass
-    var moveOnly2: MoveOnlyStruct? // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
-    var moveOnly: MoveOnlyStruct // expected-note {{contained move-only property 'S.moveOnly'}}
-    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnly3: OptionalGrandField<MoveOnlyStruct> // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly2: MoveOnlyStruct? // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly: MoveOnlyStruct // expected-note {{contained noncopyable property 'S.moveOnly'}}
+    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnly3: OptionalGrandField<MoveOnlyStruct> // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 @_moveOnly
@@ -56,10 +56,10 @@ struct SMoveOnly {
     var moveOnly: MoveOnlyKlass
 }
 
-enum E { // expected-error {{enum 'E' cannot contain a move-only type without also being move-only}}
+enum E { // expected-error {{enum 'E' cannot contain a noncopyable type without also being noncopyable}}
     case lhs(CopyableKlass)
-    case rhs(MoveOnlyKlass) // expected-note {{contained move-only enum case 'E.rhs'}}
-    case rhs2(OptionalGrandField<MoveOnlyKlass>) // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+    case rhs(MoveOnlyKlass) // expected-note {{contained noncopyable enum case 'E.rhs'}}
+    case rhs2(OptionalGrandField<MoveOnlyKlass>) // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
 }
 
 @_moveOnly
@@ -67,32 +67,32 @@ enum EMoveOnly {
     case lhs(CopyableKlass)
     case rhs(MoveOnlyKlass)
 
-    init?() {} // expected-error {{move-only types cannot have failable initializers yet}}
+    init?() {} // expected-error {{noncopyable types cannot have failable initializers yet}}
 }
 
 extension EMoveOnly {
-    init!(three: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
+    init!(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
 }
 
 extension MoveOnlyStruct {
-    convenience init?(three: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
+    convenience init?(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
 }
 
 func foo() {
     class C2 {
         var copyable: CopyableKlass? = nil
-        var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+        var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
     }
 
     @_moveOnly
     class C2MoveOnly {
         var copyable: CopyableKlass? = nil
-        var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+        var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
     }
 
-    struct S2 { // expected-error {{struct 'S2' cannot contain a move-only type without also being move-only}}
+    struct S2 { // expected-error {{struct 'S2' cannot contain a noncopyable type without also being noncopyable}}
         var copyable: CopyableKlass
-        var moveOnly: MoveOnlyKlass // expected-note {{contained move-only property 'S2.moveOnly'}}
+        var moveOnly: MoveOnlyKlass // expected-note {{contained noncopyable property 'S2.moveOnly'}}
     }
 
     @_moveOnly
@@ -101,9 +101,9 @@ func foo() {
         var moveOnly: MoveOnlyKlass
     }
 
-    enum E2 { // expected-error {{enum 'E2' cannot contain a move-only type without also being move-only}}
+    enum E2 { // expected-error {{enum 'E2' cannot contain a noncopyable type without also being noncopyable}}
         case lhs(CopyableKlass)
-        case rhs(MoveOnlyKlass) // expected-note {{contained move-only enum case 'E2.rhs'}}
+        case rhs(MoveOnlyKlass) // expected-note {{contained noncopyable enum case 'E2.rhs'}}
     }
 
     @_moveOnly
@@ -114,18 +114,18 @@ func foo() {
     {
         class C3 {
             var copyable: CopyableKlass? = nil
-            var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+            var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
         }
 
         @_moveOnly
         class C3MoveOnly {
             var copyable: CopyableKlass? = nil
-            var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+            var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
         }
 
-        struct S3 { // expected-error {{struct 'S3' cannot contain a move-only type without also being move-only}}
+        struct S3 { // expected-error {{struct 'S3' cannot contain a noncopyable type without also being noncopyable}}
             var copyable: CopyableKlass
-            var moveOnly: MoveOnlyKlass // expected-note {{contained move-only property 'S3.moveOnly'}}
+            var moveOnly: MoveOnlyKlass // expected-note {{contained noncopyable property 'S3.moveOnly'}}
         }
 
         @_moveOnly
@@ -134,9 +134,9 @@ func foo() {
             var moveOnly: MoveOnlyKlass
         }
 
-        enum E3 { // expected-error {{enum 'E3' cannot contain a move-only type without also being move-only}}
+        enum E3 { // expected-error {{enum 'E3' cannot contain a noncopyable type without also being noncopyable}}
             case lhs(CopyableKlass)
-            case rhs(MoveOnlyKlass) // expected-note {{contained move-only enum case 'E3.rhs'}}
+            case rhs(MoveOnlyKlass) // expected-note {{contained noncopyable enum case 'E3.rhs'}}
         }
 
         @_moveOnly
@@ -167,24 +167,24 @@ protocol Q {}
 }
 @_moveOnly enum ProtocolCheckMoveOnlyEnum {}
 
-extension ProtocolCheckMoveOnlyKlass : P {} // expected-error {{move-only class 'ProtocolCheckMoveOnlyKlass' cannot conform to 'P'}}
+extension ProtocolCheckMoveOnlyKlass : P {} // expected-error {{noncopyable class 'ProtocolCheckMoveOnlyKlass' cannot conform to 'P'}}
 extension ProtocolCheckMoveOnlyStruct : P, Q {}
-// expected-error@-1 {{move-only struct 'ProtocolCheckMoveOnlyStruct' cannot conform to 'P'}}
-// expected-error@-2 {{move-only struct 'ProtocolCheckMoveOnlyStruct' cannot conform to 'Q'}}
+// expected-error@-1 {{noncopyable struct 'ProtocolCheckMoveOnlyStruct' cannot conform to 'P'}}
+// expected-error@-2 {{noncopyable struct 'ProtocolCheckMoveOnlyStruct' cannot conform to 'Q'}}
 // expected-note@-3 {{'ProtocolCheckMoveOnlyStruct' declares conformance to protocol 'P' here}}
 
 extension ProtocolCheckMoveOnlyStruct: P {}
 // expected-error@-1 {{redundant conformance of 'ProtocolCheckMoveOnlyStruct' to protocol 'P'}}
-// expected-error@-2 {{move-only struct 'ProtocolCheckMoveOnlyStruct' cannot conform to 'P'}}
+// expected-error@-2 {{noncopyable struct 'ProtocolCheckMoveOnlyStruct' cannot conform to 'P'}}
 
 extension ProtocolCheckMoveOnlyEnum : P & Q, Sendable {}
-// expected-error@-1 {{move-only enum 'ProtocolCheckMoveOnlyEnum' cannot conform to 'P & Q'}}
+// expected-error@-1 {{noncopyable enum 'ProtocolCheckMoveOnlyEnum' cannot conform to 'P & Q'}}
 
 extension ProtocolCheckMoveOnlyEnum : Any {}
-// expected-error@-1 {{move-only enum 'ProtocolCheckMoveOnlyEnum' cannot conform to 'Any'}}
+// expected-error@-1 {{noncopyable enum 'ProtocolCheckMoveOnlyEnum' cannot conform to 'Any'}}
 
 extension ProtocolCheckMoveOnlyEnum : AnyHashable {}
-// expected-error@-1 {{move-only enum 'ProtocolCheckMoveOnlyEnum' cannot conform to 'AnyHashable'}}
+// expected-error@-1 {{noncopyable enum 'ProtocolCheckMoveOnlyEnum' cannot conform to 'AnyHashable'}}
 // expected-error@-2 {{inheritance from non-protocol type 'AnyHashable'}}
 
 // But a normal extension is ok.
@@ -194,13 +194,13 @@ extension ProtocolCheckMoveOnlyEnum {}
 
 // Check if we define a move only type and make it conform on the base type
 @_moveOnly
-class MoveOnlyKlassP : P {} // expected-error {{move-only class 'MoveOnlyKlassP' cannot conform to 'P'}}
+class MoveOnlyKlassP : P {} // expected-error {{noncopyable class 'MoveOnlyKlassP' cannot conform to 'P'}}
 @_moveOnly
-struct MoveOnlyStructP : P { // expected-error {{move-only struct 'MoveOnlyStructP' cannot conform to 'P'}}
+struct MoveOnlyStructP : P { // expected-error {{noncopyable struct 'MoveOnlyStructP' cannot conform to 'P'}}
     var mv: MoveOnlyKlass
 }
 @_moveOnly
-enum MoveOnlyEnumP : P {} // expected-error {{move-only enum 'MoveOnlyEnumP' cannot conform to 'P'}}
+enum MoveOnlyEnumP : P {} // expected-error {{noncopyable enum 'MoveOnlyEnumP' cannot conform to 'P'}}
 
 // ensure there is no auto-synthesis of Equatable, Hashable, etc, for this move-only enum,
 // because it normally would be synthesized since it only has cases without associated values.
@@ -230,16 +230,16 @@ enum StrengthLevel: Int { // ensure move-only raw enums do not conform to RawRep
 
 public class Holder {
     var one: MoveOnlyStruct {
-        get async {  } // expected-error {{getter of move-only type cannot be 'async' or 'throws'}}
+        get async {  } // expected-error {{getter of noncopyable type cannot be 'async' or 'throws'}}
     }
     var two: MoveOnlyKlass {
-        get throws {  } // expected-error {{getter of move-only type cannot be 'async' or 'throws'}}
+        get throws {  } // expected-error {{getter of noncopyable type cannot be 'async' or 'throws'}}
     }
 }
 
 struct StructHolder {
     var three: EMoveOnly {
-        get async throws {  } // expected-error {{getter of move-only type cannot be 'async' or 'throws'}}
+        get async throws {  } // expected-error {{getter of noncopyable type cannot be 'async' or 'throws'}}
     }
 }
 

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -93,35 +93,35 @@ enum Wrong_NoncopyableOption<T> : Sendable { // expected-note {{consider making 
 func takeAnySendable(_ s: any Sendable) {}
 func takeSomeSendable(_ s: some Sendable) {}
 
-// expected-error@+1 {{move-only type 'FileDescriptor' cannot be used with generics yet}}
+// expected-error@+1 {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
 func mkSendable() -> Sendable { return FileDescriptor(id: 0) }
 
 func tryToCastIt(_ fd: borrowing FileDescriptor) {
-  let _: any Sendable = fd // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
-  let _: Sendable = fd // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
+  let _: any Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  let _: Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
 
-  takeAnySendable(fd) // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
-  takeSomeSendable(fd) // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
+  takeAnySendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  takeSomeSendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
 
-  let _ = fd as Sendable // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
+  let _ = fd as Sendable // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
 
   let _ = fd as? Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   let _ = fd as! Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   let _ = fd is Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 
   let sendy = mkSendable()
   let _ = sendy as FileDescriptor // expected-error {{cannot convert value of type 'any Sendable' to type 'FileDescriptor' in coercion}}
   let _ = sendy is FileDescriptor // expected-warning {{cast from 'any Sendable' to unrelated type 'FileDescriptor' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   let _ = sendy as! FileDescriptor // expected-warning {{cast from 'any Sendable' to unrelated type 'FileDescriptor' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
   let _ = sendy as? FileDescriptor// expected-warning {{cast from 'any Sendable' to unrelated type 'FileDescriptor' always fails}}
-  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
 }
 
 protocol GiveSendable<T> {
@@ -146,7 +146,7 @@ class Container<T> where T:Sendable {
 }
 
 func createContainer(_ fd: borrowing FileDescriptor) {
-  let _: Container<Sendable> = Container(fd) // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
+  let _: Container<Sendable> = Container(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
   let _: Container<Sendable> = Container(CopyableStruct())
 }
 
@@ -159,7 +159,7 @@ extension Sendable {
 }
 
 func tryToDupe(_ fd: borrowing FileDescriptor) {
-  fd.doIllegalThings() // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
+  fd.doIllegalThings() // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
 }
 
 @_moveOnly

--- a/test/Sema/noimplicitcopy_attr.swift
+++ b/test/Sema/noimplicitcopy_attr.swift
@@ -144,11 +144,11 @@ struct MoveOnly {
     var k = Klass()
 }
 
-func useMoveOnly(@_noImplicitCopy _ x: __shared MoveOnly) -> MoveOnly { // expected-error {{'@_noImplicitCopy' has no effect when applied to a move only type}}
+func useMoveOnly(@_noImplicitCopy _ x: __shared MoveOnly) -> MoveOnly { // expected-error {{'@_noImplicitCopy' has no effect when applied to a noncopyable type}}
     return x
 }
 
 func useMoveOnly2(_ x: __shared MoveOnly) {
-    @_noImplicitCopy let y = x // expected-error {{'@_noImplicitCopy' has no effect when applied to a move only type}}
+    @_noImplicitCopy let y = x // expected-error {{'@_noImplicitCopy' has no effect when applied to a noncopyable type}}
     let _ = y
 }


### PR DESCRIPTION
🚧 here be lots of find-replace 🚧

- replaces "move-only" terminology with "noncopyable"
- replaces compiler jargon like "guaranteed parameters"
  and "lvalue" with corresponding language-level notions
- simplifies diagnostics about closures.

and probably more.

rdar://109281444