### PR TITLE
[5.9] [Macros] Rework the way we assign closure and local discriminators

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -335,10 +335,6 @@ public:
   /// The # of times we have performed typo correction.
   unsigned NumTypoCorrections = 0;
 
-  /// The next auto-closure discriminator.  This needs to be preserved
-  /// across invocations of both the parser and the type-checker.
-  unsigned NextAutoClosureDiscriminator = 0;
-
   /// Cached mapping from types to their associated tangent spaces.
   llvm::DenseMap<Type, Optional<TangentSpace>> AutoDiffTangentSpaces;
 
@@ -1106,6 +1102,13 @@ public:
   /// name and context.
   unsigned getNextMacroDiscriminator(MacroDiscriminatorContext context,
                                      DeclBaseName baseName);
+
+  /// Get the next discriminator within the given declaration context.
+  unsigned getNextDiscriminator(const DeclContext *dc);
+
+  /// Set the maximum assigned discriminator within the given declaration context.
+  void setMaxAssignedDiscriminator(
+      const DeclContext *dc, unsigned discriminator);
 
   /// Retrieve the Clang module loader for this ASTContext.
   ///

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -401,6 +401,9 @@ struct ASTContext::Implementation {
   llvm::DenseMap<std::pair<const void *, Identifier>, unsigned>
       NextMacroDiscriminator;
 
+  /// Local and closure discriminators per context.
+  llvm::DenseMap<const DeclContext *, unsigned> NextDiscriminator;
+
   /// Structure that captures data that is segregated into different
   /// arenas.
   struct Arena {
@@ -2168,6 +2171,18 @@ unsigned ASTContext::getNextMacroDiscriminator(
   std::pair<const void *, Identifier> key(
       context.getOpaqueValue(), baseName.getIdentifier());
   return getImpl().NextMacroDiscriminator[key]++;
+}
+
+/// Get the next discriminator within the given declaration context.
+unsigned ASTContext::getNextDiscriminator(const DeclContext *dc) {
+  return getImpl().NextDiscriminator[dc];
+}
+
+/// Set the maximum assigned discriminator within the given declaration context.
+void ASTContext::setMaxAssignedDiscriminator(
+    const DeclContext *dc, unsigned discriminator) {
+  assert(discriminator >= getImpl().NextDiscriminator[dc]);
+  getImpl().NextDiscriminator[dc] = discriminator;
 }
 
 void ASTContext::verifyAllLoadedModules() const {

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -400,3 +400,12 @@ func testFreestandingWithClosure(i: Int) {
     return x
   }
 }
+
+// Nested macros with closures
+@freestanding(expression) macro coerceToInt<T>(_ value: T) -> Int = #externalMacro(module: "MacroDefinition", type: "CoerceToIntMacro")
+
+func testFreestandingClosureNesting() {
+  _ = #stringify({ () -> Int in
+    #coerceToInt(2)
+  })
+}


### PR DESCRIPTION
* **Explanation**: Make the assignment of discriminators only walk macro arguments, and then lazily assign discriminators for anything within a macro expansion or in ill-formed code. This replaces the single global "next autoclosure discriminator" scheme with a per-DeclContext scheme, that is more reliable/robust, although it does mean that discriminators of closures and locals within macro expansions are dependent on ordering. This eliminates some crashes involving macro expansions including closures and local variables.
* **Scope**: Narrow; only code within macro expansions should be affected.
* **Risk**: Medium-low; this updates some common code paths used to assign closure/local variable descriptors, but any actual change should be limited to code within macro expansions.
* **Issue**:  rdar://108682196
* **Original pull request**: https://github.com/apple/swift/pull/66198
