### PR TITLE
[Macros] Fix existential diagnostics for declaration macro expansions

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5343,9 +5343,15 @@ void TypeChecker::checkExistentialTypes(Decl *decl) {
   } else if (auto *macroDecl = dyn_cast<MacroDecl>(decl)) {
     checkExistentialTypes(ctx, macroDecl->getGenericParams());
     checkExistentialTypes(ctx, macroDecl->getTrailingWhereClause());
+  } else if (auto *macroExpansionDecl = dyn_cast<MacroExpansionDecl>(decl)) {
+    ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/false);
+    macroExpansionDecl->getArgs()->walk(visitor);
+    for (auto *genArg : macroExpansionDecl->getGenericArgs())
+      genArg->walk(visitor);
   }
 
-  if (isa<TypeDecl>(decl) || isa<ExtensionDecl>(decl))
+  if (isa<TypeDecl>(decl) || isa<ExtensionDecl>(decl) ||
+      isa<MacroExpansionDecl>(decl))
     return;
 
   ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/false);

--- a/test/Macros/Inputs/freestanding_macro_library.swift
+++ b/test/Macros/Inputs/freestanding_macro_library.swift
@@ -2,7 +2,10 @@
 public macro structWithUnqualifiedLookup() = #externalMacro(module: "MacroDefinition", type: "DefineStructWithUnqualifiedLookupMacro")
 
 @freestanding(declaration)
-public macro anonymousTypes(public: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+public macro anonymousTypes(public: Bool = false, causeErrors: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+
+@freestanding(declaration)
+public macro introduceTypeCheckingErrors() = #externalMacro(module: "MacroDefinition", type: "IntroduceTypeCheckingErrorsMacro")
 
 @freestanding(declaration)
 public macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -189,3 +189,14 @@ struct MyStruct<T: MyProto> {
 #undefinedMacro { definitelyNotDefined }
 // expected-error@-1{{cannot find 'definitelyNotDefined' in scope}}
 // expected-error@-2{{no macro named 'undefinedMacro'}}
+
+@freestanding(declaration) macro genericUnary<T>(_: T) = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}
+// expected-note@-2{{'genericUnary' declared here}}
+
+struct SomeType {
+  #genericUnary<Equatable>(0 as Hashable)
+  // expected-error@-1{{use of protocol 'Equatable' as a type must be written 'any Equatable'}}
+  // expected-error@-2{{use of protocol 'Hashable' as a type must be written 'any Hashable'}}
+  // expected-error@-3{{external macro implementation type}}
+}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -147,6 +147,11 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:   func hello() -> String {
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
+// EXPAND_MACRO_DECL-NEXT: }
+// EXPAND_MACRO_DECL-NEXT: struct $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu1_: Equatable {
+// EXPAND_MACRO_DECL-NEXT:   static func == (lhs: Self, rhs: Self) -> Bool {
+// EXPAND_MACRO_DECL-NEXT:     false
+// EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-NEXT: }"
 
 //##-- cursor-info on attached macro


### PR DESCRIPTION
`TypeChecker::checkExistentialTypes` has decl-specific logic and backs out without invoking `ExistentialTypeVisitor` on `TypeDecl`s, but `MacroExpansionDecl` isn't a type decl and would fall into `ExistentialTypeVisitor` which will visit its expansion. The caller of `checkExistentialTypes` already visits auxiliary decls, so here we should only visit arguments and generic arguments of a macro.

Fixes a case where a declaration macro produces a type that conforms to a PAT. We now also run existential diagnostics on generic arguments on a `MacroExpansionDecl` that was previously not handled.

Note: I tried bailing out in `walkToDeclPre` but we should really visit macro arguments and generic arguments. Not walking expansions in `ExistentialTypeVisitor` is also not the right fix because we need to be able to visit macro expansions in arguments.

rdar://109779928