### PR TITLE
[Module printing] Don't print attached macros in generated interfaces

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -346,6 +346,9 @@ struct PrintOptions {
   /// prevent printing from doing "extra" work.
   bool PrintCurrentMembersOnly = false;
 
+  /// Whether to suppress printing of custom attributes that are expanded macros.
+  bool SuppressExpandedMacros = true;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {DAK_Transparent, DAK_Effects,
                                               DAK_FixedLayout,
@@ -653,6 +656,7 @@ struct PrintOptions {
     result.EnumRawValues = EnumRawValueMode::PrintObjCOnly;
     result.MapCrossImportOverlaysToDeclaringModule = true;
     result.PrintCurrentMembersOnly = false;
+    result.SuppressExpandedMacros = true;
     return result;
   }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -789,6 +789,15 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
     if (Options.excludeAttrKind(DA->getKind()))
       continue;
 
+    // If we're supposed to suppress expanded macros, check whether this is
+    // a macro.
+    if (Options.SuppressExpandedMacros) {
+      if (auto customAttr = dyn_cast<CustomAttr>(DA)) {
+        if (D->getResolvedMacro(const_cast<CustomAttr *>(customAttr)))
+          continue;
+      }
+    }
+
     // If this attribute is only allowed because this is a Clang decl, don't
     // print it.
     if (D && D->hasClangNode()

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -26,6 +26,7 @@ public struct PublicEquatable {
   public init() { }
 }
 
+// INTERFACE-NOT: @Equatable
 // INTERFACE: public struct PublicEquatable
 // INTERFACE: extension ModuleWithEquatable.PublicEquatable : Swift.Equatable
 

--- a/test/ModuleInterface/Observable.swift
+++ b/test/ModuleInterface/Observable.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-host-lib-dir/plugins -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library -disable-availability-checking
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: swift_swift_parser
+
+import _Observation
+
+// CHECK-NOT: @Observable
+// CHECK-NOT: @ObservationIgnored
+// CHECK-NOT: @ObservationTracked
+
+@Observable
+public class SomeClass {
+  public var field = 3
+  @ObservationIgnored public var ignored = 4
+}
+
+public func requiresObservable<T: Observable>(_: T) { }
+
+@inlinable func useObservable(sc: SomeClass) {
+  requiresObservable(sc)
+}


### PR DESCRIPTION
Macros are expanded as part of interface generation, so they shouldn't also be printed into the Swift interface.

Fixes rdar://109378191.
