### PR TITLE
[IRGen] Fix refcount bytes computation for single payload enums

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -218,8 +218,8 @@ public:
                                  nestedRefCountBytes);
         B.fillPlaceholderWithInt(skipBytesPlaceholder, IGM.SizeTy, nestedSkip);
 
-        refCountBytes += (4 * sizeof(uint64_t)) +
-                         (3 * IGM.getPointerSize().getValue()) +
+        refCountBytes += (3 * sizeof(uint64_t)) +
+                         (4 * IGM.getPointerSize().getValue()) +
                          nestedRefCountBytes;
         break;
       }


### PR DESCRIPTION
Nested ref count byte was accidentally counted as Int64, but should be Size

