### PR TITLE
[move-only] Make sure to run the moveonly interpreter test also at -O none so we can make sure it works even without opts.

### DIFF
--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -1,5 +1,5 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
-// this test takes a long time, so run this once with optimizations on.
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
This doesn't take very long to run on my own personal machine. I believe the issue that was run into is that part of the stdlib had to be rebuilt on the relevant engineers machine.

That being said, this is an important interpreter test that needs to be run with/without optimization to ensure that in either case we can run the moveonly test cases therein appropriately.