### PR TITLE
[DiscardingTG] Fix runtime signature mismatch for statically known `-> Void` closure

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -832,7 +832,7 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   //  the async context to get at the parameters.
   //  See e.g. FutureAsyncContextPrefix.
 
-  if (!futureResultType) {
+  if (!futureResultType || taskCreateFlags.isDiscardingTask()) {
     auto asyncContextPrefix = reinterpret_cast<AsyncContextPrefix *>(
         reinterpret_cast<char *>(allocation) + headerSize -
         sizeof(AsyncContextPrefix));


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/65613, DiscardingTG started to accept `() -> Void` instead of `() -> T`, but it also changed the number of arguments accepted by the closure from 3 to 2. So it should use `non_future_adapter` instead of `future_adapter` to avoid runtime signature mismatch.


