### PR TITLE
[5.9] Fix SILCombine to preserve a release of a move-only type

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2311,6 +2311,8 @@ namespace {
       return handleReference(classType, properties);
     }
 
+    // WARNING: when the specification of trivial types changes, also update
+    // the isValueTrivial() API used by SILCombine.
     TypeLowering *visitAnyStructType(CanType structType,
                                      AbstractionPattern origType,
                                      StructDecl *D,
@@ -2379,7 +2381,9 @@ namespace {
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
                                                                     properties);
     }
-        
+
+    // WARNING: when the specification of trivial types changes, also update
+    // the isValueTrivial() API used by SILCombine.
     TypeLowering *visitAnyEnumType(CanType enumType,
                                    AbstractionPattern origType,
                                    EnumDecl *D,

--- a/test/SILOptimizer/sil_combine_moveonly.sil
+++ b/test/SILOptimizer/sil_combine_moveonly.sil
@@ -1,0 +1,28 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+
+ sil_stage canonical
+
+ import Builtin
+
+ struct S : ~Copyable {
+   deinit {}
+ }
+
+ // Test that a release_value is not removed for a struct-with-deinit.
+ // Doing so would forget the deinit.
+ //
+ // public func testStructDeinit() {
+ //   var s = S()
+ // }
+ //
+ // CHECK-LABEL: sil @testStructDeinit : $@convention(thin) () -> () {
+ // CHECK:         release_value %{{.*}} : $S
+ // CHECK-LABEL: } // end sil function 'testStructDeinit'
+ sil @testStructDeinit : $@convention(thin) () -> () {
+ bb0:
+   %0 = struct $S ()
+   release_value %0 : $S
+   %5 = tuple ()
+   return %5 : $()
+ }
+ 


### PR DESCRIPTION
The release needs to be preserved in case a user-defined deinit is present in the released type. Checking for move-only is slightly conservative.

Fixes rdar://109846094 ([move-only] SILCombine eliminates struct deinitialization)

(cherry picked from commit dc974e8c00d923474905d9c41d6b71bc045751d9)

- Explanation: SILCombine removes releases of aggregates whose members don't contain any references. This deletes struct deinitializers, so they silently never run.

- Scope of Issue: A struct's deinit would silently fail to run when the struct was a member within another type. In the most trivial cases, with no type composition, and earlier MoveOnlyDeinitInsertion pass was hiding the problem.

- Risk: Zero risk to regular copyable code. And non-copyable was already broken.

- PR to main: https://github.com/apple/swift/pull/66161

- Reviewed By: Michael Gottesman

- Resolves: rdar://109846094 ([move-only] SILCombine eliminates struct deinitialization)
