### PR TITLE
Disable taskgroup test on freestanding; they're not supported

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -1,8 +1,8 @@
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 // TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
 
-// This test uses `leaks` which is only available on apple platforms; limit it to macOS:
-// REQUIRES: OS=macosx
+// Task group addTask is not supported in freestanding mode
+// UNSUPPORTED: freestanding
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -19,7 +19,7 @@ final class Something {
   }
 
   deinit {
-    print("deinit, Something, int: \(int)")
+    print("deinit, Something, int: \(self.int)")
   }
 }
 
@@ -27,7 +27,7 @@ func test_taskGroup_next() async {
   let tasks = 5
   _ = await withTaskGroup(of: Something.self, returning: Int.self) { group in
     for n in 0..<tasks {
-      group.spawn {
+      group.addTask {
         Something(int: n)
       }
     }

--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -10,8 +10,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-import Darwin
-
 final class Something {
   let int: Int
   init(int: Int) {


### PR DESCRIPTION
rdar://109899236

Since none of the task group APIs are usable in freestanding, disable this freshly added test there as well:

```
-- Testing: 24 of 16230 tests, 10 workers --
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift (1 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift (2 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift (3 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift (4 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift (5 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_discarding_dontLeak_class_error.swift (6 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift (7 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_task_locals_prevent_illegal_use_taskgroup.swift (8 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift (9 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift (10 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift (11 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/taskgroup_cancelAll_cancellationHandler.swift (12 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift (13 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_discarding.swift (14 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_next_on_pending.swift (15 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_is_empty.swift (16 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_throw_recover.swift (17 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/taskgroup_cancelAll_from_child.swift (18 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_task_locals_prevent_illegal_use_discarding_taskgroup.swift (19 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_throw_rethrow.swift (20 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_task_cancellation_taskGroup.swift (21 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_next_on_completed.swift (22 of 24)
UNSUPPORTED: Swift(freestanding-x86_64) :: Sanitizers/tsan/async_taskgroup_next.swift (23 of 24)
PASS: Swift(freestanding-x86_64) :: Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift (24 of 24)
```