### PR TITLE
[CMake] Add paths for building Swift code against host toolchain

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -261,9 +261,15 @@ function(add_pure_swift_host_tool name)
   add_executable(${name} ${APSHT_SOURCES})
   _add_host_swift_compile_options(${name})
 
-  set_property(TARGET ${name}
-    APPEND PROPERTY INSTALL_RPATH
-      "@executable_path/../lib/swift/host")
+  if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
+    set_property(TARGET ${name}
+      APPEND PROPERTY INSTALL_RPATH
+        "@executable_path/../lib/swift/host")
+  else()
+    set_property(TARGET ${name}
+      APPEND PROPERTY INSTALL_RPATH
+        "$ORIGIN/../lib/swift/host")
+  endif()
 
   set_property(TARGET ${name}
     PROPERTY BUILD_WITH_INSTALL_RPATH YES)

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -7,7 +7,7 @@
 
 // RUN: split-file %s %t/src
 
-//#-- Prepare the macro dylib plugin.
+//#-- Prepare the macro shared library plugin.
 // RUN: %host-build-swift \
 // RUN:   -swift-version 5 \
 // RUN:   -emit-library -o %t/plugin/%target-library-name(MacroDefinition) \
@@ -76,7 +76,7 @@
 // RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/with_macro_nonprimary.swiftdeps.processed
 
 // WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}mock-plugin' false
-// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}libMacroDefinition.dylib' false
+// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}libMacroDefinition.{{(dylib|so|dll)}}' false
 
 // WITHOUT_PLUGIN-NOT:  MacroDefinition
 // WITHOUT_PLUGIN-NOT:  mock-plugin

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -548,9 +548,16 @@ else:
         "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s"
         % (shell_quote(config.host_sdkroot), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
 
+# Parse the host triple.
+(host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
+
+if platform.system() == 'Darwin':
+    host_build_extra_rpath=""
+else:
+    host_build_extra_rpath="-Xlinker -rpath -Xlinker %s" % (make_path(config.swift_lib_dir, 'swift', host_os))
+
 config.host_build_swift = (
-    "%s -sdk %s -target %s -I %s -L %s" % (config.swiftc_driver, config.host_sdkroot, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir)
-)
+    "%s -sdk %s -target %s -I %s -L %s %s" % (config.swiftc_driver, config.host_sdkroot, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir, host_build_extra_rpath))
 
 config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%swift-bin-dir', config.swift_bin_dir) )

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -153,11 +153,16 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
       message(FATAL_ERROR "Unknown ASKD_BOOTSTRAPPING_MODE '${ASKD_BOOTSTRAPPING_MODE}'")
     endif()
   endif()
-  set(RPATH_LIST ${RPATH_LIST} PARENT_SCOPE)
 
   if(SWIFT_SWIFT_PARSER)
     # Make sure we can find the early SwiftSyntax libraries.
     target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
+
+    # Add rpath to the host Swift libraries.
+    if (NOT ${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
+      file(RELATIVE_PATH relative_hostlib_path "${path}" "${SWIFTLIB_DIR}/host")
+      list(APPEND RPATH_LIST "$ORIGIN/${relative_hostlib_path}")
+    endif()
 
     # For the "end step" of bootstrapping configurations on Darwin, need to be
     # able to fall back to the SDK directory for libswiftCore et al.
@@ -173,10 +178,19 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
           get_filename_component(TOOLCHAIN_BIN_DIR ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
           get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" ABSOLUTE)
           target_link_directories(${target} PUBLIC ${TOOLCHAIN_LIB_DIR})
+        else()
+          get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+          get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+          set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+          target_link_directories(${target} PUBLIC ${host_lib_dir})
+
+          list(APPEND RPATH_LIST "${host_lib_dir}")
         endif()
       endif()
     endif()
   endif()
+
+  set(RPATH_LIST ${RPATH_LIST} PARENT_SCOPE)
 endfunction()
 
 # Add a new SourceKit library.


### PR DESCRIPTION
When building Swift code into the compiler (e.g, the new Swift parser along with macros support), make sure we always add the appropriate paths to (1) link against the host Swift toolchain, and (2) find the host Swift libraries (such as SwiftSyntax) at runtime.

The CMake code for doing this was only running for Darwin builds, so generalize it to also work on Linux.
