### PR TITLE
[5.9] Fix LowerAggregateInstrs to avoid lowering move-only types

### DIFF
--- a/test/SILOptimizer/loweraggregateinstrs_moveonly.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_moveonly.sil
@@ -1,0 +1,32 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -lower-aggregate-instrs %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+struct S : ~Copyable {
+  deinit {}
+}
+struct S2 : ~Copyable {
+  var s1 = S()
+  var s2 = S()
+}
+
+// Test that a struct-with-deinit is not expanded. Doing so would
+// forget the deinit.
+//
+// public func testDeinitTwo() {
+//   var s = S2()
+// }
+//
+// CHECK-LABEL: sil @testDeinitTwo : $@convention(thin) () -> () {
+// CHECK:         release_value %{{.*}} : $S2
+// CHECK-LABEL: } // end sil function 'testDeinitTwo'
+sil @testDeinitTwo : $@convention(thin) () -> () {
+bb0:
+  %0 = struct $S ()
+  %1 = struct $S2 (%0 : $S, %0 : $S)
+  release_value %1 : $S2
+  %5 = tuple ()
+  return %5 : $()
+}


### PR DESCRIPTION
Fixes rdar://109849028 ([move-only] LowerAggregateInstrs eliminates struct deinitialization)

(cherry picked from commit 95f551e4a047409fea82f12f60f95f2246e7215a)

- Explanation: LowerAggregateInstrs converts aggregate destroys and releases into memberwise destroys and releases. Doing so deletes struct deinitializers.

- Scope of Issue: A struct's deinit would silently fail to run when the struct was a member within another type. In the most trivial cases, with no type composition, and earlier MoveOnlyDeinitInsertion pass was hiding the problem.

- Risk: Zero risk to regular copyable code. And non-copyable was already broken.

- PR to main: https://github.com/apple/swift/pull/66142

- Reviewed By: Michael Gottesman

- Resolves: rdar://109849028 ([move-only] LowerAggregateInstrs eliminates struct deinitialization)
