### PR TITLE
[Serialization] Intro `-Rmodule-recovery` to remark on inconsistencies in swiftmodule files

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -878,7 +878,7 @@ ERROR(modularization_issue_decl_moved,Fatal,
       (bool, DeclName, Identifier, Identifier))
 ERROR(modularization_issue_decl_type_changed,Fatal,
       "reference to %select{top-level|type}0 %1 broken by a context change; "
-      "the details of %1 %select{from %2|}5 changed since building '%3'"
+      "the declaration kind of %1 %select{from %2|}5 changed since building '%3'"
       "%select{|, it was in %2 and is now found in %4}5",
       (bool, DeclName, Identifier, StringRef, Identifier, bool))
 ERROR(modularization_issue_decl_not_found,Fatal,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -238,6 +238,9 @@ namespace swift {
     /// Emit a remark after loading a module.
     bool EnableModuleLoadingRemarks = false;
 
+    /// Emit remarks about contextual inconsistencies in loaded modules.
+    bool EnableModuleRecoveryRemarks = false;
+
     /// Emit a remark when indexing a system module.
     bool EnableIndexingSystemModuleRemarks = false;
     

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -388,7 +388,10 @@ def emit_cross_import_remarks : Flag<["-"], "Rcross-import">,
 
 def remark_loading_module : Flag<["-"], "Rmodule-loading">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Emit a remark and file path of each loaded module">;
+  HelpText<"Emit remarks about loaded module">;
+def remark_module_recovery : Flag<["-"], "Rmodule-recovery">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit remarks about contextual inconsistencies in loaded modules">;
 
 def remark_indexing_system_module : Flag<["-"], "Rindexing-system-module">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -929,6 +929,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableCrossImportRemarks = Args.hasArg(OPT_emit_cross_import_remarks);
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
+  Opts.EnableModuleRecoveryRemarks = Args.hasArg(OPT_remark_module_recovery);
 
   Opts.EnableIndexingSystemModuleRemarks = Args.hasArg(OPT_remark_indexing_system_module);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7384,6 +7384,14 @@ llvm::Error ModuleFile::consumeExpectedError(llvm::Error &&error) {
 }
 
 void ModuleFile::diagnoseAndConsumeError(llvm::Error error) const {
+  auto &ctx = getContext();
+  if (ctx.LangOpts.EnableModuleRecoveryRemarks) {
+    error = diagnoseModularizationError(std::move(error),
+                                        DiagnosticBehavior::Remark);
+    // If error was already diagnosed it was also consumed.
+    if (!error)
+      return;
+  }
 
   consumeError(std::move(error));
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1458,7 +1458,7 @@ ModuleFile::getSubstitutionMapChecked(serialization::SubstitutionMapID id) {
   for (auto typeID : replacementTypeIDs) {
     auto typeOrError = getTypeChecked(typeID);
     if (!typeOrError) {
-      consumeError(typeOrError.takeError());
+      diagnoseAndConsumeError(typeOrError.takeError());
       continue;
     }
     replacementTypes.push_back(typeOrError.get());
@@ -1713,7 +1713,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
         if (maybeType.errorIsA<FatalDeserializationError>())
           return maybeType.takeError();
         // FIXME: Don't throw away the inner error's information.
-        consumeError(maybeType.takeError());
+        diagnoseAndConsumeError(maybeType.takeError());
         return llvm::make_error<XRefError>("couldn't decode type",
                                            pathTrace, name);
       }
@@ -2083,7 +2083,7 @@ giveUpFastPath:
             return maybeType.takeError();
 
           // FIXME: Don't throw away the inner error's information.
-          consumeError(maybeType.takeError());
+          diagnoseAndConsumeError(maybeType.takeError());
           return llvm::make_error<XRefError>("couldn't decode type",
                                              pathTrace, memberName);
         }
@@ -2922,7 +2922,7 @@ class DeclDeserializer {
 
       auto maybeType = MF.getTypeChecked(typeID);
       if (!maybeType) {
-        llvm::consumeError(maybeType.takeError());
+        MF.diagnoseAndConsumeError(maybeType.takeError());
         continue;
       }
       inheritedTypes.push_back(
@@ -3248,10 +3248,10 @@ public:
       return overriddenOrError.takeError();
     } else if (MF.allowCompilerErrors()) {
       // Drop overriding relationship when allowing errors.
-      llvm::consumeError(overriddenOrError.takeError());
+      MF.diagnoseAndConsumeError(overriddenOrError.takeError());
       overridden = nullptr;
     } else {
-      llvm::consumeError(overriddenOrError.takeError());
+      MF.diagnoseAndConsumeError(overriddenOrError.takeError());
       if (overriddenAffectsABI || !ctx.LangOpts.EnableDeserializationRecovery) {
         return llvm::make_error<OverrideError>(name, errorFlags,
                                                numVTableEntries);
@@ -3395,7 +3395,7 @@ public:
       if (overridden.errorIsA<FatalDeserializationError>())
         return overridden.takeError();
 
-      llvm::consumeError(overridden.takeError());
+      MF.diagnoseAndConsumeError(overridden.takeError());
 
       return llvm::make_error<OverrideError>(
           name, getErrorFlags(), numVTableEntries);
@@ -3507,7 +3507,7 @@ public:
 
         // FIXME: This is actually wrong. We can't just drop stored properties
         // willy-nilly if the struct is @frozen.
-        consumeError(backingDecl.takeError());
+        MF.diagnoseAndConsumeError(backingDecl.takeError());
         return var;
       }
 
@@ -3724,7 +3724,7 @@ public:
       overridden = overriddenOrError.get();
     } else {
       if (overriddenAffectsABI || !ctx.LangOpts.EnableDeserializationRecovery) {
-        llvm::consumeError(overriddenOrError.takeError());
+        MF.diagnoseAndConsumeError(overriddenOrError.takeError());
         return llvm::make_error<OverrideError>(name, errorFlags,
                                                numVTableEntries);
       }
@@ -3732,7 +3732,7 @@ public:
       if (overriddenOrError.errorIsA<FatalDeserializationError>())
         return overriddenOrError.takeError();
 
-      llvm::consumeError(overriddenOrError.takeError());
+      MF.diagnoseAndConsumeError(overriddenOrError.takeError());
       overridden = nullptr;
     }
 
@@ -4054,7 +4054,7 @@ public:
           return pattern.takeError();
 
         // Silently drop the pattern...
-        llvm::consumeError(pattern.takeError());
+        MF.diagnoseAndConsumeError(pattern.takeError());
         // ...but continue to read any further patterns we're expecting.
         continue;
       }
@@ -4572,7 +4572,7 @@ public:
       // Pass through deserialization errors.
       if (overridden.errorIsA<FatalDeserializationError>())
         return overridden.takeError();
-      llvm::consumeError(overridden.takeError());
+      MF.diagnoseAndConsumeError(overridden.takeError());
 
       DeclDeserializationError::Flags errorFlags;
       return llvm::make_error<OverrideError>(
@@ -5096,7 +5096,7 @@ llvm::Error DeclDeserializer::deserializeCustomAttrs() {
         // is safe to drop when it can't be deserialized.
         // rdar://problem/56599179. When allowing errors we're doing a best
         // effort to create a module, so ignore in that case as well.
-        consumeError(deserialized.takeError());
+        MF.diagnoseAndConsumeError(deserialized.takeError());
       } else
         return deserialized.takeError();
     } else if (!deserialized.get() && MF.allowCompilerErrors()) {
@@ -6028,7 +6028,7 @@ Expected<Type> DESERIALIZE_TYPE(NAME_ALIAS_TYPE)(
 
       // We're going to recover by falling back to the underlying type, so
       // just ignore the error.
-      llvm::consumeError(aliasOrError.takeError());
+      MF.diagnoseAndConsumeError(aliasOrError.takeError());
     }
 
     if (!alias || !alias->getDeclaredInterfaceType()->isEqual(underlyingType)) {
@@ -7355,7 +7355,7 @@ llvm::Error ModuleFile::consumeExpectedError(llvm::Error &&error) {
     if (error.isA<XRefNonLoadedModuleError>() ||
         error.isA<UnsafeDeserializationError>() ||
         error.isA<ModularizationError>()) {
-      consumeError(std::move(error));
+      diagnoseAndConsumeError(std::move(error));
       return llvm::Error::success();
     }
 
@@ -7369,7 +7369,7 @@ llvm::Error ModuleFile::consumeExpectedError(llvm::Error &&error) {
       if (TE->underlyingReasonIsA<XRefNonLoadedModuleError>() ||
           TE->underlyingReasonIsA<UnsafeDeserializationError>() ||
           TE->underlyingReasonIsA<ModularizationError>()) {
-        consumeError(std::move(errorInfo));
+        diagnoseAndConsumeError(std::move(errorInfo));
         return llvm::Error::success();
       }
 
@@ -7377,6 +7377,11 @@ llvm::Error ModuleFile::consumeExpectedError(llvm::Error &&error) {
     }
 
     return std::move(error);
+}
+
+void ModuleFile::diagnoseAndConsumeError(llvm::Error error) const {
+
+  consumeError(std::move(error));
 }
 
 namespace {
@@ -7447,7 +7452,7 @@ ModuleFile::loadAllConformances(const Decl *D, uint64_t contextData,
         // Ignore if allowing errors, it's just doing a best effort to produce
         // *some* module anyway.
         if (allowCompilerErrors())
-          consumeError(std::move(unconsumedError));
+          diagnoseAndConsumeError(std::move(unconsumedError));
         else
           fatal(std::move(unconsumedError));
       }
@@ -7537,7 +7542,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     if (maybeConformance) {
       reqConformances.push_back(maybeConformance.get());
     } else if (allowCompilerErrors()) {
-      consumeError(maybeConformance.takeError());
+      diagnoseAndConsumeError(maybeConformance.takeError());
       reqConformances.push_back(ProtocolConformanceRef::forInvalid());
     } else {
       fatal(maybeConformance.takeError());
@@ -7605,7 +7610,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       second = *secondOrError;
     } else if (getContext().LangOpts.EnableDeserializationRecovery) {
       second = ErrorType::get(getContext());
-      consumeError(secondOrError.takeError());
+      diagnoseAndConsumeError(secondOrError.takeError());
     } else {
       fatal(secondOrError.takeError());
     }
@@ -7615,7 +7620,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       third = cast_or_null<TypeDecl>(*thirdOrError);
     } else if (getContext().LangOpts.EnableDeserializationRecovery) {
       third = nullptr;
-      consumeError(thirdOrError.takeError());
+      diagnoseAndConsumeError(thirdOrError.takeError());
     } else {
       fatal(thirdOrError.takeError());
     }
@@ -7656,7 +7661,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     if (deserializedReq) {
       req = cast_or_null<ValueDecl>(*deserializedReq);
     } else if (getContext().LangOpts.EnableDeserializationRecovery) {
-      consumeError(deserializedReq.takeError());
+      diagnoseAndConsumeError(deserializedReq.takeError());
       req = nullptr;
       needToFillInOpaqueValueWitnesses = true;
     } else {
@@ -7673,7 +7678,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     // In that case, we want the conformance to still be available, but
     // we can't make use of the relationship to the underlying decl.
     } else if (getContext().LangOpts.EnableDeserializationRecovery) {
-      consumeError(deserializedWitness.takeError());
+      diagnoseAndConsumeError(deserializedWitness.takeError());
       isOpaque = true;
       witness = nullptr;
     } else {
@@ -7706,7 +7711,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       if (witnessSubstitutions.errorIsA<XRefNonLoadedModuleError>() ||
           witnessSubstitutions.errorIsA<UnsafeDeserializationError>() ||
           allowCompilerErrors()) {
-        consumeError(witnessSubstitutions.takeError());
+        diagnoseAndConsumeError(witnessSubstitutions.takeError());
         isOpaque = true;
       }
       else

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -328,7 +328,7 @@ void ModuleFile::lookupValue(DeclName name,
         if (!declOrError) {
           if (!getContext().LangOpts.EnableDeserializationRecovery)
             fatal(declOrError.takeError());
-          llvm::consumeError(declOrError.takeError());
+          diagnoseAndConsumeError(declOrError.takeError());
           continue;
         }
         auto VD = cast<ValueDecl>(declOrError.get());
@@ -347,7 +347,7 @@ void ModuleFile::lookupValue(DeclName name,
         if (!declOrError) {
           if (!getContext().LangOpts.EnableDeserializationRecovery)
             fatal(declOrError.takeError());
-          llvm::consumeError(declOrError.takeError());
+          diagnoseAndConsumeError(declOrError.takeError());
           continue;
         }
         auto VD = cast<ValueDecl>(declOrError.get());
@@ -589,7 +589,7 @@ void ModuleFile::lookupVisibleDecls(ImportPath::Access accessPath,
     if (!declOrError) {
       if (!getContext().LangOpts.EnableDeserializationRecovery)
         fatal(declOrError.takeError());
-      llvm::consumeError(declOrError.takeError());
+      diagnoseAndConsumeError(declOrError.takeError());
       return;
     }
     consumer.foundDecl(cast<ValueDecl>(declOrError.get()),
@@ -638,7 +638,7 @@ void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
       if (!declOrError) {
         if (!getContext().LangOpts.EnableDeserializationRecovery)
           fatal(declOrError.takeError());
-        llvm::consumeError(declOrError.takeError());
+        diagnoseAndConsumeError(declOrError.takeError());
       }
     }
   } else {
@@ -651,7 +651,7 @@ void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
       if (!declOrError) {
         if (!getContext().LangOpts.EnableDeserializationRecovery)
           fatal(declOrError.takeError());
-        llvm::consumeError(declOrError.takeError());
+        diagnoseAndConsumeError(declOrError.takeError());
       }
     }
   }
@@ -708,7 +708,7 @@ void ModuleFile::loadDerivativeFunctionConfigurations(
     if (!derivativeGenSigOrError) {
       if (!getContext().LangOpts.EnableDeserializationRecovery)
         fatal(derivativeGenSigOrError.takeError());
-      llvm::consumeError(derivativeGenSigOrError.takeError());
+      diagnoseAndConsumeError(derivativeGenSigOrError.takeError());
     }
     auto derivativeGenSig = derivativeGenSigOrError.get();
     // NOTE(TF-1038): Result indices are currently unsupported in derivative
@@ -882,7 +882,7 @@ void ModuleFile::lookupClassMembers(ImportPath::Access accessPath,
         if (!decl) {
           if (!getContext().LangOpts.EnableDeserializationRecovery)
             fatal(decl.takeError());
-          llvm::consumeError(decl.takeError());
+          diagnoseAndConsumeError(decl.takeError());
           continue;
         }
 
@@ -905,7 +905,7 @@ void ModuleFile::lookupClassMembers(ImportPath::Access accessPath,
         if (!decl) {
           if (!getContext().LangOpts.EnableDeserializationRecovery)
             fatal(decl.takeError());
-          llvm::consumeError(decl.takeError());
+          diagnoseAndConsumeError(decl.takeError());
           continue;
         }
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -341,6 +341,12 @@ private:
   template <typename T, typename ...Args>
   T *createDecl(Args &&... args);
 
+  Decl *handleErrorAndSupplyMissingMiscMember(llvm::Error &&error) const;
+
+  Decl *handleErrorAndSupplyMissingMember(ASTContext &context,
+                                          Decl *container,
+                                          llvm::Error &&error) const;
+
 public:
   /// Change the status of the current module.
   Status error(Status issue) {
@@ -404,6 +410,13 @@ public:
     return llvm::consumeError(diagnoseFatal(msg));
   }
 
+  /// Consume errors that are usually safe to ignore because they
+  /// are expected to support language features or caused by project
+  /// misconfigurations.
+  ///
+  /// If the error is handled, success is returned, otherwise the original
+  /// error is returned.
+  llvm::Error consumeExpectedError(llvm::Error &&error);
 
   /// Report an unexpected format error that could happen only from a
   /// memory-level inconsistency. Please prefer passing an error to

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -418,6 +418,10 @@ public:
   /// error is returned.
   llvm::Error consumeExpectedError(llvm::Error &&error);
 
+  /// Report project errors as remarks if desired, otherwise drop the error
+  /// silently.
+  void diagnoseAndConsumeError(llvm::Error error) const;
+
   /// Report an unexpected format error that could happen only from a
   /// memory-level inconsistency. Please prefer passing an error to
   /// `fatal(llvm::Error error)` when possible.

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -422,6 +422,12 @@ public:
   /// silently.
   void diagnoseAndConsumeError(llvm::Error error) const;
 
+  /// Report modularization error, either directly or indirectly if it
+  /// caused a \c TypeError or \c ExtensionError. Returns any unhandled errors.
+  llvm::Error
+  diagnoseModularizationError(llvm::Error error,
+                   DiagnosticBehavior limit = DiagnosticBehavior::Fatal) const;
+
   /// Report an unexpected format error that could happen only from a
   /// memory-level inconsistency. Please prefer passing an error to
   /// `fatal(llvm::Error error)` when possible.

--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t
+
+/// Compile two library modules A and A_related, and a middle library LibWithXRef with a reference to a type in A.
+// RUN: %target-swift-frontend %t/LibOriginal.swift -emit-module-path %t/A.swiftmodule -module-name A -I %t
+// RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related
+// RUN: %target-swift-frontend %t/LibWithXRef.swift -emit-module-path %t/sdk/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t -swift-version 5 -enable-library-evolution
+
+/// Move MyType from A to A_related, triggering most notes.
+// RUN: %target-swift-frontend %t/EmptyOverlay.swift -emit-module-path %t/A.swiftmodule -module-name A -I %t
+// RUN: %target-swift-frontend %t/LibOriginal.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related -I %t
+// RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk -swift-version 4 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK-MOVED %s
+
+/// Main error downgraded to a remark.
+// CHECK-MOVED: LibWithXRef.swiftmodule:1:1: remark: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
+//--- module.modulemap
+module A {
+    header "A.h"
+}
+
+//--- A.h
+void foo() {}
+
+//--- Empty.swift
+
+//--- EmptyOverlay.swift
+@_exported import A
+
+//--- LibOriginal.swift
+@_exported import A
+
+public struct MyType {
+    public init() {}
+}
+
+//--- LibWithXRef.swift
+import A
+import A_related
+
+public func foo() -> MyType {
+    fatalError()
+}
+
+//--- Client.swift
+import LibWithXRef
+
+foo()

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -19,14 +19,14 @@
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/B.swiftmodule -module-name B
 // RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-KIND-CHANGED %s
-// CHECK-KIND-CHANGED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the details of 'MyType' from 'A' changed since building 'LibWithXRef'
+// CHECK-KIND-CHANGED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the declaration kind of 'MyType' from 'A' changed since building 'LibWithXRef'
 
 /// Change MyType into a function and move it.
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A.swiftmodule -module-name A
 // RUN: %target-swift-frontend %t/LibTypeChanged.swift -emit-module-path %t/B.swiftmodule -module-name B
 // RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-KIND-CHANGED-AND-MOVED %s
-// CHECK-KIND-CHANGED-AND-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the details of 'MyType' changed since building 'LibWithXRef', it was in 'A' and is now found in 'B'
+// CHECK-KIND-CHANGED-AND-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the declaration kind of 'MyType' changed since building 'LibWithXRef', it was in 'A' and is now found in 'B'
 
 /// Remove MyType from all imported modules.
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A.swiftmodule -module-name A


### PR DESCRIPTION
Deserialization recovery is a long standing feature designed to support reading from swiftmodule files despite small context changes. It is expected for recovery to drop errors related to Swift language version differences or cross-references to implementation-only imported modules. However, it also attempts to recover from project configuration issues, which can lead to unexpected behavior like silently dropping a function because it relies on a type that can't be deserialized. These issues used to be hard to investigate for the general developer.

To improve the situation, this PR introduces the flag `-Rmodule-recovery` that will display remarks when recovery drops a decl for any reason.

This follows #65713 that introduced the errors that can now be also displayed as remarks. Next I'll add contextual notes and try to improve how we display these diagnostics.