### PR TITLE
[5.9][Runtime] Add ptrauth to standard concurrency descriptors.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -997,7 +997,7 @@ void swift_disableDynamicReplacementScope(const DynamicReplacementScope *scope);
 struct ConcurrencyStandardTypeDescriptors {
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 #define STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)                    \
-  const ContextDescriptor *TYPENAME;
+  const ContextDescriptor * __ptrauth_swift_type_descriptor TYPENAME;
 #include "swift/Demangling/StandardTypesMangling.def"
 };
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/66210 to `release/5.9`.

Put the __ptrauth_swift_type_descriptor qualifier on the fields of ConcurrencyStandardTypeDescriptors.