### PR TITLE
Soften @objcImpl errors into warnings in 5.9

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1660,6 +1660,11 @@ NOTE(objc_implementation_one_matched_requirement,none,
      "'@objc(%4)' to use it}3",
      (DescriptiveDeclKind, ValueDecl *, ObjCSelector, bool, StringRef))
 
+WARNING(wrap_objc_implementation_will_become_error,none,
+        "%0; this will become an error before '@_objcImplementation' is "
+        "stabilized",
+        (DiagnosticInfo *))
+
 ERROR(cdecl_not_at_top_level,none,
       "@_cdecl can only be applied to global functions", ())
 ERROR(cdecl_empty_name,none,

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2874,9 +2874,16 @@ namespace {
 class ObjCImplementationChecker {
   DiagnosticEngine &diags;
 
-  template<typename ...ArgTypes>
-  InFlightDiagnostic diagnose(ArgTypes &&...Args) {
-    auto diag = diags.diagnose(std::forward<ArgTypes>(Args)...);
+  template<typename Loc, typename ...ArgTypes>
+  InFlightDiagnostic diagnose(Loc loc, Diag<ArgTypes...> diagID,
+                        typename detail::PassArgument<ArgTypes>::type... Args) {
+    auto diag = diags.diagnose(loc, diagID, std::forward<ArgTypes>(Args)...);
+
+    // WORKAROUND (5.9): Soften newly-introduced errors to make things easier
+    // for early adopters.
+    if (diags.declaredDiagnosticKindFor(diagID.ID) == DiagnosticKind::Error)
+      diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
+
     return diag;
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3115,13 +3115,13 @@ private:
       }
 
       // Ambiguous match (many requirements match one candidate)
-      cand->diagnose(diag::objc_implementation_multiple_matching_requirements,
+      diagnose(cand, diag::objc_implementation_multiple_matching_requirements,
                      cand->getDescriptiveKind(), cand);
 
       bool shouldOfferFix = !candExplicitObjCName;
       for (auto req : matchedRequirements.matches) {
         auto diag =
-            cand->diagnose(diag::objc_implementation_one_matched_requirement,
+            diagnose(cand, diag::objc_implementation_one_matched_requirement,
                            req->getDescriptiveKind(), req,
                            *req->getObjCRuntimeName(), shouldOfferFix,
                            req->getObjCRuntimeName()->getString(scratch));
@@ -3164,14 +3164,14 @@ private:
           cast<IterableDeclContext>(req->getDeclContext()->getAsDecl());
       auto ext =
           cast<ExtensionDecl>(reqIDC->getImplementationContext());
-      ext->diagnose(diag::objc_implementation_multiple_matching_candidates,
+      diagnose(ext, diag::objc_implementation_multiple_matching_candidates,
                     req->getDescriptiveKind(), req,
                     *req->getObjCRuntimeName());
 
       for (auto cand : cands.matches) {
         bool shouldOfferFix = !unmatchedCandidates[cand];
         auto diag =
-            cand->diagnose(diag::objc_implementation_candidate_impl_here,
+            diagnose(cand, diag::objc_implementation_candidate_impl_here,
                            cand->getDescriptiveKind(), cand, shouldOfferFix,
                            req->getObjCRuntimeName()->getString(scratch));
 
@@ -3182,7 +3182,7 @@ private:
         }
       }
 
-      req->diagnose(diag::objc_implementation_requirement_here,
+      diagnose(req, diag::objc_implementation_requirement_here,
                     req->getDescriptiveKind(), req);
     }
 

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -3,11 +3,11 @@
 
 @_objcImplementation extension ObjCClass {
   // expected-note@-1 {{previously implemented by extension here}}
-  // expected-error@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'}}
-  // expected-error@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'}}
-  // FIXME: give better diagnostic expected-error@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'}}
-  // FIXME: give better diagnostic expected-error@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'}}
-  // FIXME: give better diagnostic expected-error@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for instance method 'method(fromHeader4:)'; this will become an error before '@_objcImplementation' is stabilized}}
+  // expected-warning@-3 {{extension for main class interface should provide implementation for property 'propertyFromHeader9'; this will become an error before '@_objcImplementation' is stabilized}}
+  // FIXME: give better diagnostic expected-warning@-4 {{extension for main class interface should provide implementation for property 'propertyFromHeader8'; this will become an error before '@_objcImplementation' is stabilized}}
+  // FIXME: give better diagnostic expected-warning@-5 {{extension for main class interface should provide implementation for property 'propertyFromHeader7'; this will become an error before '@_objcImplementation' is stabilized}}
+  // FIXME: give better diagnostic expected-warning@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'; this will become an error before '@_objcImplementation' is stabilized}}
 
   func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.
@@ -19,7 +19,7 @@
 
   func categoryMethod(fromHeader3: CInt) {
     // FIXME: should emit expected-DISABLED-error@-1 {{instance method 'categoryMethod(fromHeader3:)' should be implemented in extension for category 'PresentAdditions', not main class interface}}
-    // FIXME: expected-error@-2 {{instance method 'categoryMethod(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // FIXME: expected-warning@-2 {{instance method 'categoryMethod(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error before '@_objcImplementation' is stabilized}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -33,7 +33,7 @@
   }
 
   func methodNot(fromHeader3: CInt) {
-    // expected-error@-1 {{instance method 'methodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // expected-warning@-1 {{instance method 'methodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error before '@_objcImplementation' is stabilized}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // expected-note@-3 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -94,7 +94,7 @@
   }
 
   internal var propertyNotFromHeader1: CInt
-  // expected-error@-1 {{property 'propertyNotFromHeader1' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?}}
+  // expected-warning@-1 {{property 'propertyNotFromHeader1' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?; this will become an error before '@_objcImplementation' is stabilized}}
   // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible property not declared in the header}} {{3-3=private }}
   // expected-note@-3 {{add 'final' to define a Swift property that cannot be overridden}} {{3-3=final }}
 
@@ -135,7 +135,7 @@
   }
 
   func classMethod2(_: CInt) {
-    // expected-error@-1 {{instance method 'classMethod2' does not match class method declared in header}} {{3-3=class }}
+    // expected-warning@-1 {{instance method 'classMethod2' does not match class method declared in header; this will become an error before '@_objcImplementation' is stabilized}} {{3-3=class }}
   }
 
   func instanceMethod1(_: CInt) {
@@ -143,25 +143,25 @@
   }
 
   class func instanceMethod2(_: CInt) {
-    // expected-error@-1 {{class method 'instanceMethod2' does not match instance method declared in header}} {{3-9=}}
+    // expected-warning@-1 {{class method 'instanceMethod2' does not match instance method declared in header; this will become an error before '@_objcImplementation' is stabilized}} {{3-9=}}
   }
 }
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {
   // expected-note@-1 {{previously implemented by extension here}}
-  // expected-error@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'}}
-  // FIXME: give better diagnostic expected-error@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'}}
+  // expected-warning@-2 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader4:)'; this will become an error before '@_objcImplementation' is stabilized}}
+  // FIXME: give better diagnostic expected-warning@-3 {{extension for category 'PresentAdditions' should provide implementation for instance method 'categoryMethod(fromHeader3:)'; this will become an error before '@_objcImplementation' is stabilized}}
 
   func method(fromHeader3: CInt) {
     // FIXME: should emit expected-DISABLED-error@-1 {{instance method 'method(fromHeader3:)' should be implemented in extension for main class interface, not category 'PresentAdditions'}}
-    // FIXME: expected-error@-2 {{instance method 'method(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // FIXME: expected-warning@-2 {{instance method 'method(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error before '@_objcImplementation' is stabilized}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
 
   var propertyFromHeader7: CInt {
     // FIXME: should emit expected-DISABLED-error@-1 {{property 'propertyFromHeader7' should be implemented in extension for main class interface, not category 'PresentAdditions'}}
-    // FIXME: expected-error@-2 {{property 'propertyFromHeader7' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?}}
+    // FIXME: expected-warning@-2 {{property 'propertyFromHeader7' does not match any property declared in the headers for 'ObjCClass'; did you use the property's Swift name?; this will become an error before '@_objcImplementation' is stabilized}}
     // FIXME: expected-note@-3 {{add 'private' or 'fileprivate' to define an Objective-C-compatible property not declared in the header}} {{3-3=private }}
     // FIXME: expected-note@-4 {{add 'final' to define a Swift property that cannot be overridden}} {{3-3=final }}
     get { return 1 }
@@ -184,7 +184,7 @@
   }
 
   func categoryMethodNot(fromHeader3: CInt) {
-    // expected-error@-1 {{instance method 'categoryMethodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?}}
+    // expected-warning@-1 {{instance method 'categoryMethodNot(fromHeader3:)' does not match any instance method declared in the headers for 'ObjCClass'; did you use the instance method's Swift name?; this will become an error before '@_objcImplementation' is stabilized}}
     // expected-note@-2 {{add 'private' or 'fileprivate' to define an Objective-C-compatible instance method not declared in the header}} {{3-3=private }}
     // expected-note@-3 {{add 'final' to define a Swift instance method that cannot be overridden}} {{3-3=final }}
   }
@@ -209,10 +209,10 @@
 }
 
 @_objcImplementation(SwiftNameTests) extension ObjCClass {
-  // expected-error@-1 {{extension for category 'SwiftNameTests' should provide implementation for instance method 'methodSwiftName6B()'}}
+  // expected-warning@-1 {{extension for category 'SwiftNameTests' should provide implementation for instance method 'methodSwiftName6B()'; this will become an error before '@_objcImplementation' is stabilized}}
 
   func methodSwiftName1() {
-    // expected-error@-1 {{selector 'methodSwiftName1' for instance method 'methodSwiftName1()' not found in header; did you mean 'methodObjCName1'?}} {{3-3=@objc(methodObjCName1) }}
+    // expected-warning@-1 {{selector 'methodSwiftName1' for instance method 'methodSwiftName1()' not found in header; did you mean 'methodObjCName1'?; this will become an error before '@_objcImplementation' is stabilized}} {{3-3=@objc(methodObjCName1) }}
   }
 
   @objc(methodObjCName2) func methodSwiftName2() {
@@ -220,34 +220,34 @@
   }
 
   func methodObjCName3() {
-    // expected-error@-1 {{selector 'methodObjCName3' used in header by an instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
+    // expected-warning@-1 {{selector 'methodObjCName3' used in header by an instance method with a different name; did you mean 'methodSwiftName3()'?; this will become an error before '@_objcImplementation' is stabilized}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
     // FIXME: probably needs an @objc too, since the name is not explicit
   }
 
   @objc(methodWrongObjCName4) func methodSwiftName4() {
-    // expected-error@-1 {{selector 'methodWrongObjCName4' for instance method 'methodSwiftName4()' not found in header; did you mean 'methodObjCName4'?}} {{9-29=methodObjCName4}}
+    // expected-warning@-1 {{selector 'methodWrongObjCName4' for instance method 'methodSwiftName4()' not found in header; did you mean 'methodObjCName4'?; this will become an error before '@_objcImplementation' is stabilized}} {{9-29=methodObjCName4}}
   }
 
   @objc(methodObjCName5) func methodWrongSwiftName5() {
-    // expected-error@-1 {{selector 'methodObjCName5' used in header by an instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
+    // expected-warning@-1 {{selector 'methodObjCName5' used in header by an instance method with a different name; did you mean 'methodSwiftName5()'?; this will become an error before '@_objcImplementation' is stabilized}} {{31-52=methodSwiftName5}}
   }
 
   @objc(methodObjCName6A) func methodSwiftName6B() {
-    // expected-error@-1 {{selector 'methodObjCName6A' used in header by an instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
+    // expected-warning@-1 {{selector 'methodObjCName6A' used in header by an instance method with a different name; did you mean 'methodSwiftName6A()'?; this will become an error before '@_objcImplementation' is stabilized}} {{32-49=methodSwiftName6A}}
   }
 }
 
 @_objcImplementation(AmbiguousMethods) extension ObjCClass {
-  // expected-error@-1 {{found multiple implementations that could match instance method 'ambiguousMethod4(with:)' with selector 'ambiguousMethod4WithCInt:'}}
+  // expected-warning@-1 {{found multiple implementations that could match instance method 'ambiguousMethod4(with:)' with selector 'ambiguousMethod4WithCInt:'; this will become an error before '@_objcImplementation' is stabilized}}
 
   @objc func ambiguousMethod1(with: CInt) {
-    // expected-error@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header; this will become an error before '@_objcImplementation' is stabilized}}
     // expected-note@-2 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCInt:') is a potential match; insert '@objc(ambiguousMethod1WithCInt:)' to use it}} {{8-8=(ambiguousMethod1WithCInt:)}}
     // expected-note@-3 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCChar:') is a potential match; insert '@objc(ambiguousMethod1WithCChar:)' to use it}} {{8-8=(ambiguousMethod1WithCChar:)}}
   }
 
   func ambiguousMethod1(with: CChar) {
-    // expected-error@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod1(with:)' could match several different members declared in the header; this will become an error before '@_objcImplementation' is stabilized}}
     // expected-note@-2 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCInt:') is a potential match; insert '@objc(ambiguousMethod1WithCInt:)' to use it}} {{3-3=@objc(ambiguousMethod1WithCInt:) }}
     // expected-note@-3 {{instance method 'ambiguousMethod1(with:)' (with selector 'ambiguousMethod1WithCChar:') is a potential match; insert '@objc(ambiguousMethod1WithCChar:)' to use it}} {{3-3=@objc(ambiguousMethod1WithCChar:) }}
   }
@@ -258,11 +258,11 @@
 
   func ambiguousMethod2(with: CChar) {
     // FIXME: OK, matches -ambiguousMethod2WithCChar: because the WithCInt: variant has been eliminated
-    // FIXME: expected-error@-2 {{selector 'ambiguousMethod2With:' for instance method 'ambiguousMethod2(with:)' not found in header; did you mean 'ambiguousMethod2WithCChar:'?}}
+    // FIXME: expected-warning@-2 {{selector 'ambiguousMethod2With:' for instance method 'ambiguousMethod2(with:)' not found in header; did you mean 'ambiguousMethod2WithCChar:'?; this will become an error before '@_objcImplementation' is stabilized}}
   }
 
   func ambiguousMethod3(with: CInt) {
-    // expected-error@-1 {{instance method 'ambiguousMethod3(with:)' could match several different members declared in the header}}
+    // expected-warning@-1 {{instance method 'ambiguousMethod3(with:)' could match several different members declared in the header; this will become an error before '@_objcImplementation' is stabilized}}
     // expected-note@-2 {{instance method 'ambiguousMethod3(with:)' (with selector 'ambiguousMethod3WithCInt:') is a potential match; insert '@objc(ambiguousMethod3WithCInt:)' to use it}} {{3-3=@objc(ambiguousMethod3WithCInt:) }}
     // expected-note@-3 {{instance method 'ambiguousMethod3(with:)' (with selector 'ambiguousMethod3WithCChar:') is a potential match; insert '@objc(ambiguousMethod3WithCChar:)' to use it}} {{3-3=@objc(ambiguousMethod3WithCChar:) }}
   }
@@ -292,7 +292,7 @@
 }
 
 @_objcImplementation(Conformance) extension ObjCClass {
-  // expected-error@-1 {{extension for category 'Conformance' should provide implementation for instance method 'requiredMethod2()'}}
+  // expected-warning@-1 {{extension for category 'Conformance' should provide implementation for instance method 'requiredMethod2()'; this will become an error before '@_objcImplementation' is stabilized}}
   // no-error concerning 'optionalMethod2()'
 
   func requiredMethod1() {}


### PR DESCRIPTION
**Explanation**: We’re continuing to add useful refinements to `@_objcImplementation` diagnostics, but we don’t want to break projects that have already started adopting it, so in Swift 5.9 we are softening some @objcImpl errors into warnings. They will become errors again in a future version of Swift.

**Scope**: Projects adopting `@_objcImplementation` in Swift 5.9, before the feature is official or fully stable.

**Issue**: Fixes rdar://109742882

**Risk**: Very low. This change merely causes some errors to be emitted as warnings.

**Testing**: Unit tests check that `@_objcImplementation` diagnostics are emitted as warnings when appropriate.

**Reviewer**: @tshortli, @nkcsgexi, and @DougGregor are all qualified to review this PR.