### PR TITLE
[Test] Use production available features in option-filtering.swift

### DIFF
--- a/test/ModuleInterface/option-filtering.swift
+++ b/test/ModuleInterface/option-filtering.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -O -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation -enable-experimental-feature StaticAssert -enable-experimental-feature VariadicGenerics
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -O -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature NoImplicitCopy
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE-NOT: -enable-experimental-feature LayoutStringValueWitnesses
 // CHECK-SWIFTINTERFACE-NOT: -enable-experimental-feature LayoutStringValueWitnessesInstantiation
 // CHECK-SWIFTINTERFACE: swift-module-flags-ignorable:
-// CHECK-SWIFTINTERFACE-SAME: -enable-experimental-feature StaticAssert
-// CHECK-SWIFTINTERFACE-SAME: -enable-experimental-feature VariadicGenerics
+// CHECK-SWIFTINTERFACE-SAME: -enable-experimental-feature MoveOnlyClasses
+// CHECK-SWIFTINTERFACE-SAME: -enable-experimental-feature NoImplicitCopy
 
 public func foo() { }


### PR DESCRIPTION
rdar://109832161

Some features used in this test were not available in production compilers, causing build failures.
