### PR TITLE
IRGen: Avoid emitting resilient tag indices for unavailable enum cases

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5494,6 +5494,8 @@ static Address getAddrOfSimpleVariable(IRGenModule &IGM,
 /// The result is always a GlobalValue.
 Address IRGenModule::getAddrOfFieldOffset(VarDecl *var,
                                           ForDefinition_t forDefinition) {
+  assert(!Lowering::shouldSkipLowering(var));
+
   LinkEntity entity = LinkEntity::forFieldOffset(var);
   return getAddrOfSimpleVariable(*this, GlobalVars, entity,
                                  forDefinition);
@@ -5501,6 +5503,8 @@ Address IRGenModule::getAddrOfFieldOffset(VarDecl *var,
 
 Address IRGenModule::getAddrOfEnumCase(EnumElementDecl *Case,
                                        ForDefinition_t forDefinition) {
+  assert(!Lowering::shouldSkipLowering(Case));
+
   LinkEntity entity = LinkEntity::forEnumCase(Case);
   auto addr = getAddrOfSimpleVariable(*this, GlobalVars, entity, forDefinition);
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -263,6 +263,9 @@ EnumImplStrategy::getTagIndex(EnumElementDecl *Case) const {
 static void emitResilientTagIndex(IRGenModule &IGM,
                                   const EnumImplStrategy *strategy,
                                   EnumElementDecl *Case) {
+  if (Lowering::shouldSkipLowering(Case))
+    return;
+
   auto resilientIdx = strategy->getTagIndex(Case);
   auto *global = cast<llvm::GlobalVariable>(
     IGM.getAddrOfEnumCase(Case, ForDefinition).getAddress());

--- a/test/IRGen/unavailable_decl_optimization_complete_enum.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_enum.swift
@@ -1,14 +1,27 @@
 // RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -enable-library-evolution %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP,CHECK-RESILIENT,CHECK-NO-STRIP-RESILIENT
 
 // RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -enable-library-evolution -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP,CHECK-RESILIENT,CHECK-STRIP-RESILIENT
 
 // CHECK: private constant [27 x i8] c"availableEnumAvailableCase\00"
 
 // FIXME: Should this reflection metadata for an unavailable case be stripped?
 // CHECK: private constant [29 x i8] c"availableEnumUnavailableCase\00"
 
+// CHECK-NO-STRIP-RESILIENT: @"$s4Test13AvailableEnumO09availableC34UnavailableCaseWithAssociatedValueyAcA0E6StructVcACmFWC" = {{.*}}constant
+// CHECK-STRIP-RESILIENT-NOT: @"$s4Test13AvailableEnumO09availableC34UnavailableCaseWithAssociatedValueyAcA0E6StructVcACmFWC" =
+
+// CHECK-RESILIENT: @"$s4Test13AvailableEnumO09availablecB4CaseyA2CmFWC" = {{.*}}constant
+
+// CHECK-NO-STRIP-RESILIENT: @"$s4Test13AvailableEnumO09availableC15UnavailableCaseyA2CmFWC" = {{.*}}constant
+// CHECK-STRIP-RESILIENT-NOT: @"$s4Test13AvailableEnumO09availableC15UnavailableCaseyA2CmFWC" =
+
 // CHECK-NO-STRIP: private constant [25 x i8] c"unavailableEnumFirstCase\00"
 // CHECK-STRIP-NOT: private constant [25 x i8] c"unavailableEnumFirstCase\00"
+
+// CHECK-NO-STRIP-RESILIENT: @"$s4Test15UnavailableEnumO011unavailableC9FirstCaseyA2CmFWC" = {{.*}}constant
+// CHECK-STRIP-RESILIENT-NOT: @"$s4Test15UnavailableEnumO011unavailableC9FirstCaseyA2CmFWC"
 
 @available(*, unavailable)
 public struct UnavailableStruct {}
@@ -38,15 +51,6 @@ public enum UnavailableEnum {
   // CHECK-NO-STRIP: s4Test15UnavailableEnumO6methodyyF
   // CHECK-STRIP-NOT: s4Test15UnavailableEnumO6methodyyF
   public func method() {}
-
-  // CHECK-NO-STRIP: s4Test15UnavailableEnumO21__derived_enum_equalsySbAC_ACtFZ
-  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO21__derived_enum_equalsySbAC_ACtFZ
-
-  // CHECK-NO-STRIP: s4Test15UnavailableEnumO4hash4intoys6HasherVz_tF
-  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO4hash4intoys6HasherVz_tF
-
-  // CHECK-NO-STRIP: s4Test15UnavailableEnumO9hashValueSivg
-  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO9hashValueSivg
 }
 
 // CHECK: s4Test13AvailableEnumOwug


### PR DESCRIPTION
When `-unavailable-decl-optimization=complete` is specified, skip emission of resilient tag indices for enum cases that are marked unavailable with `@available`.

Resolves rdar://109805050
