### PR TITLE
Implement checking for missing consume-on-all-paths of `self` in `discard`-ing contexts.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -776,7 +776,11 @@ ERROR(sil_movechecking_notconsumable_but_assignable_was_consumed, none,
 ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
       "cannot partially consume '%0' when it has a deinitializer",
       (StringRef))
+ERROR(sil_movechecking_discard_missing_consume_self, none,
+      "must consume 'self' before exiting method that discards self", ())
 
+NOTE(sil_movechecking_discard_self_here, none,
+     "discarded self here", ())
 NOTE(sil_movechecking_partial_consume_here, none,
      "partially consumed here", ())
 NOTE(sil_movechecking_consuming_use_here, none,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -119,6 +119,12 @@ public:
   /// way to file a bug.
   void emitCheckedMissedCopyError(SILInstruction *copyInst);
 
+  /// Assuming the given instruction represents the implicit destruction of
+  /// 'self', emits an error saying that you needed to explicitly 'consume self'
+  /// here because you're in a discarding context.
+  void emitMissingConsumeInDiscardingContext(SILInstruction *leftoverDestroy,
+                                             SILInstruction *dropDeinit);
+
   void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectOwnedDiagnostic(MarkMustCheckInst *markedValue);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -117,6 +117,20 @@ struct OSSACanonicalizer {
              return !isa<PartialApplyInst>(user);
            });
   }
+
+  struct DropDeinitFilter {
+    bool operator()(SILInstruction *inst) const {
+      return isa<DropDeinitInst>(inst);
+    }
+  };
+  using DropDeinitIter =
+      llvm::filter_iterator<SILInstruction *const *, DropDeinitFilter>;
+  using DropDeinitRange = iterator_range<DropDeinitIter>;
+
+  /// Returns a range of final uses of the mark_must_check that are drop_deinit
+  DropDeinitRange getDropDeinitUses() const {
+    return llvm::make_filter_range(consumingBoundaryUsers, DropDeinitFilter());
+  }
 };
 
 /// Search for candidate object mark_must_checks. If we find one that does not

--- a/test/SILOptimizer/discard_checking.swift
+++ b/test/SILOptimizer/discard_checking.swift
@@ -1,0 +1,479 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s -disable-availability-checking
+
+// REQUIRES: concurrency
+
+enum Color {
+  case red, green, blue, none
+}
+enum E: Error {
+  case someError
+}
+
+func globalConsumingFn(_ b: consuming Basics) {}
+
+struct Basics: ~Copyable {
+  consuming func test1(_ b: Bool) {
+    guard b else {
+      fatalError("bah!") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+    discard self // expected-note {{discarded self here}}
+  }
+
+  consuming func test1_fixed(_ b: Bool) {
+    guard b else {
+      _ = consume self
+      fatalError("bah!")
+    }
+    discard self
+  }
+
+  consuming func test2(_ c: Color) throws {
+    repeat {
+      switch c {
+      case .red:
+        fatalError("bah!") // expected-error {{must consume 'self' before exiting method that discards self}}
+      case .blue:
+        throw E.someError // expected-error {{must consume 'self' before exiting method that discards self}}
+      case .green:
+        self = Basics()
+      default: print("hi")
+      }
+    } while true
+    discard self // expected-note 2{{discarded self here}}
+  }
+
+  consuming func test2_fixed(_ c: Color) throws {
+    repeat {
+      switch c {
+      case .red:
+        discard self
+        fatalError("bah!")
+      case .blue:
+        discard self
+        throw E.someError
+      case .green:
+        self = Basics()
+      default: print("hi")
+      }
+    } while true
+    discard self
+  }
+
+  consuming func test3(_ c: Color) {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    } else if case .blue = c {
+      try! test2(c)
+      return
+    } else if case .green = c {
+      return // expected-error {{must consume 'self' before exiting method that discards self}}
+    } else {
+      _ = consume self
+    }
+  }
+
+  consuming func test3_fixed(_ c: Color) {
+    if case .red = c {
+      discard self
+      return
+    } else if case .blue = c {
+      try! test2(c)
+      return
+    } else if case .green = c {
+      _ = consume self
+      return
+    } else {
+      _ = consume self
+    }
+  }
+
+  consuming func test4(_ c: Color) {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    }
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
+
+  consuming func test4_fixed(_ c: Color) {
+    if case .red = c {
+      discard self
+    } else {
+      _ = consume self
+    }
+  }
+
+  consuming func test5(_ c: Color) {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    } else {
+      return // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+  }
+
+  consuming func test5_fixed(_ c: Color) {
+    if case .red = c {
+      discard self
+    } else {
+      discard self
+      return
+    }
+  }
+
+  // TODO: rdar://110239743 (diagnostic locations for missing consume-before-exit in discarding methods are wonky)
+  consuming func test6(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    } else {
+      mutator() // expected-error {{must consume 'self' before exiting method that discards self}}
+      throw E.someError // <- better spot
+    }
+  }
+
+  consuming func test6_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+    } else {
+      mutator()
+      globalConsumingFn(self)
+      throw E.someError
+    }
+  }
+
+  consuming func test7(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    }
+    fatalError("oh no") // expected-error {{must consume 'self' before exiting method that discards self}}
+  }
+
+  consuming func test7_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+      return
+    }
+    _ = consume self
+    fatalError("oh no")
+  }
+
+  consuming func test8(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+    }
+    if case .blue = c {
+      fatalError("hi") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+  }
+
+  consuming func test8_stillMissingAConsume1(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    if case .blue = c {
+      _ = consume self
+      fatalError("hi")
+    }
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
+
+  consuming func test8_stillMissingAConsume2(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    if case .blue = c {
+      fatalError("hi") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+    _ = consume self
+  }
+
+  consuming func test8_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+      return
+    }
+    if case .blue = c {
+      _ = consume self
+      fatalError("hi")
+    }
+    _ = consume self
+  }
+
+  consuming func test9(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+
+    do {
+      throw E.someError
+    } catch E.someError {
+      try test8(c)
+      return
+    } catch {
+      print("hi")
+      return  // <- better spot!!
+    }
+    _ = consume self // expected-warning {{will never be executed}}
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
+
+  consuming func test9_fixed(_ c: Color) throws {
+    if case .red = c {
+      discard self
+      return
+    }
+
+    do {
+      throw E.someError
+    } catch E.someError {
+      try test8(c)
+      return
+    } catch {
+      print("hi")
+      _ = consume self
+      return
+    }
+    _ = consume self // expected-warning {{will never be executed}}
+  }
+
+  consuming func test10(_ c: Color) throws {
+    if case .red = c {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+
+    do {
+      throw E.someError // expected-error {{must consume 'self' before exiting method that discards self}}
+    } catch E.someError {
+      return // <- better spot
+    } catch {
+      return // <- ok spot
+    }
+  }
+
+  consuming func test11(_ c: Color) {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    defer { print("hi") }
+    mutator()
+    _ = consume self
+    self = Basics()
+    borrower()
+    let x = self
+    self = x
+    mutator() // expected-error {{must consume 'self' before exiting method that discards self}}
+  }
+
+  consuming func test11_fixed(_ c: Color) {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    defer { print("hi") }
+    mutator()
+    _ = consume self
+    self = Basics()
+    borrower()
+    let x = self
+    self = x
+    mutator()
+    discard self
+  }
+
+  consuming func test12(_ c: Color) throws {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    try thrower() // expected-error {{must consume 'self' before exiting method that discards self}}
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test12_fixed1(_ c: Color) throws {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    try? thrower()
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test12_fixed2(_ c: Color) throws {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    do {
+      try thrower()
+    } catch {
+      print("hi")
+      _ = consume self
+      throw error
+    }
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test12Bang(_ c: Color) throws {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    try! thrower() // expected-error {{must consume 'self' before exiting method that discards self}}
+    print("hi")
+    _ = consume self
+  }
+
+  consuming func test13(_ c: Color) async { // expected-error {{must consume 'self' before exiting method that discards self}}
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    await asyncer()
+  } // <- better spot
+
+  consuming func test13_fixed(_ c: Color) async {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    await asyncer()
+    _ = consume self
+  }
+
+  consuming func test14(_ c: Color) async {
+    guard case .red = c else {
+      discard self // expected-note {{discarded self here}}
+      return
+    }
+    await withCheckedContinuation { cont in // expected-error {{must consume 'self' before exiting method that discards self}}
+      cont.resume()
+    }
+    print("back!")
+  } // <- better spot
+
+  consuming func test14_fixed(_ c: Color) async {
+    guard case .red = c else {
+      discard self
+      return
+    }
+    await withCheckedContinuation { cont in
+      cont.resume()
+    }
+    print("back!")
+    _ = consume self
+  }
+
+  consuming func positiveTest(_ i: Int) {
+    switch i {
+    case 0: _ = self
+    case 1: let _ = self
+    case 2:
+      let other = self
+      _ = other
+    case 3:
+      _ = consume self
+    case 4:
+      self.test11(.red)
+    case 5:
+      globalConsumingFn(self)
+    default:
+      discard self
+    }
+  }
+
+  // FIXME move checker is treating the defer like a closure capture (rdar://100468597)
+  // not expecting any errors here
+  consuming func brokenPositiveTest(_ i: Int) { // expected-error {{missing reinitialization of inout parameter 'self' after consume}}
+    defer { discard self } // expected-note {{consumed here}}
+    switch i {
+    case 0, 1, 2, 3: return
+    default:
+      break
+    }
+  }
+
+  consuming func negativeTest(_ i: Int) throws {
+    switch i {
+    case 0:
+      fallthrough
+    case 1:
+      throw E.someError // expected-error 2{{must consume 'self' before exiting method that discards self}}
+    case 2:
+      return // expected-error {{must consume 'self' before exiting method that discards self}}
+    case 3:
+      fatalError("no") // expected-error {{must consume 'self' before exiting method that discards self}}
+    case 4:
+      globalConsumingFn(self)
+    default:
+      discard self // expected-note 4{{discarded self here}}
+    }
+  }
+
+  consuming func loopyExit_bad(_ i: Int) {
+    if i < 0 {
+      discard self // expected-note 2{{discarded self here}}
+      return
+    }
+
+    // TODO: rdar://110239087 (avoid duplicate consume-before-exit diagnostics for loop in discarding method)
+    for _ in 0..<i {  // expected-error {{must consume 'self' before exiting method that discards self}}
+      self = Basics() // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+
+    return
+  }
+
+  consuming func loopyExit_good(_ i: Int) {
+    if i < 0 {
+      discard self
+      return
+    }
+
+    for _ in 0..<i {
+      self = Basics()
+    }
+
+    _ = consume self
+    return
+  }
+
+  mutating func mutator() { self = Basics() }
+  borrowing func borrower() {}
+  borrowing func thrower() throws {}
+
+  @MainActor borrowing func asyncer() async {}
+
+  deinit { print("hi") }
+}
+
+struct Money: ~Copyable {
+  enum Error: Swift.Error {
+    case insufficientFunds
+  }
+
+  let balance: Int
+
+  consuming func spend(_ charge: Int) throws -> Money {
+    guard charge > 0 else {
+      fatalError("can't charge a negative amount!") // expected-error {{must consume 'self' before exiting method that discards self}}
+    }
+
+    if balance < charge  {
+      throw Error.insufficientFunds // expected-error {{must consume 'self' before exiting method that discards self}}
+    } else if balance > charge {
+      self = Money(balance: balance - charge)
+      return self
+    }
+
+    discard self // expected-note 2{{discarded self here}}
+    return Money(balance: 0)
+  }
+
+  deinit {
+    assert(balance > 0)
+  }
+}


### PR DESCRIPTION
As part of SE-390, you're required to write either:

  - `consume self`
  - pass self as a `consuming` parameter to a function
  - `discard self`

before the function ends in a context that contains a
`discard self` somewhere. This prevents people from accidentally
invoking the deinit due to implicit destruction of `self` before
exiting the function.

rdar://106099027