### PR TITLE
Emit updated debug info when inout parameters are consumed and reinitialized.

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -194,6 +194,16 @@ inline Operand *getSingleDebugUse(SILValue value) {
   return *ii;
 }
 
+/// If \p value has any debug user(s), return the operand associated with some
+/// use. Otherwise, returns nullptr.
+inline Operand *getAnyDebugUse(SILValue value) {
+  auto range = getDebugUses(value);
+  auto ii = range.begin(), ie = range.end();
+  if (ii == ie)
+    return nullptr;
+  return *ii;
+}
+
 /// Erases the instruction \p I from it's parent block and deletes it, including
 /// all debug instructions which use \p I.
 /// Precondition: The instruction may only have debug instructions as uses.

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -77,7 +77,7 @@ static void getVariableNameForValue(SILValue value2,
                                     SmallString<64> &resultingString) {
   // Before we do anything, lets see if we have an exact debug_value on our
   // mmci. In such a case, we can end early and are done.
-  if (auto *use = getSingleDebugUse(value2)) {
+  if (auto *use = getAnyDebugUse(value2)) {
     if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
       assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
       resultingString += debugVar.getName();
@@ -112,7 +112,7 @@ static void getVariableNameForValue(SILValue value2,
 
     // If we do not do an exact match, see if we can find a debug_var inst. If
     // we do, we always break since we have a root value.
-    if (auto *use = getSingleDebugUse(searchValue)) {
+    if (auto *use = getAnyDebugUse(searchValue)) {
       if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
         assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
         variableNamePath.push_back(use->getUser());

--- a/test/SILOptimizer/moveonly_debug_info_reinit.swift
+++ b/test/SILOptimizer/moveonly_debug_info_reinit.swift
@@ -39,3 +39,27 @@ func bar(_ x: consuming Foo, y: consuming Foo, z: consuming Foo) {
     // CHECK: debug_value undef : $*Foo, var, name "x"
     use(&x)
 }
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}10inoutParam
+func inoutParam(_ x: inout Foo, y: consuming Foo, z: consuming Foo) {
+    // CHECK: debug_value [[X:%[0-9]+]] : $*Foo, var, name "x"
+
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+    let _ = x
+
+    // CHECK: debug_value undef : $*Foo, var, name "y"
+    // CHECK: debug_value [[X]] : $*Foo, var, name "x"
+    x = y
+    // CHECK: [[USE:%.*]] = function_ref @use
+    // CHECK: apply [[USE]]
+    // CHECK: debug_value undef : $*Foo, var, name "x"
+    use(&x)
+    let _ = x
+
+    // CHECK: debug_value undef : $*Foo, var, name "z"
+    // CHECK: debug_value [[X]] : $*Foo, var, name "x"
+    x = z
+}


### PR DESCRIPTION
Change SILGen to emit the `debug_value` instruction using the original inout parameter address, instead of the `mark_must_check` inserted for move-only parameters, because code in the MoveOnlyAddressChecker did not expect to find the debug_value anywhere but on the original address. Update move-only diagnostics so that they pick up the declaration name for a memory location from any debug_value instruction if there are more than one. rdar://109740281