### PR TITLE
Optimizer/IRGen: allow enums in static initializers of globals

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -21,4 +21,5 @@ swift_compiler_sources(Optimizer
   SimplifyStrongRetainRelease.swift
   SimplifyStructExtract.swift
   SimplifyTupleExtract.swift
-  SimplifyUncheckedEnumData.swift)
+  SimplifyUncheckedEnumData.swift
+  SimplifyValueToBridgeObject.swift)

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -16,6 +16,7 @@ swift_compiler_sources(Optimizer
   SimplifyDebugStep.swift
   SimplifyDestructure.swift
   SimplifyGlobalValue.swift
+  SimplifyInitEnumDataAddr.swift
   SimplifyLoad.swift
   SimplifyPartialApply.swift
   SimplifyStrongRetainRelease.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyInitEnumDataAddr.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyInitEnumDataAddr.swift
@@ -1,0 +1,53 @@
+//===--- SimplifyInitEnumDataAddr.swift -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension InitEnumDataAddrInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+
+    // Optimize the sequence
+    // ```
+    //   %1 = init_enum_data_addr %enum_addr, #someCaseWithPayload
+    //   store %payload to %1
+    //   inject_enum_addr %enum_addr, #someCaseWithPayload
+    // ```
+    // to
+    // ```
+    //   %1 = enum  $E, #someCaseWithPayload, %payload
+    //   store %1 to %enum_addr
+    // ```
+    // This sequence of three instructions must appear in consecutive order.
+    // But usually this is the case, because it's generated this way by SILGen.
+    //
+    if let nextInst = self.next,
+       let store = nextInst as? StoreInst,
+       store.destination == self,
+       let singleUse = self.uses.singleUse,
+       singleUse.instruction == store,
+       let nextAfterStore = store.next,
+       let inject = nextAfterStore as? InjectEnumAddrInst,
+       inject.enum == self.enum,
+       inject.enum.type.isLoadable(in: parentFunction) {
+
+      assert(self.caseIndex == inject.caseIndex, "mismatching case indices when creating an enum")
+
+      let builder = Builder(before: store, context)
+      let enumInst = builder.createEnum(caseIndex: self.caseIndex, payload: store.source, enumType: self.enum.type.objectType)
+      let storeOwnership = StoreInst.Ownership(for: self.enum.type, in: parentFunction, initialize: true)
+      builder.createStore(source: enumInst, destination: self.enum, ownership: storeOwnership)
+      context.erase(instruction: store)
+      context.erase(instruction: inject)
+      context.erase(instruction: self)
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyValueToBridgeObject.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyValueToBridgeObject.swift
@@ -1,0 +1,38 @@
+//===--- SimplifyValueToBridgeObject.swift --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension ValueToBridgeObjectInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+
+    // Optimize the sequence
+    // ```
+    //   %1 = value_to_bridge_object %0
+    //   %2 = struct $SomeInt (%1)
+    //   %3 = unchecked_trivial_bit_cast %2
+    //   %4 = struct_extract %3, #valueFieldInInt
+    //   %5 = value_to_bridge_object %4
+    // ```
+    // to
+    // ```
+    //   %5 = value_to_bridge_object %0
+    // ```
+    // This sequence comes up in the code for constructing an empty string literal.
+    //
+    if let se = self.value as? StructExtractInst,
+       let utbc = se.struct as? UncheckedTrivialBitCastInst,
+       let vtbo = utbc.fromValue as? ValueToBridgeObjectInst {
+      self.operand.set(to: vtbo.value, context)
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -168,8 +168,7 @@ struct FunctionPassContext : MutatingContext {
   var notifyInstructionChanged: (Instruction) -> () { return { inst in } }
 
   func continueWithNextSubpassRun(for inst: Instruction? = nil) -> Bool {
-    let bridgedInst = OptionalBridgedInstruction(inst?.bridged.obj)
-    return _bridged.continueWithNextSubpassRun(bridgedInst)
+    return _bridged.continueWithNextSubpassRun(inst.bridged)
   }
 
   func createSimplifyContext(preserveDebugInfo: Bool, notifyInstructionChanged: @escaping (Instruction) -> ()) -> SimplifyContext {

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -113,7 +113,7 @@ public struct Builder {
     return notifyNew(cast.getAs(UpcastInst.self))
   }
 
-  public func createLoad(fromAddress: Value, ownership: LoadInst.LoadOwnership) -> LoadInst {
+  public func createLoad(fromAddress: Value, ownership: LoadInst.Ownership) -> LoadInst {
     let load = bridged.createLoad(fromAddress.bridged, ownership.rawValue)
     return notifyNew(load.getAs(LoadInst.self))
   }
@@ -184,6 +184,12 @@ public struct Builder {
     let ued = bridged.createUncheckedEnumData(enumVal.bridged, caseIndex, resultType.bridged)
     return notifyNew(ued.getAs(UncheckedEnumDataInst.self))
   }
+
+  public func createEnum(caseIndex: Int, payload: Value?, enumType: Type) -> EnumInst {
+    let enumInst = bridged.createEnum(caseIndex, payload.bridged, enumType.bridged)
+    return notifyNew(enumInst.getAs(EnumInst.self))
+  }
+
   @discardableResult
   public func createSwitchEnum(enum enumVal: Value,
                                cases: [(Int, BasicBlock)],
@@ -225,7 +231,6 @@ public struct Builder {
     return notifyNew(bridged.createGlobalValue(global.bridged).getAs(GlobalValueInst.self))
   }
 
-  @discardableResult
   public func createStruct(type: Type, elements: [Value]) -> StructInst {
     let structInst = elements.withBridgedValues { valuesRef in
       return bridged.createStruct(type.bridged, valuesRef)
@@ -233,7 +238,6 @@ public struct Builder {
     return notifyNew(structInst.getAs(StructInst.self))
   }
 
-  @discardableResult
   public func createTuple(type: Type, elements: [Value]) -> TupleInst {
     let tuple = elements.withBridgedValues { valuesRef in
       return bridged.createTuple(type.bridged, valuesRef)
@@ -241,4 +245,9 @@ public struct Builder {
     return notifyNew(tuple.getAs(TupleInst.self))
   }
 
+  @discardableResult
+  public func createStore(source: Value, destination: Value, ownership: StoreInst.Ownership) -> StoreInst {
+    let store = bridged.createStore(source.bridged, destination.bridged, ownership.rawValue)
+    return notifyNew(store.getAs(StoreInst.self))
+  }
 }

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -123,6 +123,7 @@ extension Instruction {
       return !fri.referencedFunction.isAsync
     case is StructInst,
          is TupleInst,
+         is EnumInst,
          is IntegerLiteralInst,
          is FloatLiteralInst,
          is ObjectInst,

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -148,6 +148,12 @@ extension OptionalBridgedInstruction {
   }
 }
 
+extension Optional where Wrapped == Instruction {
+  public var bridged: OptionalBridgedInstruction {
+    OptionalBridgedInstruction(self?.bridged.obj)
+  }
+}
+
 public class SingleValueInstruction : Instruction, Value {
   final public var definingInstruction: Instruction? { self }
 
@@ -222,11 +228,23 @@ extension StoringInstruction {
 
 final public class StoreInst : Instruction, StoringInstruction {
   // must match with enum class StoreOwnershipQualifier
-  public enum StoreOwnership: Int {
+  public enum Ownership: Int {
     case unqualified = 0, initialize = 1, assign = 2, trivial = 3
+
+    public init(for type: Type, in function: Function, initialize: Bool) {
+      if function.hasOwnership {
+        if type.isTrivial(in: function) {
+          self = .trivial
+        } else {
+          self = initialize ? .initialize : .assign
+        }
+      } else {
+        self = .unqualified
+      }
+    }
   }
-  public var destinationOwnership: StoreOwnership {
-    StoreOwnership(rawValue: bridged.StoreInst_getStoreOwnership())!
+  public var destinationOwnership: Ownership {
+    Ownership(rawValue: bridged.StoreInst_getStoreOwnership())!
   }
 }
 
@@ -307,6 +325,7 @@ final public class DestroyAddrInst : Instruction, UnaryInstruction {
 }
 
 final public class InjectEnumAddrInst : Instruction, UnaryInstruction, EnumInstruction {
+  public var `enum`: Value { operand.value }
   public var caseIndex: Int { bridged.InjectEnumAddrInst_caseIndex() }
 }
 
@@ -351,11 +370,11 @@ final public class LoadInst : SingleValueInstruction, UnaryInstruction {
   public var address: Value { operand.value }
 
   // must match with enum class LoadOwnershipQualifier
-  public enum LoadOwnership: Int {
+  public enum Ownership: Int {
     case unqualified = 0, take = 1, copy = 2, trivial = 3
   }
-  public var ownership: LoadOwnership {
-    LoadOwnership(rawValue: bridged.LoadInst_getLoadOwnership())!
+  public var ownership: Ownership {
+    Ownership(rawValue: bridged.LoadInst_getLoadOwnership())!
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -388,6 +388,10 @@ final public class UncheckedAddrCastInst : SingleValueInstruction, UnaryInstruct
   public var fromAddress: Value { operand.value }
 }
 
+final public class UncheckedTrivialBitCastInst : SingleValueInstruction, UnaryInstruction {
+  public var fromValue: Value { operand.value }
+}
+
 final public
 class RawPointerToRefInst : SingleValueInstruction, UnaryInstruction {
   public var pointer: Value { operand.value }
@@ -626,7 +630,9 @@ final public
 class ObjCMetatypeToObjectInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
-class ValueToBridgeObjectInst : SingleValueInstruction, UnaryInstruction {}
+class ValueToBridgeObjectInst : SingleValueInstruction, UnaryInstruction {
+  public var value: Value { return operand.value }
+}
 
 final public
 class MarkDependenceInst : SingleValueInstruction {

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -77,6 +77,7 @@ public func registerSILClasses() {
   register(UpcastInst.self)
   register(UncheckedRefCastInst.self)
   register(UncheckedAddrCastInst.self)
+  register(UncheckedTrivialBitCastInst.self)
   register(MarkMustCheckInst.self)
   register(ObjectInst.self)
   register(RawPointerToRefInst.self)

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -31,6 +31,10 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     return !bridged.isNonTrivialOrContainsRawPointer(function.bridged.getFunction())
   }
 
+  public func isLoadable(in function: Function) -> Bool {
+    return bridged.isLoadable(function.bridged.getFunction())
+  }
+
   public func isReferenceCounted(in function: Function) -> Bool {
     return bridged.isReferenceCounted(function.bridged.getFunction())
   }

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -204,3 +204,9 @@ final class PlaceholderValue : Value {
 extension OptionalBridgedValue {
   public var value: Value? { obj.getAs(AnyObject.self) as? Value }
 }
+
+extension Optional where Wrapped == Value {
+  public var bridged: OptionalBridgedValue {
+    OptionalBridgedValue(obj: self?.bridged.obj)
+  }
+}

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -346,6 +346,8 @@ public:
     return !isAddressOnly(F);
   }
 
+  bool isLoadable(const SILFunction *f) const { return isLoadable(*f); }
+
   /// True if either:
   /// 1) The type, or the referenced type of an address type, is loadable.
   /// 2) The SIL Module conventions uses lowered addresses

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -616,3 +616,28 @@ unsigned EnumPayload::getAllocSizeInBits(const llvm::DataLayout &DL) const {
   }
   return size;
 }
+
+void EnumPayload::print(llvm::raw_ostream &OS) {
+  if (StorageType) {
+    OS << "storage-type: ";
+    StorageType->print(OS);
+    OS << '\n';
+  }
+  for (LazyValue pv : PayloadValues) {
+    if (auto *v = pv.dyn_cast<llvm::Value*>()) {
+      OS << "value: ";
+      v->print(OS);
+      OS << '\n';
+    } else {
+      auto *t = pv.get<llvm::Type*>();
+      OS << "type: ";
+      t->print(OS);
+      OS << '\n';
+    }
+  }
+}
+
+void EnumPayload::dump() {
+  print(llvm::errs());
+}
+

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -120,9 +120,10 @@ static APInt createElementMask(const llvm::DataLayout &DL,
   return mask;
 }
 
-void EnumPayload::insertValue(IRGenFunction &IGF, llvm::Value *value,
+void EnumPayload::insertValue(IRGenModule &IGM,
+                              IRBuilder &builder, llvm::Value *value,
                               unsigned payloadOffset) {
-  auto &DL = IGF.IGM.DataLayout;
+  auto &DL = IGM.DataLayout;
 
   // Create a mask for the value we are going to insert.
   auto type = value->getType();
@@ -130,7 +131,7 @@ void EnumPayload::insertValue(IRGenFunction &IGF, llvm::Value *value,
   auto mask = createElementMask(DL, type, payloadOffset, payloadSize);
 
   // Scatter the value into the payload.
-  emitScatterBits(IGF, mask, value);
+  emitScatterBits(IGM, builder, mask, value);
 }
 
 llvm::Value *EnumPayload::extractValue(IRGenFunction &IGF, llvm::Type *type,
@@ -175,13 +176,14 @@ void EnumPayload::explode(IRGenModule &IGM, Explosion &out) const {
   }
 }
 
-void EnumPayload::packIntoEnumPayload(IRGenFunction &IGF,
+void EnumPayload::packIntoEnumPayload(IRGenModule &IGM,
+                                      IRBuilder &builder,
                                       EnumPayload &outerPayload,
                                       unsigned bitOffset) const {
-  auto &DL = IGF.IGM.DataLayout;
+  auto &DL = IGM.DataLayout;
   for (auto &value : PayloadValues) {
     auto v = forcePayloadValue(value);
-    outerPayload.insertValue(IGF, v, bitOffset);
+    outerPayload.insertValue(IGM, builder, v, bitOffset);
     bitOffset += DL.getTypeSizeInBits(v->getType());
   }
 }
@@ -419,12 +421,13 @@ EnumPayload::emitApplyAndMask(IRGenFunction &IGF, const APInt &mask) {
 }
 
 void
-EnumPayload::emitApplyOrMask(IRGenFunction &IGF, const APInt &mask) {
+EnumPayload::emitApplyOrMask(IRGenModule &IGM,
+                             IRBuilder &builder, const APInt &mask) {
   // Early exit if the mask has no effect.
   if (mask == 0)
     return;
 
-  auto &DL = IGF.IGM.DataLayout;
+  auto &DL = IGM.DataLayout;
   auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
 
   for (auto &pv : PayloadValues) {
@@ -438,21 +441,21 @@ EnumPayload::emitApplyOrMask(IRGenFunction &IGF, const APInt &mask) {
     if (maskPiece == 0)
       continue;
     
-    auto payloadIntTy = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), size);
+    auto payloadIntTy = llvm::IntegerType::get(IGM.getLLVMContext(), size);
     auto maskConstant = llvm::ConstantInt::get(payloadIntTy, maskPiece);
     
     // If the payload value is vacant, or the mask is all ones,
     // we can adopt the mask value directly.
     if (pv.is<llvm::Type *>() || maskPiece.isAllOnesValue()) {
-      pv = IGF.Builder.CreateBitOrPointerCast(maskConstant, payloadTy);
+      pv = builder.CreateBitOrPointerCast(maskConstant, payloadTy);
       continue;
     }
     
     // Otherwise, apply the mask to the existing value.
     auto v = pv.get<llvm::Value*>();
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-    v = IGF.Builder.CreateOr(v, maskConstant);
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadTy);
+    v = builder.CreateBitOrPointerCast(v, payloadIntTy);
+    v = builder.CreateOr(v, maskConstant);
+    v = builder.CreateBitOrPointerCast(v, payloadTy);
     pv = v;
   }
 }
@@ -490,11 +493,11 @@ EnumPayload::emitApplyOrMask(IRGenFunction &IGF,
   }
 }
 
-void EnumPayload::emitScatterBits(IRGenFunction &IGF,
+void EnumPayload::emitScatterBits(IRGenModule &IGM,
+                                  IRBuilder &builder,
                                   const APInt &mask,
                                   llvm::Value *value) {
-  auto &DL = IGF.IGM.DataLayout;
-  auto &B = IGF.Builder;
+  auto &DL = IGM.DataLayout;
 
   unsigned valueBits = DL.getTypeSizeInBits(value->getType());
   auto totalBits = std::min(valueBits, mask.countPopulation());
@@ -519,20 +522,20 @@ void EnumPayload::emitScatterBits(IRGenFunction &IGF,
     if (DL.isBigEndian()) {
       offset = totalBits - partCount - usedBits;
     }
-    auto partValue = irgen::emitScatterBits(IGF, partMask, value, offset);
+    auto partValue = irgen::emitScatterBits(IGM, builder, partMask, value, offset);
 
     // If necessary OR with the existing value.
     if (auto existingValue = pv.dyn_cast<llvm::Value*>()) {
       if (partType != partValue->getType()) {
-        existingValue = B.CreateBitOrPointerCast(existingValue,
+        existingValue = builder.CreateBitOrPointerCast(existingValue,
                                                  partValue->getType());
       }
-      partValue = B.CreateOr(partValue, existingValue);
+      partValue = builder.CreateOr(partValue, existingValue);
     }
 
     // Convert the integer result to the target type.
     if (partType != partValue->getType()) {
-      partValue = B.CreateBitOrPointerCast(partValue, partType);
+      partValue = builder.CreateBitOrPointerCast(partValue, partType);
     }
 
     // Update this payload element.

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -174,6 +174,10 @@ public:
                                    const SpareBitVector &spareBits,
                                    unsigned firstBitOffset,
                                    unsigned bitWidth) const;
+
+  void print(llvm::raw_ostream &OS);
+  void dump();
+
 private:
   /// Calculate the total number of bits this payload requires.
   /// This will always be a multiple of 8.

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -104,7 +104,8 @@ public:
   /// If \p numBitsUsedInValue is non-negative denotes the actual number of bits
   /// that need storing in \p value otherwise the full bit-width of \p value
   /// will be stored.
-  void insertValue(IRGenFunction &IGF,
+  void insertValue(IRGenModule &IGM,
+                   IRBuilder &builder,
                    llvm::Value *value, unsigned bitOffset);
   
   /// Extract a value from the enum payload.
@@ -120,7 +121,8 @@ public:
   void explode(IRGenModule &IGM, Explosion &out) const;
   
   /// Pack into another enum payload.
-  void packIntoEnumPayload(IRGenFunction &IGF,
+  void packIntoEnumPayload(IRGenModule &IGM,
+                           IRBuilder &builder,
                            EnumPayload &dest,
                            unsigned bitOffset) const;
   
@@ -153,7 +155,8 @@ public:
   void emitApplyAndMask(IRGenFunction &IGF, const APInt &mask);
   
   /// Apply an OR mask to the payload.
-  void emitApplyOrMask(IRGenFunction &IGF, const APInt &mask);
+  void emitApplyOrMask(IRGenModule &IGM,
+                       IRBuilder &builder, const APInt &mask);
   
   /// Apply an OR mask to the payload.
   void emitApplyOrMask(IRGenFunction &IGF, EnumPayload mask);
@@ -161,7 +164,8 @@ public:
   /// Scatter the bits in value to the bit positions indicated by the
   /// mask. The new bits are added using OR, so an emitApplyAndMask
   /// call should be used first if existing bits need to be cleared.
-  void emitScatterBits(IRGenFunction &IGF,
+  void emitScatterBits(IRGenModule &IGM,
+                       IRBuilder &builder,
                        const APInt &mask,
                        llvm::Value *value);
 

--- a/lib/IRGen/Explosion.h
+++ b/lib/IRGen/Explosion.h
@@ -60,6 +60,10 @@ public:
     return *this;
   }
 
+  Explosion(llvm::Value *singleValue) : NextValue(0) {
+    add(singleValue);
+  }
+
   ~Explosion() {
     assert(empty() && "explosion had values remaining when destroyed!");
   }
@@ -131,6 +135,10 @@ public:
   llvm::Value *claimNext() {
     assert(NextValue < Values.size());
     return Values[NextValue++];
+  }
+
+  llvm::Constant *claimNextConstant() {
+    return cast<llvm::Constant>(claimNext());
   }
 
   /// Claim and return the next N values in this explosion.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -3860,7 +3860,7 @@ bool irgen::addNativeArgument(IRGenFunction &IGF,
     // Pass the argument explosion directly, mapping into the native swift
     // calling convention.
     Explosion nonNativeParam;
-    ti.reexplode(IGF, in, nonNativeParam);
+    ti.reexplode(in, nonNativeParam);
     Explosion nativeParam = nativeSchema.mapIntoNative(
         IGF.IGM, IGF, nonNativeParam, paramType, isOutlined);
     nativeParam.transferInto(out, nativeParam.size());

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -16,7 +16,10 @@
 
 #include "llvm/IR/Constants.h"
 
+#include "BitPatternReader.h"
+#include "Explosion.h"
 #include "GenConstant.h"
+#include "GenEnum.h"
 #include "GenIntegerLiteral.h"
 #include "GenStruct.h"
 #include "GenTuple.h"
@@ -115,43 +118,83 @@ llvm::Constant *irgen::emitAddrOfConstantString(IRGenModule &IGM,
 namespace {
 
 /// Fill in the missing values for padding.
-void insertPadding(SmallVectorImpl<llvm::Constant *> &Elements,
+void insertPadding(SmallVectorImpl<Explosion> &elements,
                    llvm::StructType *sTy) {
   // fill in any gaps, which are the explicit padding that swiftc inserts.
-  for (unsigned i = 0, e = Elements.size(); i != e; ++i) {
-    auto &elt = Elements[i];
-    if (elt == nullptr) {
+  for (unsigned i = 0, e = elements.size(); i != e; ++i) {
+    if (elements[i].empty()) {
       auto *eltTy = sTy->getElementType(i);
       assert(eltTy->isArrayTy() &&
              eltTy->getArrayElementType()->isIntegerTy(8) &&
              "Unexpected non-byte-array type for constant struct padding");
-      elt = llvm::UndefValue::get(eltTy);
+      elements[i].add(llvm::UndefValue::get(eltTy));
     }
   }
 }
 
+/// Creates a struct which contains all values of `explosions`.
+///
+/// If all explosions have a single element and those elements match the
+/// elements of `structTy`, it uses this type as result type.
+/// Otherwise, it creates an anonymous struct. This can be the case for enums.
+llvm::Constant *createStructFromExplosion(SmallVectorImpl<Explosion> &explosions,
+                                          llvm::StructType *structTy) {
+  assert(explosions.size() == structTy->getNumElements());
+  bool canUseStructType = true;
+  llvm::SmallVector<llvm::Constant *, 32> values;
+  unsigned idx = 0;
+  for (auto &elmt : explosions) {
+    if (elmt.size() != 1)
+      canUseStructType = false;
+    for (llvm::Value *v : elmt.claimAll()) {
+      if (v->getType() != structTy->getElementType(idx))
+        canUseStructType = false;
+      values.push_back(cast<llvm::Constant>(v));
+    }
+    idx++;
+  }
+  if (canUseStructType) {
+    return llvm::ConstantStruct::get(structTy, values);
+  } else {
+    return llvm::ConstantStruct::getAnon(values, /*Packed=*/ true);
+  }
+}
+
+void initWithEmptyExplosions(SmallVectorImpl<Explosion> &explosions,
+                             unsigned count) {
+  for (unsigned i = 0; i < count; i++) {
+    explosions.push_back(Explosion());
+  }
+}
+
 template <typename InstTy, typename NextIndexFunc>
-llvm::Constant *emitConstantStructOrTuple(IRGenModule &IGM, InstTy inst,
-                                          NextIndexFunc nextIndex) {
+Explosion emitConstantStructOrTuple(IRGenModule &IGM, InstTy inst,
+                                    NextIndexFunc nextIndex, bool flatten) {
   auto type = inst->getType();
   auto *sTy = cast<llvm::StructType>(IGM.getTypeInfo(type).getStorageType());
 
-  SmallVector<llvm::Constant *, 32> elts(sTy->getNumElements(), nullptr);
+  SmallVector<Explosion, 32> elements;
+  initWithEmptyExplosions(elements, sTy->getNumElements());
 
-  // run over the Swift initializers, putting them into the struct as
-  // appropriate.
   for (unsigned i = 0, e = inst->getElements().size(); i != e; ++i) {
     auto operand = inst->getOperand(i);
     Optional<unsigned> index = nextIndex(IGM, type, i);
     if (index.has_value()) {
-      assert(elts[index.value()] == nullptr &&
+      unsigned idx = index.value();
+      assert(elements[idx].empty() &&
              "Unexpected constant struct field overlap");
-
-      elts[index.value()] = emitConstantValue(IGM, operand);
+      elements[idx] = emitConstantValue(IGM, operand, flatten);
     }
   }
-  insertPadding(elts, sTy);
-  return llvm::ConstantStruct::get(sTy, elts);
+  if (flatten) {
+    Explosion out;
+    for (auto &elmt : elements) {
+      out.add(elmt.claimAll());
+    }
+    return out;
+  }
+  insertPadding(elements, sTy);
+  return createStructFromExplosion(elements, sTy);
 }
 } // end anonymous namespace
 
@@ -181,7 +224,36 @@ static BuiltinInst *getOffsetSubtract(const TupleExtractInst *TE, SILModule &M) 
   return BI;
 }
 
-llvm::Constant *irgen::emitConstantValue(IRGenModule &IGM, SILValue operand) {
+static bool isPowerOfTwo(unsigned x) {
+  return (x & -x) == x;
+}
+
+/// Replace i24, i40, i48 and i56 constants in `e` with the corresponding byte values.
+/// Such unaligned integer constants are not correctly layed out in the data section.
+static Explosion replaceUnalignedIntegerValues(IRGenModule &IGM, Explosion e) {
+  Explosion out;
+  while (!e.empty()) {
+    llvm::Value *v = e.claimNext();
+
+    if (auto *constInt = dyn_cast<llvm::ConstantInt>(v)) {
+      unsigned size = constInt->getBitWidth();
+      if (size % 8 == 0 && !isPowerOfTwo(size)) {
+        BitPatternReader reader(constInt->getValue(), IGM.Triple.isLittleEndian());
+        while (size > 0) {
+          APInt byte = reader.read(8);
+          out.add(llvm::ConstantInt::get(IGM.getLLVMContext(), byte));
+          size -= 8;
+        }
+        continue;
+      }
+    }
+    out.add(v);
+  }
+  return out;
+}
+
+Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
+                                   bool flatten) {
   if (auto *SI = dyn_cast<StructInst>(operand)) {
     // The only way to get a struct's stored properties (which we need to map to
     // their physical/LLVM index) is to iterate over the properties
@@ -195,10 +267,26 @@ llvm::Constant *irgen::emitConstantValue(IRGenModule &IGM, SILValue operand) {
           (void)_i;
           auto *FD = *Iter++;
           return irgen::getPhysicalStructFieldIndex(IGM, Type, FD);
-        });
+        }, flatten);
   } else if (auto *TI = dyn_cast<TupleInst>(operand)) {
     return emitConstantStructOrTuple(IGM, TI,
-                                     irgen::getPhysicalTupleElementStructIndex);
+                                     irgen::getPhysicalTupleElementStructIndex,
+                                     flatten);
+  } else if (auto *ei = dyn_cast<EnumInst>(operand)) {
+    Explosion data;
+    if (ei->hasOperand()) {
+      data = emitConstantValue(IGM, ei->getOperand(), /*flatten=*/ true);
+    }
+    // Use `emitValueInjection` to create the enum constant.
+    // Usually this method creates code in the current function. But if all
+    // arguments to the enum are constant, the builder never has to emit an
+    // instruction. Instead it can constant fold everything and just returns
+    // the final constant.
+    Explosion out;
+    IRBuilder builder(IGM.getLLVMContext(), false);
+    getEnumImplStrategy(IGM, ei->getType())
+      .emitValueInjection(IGM, builder, ei->getElement(), data, out);
+    return replaceUnalignedIntegerValues(IGM, std::move(out));
   } else if (auto *ILI = dyn_cast<IntegerLiteralInst>(operand)) {
     return emitConstantInt(IGM, ILI);
   } else if (auto *FLI = dyn_cast<FloatLiteralInst>(operand)) {
@@ -206,53 +294,56 @@ llvm::Constant *irgen::emitConstantValue(IRGenModule &IGM, SILValue operand) {
   } else if (auto *SLI = dyn_cast<StringLiteralInst>(operand)) {
     return emitAddrOfConstantString(IGM, SLI);
   } else if (auto *BI = dyn_cast<BuiltinInst>(operand)) {
+    auto args = BI->getArguments();
     switch (IGM.getSILModule().getBuiltinInfo(BI->getName()).ID) {
       case BuiltinValueKind::ZeroInitializer:
         return emitConstantZero(IGM, BI);
       case BuiltinValueKind::PtrToInt: {
-        llvm::Constant *ptr = emitConstantValue(IGM, BI->getArguments()[0]);
+        auto *ptr = emitConstantValue(IGM, args[0]).claimNextConstant();
         return llvm::ConstantExpr::getPtrToInt(ptr, IGM.IntPtrTy);
       }
       case BuiltinValueKind::ZExtOrBitCast: {
-        llvm::Constant *value = emitConstantValue(IGM, BI->getArguments()[0]);
-        return llvm::ConstantExpr::getZExtOrBitCast(value, IGM.getStorageType(BI->getType()));
+        auto *val = emitConstantValue(IGM, args[0]).claimNextConstant();
+        return llvm::ConstantExpr::getZExtOrBitCast(val,
+                                                    IGM.getStorageType(BI->getType()));
       }
       case BuiltinValueKind::StringObjectOr: {
         // It is a requirement that the or'd bits in the left argument are
         // initialized with 0. Therefore the or-operation is equivalent to an
         // addition. We need an addition to generate a valid relocation.
-        llvm::Constant *rhs = emitConstantValue(IGM, BI->getArguments()[1]);
-        if (auto *TE = dyn_cast<TupleExtractInst>(BI->getArguments()[0])) {
+        auto *rhs = emitConstantValue(IGM, args[1]).claimNextConstant();
+        if (auto *TE = dyn_cast<TupleExtractInst>(args[0])) {
           // Handle StringObjectOr(tuple_extract(usub_with_overflow(x, offset)), bits)
           // This pattern appears in UTF8 String literal construction.
           // Generate the equivalent: add(x, sub(bits - offset)
           BuiltinInst *SubtrBI = getOffsetSubtract(TE, IGM.getSILModule());
           assert(SubtrBI && "unsupported argument of StringObjectOr");
-          auto *ptr = emitConstantValue(IGM, SubtrBI->getArguments()[0]);
-          auto *offset = emitConstantValue(IGM, SubtrBI->getArguments()[1]);
+          auto subArgs = SubtrBI->getArguments();
+          auto *ptr = emitConstantValue(IGM, subArgs[0]).claimNextConstant();
+          auto *offset = emitConstantValue(IGM, subArgs[1]).claimNextConstant();
           auto *totalOffset = llvm::ConstantExpr::getSub(rhs, offset);
           return llvm::ConstantExpr::getAdd(ptr, totalOffset);
         }
-        llvm::Constant *lhs = emitConstantValue(IGM, BI->getArguments()[0]);
+        auto *lhs = emitConstantValue(IGM, args[0]).claimNextConstant();
         return llvm::ConstantExpr::getAdd(lhs, rhs);
       }
       default:
         llvm_unreachable("unsupported builtin for constant expression");
     }
   } else if (auto *VTBI = dyn_cast<ValueToBridgeObjectInst>(operand)) {
-    auto *val = emitConstantValue(IGM, VTBI->getOperand());
+    auto *val = emitConstantValue(IGM, VTBI->getOperand()).claimNextConstant();
     auto *sTy = IGM.getTypeInfo(VTBI->getType()).getStorageType();
     return llvm::ConstantExpr::getIntToPtr(val, sTy);
 
   } else if (auto *CFI = dyn_cast<ConvertFunctionInst>(operand)) {
-    return emitConstantValue(IGM, CFI->getOperand());
+    return emitConstantValue(IGM, CFI->getOperand()).claimNextConstant();
 
   } else if (auto *T2TFI = dyn_cast<ThinToThickFunctionInst>(operand)) {
     SILType type = operand->getType();
     auto *sTy = cast<llvm::StructType>(IGM.getTypeInfo(type).getStorageType());
 
     auto *function = llvm::ConstantExpr::getBitCast(
-        emitConstantValue(IGM, T2TFI->getCallee()),
+        emitConstantValue(IGM, T2TFI->getCallee()).claimNextConstant(),
         sTy->getTypeAtIndex((unsigned)0));
 
     auto *context = llvm::ConstantExpr::getBitCast(
@@ -287,7 +378,9 @@ llvm::Constant *irgen::emitConstantValue(IRGenModule &IGM, SILValue operand) {
 llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
                                          StructLayout *ClassLayout) {
   auto *sTy = cast<llvm::StructType>(ClassLayout->getType());
-  SmallVector<llvm::Constant *, 32> elts(sTy->getNumElements(), nullptr);
+
+  SmallVector<Explosion, 32> elements;
+  initWithEmptyExplosions(elements, sTy->getNumElements());
 
   unsigned NumElems = OI->getAllElements().size();
   assert(NumElems == ClassLayout->getElements().size());
@@ -297,9 +390,11 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
     SILValue Val = OI->getAllElements()[i];
     const ElementLayout &EL = ClassLayout->getElements()[i];
     if (!EL.isEmpty()) {
-      unsigned EltIdx = EL.getStructIndex();
-      assert(EltIdx != 0 && "the first element is the object header");
-      elts[EltIdx] = emitConstantValue(IGM, Val);
+      unsigned idx = EL.getStructIndex();
+      assert(idx != 0 && "the first element is the object header");
+      assert(elements[idx].empty() &&
+             "Unexpected constant struct field overlap");
+      elements[idx] = emitConstantValue(IGM, Val);
     }
   }
   // Construct the object header.
@@ -322,14 +417,14 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
                                         /*initializer*/ nullptr, "$ss19__EmptyArrayStorageCN");
       IGM.swiftStaticArrayMetadata = var;
     }
-    elts[0] = llvm::ConstantStruct::get(ObjectHeaderTy, {
+    elements[0].add(llvm::ConstantStruct::get(ObjectHeaderTy, {
       IGM.swiftStaticArrayMetadata,
-      llvm::ConstantExpr::getPtrToInt(IGM.swiftImmortalRefCount, IGM.IntPtrTy)});
+      llvm::ConstantExpr::getPtrToInt(IGM.swiftImmortalRefCount, IGM.IntPtrTy)}));
   } else {
-    elts[0] = llvm::Constant::getNullValue(ObjectHeaderTy);
+    elements[0].add(llvm::Constant::getNullValue(ObjectHeaderTy));
   }
-  insertPadding(elts, sTy);
-  return llvm::ConstantStruct::get(sTy, elts);
+  insertPadding(elements, sTy);
+  return createStructFromExplosion(elements, sTy);
 }
 
 void ConstantAggregateBuilderBase::addUniqueHash(StringRef data) {

--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -38,7 +38,8 @@ llvm::Constant *emitAddrOfConstantString(IRGenModule &IGM,
                                          StringLiteralInst *SLI);
 
 /// Construct a constant from a SILValue containing constant values.
-llvm::Constant *emitConstantValue(IRGenModule &IGM, SILValue value);
+Explosion emitConstantValue(IRGenModule &IGM, SILValue value,
+                            bool flatten = false);
 
 /// Construct an object (with a HeapObject header) from an ObjectInst
 /// containing constant values.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -61,6 +61,7 @@
 #include "Explosion.h"
 #include "FixedTypeInfo.h"
 #include "GenCall.h"
+#include "GenConstant.h"
 #include "GenClass.h"
 #include "GenDecl.h"
 #include "GenMeta.h"
@@ -1266,12 +1267,6 @@ void IRGenerator::emitGlobalTopLevel(
 
     CurrentIGMPtr IGM = getGenModule(&f);
     IGM->emitSILFunction(&f);
-  }
-
-  // Emit static initializers.
-  for (auto Iter : *this) {
-    IRGenModule *IGM = Iter.second;
-    IGM->emitSILStaticInitializers();
   }
 
   // Emit witness tables.
@@ -2654,35 +2649,34 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     fixedAlignment = getFixedBufferAlignment(*this);
   }
 
+  llvm::Constant *initVal = nullptr;
+
   // Check whether we've created the global variable already.
   // FIXME: We should integrate this into the LinkEntity cache more cleanly.
   auto gvar = Module.getGlobalVariable(link.getName(), /*allowInternal*/ true);
   if (gvar) {
-    if (forDefinition)
+    if (forDefinition) {
       updateLinkageForDefinition(*this, gvar, entity);
-  } else {
-    llvm::Type *storageTypeWithContainer = storageType;
-    if (var->isInitializedObject()) {
-      if (canMakeStaticObjectsReadOnly()) {
-        gvar = createVariable(*this, link, storageType, fixedAlignment);
-        gvar->setConstant(true);
-      } else {
-        // A statically initialized object must be placed into a container struct
-        // because the swift_initStaticObject needs a swift_once_t at offset -1:
-        //     struct Container {
-        //       swift_once_t token[fixedAlignment / sizeof(swift_once_t)];
-        //       HeapObject object;
-        //     };
-        std::string typeName = storageType->getStructName().str() + 'c';
-        assert(fixedAlignment >= getPointerAlignment());
-        unsigned numTokens = fixedAlignment.getValue() /
-          getPointerAlignment().getValue();
-        storageTypeWithContainer = llvm::StructType::create(getLLVMContext(),
-                {llvm::ArrayType::get(OnceTy, numTokens), storageType}, typeName);
-        gvar = createVariable(*this, link, storageTypeWithContainer,
-                              fixedAlignment);
+
+      if (var->getStaticInitializerValue()) {
+        assert(gvar->hasInitializer() &&
+               "global variable referenced before created");
       }
+    }
+    if (forDefinition && !gvar->hasInitializer())
+      initVal = getGlobalInitValue(var, storageType, fixedAlignment);
+  } else {
+    // The global doesn't exist yet. Create it.
+
+    initVal = getGlobalInitValue(var, storageType, fixedAlignment);
+    llvm::Type *globalTy = initVal ? initVal->getType() : storageType;
+
+    if (var->isInitializedObject()) {
+      // An initialized object is always a compiler-generated "outlined"
+      // variable. Therefore we don't generate debug info for it.
+      gvar = createVariable(*this, link, globalTy, fixedAlignment);
     } else {
+      // Create a global variable with debug info.
       StringRef name;
       Optional<SILLocation> loc;
       if (var->getDecl()) {
@@ -2694,20 +2688,31 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
           loc = var->getLocation();
         name = var->getName();
       }
+
       DebugTypeInfo DbgTy =
           inFixedBuffer
               ? DebugTypeInfo::getGlobalFixedBuffer(
-                    var, storageTypeWithContainer, fixedSize, fixedAlignment)
-              : DebugTypeInfo::getGlobal(var, storageTypeWithContainer, *this);
-      gvar = createVariable(*this, link, storageTypeWithContainer,
-                            fixedAlignment, DbgTy, loc, name);
+                    var, globalTy, fixedSize, fixedAlignment)
+              : DebugTypeInfo::getGlobal(var, globalTy, *this);
+
+      gvar = createVariable(*this, link, globalTy, fixedAlignment, DbgTy, loc, name);
     }
-    /// Add a zero initializer.
-    if (forDefinition)
-      gvar->setInitializer(llvm::Constant::getNullValue(storageTypeWithContainer));
-    else
+    if (!forDefinition)
       gvar->setComdat(nullptr);
   }
+  if (forDefinition && !gvar->hasInitializer()) {
+    if (initVal) {
+      gvar->setInitializer(initVal);
+      if (var->isLet() ||
+          (var->isInitializedObject() && canMakeStaticObjectsReadOnly())) {
+        gvar->setConstant(true);
+      }
+    } else {
+      /// Add a zero initializer.
+      gvar->setInitializer(llvm::Constant::getNullValue(storageType));
+    }
+  }
+
   llvm::Constant *addr = gvar;
   if (var->isInitializedObject() && !canMakeStaticObjectsReadOnly()) {
     // Project out the object from the container.
@@ -2728,6 +2733,48 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     storageType = cast<ClassTypeInfo>(ti).getClassLayoutType();
 
   return Address(addr, storageType, Alignment(gvar->getAlignment()));
+}
+
+llvm::Constant *IRGenModule::getGlobalInitValue(SILGlobalVariable *var,
+                                                llvm::Type *storageType,
+                                                Alignment alignment) {
+  if (var->isInitializedObject()) {
+    StructLayout *layout = StaticObjectLayouts[var].get();
+    ObjectInst *oi = cast<ObjectInst>(var->getStaticInitializerValue());
+    llvm::Constant *initVal = emitConstantObject(*this, oi, layout);
+    if (!canMakeStaticObjectsReadOnly()) {
+      // A statically initialized object must be placed into a container struct
+      // because the swift_initStaticObject needs a swift_once_t at offset -1:
+      //     struct Container {
+      //       swift_once_t token[fixedAlignment / sizeof(swift_once_t)];
+      //       HeapObject object;
+      //     };
+      std::string typeName = storageType->getStructName().str() + 'c';
+      assert(alignment >= getPointerAlignment());
+      unsigned numTokens = alignment.getValue() /
+                           getPointerAlignment().getValue();
+      auto *containerTy = llvm::StructType::create(getLLVMContext(),
+              {llvm::ArrayType::get(OnceTy, numTokens), initVal->getType()},
+              typeName);
+      auto *zero = llvm::ConstantAggregateZero::get(containerTy->getElementType(0));
+      initVal = llvm::ConstantStruct::get(containerTy, {zero , initVal});
+    }
+    return initVal;
+  }
+  if (SILInstruction *initInst = var->getStaticInitializerValue()) {
+    Explosion initExp = emitConstantValue(*this,
+                                  cast<SingleValueInstruction>(initInst));
+    if (initExp.size() == 1) {
+      return initExp.claimNextConstant();
+    }
+    // In case of enums, the initializer might contain multiple constants,
+    // which does not match with the storage type.
+    ArrayRef<llvm::Value *> elements = initExp.claimAll();
+    ArrayRef<llvm::Constant *> constElements(
+                  (llvm::Constant *const*)elements.data(), elements.size());
+    return llvm::ConstantStruct::getAnon(constElements, /*Packed=*/ true);
+  }
+  return nullptr;
 }
 
 /// Return True if the function \p f is a 'readonly' function. Checking

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -408,17 +408,18 @@ namespace {
                           Explosion &out) const override {
       // The projected value is the payload.
       if (getLoadableSingleton())
-        getLoadableSingleton()->reexplode(IGF, in, out);
+        getLoadableSingleton()->reexplode(in, out);
     }
 
-    void emitValueInjection(IRGenFunction &IGF,
+    void emitValueInjection(IRGenModule &IGM,
+                            IRBuilder &builder,
                             EnumElementDecl *elt,
                             Explosion &params,
                             Explosion &out) const override {
       // If the element carries no data, neither does the injection.
       // Otherwise, the result is identical.
       if (getLoadableSingleton())
-        getLoadableSingleton()->reexplode(IGF, params, out);
+        getLoadableSingleton()->reexplode(params, out);
     }
 
     void destructiveProjectDataForLoad(IRGenFunction &IGF,
@@ -564,9 +565,9 @@ namespace {
       collector.collectTypeMetadataForLayout(T);
     }
 
-    void reexplode(IRGenFunction &IGF, Explosion &src, Explosion &dest)
+    void reexplode(Explosion &src, Explosion &dest)
     const override {
-      if (getLoadableSingleton()) getLoadableSingleton()->reexplode(IGF, src, dest);
+      if (getLoadableSingleton()) getLoadableSingleton()->reexplode(src, dest);
     }
 
     void copy(IRGenFunction &IGF, Explosion &src, Explosion &dest,
@@ -610,10 +611,11 @@ namespace {
       }
     }
 
-    void packIntoEnumPayload(IRGenFunction &IGF, EnumPayload &payload,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder, EnumPayload &payload,
                              Explosion &in, unsigned offset) const override {
       if (getLoadableSingleton())
-        return getLoadableSingleton()->packIntoEnumPayload(IGF, payload,
+        return getLoadableSingleton()->packIntoEnumPayload(IGM, builder, payload,
                                                            in, offset);
     }
 
@@ -909,7 +911,8 @@ namespace {
       (void)in.claim(getExplosionSize());
     }
 
-    void emitValueInjection(IRGenFunction &IGF,
+    void emitValueInjection(IRGenModule &IGM,
+                            IRBuilder &builder,
                             EnumElementDecl *elt,
                             Explosion &params,
                             Explosion &out) const override {
@@ -1487,7 +1490,7 @@ namespace {
       assert(TIK >= Loadable);
     }
 
-    void reexplode(IRGenFunction &IGF, Explosion &src, Explosion &dest)
+    void reexplode(Explosion &src, Explosion &dest)
     const override {
       assert(TIK >= Loadable);
       dest.add(src.claim(getExplosionSize()));
@@ -1545,19 +1548,20 @@ namespace {
       return {std::move(payload), extraTag};
     }
     
-    void packIntoEnumPayload(IRGenFunction &IGF,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder,
                              EnumPayload &outerPayload,
                              Explosion &src,
                              unsigned offset) const override {
       // Pack payload, if any.
-      auto payload = EnumPayload::fromExplosion(IGF.IGM, src, PayloadSchema);
-      payload.packIntoEnumPayload(IGF, outerPayload, offset);
+      auto payload = EnumPayload::fromExplosion(IGM, src, PayloadSchema);
+      payload.packIntoEnumPayload(IGM, builder, outerPayload, offset);
 
       // Pack tag bits, if any.
       if (ExtraTagBitCount > 0) {
         unsigned extraTagOffset = PayloadBitCount + offset;
 
-        outerPayload.insertValue(IGF, src.claimNext(), extraTagOffset);
+        outerPayload.insertValue(IGM, builder, src.claimNext(), extraTagOffset);
       }
     }
 
@@ -2318,19 +2322,20 @@ namespace {
     }
 
   public:
-    void emitValueInjection(IRGenFunction &IGF,
+    void emitValueInjection(IRGenModule &IGM,
+                            IRBuilder &builder,
                             EnumElementDecl *elt,
                             Explosion &params,
                             Explosion &out) const override {
       // The payload case gets its native representation. If there are extra
       // tag bits, set them to zero.
       if (elt == getPayloadElement()) {
-        auto payload = EnumPayload::zero(IGF.IGM, PayloadSchema);
+        auto payload = EnumPayload::zero(IGM, PayloadSchema);
         auto &loadablePayloadTI = getLoadablePayloadTypeInfo();
-        loadablePayloadTI.packIntoEnumPayload(IGF, payload, params, 0);
-        payload.explode(IGF.IGM, out);
+        loadablePayloadTI.packIntoEnumPayload(IGM, builder, payload, params, 0);
+        payload.explode(IGM, out);
         if (ExtraTagBitCount > 0)
-          out.add(getZeroExtraTagConstant(IGF.IGM));
+          out.add(getZeroExtraTagConstant(IGM));
         return;
       }
 
@@ -2338,11 +2343,11 @@ namespace {
       // by setting the tag bits.
       APInt payloadPattern, extraTag;
       std::tie(payloadPattern, extraTag) = getNoPayloadCaseValue(elt);
-      auto payload = EnumPayload::fromBitPattern(IGF.IGM, payloadPattern,
+      auto payload = EnumPayload::fromBitPattern(IGM, payloadPattern,
                                                  PayloadSchema);
-      payload.explode(IGF.IGM, out);
+      payload.explode(IGM, out);
       if (ExtraTagBitCount > 0) {
-        out.add(llvm::ConstantInt::get(IGF.IGM.getLLVMContext(), extraTag));
+        out.add(llvm::ConstantInt::get(IGM.getLLVMContext(), extraTag));
       }
     }
 
@@ -2541,7 +2546,7 @@ namespace {
                                   Explosion &asEnumOut) const {
       auto &payloadTI = getLoadablePayloadTypeInfo();
       auto payload = EnumPayload::zero(IGF.IGM, PayloadSchema);
-      payloadTI.packIntoEnumPayload(IGF, payload, asPayloadIn, 0);
+      payloadTI.packIntoEnumPayload(IGF.IGM, IGF.Builder, payload, asPayloadIn, 0);
       payload.explode(IGF.IGM, asEnumOut);
     }
 
@@ -2552,7 +2557,7 @@ namespace {
 
       switch (CopyDestroyKind) {
       case TriviallyDestroyable:
-        reexplode(IGF, src, dest);
+        reexplode(src, dest);
         return;
 
       case ABIInaccessible:
@@ -3815,9 +3820,9 @@ namespace {
                                     llvm::Value *tagIndex) const {
       auto result = EnumPayload::zero(IGF.IGM, PayloadSchema);
       if (!CommonSpareBits.empty())
-        result.emitScatterBits(IGF, ~CommonSpareBits.asAPInt(), tagIndex);
+        result.emitScatterBits(IGF.IGM, IGF.Builder, ~CommonSpareBits.asAPInt(), tagIndex);
       if (!PayloadTagBits.empty())
-        result.emitScatterBits(IGF, PayloadTagBits.asAPInt(), tag);
+        result.emitScatterBits(IGF.IGM, IGF.Builder, PayloadTagBits.asAPInt(), tag);
       return result;
     }
 
@@ -4303,17 +4308,18 @@ namespace {
                      cast<LoadableTypeInfo>(*foundPayload->ti), out);
     }
 
-    void packIntoEnumPayload(IRGenFunction &IGF,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder,
                              EnumPayload &outerPayload,
                              Explosion &src,
                              unsigned offset) const override {
       auto innerPayload = EnumPayload::fromExplosion(IGM, src,
                                                      PayloadSchema);
       // Pack the payload, if any.
-      innerPayload.packIntoEnumPayload(IGF, outerPayload, offset);
+      innerPayload.packIntoEnumPayload(IGM, builder, outerPayload, offset);
       // Pack the extra bits, if any.
       if (ExtraTagBitCount > 0)
-        outerPayload.insertValue(IGF, src.claimNext(),
+        outerPayload.insertValue(IGM, builder, src.claimNext(),
                                  CommonSpareBits.size() + offset);
     }
 
@@ -4333,7 +4339,7 @@ namespace {
     }
 
   private:
-    void emitPayloadInjection(IRGenFunction &IGF,
+    void emitPayloadInjection(IRBuilder &builder,
                               const FixedTypeInfo &payloadTI,
                               Explosion &params, Explosion &out,
                               unsigned tag) const {
@@ -4341,13 +4347,13 @@ namespace {
       auto &loadablePayloadTI = cast<LoadableTypeInfo>(payloadTI); // FIXME
       
       auto payload = EnumPayload::zero(IGM, PayloadSchema);
-      loadablePayloadTI.packIntoEnumPayload(IGF, payload, params, 0);
+      loadablePayloadTI.packIntoEnumPayload(IGM, builder, payload, params, 0);
 
       // If we have spare bits, pack tag bits into them.
       unsigned numSpareBits = PayloadTagBits.count();
       if (numSpareBits > 0) {
         APInt tagMaskVal = scatterBits(PayloadTagBits.asAPInt(), tag);
-        payload.emitApplyOrMask(IGF, tagMaskVal);
+        payload.emitApplyOrMask(IGM, builder, tagMaskVal);
       }
 
       payload.explode(IGM, out);
@@ -4434,7 +4440,7 @@ namespace {
         auto mask = APInt::getLowBitsSet(CommonSpareBits.size(),
                                          std::min(32U, numCaseBits));
         payload = EnumPayload::zero(IGM, PayloadSchema);
-        payload.emitScatterBits(IGF, mask, tagIndex);
+        payload.emitScatterBits(IGF.IGM, IGF.Builder, mask, tagIndex);
       }
 
       // If the tag bits do not fit in the spare bits, the remaining tag bits
@@ -4448,8 +4454,7 @@ namespace {
       return {payload, extraTag};
     }
 
-    void emitNoPayloadInjection(IRGenFunction &IGF, Explosion &out,
-                                unsigned index) const {
+    void emitNoPayloadInjection(Explosion &out, unsigned index) const {
       APInt payloadVal, extraTag;
       std::tie(payloadVal, extraTag) = getNoPayloadCaseValue(index);
       
@@ -4526,7 +4531,8 @@ namespace {
     }
 
   public:
-    void emitValueInjection(IRGenFunction &IGF,
+    void emitValueInjection(IRGenModule &IGM,
+                            IRBuilder &builder,
                             EnumElementDecl *elt,
                             Explosion &params,
                             Explosion &out) const override {
@@ -4535,7 +4541,7 @@ namespace {
                                    ElementsWithPayload.end(),
                                [&](const Element &e) { return e.decl == elt; });
       if (payloadI != ElementsWithPayload.end())
-        return emitPayloadInjection(IGF, cast<FixedTypeInfo>(*payloadI->ti),
+        return emitPayloadInjection(builder, cast<FixedTypeInfo>(*payloadI->ti),
                                     params, out,
                                     payloadI - ElementsWithPayload.begin());
 
@@ -4543,7 +4549,7 @@ namespace {
                                  ElementsWithNoPayload.end(),
                                [&](const Element &e) { return e.decl == elt; });
       assert(emptyI != ElementsWithNoPayload.end() && "case not in enum");
-      emitNoPayloadInjection(IGF, out, emptyI - ElementsWithNoPayload.begin());
+      emitNoPayloadInjection(out, emptyI - ElementsWithNoPayload.begin());
     }
 
     void copy(IRGenFunction &IGF, Explosion &src, Explosion &dest,
@@ -4552,7 +4558,7 @@ namespace {
 
       switch (CopyDestroyKind) {
       case TriviallyDestroyable:
-        reexplode(IGF, src, dest);
+        reexplode(src, dest);
         return;
 
       case ABIInaccessible:
@@ -5030,7 +5036,7 @@ namespace {
         APInt tagBitMask = scatterBits(PayloadTagBits.asAPInt(), spareTagBits);
 
         payload.emitApplyAndMask(IGF, spareBitMask);
-        payload.emitApplyOrMask(IGF, tagBitMask);
+        payload.emitApplyOrMask(IGM, IGF.Builder, tagBitMask);
         payload.store(IGF, payloadAddr);
       }
 
@@ -5070,7 +5076,7 @@ namespace {
         payload.emitApplyAndMask(IGF, spareBitMask);
 
         // Store the tag into the spare bits.
-        payload.emitScatterBits(IGF, PayloadTagBits.asAPInt(), spareTagBits);
+        payload.emitScatterBits(IGF.IGM, IGF.Builder, PayloadTagBits.asAPInt(), spareTagBits);
 
         // Store the payload back.
         payload.store(IGF, payloadAddr);
@@ -5430,7 +5436,7 @@ namespace {
         // Factor the index value into parts to scatter into the payload and
         // to store in the extra tag bits, if any.
         auto payload = EnumPayload::zero(IGM, PayloadSchema);
-        payload.emitScatterBits(IGF, CommonSpareBits.asAPInt(), indexValue);
+        payload.emitScatterBits(IGF.IGM, IGF.Builder, CommonSpareBits.asAPInt(), indexValue);
         payload.store(IGF, projectPayload(IGF, dest));
         if (getExtraTagBitCountForExtraInhabitants() > 0) {
           auto tagBits = IGF.Builder.CreateLShr(indexValue,
@@ -5836,7 +5842,8 @@ namespace {
       llvm_unreachable("resilient enums are always indirect");
     }
   
-    void emitValueInjection(IRGenFunction &IGF,
+    void emitValueInjection(IRGenModule &IGM,
+                            IRBuilder &builder,
                             EnumElementDecl *elt,
                             Explosion &params,
                             Explosion &out) const override {
@@ -5888,7 +5895,7 @@ namespace {
       llvm_unreachable("resilient enums are always indirect");
     }
 
-    void reexplode(IRGenFunction &IGF, Explosion &src,
+    void reexplode(Explosion &src,
                            Explosion &dest) const override {
       llvm_unreachable("resilient enums are always indirect");
     }
@@ -5907,7 +5914,8 @@ namespace {
       llvm_unreachable("resilient enums are always indirect");
     }
 
-    void packIntoEnumPayload(IRGenFunction &IGF,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder,
                              EnumPayload &outerPayload,
                              Explosion &src,
                              unsigned offset) const override {
@@ -6347,9 +6355,9 @@ namespace {
                     bool isOutlined) const override {
       return Strategy.initialize(IGF, e, addr, isOutlined);
     }
-    void reexplode(IRGenFunction &IGF, Explosion &src,
+    void reexplode( Explosion &src,
                    Explosion &dest) const override {
-      return Strategy.reexplode(IGF, src, dest);
+      return Strategy.reexplode(src, dest);
     }
     void copy(IRGenFunction &IGF, Explosion &src,
               Explosion &dest, Atomicity atomicity) const override {
@@ -6362,11 +6370,12 @@ namespace {
     void fixLifetime(IRGenFunction &IGF, Explosion &src) const override {
       return Strategy.fixLifetime(IGF, src);
     }
-    void packIntoEnumPayload(IRGenFunction &IGF,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder,
                              EnumPayload &payload,
                              Explosion &in,
                              unsigned offset) const override {
-      return Strategy.packIntoEnumPayload(IGF, payload, in, offset);
+      return Strategy.packIntoEnumPayload(IGM, builder, payload, in, offset);
     }
     void unpackFromEnumPayload(IRGenFunction &IGF,
                                const EnumPayload &payload,
@@ -7057,7 +7066,7 @@ void irgen::emitInjectLoadableEnum(IRGenFunction &IGF, SILType enumTy,
                                     Explosion &data,
                                     Explosion &out) {
   getEnumImplStrategy(IGF.IGM, enumTy)
-    .emitValueInjection(IGF, theCase, data, out);
+    .emitValueInjection(IGF.IGM, IGF.Builder, theCase, data, out);
 }
 
 void irgen::emitProjectLoadableEnum(IRGenFunction &IGF, SILType enumTy,
@@ -7186,13 +7195,13 @@ llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
 /// move them to the bit positions indicated by the mask.
 /// Equivalent to a parallel bit deposit instruction (PDEP),
 /// although we don't currently emit PDEP directly.
-llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
+llvm::Value *irgen::emitScatterBits(IRGenModule &IGM,
+                                    IRBuilder &builder,
                                     llvm::APInt mask,
                                     llvm::Value *source,
                                     unsigned packedLowBit) {
-  auto &DL = IGF.IGM.DataLayout;
-  auto &B = IGF.Builder;
-  auto &C = IGF.IGM.getLLVMContext();
+  auto &DL = IGM.DataLayout;
+  auto &C = IGM.getLLVMContext();
 
   // Expand or contract the packed bits to the destination type.
   auto bitSize = mask.getBitWidth();
@@ -7200,7 +7209,7 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
   if (!sourceTy) {
     auto numBits = DL.getTypeSizeInBits(source->getType());
     sourceTy = llvm::IntegerType::get(C, numBits);
-    source = B.CreateBitOrPointerCast(source, sourceTy);
+    source = builder.CreateBitOrPointerCast(source, sourceTy);
   }
   assert(packedLowBit < sourceTy->getBitWidth() &&
       "packedLowBit out of range");
@@ -7210,11 +7219,11 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
   if (usedBits > 0 && sourceTy->getBitWidth() > bitSize) {
     // Need to shift before truncation if the packed value is wider
     // than the mask.
-    source = B.CreateLShr(source, uint64_t(usedBits));
+    source = builder.CreateLShr(source, uint64_t(usedBits));
     usedBits = 0;
   }
   if (sourceTy->getBitWidth() != bitSize) {
-    source = B.CreateZExtOrTrunc(source, destTy);
+    source = builder.CreateZExtOrTrunc(source, destTy);
   }
 
   // No need to AND with the mask if the whole source can just be
@@ -7240,18 +7249,18 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
     llvm::Value *part = source;
     int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
     if (offset > 0) {
-      part = B.CreateShl(part, uint64_t(offset));
+      part = builder.CreateShl(part, uint64_t(offset));
     } else if (offset < 0) {
-      part = B.CreateLShr(part, uint64_t(-offset));
+      part = builder.CreateLShr(part, uint64_t(-offset));
     }
 
     // Mask out selected bits.
     if (needMask) {
-      part = B.CreateAnd(part, partMask);
+      part = builder.CreateAnd(part, partMask);
     }
 
     // Accumulate the result.
-    result = result ? B.CreateOr(result, part) : part;
+    result = result ? builder.CreateOr(result, part) : part;
 
     // Update the offset and remaining mask.
     usedBits += partMask.countPopulation();

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -33,6 +33,12 @@ namespace swiftcall {
 }
 
 namespace swift {
+namespace irgen {
+  class IRBuilder;
+}
+}
+
+namespace swift {
   class EnumElementDecl;
   enum IsInitialization_t : bool;
   enum IsTake_t : bool;
@@ -109,7 +115,8 @@ llvm::APInt gatherBits(const llvm::APInt &mask,
 /// move them to the bit positions indicated by the mask.
 /// Equivalent to a parallel bit deposit instruction (PDEP),
 /// although we don't currently emit PDEP directly.
-llvm::Value *emitScatterBits(IRGenFunction &IGF,
+llvm::Value *emitScatterBits(IRGenModule &IGM,
+                             IRBuilder &builder,
                              llvm::APInt mask,
                              llvm::Value *packedBits,
                              unsigned packedLowBit);
@@ -321,7 +328,8 @@ public:
   
   /// Emit the construction sequence for an enum case into an explosion.
   /// Corresponds to the SIL 'enum' instruction.
-  virtual void emitValueInjection(IRGenFunction &IGF,
+  virtual void emitValueInjection(IRGenModule &IGM,
+                                  IRBuilder &builder,
                                   EnumElementDecl *elt,
                                   Explosion &params,
                                   Explosion &out) const = 0;
@@ -424,14 +432,15 @@ public:
                       bool isOutlined, SILType T) const = 0;
   virtual void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
                           bool isOutlined) const = 0;
-  virtual void reexplode(IRGenFunction &IGF, Explosion &src,
+  virtual void reexplode(Explosion &src,
                          Explosion &dest) const = 0;
   virtual void copy(IRGenFunction &IGF, Explosion &src,
                     Explosion &dest, Atomicity atomicity) const = 0;
   virtual void consume(IRGenFunction &IGF, Explosion &src,
                        Atomicity atomicity, SILType T) const = 0;
   virtual void fixLifetime(IRGenFunction &IGF, Explosion &src) const = 0;
-  virtual void packIntoEnumPayload(IRGenFunction &IGF,
+  virtual void packIntoEnumPayload(IRGenModule &IGM,
+                                   IRBuilder &builder,
                                    EnumPayload &payload,
                                    Explosion &in,
                                    unsigned offset) const = 0;

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -510,15 +510,16 @@ namespace {
       asDerived().emitValueRelease(IGF, value, IGF.getDefaultAtomicity());
     }
 
-    void packIntoEnumPayload(IRGenFunction &IGF,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder,
                              EnumPayload &payload,
                              Explosion &src,
                              unsigned offset) const override {
-      payload.insertValue(IGF, src.claimNext(), offset);
-      auto wordSize = IGF.IGM.getPointerSize().getValueInBits();
+      payload.insertValue(IGM, builder, src.claimNext(), offset);
+      auto wordSize = IGM.getPointerSize().getValueInBits();
       for (unsigned i = 0; i < getNumStoredProtocols(); ++i) {
         offset += wordSize;
-        payload.insertValue(IGF, src.claimNext(), offset);
+        payload.insertValue(IGM, builder, src.claimNext(), offset);
       }
     }
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -786,7 +786,7 @@ static void emitApplyArgument(IRGenFunction &IGF,
   if (!isSubstituted) {
     auto &substArgTI = cast<LoadableTypeInfo>(
         IGF.getTypeInfo(silConv.getSILType(substParam, substFnTy, context)));
-    substArgTI.reexplode(IGF, in, out);
+    substArgTI.reexplode(in, out);
     return;
   }
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1010,7 +1010,7 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
     assert(nativeParam.empty());
 
     // Pass along the value.
-    ti.reexplode(subIGF, nonNativeParam, translatedParams);
+    ti.reexplode(nonNativeParam, translatedParams);
   }
 
   // Prepare the call to the underlying method.

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -785,10 +785,10 @@ public:
     return ExplosionSize;
   }
 
-  void reexplode(IRGenFunction &IGF, Explosion &src,
+  void reexplode(Explosion &src,
                  Explosion &dest) const override {
     for (auto &field : getFields())
-      cast<LoadableTypeInfo>(field.getTypeInfo()).reexplode(IGF, src, dest);
+      cast<LoadableTypeInfo>(field.getTypeInfo()).reexplode(src, dest);
   }
 
   void copy(IRGenFunction &IGF, Explosion &src,
@@ -811,7 +811,8 @@ public:
       cast<LoadableTypeInfo>(field.getTypeInfo()).fixLifetime(IGF, src);
   }
   
-  void packIntoEnumPayload(IRGenFunction &IGF,
+  void packIntoEnumPayload(IRGenModule &IGM,
+                           IRBuilder &builder,
                            EnumPayload &payload,
                            Explosion &src,
                            unsigned startOffset) const override {
@@ -820,7 +821,7 @@ public:
         unsigned offset = field.getFixedByteOffset().getValueInBits()
           + startOffset;
         cast<LoadableTypeInfo>(field.getTypeInfo())
-          .packIntoEnumPayload(IGF, payload, src, offset);
+          .packIntoEnumPayload(IGM, builder, payload, src, offset);
       }
     }
   }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -947,11 +947,11 @@ FixedTypeInfo::storeSpareBitExtraInhabitant(IRGenFunction &IGF,
   
   // Scatter the occupied bits.
   auto OccupiedBits = ~SpareBits.asAPInt();
-  llvm::Value *occupied = emitScatterBits(IGF, OccupiedBits,
+  llvm::Value *occupied = emitScatterBits(IGF.IGM, IGF.Builder, OccupiedBits,
                                           occupiedIndex, 0);
   
   // Scatter the spare bits.
-  llvm::Value *spare = emitScatterBits(IGF, SpareBits.asAPInt(),
+  llvm::Value *spare = emitScatterBits(IGF.IGM, IGF.Builder, SpareBits.asAPInt(),
                                        spareIndex, 0);
   
   // Combine the values and store to the destination.
@@ -988,7 +988,8 @@ namespace {
     void fixLifetime(IRGenFunction &IGF, Explosion &src) const override {}
     void destroy(IRGenFunction &IGF, Address addr, SILType T,
                  bool isOutlined) const override {}
-    void packIntoEnumPayload(IRGenFunction &IGF, EnumPayload &payload,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder, EnumPayload &payload,
                              Explosion &src, unsigned offset) const override {}
     void unpackFromEnumPayload(IRGenFunction &IGF,
                                const EnumPayload &payload,
@@ -1200,7 +1201,7 @@ namespace {
       }
     }
     
-    void reexplode(IRGenFunction &IGF, Explosion &sourceExplosion,
+    void reexplode(Explosion &sourceExplosion,
                    Explosion &targetExplosion) const override {
       for (auto scalarTy : ScalarTypes) {
         (void)scalarTy;
@@ -1210,7 +1211,7 @@ namespace {
     
     void copy(IRGenFunction &IGF, Explosion &sourceExplosion,
               Explosion &targetExplosion, Atomicity atomicity) const override {
-      reexplode(IGF, sourceExplosion, targetExplosion);
+      reexplode(sourceExplosion, targetExplosion);
     }
 
     void consume(IRGenFunction &IGF, Explosion &explosion,
@@ -1245,12 +1246,13 @@ namespace {
                              (offset + getFixedSize()).asCharUnits());
     }
     
-    void packIntoEnumPayload(IRGenFunction &IGF,
+    void packIntoEnumPayload(IRGenModule &IGM,
+                             IRBuilder &builder,
                              EnumPayload &payload,
                              Explosion &source,
                              unsigned offset) const override {
       for (auto scalarTy: ScalarTypes) {
-        payload.insertValue(IGF, source.claimNext(), offset);
+        payload.insertValue(IGM, builder, source.claimNext(), offset);
         offset += scalarTy->getIntegerBitWidth();
       }
     }
@@ -2975,7 +2977,7 @@ bool irgen::tryEmitConsumeUsingDeinit(IRGenFunction &IGF, Explosion &explosion,
   return tryEmitDeinitCall(IGF, T,
     // Direct parameter case
     [&](Explosion &arg) {
-      ti->reexplode(IGF, explosion, arg);
+      ti->reexplode(explosion, arg);
     },
     // Indirect parameter setup
     [&]() -> Address {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1507,7 +1507,6 @@ public:
   void emitSILWitnessTable(SILWitnessTable *wt);
   void emitSILProperty(SILProperty *prop);
   void emitSILDifferentiabilityWitness(SILDifferentiabilityWitness *dw);
-  void emitSILStaticInitializers();
   llvm::Constant *emitFixedTypeLayout(CanType t, const FixedTypeInfo &ti);
   void emitProtocolConformance(const ConformanceDescription &record);
   void emitNestedTypeDecls(DeclRange members);
@@ -1721,6 +1720,9 @@ public:
   Address getAddrOfSILGlobalVariable(SILGlobalVariable *var,
                                      const TypeInfo &ti,
                                      ForDefinition_t forDefinition);
+  llvm::Constant *getGlobalInitValue(SILGlobalVariable *var,
+                                     llvm::Type *storageType,
+                                     Alignment alignment);
   llvm::Function *getAddrOfWitnessTableLazyAccessFunction(
                                                const NormalProtocolConformance *C,
                                                CanType conformingType,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -524,7 +524,7 @@ public:
 
       // Otherwise, claim out the right number of values.
       Explosion resultValue;
-      cast<LoadableTypeInfo>(resultTI).reexplode(*this, allValues, resultValue);
+      cast<LoadableTypeInfo>(resultTI).reexplode(allValues, resultValue);
       setLoweredExplosion(result, resultValue);
     }
   }

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -32,6 +32,7 @@ namespace swiftcall {
 namespace swift {
 namespace irgen {
   class EnumPayload;
+  class IRBuilder;
   using clang::CodeGen::swiftcall::SwiftAggLowering;
 
 struct LoadedRef {
@@ -117,7 +118,7 @@ public:
   /// level and produce them at another.
   ///
   /// Essentially, this is like take-initializing the new explosion.
-  virtual void reexplode(IRGenFunction &IGF, Explosion &sourceExplosion,
+  virtual void reexplode(Explosion &sourceExplosion,
                          Explosion &targetExplosion) const = 0;
 
   /// Shift values from the source explosion to the target explosion
@@ -135,7 +136,8 @@ public:
   virtual void fixLifetime(IRGenFunction &IGF, Explosion &explosion) const = 0;
   
   /// Pack the source explosion into an enum payload.
-  virtual void packIntoEnumPayload(IRGenFunction &IGF,
+  virtual void packIntoEnumPayload(IRGenModule &IGM,
+                                   IRBuilder &builder,
                                    EnumPayload &payload,
                                    Explosion &sourceExplosion,
                                    unsigned offset) const = 0;

--- a/lib/IRGen/ScalarPairTypeInfo.h
+++ b/lib/IRGen/ScalarPairTypeInfo.h
@@ -159,13 +159,14 @@ public:
     }
   }
 
-  void packIntoEnumPayload(IRGenFunction &IGF,
+  void packIntoEnumPayload(IRGenModule &IGM,
+                           IRBuilder &builder,
                            EnumPayload &payload,
                            Explosion &src,
                            unsigned offset) const override {
-    payload.insertValue(IGF, src.claimNext(), offset);
-    payload.insertValue(IGF, src.claimNext(),
-      offset + asDerived().getSecondElementOffset(IGF.IGM).getValueInBits());
+    payload.insertValue(IGM, builder, src.claimNext(), offset);
+    payload.insertValue(IGM, builder, src.claimNext(),
+      offset + asDerived().getSecondElementOffset(IGM).getValueInBits());
   }
   
   void unpackFromEnumPayload(IRGenFunction &IGF,

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -68,7 +68,7 @@ public:
     asDerived().Derived::assign(IGF, temp, dest, isOutlined, T);
   }
 
-  void reexplode(IRGenFunction &IGF, Explosion &in,
+  void reexplode(Explosion &in,
                  Explosion &out) const override {
     unsigned size = asDerived().Derived::getExplosionSize();
     in.transferInto(out, size);
@@ -207,11 +207,12 @@ public:
     }
   }
   
-  void packIntoEnumPayload(IRGenFunction &IGF,
+  void packIntoEnumPayload(IRGenModule &IGM,
+                           IRBuilder &builder,
                            EnumPayload &payload,
                            Explosion &src,
                            unsigned offset) const override {
-    payload.insertValue(IGF, src.claimNext(), offset);
+    payload.insertValue(IGM, builder, src.claimNext(), offset);
   }
   
   void unpackFromEnumPayload(IRGenFunction &IGF,

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -123,7 +123,7 @@ sil_global [let] @string_with_offset : $MyString = {
   %9 = value_to_bridge_object %8 : $Builtin.Int64
   %initval = struct $MyString (%9 : $Builtin.BridgeObject)
 }
-// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @.str.22.abc123asd3sdj3basfasdf to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
+// CHECK: @string_with_offset = {{.*constant .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @.str.22.abc123asd3sdj3basfasdf to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:

--- a/test/SILOptimizer/simplify_init_enum_data_addr.sil
+++ b/test/SILOptimizer/simplify_init_enum_data_addr.sil
@@ -1,0 +1,75 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=init_enum_data_addr | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+enum E {
+  case A(Int)
+  case B(AnyObject)
+}
+
+enum GenE<T> {
+  case A(Int)
+  case B(T)
+}
+// CHECK-LABEL: sil @optional_int
+// CHECK:         %2 = enum $Optional<Int>, #Optional.some!enumelt, %1 : $Int
+// CHECK:         store %2 to %0 : $*Optional<Int>
+// CHECK:         %4 = tuple ()
+// CHECK:         return %4
+// CHECK:       } // end sil function 'optional_int'
+sil @optional_int : $@convention(thin) (Int) -> @out Optional<Int> {
+bb0(%0 : $*Optional<Int>, %1 : $Int):
+  %2 = init_enum_data_addr %0 : $*Optional<Int>, #Optional.some!enumelt
+  store %1 to %2 : $*Int
+  inject_enum_addr %0 : $*Optional<Int>, #Optional.some!enumelt
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @ossa_trivial
+// CHECK:         %2 = enum $Optional<Int>, #Optional.some!enumelt, %1 : $Int
+// CHECK:         store %2 to [trivial] %0 : $*Optional<Int>
+// CHECK:         %4 = tuple ()
+// CHECK:         return %4
+// CHECK:       } // end sil function 'ossa_trivial'
+sil [ossa] @ossa_trivial : $@convention(thin) (Int) -> @out Optional<Int> {
+bb0(%0 : $*Optional<Int>, %1 : $Int):
+  %2 = init_enum_data_addr %0 : $*Optional<Int>, #Optional.some!enumelt
+  store %1 to [trivial] %2 : $*Int
+  inject_enum_addr %0 : $*Optional<Int>, #Optional.some!enumelt
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @ossa_nontrivial
+// CHECK:         %2 = enum $E, #E.A!enumelt, %1 : $Int
+// CHECK:         store %2 to [init] %0 : $*E
+// CHECK:         %4 = tuple ()
+// CHECK:         return %4
+// CHECK:       } // end sil function 'ossa_nontrivial'
+sil [ossa] @ossa_nontrivial : $@convention(thin) (Int) -> @out E {
+bb0(%0 : $*E, %1 : $Int):
+  %2 = init_enum_data_addr %0 : $*E, #E.A!enumelt
+  store %1 to [trivial] %2 : $*Int
+  inject_enum_addr %0 : $*E, #E.A!enumelt
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @not_loadable
+// CHECK:         %2 = init_enum_data_addr
+// CHECK:         store %1 to [trivial] %2
+// CHECK:         inject_enum_addr
+// CHECK:       } // end sil function 'not_loadable'
+sil [ossa] @not_loadable : $@convention(thin) <T> (Int) -> @out GenE<T> {
+bb0(%0 : $*GenE<T>, %1 : $Int):
+  %2 = init_enum_data_addr %0 : $*GenE<T>, #GenE.A!enumelt
+  store %1 to [trivial] %2 : $*Int
+  inject_enum_addr %0 : $*GenE<T>, #GenE.A!enumelt
+  %5 = tuple ()
+  return %5 : $()
+}
+

--- a/test/SILOptimizer/simplify_value_to_bridge_object.sil
+++ b/test/SILOptimizer/simplify_value_to_bridge_object.sil
@@ -1,0 +1,36 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=value_to_bridge_object | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+// CHECK-LABEL: sil @empty_string_literal_sequence
+// CHECK:         %1 = value_to_bridge_object %0
+// CHECK:         return %1
+// CHECK:       } // end sil function 'empty_string_literal_sequence'
+sil @empty_string_literal_sequence : $@convention(thin) (Builtin.Int64) -> Builtin.BridgeObject {
+bb0(%0 : $Builtin.Int64):
+  %1 = value_to_bridge_object %0 : $Builtin.Int64
+  %2 = unchecked_trivial_bit_cast %1 : $Builtin.BridgeObject to $UInt64
+  %3 = struct_extract %2 : $UInt64, #UInt64._value
+  %4 = value_to_bridge_object %3 : $Builtin.Int64
+  return %4 : $Builtin.BridgeObject
+}
+
+// CHECK-LABEL: sil [ossa] @keep_both_vtbo_instructions
+// CHECK:         %1 = value_to_bridge_object %0
+// CHECK:         %2 = value_to_bridge_object %0
+// CHECK:         %3 = tuple (%1 : $Builtin.BridgeObject, %2 : $Builtin.BridgeObject)
+// CHECK:         return %3
+// CHECK:       } // end sil function 'keep_both_vtbo_instructions'
+sil [ossa] @keep_both_vtbo_instructions : $@convention(thin) (Builtin.Int64) -> (Builtin.BridgeObject, Builtin.BridgeObject) {
+bb0(%0 : $Builtin.Int64):
+  %1 = value_to_bridge_object %0 : $Builtin.Int64
+  %2 = unchecked_trivial_bit_cast %1 : $Builtin.BridgeObject to $UInt64
+  %3 = struct_extract %2 : $UInt64, #UInt64._value
+  %4 = value_to_bridge_object %3 : $Builtin.Int64
+  %5 = tuple (%1 : $Builtin.BridgeObject, %4 : $Builtin.BridgeObject)
+  return %5 : $(Builtin.BridgeObject, Builtin.BridgeObject)
+}
+

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -1,0 +1,203 @@
+// RUN: %target-build-swift -parse-as-library -O %s -module-name=test -emit-sil | %FileCheck %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -parse-as-library -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: swift_in_compiler
+
+
+// CHECK-LABEL: sil_global @$s4test6optIntSiSgvp : $Optional<Int> = {
+public var optInt: Int? = 27
+
+// CHECK-LABEL: sil_global @$s4test9optIntNilSiSgvp : $Optional<Int> = {
+public var optIntNil: Int? = nil
+
+// CHECK-LABEL: sil_global @$s4test6optPtrSVSgvp : $Optional<UnsafeRawPointer> = {
+public var optPtr: UnsafeRawPointer? = nil
+
+public struct S {
+  var a: Int?
+  var b: Int8
+}
+
+public struct S2 {
+  var s: S
+  var c: Int8
+}
+
+// CHECK-LABEL: sil_global @$s4test1sAA1SVSgvp : $Optional<S> = {
+public var s: S? = S(a: 27, b: 42)
+
+// CHECK-LABEL: sil_global @$s4test4snilAA1SVSgvp : $Optional<S> = {
+public var snil: S? = nil
+
+// CHECK-LABEL: sil_global @$s4test5sanilAA1SVSgvp : $Optional<S> = {
+public var sanil: S? = S(a: nil, b: 42)
+
+// CHECK-LABEL: sil_global @$s4test2tsAA1SV_s4Int8Vtvp : $(S, Int8) = {
+public var ts: (S, Int8) = (S(a: 27, b:42), 13)
+
+// CHECK-LABEL: sil_global @$s4test2s2AA2S2Vvp : $S2 = {
+public var s2: S2 = S2(s: S(a: 27, b: 42), c: 13)
+
+public enum MP {
+  case A(Int)
+  case B(Int8)
+  case C
+  case D(Int?)
+}
+
+// CHECK-LABEL: sil_global @$s4test3mpaAA2MPOvp : $MP = {
+public var mpa: MP = .A(27)
+// CHECK-LABEL: sil_global @$s4test3mpbAA2MPOvp : $MP = {
+public var mpb: MP = .B(42)
+// CHECK-LABEL: sil_global @$s4test3mpcAA2MPOvp : $MP = {
+public var mpc: MP = .C
+// CHECK-LABEL: sil_global @$s4test3mpdAA2MPOvp : $MP = {
+public var mpd: MP = .D(103)
+// CHECK-LABEL: sil_global @$s4test6mpdnilAA2MPOvp : $MP = {
+public var mpdnil: MP = .D(nil)
+// CHECK-LABEL: sil_global @$s4test6optmpaAA2MPOSgvp : $Optional<MP> = {
+public var optmpa: MP? = .A(27)
+// CHECK-LABEL: sil_global @$s4test6optmpbAA2MPOSgvp : $Optional<MP> = {
+public var optmpb: MP? = .B(42)
+// CHECK-LABEL: sil_global @$s4test6optmpcAA2MPOSgvp : $Optional<MP> = {
+public var optmpc: MP? = .C
+// CHECK-LABEL: sil_global @$s4test6optmpdAA2MPOSgvp : $Optional<MP> = {
+public var optmpd: MP? = .D(103)
+// CHECK-LABEL: sil_global @$s4test9optmpdnilAA2MPOSgvp : $Optional<MP> = {
+public var optmpdnil: MP? = .D(nil)
+// CHECK-LABEL: sil_global @$s4test8optmpnilAA2MPOSgvp : $Optional<MP> = {
+public var optmpnil: MP? = nil
+
+// CHECK-LABEL: sil_global @$s4test3strSSSgvp : $Optional<String> = {
+public var str: String? = "a long string exceeding the inline buffer"
+// CHECK-LABEL: sil_global @$s4test6strnilSSSgvp : $Optional<String> = {
+public var strnil: String? = nil
+// CHECK-LABEL: sil_global @$s4test8shortstrSSSgvp : $Optional<String> = {
+public var shortstr: String? = "short"
+// CHECK-LABEL: sil_global @$s4test8emptystrSSSgvp : $Optional<String> = {
+public var emptystr: String? = ""
+
+public struct SpareBits {
+    var o: UInt64 = 0
+    var x: UInt8 = 0
+    var y: UInt64 = 0
+    var x_2: UInt8 = 0
+    var y_2: UInt64 = 0
+    var x_3: UInt8 = 0
+    var y_3: UInt64 = 0
+    var x_4: UInt8 = 0
+    var y_4: UInt64 = 0
+    var x_5: UInt8 = 0
+    var y_5: UInt64 = 0
+    var x_6: UInt8 = 0
+    var y_6: UInt64 = 0
+}
+
+
+public enum Multipayload {
+    case a
+    case b(UnsafeRawPointer)
+    case c(SpareBits)
+    case e(String)
+    case f
+    case g
+}
+
+// CHECK-LABEL: sil_global hidden @$s4test4mpsbAA12MultipayloadOvp : $Multipayload = {
+var mpsb = Multipayload.c(SpareBits(o: 1, x: 2, y: 3, x_2: 4, y_2: 5, x_3: 6, y_3: 7, x_4: 8, y_4: 9, x_5: 10, y_5: 11, x_6: 12, y_6: 13))
+// CHECK-LABEL: sil_global hidden @$s4test4mpslAA12MultipayloadOvp : $Multipayload = {
+var mpsl = Multipayload.e("a long string exceeding the inline buffer")
+// CHECK-LABEL: sil_global hidden @$s4test4mpssAA12MultipayloadOvp : $Multipayload = {
+var mpss = Multipayload.e("short")
+
+public struct Inner {
+  var x: UInt64
+  var y: UInt8
+}
+
+public struct Outer {
+  var i: Inner
+  var z: UInt8
+}
+
+// CHECK-LABEL: sil_global hidden @$s4test5outerAA5OuterVSgvp : $Optional<Outer> = {
+var outer: Outer? = Outer(i: Inner(x: 2, y: 3), z: 4)
+
+// CHECK-LABEL: sil_global hidden @$s4test8optionalSiSgvp : $Optional<Int> = {
+var optional: Int? = Optional(42)
+
+// CHECK-LABEL: sil_global private @$s4test9createArrSaySiSgGyFTv_ : $_ContiguousArrayStorage<Optional<Int>> = {
+@inline(never)
+func createArr() -> [Int?] {
+  return [ 27, 42, nil, 103 ]
+}
+
+@main
+struct Main {
+  static func main() {
+    // CHECK-OUTPUT: optInt: Optional(27)
+    print("optInt:", optInt as Any)
+    // CHECK-OUTPUT: optIntNil: nil
+    print("optIntNil:", optIntNil as Any)
+    // CHECK-OUTPUT: optPtr: nil
+    print("optPtr:", optPtr as Any)
+    // CHECK-OUTPUT: s: Optional(test.S(a: Optional(27), b: 42))
+    print("s:", s as Any)
+    // CHECK-OUTPUT: snil: nil
+    print("snil:", snil as Any)
+    // CHECK-OUTPUT: sanil: Optional(test.S(a: nil, b: 42))
+    print("sanil:", sanil as Any)
+    // CHECK-OUTPUT: ts: (test.S(a: Optional(27), b: 42), 13)
+    print("ts:", ts as Any)
+    // CHECK-OUTPUT: s2: S2(s: test.S(a: Optional(27), b: 42), c: 13)
+    print("s2:", s2 as Any)
+    // CHECK-OUTPUT: mpa: A(27)
+    print("mpa:", mpa as Any)
+    // CHECK-OUTPUT: mpb: B(42)
+    print("mpb:", mpb as Any)
+    // CHECK-OUTPUT: mpc: C
+    print("mpc:", mpc as Any)
+    // CHECK-OUTPUT: mpd: D(Optional(103))
+    print("mpd:", mpd as Any)
+    // CHECK-OUTPUT: mpdnil: D(nil)
+    print("mpdnil:", mpdnil as Any)
+    // CHECK-OUTPUT: optmpa: Optional(test.MP.A(27))
+    print("optmpa:", optmpa as Any)
+    // CHECK-OUTPUT: optmpb: Optional(test.MP.B(42))
+    print("optmpb:", optmpb as Any)
+    // CHECK-OUTPUT: optmpc: Optional(test.MP.C)
+    print("optmpc:", optmpc as Any)
+    // CHECK-OUTPUT: optmpd: Optional(test.MP.D(Optional(103)))
+    print("optmpd:", optmpd as Any)
+    // CHECK-OUTPUT: optmpdnil: Optional(test.MP.D(nil))
+    print("optmpdnil:", optmpdnil as Any)
+    // CHECK-OUTPUT: optmpnil: nil
+    print("optmpnil:", optmpnil as Any)
+    // CHECK-OUTPUT: str: Optional("a long string exceeding the inline buffer")
+    print("str:", str as Any)
+    // CHECK-OUTPUT: strnil: nil
+    print("strnil:", strnil as Any)
+    // CHECK-OUTPUT: shortstr: Optional("short")
+    print("shortstr:", shortstr as Any)
+    // CHECK-OUTPUT: emptystr: Optional("")
+    print("emptystr:", emptystr as Any)
+    // CHECK-OUTPUT: mpsb: c(test.SpareBits(o: 1, x: 2, y: 3, x_2: 4, y_2: 5, x_3: 6, y_3: 7, x_4: 8, y_4: 9, x_5: 10, y_5: 11, x_6: 12, y_6: 13))
+    print("mpsb:", mpsb)
+    // CHECK-OUTPUT: mpsl: e("a long string exceeding the inline buffer")
+    print("mpsl:", mpsl)
+    // CHECK-OUTPUT: mpss: e("short")
+    print("mpss:", mpss)
+    // CHECK-OUTPUT: outer: Optional(test.Outer(i: test.Inner(x: 2, y: 3), z: 4))
+    print("outer:", outer as Any)
+    // CHECK-OUTPUT: optional: Optional(42)
+    print("optional:", optional as Any)
+    // CHECK-OUTPUT: createArr: [Optional(27), Optional(42), nil, Optional(103)]
+    print("createArr:", createArr())
+  }
+}
+
+

--- a/test/SILOptimizer/static_strings.swift
+++ b/test/SILOptimizer/static_strings.swift
@@ -13,13 +13,13 @@
 // optimal code for static String variables.
 
 public struct S {
-  // CHECK: {{^@"}}[[SMALL:.*smallstr.*pZ]]" ={{.*}} global {{.*}} inttoptr
+  // CHECK: {{^@"}}[[SMALL:.*smallstr.*pZ]]" ={{.*}} constant {{.*}} inttoptr
   public static let smallstr = "abc123a"
-  // CHECK: {{^@"}}[[LARGE:.*largestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
+  // CHECK: {{^@"}}[[LARGE:.*largestr.*pZ]]" ={{.*}} constant {{.*}} inttoptr {{.*}} add
   public static let largestr = "abc123asd3sdj3basfasdf"
-  // CHECK: {{^@"}}[[UNICODE:.*unicodestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
+  // CHECK: {{^@"}}[[UNICODE:.*unicodestr.*pZ]]" ={{.*}} constant {{.*}} inttoptr {{.*}} add
   public static let unicodestr = "❄️gastroperiodyni"
-  // CHECK: {{^@"}}[[EMPTY:.*emptystr.*pZ]]" ={{.*}} global {{.*}} inttoptr
+  // CHECK: {{^@"}}[[EMPTY:.*emptystr.*pZ]]" ={{.*}} constant {{.*}} inttoptr
   public static let emptystr = ""
 }
 

--- a/test/SILOptimizer/static_strings.swift
+++ b/test/SILOptimizer/static_strings.swift
@@ -19,6 +19,8 @@ public struct S {
   public static let largestr = "abc123asd3sdj3basfasdf"
   // CHECK: {{^@"}}[[UNICODE:.*unicodestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
   public static let unicodestr = "❄️gastroperiodyni"
+  // CHECK: {{^@"}}[[EMPTY:.*emptystr.*pZ]]" ={{.*}} global {{.*}} inttoptr
+  public static let emptystr = ""
 }
 
 // unsafeMutableAddressor for S.smallstr
@@ -57,6 +59,18 @@ public struct S {
 // CHECK-NEXT:   ret {{.*}}
 // CHECK-NEXT: }
 
+// unsafeMutableAddressor for S.emptystr
+// CHECK: define {{.*emptystr.*}}u"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}} @"[[EMPTY]]"
+// CHECK-NEXT: }
+
+// getter for S.emptystr
+// CHECK: define {{.*emptystr.*}}gZ"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+
 // CHECK-LABEL: define {{.*}}get_smallstr
 // CHECK:      entry:
 // CHECK-NEXT:   ret {{.*}}
@@ -84,14 +98,25 @@ public func get_unicodestr() -> String {
   return S.unicodestr
 }
 
+// CHECK-LABEL: define {{.*}}get_emptystr
+// CHECK:      entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+@inline(never)
+public func get_emptystr() -> String {
+  return S.emptystr
+}
+
 // Also check if the generated code is correct.
 
 // CHECK-OUTPUT: abc123a
 // CHECK-OUTPUT: abc123asd3sdj3basfasdf
 // CHECK-OUTPUT: ❄️gastroperiodyni
+// CHECK-OUTPUT: <>
 print(get_smallstr())
 print(get_largestr())
 print(get_unicodestr())
+print("<\(get_emptystr())>")
 
 // Really load the globals from their addresses.
 @_optimize(none)
@@ -99,10 +124,12 @@ func print_strings_from_addressors() {
   print(S.smallstr)
   print(S.largestr)
   print(S.unicodestr)
+  print("<\(S.emptystr)>")
 }
 
 // CHECK-OUTPUT: abc123a
 // CHECK-OUTPUT: abc123asd3sdj3basfasdf
 // CHECK-OUTPUT: ❄️gastroperiodyni
+// CHECK-OUTPUT: <>
 print_strings_from_addressors()
 

--- a/validation-test/SILOptimizer/static_enums_fuzzing.swift
+++ b/validation-test/SILOptimizer/static_enums_fuzzing.swift
@@ -1,0 +1,362 @@
+// RUN: %empty-directory(%t) 
+// RUN: %swift_driver %s >%t/static_enums.swift
+
+// RUN: %target-build-swift -parse-as-library -O %t/static_enums.swift -module-name=test -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %t/static_enums.swift
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: swift_in_compiler
+
+// Note: This code is not the testfile itself but generates the testfile in the %t directory.
+
+createTestfile()
+
+func createTestfile() {
+  let globals = createGlobals(count: 500)
+
+  print(typeDefinitions)
+
+  for (idx, t) in globals.enumerated() {
+    print("public var global\(idx)var: \(t.getType()) = \(t.getInitValue())")
+  }
+
+  print()
+
+  for (idx, t) in globals.enumerated() {
+    print("""
+          @inline(never) func printGlobal\(idx)() {
+            print("global\(idx)var: \", global\(idx)var as Any)
+          }
+          """)
+  }
+
+  print(mainFunctionProlog)
+
+  for (idx, t) in globals.enumerated() {
+    print("""
+              // CHECK: global\(idx)var: \(t.getExpectedOutput(topLevel: true))
+              printGlobal\(idx)()
+          """)
+  }
+
+  print(mainFunctionEpilog)
+}
+
+func createGlobals(count: Int) -> [any Value] {
+  var globals = [any Value]()
+  var avoidDuplicates = Set<String>()
+
+  var generator = RandomGenerator()
+
+  var numCreated = 0
+  while numCreated < count {
+    let t = generator.createValue(depth: 3)
+    if t.containsEnum {
+      let key = "\(t.getType())=\(t.getInitValue())"
+      if avoidDuplicates.insert(key).inserted {
+        globals.append(t)
+        numCreated += 1
+      }
+    }
+  }
+  return globals
+}
+
+var typeDefinitions: String {
+  """
+    public struct S<T, V> {
+      var a: T
+      var b: V
+    }
+
+    public enum E {
+      case X, Y, Z
+    }
+
+    public enum MPE<T, V> {
+      case A(T)
+      case B(V)
+      case C
+    }
+
+  """
+}
+
+var mainFunctionProlog: String {
+  """
+
+  @main
+  struct Main {
+    static func main() {
+  """
+}
+
+var mainFunctionEpilog: String {
+  """
+    }
+  }
+  """
+}
+
+protocol Value {
+  init(generator: inout RandomGenerator, depth: Int)
+
+  func getType() -> String
+  func getInitValue() -> String
+  func getExpectedOutput(topLevel: Bool) -> String
+  func getRuntimeTypeName(topLevel: Bool) -> String
+  var containsEnum: Bool { get }
+}
+
+extension Value {
+  func getExpectedOutput(topLevel: Bool) -> String {
+    return getInitValue()
+  }
+  var containsEnum: Bool { false }
+}
+
+struct SmallInt : Value {
+
+  init(generator: inout RandomGenerator, depth: Int) {}
+
+  func getType() -> String { "Int8" }
+  func getInitValue() -> String  { "42" }
+  func getRuntimeTypeName(topLevel: Bool) -> String { topLevel ? "Int8" : "Swift.Int8" }
+}
+
+struct LargeInt : Value {
+
+  init(generator: inout RandomGenerator, depth: Int) {}
+
+  func getType() -> String { "Int64" }
+  func getInitValue() -> String  { "1311768468603649711" }
+  func getRuntimeTypeName(topLevel: Bool) -> String { topLevel ? "Int64" : "Swift.Int64" }
+}
+
+struct SmallString : Value {
+
+  init(generator: inout RandomGenerator, depth: Int) {}
+
+  func getType() -> String { "String" }
+  func getInitValue() -> String  { "\"small\"" }
+  func getRuntimeTypeName(topLevel: Bool) -> String { topLevel ? "String" : "Swift.String" }
+}
+
+struct LargeString : Value {
+
+  init(generator: inout RandomGenerator, depth: Int) {}
+
+  func getType() -> String { "String" }
+  func getInitValue() -> String  { "\"large string which exceeds the inline buffer\"" }
+  func getRuntimeTypeName(topLevel: Bool) -> String { topLevel ? "String" : "Swift.String" }
+}
+
+struct OptionalValue : Value {
+
+  let payload: any Value
+  let isSome: Bool
+
+  init(generator: inout RandomGenerator, depth: Int) {
+    self.isSome = Bool.random(using: &generator)
+    self.payload = generator.createValue(depth: depth)
+  }
+  
+
+  func getType() -> String {
+    payload.getType() + "?"
+  }
+
+  func getInitValue() -> String  {
+    if isSome {
+      if let plOpt = payload as? OptionalValue {
+        if !plOpt.isSome {
+          return "Optional(Optional(nil))"
+        }
+        return "Optional(\(payload.getInitValue()))"
+      } else {
+        return "\(payload.getInitValue())"
+      }
+    } else {
+      return "nil"
+    }
+  }
+
+  func getExpectedOutput(topLevel: Bool) -> String  {
+    if isSome {
+      return "Optional(\(payload.getExpectedOutput(topLevel: false)))"
+    } else {
+      return "nil"
+    }
+  }
+
+  func getRuntimeTypeName(topLevel: Bool) -> String {
+    let prefix = topLevel ? "" : "Swift."
+    return "\(prefix)Optional<\(payload.getRuntimeTypeName(topLevel: topLevel))>"
+  }
+
+  var containsEnum: Bool { true }
+}
+
+struct Struct : Value {
+
+  let a: any Value
+  let b: any Value
+
+  init(generator: inout RandomGenerator, depth: Int) {
+    self.a = generator.createValue(depth: depth)
+    self.b = generator.createValue(depth: depth)
+  }
+  
+
+  func getType() -> String {
+    "S<\(a.getType()), \(b.getType())>"
+  }
+
+  func getInitValue() -> String  {
+    "S(a: \(a.getInitValue()), b: \(b.getInitValue()))"
+  }
+
+  func getExpectedOutput(topLevel: Bool) -> String  {
+    "\(getRuntimeTypeName(topLevel: topLevel))(a: \(a.getExpectedOutput(topLevel: false)), b: \(b.getExpectedOutput(topLevel: false)))"
+  }
+
+  func getRuntimeTypeName(topLevel: Bool) -> String {
+    let prefix = topLevel ? "" : "test."
+    return "\(prefix)S<\(a.getRuntimeTypeName(topLevel: topLevel)), \(b.getRuntimeTypeName(topLevel: topLevel))>"
+  }
+
+  var containsEnum: Bool { a.containsEnum || b.containsEnum }
+}
+
+struct Enum : Value {
+  let caseIdx: Int
+  
+  init(generator: inout RandomGenerator, depth: Int) {
+    self.caseIdx = Int.random(in: 0..<3, using: &generator)
+  }
+  
+
+  func getType() -> String {
+    "E"
+  }
+
+  func getInitValue() -> String  {
+    "E.\(caseName)"
+  }
+
+  func getExpectedOutput(topLevel: Bool) -> String  {
+    let prefix = topLevel ? "" : "test.E."
+    return "\(prefix)\(caseName)"
+  }
+
+  func getRuntimeTypeName(topLevel: Bool) -> String {
+    let prefix = topLevel ? "" : "test."
+    return "\(prefix)E"
+  }
+
+  var containsEnum: Bool { true }
+
+  private var caseName: String {
+    switch caseIdx {
+      case 0: return "X"
+      case 1: return "Y"
+      case 2: return "Z"
+      default: fatalError()
+    }
+  }
+}
+
+struct MultiPayloadEnum : Value {
+  let payloadA: any Value
+  let payloadB: any Value
+  let caseIdx: Int
+  
+  init(generator: inout RandomGenerator, depth: Int) {
+    self.caseIdx = Int.random(in: 0..<3, using: &generator)
+    self.payloadA = generator.createValue(depth: depth)
+    self.payloadB = generator.createValue(depth: depth)
+  }
+  
+  func getType() -> String {
+    "MPE<\(payloadA.getType()), \(payloadB.getType())>"
+  }
+
+  func getInitValue() -> String  {
+    switch caseIdx {
+      case 0: return "MPE.A(\(payloadA.getInitValue()))"
+      case 1: return "MPE.B(\(payloadB.getInitValue()))"
+      case 2: return "MPE.C"
+      default: fatalError()
+    }
+  }
+
+  func getExpectedOutput(topLevel: Bool) -> String  {
+    let prefix = topLevel ? "" : "\(getRuntimeTypeName(topLevel: topLevel))."
+    switch caseIdx {
+      case 0: return "\(prefix)A(\(payloadA.getExpectedOutput(topLevel: false)))"
+      case 1: return "\(prefix)B(\(payloadB.getExpectedOutput(topLevel: false)))"
+      case 2: return "\(prefix)C"
+      default: fatalError()
+    }
+  }
+
+  func getRuntimeTypeName(topLevel: Bool) -> String {
+    let prefix = topLevel ? "" : "test."
+    return "\(prefix)MPE<\(payloadA.getRuntimeTypeName(topLevel: topLevel)), \(payloadB.getRuntimeTypeName(topLevel: topLevel))>"
+  }
+
+  var containsEnum: Bool { true }
+}
+
+// Can't use the default random generator becaus we need deterministic results
+struct RandomGenerator : RandomNumberGenerator {
+  var state: (UInt64, UInt64, UInt64, UInt64) = (15042304078070129153, 10706435816813474385, 14710304063852993123, 11070704559760783939)
+
+  mutating func next() -> UInt64 {
+    let result = rotl(state.1 &* 5, 7) &* 9
+
+    let t = state.1 << 17
+    state.2 ^= state.0
+    state.3 ^= state.1
+    state.1 ^= state.2
+    state.0 ^= state.3
+    state.2 ^= t
+    state.3 = rotl(state.3, 45)
+
+    return result
+  }
+
+  private func rotl(_ x: UInt64, _ k: UInt64) -> UInt64 {
+    return (x << k) | (x >> (64 &- k))
+  }
+
+  mutating func createValue(depth: Int) -> any Value {
+    if depth > 0 {
+      let idx = Int.random(in: 0..<Self.allValueTypes.count, using: &self)
+      return Self.allValueTypes[idx].init(generator: &self, depth: depth - 1)
+    } else {
+      let idx = Int.random(in: 0..<Self.allTerminalTypes.count, using: &self)
+      return Self.allTerminalTypes[idx].init(generator: &self, depth: 0)
+    }
+  }
+
+  private static let allValueTypes: [any Value.Type] = [
+    SmallInt.self,
+    LargeInt.self,
+    SmallString.self,
+    LargeString.self,
+    Enum.self,
+    OptionalValue.self,
+    Struct.self,
+    MultiPayloadEnum.self
+  ]
+
+  private static let allTerminalTypes: [any Value.Type] = [
+    SmallInt.self,
+    LargeInt.self,
+    SmallString.self,
+    LargeString.self,
+    Enum.self
+  ]
+}
+

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -144,6 +144,9 @@ config.swift_stdlib_enable_objc_interop = "@SWIFT_STDLIB_ENABLE_OBJC_INTEROP@" =
 # Configured in DarwinSDKs.cmake
 config.freestanding_sdk_name = "@SWIFT_SDK_FREESTANDING_LIB_SUBDIR@"
 
+if "@BOOTSTRAPPING_MODE@" != "OFF":
+  config.available_features.add('swift_in_compiler')
+
 # Let the main config do the real work.
 config.test_exec_root = os.path.dirname(os.path.realpath(__file__))
 lit_config.load_config(config, "@SWIFT_SOURCE_DIR@/validation-test/lit.cfg")


### PR DESCRIPTION
The main change in this PR is in IRGen which needs to be able to emit constant enum values.
Use `emitValueInjection` to create the enum constant. Usually this method creates code in the current function. But if all arguments to the enum are constant, the builder never has to emit an instruction. Instead it can constant fold everything and just returns the final constant.

This PR also contains a few other statically-initialized-global related improvements:
* create statically initialized let-globals as constant global (`constant` instead of `global`)
* simplification for the `init_enum_data_addr` instruction
* simplification for the `value_to_bridge_object` instruction

For details see the commit messages.

rdar://26521135