### PR TITLE
[move-only] Teach SILGenApply how to emit subscripts with borrowed base values.

### DIFF
--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -280,7 +280,7 @@ public:
 
   ArgumentSource copyForDiagnostics() const;
 
-  void dump() const;
+  LLVM_DUMP_METHOD void dump() const;
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
 private:

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3047,7 +3047,12 @@ Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
   // subscript instead.
   SubscriptExpr *subscriptExpr = nullptr;
   if ((subscriptExpr = dyn_cast<SubscriptExpr>(argExpr))) {
-    argExpr = subscriptExpr->getBase();
+    auto *decl = cast<SubscriptDecl>(subscriptExpr->getDecl().getDecl());
+    if (decl->getReadImpl() != ReadImplKind::Read) {
+      subscriptExpr = nullptr;
+    } else {
+      argExpr = subscriptExpr->getBase();
+    }
   }
 
   // If there's a load around the outer part of this arg expr, look past it.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3042,6 +3042,14 @@ Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
 
   auto argExpr = asKnownExpr();
 
+  // If we have a subscript, strip it off and make sure that our base is
+  // something that we can process. If we do and we succeed below, we return the
+  // subscript instead.
+  SubscriptExpr *subscriptExpr = nullptr;
+  if ((subscriptExpr = dyn_cast<SubscriptExpr>(argExpr))) {
+    argExpr = subscriptExpr->getBase();
+  }
+
   // If there's a load around the outer part of this arg expr, look past it.
   bool sawLoad = false;
   if (auto *li = dyn_cast<LoadExpr>(argExpr)) {
@@ -3096,6 +3104,12 @@ Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
   // Claim the value of this argument since we found a storage reference that
   // has a move only base.
   (void)std::move(*this).asKnownExpr();
+
+  // If we saw a subscript expr and the base of the subscript expr passed our
+  // tests above, we can emit the call to the subscript directly as a borrowed
+  // lvalue. Return the subscript expr here so that we emit it appropriately.
+  if (subscriptExpr)
+    return subscriptExpr;
 
   return result.getTransitiveRoot();
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1964,6 +1964,9 @@ InitializationPtr SILGenFunction::emitLocalVariableWithCleanup(
 std::unique_ptr<TemporaryInitialization>
 SILGenFunction::emitTemporary(SILLocation loc, const TypeLowering &tempTL) {
   SILValue addr = emitTemporaryAllocation(loc, tempTL.getLoweredType());
+  if (addr->getType().isMoveOnly())
+    addr = B.createMarkMustCheckInst(
+        loc, addr, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
   return useBufferAsTemporary(addr, tempTL);
 }
 
@@ -1971,6 +1974,9 @@ std::unique_ptr<TemporaryInitialization>
 SILGenFunction::emitFormalAccessTemporary(SILLocation loc,
                                           const TypeLowering &tempTL) {
   SILValue addr = emitTemporaryAllocation(loc, tempTL.getLoweredType());
+  if (addr->getType().isMoveOnly())
+    addr = B.createMarkMustCheckInst(
+        loc, addr, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
   CleanupHandle cleanup =
       enterDormantFormalAccessTemporaryCleanup(addr, loc, tempTL);
   return std::unique_ptr<TemporaryInitialization>(

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -44,16 +44,20 @@ public enum NonTrivialEnum {
     case third(NonTrivialStruct)
 }
 
-@_moveOnly
-public struct AddressOnlyGeneric<T> {
+public struct AddressOnlyGeneric<T> : ~Copyable {
     var t: T
 }
 
-public protocol P {}
+public protocol P {
+}
+extension CopyableKlass : P {}
 
 @_moveOnly
 public struct AddressOnlyProtocol {
-    var t: P
+    var t: P = CopyableKlass()
+
+    func nonMutatingFunc() {}
+    mutating func mutatingFunc() {}
 }
 
 var varGlobal = NonTrivialStruct()
@@ -999,4 +1003,2026 @@ struct AddressOnlySetterTester : ~Copyable {
         // CHECK: } // end sil function '$s8moveonly23AddressOnlySetterTesterV1aAA0bC8ProtocolVvs'
         set { fatalError() }
     }
+}
+
+/////////////////////
+// MARK: Subscript //
+/////////////////////
+
+// MARK: Getter Only
+
+public struct LoadableSubscriptGetOnlyTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyProtocol {
+        get {
+            fatalError()
+        }
+    }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetOnlyTester()
+    m = LoadableSubscriptGetOnlyTester()
+    m[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_LetyyF'
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetOnlyTester()
+    m[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE6_InOut1myAA0gcdE6TesterVz_tF : $@convention(thin) (@inout LoadableSubscriptGetOnlyTester) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   end_borrow [[LOAD_BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE6_InOut1myAA0gcdE6TesterVz_tF'
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetOnlyTester) {
+    m[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE7_GlobalyyF : $@convention(thin) () -> () {
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly36globalLoadableSubscriptGetOnlyTesterAA0cdefG0Vvp :
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE7_GlobalyyF'
+var globalLoadableSubscriptGetOnlyTester = LoadableSubscriptGetOnlyTester()
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetOnlyTester[0].nonMutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetOnlyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetOnlyTester()
+    var computedTester: LoadableSubscriptGetOnlyTester { fatalError() }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The first get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+//
+// The second get call.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[VALUE:%.*]] = apply {{%.*}}([[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ let L
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
+// CHECK: [[COPY:%.*]] = copy_value [[EXT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: destroy_value [[COPY]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_LetyyF'
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE6_InOut1myAA0lcde6TesterghjI0Vz_tF : $@convention(thin) (@inout LoadableSubscriptGetOnlyTesterNonCopyableStructParent) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE6_InOut1myAA0lcde6TesterghjI0Vz_tF'
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetOnlyTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE7_GlobalyyF : $@convention(thin) () -> () {
+// CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly59globalLoadableSubscriptGetOnlyTesterNonCopyableStructParentAA0cdefghijK0Vvp
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE7_GlobalyyF'
+var globalLoadableSubscriptGetOnlyTesterNonCopyableStructParent = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetOnlyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+}
+
+public class LoadableSubscriptGetOnlyTesterClassParent {
+    var tester = LoadableSubscriptGetOnlyTester()
+    var computedTester: LoadableSubscriptGetOnlyTester { fatalError() }
+    var testerParent = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+}
+
+// TODO(MG): I am preparing a small pass that cleans up the copy_value
+// below. The code in SILGen is in some very generic code that changing could
+// have other unintentional side-effects, so it makes sense to instead just add
+// a small cleanup transform before we do move checking to cleanup this pattern.
+//
+// CHECK-LABEL: sil [ossa] @$s8moveonly065testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressE4_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
+//
+// First read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $LoadableSubscriptGetOnlyTester
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[TEMP]]
+// CHECK: [[TEMP2:%.*]] = alloc_stack $
+// CHECK: apply {{%.*}}([[TEMP2]], {{%.*}}, [[LOAD]])
+// CHECK: destroy_addr [[TEMP2]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: end_apply [[CORO_TOKEN]]
+//
+// Second read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $LoadableSubscriptGetOnlyTester
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[TEMP]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK: [[TEMP2:%.*]] = alloc_stack $
+// CHECK: apply {{%.*}}([[TEMP2]], {{%.*}}, [[LOAD]])
+// CHECK: destroy_addr [[TEMP2]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: end_apply [[CORO_TOKEN]]
+//
+// Third read. This is a case that we can't handle today due to the way the AST
+// looks:
+//
+// (subscript_expr type='AddressOnlyProtocol'
+//   (member_ref_expr type='LoadableSubscriptGetOnlyTester'
+//     (load_expr implicit type='LoadableSubscriptGetOnlyTesterClassParent'
+//       (declref_expr type='@lvalue LoadableSubscriptGetOnlyTesterClassParent'
+//   (argument_list
+//     (argument
+//       (integer_literal_expr type='Int'
+//
+// due to the load_expr in the subscript base, SILGen emits a base rvalue for
+// the load_expr and copies it, ending the coroutine. What we need is the
+// ability to have an lvalue pseudo-component that treats the declref_expr (and
+// any member_ref_expr) as a base and allows for a load_expr to be followed by N
+// member_ref_expr.
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: destroy_addr [[TEMP]]
+
+// CHECK: } // end sil function '$s8moveonly065testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetOnlyTesterClassParent()
+    m = LoadableSubscriptGetOnlyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+// MARK: Getter + Setter.
+// This is different since adding a setter changes how we codegen.
+
+public struct LoadableSubscriptGetSetTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyProtocol {
+        get {
+            fatalError()
+        }
+        set {
+            fatalError()
+        }
+    }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetSetTester()
+    m = LoadableSubscriptGetSetTester()
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: } // end sil function '$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetSetTester()
+    m[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly56testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF : $@convention(thin) (@inout LoadableSubscriptGetSetTester) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK:   end_borrow [[LOAD_BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly56testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF'
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetSetTester) {
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly57testSubscriptGetSet_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly35globalLoadableSubscriptGetSetTesterAA0cdefG0Vvp
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly35globalLoadableSubscriptGetSetTesterAA0cdefG0Vvp
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly35globalLoadableSubscriptGetSetTesterAA0cdefG0Vvp
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly57testSubscriptGetSet_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptGetSetTester = LoadableSubscriptGetSetTester()
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetSetTester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetSetTester[0] = AddressOnlyProtocol()
+    globalLoadableSubscriptGetSetTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetSetTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetSetTester()
+    var computedTester: LoadableSubscriptGetSetTester { fatalError() }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly84testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The first get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The mutating call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: end_borrow [[LOAD]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: end_access [[ACCESS]]
+//
+// The second get call.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[VALUE:%.*]] = apply {{%.*}}([[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// } // end sil function '$s8moveonly077testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly84testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ let L
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
+// CHECK: [[COPY:%.*]] = copy_value [[EXT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: destroy_value [[COPY]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: } // end sil function '$s8moveonly84testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly86testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF : $@convention(thin) (@inout LoadableSubscriptGetSetTesterNonCopyableStructParent) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: } // end sil function '$s8moveonly86testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF'
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetSetTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly87testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly58globalLoadableSubscriptGetSetTesterNonCopyableStructParentAA0cdefghijK0Vvp
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly58globalLoadableSubscriptGetSetTesterNonCopyableStructParentAA0cdefghijK0Vvp
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly87testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptGetSetTesterNonCopyableStructParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptGetSetTesterClassParent {
+    var tester = LoadableSubscriptGetSetTester()
+    var computedTester: LoadableSubscriptGetSetTester { fatalError() }
+    var computedTester2: LoadableSubscriptGetSetTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly72testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
+//
+// First read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// First mutation.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: end_borrow [[LOAD]]
+// Mutating Func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+//
+// Second read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[EXT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Second mutate
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[GEP:%.*]] = struct_element_addr [[CORO_RESULT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: end_borrow [[LOAD]]
+// Mutating func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter func
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: end_apply [[CORO_TOKEN]]
+//
+// Third read. This is a case that we can't handle today due to the way the AST
+// looks:
+//
+// (subscript_expr type='AddressOnlyProtocol'
+//   (member_ref_expr type='LoadableSubscriptGetSetTester'
+//     (load_expr implicit type='LoadableSubscriptGetSetTesterClassParent'
+//       (declref_expr type='@lvalue LoadableSubscriptGetSetTesterClassParent'
+//   (argument_list
+//     (argument
+//       (integer_literal_expr type='Int'
+//
+// due to the load_expr in the subscript base, SILGen emits a base rvalue for
+// the load_expr and copies it, ending the coroutine. What we need is the
+// ability to have an lvalue pseudo-component that treats the declref_expr (and
+// any member_ref_expr) as a base and allows for a load_expr to be followed by N
+// member_ref_expr.
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// First read
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// Getter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Mutation
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: end_borrow [[LOAD]]
+// Mutating Func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: } // end sil function '$s8moveonly72testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetSetTesterClassParent()
+    m = LoadableSubscriptGetSetTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: read and setter
+// This is different since adding a setter changes how we codegen.
+
+public struct LoadableSubscriptReadSetTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyProtocol {
+        _read {
+            fatalError()
+        }
+        set {
+            fatalError()
+        }
+    }
+}
+
+// TODO: This case causes us to emit an extra copy. We need to change how SILGen
+// emits through load_expr to fix this. We need the end_apply to be around the
+// entire nonMutatingFunc.
+//
+// CHECK-LABEL: sil [ossa] @$s8moveonly55testSubscriptReadSet_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The read call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// Eventually, we need this end_apply to be around the nonMutatingFunc.
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly55testSubscriptReadSet_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadSetTester()
+    m = LoadableSubscriptReadSetTester()
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly55testSubscriptReadSet_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: } // end sil function '$s8moveonly55testSubscriptReadSet_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadSetTester()
+    m[0].nonMutatingFunc()
+}
+
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly57testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF : $@convention(thin) (@inout LoadableSubscriptReadSetTester) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD_BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK:   end_access [[ACCESS]]
+//
+// The mutating function call.
+// Getter
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD:%.*]] = load_borrow [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// Mutating Func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly57testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTester) {
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly58testSubscriptReadSet_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly36globalLoadableSubscriptReadSetTesterAA0cdefG0Vvp
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly36globalLoadableSubscriptReadSetTesterAA0cdefG0Vvp
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly36globalLoadableSubscriptReadSetTesterAA0cdefG0Vvp
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly58testSubscriptReadSet_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptReadSetTester = LoadableSubscriptReadSetTester()
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadSetTester[0].nonMutatingFunc()
+    globalLoadableSubscriptReadSetTester[0] = AddressOnlyProtocol()
+    globalLoadableSubscriptReadSetTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptReadSetTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptReadSetTester()
+    var computedTester: LoadableSubscriptReadSetTester { fatalError() }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly85testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The first get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The mutating call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
+// TODO: Another case where we need to expand coroutines
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: end_access [[ACCESS]]
+//
+// The second get call.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TESTER:%.*]] = apply {{%.*}}([[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROWED_TESTER:%.*]] = begin_borrow [[TESTER]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[BORROWED_TESTER]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROWED_TESTER]]
+// } // end sil function '$s8moveonly077testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly85testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ let L
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
+// CHECK: [[COPY:%.*]] = copy_value [[EXT]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: } // end sil function '$s8moveonly85testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly87testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF : $@convention(thin) (@inout LoadableSubscriptReadSetTesterNonCopyableStructParent) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// Call to non_mutating
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD_BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// Modify
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly87testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF'
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly88testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly59globalLoadableSubscriptReadSetTesterNonCopyableStructParentAA0cdefghijK0Vvp :
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly59globalLoadableSubscriptReadSetTesterNonCopyableStructParentAA0cdefghijK0Vvp :
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly88testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptReadSetTesterNonCopyableStructParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptReadSetTesterClassParent {
+    var tester = LoadableSubscriptReadSetTester()
+    var computedTester: LoadableSubscriptReadSetTester { fatalError() }
+    var computedTester2: LoadableSubscriptReadSetTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly73testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
+//
+// First read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// First mutation.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// Mutating Func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+//
+// Second read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[EXT]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Second mutate
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[GEP:%.*]] = struct_element_addr [[CORO_RESULT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// Mutating Func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+//
+// Third read. This is a case that we can't handle today due to the way the AST
+// looks:
+//
+// (subscript_expr type='AddressOnlyProtocol'
+//   (member_ref_expr type='LoadableSubscriptReadSetTester'
+//     (load_expr implicit type='LoadableSubscriptReadSetTesterClassParent'
+//       (declref_expr type='@lvalue LoadableSubscriptReadSetTesterClassParent'
+//   (argument_list
+//     (argument
+//       (integer_literal_expr type='Int'
+//
+// due to the load_expr in the subscript base, SILGen emits a base rvalue for
+// the load_expr and copies it, ending the coroutine. What we need is the
+// ability to have an lvalue pseudo-component that treats the declref_expr (and
+// any member_ref_expr) as a base and allows for a load_expr to be followed by N
+// member_ref_expr.
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+//
+// Fourth read
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+//
+// Fourth Mutation
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_borrow [[LOAD]]
+// Mutating Func
+// CHECK: apply {{%.*}}([[TEMP]])
+// Setter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: } // end sil function '$s8moveonly73testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadSetTesterClassParent()
+    m = LoadableSubscriptReadSetTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: _read and _modify
+
+public struct LoadableSubscriptReadModifyTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyProtocol {
+        _read {
+            fatalError()
+        }
+        _modify {
+            fatalError()
+        }
+    }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The read call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// Eventually, we need this end_apply to be around the nonMutatingFunc.
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadModifyTester()
+    m = LoadableSubscriptReadModifyTester()
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: } // end sil function '$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadModifyTester()
+    m[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly60testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF : $@convention(thin) (@inout LoadableSubscriptReadModifyTester) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD_BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[ACCESS]])
+// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[ACCESS]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly60testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF'
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTester) {
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly61testSubscriptReadModify_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly39globalLoadableSubscriptReadModifyTesterAA0cdefG0Vvp : 
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly39globalLoadableSubscriptReadModifyTesterAA0cdefG0Vvp :
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly39globalLoadableSubscriptReadModifyTesterAA0cdefG0Vvp :
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly61testSubscriptReadModify_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptReadModifyTester = LoadableSubscriptReadModifyTester()
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadModifyTester[0].nonMutatingFunc()
+    globalLoadableSubscriptReadModifyTester[0] = AddressOnlyProtocol()
+    globalLoadableSubscriptReadModifyTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptReadModifyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptReadModifyTester()
+    var computedTester: LoadableSubscriptReadModifyTester { fatalError() }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly88testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The first get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The mutating call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The second get call.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[VALUE:%.*]] = apply {{%.*}}([[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROWED_VALUE]]
+// } // end sil function '$s8moveonly077testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly88testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ let L
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
+// CHECK: [[COPY:%.*]] = copy_value [[EXT]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW]]
+// CHECK: destroy_value [[COPY]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: } // end sil function '$s8moveonly88testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly90testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF : $@convention(thin) (@inout LoadableSubscriptReadModifyTesterNonCopyableStructParent) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly90testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF'
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly91testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly62globalLoadableSubscriptReadModifyTesterNonCopyableStructParentAA0cdefghijK0Vvp :
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly62globalLoadableSubscriptReadModifyTesterNonCopyableStructParentAA0cdefghijK0Vvp :
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly91testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptReadModifyTesterNonCopyableStructParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptReadModifyTesterClassParent {
+    var tester = LoadableSubscriptReadModifyTester()
+    var computedTester: LoadableSubscriptReadModifyTester { fatalError() }
+    var computedTester2: LoadableSubscriptReadModifyTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly76testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
+//
+// First read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// First mutation.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+//
+// Second read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[EXT]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Second mutate
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[GEP:%.*]] = struct_element_addr [[CORO_RESULT]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// Mutating func
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+//
+// Third read. This is a case that we can't handle today due to the way the AST
+// looks:
+//
+// (subscript_expr type='AddressOnlyProtocol'
+//   (member_ref_expr type='LoadableSubscriptReadModifyTester'
+//     (load_expr implicit type='LoadableSubscriptReadModifyTesterClassParent'
+//       (declref_expr type='@lvalue LoadableSubscriptReadModifyTesterClassParent'
+//   (argument_list
+//     (argument
+//       (integer_literal_expr type='Int'
+//
+// due to the load_expr in the subscript base, SILGen emits a base rvalue for
+// the load_expr and copies it, ending the coroutine. What we need is the
+// ability to have an lvalue pseudo-component that treats the declref_expr (and
+// any member_ref_expr) as a base and allows for a load_expr to be followed by N
+// member_ref_expr.
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW]]
+// CHECK: destroy_value [[CORO_RESULT_COPY]]
+//
+// First read
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Mutation
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: } // end sil function '$s8moveonly76testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadModifyTesterClassParent()
+    m = LoadableSubscriptReadModifyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: get and _modify
+
+public struct LoadableSubscriptGetModifyTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyProtocol {
+        get {
+            fatalError()
+        }
+        _modify {
+            fatalError()
+        }
+    }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetModifyTester()
+    m = LoadableSubscriptGetModifyTester()
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The get call
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: } // end sil function '$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetModifyTester()
+    m[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly59testSubscriptGetModify_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF : $@convention(thin) (@inout LoadableSubscriptGetModifyTester) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+//
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
+// CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK:   end_borrow [[LOAD_BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[ACCESS]])
+// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[ACCESS]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly59testSubscriptGetModify_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF'
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetModifyTester) {
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyProtocol()
+    m[0].mutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly60testSubscriptGetModify_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly38globalLoadableSubscriptGetModifyTesterAA0cdefG0Vvp :
+//
+// The get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The assignment:
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly38globalLoadableSubscriptGetModifyTesterAA0cdefG0Vvp :
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The mutating function call.
+// CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly38globalLoadableSubscriptGetModifyTesterAA0cdefG0Vvp :
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// CHECK: } // end sil function '$s8moveonly60testSubscriptGetModify_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptGetModifyTester = LoadableSubscriptGetModifyTester()
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetModifyTester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetModifyTester[0] = AddressOnlyProtocol()
+    globalLoadableSubscriptGetModifyTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetModifyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetModifyTester()
+    var computedTester: LoadableSubscriptGetModifyTester { fatalError() }
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly87testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// The first get call
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// The mutating call.
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_access [[ACCESS]]
+//
+// The second get call.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+// CHECK: [[VALUE:%.*]] = apply {{%.*}}([[LOAD_BORROW]])
+// CHECK: end_borrow [[LOAD_BORROW]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// } // end sil function '$s8moveonly077testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly87testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ let L
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+//
+// CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
+// CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
+// CHECK: [[COPY:%.*]] = copy_value [[EXT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+// CHECK: destroy_value [[COPY]]
+// CHECK: end_borrow [[LOAD]]
+// CHECK: } // end sil function '$s8moveonly87testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF'
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly90testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF : $@convention(thin) () -> () {
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly61globalLoadableSubscriptGetModifyTesterNonCopyableStructParentAA0cdefghijK0Vvp :
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TEMP]])
+// CHECK:   destroy_addr [[TEMP]]
+//
+// CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly61globalLoadableSubscriptGetModifyTesterNonCopyableStructParentAA0cdefghijK0Vvp :
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
+// CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
+// CHECK:   end_apply [[CORO_TOKEN]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly90testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF'
+var globalLoadableSubscriptGetModifyTesterNonCopyableStructParent = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptGetModifyTesterClassParent {
+    var tester = LoadableSubscriptGetModifyTester()
+    var computedTester: LoadableSubscriptGetModifyTester { fatalError() }
+    var computedTester2: LoadableSubscriptGetModifyTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+}
+
+// CHECK-LABEL: sil [ossa] @$s8moveonly75testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box $
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
+//
+// First read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// First mutation.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+//
+// Second read.
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[EXT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
+// CHECK: destroy_value [[COPYABLE_CLASS]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Second mutate
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[GEP:%.*]] = struct_element_addr [[CORO_RESULT]]
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+//
+// Third read. This is a case that we can't handle today due to the way the AST
+// looks:
+//
+// (subscript_expr type='AddressOnlyProtocol'
+//   (member_ref_expr type='LoadableSubscriptGetModifyTester'
+//     (load_expr implicit type='LoadableSubscriptGetModifyTesterClassParent'
+//       (declref_expr type='@lvalue LoadableSubscriptGetModifyTesterClassParent'
+//   (argument_list
+//     (argument
+//       (integer_literal_expr type='Int'
+//
+// due to the load_expr in the subscript base, SILGen emits a base rvalue for
+// the load_expr and copies it, ending the coroutine. What we need is the
+// ability to have an lvalue pseudo-component that treats the declref_expr (and
+// any member_ref_expr) as a base and allows for a load_expr to be followed by N
+// member_ref_expr.
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// First read
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: [[TEMP:%.*]] = alloc_stack $
+// Getter
+// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: destroy_addr [[TEMP]]
+//
+// Mutation
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[COPYABLE_CLASS:%.*]] = load [copy] [[ACCESS]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
+// CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
+// CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
+// CHECK: end_apply [[CORO_TOKEN_2]]
+// CHECK: end_apply [[CORO_TOKEN]]
+// CHECK: } // end sil function '$s8moveonly75testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF'
+public func testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetModifyTesterClassParent()
+    m = LoadableSubscriptGetModifyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
 }

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1799,10 +1799,6 @@ public struct LoadableSubscriptReadSetTester : ~Copyable {
     }
 }
 
-// TODO: This case causes us to emit an extra copy. We need to change how SILGen
-// emits through load_expr to fix this. We need the end_apply to be around the
-// entire nonMutatingFunc.
-//
 // CHECK-LABEL: sil [ossa] @$s8moveonly55testSubscriptReadSet_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
@@ -1811,15 +1807,11 @@ public struct LoadableSubscriptReadSetTester : ~Copyable {
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
-// Eventually, we need this end_apply to be around the nonMutatingFunc.
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
@@ -1881,13 +1873,10 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Let() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
 // CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD_BORROW]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
 //
 // The assignment:
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
@@ -1926,13 +1915,10 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout L
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // The assignment:
 // CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly36globalLoadableSubscriptReadSetTesterAA0cdefG0Vvp
@@ -1983,13 +1969,10 @@ public struct LoadableSubscriptReadSetTesterNonCopyableStructParent : ~Copyable 
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // The mutating call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
@@ -2055,13 +2038,10 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD_BORROW]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
 //
 // Modify
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
@@ -2089,13 +2069,10 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
 //
 // CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly59globalLoadableSubscriptReadSetTesterNonCopyableStructParentAA0cdefghijK0Vvp :
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
@@ -2140,14 +2117,11 @@ public class LoadableSubscriptReadSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // First mutation.
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -2177,14 +2151,11 @@ public class LoadableSubscriptReadSetTesterClassParent {
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[EXT]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // Second mutate
 //
@@ -2244,8 +2215,7 @@ public class LoadableSubscriptReadSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
@@ -2305,13 +2275,10 @@ public struct LoadableSubscriptReadModifyTester : ~Copyable {
 // CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
 // Eventually, we need this end_apply to be around the nonMutatingFunc.
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
@@ -2368,13 +2335,10 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
 // CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD_BORROW]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
@@ -2407,13 +2371,10 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inou
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // The assignment:
 // CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly39globalLoadableSubscriptReadModifyTesterAA0cdefG0Vvp :
@@ -2460,13 +2421,10 @@ public struct LoadableSubscriptReadModifyTesterNonCopyableStructParent : ~Copyab
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // The mutating call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
@@ -2528,13 +2486,10 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
@@ -2555,13 +2510,10 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   apply {{%.*}}([[CORO_RESULT]])
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
 //
 // CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly62globalLoadableSubscriptReadModifyTesterNonCopyableStructParentAA0cdefghijK0Vvp :
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
@@ -2600,14 +2552,11 @@ public class LoadableSubscriptReadModifyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // First mutation.
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -2630,14 +2579,11 @@ public class LoadableSubscriptReadModifyTesterClassParent {
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[EXT]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // Second mutate
 //
@@ -2693,12 +2639,9 @@ public class LoadableSubscriptReadModifyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[CORO_RESULT]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT_2]])
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_apply [[CORO_TOKEN]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 //
 // Mutation
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1028,9 +1028,10 @@ public struct LoadableSubscriptGetOnlyTester : ~Copyable {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_VaryyF'
@@ -1048,9 +1049,10 @@ public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Var() {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_LetyyF'
 public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Let() {
@@ -1065,9 +1067,10 @@ public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Let() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
 // CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK:   apply {{%.*}}([[TEMP_MARK]])
+// CHECK:   destroy_addr [[TEMP_MARK]]
 // CHECK:   end_borrow [[LOAD_BORROW]]
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE6_InOut1myAA0gcdE6TesterVz_tF'
@@ -1083,9 +1086,10 @@ public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_InOut(m: inout L
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE7_GlobalyyF'
@@ -1110,9 +1114,10 @@ public struct LoadableSubscriptGetOnlyTesterNonCopyableStructParent : ~Copyable 
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -1125,10 +1130,11 @@ public struct LoadableSubscriptGetOnlyTesterNonCopyableStructParent : ~Copyable 
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROWED_VALUE]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 // } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
 public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
     var m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
@@ -1146,10 +1152,11 @@ public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
 // CHECK: [[COPY:%.*]] = copy_value [[EXT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 // CHECK: destroy_value [[COPY]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_LetyyF'
@@ -1166,9 +1173,10 @@ public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD]])
+// CHECK:   apply {{%.*}}([[TEMP_MARK]])
+// CHECK:   destroy_addr [[TEMP_MARK]]
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE6_InOut1myAA0lcde6TesterghjI0Vz_tF'
@@ -1183,9 +1191,10 @@ public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD]])
+// CHECK:   apply {{%.*}}([[TEMP_MARK]])
+// CHECK:   destroy_addr [[TEMP_MARK]]
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE7_GlobalyyF'
@@ -1217,12 +1226,14 @@ public class LoadableSubscriptGetOnlyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $LoadableSubscriptGetOnlyTester
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
-// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP]]
-// CHECK: [[LOAD:%.*]] = load_borrow [[TEMP]]
+// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP_MARK]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[TEMP_MARK]]
 // CHECK: [[TEMP2:%.*]] = alloc_stack $
-// CHECK: apply {{%.*}}([[TEMP2]], {{%.*}}, [[LOAD]])
-// CHECK: destroy_addr [[TEMP2]]
+// CHECK: [[TEMP2_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP2]]
+// CHECK: apply {{%.*}}([[TEMP2_MARK]], {{%.*}}, [[LOAD]])
+// CHECK: destroy_addr [[TEMP2_MARK]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: end_apply [[CORO_TOKEN]]
 //
@@ -1233,13 +1244,15 @@ public class LoadableSubscriptGetOnlyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $LoadableSubscriptGetOnlyTester
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
-// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP]]
-// CHECK: [[GEP:%.*]] = struct_element_addr [[TEMP]]
+// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP_MARK]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[TEMP_MARK]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK: [[TEMP2:%.*]] = alloc_stack $
-// CHECK: apply {{%.*}}([[TEMP2]], {{%.*}}, [[LOAD]])
-// CHECK: destroy_addr [[TEMP2]]
+// CHECK: [[TEMP2_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP2]]
+// CHECK: apply {{%.*}}([[TEMP2_MARK]], {{%.*}}, [[LOAD]])
+// CHECK: destroy_addr [[TEMP2_MARK]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: end_apply [[CORO_TOKEN]]
 //
@@ -1268,9 +1281,10 @@ public class LoadableSubscriptGetOnlyTesterClassParent {
 // CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[BORROW]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 
 // CHECK: } // end sil function '$s8moveonly065testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressE4_VaryyF'
 public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
@@ -1304,29 +1318,32 @@ public struct LoadableSubscriptGetSetTester : ~Copyable {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[TEMP_MARK]])
+// CHECK: destroy_addr [[TEMP_MARK]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // The mutating function call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: } // end sil function '$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_VaryyF'
@@ -1346,9 +1363,10 @@ public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Var() {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: } // end sil function '$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_LetyyF'
 public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Let() {
@@ -1363,27 +1381,30 @@ public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Let() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
 // CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK:   end_borrow [[LOAD_BORROW]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   destroy_addr [[MARK_TEMP]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[ACCESS]])
 // CHECK: end_access [[ACCESS]]
 //
 // The mutating function call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[ACCESS]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: } // end sil function '$s8moveonly56testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF'
@@ -1401,19 +1422,21 @@ public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut(m: inout Lo
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // The assignment:
 // CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly35globalLoadableSubscriptGetSetTesterAA0cdefG0Vvp
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // The mutating function call.
@@ -1421,11 +1444,12 @@ public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut(m: inout Lo
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: } // end sil function '$s8moveonly57testSubscriptGetSet_BaseLoadable_ResultAddressOnly_GlobalyyF'
@@ -1452,22 +1476,24 @@ public struct LoadableSubscriptGetSetTesterNonCopyableStructParent : ~Copyable {
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // The mutating call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK: end_borrow [[LOAD]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK: end_access [[ACCESS]]
 //
 // The second get call.
@@ -1478,10 +1504,11 @@ public struct LoadableSubscriptGetSetTesterNonCopyableStructParent : ~Copyable {
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROWED_VALUE]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 // } // end sil function '$s8moveonly077testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
 public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
     var m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
@@ -1500,10 +1527,11 @@ public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_Resul
 // CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
 // CHECK: [[COPY:%.*]] = copy_value [[EXT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 // CHECK: destroy_value [[COPY]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: } // end sil function '$s8moveonly84testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF'
@@ -1520,20 +1548,22 @@ public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_Resul
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   destroy_addr [[MARK_TEMP]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK:   end_borrow [[LOAD]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK: } // end sil function '$s8moveonly86testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF'
 public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetSetTesterNonCopyableStructParent) {
     m.tester[0].nonMutatingFunc()
@@ -1547,22 +1577,24 @@ public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_Resul
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   destroy_addr [[MARK_TEMP]]
 //
 // CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly58globalLoadableSubscriptGetSetTesterNonCopyableStructParentAA0cdefghijK0Vvp
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
 // CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK:   end_borrow [[LOAD]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly87testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF'
 var globalLoadableSubscriptGetSetTesterNonCopyableStructParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
@@ -1593,12 +1625,13 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // First mutation.
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -1607,13 +1640,14 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK: end_borrow [[LOAD]]
 // Mutating Func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 //
 // Second read.
@@ -1624,12 +1658,13 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[EXT]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[EXT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // Second mutate
 //
@@ -1640,13 +1675,14 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[GEP:%.*]] = struct_element_addr [[CORO_RESULT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK: end_borrow [[LOAD]]
 // Mutating func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter func
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK: end_apply [[CORO_TOKEN]]
 //
 // Third read. This is a case that we can't handle today due to the way the AST
@@ -1674,9 +1710,10 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // First read
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -1685,11 +1722,12 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // Getter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // Mutation
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -1698,13 +1736,14 @@ public class LoadableSubscriptGetSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK: end_borrow [[LOAD]]
 // Mutating Func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: } // end sil function '$s8moveonly72testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF'
 public func testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
@@ -1757,23 +1796,25 @@ public struct LoadableSubscriptReadSetTester : ~Copyable {
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // The mutating function call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: } // end sil function '$s8moveonly55testSubscriptReadSet_BaseLoadable_ResultAddressOnly_VaryyF'
@@ -1823,22 +1864,24 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Let() {
 //
 // The assignment:
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[ACCESS]])
 // CHECK:   end_access [[ACCESS]]
 //
 // The mutating function call.
 // Getter
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[ACCESS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // Mutating Func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[ACCESS]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[ACCESS]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: } // end sil function '$s8moveonly57testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut1myAA0gcdE6TesterVz_tF
@@ -1867,10 +1910,11 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout L
 // The assignment:
 // CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly36globalLoadableSubscriptReadSetTesterAA0cdefG0Vvp
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // The mutating function call.
@@ -1878,13 +1922,14 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout L
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD_BORROW]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[MARK]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[MARK]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: } // end sil function '$s8moveonly58testSubscriptReadSet_BaseLoadable_ResultAddressOnly_GlobalyyF'
@@ -1924,14 +1969,15 @@ public struct LoadableSubscriptReadSetTesterNonCopyableStructParent : ~Copyable 
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
 // TODO: Another case where we need to expand coroutines
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[LOAD]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK: end_access [[ACCESS]]
 //
 // The second get call.
@@ -1994,13 +2040,14 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[MARK_TEMP]]
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly87testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut1myAA0lcde6TesterghjI0Vz_tF'
 public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTesterNonCopyableStructParent) {
@@ -2028,13 +2075,14 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 // CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK:   copy_addr [[CORO_RESULT]] to [init] [[MARK_TEMP]]
 // CHECK:   end_apply [[CORO_TOKEN]]
 // CHECK:   end_borrow [[LOAD]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly88testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_GlobalyyF'
 var globalLoadableSubscriptReadSetTesterNonCopyableStructParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
@@ -2081,14 +2129,15 @@ public class LoadableSubscriptReadSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // Mutating Func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
@@ -2119,14 +2168,15 @@ public class LoadableSubscriptReadSetTesterClassParent {
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[GEP:%.*]] = struct_element_addr [[CORO_RESULT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // Mutating Func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[GEP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[GEP]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
@@ -2181,15 +2231,16 @@ public class LoadableSubscriptReadSetTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[CORO_RESULT]]
 // CHECK: ([[CORO_RESULT_2:%.*]], [[CORO_TOKEN_2:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD]])
-// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[TEMP]]
+// CHECK: copy_addr [[CORO_RESULT_2]] to [init] [[MARK_TEMP]]
 // CHECK: end_apply [[CORO_TOKEN_2]]
 // CHECK: end_borrow [[LOAD]]
 // Mutating Func
-// CHECK: apply {{%.*}}([[TEMP]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
 // Setter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: } // end sil function '$s8moveonly73testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF'
 public func testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
@@ -2237,11 +2288,12 @@ public struct LoadableSubscriptReadModifyTester : ~Copyable {
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
-// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: copy_addr [take] [[MARK_TEMP]] to [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -2299,9 +2351,10 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[ACCESS]])
-// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: copy_addr [take] [[MARK_TEMP]] to [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -2338,11 +2391,12 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inou
 // The assignment:
 // CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly39globalLoadableSubscriptReadModifyTesterAA0cdefG0Vvp :
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
-// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: copy_addr [take] [[MARK_TEMP]] to [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -2664,19 +2718,21 @@ public struct LoadableSubscriptGetModifyTester : ~Copyable {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
-// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: copy_addr [take] [[MARK_TEMP]] to [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -2705,9 +2761,10 @@ public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Var() {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: } // end sil function '$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_LetyyF'
 public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Let() {
@@ -2722,18 +2779,20 @@ public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Let() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
 // CHECK:   [[LOAD_BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK:   end_borrow [[LOAD_BORROW]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   destroy_addr [[MARK_TEMP]]
 //
 // The assignment:
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[ACCESS]])
-// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: copy_addr [take] [[MARK_TEMP]] to [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -2759,20 +2818,22 @@ public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_InOut(m: inout
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // The assignment:
 // CHECK: [[GLOBAL_ADDR:%.*]] = global_addr @$s8moveonly38globalLoadableSubscriptGetModifyTesterAA0cdefG0Vvp :
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}) : $@convention(method) (@thin AddressOnlyProtocol.Type) -> @out AddressOnlyProtocol
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL_ADDR]]
 // CHECK: [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[MARK]])
-// CHECK: copy_addr [take] [[TEMP]] to [[CORO_RESULT]]
+// CHECK: copy_addr [take] [[MARK_TEMP]] to [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_access [[ACCESS]]
 //
@@ -2809,11 +2870,12 @@ public struct LoadableSubscriptGetModifyTesterNonCopyableStructParent : ~Copyabl
 // CHECK: [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD_BORROW]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD_BORROW]])
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // The mutating call.
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
@@ -2832,10 +2894,11 @@ public struct LoadableSubscriptGetModifyTesterNonCopyableStructParent : ~Copyabl
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: end_access [[ACCESS]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROWED_VALUE]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[BORROWED_VALUE]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 // } // end sil function '$s8moveonly077testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF'
 public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
     var m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
@@ -2854,10 +2917,11 @@ public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_Re
 // CHECK: [[EXT:%.*]] = struct_extract [[LOAD]]
 // CHECK: [[COPY:%.*]] = copy_value [[EXT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[COPY]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 // CHECK: destroy_value [[COPY]]
 // CHECK: end_borrow [[LOAD]]
 // CHECK: } // end sil function '$s8moveonly87testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF'
@@ -2873,11 +2937,12 @@ public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_Re
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[MARK]]
 // CHECK:   [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK:   apply {{%.*}}([[TEMP]], {{%.*}}, [[LOAD]])
+// CHECK:   [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[LOAD]])
 // CHECK:   end_borrow [[LOAD]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK:   apply {{%.*}}([[TEMP]])
-// CHECK:   destroy_addr [[TEMP]]
+// CHECK:   apply {{%.*}}([[MARK_TEMP]])
+// CHECK:   destroy_addr [[MARK_TEMP]]
 //
 // CHECK:   [[GLOBAL:%.*]] = global_addr @$s8moveonly61globalLoadableSubscriptGetModifyTesterNonCopyableStructParentAA0cdefghijK0Vvp :
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
@@ -2916,12 +2981,13 @@ public class LoadableSubscriptGetModifyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // First mutation.
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -2942,12 +3008,13 @@ public class LoadableSubscriptGetModifyTesterClassParent {
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[EXT:%.*]] = struct_extract [[CORO_RESULT]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[EXT]])
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[EXT]])
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: end_borrow [[BORROW_COPYABLE_CLASS]]
 // CHECK: destroy_value [[COPYABLE_CLASS]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // Second mutate
 //
@@ -2987,9 +3054,10 @@ public class LoadableSubscriptGetModifyTesterClassParent {
 // CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
 // CHECK: end_apply [[CORO_TOKEN]]
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CORO_RESULT_COPY]]
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[BORROW]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[BORROW]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // First read
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
@@ -2998,11 +3066,12 @@ public class LoadableSubscriptGetModifyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $
+// CHECK: [[MARK_TEMP:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
 // Getter
-// CHECK: apply {{%.*}}([[TEMP]], {{%.*}}, [[CORO_RESULT]])
+// CHECK: apply {{%.*}}([[MARK_TEMP]], {{%.*}}, [[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
+// CHECK: apply {{%.*}}([[MARK_TEMP]])
+// CHECK: destroy_addr [[MARK_TEMP]]
 //
 // Mutation
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -29,6 +29,7 @@ public struct NonTrivialStruct {
 sil @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
 sil @getNonTrivialStruct : $@convention(thin) () -> @owned NonTrivialStruct
 sil @consumeNonTrivialStructAddr : $@convention(thin) (@in NonTrivialStruct) -> ()
+sil @consumeNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
 
 @_moveOnly
 public struct NonTrivialStructPair {
@@ -533,5 +534,44 @@ sil [ossa] @test_in_use : $@convention(thin) () -> () {
   destroy_addr %2 : $*NonTrivialStruct
   dealloc_stack %0 : $*NonTrivialStruct
   %9999 = tuple ()
+  return %9999 : $()
+}
+
+//////////////////////////////////////////
+// MARK: Load Take As Borrow/Copy Tests //
+//////////////////////////////////////////
+
+// CHECK-LABEL: sil [ossa] @load_take_as_load_borrow : $@convention(thin) (@owned NonTrivialStruct) -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack $NonTrivialStruct
+// CHECK: [[BORROW:%.*]] = load_borrow [[ALLOC]]
+// CHECK: end_borrow [[BORROW]]
+// CHECK: } // end sil function 'load_take_as_load_borrow'
+sil [ossa] @load_take_as_load_borrow : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
+  store %0 to [init] %1a : $*NonTrivialStruct
+  %2 = load [take] %1a : $*NonTrivialStruct
+  destroy_value %2 : $NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @load_take_as_load_take : $@convention(thin) (@owned NonTrivialStruct) -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack $NonTrivialStruct
+// CHECK: [[LOAD:%.*]] = load [take] [[ALLOC]]
+// CHECK: apply {{%.*}}([[LOAD]])
+// CHECK: } // end sil function 'load_take_as_load_take'
+sil [ossa] @load_take_as_load_take : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
+  store %0 to [init] %1a : $*NonTrivialStruct
+  %2 = load [take] %1a : $*NonTrivialStruct
+  %f = function_ref @consumeNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  apply %f(%2) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -507,3 +507,25 @@ bb3:
   %23 = tuple ()
   return %23 : $()
 }
+
+/////////////////////////////////////////////
+// MARK: Load Take as Load Copy Diagnostic //
+/////////////////////////////////////////////
+
+sil [ossa] @load_take_as_load_copy : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct, let, name "foo"
+  %1a = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
+  // expected-error @-1 {{'foo' consumed more than once}}
+  store %0 to [init] %1a : $*NonTrivialStruct
+  %2 = load [take] %1a : $*NonTrivialStruct
+  %2a = copy_value %2 : $NonTrivialStruct
+  %f = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  apply %f(%2) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  // expected-note @-1 {{consumed here}}
+  apply %f(%2a) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  // expected-note @-1 {{consumed again here}}
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -1,0 +1,487 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+
+class CopyableKlass {}
+protocol P {}
+extension CopyableKlass : P {}
+
+public struct NonTrivialStruct : ~Copyable {
+    var k = CopyableKlass()
+}
+
+public struct AddressOnlyMoveOnlyContainingProtocol : ~Copyable {
+    var copyable: any P = CopyableKlass()
+    var moveOnly = NonTrivialStruct()
+
+    func nonMutatingFunc() {}
+    mutating func mutatingFunc() {}
+}
+
+// MARK: Getter Only
+
+public struct LoadableSubscriptGetOnlyTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyMoveOnlyContainingProtocol {
+        get {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetOnlyTester()
+    m = LoadableSubscriptGetOnlyTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetOnlyTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetOnlyTester) {
+    m[0].nonMutatingFunc()
+}
+
+var globalLoadableSubscriptGetOnlyTester = LoadableSubscriptGetOnlyTester()
+public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetOnlyTester[0].nonMutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetOnlyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetOnlyTester()
+    var computedTester: LoadableSubscriptGetOnlyTester { fatalError() }
+}
+
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetOnlyTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+}
+
+var globalLoadableSubscriptGetOnlyTesterNonCopyableStructParent = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetOnlyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+}
+
+public class LoadableSubscriptGetOnlyTesterClassParent {
+    var tester = LoadableSubscriptGetOnlyTester()
+    var computedTester: LoadableSubscriptGetOnlyTester { fatalError() }
+    var testerParent = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+}
+
+public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetOnlyTesterClassParent()
+    m = LoadableSubscriptGetOnlyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+// MARK: Getter + Setter.
+// This is different since adding a setter changes how we codegen.
+
+public struct LoadableSubscriptGetSetTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyMoveOnlyContainingProtocol {
+        get {
+            fatalError()
+        }
+        set {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetSetTester()
+    m = LoadableSubscriptGetSetTester()
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetSetTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetSetTester) {
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptGetSetTester = LoadableSubscriptGetSetTester()
+public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetSetTester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetSetTester[0] = AddressOnlyMoveOnlyContainingProtocol()
+    globalLoadableSubscriptGetSetTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetSetTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetSetTester()
+    var computedTester: LoadableSubscriptGetSetTester { fatalError() }
+}
+
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetSetTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptGetSetTesterNonCopyableStructParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptGetSetTesterClassParent {
+    var tester = LoadableSubscriptGetSetTester()
+    var computedTester: LoadableSubscriptGetSetTester { fatalError() }
+    var computedTester2: LoadableSubscriptGetSetTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+}
+
+public func testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetSetTesterClassParent()
+    m = LoadableSubscriptGetSetTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: read and setter
+// This is different since adding a setter changes how we codegen.
+
+public struct LoadableSubscriptReadSetTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyMoveOnlyContainingProtocol {
+        _read {
+            fatalError()
+        }
+        set {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadSetTester()
+    m = LoadableSubscriptReadSetTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadSetTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTester) {
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+var globalLoadableSubscriptReadSetTester = LoadableSubscriptReadSetTester()
+public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadSetTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadSetTester[0] = AddressOnlyMoveOnlyContainingProtocol()
+    globalLoadableSubscriptReadSetTester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptReadSetTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptReadSetTester()
+    var computedTester: LoadableSubscriptReadSetTester { fatalError() }
+}
+
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+var globalLoadableSubscriptReadSetTesterNonCopyableStructParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+public class LoadableSubscriptReadSetTesterClassParent {
+    var tester = LoadableSubscriptReadSetTester()
+    var computedTester: LoadableSubscriptReadSetTester { fatalError() }
+    var computedTester2: LoadableSubscriptReadSetTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+}
+
+public func testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadSetTesterClassParent()
+    m = LoadableSubscriptReadSetTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+// MARK: _read and _modify
+
+public struct LoadableSubscriptReadModifyTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyMoveOnlyContainingProtocol {
+        _read {
+            fatalError()
+        }
+        _modify {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadModifyTester()
+    m = LoadableSubscriptReadModifyTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadModifyTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTester) {
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptReadModifyTester = LoadableSubscriptReadModifyTester()
+public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadModifyTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadModifyTester[0] = AddressOnlyMoveOnlyContainingProtocol()
+    globalLoadableSubscriptReadModifyTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptReadModifyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptReadModifyTester()
+    var computedTester: LoadableSubscriptReadModifyTester { fatalError() }
+}
+
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptReadModifyTesterNonCopyableStructParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptReadModifyTesterClassParent {
+    var tester = LoadableSubscriptReadModifyTester()
+    var computedTester: LoadableSubscriptReadModifyTester { fatalError() }
+    var computedTester2: LoadableSubscriptReadModifyTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+}
+
+public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptReadModifyTesterClassParent()
+    m = LoadableSubscriptReadModifyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: get and _modify
+
+public struct LoadableSubscriptGetModifyTester : ~Copyable {
+    subscript(_ i: Int) -> AddressOnlyMoveOnlyContainingProtocol {
+        get {
+            fatalError()
+        }
+        _modify {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetModifyTester()
+    m = LoadableSubscriptGetModifyTester()
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetModifyTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptGetModifyTester) {
+    m[0].nonMutatingFunc()
+    m[0] = AddressOnlyMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptGetModifyTester = LoadableSubscriptGetModifyTester()
+public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetModifyTester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetModifyTester[0] = AddressOnlyMoveOnlyContainingProtocol()
+    globalLoadableSubscriptGetModifyTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetModifyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetModifyTester()
+    var computedTester: LoadableSubscriptGetModifyTester { fatalError() }
+}
+
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Let() {
+    let m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+var globalLoadableSubscriptGetModifyTesterNonCopyableStructParent = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
+    globalLoadableSubscriptGetModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptGetModifyTesterClassParent {
+    var tester = LoadableSubscriptGetModifyTester()
+    var computedTester: LoadableSubscriptGetModifyTester { fatalError() }
+    var computedTester2: LoadableSubscriptGetModifyTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+}
+
+public func testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultAddressOnly_Var() {
+    var m = LoadableSubscriptGetModifyTesterClassParent()
+    m = LoadableSubscriptGetModifyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -201,7 +201,6 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Var() {
     var m = LoadableSubscriptReadSetTester()
     m = LoadableSubscriptReadSetTester()
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = AddressOnlyMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
@@ -216,7 +215,6 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Let() {
 
 public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTester) {
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = AddressOnlyMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
@@ -225,7 +223,6 @@ public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_InOut(m: inout L
 var globalLoadableSubscriptReadSetTester = LoadableSubscriptReadSetTester()
 public func testSubscriptReadSet_BaseLoadable_ResultAddressOnly_Global() {
     globalLoadableSubscriptReadSetTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadSetTester[0] = AddressOnlyMoveOnlyContainingProtocol()
     globalLoadableSubscriptReadSetTester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
@@ -241,7 +238,6 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
     var m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
     m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
@@ -254,7 +250,6 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 
 public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadSetTesterNonCopyableStructParent) {
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
 }
@@ -262,7 +257,6 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 var globalLoadableSubscriptReadSetTesterNonCopyableStructParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
 public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
     globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
 }
@@ -281,17 +275,14 @@ public func testSubscriptReadSetThroughParentClass_BaseLoadable_ResultAddressOnl
     var m = LoadableSubscriptReadSetTesterClassParent()
     m = LoadableSubscriptReadSetTesterClassParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
 }
@@ -313,7 +304,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Var() {
     var m = LoadableSubscriptReadModifyTester()
     m = LoadableSubscriptReadModifyTester()
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = AddressOnlyMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
 }
@@ -326,7 +316,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {
 
 public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTester) {
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = AddressOnlyMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
 }
@@ -334,7 +323,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inou
 var globalLoadableSubscriptReadModifyTester = LoadableSubscriptReadModifyTester()
 public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Global() {
     globalLoadableSubscriptReadModifyTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadModifyTester[0] = AddressOnlyMoveOnlyContainingProtocol()
     globalLoadableSubscriptReadModifyTester[0].mutatingFunc()
 }
@@ -349,7 +337,6 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
     var m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
     m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
 }
@@ -362,14 +349,12 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
 
 public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTesterNonCopyableStructParent) {
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
 }
 
 var globalLoadableSubscriptReadModifyTesterNonCopyableStructParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
 public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_Global() {
     globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
 }
 
@@ -387,15 +372,12 @@ public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddress
     var m = LoadableSubscriptReadModifyTesterClassParent()
     m = LoadableSubscriptReadModifyTesterClassParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     m.testerParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].mutatingFunc()
 }
 

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -198,7 +198,6 @@ public func testSubscriptReadSet_BaseLoadable_ResultLoadable_Var() {
     var m = LoadableSubscriptReadSetTester()
     m = LoadableSubscriptReadSetTester()
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = LoadableMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
@@ -213,7 +212,6 @@ public func testSubscriptReadSet_BaseLoadable_ResultLoadable_Let() {
 
 public func testSubscriptReadSet_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadSetTester) {
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = LoadableMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
@@ -222,7 +220,6 @@ public func testSubscriptReadSet_BaseLoadable_ResultLoadable_InOut(m: inout Load
 var globalLoadableSubscriptReadSetTester = LoadableSubscriptReadSetTester()
 public func testSubscriptReadSet_BaseLoadable_ResultLoadable_Global() {
     globalLoadableSubscriptReadSetTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadSetTester[0] = LoadableMoveOnlyContainingProtocol()
     globalLoadableSubscriptReadSetTester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
@@ -238,7 +235,6 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
     var m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
     m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
@@ -251,7 +247,6 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 
 public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadSetTesterNonCopyableStructParent) {
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
 }
@@ -259,7 +254,6 @@ public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_Resu
 var globalLoadableSubscriptReadSetTesterNonCopyableStructParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
 public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
     globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
 }
@@ -278,17 +272,14 @@ public func testSubscriptReadSetThroughParentClass_BaseLoadable_ResultLoadable_V
     var m = LoadableSubscriptReadSetTesterClassParent()
     m = LoadableSubscriptReadSetTesterClassParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].mutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
 }
@@ -310,7 +301,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Var() {
     var m = LoadableSubscriptReadModifyTester()
     m = LoadableSubscriptReadModifyTester()
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = LoadableMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
 }
@@ -323,7 +313,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Let() {
 
 public func testSubscriptReadModify_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadModifyTester) {
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m[0] = LoadableMoveOnlyContainingProtocol()
     m[0].mutatingFunc()
 }
@@ -331,7 +320,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultLoadable_InOut(m: inout L
 var globalLoadableSubscriptReadModifyTester = LoadableSubscriptReadModifyTester()
 public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Global() {
     globalLoadableSubscriptReadModifyTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadModifyTester[0] = LoadableMoveOnlyContainingProtocol()
     globalLoadableSubscriptReadModifyTester[0].mutatingFunc()
 }
@@ -346,7 +334,6 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
     var m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
     m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
 }
@@ -359,14 +346,12 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
 
 public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadModifyTesterNonCopyableStructParent) {
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
 }
 
 var globalLoadableSubscriptReadModifyTesterNonCopyableStructParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
 public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
     globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
 }
 
@@ -384,15 +369,12 @@ public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultLoadabl
     var m = LoadableSubscriptReadModifyTesterClassParent()
     m = LoadableSubscriptReadModifyTesterClassParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.tester[0].mutatingFunc()
     m.testerParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].mutatingFunc()
 }
 

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -1,0 +1,484 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+
+class CopyableKlass {}
+
+public struct NonTrivialStruct : ~Copyable {
+    var k = CopyableKlass()
+}
+
+public struct LoadableMoveOnlyContainingProtocol : ~Copyable {
+    var moveOnly = NonTrivialStruct()
+
+    func nonMutatingFunc() {}
+    mutating func mutatingFunc() {}
+}
+
+// MARK: Getter Only
+
+public struct LoadableSubscriptGetOnlyTester : ~Copyable {
+    subscript(_ i: Int) -> LoadableMoveOnlyContainingProtocol {
+        get {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptGetOnly_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetOnlyTester()
+    m = LoadableSubscriptGetOnlyTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnly_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptGetOnlyTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnly_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptGetOnlyTester) {
+    m[0].nonMutatingFunc()
+}
+
+var globalLoadableSubscriptGetOnlyTester = LoadableSubscriptGetOnlyTester()
+public func testSubscriptGetOnly_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptGetOnlyTester[0].nonMutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetOnlyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetOnlyTester()
+    var computedTester: LoadableSubscriptGetOnlyTester { fatalError() }
+}
+
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptGetOnlyTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+}
+
+var globalLoadableSubscriptGetOnlyTesterNonCopyableStructParent = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptGetOnlyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+}
+
+public class LoadableSubscriptGetOnlyTesterClassParent {
+    var tester = LoadableSubscriptGetOnlyTester()
+    var computedTester: LoadableSubscriptGetOnlyTester { fatalError() }
+    var testerParent = LoadableSubscriptGetOnlyTesterNonCopyableStructParent()
+}
+
+public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetOnlyTesterClassParent()
+    m = LoadableSubscriptGetOnlyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+// MARK: Getter + Setter.
+// This is different since adding a setter changes how we codegen.
+
+public struct LoadableSubscriptGetSetTester : ~Copyable {
+    subscript(_ i: Int) -> LoadableMoveOnlyContainingProtocol {
+        get {
+            fatalError()
+        }
+        set {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptGetSet_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetSetTester()
+    m = LoadableSubscriptGetSetTester()
+    m[0].nonMutatingFunc()
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+public func testSubscriptGetSet_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptGetSetTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetSet_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptGetSetTester) {
+    m[0].nonMutatingFunc()
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptGetSetTester = LoadableSubscriptGetSetTester()
+public func testSubscriptGetSet_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptGetSetTester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetSetTester[0] = LoadableMoveOnlyContainingProtocol()
+    globalLoadableSubscriptGetSetTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetSetTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetSetTester()
+    var computedTester: LoadableSubscriptGetSetTester { fatalError() }
+}
+
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptGetSetTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptGetSetTesterNonCopyableStructParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptGetSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptGetSetTesterClassParent {
+    var tester = LoadableSubscriptGetSetTester()
+    var computedTester: LoadableSubscriptGetSetTester { fatalError() }
+    var computedTester2: LoadableSubscriptGetSetTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptGetSetTesterNonCopyableStructParent()
+}
+
+public func testSubscriptGetSetThroughParentClass_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetSetTesterClassParent()
+    m = LoadableSubscriptGetSetTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: read and setter
+// This is different since adding a setter changes how we codegen.
+
+public struct LoadableSubscriptReadSetTester : ~Copyable {
+    subscript(_ i: Int) -> LoadableMoveOnlyContainingProtocol {
+        _read {
+            fatalError()
+        }
+        set {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptReadSet_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptReadSetTester()
+    m = LoadableSubscriptReadSetTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+public func testSubscriptReadSet_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptReadSetTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+
+public func testSubscriptReadSet_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadSetTester) {
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+var globalLoadableSubscriptReadSetTester = LoadableSubscriptReadSetTester()
+public func testSubscriptReadSet_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptReadSetTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadSetTester[0] = LoadableMoveOnlyContainingProtocol()
+    globalLoadableSubscriptReadSetTester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptReadSetTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptReadSetTester()
+    var computedTester: LoadableSubscriptReadSetTester { fatalError() }
+}
+
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadSetTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+var globalLoadableSubscriptReadSetTesterNonCopyableStructParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+public func testSubscriptReadSetThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadSetTesterNonCopyableStructParent.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+public class LoadableSubscriptReadSetTesterClassParent {
+    var tester = LoadableSubscriptReadSetTester()
+    var computedTester: LoadableSubscriptReadSetTester { fatalError() }
+    var computedTester2: LoadableSubscriptReadSetTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptReadSetTesterNonCopyableStructParent()
+}
+
+public func testSubscriptReadSetThroughParentClass_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptReadSetTesterClassParent()
+    m = LoadableSubscriptReadSetTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].mutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+// MARK: _read and _modify
+
+public struct LoadableSubscriptReadModifyTester : ~Copyable {
+    subscript(_ i: Int) -> LoadableMoveOnlyContainingProtocol {
+        _read {
+            fatalError()
+        }
+        _modify {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptReadModifyTester()
+    m = LoadableSubscriptReadModifyTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptReadModifyTester()
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+}
+
+public func testSubscriptReadModify_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadModifyTester) {
+    m[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptReadModifyTester = LoadableSubscriptReadModifyTester()
+public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptReadModifyTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadModifyTester[0] = LoadableMoveOnlyContainingProtocol()
+    globalLoadableSubscriptReadModifyTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptReadModifyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptReadModifyTester()
+    var computedTester: LoadableSubscriptReadModifyTester { fatalError() }
+}
+
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadModifyTesterNonCopyableStructParent) {
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptReadModifyTesterNonCopyableStructParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    globalLoadableSubscriptReadModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptReadModifyTesterClassParent {
+    var tester = LoadableSubscriptReadModifyTester()
+    var computedTester: LoadableSubscriptReadModifyTester { fatalError() }
+    var computedTester2: LoadableSubscriptReadModifyTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptReadModifyTesterNonCopyableStructParent()
+}
+
+public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptReadModifyTesterClassParent()
+    m = LoadableSubscriptReadModifyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].mutatingFunc()
+}
+
+// MARK: get and _modify
+
+public struct LoadableSubscriptGetModifyTester : ~Copyable {
+    subscript(_ i: Int) -> LoadableMoveOnlyContainingProtocol {
+        get {
+            fatalError()
+        }
+        _modify {
+            fatalError()
+        }
+    }
+}
+
+public func testSubscriptGetModify_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetModifyTester()
+    m = LoadableSubscriptGetModifyTester()
+    m[0].nonMutatingFunc()
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+public func testSubscriptGetModify_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptGetModifyTester()
+    m[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetModify_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptGetModifyTester) {
+    m[0].nonMutatingFunc()
+    m[0] = LoadableMoveOnlyContainingProtocol()
+    m[0].mutatingFunc()
+}
+
+var globalLoadableSubscriptGetModifyTester = LoadableSubscriptGetModifyTester()
+public func testSubscriptGetModify_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptGetModifyTester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetModifyTester[0] = LoadableMoveOnlyContainingProtocol()
+    globalLoadableSubscriptGetModifyTester[0].mutatingFunc()
+}
+
+// Make sure that we get the same behavior when we access through another noncopyable struct.
+public struct LoadableSubscriptGetModifyTesterNonCopyableStructParent : ~Copyable {
+    var tester = LoadableSubscriptGetModifyTester()
+    var computedTester: LoadableSubscriptGetModifyTester { fatalError() }
+}
+
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+}
+
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Let() {
+    let m = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+    m.tester[0].nonMutatingFunc()
+}
+
+var globalLoadableSubscriptGetModifyTesterNonCopyableStructParent = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultLoadable_Global() {
+    globalLoadableSubscriptGetModifyTesterNonCopyableStructParent.tester[0].nonMutatingFunc()
+    globalLoadableSubscriptGetModifyTesterNonCopyableStructParent.tester[0].mutatingFunc()
+}
+
+public class LoadableSubscriptGetModifyTesterClassParent {
+    var tester = LoadableSubscriptGetModifyTester()
+    var computedTester: LoadableSubscriptGetModifyTester { fatalError() }
+    var computedTester2: LoadableSubscriptGetModifyTester {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    var testerParent = LoadableSubscriptGetModifyTesterNonCopyableStructParent()
+}
+
+public func testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultLoadable_Var() {
+    var m = LoadableSubscriptGetModifyTesterClassParent()
+    m = LoadableSubscriptGetModifyTesterClassParent()
+    m.tester[0].nonMutatingFunc()
+    m.tester[0].mutatingFunc()
+    m.testerParent.tester[0].nonMutatingFunc()
+    m.testerParent.tester[0].mutatingFunc()
+    m.computedTester[0].nonMutatingFunc()
+    // expected-error @-1 {{copy of noncopyable typed value}}
+    m.computedTester2[0].nonMutatingFunc()
+    m.computedTester2[0].mutatingFunc()
+}


### PR DESCRIPTION
I also added a bunch of tests that showed the behavior of subscripts/other accessors with the following combinations of semantics:

1. get only.
2. get/set.
3. get/modify.
4. read/set.
5. read/modify.

rdar://109746476