### PR TITLE
[test] Replace swift_obj_root for alternates that work in LLVM unified builds

### DIFF
--- a/test/Concurrency/fail_implicit_concurrency_load.swift
+++ b/test/Concurrency/fail_implicit_concurrency_load.swift
@@ -5,8 +5,8 @@
 // REQUIRES: concurrency
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/inputs
-// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
 
 // RUN: echo "[{" > %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
@@ -16,13 +16,13 @@
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/SwiftShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"_SwiftConcurrencyShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/_SwiftConcurrencyShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json

--- a/test/Demangle/objc-getclass.cpp
+++ b/test/Demangle/objc-getclass.cpp
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang %s -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -lswiftCore -lobjc -o %t/objc-getclass
+// RUN: %target-clang %s -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -lswiftCore -lobjc -o %t/objc-getclass
 // RUN: %target-codesign %t/objc-getclass
 // RUN: %target-run %t/objc-getclass %S/Inputs/objc-getclass.txt
 

--- a/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
+++ b/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
@@ -5,9 +5,9 @@
 
 // REQUIRES: shell
 // RUN: %{python} -c 'for i in range(500001): print("-DTEST5_" + str(i))' > %t.resp
-// RUN: cp %S/Inputs/print-args.sh %swift_obj_root/bin/legacy-driver-propagates-response-file.sh
+// RUN: cp %S/Inputs/print-args.sh %swift-bin-dir/legacy-driver-propagates-response-file.sh
 // RUN: env SWIFT_USE_NEW_DRIVER=legacy-driver-propagates-response-file.sh %swiftc_driver_plain %s @%t.resp | %FileCheck %s
-// RUN: rm %swift_obj_root/bin/legacy-driver-propagates-response-file.sh
+// RUN: rm %swift-bin-dir/legacy-driver-propagates-response-file.sh
 
 // CHECK:      -Xfrontend
 // CHECK-NEXT: -new-driver-path

--- a/test/Frontend/module-alias-explicit-build.swift
+++ b/test/Frontend/module-alias-explicit-build.swift
@@ -7,8 +7,8 @@
 /// Create a module Bar
 // RUN: echo 'public func bar() {}' > %t/inputs/FileBar.swift
 // RUN: %target-swift-frontend -module-name Bar %t/inputs/FileBar.swift -emit-module -emit-module-path %t/inputs/Bar.swiftmodule
-// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
 
 /// Check Bar.swiftmodule is created
 // RUN: test -f %t/inputs/Bar.swiftmodule
@@ -39,13 +39,13 @@
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/SwiftShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"_SwiftConcurrencyShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/_SwiftConcurrencyShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json

--- a/test/IRGen/conditional-dead-strip-exec.swift
+++ b/test/IRGen/conditional-dead-strip-exec.swift
@@ -5,7 +5,7 @@
 
 // RUN: %target-build-swift -Xfrontend -conditional-runtime-records %s -emit-ir -o %t/main.ll
 
-// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/conditional-dead-strip-reflection.swift
+++ b/test/IRGen/conditional-dead-strip-reflection.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -conditional-runtime-records %s -emit-ir -o %t/main.ll
-// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-swift-reflection-dump %t/main | %FileCheck %s
 
 // FIXME(mracek): More work needed to get this to work on non-Apple platforms.

--- a/test/IRGen/virtual-function-elimination-exec.swift
+++ b/test/IRGen/virtual-function-elimination-exec.swift
@@ -4,7 +4,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -enable-llvm-vfe %s -Onone -emit-ir -o %t/main.ll
-// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/virtual-function-elimination-generics-exec.swift
+++ b/test/IRGen/virtual-function-elimination-generics-exec.swift
@@ -4,7 +4,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -enable-llvm-vfe %s -Onone -emit-ir -o %t/main.ll
-// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/witness-method-elimination-exec-relative.swift
+++ b/test/IRGen/witness-method-elimination-exec-relative.swift
@@ -4,7 +4,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -enable-llvm-wme %s -Onone -emit-ir -o %t/main.ll -Xfrontend -enable-relative-protocol-witness-tables
-// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/IRGen/witness-method-elimination-exec.swift
+++ b/test/IRGen/witness-method-elimination-exec.swift
@@ -4,7 +4,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -enable-llvm-wme %s -Onone -emit-ir -o %t/main.ll
-// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Interpreter/lto_static_lib.swift
+++ b/test/Interpreter/lto_static_lib.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -parse-as-library -lto=llvm-thin %s -emit-bc -o %t/a.o %lto_flags
 // RUN: ar -r -s %t/archive.a %t/a.o
-// RUN: %target-clang %t/archive.a -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-clang %t/archive.a -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name -flto -o %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/PrintAsObjC/compatibility-symbols.swift
+++ b/test/PrintAsObjC/compatibility-symbols.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -emit-objc-header-path %t/empty.h
-// RUN: %clang -extract-api -o %t/empty.symbols.json --target=%target-triple -isysroot %clang-importer-sdk-path -F %clang-importer-sdk-path/frameworks --extract-api-ignores=%swift_obj_root/share/swift/compatibility-symbols -fmodules -x objective-c-header %t/empty.h
+// RUN: %clang -extract-api -o %t/empty.symbols.json --target=%target-triple -isysroot %clang-importer-sdk-path -F %clang-importer-sdk-path/frameworks --extract-api-ignores=%swift-share-dir/swift/compatibility-symbols -fmodules -x objective-c-header %t/empty.h
 // RUN: %FileCheck %s --input-file %t/empty.symbols.json
 
 // REQUIRES: objc_interop

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -5,7 +5,7 @@
 // RUN: touch %t/swift-root/libexec/swift/Foo.exe
 // RUN: touch %t/swift-root/bin/Foo.exe
 
-// RUN: %target-clang %s -std=c++11 -I %swift_src_root/include -I %swift_obj_root/include -I %swift_src_root/stdlib/public/SwiftShims -I %clang-include-dir -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name/%target-arch -L%llvm_obj_root/lib/swift/%target-sdk-name/%target-arch -lswiftCore -o %t/paths-test
+// RUN: %target-clang %s -std=c++11 -I %swift_src_root/include -I %swift_obj_root/include -I %swift_src_root/stdlib/public/SwiftShims -I %clang-include-dir -isysroot %sdk -L%swift-lib-dir/swift/%target-sdk-name/%target-arch -L%llvm_obj_root/lib/swift/%target-sdk-name/%target-arch -lswiftCore -o %t/paths-test
 // RUN: %target-codesign %t/paths-test
 // RUN: %target-run %t/paths-test | %FileCheck %s
 // RUN: env %env-SWIFT_ROOT=%t/swift-root %target-run %t/paths-test | %FileCheck %s --check-prefix CHECK-FR

--- a/test/ScanDependencies/can_import_with_map.swift
+++ b/test/ScanDependencies/can_import_with_map.swift
@@ -4,8 +4,8 @@
 // RUN: mkdir -p %t/inputs
 // RUN: echo "public func foo() {}" >> %t/foo.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
-// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
 
 // RUN: echo "[{" > %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
@@ -37,13 +37,13 @@
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/SwiftShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"_SwiftConcurrencyShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/_SwiftConcurrencyShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json

--- a/test/ScanDependencies/explicit-framework-irgen.swift
+++ b/test/ScanDependencies/explicit-framework-irgen.swift
@@ -4,8 +4,8 @@
 // RUN: echo "/// Some cool comments" > %t/foo.swift
 // RUN: echo "public func foo() {}" >> %t/foo.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
-// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
 
 // RUN: echo "[{" > %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
@@ -37,13 +37,13 @@
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/SwiftShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"_SwiftConcurrencyShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/_SwiftConcurrencyShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json

--- a/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
+++ b/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
@@ -5,8 +5,8 @@
 // RUN: echo "public func anotherFuncA() {}" > %t/A.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/A.swiftmodule -emit-module-doc-path %t/inputs/A.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/A.swiftsourceinfo -import-underlying-module -I%S/Inputs/CHeaders -module-cache-path %t.module-cache %t/A.swift -module-name A
 // RUN: %target-swift-emit-pcm -module-name A -o %t/inputs/A.pcm %S/Inputs/CHeaders/module.modulemap
-// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift_obj_root/lib/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/_SwiftConcurrencyShims.pcm
 
 // RUN: echo "[{" > %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
@@ -38,13 +38,13 @@
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/SwiftShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"_SwiftConcurrencyShims\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
-// RUN: echo "\"clangModuleMapPath\": \"%swift_obj_root/lib/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModulePath\": \"%t/inputs/_SwiftConcurrencyShims.pcm\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -352,7 +352,9 @@ config.gyb = make_path(config.swift_utils, 'gyb.py')
 config.rth = make_path(config.swift_utils, 'rth') # Resilience test helper
 config.scale_test = make_path(config.swift_utils, 'scale-test')
 config.PathSanitizingFileCheck = make_path(config.swift_utils, 'PathSanitizingFileCheck')
+config.swift_bin_dir = make_path(config.swift, '..', '..', 'bin')
 config.swift_lib_dir = make_path(config.swift, '..', '..', 'lib')
+config.swift_share_dir = make_path(config.swift, '..', '..', 'share')
 config.round_trip_syntax_test = make_path(config.swift_utils, 'round-trip-syntax-test')
 config.refactor_check_compiles = make_path(config.swift_utils, 'refactor-check-compiles.py')
 
@@ -551,7 +553,9 @@ config.host_build_swift = (
 )
 
 config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
+config.substitutions.append( ('%swift-bin-dir', config.swift_bin_dir) )
 config.substitutions.append( ('%swift-lib-dir', config.swift_lib_dir) )
+config.substitutions.append( ('%swift-share-dir', config.swift_share_dir) )
 config.substitutions.append( ('%swift-host-lib-dir', config.swift_host_lib_dir))
 config.substitutions.append( ('%llvm_src_root', config.llvm_src_root) )
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )


### PR DESCRIPTION
In LLVM unified builds `%swift_obj_root` points to `<LLVM build dir>/tools/swift`, and folders like `bin`, `lib` and `share` are not under `swift_obj_root`, which makes some tests fail.

For the cases in which `%swift_obj_root/lib` was used, replace it by using `%swift-lib-dir` instead. Replicate `%swift-lib-dir` to create `%swift-bin-dir` and `%swift-share-dir`, and use those instead of `%swift_obj_root/bin` and `%swift_obj_root/share`.

This alternates work both in Swift build-script builds and also in LLVM unified builds.

