### PR TITLE
[move-only] Change closure capture diagnostic for let patterns to say that it cannot be captured by an escaping closure.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -758,11 +758,10 @@ ERROR(sil_movechecking_value_used_after_consume, none,
       "'%0' used after consume", (StringRef))
 ERROR(sil_movechecking_guaranteed_value_consumed, none,
       "'%0' is borrowed and cannot be consumed", (StringRef))
-
-// FIXME: this diagnostic shouldn't ever be emitted now. rdar://109742587 (closures may still try to consume captures, e.g., borrowed parameters)
-ERROR(sil_movechecking_guaranteed_value_captured_by_closure, none,
-      "'%0' is borrowed and cannot be consumed by closure capture", (StringRef))
-
+ERROR(sil_movechecking_borrowed_parameter_captured_by_closure, none,
+      "'%0' cannot be captured by an escaping closure since it is a borrowed "
+      "parameter",
+      (StringRef))
 ERROR(sil_movechecking_capture_consumed, none,
       "noncopyable '%0' cannot be consumed when captured by a closure", (StringRef))
 ERROR(sil_movechecking_inout_not_reinitialized_before_end_of_function, none,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -203,7 +203,7 @@ void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
   // See if we have any closure capture uses and emit a better diagnostic.
   if (getCanonicalizer().hasPartialApplyConsumingUse()) {
     diagnose(astContext, markedValue,
-             diag::sil_movechecking_guaranteed_value_captured_by_closure,
+             diag::sil_movechecking_borrowed_parameter_captured_by_closure,
              varName);
     emitObjectDiagnosticsForPartialApplyUses(varName);
     registerDiagnosticEmitted(markedValue);

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -13,6 +13,7 @@ struct SingleElt {
 }
 
 func consumeVal(_ x: consuming SingleElt) {}
+func consumeVal(_ x: consuming Empty) {}
 func borrowVal(_ x: borrowing SingleElt) {}
 func borrowConsumeVal(_ x: borrowing SingleElt, _ y: consuming SingleElt) {}
 
@@ -1339,7 +1340,7 @@ struct ClosureHolder {
     }
 }
 
-func closureCoroutineAssignmentLetBorrowingArgument(_ e: borrowing Empty) { // expected-error {{'e' is borrowed and cannot be consumed by closure capture}}
+func closureCoroutineAssignmentLetBorrowingArgument(_ e: borrowing Empty) { // expected-error {{'e' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f: () -> () = { // expected-note {{closure capturing 'e' here}}
         _ = e
     }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3494,7 +3494,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
 
 public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     var f = {}
     f = {// expected-note {{closure capturing 'x2' here}}
         defer {
@@ -3636,8 +3636,8 @@ public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
 
 public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-3 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     var f = {}
     f = {// expected-note {{closure capturing 'x2' here}}
         var g = {}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2731,7 +2731,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 /////////////////////////////
 
 public func closureLetClassUseAfterConsume1(_ x: borrowing Klass) {
-    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-1 {{'x' cannot be captured by an escaping closure since it is a borrowed parameter}}
     // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     let f = { // expected-note {{closure capturing 'x' here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
@@ -2830,7 +2830,7 @@ public func closureLetCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { /
 
 public func closureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
@@ -2897,7 +2897,7 @@ public func closureLetCaptureClassOwnedArgUseAfterConsume4(_ x2: consuming Klass
 /////////////////////////////
 
 public func closureVarClassUseAfterConsume1(_ x: borrowing Klass) {
-    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-1 {{'x' cannot be captured by an escaping closure since it is a borrowed parameter}}
     // expected-error @-2 {{noncopyable 'x' cannot be consumed when captured by a closure}}
     var f = {}
     f = { // expected-note {{closure capturing 'x' here}}
@@ -3007,7 +3007,7 @@ public func closureVarCaptureClassUseAfterConsumeError(_ x: borrowing Klass) { /
 
 public func closureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     var f = {}
     f = { // expected-note {{closure capturing 'x2' here}}
         borrowVal(x2)
@@ -3206,7 +3206,7 @@ public func closureLetAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
 
 public func closureLetAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         defer {
             borrowVal(x2)
@@ -3343,8 +3343,8 @@ public func closureLetAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
 
 public func closureLetAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-3 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         let g = { // expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)
@@ -3490,7 +3490,7 @@ public func closureVarAndDeferCaptureClassUseAfterConsume3(_ x: borrowing Klass)
 
 public func closureVarAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     var f = {}
     f = {// expected-note {{closure capturing 'x2' here}}
         defer {
@@ -3630,8 +3630,8 @@ public func closureVarAndClosureCaptureClassUseAfterConsume3(_ x: borrowing Klas
 
 public func closureVarAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-3 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     var f = {}
     f = {// expected-note {{closure capturing 'x2' here}}
         var g = {}
@@ -3764,8 +3764,8 @@ public func closureVarAndClosureLetCaptureClassUseAfterConsume3(_ x: borrowing K
 
 public func closureVarAndClosureLetCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-3 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     var f = {}
     f = {// expected-note {{closure capturing 'x2' here}}
 let g = {// expected-note {{closure capturing 'x2' here}}
@@ -3893,8 +3893,8 @@ public func closureLetAndClosureVarCaptureClassUseAfterConsume3(_ x: borrowing K
 
 public func closureLetAndClosureVarCaptureClassArgUseAfterConsume(_ x2: borrowing Klass) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-3 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = {// expected-note {{closure capturing 'x2' here}}
         var g = {}
         g = {// expected-note {{closure capturing 'x2' here}}

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1728,7 +1728,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy)
 
 public func closureClassUseAfterConsume1(_ x: borrowing NonTrivialStruct) {
     // expected-error @-1 {{noncopyable 'x' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x' here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consumed here}}
@@ -1789,7 +1789,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: borrowing NonTrivialStr
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consumed here}}
@@ -1981,8 +1981,9 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: borrowing NonTrivia
     consumeVal(x2)
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
+public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
+    // expected-error @-1 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-2 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         defer {
             borrowVal(x2)
@@ -2086,8 +2087,8 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: borrowing NonTriv
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: borrowing NonTrivialStruct) {
     // expected-error @-1 {{noncopyable 'x2' cannot be consumed when captured by a closure}}
-    // expected-error @-2 {{'x2' is borrowed and cannot be consumed by closure capture}}
-    // expected-error @-3 {{'x2' is borrowed and cannot be consumed by closure capture}}
+    // expected-error @-2 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    // expected-error @-3 {{'x2' cannot be captured by an escaping closure since it is a borrowed parameter}}
     let f = { // expected-note {{closure capturing 'x2' here}}
         let g = { // expected-note {{closure capturing 'x2' here}}
             borrowVal(x2)


### PR DESCRIPTION
rdar://109742587
