### PR TITLE
[Build] Don't configure LLDB with tests enabled if the tests will be skipped

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2187,6 +2187,12 @@ for host in "${ALL_HOSTS[@]}"; do
                     DOTEST_ARGS="${DOTEST_ARGS};-E;${DOTEST_EXTRA}"
                 fi
 
+                if [[ "${SKIP_TEST_LLDB}" ]]; then
+                    should_configure_tests="FALSE"
+                else
+                    should_configure_tests=$(false_true ${BUILD_TOOLCHAIN_ONLY})
+                fi
+
                 cmake_options=(
                     "${cmake_options[@]}"
                     -C${LLDB_SOURCE_DIR}/cmake/caches/${cmake_cache}
@@ -2205,7 +2211,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_ENABLE_PYTHON=ON
                     -DLLDB_ENABLE_LZMA=OFF
                     -DLLDB_ENABLE_LUA=OFF
-                    -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
+                    -DLLDB_INCLUDE_TESTS:BOOL="${should_configure_tests}"
                     -DLLDB_TEST_LIBCXX_ROOT_DIR:STRING="${libcxx_build_dir}"
                     -DLLDB_TEST_USER_ARGS="${DOTEST_ARGS}"
                 )


### PR DESCRIPTION
Currently the `--skip-test-lldb` flag will only skip *running* the tests. But we still pass `LLDB_INCLUDE_TESTS` to CMake when configuring LLDB.

Since https://github.com/apple/swift/pull/66018 configuring LLDB tests will now always require libcxx to be built. For some presets (e.g., `buildbot_osx_package`) we don't need to build libcxx and we explicitly pass `--skip-test-lldb`; this means if we were to try configure LLDB tests we would hard error.

The proposed solution is to check whether the user wants to skip LLDB tests, and if so, set `LLDB_INCLUDE_TESTS=FALSE`.

rdar://109774179