### PR TITLE
[5.9] [Walker] Don't visit VarDecls encountered in freestanding macro expansions

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -335,10 +335,6 @@ public:
   /// The # of times we have performed typo correction.
   unsigned NumTypoCorrections = 0;
 
-  /// The next auto-closure discriminator.  This needs to be preserved
-  /// across invocations of both the parser and the type-checker.
-  unsigned NextAutoClosureDiscriminator = 0;
-
   /// Cached mapping from types to their associated tangent spaces.
   llvm::DenseMap<Type, Optional<TangentSpace>> AutoDiffTangentSpaces;
 
@@ -1106,6 +1102,13 @@ public:
   /// name and context.
   unsigned getNextMacroDiscriminator(MacroDiscriminatorContext context,
                                      DeclBaseName baseName);
+
+  /// Get the next discriminator within the given declaration context.
+  unsigned getNextDiscriminator(const DeclContext *dc);
+
+  /// Set the maximum assigned discriminator within the given declaration context.
+  void setMaxAssignedDiscriminator(
+      const DeclContext *dc, unsigned discriminator);
 
   /// Retrieve the Clang module loader for this ASTContext.
   ///

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -401,6 +401,9 @@ struct ASTContext::Implementation {
   llvm::DenseMap<std::pair<const void *, Identifier>, unsigned>
       NextMacroDiscriminator;
 
+  /// Local and closure discriminators per context.
+  llvm::DenseMap<const DeclContext *, unsigned> NextDiscriminator;
+
   /// Structure that captures data that is segregated into different
   /// arenas.
   struct Arena {
@@ -2168,6 +2171,18 @@ unsigned ASTContext::getNextMacroDiscriminator(
   std::pair<const void *, Identifier> key(
       context.getOpaqueValue(), baseName.getIdentifier());
   return getImpl().NextMacroDiscriminator[key]++;
+}
+
+/// Get the next discriminator within the given declaration context.
+unsigned ASTContext::getNextDiscriminator(const DeclContext *dc) {
+  return getImpl().NextDiscriminator[dc];
+}
+
+/// Set the maximum assigned discriminator within the given declaration context.
+void ASTContext::setMaxAssignedDiscriminator(
+    const DeclContext *dc, unsigned discriminator) {
+  assert(discriminator >= getImpl().NextDiscriminator[dc]);
+  getImpl().NextDiscriminator[dc] = discriminator;
 }
 
 void ASTContext::verifyAllLoadedModules() const {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -460,7 +460,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (shouldWalkExpansion) {
       MED->visitAuxiliaryDecls([&](Decl *decl) {
         if (alreadyFailed) return;
-        alreadyFailed = inherited::visit(decl);
+        if (!isa<VarDecl>(decl))
+          alreadyFailed = inherited::visit(decl);
       });
       MED->forEachExpandedExprOrStmt([&](ASTNode expandedNode) {
         if (alreadyFailed) return;

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -400,3 +400,12 @@ func testFreestandingWithClosure(i: Int) {
     return x
   }
 }
+
+// Nested macros with closures
+@freestanding(expression) macro coerceToInt<T>(_ value: T) -> Int = #externalMacro(module: "MacroDefinition", type: "CoerceToIntMacro")
+
+func testFreestandingClosureNesting() {
+  _ = #stringify({ () -> Int in
+    #coerceToInt(2)
+  })
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -52,6 +52,9 @@ macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(mo
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
 @freestanding(declaration, names: arbitrary) macro bitwidthNumberedStructs(_ baseName: String, blah: Bool) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
+
+@freestanding(declaration, names: named(value)) macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
+
 #endif
 
 #if TEST_DIAGNOSTICS
@@ -408,4 +411,9 @@ func testFreestandingClosureNesting() {
   _ = #stringify({ () -> Int in
     #coerceToInt(2)
   })
+}
+
+// Freestanding declaration macros that produce local variables
+func testLocalVarsFromDeclarationMacros() {
+  #varValue
 }


### PR DESCRIPTION
* **Explanation**: VarDecls are always walked via their pattern bindings, so we end up
with double-visitation if we also visit them in freestanding macro expansions, causing a compiler assertion.
* **Scope**: Narrow; only code within macro expansions is affected.
* **Risk**: Low due to narrow scope.
* **Issue**:  rdar://109376102.
* **Original pull request**: https://github.com/apple/swift/pull/66202
