### PR TITLE
swift_build_support/cmake.py: parallelize default CMake build

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -15,8 +15,8 @@
 # ----------------------------------------------------------------------------
 
 
-import os
 import multiprocessing
+import os
 import platform
 import re
 from numbers import Number
@@ -275,9 +275,9 @@ class CMake(object):
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
         build_jobs = self.args.build_jobs or multiprocessing.cpu_count()
-        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui', 
-                                    '--parallel=%s' % build_jobs, '--',
-                                    '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
+        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui',
+                                     '--parallel=%s' % build_jobs, '--',
+                                     '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
         shell.call_without_sleeping(['make', '-j%s' % build_jobs],
                                     echo=True)
         os.chdir(cwd)

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -16,6 +16,7 @@
 
 
 import os
+import multiprocessing
 import platform
 import re
 from numbers import Number
@@ -273,9 +274,11 @@ class CMake(object):
 
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
-        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui', '--',
+        build_jobs = self.args.build_jobs or multiprocessing.cpu_count()
+        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui', 
+                                    '--parallel=%s' % build_jobs, '--',
                                     '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
-        shell.call_without_sleeping(['make', '-j%s' % self.args.build_jobs],
+        shell.call_without_sleeping(['make', '-j%s' % build_jobs],
                                     echo=True)
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')


### PR DESCRIPTION
CMake's bootstrapping script can't infer a number of parallel build jobs from the number of CPU cores on its own, which means that it's not parallelized by default. Let's get the value of CPU cores when `build_jobs` argument is not explicitly set.
