### PR TITLE
[5.9] Fix a crash during lookup of an operator with package acl

### DIFF
--- a/test/Sema/accessibility_package_in_extension.swift
+++ b/test/Sema/accessibility_package_in_extension.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -verify -module-name Lib %t/Lib.swift -emit-module -emit-module-path %t/Lib.swiftmodule -package-name myPkg
+
+/// Type-checking an operator (L30 below) causes look up of all of its decls regardless of which access modifier is
+/// used (decl in both Client and Lib in this case) before filtering. The decl in Lib is a package decl and has
+/// package-name associated with it, but the use site (in Client) does not have package-name. The package decl
+/// should be filtered out and the public == decl should be picked.
+// RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
+
+
+//--- Lib.swift
+public class Decl {
+  package static func == (lhs: Decl, rhs: Decl) -> Bool {
+    return true
+  }
+}
+
+//--- Client.swift
+import Lib
+
+extension Decl: Equatable {
+  public static func == (lhs: Decl, rhs: Decl) -> Bool {
+    return false
+  }
+}
+
+public protocol Proto {}
+extension Proto {
+  func foo(first: Decl, second: Decl) -> Bool {
+    // Type-checking below causes a look up of == in both Client and Lib
+    return first == second
+  }
+}


### PR DESCRIPTION
* Description: Type-checking an operator requires look up of all of its decls regardless of which access modifier is used before filtering. If one of them is a package decl in an imported module that was built with package-name, but the use site of the operator decl is in a module that is not built with package-name, it currently crashes as it tries to access package context of the use site, which is null. The change in this PR checks if both decl site and use site have package contexts before accessing the package name property, otherwise return false to be filtered out.  This PR also includes a check of source file kind before showing diagnostics to ensure that errors are not shown if source is interface as interface does not include package symbols. 
* Risk: Low. It adds a null check on package context before accessing package name. 
* Original PR: https://github.com/apple/swift/pull/66155 
* Reviewed By: @tshortli @xedin @xymus   
* Testing: Added a test that ensures coverage of the affected flow
* Resolves: rdar://108961906