### PR TITLE
[Swift-ObjC-Interop] Speculative cyclic lookup fix

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4514,7 +4514,13 @@ namespace {
         SmallVector<Decl *, 4> matchingTopLevelDecls;
 
         // Get decls with a matching @objc attribute
-        module->lookupTopLevelDeclsByObjCName(matchingTopLevelDecls, name);
+        module->getTopLevelDeclsWhereAttributesMatch(
+            matchingTopLevelDecls, [&name](const DeclAttributes attrs) -> bool {
+              if (auto objcAttr = attrs.getAttribute<ObjCAttr>())
+                if (auto objcName = objcAttr->getName())
+                  return objcName->getSimpleName() == name;
+              return false;
+            });
 
         // Filter by decl kind
         for (auto result : matchingTopLevelDecls) {


### PR DESCRIPTION
Explanation:

In certain scenarios (ie. mixed modules), we must be able to associate an ObjC forward declaration with a corresponding `@objc` exposed native Swift declaration. There is no existing look up table to facilitate lookups of Swift declaration via `@objc` name. 

Prior to [61606](https://github.com/apple/swift/pull/61606), the behavior used `getTopLevelDeclsWhereAttributesMatch` to fetch all Swift declarations with a matching `@objc` name. In an attempt to make this faster, I created `lookupTopLevelDeclsByObjCName` which does the same, but finds _all_ declarations that have any `@objc` name and puts them into a cache. This lookup deserializes too many declarations.

This patch reverts to the old lookup method, which due to a narrowed predicate, does far less deserialization. 

Issue:

Deserialization was taking too long on some framework @slavapestov can provide more detail.

Risk: 

This is a partial revert, and the existing lookup behavior was used in Swift5.8 and before, so should be low risk. Since the other changes are gated behind a flag, without the flag on, this patch is likely equivalent to reverting [61606](https://github.com/apple/swift/pull/61606) in its entirety.

Testing: 

CI