### PR TITLE
[Sema] Increase impact of ternary then branch aiming better diagnostics

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14753,8 +14753,15 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
       // means that result would attempt a type from each side if
       // one is available and that would result in two fixes - one for
       // each mismatched branch.
-      if (branchElt->forElse())
+      if (branchElt->forElse()) {
         impact = 10;
+      } else {
+        // Also increase impact for `then` branch lower than `else` to still
+        // eliminate ambiguity, but slightly worst than the average fix to avoid
+        // so the solution which record this fix wouldn't be picked over one
+        // that has contextual mismatch fix on the result of ternary expression.
+        impact = 5;
+      }
     }
     using SingleValueStmtBranch = LocatorPathElt::SingleValueStmtBranch;
     if (auto branchElt = locator->getLastElementAs<SingleValueStmtBranch>()) {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -951,3 +951,7 @@ let _ = "foo \(42 /*
 // expected-error @-3 {{cannot find ')' to match opening '(' in string interpolation}} expected-error @-3 {{unterminated string literal}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}
+
+// https://github.com/apple/swift/issues/66192
+func I66192(_: Int) {}
+I66192(true ? "yes" : "no") // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Another small diagnostic quality one.
In this scenario, solution which recorded the argument mismatch on the result of ternary which is the correct fix to apply in that case was being considered worst than the then branch contextual mismatch leading to misleading diagnostics. To me it does make sense to have the ternary branch slightly worst to avoid this sort of things, but let me know what you think.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/66192

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
