### PR TITLE
[cxx-interop] Synthesize a deprecated zero initializer for C++ structs

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -438,10 +438,6 @@ synthesizeStructDefaultConstructorBody(AbstractFunctionDecl *afd,
   ASTContext &ctx = constructor->getASTContext();
   auto structDecl = static_cast<StructDecl *>(context);
 
-  // We should call into C++ constructors directly.
-  assert(!isa<clang::CXXRecordDecl>(structDecl->getClangDecl()) &&
-         "Should not synthesize a C++ object constructor.");
-
   // Use a builtin to produce a zero initializer, and assign it to self.
 
   // Construct the left-hand reference to self.

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -20,9 +20,13 @@
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ConstructorWithParam {
 // CHECK-NEXT:   init(_ val: Int32)
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct CopyAndMoveConstructor {
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct Base {
 // CHECK-NEXT:   init()
@@ -38,10 +42,14 @@
 // CHECK-NEXT: }
 // CHECK:      struct TemplatedConstructor {
 // CHECK-NEXT:   init<T>(_ value: T)
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   var value: ArgType
 // CHECK-NEXT: }
 // CHECK:      struct TemplatedConstructorWithExtraArg {
 // CHECK-NEXT:   init<T>(_: Int32, _ value: T)
 // CHECK-NEXT:   init<T>(_ value: T, _: Int32)
 // CHECK-NEXT:   init<T, U>(_ value: T, _ other: U)
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/constructors-objc-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-objc-module-interface.swift
@@ -7,4 +7,6 @@
 
 // CHECK:      struct ConstructorWithNSArrayParam {
 // CHECK-NEXT:   init(_ array: [Any]!)
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/constructors-typechecker.swift
+++ b/test/Interop/Cxx/class/constructors-typechecker.swift
@@ -6,7 +6,7 @@ let explicit = ExplicitDefaultConstructor()
 
 let implicit = ImplicitDefaultConstructor()
 
-let deletedImplicitly = ConstructorWithParam() // expected-error {{missing argument for parameter #1 in call}}
+let deletedImplicitly = ConstructorWithParam() // expected-warning {{'init()' is deprecated}}
 
 let deletedExplicitly = DefaultConstructorDeleted() // expected-error {{missing argument for parameter 'a' in call}}
 

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
@@ -3,6 +3,8 @@
 // CHECK: class C {
 // CHECK-NEXT: }
 // CHECK-NEXT: struct S {
+// CHECK-NEXT:   @available(*, deprecated, message
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   mutating func f() -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: func getSPtr() -> UnsafeMutablePointer<S>!


### PR DESCRIPTION
When importing a C header in the C++ language mode, Clang/Swift treat C structs as C++ structs.

Currently Swift synthesizes a default initializer that zero-initializes the backing memory of the struct for C structs, but not for C++ structs.

This is causing issues in existing projects that use C libraries and rely on having the default initializer available in Swift. This change enables the synthesis of a default initializer for C++ structs. Since many C++ structs are not designed to be initialized this way, the initializer is marked as deprecated in Swift.

rdar://109727620