### PR TITLE
[Walker] Don't visit VarDecls encountered in freestanding macro expansions

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -460,7 +460,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (shouldWalkExpansion) {
       MED->visitAuxiliaryDecls([&](Decl *decl) {
         if (alreadyFailed) return;
-        alreadyFailed = inherited::visit(decl);
+        if (!isa<VarDecl>(decl))
+          alreadyFailed = inherited::visit(decl);
       });
       MED->forEachExpandedExprOrStmt([&](ASTNode expandedNode) {
         if (alreadyFailed) return;

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -52,6 +52,9 @@ macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(mo
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
 @freestanding(declaration, names: arbitrary) macro bitwidthNumberedStructs(_ baseName: String, blah: Bool) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
+
+@freestanding(declaration, names: named(value)) macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
+
 #endif
 
 #if TEST_DIAGNOSTICS
@@ -408,4 +411,9 @@ func testFreestandingClosureNesting() {
   _ = #stringify({ () -> Int in
     #coerceToInt(2)
   })
+}
+
+// Freestanding declaration macros that produce local variables
+func testLocalVarsFromDeclarationMacros() {
+  #varValue
 }


### PR DESCRIPTION
VarDecls are always walked via their pattern bindings, so we end up with double-visitation if we also visit them here.

Fixes rdar://109376102.
