### PR TITLE
[Swift-ObjC-Interop] Speculative cyclic lookup fix

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4525,7 +4525,13 @@ namespace {
         SmallVector<Decl *, 4> matchingTopLevelDecls;
 
         // Get decls with a matching @objc attribute
-        module->lookupTopLevelDeclsByObjCName(matchingTopLevelDecls, name);
+        module->getTopLevelDeclsWhereAttributesMatch(
+            matchingTopLevelDecls, [&name](const DeclAttributes attrs) -> bool {
+              if (auto objcAttr = attrs.getAttribute<ObjCAttr>())
+                if (auto objcName = objcAttr->getName())
+                  return objcName->getSimpleName() == name;
+              return false;
+            });
 
         // Filter by decl kind
         for (auto result : matchingTopLevelDecls) {


### PR DESCRIPTION
The lookup to resolve an ObjC forward declaration
to its potential native Swift definition within
a mixed module is becoming cyclic somehow.

The old uncached lookup still works, so it seems
this is an issue with cache invalidation somehow.
Until the root of the issue is resolved, never mark the cache as populated.
This is the same behaviour as before the cached lookup was introduced, but
we can easily turn the caching back on later.