### PR TITLE
Improve diagnostics when package acl is used but no package-name is passed

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1782,7 +1782,7 @@ WARNING(access_control_non_objc_open_member,none,
       "non-'@objc' %0 in extensions cannot be overridden; use 'public' instead",
       (DescriptiveDeclKind))
 ERROR(access_control_requires_package_name, none,
-      "%0 has a package access level but no -package-name was passed: %1",
+      "%0 has a package access level but no -package-name was specified: %1",
       (Identifier, StringRef))
 ERROR(invalid_decl_attribute,none,
       "'%0' attribute cannot be applied to this declaration", (DeclAttribute))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1782,8 +1782,8 @@ WARNING(access_control_non_objc_open_member,none,
       "non-'@objc' %0 in extensions cannot be overridden; use 'public' instead",
       (DescriptiveDeclKind))
 ERROR(access_control_requires_package_name, none,
-      "decl has a package access level but no -package-name was passed",
-      ())
+      "%0 has a package access level but no -package-name was passed: %1",
+      (Identifier, StringRef))
 ERROR(invalid_decl_attribute,none,
       "'%0' attribute cannot be applied to this declaration", (DeclAttribute))
 ERROR(attr_invalid_on_decl_kind,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3979,7 +3979,11 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
       if (srcFile && srcFile->Kind != SourceFileKind::Interface) {
         // No package context was found; show diagnostics
         auto &d = VD->getASTContext().Diags;
-        d.diagnose(VD->getLoc(), diag::access_control_requires_package_name);
+        auto filename = srcFile ? srcFile->getFilename() : resultDC->getParentModule()->getBaseIdentifier().str();
+        d.diagnose(VD->getLoc(),
+                   diag::access_control_requires_package_name,
+                   VD->getBaseIdentifier(),
+                   filename);
       }
       // Instead of reporting and failing early, return the scope of resultDC to
       // allow continuation (should still non-zero exit later if in script mode)

--- a/test/diagnostics/package-name-diagnostics.swift
+++ b/test/diagnostics/package-name-diagnostics.swift
@@ -3,11 +3,11 @@
 // Package name should not be empty
 // RUN: not %target-swift-frontend -typecheck %s -package-name "" 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
 // CHECK-EMPTY: error: package-name is empty
-// CHECK-EMPTY: error: 'log' has a package access level but no -package-name was passed: {{.*}}.swift
+// CHECK-EMPTY: error: 'log' has a package access level but no -package-name was specified: {{.*}}.swift
 
 // If package access level is used but no package-name is passed, it should error
 // RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s -check-prefix CHECK-MISSING
-// CHECK-MISSING: error: 'log' has a package access level but no -package-name was passed: {{.*}}.swift
+// CHECK-MISSING: error: 'log' has a package access level but no -package-name was specified: {{.*}}.swift
 
 // Package name can be same as the module name
 // RUN: %target-swift-frontend -module-name Logging -package-name Logging %s -emit-module -emit-module-path %t/Logging.swiftmodule

--- a/test/diagnostics/package-name-diagnostics.swift
+++ b/test/diagnostics/package-name-diagnostics.swift
@@ -3,11 +3,11 @@
 // Package name should not be empty
 // RUN: not %target-swift-frontend -typecheck %s -package-name "" 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
 // CHECK-EMPTY: error: package-name is empty
-// CHECK-EMPTY: error: decl has a package access level but no -package-name was passed
+// CHECK-EMPTY: error: 'log' has a package access level but no -package-name was passed: {{.*}}.swift
 
 // If package access level is used but no package-name is passed, it should error
 // RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s -check-prefix CHECK-MISSING
-// CHECK-MISSING: error: decl has a package access level but no -package-name was passed
+// CHECK-MISSING: error: 'log' has a package access level but no -package-name was passed: {{.*}}.swift
 
 // Package name can be same as the module name
 // RUN: %target-swift-frontend -module-name Logging -package-name Logging %s -emit-module -emit-module-path %t/Logging.swiftmodule


### PR DESCRIPTION
Include a decl name and a file containing package access modifier in diagnostics.