### PR TITLE
[5.9][ConstraintSystem] Some more variadic generic fixes

### DIFF
--- a/include/swift/AST/PackConformance.h
+++ b/include/swift/AST/PackConformance.h
@@ -68,6 +68,8 @@ public:
 
   ArrayRef<ProtocolConformanceRef> getPatternConformances() const;
 
+  bool isInvalid() const;
+
   bool isCanonical() const;
 
   PackConformance *getCanonicalConformance() const;
@@ -103,4 +105,4 @@ void simple_display(llvm::raw_ostream &out, PackConformance *conformance);
 
 } // end namespace swift
 
-#endif  // SWIFT_AST_PACKCONFORMANCE_H
+#endif // SWIFT_AST_PACKCONFORMANCE_H

--- a/include/swift/AST/PackExpansionMatcher.h
+++ b/include/swift/AST/PackExpansionMatcher.h
@@ -186,6 +186,23 @@ public:
       }
     }
 
+    // Both sides have equal number of pack expansion type.
+    if (lhsElts.size() == rhsElts.size()) {
+      for (unsigned i = 0, n = lhsElts.size(); i != n; ++i) {
+        auto lhsType = getElementType(lhsElts[i]);
+        auto rhsType = getElementType(rhsElts[i]);
+
+        if (IsPackExpansionType(lhsType) && IsPackExpansionType(rhsType)) {
+          pairs.emplace_back(lhsType, rhsType, i, i);
+        } else {
+          pairs.clear();
+          return true;
+        }
+      }
+
+      return false;
+    }
+
     // Otherwise, all remaining possibilities are invalid:
     // - Neither side has any pack expansions, and they have different lengths.
     // - One side has a pack expansion but the other side is too short, eg

--- a/include/swift/AST/PackExpansionMatcher.h
+++ b/include/swift/AST/PackExpansionMatcher.h
@@ -186,7 +186,13 @@ public:
       }
     }
 
-    // Both sides have equal number of pack expansion type.
+    // If both sides have the same number of elements and all of
+    // them are pack expansions there is not going to be any
+    // expansion "absorption" and it's okay to match per-index.
+    //
+    // Like in all previous cases the callers are responsible
+    // to check whether the element types actually line up,
+    // this is a purely structural match.
     if (lhsElts.size() == rhsElts.size()) {
       for (unsigned i = 0, n = lhsElts.size(); i != n; ++i) {
         auto lhsType = getElementType(lhsElts[i]);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1827,8 +1827,11 @@ static ProtocolConformanceRef getPackTypeConformance(
     patternConformances.push_back(patternConformance);
   }
 
-  return ProtocolConformanceRef(
-      PackConformance::get(type, protocol, patternConformances));
+  auto *conformance = PackConformance::get(type, protocol, patternConformances);
+  if (conformance->isInvalid())
+    return ProtocolConformanceRef::forInvalid();
+
+  return ProtocolConformanceRef(conformance);
 }
 
 ProtocolConformanceRef

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -55,6 +55,11 @@ size_t PackConformance::numTrailingObjects(
   return ConformingType->getNumElements();
 }
 
+bool PackConformance::isInvalid() const {
+  return llvm::any_of(getPatternConformances(),
+                      [&](const auto ref) { return ref.isInvalid(); });
+}
+
 ArrayRef<ProtocolConformanceRef>
 PackConformance::getPatternConformances() const {
   return {getTrailingObjects<ProtocolConformanceRef>(),
@@ -244,6 +249,9 @@ PackConformance::subst(InFlightSubstitution &IFS) const {
 
   auto substConformance = PackConformance::get(substConformingType, Protocol,
                                                expander.substConformances);
+  if (substConformance->isInvalid())
+    return ProtocolConformanceRef::forInvalid();
+
   return ProtocolConformanceRef(substConformance);
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4547,8 +4547,13 @@ operator()(CanType dependentType, Type conformingReplacementType,
         (*this)(dependentType, conformingPackElt, conformedProtocol);
       conformances.push_back(conformance);
     }
-    return ProtocolConformanceRef(
-        PackConformance::get(conformingPack, conformedProtocol, conformances));
+
+    auto *conformance =
+        PackConformance::get(conformingPack, conformedProtocol, conformances);
+    if (conformance->isInvalid())
+      return ProtocolConformanceRef::forInvalid();
+
+    return ProtocolConformanceRef(conformance);
   }
 
   assert((conformingReplacementType->is<ErrorType>() ||

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8393,6 +8393,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (path.back().is<LocatorPathElt::PackElement>())
       path.pop_back();
 
+    // This is similar to `PackElement` but locator points to the requirement
+    // associted with pack expansion pattern (i.e. `repeat each T: P`) where
+    // the path is something like:
+    // `... -> type req # -> pack expansion pattern`.
+    if (path.back().is<LocatorPathElt::PackExpansionPattern>())
+      path.pop_back();
+
     if (auto req = path.back().getAs<LocatorPathElt::AnyRequirement>()) {
       // If this is a requirement associated with `Self` which is bound
       // to `Any`, let's consider this "too incorrect" to continue.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6290,11 +6290,18 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
             *choice, [this](Type type) -> Type { return simplifyType(type); }))
       fnInterfaceType = fnInterfaceType->castTo<AnyFunctionType>()->getResult();
 
+#ifndef NDEBUG
+    // If variadic generics are not involved, interface type should
+    // always match applied type.
     if (auto *fn = fnInterfaceType->getAs<AnyFunctionType>()) {
-      assert(fn->getNumParams() == fnType->getNumParams() &&
-             "Parameter mismatch?");
-      (void)fn;
+      if (llvm::none_of(fn->getParams(), [&](const auto &param) {
+            return param.getPlainType()->hasParameterPack();
+          })) {
+        assert(fn->getNumParams() == fnType->getNumParams() &&
+               "Parameter mismatch?");
+      }
     }
+#endif
   } else {
     fnInterfaceType = resolveInterfaceType(rawFnType);
   }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -533,8 +533,10 @@ func test_pack_expansion_to_void_conv_for_closure_result<each T>(x: repeat each 
 // rdar://109539394 - crash on passing multiple variadic lists to singly variadic callee
 do {
   func test1<each T>(_: repeat each T) {}
+  func test2<each T>(_: repeat each T) where repeat each T: RawRepresentable {} // expected-note {{where 'each T' = 'each T2'}}
 
   func caller<each T1, each T2>(t1: repeat each T1, t2: repeat each T2) {
     test1(repeat each t1, repeat each t2) // Ok
+    test2(repeat each t2, repeat each t1) // expected-error {{local function 'test2' requires that 'each T2' conform to 'RawRepresentable'}}
   }
 }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -529,3 +529,12 @@ func test_pack_expansion_to_void_conv_for_closure_result<each T>(x: repeat each 
   let _: (Int) -> Void = { repeat ($0, print(each x)) } // expected-warning {{'repeat (Int, ())' is unused}}
   let _: (Int, String) -> Void = { ($0, repeat ($1, print(each x))) } // expected-warning {{'(Int, repeat (String, ()))' is unused}}
 }
+
+// rdar://109539394 - crash on passing multiple variadic lists to singly variadic callee
+do {
+  func test1<each T>(_: repeat each T) {}
+
+  func caller<each T1, each T2>(t1: repeat each T1, t2: repeat each T2) {
+    test1(repeat each t1, repeat each t2) // Ok
+  }
+}


### PR DESCRIPTION
- Explanation:
  - Limit assert in `getFunctionArgApplyInfo` to types without type parameter packs
  - PackMacher: Match pack expansion elements pair-wise if pack arity matches
  - Diagnose conformance failures related to pack expansion patterns
  - Add a possibility to check whether PackConformance is invalid

- Scope: Expressions with value pack expansions.

- Main Branch PR: https://github.com/apple/swift/pull/66080

- Risk: Very Low

- Reviewed By: @hborla 

- Testing: Added regression test-cases to the suite.

Resolves: rdar://109539394


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
