### PR TITLE
Fix case mismatch in test error message expectation

### DIFF
--- a/test/Distributed/distributed_actor_ban_owned_shared.swift
+++ b/test/Distributed/distributed_actor_ban_owned_shared.swift
@@ -15,7 +15,7 @@ distributed actor First {
   distributed func owned(_: __owned Param) async throws {} // expected-error{{cannot declare '__owned' argument '_' in distributed instance method 'owned'}}
   distributed func shared(_: __shared Param) async throws {} // expected-error{{cannot declare '__shared' argument '_' in distributed instance method 'shared'}}
   distributed func consuming(_: consuming Param) async throws {}
-  // expected-error@-1{{Copyable types cannot be 'consuming' or 'borrowing' yet}}
+  // expected-error@-1{{copyable types cannot be 'consuming' or 'borrowing' yet}}
   // expected-error@-2{{parameter '' of type '<<error type>>' in distributed instance method does not conform to serialization requirement 'Codable'}}
 }
 


### PR DESCRIPTION
`test/Distributed/distributed_actor_ban_owned_shared.swift` expects a test error message with a casing mismatch, so the test fails. This fixes it.

See other test expecting the same message:
https://github.com/apple/swift/blob/56fca834b2e3b2fe34b97a3998bb7d159edb7775/test/Parse/ownership_modifiers.swift#L21
See error message definition:
https://github.com/apple/swift/blob/56fca834b2e3b2fe34b97a3998bb7d159edb7775/include/swift/AST/DiagnosticsSema.def#L7158