### PR TITLE
Support NUMBER_OF_PROCESSORS not being defined when running tests on Windows

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1447,7 +1447,8 @@ if run_vendor == 'apple':
 
 elif run_os in ['windows-msvc']:
     lit_config.note('Testing Windows ' + config.variant_triple)
-    config.environment['NUMBER_OF_PROCESSORS'] = os.environ['NUMBER_OF_PROCESSORS']
+    if 'NUMBER_OF_PROCESSORS' in os.environ:
+        config.environment['NUMBER_OF_PROCESSORS'] = os.environ['NUMBER_OF_PROCESSORS']
     if 'PROCESSOR_ARCHITEW6432' in os.environ:
         config.environment['PROCESSOR_ARCHITEW6432'] = os.environ['PROCESSOR_ARCHITEW6432']
     if 'PROCESSOR_ARCHITECTURE' in os.environ:


### PR DESCRIPTION
In some cases clean Windows builds were hitting:

```
lit.py: S:\SourceCache\llvm-project\llvm\utils\lit\lit\TestingConfig.py:138: fatal: unable to parse config file 'S:/SourceCache/swift\\test\\lit.cfg', traceback: Traceback (most recent call last):
  File "S:\SourceCache\llvm-project\llvm\utils\lit\lit\TestingConfig.py", line 127, in load_from_path
    exec(compile(data, path, 'exec'), cfg_globals, None)
  File "S:/SourceCache/swift\test\lit.cfg", line 1450, in <module>
    config.environment['NUMBER_OF_PROCESSORS'] = os.environ['NUMBER_OF_PROCESSORS']
  File "C:\Users\tristan\AppData\Local\Programs\Python\Python39\lib\os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'NUMBER_OF_PROCESSORS'
```

This is likely because https://github.com/tristanlabelle/llvm-project/blob/llvm.org/main/llvm/utils/lit/lit/TestingConfig.py has an allow list of environment variables that does not include `NUMBER_OF_PROCESSORS`. It doesn't seem like anything else in that repo depends on the environment variable being set, so this adds support for its absence.
