### PR TITLE
[5.9] [Macros] Fix existential diagnostics for declaration macro expansions

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5335,9 +5335,15 @@ void TypeChecker::checkExistentialTypes(Decl *decl) {
   } else if (auto *macroDecl = dyn_cast<MacroDecl>(decl)) {
     checkExistentialTypes(ctx, macroDecl->getGenericParams());
     checkExistentialTypes(ctx, macroDecl->getTrailingWhereClause());
+  } else if (auto *macroExpansionDecl = dyn_cast<MacroExpansionDecl>(decl)) {
+    ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/false);
+    macroExpansionDecl->getArgs()->walk(visitor);
+    for (auto *genArg : macroExpansionDecl->getGenericArgs())
+      genArg->walk(visitor);
   }
 
-  if (isa<TypeDecl>(decl) || isa<ExtensionDecl>(decl))
+  if (isa<TypeDecl>(decl) || isa<ExtensionDecl>(decl) ||
+      isa<MacroExpansionDecl>(decl))
     return;
 
   ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/false);

--- a/test/Macros/Inputs/freestanding_macro_library.swift
+++ b/test/Macros/Inputs/freestanding_macro_library.swift
@@ -2,7 +2,10 @@
 public macro structWithUnqualifiedLookup() = #externalMacro(module: "MacroDefinition", type: "DefineStructWithUnqualifiedLookupMacro")
 
 @freestanding(declaration)
-public macro anonymousTypes(public: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+public macro anonymousTypes(public: Bool = false, causeErrors: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+
+@freestanding(declaration)
+public macro introduceTypeCheckingErrors() = #externalMacro(module: "MacroDefinition", type: "IntroduceTypeCheckingErrorsMacro")
 
 @freestanding(declaration)
 public macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -189,3 +189,14 @@ struct MyStruct<T: MyProto> {
 #undefinedMacro { definitelyNotDefined }
 // expected-error@-1{{cannot find 'definitelyNotDefined' in scope}}
 // expected-error@-2{{no macro named 'undefinedMacro'}}
+
+@freestanding(declaration) macro genericUnary<T>(_: T) = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}
+// expected-note@-2{{'genericUnary' declared here}}
+
+struct SomeType {
+  #genericUnary<Equatable>(0 as Hashable)
+  // expected-error@-1{{use of protocol 'Equatable' as a type must be written 'any Equatable'}}
+  // expected-error@-2{{use of protocol 'Hashable' as a type must be written 'any Hashable'}}
+  // expected-error@-3{{external macro implementation type}}
+}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -147,6 +147,11 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:   func hello() -> String {
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
+// EXPAND_MACRO_DECL-NEXT: }
+// EXPAND_MACRO_DECL-NEXT: struct $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu1_: Equatable {
+// EXPAND_MACRO_DECL-NEXT:   static func == (lhs: Self, rhs: Self) -> Bool {
+// EXPAND_MACRO_DECL-NEXT:     false
+// EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-NEXT: }"
 
 //##-- cursor-info on attached macro


### PR DESCRIPTION
Cherry-pick of #66132

---

* **Explanation**: Declarations produced by freestanding declaration macros were incorrectly rejected when they declared a conformance to a "PAT" protocol.
* **Scope**: Existential type checking
* **Risk**: Low. This prevented `ExistentialTypeVisitor` from visiting macro-expanded decls as childrens of a `MacroExpansionDecl`. They'd be checked as auxiliary decls by `checkExistentialTypes` instead, just like other decls.
* **Testing**: Added test cases that cover macro expansions, nested macro expansions, macro arguments, and macro generic arguments.
* **Issue**: rdar://109779928
* **Reviewers**: @DougGregor