### PR TITLE
[Distributed] Explicitly ban __owned and other specifiers we don't support

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5085,6 +5085,9 @@ ERROR(distributed_actor_func_nonisolated, none,
 ERROR(distributed_actor_func_inout, none,
       "cannot declare 'inout' argument %0 in %1 %2",
       (DeclName, DescriptiveDeclKind, DeclName))
+ERROR(distributed_actor_func_unsupported_specifier, none,
+      "cannot declare '%0' argument %1 in %2 %3",
+      (StringRef, DeclName, DescriptiveDeclKind, DeclName))
 ERROR(distributed_actor_func_closure, none,
       "%0 %1 cannot declare closure arguments, as they cannot be serialized",
       (DescriptiveDeclKind, DeclName))

--- a/test/Distributed/distributed_actor_ban_owned_shared.swift
+++ b/test/Distributed/distributed_actor_ban_owned_shared.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+class Param: Codable {}
+
+distributed actor First {
+  distributed func owned(_: __owned Param) async throws {} // expected-error{{cannot declare '__owned' argument '_' in distributed instance method 'owned'}}
+  distributed func shared(_: __shared Param) async throws {} // expected-error{{cannot declare '__shared' argument '_' in distributed instance method 'shared'}}
+  distributed func consuming(_: consuming Param) async throws {}
+  // expected-error@-1{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+  // expected-error@-2{{parameter '' of type '<<error type>>' in distributed instance method does not conform to serialization requirement 'Codable'}}
+}
+
+func test(first: First) async throws {
+  try await first.owned(.init())
+  try await first.shared(.init())
+}


### PR DESCRIPTION
We'd actually get irgen issues today, so let's explicitly prevent those.

Resolves rdar://109225190