### PR TITLE
[AST] NFC: Fold `PackConformance::isInvalid` into `ProtocolConformanceRef::isInvalid`

### DIFF
--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -89,9 +89,7 @@ public:
   static ProtocolConformanceRef forMissingOrInvalid(
       Type type, ProtocolDecl *proto);
 
-  bool isInvalid() const {
-    return !Union;
-  }
+  bool isInvalid() const;
 
   explicit operator bool() const { return !isInvalid(); }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1827,11 +1827,8 @@ static ProtocolConformanceRef getPackTypeConformance(
     patternConformances.push_back(patternConformance);
   }
 
-  auto *conformance = PackConformance::get(type, protocol, patternConformances);
-  if (conformance->isInvalid())
-    return ProtocolConformanceRef::forInvalid();
-
-  return ProtocolConformanceRef(conformance);
+  return ProtocolConformanceRef(
+      PackConformance::get(type, protocol, patternConformances));
 }
 
 ProtocolConformanceRef

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -249,9 +249,6 @@ PackConformance::subst(InFlightSubstitution &IFS) const {
 
   auto substConformance = PackConformance::get(substConformingType, Protocol,
                                                expander.substConformances);
-  if (substConformance->isInvalid())
-    return ProtocolConformanceRef::forInvalid();
-
   return ProtocolConformanceRef(substConformance);
 }
 

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -42,6 +42,16 @@ ProtocolConformanceRef::ProtocolConformanceRef(ProtocolDecl *protocol,
   }
 }
 
+bool ProtocolConformanceRef::isInvalid() const {
+  if (!Union)
+    return true;
+
+  if (auto pack = Union.dyn_cast<PackConformance *>())
+    return pack->isInvalid();
+
+  return false;
+}
+
 ProtocolDecl *ProtocolConformanceRef::getRequirement() const {
   assert(!isInvalid());
 


### PR DESCRIPTION
Instead of making callers responsible for that (like in other cases), 
let's fold the code check `isInvalid` to make mistakes less likely.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
