### PR TITLE
[Runtime] Handle single payload enums in swift_resolve_resilientAcces…

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -436,6 +436,9 @@ void swift::swift_resolve_resilientAccessors(
     case RefCountingKind::Metatype:
       i += sizeof(uintptr_t);
       break;
+    case RefCountingKind::SinglePayloadEnumSimple:
+      i += (3 * sizeof(uint64_t)) + (4 * sizeof(size_t));
+      break;
     default:
       break;
     }

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -317,6 +317,7 @@ public enum MultiPayloadEnum {
     case b(Int, String)
     case c(Bool)
     case d
+    case e(SimpleClass)
 }
 
 public struct MultiPayloadEnumWrapper {
@@ -324,6 +325,26 @@ public struct MultiPayloadEnumWrapper {
     let y: AnyObject
 
     public init(x: MultiPayloadEnum, y: AnyObject) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct MixedEnumWrapper {
+    let x: SinglePayloadSimpleClassEnum
+    let y: MultiPayloadEnum
+
+    public init(x: SinglePayloadSimpleClassEnum, y: MultiPayloadEnum) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct MixedEnumWrapperWrapperGeneric<T> {
+    let x: MixedEnumWrapper
+    let y: T
+
+    public init(x: MixedEnumWrapper, y: T) {
         self.x = x
         self.y = y
     }

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -395,6 +395,42 @@ func testGenericResilient() {
 
 testGenericResilient()
 
+func testMixedEnumWrapperWrapperGeneric() {
+    let ptr = allocateInternalGenericPtr(of: MixedEnumWrapperWrapperGeneric<TestClass>.self)
+
+    do {
+        let x = MixedEnumWrapperWrapperGeneric(x: MixedEnumWrapper(x: .nonEmpty(SimpleClass(x: 23)),
+                                                                   y: .e(SimpleClass(x: 32))),
+                                               y: TestClass())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = MixedEnumWrapperWrapperGeneric(x: MixedEnumWrapper(x: .nonEmpty(SimpleClass(x: 28)),
+                                                                   y: .e(SimpleClass(x: 82))),
+                                               y: TestClass())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: TestClass deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    // CHECK-NEXT: SimpleClass deinitialized!
+    // CHECK-NEXT: TestClass deinitialized!
+    testGenericDestroy(ptr, of: MixedEnumWrapperWrapperGeneric<TestClass>.self)
+
+    ptr.deallocate()
+}
+
+testMixedEnumWrapperWrapperGeneric()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
…sors

rdar://109803119

It is sufficient to skip the header, because everything after that are regular ref counts
