### PR TITLE
Support swift_attr(“@Sendable”) on ObjC protocols

### DIFF
--- a/include/swift/AST/RequirementSignature.h
+++ b/include/swift/AST/RequirementSignature.h
@@ -73,6 +73,9 @@ public:
   GenericSignatureErrors getErrors() const {
     return Errors;
   }
+
+  void dump(llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace swift

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4438,6 +4438,37 @@ void Requirement::dump(raw_ostream &out) const {
     out << getLayoutConstraint();
 }
 
+void RequirementSignature::dump(llvm::raw_ostream &os) const {
+  os << "(signature";
+
+  if (getErrors().contains(GenericSignatureErrorFlags::CompletionFailed))
+    os << " completion_failed";
+  if (getErrors().contains(GenericSignatureErrorFlags::HasConcreteConformances))
+    os << " has_concrete_conformances";
+  if (getErrors().contains(GenericSignatureErrorFlags::HasInvalidRequirements))
+    os << " has_invalid_requirements";
+
+  for (auto &req : getRequirements()) {
+    os << "\n  (requirement ";
+    req.dump(os);
+    os << ")";
+  }
+
+  for (auto &alias : getTypeAliases()) {
+    os << "\n  (type_alias ";
+    os << alias.getName() << " ";
+    alias.getUnderlyingType().dump(os);
+    os << ")";
+  }
+
+  os << ")";
+}
+
+void RequirementSignature::dump() const {
+  dump(llvm::errs());
+  llvm::errs() << '\n';
+}
+
 void SILParameterInfo::dump() const {
   print(llvm::errs());
   llvm::errs() << '\n';

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2941,6 +2941,14 @@ InheritedProtocolsRequest::evaluate(Evaluator &evaluator,
     }
   }
 
+  // Check for SynthesizedProtocolAttrs on the protocol. ClangImporter uses
+  // these to add `Sendable` conformances to protocols without modifying the
+  // inherited type list.
+  for (auto attr : PD->getAttrs().getAttributes<SynthesizedProtocolAttr>()) {
+    if (known.insert(attr->getProtocol()).second)
+      result.push_back(attr->getProtocol());
+  }
+
   return PD->getASTContext().AllocateCopy(result);
 }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -705,7 +705,7 @@ void swift::rewriting::realizeRequirement(
 }
 
 /// Collect structural requirements written in the inheritance clause of an
-/// AssociatedTypeDecl or GenericTypeParamDecl.
+/// AssociatedTypeDecl, GenericTypeParamDecl, or ProtocolDecl.
 void swift::rewriting::realizeInheritedRequirements(
     TypeDecl *decl, Type type, bool shouldInferRequirements,
     SmallVectorImpl<StructuralRequirement> &result,
@@ -738,6 +738,17 @@ void swift::rewriting::realizeInheritedRequirements(
                         decl->getInnermostDeclContext(), result);
     }
 
+    realizeTypeRequirement(dc, type, inheritedType, loc, result, errors);
+  }
+
+  // Also check for `SynthesizedProtocolAttr`s with additional constraints added
+  // by ClangImporter. This is how imported protocols are marked `Sendable`
+  // without changing their inheritance lists.
+  auto attrs = decl->getAttrs().getAttributes<SynthesizedProtocolAttr>();
+  for (auto attr : attrs) {
+    auto inheritedType = attr->getProtocol()->getDeclaredType();
+    auto loc = attr->getLocation();
+    
     realizeTypeRequirement(dc, type, inheritedType, loc, result, errors);
   }
 }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -408,3 +408,22 @@ extension CoffeeDelegate  {
         return await self.icedMochaServiceGenerateMocha!(NSObject())
     }
 }
+
+// rdar://99758612 -- sendable requirement on ObjC protocols
+
+class NonSendableClassConformingToSendableProtocol: NSObject, SendableProtocol {
+  // expected-error@-1 {{type 'NonSendableClassConformingToSendableProtocol' does not conform to protocol 'Sendable'}}
+}
+
+class SendableClassConformingToSendableProtocol: NSObject, SendableProtocol, @unchecked Sendable {
+  // no-error
+}
+
+class NonSendableClassConformingToSendableProtocolRefined: NSObject, SendableProtocolRefined {
+  // expected-error@-1 {{type 'NonSendableClassConformingToSendableProtocolRefined' does not conform to protocol 'Sendable'}}
+}
+
+class SendableClassConformingToSendableProtocolRefined: NSObject, SendableProtocolRefined, @unchecked Sendable {
+  // no-error
+}
+

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -43,6 +43,9 @@ import _Concurrency
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension AuditedBoth : @unchecked Sendable {
 
+// CHECK-LABEL: public protocol SendableProtocol
+// CHECK-SAME: : Sendable
+
 // CHECK-LABEL: enum SendableEnum :
 // CHECK-SAME: @unchecked Sendable
 

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -225,6 +225,9 @@ SENDABLE @interface AuditedSendable : NSObject @end
 @interface AuditedNonSendable : NSObject @end
 NONSENDABLE SENDABLE @interface AuditedBoth : NSObject @end
 
+SENDABLE @protocol SendableProtocol @end
+@protocol SendableProtocolRefined <SendableProtocol> @end
+
 typedef NS_ENUM(unsigned, SendableEnum) {
   SendableEnumFoo, SendableEnumBar
 };

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -330,7 +330,7 @@ DECL_ATTR_KINDS = [
                         ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=53),
     DeclAttribute('__synthesized_protocol', 'SynthesizedProtocol',
-                  OnConcreteNominalType,
+                  OnNominalType,
                   UserInaccessible,
                   RejectByParser,
                   NotSerialized,


### PR DESCRIPTION
When ClangImporter imports a nominal type with `@Sendable` attached, it adds a `SynthesizedProtocolAttr` to the type. That did the right thing for concrete types, but protocols currently ignore these attributes. Manually add them where necessary.

Fixes rdar://99758612.