### PR TITLE
[5.8][CMake] Don't add an extraneous rpath to the swift-frontend

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -68,8 +68,6 @@ target_link_libraries(swift-frontend
 
 add_swift_parser_link_libraries(swift-frontend)
 
-_add_swift_runtime_link_flags(swift-frontend "../../lib" "")
-
 # Create a `swift-driver` executable adjacent to the `swift-frontend` executable
 # to ensure that `swiftc` forwards to the standalone driver when invoked.
 swift_create_early_driver_copies(swift-frontend)


### PR DESCRIPTION
Cherrypick of #64103

__Explanation:__ The 5.8 release has an incorrect relative runpath added to the compiler on linux, the second one:
```
> readelf -d swift-5.8-RELEASE-ubuntu20.04/usr/bin/swift-frontend | ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib/swift/linux:$ORIGIN/../../lib/swift/linux]
```
This pull fixes that, removing a mild security risk when running the compiler.

__Scope:__ Only affects the compiler runpath on linux

__Issue:__ None

__Risk:__ low, as it only removes an unused runpath for the linux compiler

__Testing:__ Passed all CI on trunk

__Reviewer:__ @edymtt