### PR TITLE
[Variadic Generics] drop requirement of .element for tuple expansion

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3679,7 +3679,7 @@ public:
 };
 
 /// An expression to materialize a pack from a tuple containing a pack
-/// expansion, spelled \c tuple.element.
+/// expansion.
 ///
 /// These nodes are created by CSApply and should only appear in a
 /// type-checked AST in the context of a \c PackExpansionExpr .
@@ -3687,7 +3687,7 @@ class MaterializePackExpr final : public Expr {
   /// The expression from which to materialize a pack.
   Expr *FromExpr;
 
-  /// The source location of \c .element
+  /// The source location of (deprecated) \c .element
   SourceLoc ElementLoc;
 
   MaterializePackExpr(Expr *fromExpr, SourceLoc elementLoc,
@@ -3711,7 +3711,7 @@ public:
   }
 
   SourceLoc getEndLoc() const {
-    return ElementLoc;
+    return ElementLoc.isInvalid() ? ElementLoc : FromExpr->getEndLoc();
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -324,6 +324,7 @@ IDENTIFIER(size)
 IDENTIFIER(speed)
 IDENTIFIER(unchecked)
 IDENTIFIER(unsafe)
+IDENTIFIER(element)
 
 // The singleton instance of TupleTypeDecl in the Builtin module
 IDENTIFIER(TheTupleType)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6100,6 +6100,8 @@ Type isPlaceholderVar(PatternBindingDecl *PB);
 /// Dump an anchor node for a constraint locator or contextual type.
 void dumpAnchor(ASTNode anchor, SourceManager *SM, raw_ostream &out);
 
+bool isSingleUnlabeledPackExpansionTuple(Type type);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -54,8 +54,7 @@ enum class OverloadChoiceKind : int {
   /// The overload choice selects a particular declaration that
   /// was found by unwrapping an optional context type.
   DeclViaUnwrappedOptional,
-  /// The overload choice materializes a pack from a tuple using
-  /// the \c .element syntax.
+  /// The overload choice materializes a pack from a tuple.
   MaterializePack,
   /// The overload choice indexes into a tuple. Index zero will
   /// have the value of this enumerator, index one will have the value of this

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5223,7 +5223,6 @@ void PrintAST::visitPackExpansionExpr(PackExpansionExpr *expr) {
 
 void PrintAST::visitMaterializePackExpr(MaterializePackExpr *expr) {
   visit(expr->getFromExpr());
-  Printer << ".element";
 }
 
 void PrintAST::visitPackElementExpr(PackElementExpr *expr) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3559,7 +3559,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     break;
 
   case OverloadChoiceKind::MaterializePack: {
-    // Since `.element` is only applicable to single element tuples at the
+    // Since pack expansion is only applicable to single element tuples at the
     // moment we can just look through l-value base to load it.
     //
     // In the future, _if_ the syntax allows for multiple expansions

--- a/test/Interpreter/Inputs/variadic_generic_library.swift
+++ b/test/Interpreter/Inputs/variadic_generic_library.swift
@@ -44,14 +44,14 @@ public struct Predicate<each Input> {
     builder: (repeat Variable<each Input>) -> Expr
   ) where Expr: Expression<Bool> {
     self.variables = (repeat Variable<each Input>())
-    self.expression = builder(repeat each variables.element)
+    self.expression = builder(repeat each variables)
   }
 
   public func evaluate(
     _ input: repeat each Input
   ) throws -> Bool  {
     return try expression.evaluate(
-      .init(repeat (each variables.element, each input))
+      .init(repeat (each variables, each input))
     )
   }
 }

--- a/test/Interpreter/variadic_generic_tuples.swift
+++ b/test/Interpreter/variadic_generic_tuples.swift
@@ -57,7 +57,7 @@ func makeTuple<each Element>(
 
 func expandTupleElements<each T: Equatable>(_ value: repeat each T) {
   let values = makeTuple(repeat each value)
-  _ = (repeat expectEqual(each value, each values.element))
+  _ = (repeat expectEqual(each value, each values))
 }
 
 tuples.test("expandTuple") {

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -123,7 +123,7 @@ func wrapTupleElements<each T>(_ value: repeat each T) -> (repeat Wrapper<each T
   // CHECK: [[VAR:%.*]] = alloc_stack [lexical] $(repeat each T)
   let values = (repeat each value)
 
-  // Create a temporary for the 'values' in 'each values.element'
+  // Create a temporary for the 'values' in 'each values'
   // CHECK: bb3:
   // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $(repeat each T)
   // CHECK-NEXT: copy_addr [[VAR]] to [init] [[TEMP]] : $*(repeat each T)
@@ -155,7 +155,7 @@ func wrapTupleElements<each T>(_ value: repeat each T) -> (repeat Wrapper<each T
   // CHECK-NEXT: [[NEXT_INDEX:%.*]] = builtin "add_Word"([[INDEX]] : $Builtin.Word, [[ONE]] : $Builtin.Word) : $Builtin.Word
   // CHECK-NEXT: br bb4([[NEXT_INDEX]] : $Builtin.Word)
 
-  return (repeat Wrapper(value: each values.element))
+  return (repeat Wrapper(value: each values))
 
   // CHECK: destroy_addr [[TEMP]] : $*(repeat each T)
   // CHECK: dealloc_stack [[TEMP]] : $*(repeat each T)
@@ -303,7 +303,7 @@ struct FancyTuple<each T> {
   var x: (repeat each T)
 
   func makeTuple() -> (repeat each T) {
-    return (repeat each x.element)
+    return (repeat each x)
   }
 }
 


### PR DESCRIPTION
The solution in the PR is not in its final form. This version synthesizes `.element` access on the abstract tuple in the constraint system. The next step is to move away from depending on `.element` in any form, but I decided to commit the work in this stage to unblock the design proposal review and to stanch the bleeding in the form of this work getting seriously broken every couple of days by other changes in the codebase (which has been significant since I began it).

addresses rdar://107160966