### PR TITLE
[Observation] Member properties that have visibility attributes should rename using trailing trivia (#65812)

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -95,7 +95,7 @@ extension DiagnosticsError {
 
 extension ModifierListSyntax {
   func privatePrefixed(_ prefix: String) -> ModifierListSyntax {
-    let modifier: DeclModifierSyntax = DeclModifierSyntax(name: "private")
+    let modifier: DeclModifierSyntax = DeclModifierSyntax(name: "private", trailingTrivia: .space)
     return ModifierListSyntax([modifier] + filter {
       switch $0.name.tokenKind {
       case .keyword(let keyword):

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -27,6 +27,11 @@ class ContainsWeak {
 }
 
 @Observable
+public class PublicContainsWeak {
+  public weak var obj: AnyObject? = nil
+}
+
+@Observable
 class ContainsUnowned {
   unowned var obj: AnyObject? = nil
 }


### PR DESCRIPTION
Yet another cherry-pick of https://github.com/apple/swift/pull/65812

Variables declared with visibility and other modifiers ended up incorrectly synthesizing the storage without a trailing space after the private modifier.

```
public weak var obj: AnyObject? = nil
```

would incorrectly generate storage as:

```
privateweak var _obj: AnyObject? = nil
```

This change corrects that by adding a trailing trivia of a space on the private modifier.

Explanation:
When writing properties with private in addition other attributes would omit the trailing trivia spaces; e.g. `private weak` would get re-emitted by the macro as `privateweak`.

Scope:
Limited to just types that have the macro `@Observable` applied.

Risk:
Low - scoped to just adopting types, and scoped to just observation uses. No general compilation is involved.

Testing:
Added new tests covering the in-practice use of the macro including multiple attributes in addition to `private`

Issue:
rdar://109121917

Reviewer:
https://github.com/natecook1000
https://github.com/DougGregor