### PR TITLE
[stdlib] performance optimizations in `Array.replaceSubrange`

### DIFF
--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -177,14 +177,19 @@ extension _ArrayBufferProtocol {
 
     // place the values into the hole we created
     if newCount > 0 {
-      var place = holeStart
-      var i = newValues.startIndex
-      while place < holeEnd {
-        place.initialize(to: newValues[i])
-        place += 1
-        newValues.formIndex(after: &i)
+      let done: Void? = newValues.withContiguousStorageIfAvailable {
+        holeStart.initialize(from: $0.baseAddress!, count: newCount)
       }
-      _expectEnd(of: newValues, is: i)
+      if done == nil {
+        var place = holeStart
+        var i = newValues.startIndex
+        while place < holeEnd {
+          place.initialize(to: newValues[i])
+          place += 1
+          newValues.formIndex(after: &i)
+        }
+        _expectEnd(of: newValues, is: i)
+      }
     }
   }
 }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -169,11 +169,10 @@ extension _ArrayBufferProtocol {
     }
 
     // resize the hole to make it the correct size
-    if growth != 0 {
-      let tailStart = elements + subrange.upperBound
-      let tailCount = oldCount - subrange.upperBound
-      holeEnd.moveInitialize(from: tailStart, count: tailCount)
-    }
+    // safe to always call, moveInitialize to the same location is a no-op
+    let tailStart = elements + subrange.upperBound
+    let tailCount = oldCount - subrange.upperBound
+    holeEnd.moveInitialize(from: tailStart, count: tailCount)
 
     // place the values into the hole we created
     if newCount > 0 {

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -172,9 +172,12 @@ extension _ArrayBufferProtocol {
 
     // place the values into the hole we created
     var place = holeStart
-    for element in newValues {
-      place.initialize(to: element)
+    var i = newValues.startIndex
+    while place < holeEnd {
+      place.initialize(to: newValues[i])
       place += 1
+      newValues.formIndex(after: &i)
     }
+    _expectEnd(of: newValues, is: i)
   }
 }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -163,21 +163,28 @@ extension _ArrayBufferProtocol {
     // erase all the elements we're replacing to create a hole
     let holeStart = elements + subrange.lowerBound
     let holeEnd = holeStart + newCount
-    holeStart.deinitialize(count: eraseCount)
+
+    if eraseCount > 0 {
+      holeStart.deinitialize(count: eraseCount)
+    }
 
     // resize the hole to make it the correct size
-    let tailStart = elements + subrange.upperBound
-    let tailCount = oldCount - subrange.upperBound
-    holeEnd.moveInitialize(from: tailStart, count: tailCount)
+    if growth != 0 {
+      let tailStart = elements + subrange.upperBound
+      let tailCount = oldCount - subrange.upperBound
+      holeEnd.moveInitialize(from: tailStart, count: tailCount)
+    }
 
     // place the values into the hole we created
-    var place = holeStart
-    var i = newValues.startIndex
-    while place < holeEnd {
-      place.initialize(to: newValues[i])
-      place += 1
-      newValues.formIndex(after: &i)
+    if newCount > 0 {
+      var place = holeStart
+      var i = newValues.startIndex
+      while place < holeEnd {
+        place.initialize(to: newValues[i])
+        place += 1
+        newValues.formIndex(after: &i)
+      }
+      _expectEnd(of: newValues, is: i)
     }
-    _expectEnd(of: newValues, is: i)
   }
 }

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -164,9 +164,9 @@ extension _ArrayBufferProtocol {
     let holeStart = elements + subrange.lowerBound
     let holeEnd = holeStart + newCount
 
-    if eraseCount > 0 {
-      holeStart.deinitialize(count: eraseCount)
-    }
+    // directly forwards to Builtin.destroyArray
+    // TODO: should we branch here or does the compiler branch implicitly?
+    holeStart.deinitialize(count: eraseCount)
 
     // resize the hole to make it the correct size
     // safe to always call, moveInitialize to the same location is a no-op


### PR DESCRIPTION
This PR is intended to generally improve performance for replaceSubrange.

Currently, it simplifies the main codepath to avoid unneeded branches.
Additional plans:

- [ ] write benchmarks for replaceSubrange in a variety of contexts (replacing 1 element, 10%, 50%, and 100%, and growing/shrinking)
- [ ] add an additional branch for replaceSubrange that doesn't modify an existing Array in place and instead constructs a new Array with copy/move (for non-unique / growth cases)