### PR TITLE
[5.9 🍒][Dependency Scannning] Handle special case import of Clang Private "submodules"

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -525,7 +525,18 @@ public:
   /// Add a dependency on the given module, if it was not already in the set.
   void addModuleImport(ImportPath::Module module,
                        llvm::StringSet<> *alreadyAddedModules = nullptr) {
-    addModuleImport(module.front().Item.str(), alreadyAddedModules);
+    std::string ImportedModuleName = module.front().Item.str().str();
+    auto submodulePath = module.getSubmodulePath();
+    if (submodulePath.size() > 0 && !submodulePath[0].Item.empty()) {
+      assert(submodulePath.size() == 1 && "Unsupported Clang submodule import");
+      auto submoduleComponent = submodulePath[0];
+      // Special case: a submodule named "Foo.Private" can be moved to a top-level
+      // module named "Foo_Private". ClangImporter has special support for this.
+      if (submoduleComponent.Item.str() == "Private")
+        ImportedModuleName = ImportedModuleName + "_Private";
+    }
+
+    addModuleImport(ImportedModuleName, alreadyAddedModules);
   }
 
   /// Add all of the module imports in the given source

--- a/test/ScanDependencies/Inputs/CHeaders/X_Private.h
+++ b/test/ScanDependencies/Inputs/CHeaders/X_Private.h
@@ -1,0 +1,1 @@
+void funcXPrivate(void);

--- a/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/module.modulemap
@@ -42,3 +42,7 @@ module X {
   header "X.h"
   export *
 }
+module X_Private {
+  header "X_Private.h"
+  export *
+}

--- a/test/ScanDependencies/module_deps_clang_private_submodule.swift
+++ b/test/ScanDependencies/module_deps_clang_private_submodule.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache %s -o %t.deps.json -I %S/Inputs/CHeaders
+
+// RUN: %FileCheck %s < %t.deps.json
+// CHECK: "clang": "X_Private"
+import X.Private
+


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66148
---------------------------------------
There is a special case that already exists in 'ClangImporter' for implicit module loading: Import of a "submodule" named "Foo.Private" is treated as a top-level module named "Foo_Private". Clang has special support for this.

• **Release**: Swift 5.9
• **Explanation**: There is a special case that already exists in `ClangImporter` for implicit module loading: Import of a "submodule" named `Foo.Private` is treated as a top-level module named `Foo_Private`. Clang has special support for this. The dependency scanner didn't know this, so imports of `Foo.Private` instead got treated as imports of `Foo` resulting in scanning result containing incorrect result compared to what the loading compilation will expect. 
• **Scope of Issue**: Explicit module builds of projects whose source contains this kind of import will not work. 
• **Origination**: This was a missed special case in the dependency scanner implementation
• **Risk**: Minimal, this is an additive change to make sure such import statements are correctly resolved to the expected Clang top-level `_Private` module.

Resolves rdar://108287140
