### PR TITLE
[move-only] A few fixes around deinits

### DIFF
--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -371,6 +371,11 @@ public:
     return getNumIndirectSILResults();
   }
 
+  /// Returns the index of self.
+  unsigned getSILArgIndexOfSelf() const {
+    return getSILArgIndexOfFirstParam() + getNumParameters() - 1;
+  }
+
   /// Get the index into formal indirect results corresponding to the given SIL
   /// indirect result argument index.
   unsigned getIndirectFormalResultIndexForSILArg(unsigned argIdx) const {

--- a/include/swift/SIL/SILMoveOnlyDeinit.h
+++ b/include/swift/SIL/SILMoveOnlyDeinit.h
@@ -63,7 +63,12 @@ public:
 
   SILFunction *getImplementation() const { return funcImpl; }
 
-  bool isSerialized() const { return serialized; }
+  IsSerialized_t isSerialized() const {
+    return serialized ? IsSerialized : IsNotSerialized;
+  }
+  void setSerialized(IsSerialized_t inputSerialized) {
+    serialized = inputSerialized ? 1 : 0;
+  }
 
   void print(llvm::raw_ostream &os, bool verbose) const;
   void dump() const;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1079,11 +1079,6 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     preEmitFunction(constant, f, loc);
     PrettyStackTraceSILFunction X("silgen emitDeallocatingDestructor", f);
     SILGenFunction(*this, *f, dd).emitDeallocatingDestructor(dd);
-
-    // If we have a move only type, create the table for this type.
-    if (nom->isMoveOnly())
-      SILMoveOnlyDeinit::create(f->getModule(), nom, IsNotSerialized, f);
-
     postEmitFunction(constant, f);
     return;
   }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -459,6 +459,9 @@ public:
                                     SILFunction *jvp, SILFunction *vjp,
                                     const DeclAttribute *diffAttr);
 
+  /// Emit a deinit table for a noncopyable type.
+  void emitNonCopyableTypeDeinitTable(NominalTypeDecl *decl);
+
   /// Known functions for bridging.
   SILDeclRef getStringToNSStringFn();
   SILDeclRef getNSStringToStringFn();

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -473,6 +473,10 @@ class SerializeSILPass : public SILModuleTransform {
     for (auto &VT : M.getVTables()) {
       VT->setSerialized(IsNotSerialized);
     }
+
+    for (auto &Deinit : M.getMoveOnlyDeinits()) {
+      Deinit->setSerialized(IsNotSerialized);
+    }
   }
 
 public:

--- a/test/IRGen/Inputs/moveonly_split_module_source_input.swift
+++ b/test/IRGen/Inputs/moveonly_split_module_source_input.swift
@@ -7,15 +7,17 @@ class Klass {
 public struct MoveOnly : ~Copyable {
     var k = Klass()
     var k2 = Klass()
+    public init() {}
     deinit {
         print("==> I am in the deinit resiliently!")
         print("==> My name is \(k.name)")
     }
 }
 #else
-struct MoveOnly : ~Copyable {
+public struct MoveOnly : ~Copyable {
     var k = Klass()
     var k2 = Klass()
+    public init() {}
     deinit {
         print("==> I am in the deinit!")
         print("==> My name is \(k.name)")

--- a/test/IRGen/Inputs/moveonly_split_module_source_input.swift
+++ b/test/IRGen/Inputs/moveonly_split_module_source_input.swift
@@ -1,0 +1,24 @@
+
+class Klass {
+    var name = "John"
+}
+
+#if TEST_LIBRARY_EVOLUTION
+public struct MoveOnly : ~Copyable {
+    var k = Klass()
+    var k2 = Klass()
+    deinit {
+        print("==> I am in the deinit resiliently!")
+        print("==> My name is \(k.name)")
+    }
+}
+#else
+struct MoveOnly : ~Copyable {
+    var k = Klass()
+    var k2 = Klass()
+    deinit {
+        print("==> I am in the deinit!")
+        print("==> My name is \(k.name)")
+    }
+}
+#endif

--- a/test/IRGen/moveonly_split_module_source_deinit.swift
+++ b/test/IRGen/moveonly_split_module_source_deinit.swift
@@ -5,7 +5,7 @@
 
 // Make sure we call the deinit through the value witness table in the other module.
 
-// REFERRING_MODULE-LABEL: define swiftcc void @"$s6serverAAV4mainyyKFZ"(%swift.refcounted* swiftself %0, %swift.error** noalias nocapture swifterror dereferenceable(8) %1) #0 {
+// REFERRING_MODULE-LABEL: define {{.*}}swiftcc void @"$s6serverAAV4mainyyKFZ"(%swift.refcounted* swiftself %0, %swift.error** noalias nocapture swifterror dereferenceable(8) %1) {{.*}}{
 // REFERRING_MODULE: [[SERVER:%.*]] = alloca %T6server8MoveOnlyV
 // REFERRING_MODULE: [[VALUE_WITNESS_TABLE:%.*]] = getelementptr inbounds i8*, i8** %"$s6server8MoveOnlyVN.valueWitnesses"
 // REFERRING_MODULE: [[VALUE_WITNESS:%.*]] = load i8*, i8** [[VALUE_WITNESS_TABLE]]

--- a/test/IRGen/moveonly_split_module_source_deinit.swift
+++ b/test/IRGen/moveonly_split_module_source_deinit.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -emit-module -module-name server -emit-module-path %t/server.swiftmodule %s %S/Inputs/moveonly_split_module_source_input.swift
+// RUN: %target-swift-frontend -module-name server -primary-file %s %S/Inputs/moveonly_split_module_source_input.swift -emit-ir -emit-module-path %t/server.swiftmodule | %FileCheck %s -check-prefix=REFERRING_MODULE
+// RUN: %target-swift-frontend -module-name server  %s -primary-file %S/Inputs/moveonly_split_module_source_input.swift -emit-ir -emit-module-path %t/server.swiftmodule | %FileCheck %s -check-prefix=DEFINING_MODULE
+
+// Make sure we call the deinit through the value witness table in the other module.
+
+// REFERRING_MODULE-LABEL: define swiftcc void @"$s6serverAAV4mainyyKFZ"(%swift.refcounted* swiftself %0, %swift.error** noalias nocapture swifterror dereferenceable(8) %1) #0 {
+// REFERRING_MODULE: [[SERVER:%.*]] = alloca %T6server8MoveOnlyV
+// REFERRING_MODULE: [[VALUE_WITNESS_TABLE:%.*]] = getelementptr inbounds i8*, i8** %"$s6server8MoveOnlyVN.valueWitnesses"
+// REFERRING_MODULE: [[VALUE_WITNESS:%.*]] = load i8*, i8** [[VALUE_WITNESS_TABLE]]
+// REFERRING_MODULE: [[DESTROY:%.*]] = bitcast i8* [[VALUE_WITNESS]]
+// REFERRING_MODULE: [[CAST_SERVER:%.*]] = bitcast %T6server8MoveOnlyV* [[SERVER]]
+// REFERRING_MODULE: call void [[DESTROY]]({{%.*}} [[CAST_SERVER]], {{%.*}} @"$s6server8MoveOnlyVN")
+
+// Make sure that in the other module, we do call the deinit directly from the value witness.
+// DEFINING_MODULE-LABEL: define internal void @"$s6server8MoveOnlyVwxx"(%swift.opaque* noalias %object, %swift.type* %MoveOnly) {{.*}} {
+// DEFINING_MODULE: [[SELF:%.*]] = bitcast %swift.opaque* [[ARG:%.*]] to %T6server8MoveOnlyV*
+// DEFINING_MODULE: [[VAR:%.*]] = getelementptr inbounds {{%.*}}, {{%.*}}* [[SELF]]
+// DEFINING_MODULE: [[LOADED_VAR:%.*]] = load {{%.*}}*, {{%.*}}** [[VAR]],
+// DEFINING_MODULE: [[VAR2:%.*]] = getelementptr inbounds {{%.*}}, {{%.*}}* [[SELF]]
+// DEFINING_MODULE: [[LOADED_VAR2:%.*]] = load {{%.*}}*, {{%.*}}** [[VAR2]],
+// DEFINING_MODULE: call swiftcc void @"$s6server8MoveOnlyVfD"({{%.*}}* [[LOADED_VAR]], {{%.*}}* [[LOADED_VAR2]])
+@main
+public struct server {
+    public static func main() throws {
+        let server = MoveOnly()
+        _ = server
+    }
+}

--- a/test/IRGen/moveonly_split_module_source_deinit_library_evolution.swift
+++ b/test/IRGen/moveonly_split_module_source_deinit_library_evolution.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(MoveOnlySplit)) -enable-library-evolution %S/Inputs/moveonly_split_module_source_input.swift -emit-module -emit-module-path %t/MoveOnlySplit.swiftmodule -module-name MoveOnlySplit -DTEST_LIBRARY_EVOLUTION
+// RUN: %target-codesign %t/%target-library-name(MoveOnlySplit)
+
+// RUN: %target-build-swift %s -lMoveOnlySplit -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(MoveOnlySplit) | %FileCheck -check-prefix=CHECK-LIBRARY-EVOLUTION %s
+
+// REQUIRES: executable_test
+
+import MoveOnlySplit
+
+func main() {
+    let server = MoveOnly() // CHECK-LIBRARY-EVOLUTION: ==> I am in the deinit resiliently!
+}
+
+main()

--- a/test/Interpreter/Inputs/moveonly_split_module_source_input.swift
+++ b/test/Interpreter/Inputs/moveonly_split_module_source_input.swift
@@ -1,0 +1,19 @@
+
+#if TEST_LIBRARY_EVOLUTION
+public struct MoveOnly : ~Copyable {
+    var name = "John"
+    public init() {}
+    deinit {
+        print("==> I am in the deinit resiliently!")
+        print("==> My name is: \(name)!")
+    }
+}
+#else
+struct MoveOnly : ~Copyable {
+    var name = "John"
+    deinit {
+        print("==> I am in the deinit!")
+        print("==> My name is: \(name)!")
+    }
+}
+#endif

--- a/test/Interpreter/moveonly_split_module_source_deinit.swift
+++ b/test/Interpreter/moveonly_split_module_source_deinit.swift
@@ -1,0 +1,16 @@
+// Normal test.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -emit-module -module-name server -emit-module-path %t/server.swiftmodule %s %S/Inputs/moveonly_split_module_source_input.swift
+// RUN: %target-swiftc_driver  -emit-executable -module-name server -emit-module-path %t/server.swiftmodule %s %S/Inputs/moveonly_split_module_source_input.swift -o %t/server -Xlinker -add_ast_path -Xlinker %t/server.swiftmodule -Xlinker -alias -Xlinker _server_main -Xlinker _main
+// RUN: %target-codesign %t/server
+// RUN: %target-run %t/server | %FileCheck %s
+
+// REQUIRES: executable_test
+
+@main
+public struct server {
+    public static func main() throws {
+        let server = MoveOnly() // CHECK: ==> I am in the deinit!
+    }
+}

--- a/test/Interpreter/moveonly_split_module_source_deinit.swift
+++ b/test/Interpreter/moveonly_split_module_source_deinit.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-module -module-name server -emit-module-path %t/server.swiftmodule %s %S/Inputs/moveonly_split_module_source_input.swift
-// RUN: %target-swiftc_driver  -emit-executable -module-name server -emit-module-path %t/server.swiftmodule %s %S/Inputs/moveonly_split_module_source_input.swift -o %t/server -Xlinker -add_ast_path -Xlinker %t/server.swiftmodule -Xlinker -alias -Xlinker _server_main -Xlinker _main
+// RUN: %target-swiftc_driver  -emit-executable -module-name server -emit-module-path %t/server.swiftmodule %s %S/Inputs/moveonly_split_module_source_input.swift -o %t/server
 // RUN: %target-codesign %t/server
 // RUN: %target-run %t/server | %FileCheck %s
 

--- a/test/Interpreter/moveonly_split_module_source_deinit_library_evolution.swift
+++ b/test/Interpreter/moveonly_split_module_source_deinit_library_evolution.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(MoveOnlySplit)) -enable-library-evolution %S/Inputs/moveonly_split_module_source_input.swift -emit-module -emit-module-path %t/MoveOnlySplit.swiftmodule -module-name MoveOnlySplit -DTEST_LIBRARY_EVOLUTION
+// RUN: %target-codesign %t/%target-library-name(MoveOnlySplit)
+
+// RUN: %target-build-swift %s -lMoveOnlySplit -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(MoveOnlySplit) | %FileCheck -check-prefix=CHECK-LIBRARY-EVOLUTION %s
+
+// REQUIRES: executable_test
+
+import MoveOnlySplit
+
+func main() {
+    let server = MoveOnly() // CHECK-LIBRARY-EVOLUTION: ==> I am in the deinit resiliently!
+}
+
+main()

--- a/test/SILOptimizer/moveonly_deinit_insertion_library_evolution.sil
+++ b/test/SILOptimizer/moveonly_deinit_insertion_library_evolution.sil
@@ -1,0 +1,400 @@
+// RUN: %target-sil-opt -enable-library-evolution -module-name main -enable-sil-verify-all -sil-move-only-deinit-insertion -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+//===----------------------------------------------------------------------===//
+//                                Declarations
+//===----------------------------------------------------------------------===//
+
+@_moveOnly
+public class Klass {
+  deinit
+}
+
+@_moveOnly
+public struct TrivialStruct {
+  var i: Builtin.Int32
+}
+
+@_moveOnly
+public struct SingleFieldNonTrivial {
+  var k: Klass
+}
+
+@_moveOnly
+public struct ThreeNonTrivial {
+  var k: Klass
+  var i: Builtin.Int32
+  var k2: Klass
+}
+
+@_moveOnly
+struct ThreeNonTrivialNoDeinit {
+  var k: Klass
+  var i: Builtin.Int32
+  var k2: Klass
+}
+
+@_moveOnly enum TrivialMoveOnlyEnum {
+  case first
+  case second(Builtin.Int32)
+  case third(Builtin.Int64, Builtin.Int64)
+  deinit
+}
+
+@_moveOnly enum NonTrivialMoveOnlyEnum {
+  case first
+  case second(Builtin.Int32)
+  case third(Klass, Klass)
+  case fourth(Builtin.Int64, Builtin.Int64)
+  case fifth(TrivialMoveOnlyEnum)
+  deinit
+}
+
+//===----------------------------------------------------------------------===//
+//                                Object Tests
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil [ossa] @klassTest : $@convention(thin) (@owned Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Klass):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main5KlassCfD :
+// CHECK:   apply [[FUNC]]([[ARG]])
+// CHECK: } // end sil function 'klassTest'
+sil [ossa] @klassTest : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  destroy_value %0 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @trivialStructTest : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $TrivialStruct):
+// CHECK:   [[STACK:%.*]] = alloc_stack $
+// CHECK:   store [[ARG]] to [init] [[STACK]]
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main13TrivialStructVfD :
+// CHECK:   apply [[FUNC]]([[STACK]])
+// CHECK: } // end sil function 'trivialStructTest'
+sil [ossa] @trivialStructTest : $@convention(thin) (@owned TrivialStruct) -> () {
+bb0(%0 : @owned $TrivialStruct):
+  destroy_value %0 : $TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @singleFieldNonTrivialTest : $@convention(thin) (@owned SingleFieldNonTrivial) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Single
+// CHECK:   [[STACK:%.*]] = alloc_stack $
+// CHECK:   store [[ARG]] to [init] [[STACK]]
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main21SingleFieldNonTrivialVfD :
+// CHECK:   apply [[FUNC]]([[STACK]])
+// CHECK: } // end sil function 'singleFieldNonTrivialTest'
+sil [ossa] @singleFieldNonTrivialTest : $@convention(thin) (@owned SingleFieldNonTrivial) -> () {
+bb0(%0 : @owned $SingleFieldNonTrivial):
+  destroy_value %0 : $SingleFieldNonTrivial
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiFieldNonTrivialTest : $@convention(thin) (@owned ThreeNonTrivial) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $
+// CHECK:   [[STACK:%.*]] = alloc_stack $
+// CHECK:   store [[ARG]] to [init] [[STACK]]
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main15ThreeNonTrivialVfD :
+// CHECK:   apply [[FUNC]]([[STACK]])
+// CHECK: } // end sil function 'multiFieldNonTrivialTest'
+sil [ossa] @multiFieldNonTrivialTest : $@convention(thin) (@owned ThreeNonTrivial) -> () {
+bb0(%0 : @owned $ThreeNonTrivial):
+  destroy_value %0 : $ThreeNonTrivial
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @trivialMoveOnlyEnum : $@convention(thin) (@owned TrivialMoveOnlyEnum) -> () {
+// CHECK:   [[STACK:%.*]] = alloc_stack $
+// CHECK:   store [[ARG]] to [init] [[STACK]]
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main19TrivialMoveOnlyEnumOfD :
+// CHECK:   apply [[FUNC]]([[STACK]])
+// CHECK: } // end sil function 'trivialMoveOnlyEnum'
+sil [ossa] @trivialMoveOnlyEnum : $@convention(thin) (@owned TrivialMoveOnlyEnum) -> () {
+bb0(%0 : @owned $TrivialMoveOnlyEnum):
+  destroy_value %0 : $TrivialMoveOnlyEnum
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil [ossa] @nonTrivialMoveOnlyEnum : $@convention(thin) (@owned NonTrivialMoveOnlyEnum) -> () {
+bb0(%0 : @owned $NonTrivialMoveOnlyEnum):
+  destroy_value %0 : $NonTrivialMoveOnlyEnum
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+//                                 Var Tests
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil [ossa] @trivialStructAddrTest : $@convention(thin) (@in TrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*TrivialStruct):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main13TrivialStructVfD :
+// CHECK:   apply [[FUNC]]([[ARG]])
+// CHECK: } // end sil function 'trivialStructAddrTest'
+sil [ossa] @trivialStructAddrTest : $@convention(thin) (@in TrivialStruct) -> () {
+bb0(%0 : $*TrivialStruct):
+  destroy_addr %0 : $*TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @singleFieldNonTrivialAddrTest : $@convention(thin) (@in SingleFieldNonTrivial) -> () {
+// CHECK: bb0([[ARG:%.*]] : $
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main21SingleFieldNonTrivialVfD :
+// CHECK:   apply [[FUNC]]([[ARG]])
+// CHECK: } // end sil function 'singleFieldNonTrivialAddrTest'
+sil [ossa] @singleFieldNonTrivialAddrTest : $@convention(thin) (@in SingleFieldNonTrivial) -> () {
+bb0(%0 : $*SingleFieldNonTrivial):
+  destroy_addr %0 : $*SingleFieldNonTrivial
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiFieldNonTrivialAddrTest : $@convention(thin) (@in ThreeNonTrivial) -> () {
+// CHECK: bb0([[ARG:%.*]] : $
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main15ThreeNonTrivialVfD :
+// CHECK:   apply [[FUNC]]([[ARG]])
+// CHECK: } // end sil function 'multiFieldNonTrivialAddrTest'
+sil [ossa] @multiFieldNonTrivialAddrTest : $@convention(thin) (@in ThreeNonTrivial) -> () {
+bb0(%0 : $*ThreeNonTrivial):
+  destroy_addr %0 : $*ThreeNonTrivial
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @trivialMoveOnlyEnumArg : $@convention(thin) (@in TrivialMoveOnlyEnum) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*TrivialMoveOnlyEnum):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main19TrivialMoveOnlyEnumOfD
+// CHECK:   apply [[FUNC]]([[ARG]])
+// CHECK: } // end sil function 'trivialMoveOnlyEnumArg'
+sil [ossa] @trivialMoveOnlyEnumArg : $@convention(thin) (@in TrivialMoveOnlyEnum) -> () {
+bb0(%0 : $*TrivialMoveOnlyEnum):
+  destroy_addr %0 : $*TrivialMoveOnlyEnum
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nonTrivialMoveOnlyEnumAddrTest : $@convention(thin) (@in NonTrivialMoveOnlyEnum) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*NonTrivialMoveOnlyEnum):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main22NonTrivialMoveOnlyEnumOfD :
+// CHECK:   apply [[FUNC]]([[ARG]])
+// CHECK: } // end sil function 'nonTrivialMoveOnlyEnumAddrTest'
+sil [ossa] @nonTrivialMoveOnlyEnumAddrTest : $@convention(thin) (@in NonTrivialMoveOnlyEnum) -> () {
+bb0(%0 : $*NonTrivialMoveOnlyEnum):
+  destroy_addr %0 : $*NonTrivialMoveOnlyEnum
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+//                            Type Without Deinit
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil [ossa] @multiFieldNonTrivialNoDeinitTest : $@convention(thin) (@owned ThreeNonTrivialNoDeinit) -> () {
+// CHECK: destroy_value
+// CHECK: } // end sil function 'multiFieldNonTrivialNoDeinitTest'
+sil [ossa] @multiFieldNonTrivialNoDeinitTest : $@convention(thin) (@owned ThreeNonTrivialNoDeinit) -> () {
+bb0(%0 : @owned $ThreeNonTrivialNoDeinit):
+  destroy_value %0 : $ThreeNonTrivialNoDeinit
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiFieldNonTrivialNoDeinitAddrTest : $@convention(thin) (@in ThreeNonTrivialNoDeinit) -> () {
+// CHECK: destroy_addr
+// CHECK: } // end sil function 'multiFieldNonTrivialNoDeinitAddrTest'
+sil [ossa] @multiFieldNonTrivialNoDeinitAddrTest : $@convention(thin) (@in ThreeNonTrivialNoDeinit) -> () {
+bb0(%0 : $*ThreeNonTrivialNoDeinit):
+  destroy_addr %0 : $*ThreeNonTrivialNoDeinit
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+//                                Destructors
+//===----------------------------------------------------------------------===//
+
+sil hidden [ossa] @$s4main13TrivialStructVfD : $@convention(method) (@in TrivialStruct) -> () {
+bb0(%0 : $*TrivialStruct):
+  debug_value %0 : $*TrivialStruct, let, name "self", argno 1, implicit
+  end_lifetime %0 : $*TrivialStruct
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main21SingleFieldNonTrivialVfD : $@convention(method) (@in SingleFieldNonTrivial) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*SingleFieldNonTrivial):
+// CHECK:   [[ADDR:%.*]] = struct_element_addr [[ARG]]
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$s4main5KlassCfD :
+// CHECK:   [[LOAD:%.*]] = load [take] [[ADDR]]
+// CHECK:   apply [[FUNC_REF]]([[LOAD]])
+// CHECK: } // end sil function '$s4main21SingleFieldNonTrivialVfD'
+sil hidden [ossa] @$s4main21SingleFieldNonTrivialVfD : $@convention(method) (@in SingleFieldNonTrivial) -> () {
+bb0(%0 : $*SingleFieldNonTrivial):
+  debug_value %0 : $*SingleFieldNonTrivial, let, name "self", argno 1, implicit
+  %2 = struct_element_addr %0 : $*SingleFieldNonTrivial, #SingleFieldNonTrivial.k
+  destroy_addr %2 : $*Klass
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main15ThreeNonTrivialVfD : $@convention(method) (@in ThreeNonTrivial) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*ThreeNonTrivial):
+// CHECK:   [[LHS:%.*]] = struct_element_addr [[ARG]]
+// CHECK:   [[RHS:%.*]] = struct_element_addr [[ARG]]
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$s4main5KlassCfD :
+// CHECK:   [[LOAD_LHS:%.*]] = load [take] [[LHS]]
+// CHECK:   apply [[FUNC_REF]]([[LOAD_LHS]])
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$s4main5KlassCfD :
+// CHECK:   [[LOAD_RHS:%.*]] = load [take] [[RHS]]
+// CHECK:   apply [[FUNC_REF]]([[LOAD_RHS]])
+// CHECK: } // end sil function '$s4main15ThreeNonTrivialVfD'
+sil hidden [ossa] @$s4main15ThreeNonTrivialVfD : $@convention(method) (@in ThreeNonTrivial) -> () {
+bb0(%0 : $*ThreeNonTrivial):
+  debug_value %0 : $*ThreeNonTrivial, let, name "self", argno 1, implicit
+  %2 = struct_element_addr %0 : $*ThreeNonTrivial, #ThreeNonTrivial.k
+  %3 = struct_element_addr %0 : $*ThreeNonTrivial, #ThreeNonTrivial.k2
+  destroy_addr %2 : $*Klass
+  destroy_addr %3 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+sil hidden [ossa] @$s4main19TrivialMoveOnlyEnumOfD : $@convention(method) (@in TrivialMoveOnlyEnum) -> () {
+bb0(%0 : $*TrivialMoveOnlyEnum):
+  debug_value %0 : $*TrivialMoveOnlyEnum, let, name "self", argno 1, implicit
+  switch_enum_addr %0 : $*TrivialMoveOnlyEnum, case #TrivialMoveOnlyEnum.first!enumelt: bb1, case #TrivialMoveOnlyEnum.second!enumelt: bb2, case #TrivialMoveOnlyEnum.third!enumelt: bb3
+
+bb1:
+  br bb4
+
+bb2:
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main22NonTrivialMoveOnlyEnumOfD : $@convention(method) (@in NonTrivialMoveOnlyEnum) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*
+// CHECK: bb5:
+// CHECK:   [[ADDR:%.*]] = unchecked_take_enum_data_addr [[ARG]]
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$s4main19TrivialMoveOnlyEnumOfD : $@convention(method) (@in TrivialMoveOnlyEnum) -> ()
+// CHECK:   apply [[FUNC_REF]]([[ADDR]])
+// CHECK: } // end sil function '$s4main22NonTrivialMoveOnlyEnumOfD'
+sil hidden [ossa] @$s4main22NonTrivialMoveOnlyEnumOfD : $@convention(method) (@in NonTrivialMoveOnlyEnum) -> () {
+bb0(%0 : $*NonTrivialMoveOnlyEnum):
+  debug_value %0 : $*NonTrivialMoveOnlyEnum, let, name "self", argno 1, implicit
+  switch_enum_addr %0 : $*NonTrivialMoveOnlyEnum, case #NonTrivialMoveOnlyEnum.first!enumelt: bb1, case #NonTrivialMoveOnlyEnum.second!enumelt: bb2, case #NonTrivialMoveOnlyEnum.third!enumelt: bb3, case #NonTrivialMoveOnlyEnum.fourth!enumelt: bb4, case #NonTrivialMoveOnlyEnum.fifth!enumelt: bb5
+
+bb1:
+  br bb6
+
+bb2:
+  br bb6
+
+
+bb3:
+  %6 = unchecked_take_enum_data_addr %0 : $*NonTrivialMoveOnlyEnum, #NonTrivialMoveOnlyEnum.third
+  destroy_addr %6 : $*(Klass, Klass)
+  br bb6
+
+bb4:
+  br bb6
+
+bb5:
+  %11 = unchecked_take_enum_data_addr %0 : $*NonTrivialMoveOnlyEnum, #NonTrivialMoveOnlyEnum.fifth
+  destroy_addr %11 : $*TrivialMoveOnlyEnum
+  br bb6
+
+bb6:
+  %14 = tuple ()
+  return %14 : $()
+}
+
+//===----------------------------------------------------------------------===//
+//                              drop_deinit Tests
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK:         %1 = drop_deinit %0
+// CHECK-NEXT:    destroy_value %1
+// CHECK:       } // end sil function 'dropDeinitOnStruct'
+sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+bb0(%0 : @owned $TrivialStruct):
+  %1 = drop_deinit %0 : $TrivialStruct
+  destroy_value %1 : $TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK:         %1 = drop_deinit %0
+// CHECK-NEXT:    %2 = move_value %1
+// CHECK-NEXT:    destroy_value %2
+// CHECK:       } // end sil function 'dropDeinitOnMovedStruct'
+sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+bb0(%0 : @owned $TrivialStruct):
+  %1 = drop_deinit %0 : $TrivialStruct
+  %2 = move_value %1 : $TrivialStruct
+  destroy_value %2 : $TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in TrivialStruct) -> () {
+// CHECK:         %1 = drop_deinit %0
+// CHECK-NEXT:    destroy_addr %1
+// CHECK:       } // end sil function 'dropDeinitOnIndirectStruct'
+sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in TrivialStruct) -> () {
+bb0(%0 : $*TrivialStruct):
+  %1 = drop_deinit %0 : $*TrivialStruct
+  destroy_addr %1 : $*TrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @$s4main5KlassCfD : $@convention(method) (@owned Klass) -> ()
+sil @$s4main5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass
+sil @$s4main5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject
+
+sil_moveonlydeinit Klass {
+  @$s4main5KlassCfD
+}
+
+sil_moveonlydeinit TrivialStruct {
+  @$s4main13TrivialStructVfD	// TrivialStruct.deinit
+}
+
+sil_moveonlydeinit SingleFieldNonTrivial {
+  @$s4main21SingleFieldNonTrivialVfD	// SingleFieldNonTrivial.deinit
+}
+
+sil_moveonlydeinit ThreeNonTrivial {
+  @$s4main15ThreeNonTrivialVfD	// ThreeNonTrivial.deinit
+}
+
+sil_vtable Klass {
+  #Klass.deinit!deallocator: @$s4main5KlassCfD	// Klass.__deallocating_deinit
+}
+
+sil_moveonlydeinit TrivialMoveOnlyEnum {
+  @$s4main19TrivialMoveOnlyEnumOfD
+}
+
+sil_moveonlydeinit NonTrivialMoveOnlyEnum {
+  @$s4main22NonTrivialMoveOnlyEnumOfD
+}

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -1,7 +1,8 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -module-name moveonly_lifetime -o /dev/null -Xllvm -sil-print-canonical-module -Onone -verify -enable-experimental-feature MoveOnlyClasses %s 2>&1 | %FileCheck %s
 
-@_moveOnly
-class C {}
+struct C : ~Copyable {
+    deinit {}
+}
 
 @_silgen_name("getC")
 func getC() -> C
@@ -37,7 +38,7 @@ func something()
 // CHECK:         apply [[BORROW_C]]([[INSTANCE]])
 //
 // TODO: Once we maximize lifetimes this should be below something.
-// CHECK:         [[DESTROY_C:%[^,]+]] = function_ref @$s17moveonly_lifetime1CCfD
+// CHECK:         [[DESTROY_C:%[^,]+]] = function_ref @$s17moveonly_lifetime1CVfD
 // CHECK:         [[INSTANCE:%.*]] = load [take] [[STACK]]
 // CHECK:         apply [[DESTROY_C]]([[INSTANCE]])
 //

--- a/test/Serialization/moveonly_deinit.swift
+++ b/test/Serialization/moveonly_deinit.swift
@@ -1,11 +1,13 @@
 // RUN: %empty-directory(%t)
-// TODO: re-enable the simplification passes once rdar://104875010 is fixed
 // RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification -g -emit-module  -module-name OtherModule %S/Inputs/moveonly_deinit.swift -emit-module-path %t/OtherModule.swiftmodule
 // RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyEnumDeinits -Xllvm -sil-disable-pass=simplification -g -I %t %s -emit-silgen
+// RUN: %target-sil-opt -enable-experimental-feature MoveOnlyEnumDeinits %t/OtherModule.swiftmodule | %FileCheck -check-prefix=CHECK-SERIALIZED %s
 
 // Make sure we can deserialize deinits of both enums and structs.
 
 import OtherModule
 
+// CHECK-SERIALIZED: sil_moveonlydeinit [serialized] MoveOnlyStruct {
+// CHECK-SERIALIZED: sil_moveonlydeinit [serialized] MoveOnlyEnum {
 let s = MoveOnlyStruct(desc: 5)
 let e = MoveOnlyEnum.lhs(5)


### PR DESCRIPTION
Specifically:

1. I changed how we emit deinit tables so that we actually serialize them when appropriate.
2. I updated IRGen so that if we do not have the table (e.x.: we are in a different partial module when we compile without library evolution), we always invoke the deinit via the witness table. I added an IRGen to test this.
3. I noticed that the deinit devirtualizer pass did not handle resilient destructors correctly. So I fixed that.
4. I added some interpreter tests that validated that we are doing the right thing when compiling both with/without library evolution enabled.