### PR TITLE
[5.9] IRGen: Assorted `-unavailable-decl-optimization` fixes

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -1082,11 +1082,11 @@ LLVM_LIBRARY_VISIBILITY bool usesObjCAllocator(ClassDecl *theClass);
 /// Returns true if SIL/IR lowering for the given declaration should be skipped.
 /// A declaration may not require lowering if, for example, it is annotated as
 /// unavailable and optimization settings allow it to be omitted.
-LLVM_LIBRARY_VISIBILITY bool shouldSkipLowering(Decl *D);
+LLVM_LIBRARY_VISIBILITY bool shouldSkipLowering(const Decl *D);
 
 /// Returns true if SIL/IR lowering for the given declaration should produce
 /// a stub that traps at runtime because the code ought to be unreachable.
-LLVM_LIBRARY_VISIBILITY bool shouldLowerToUnavailableCodeStub(Decl *D);
+LLVM_LIBRARY_VISIBILITY bool shouldLowerToUnavailableCodeStub(const Decl *D);
 } // namespace Lowering
 
 /// Apply the given function to each ABI member of \c D skipping the members

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -181,8 +181,12 @@ AvailabilityInference::parentDeclForInferredAvailability(const Decl *D) {
       return NTD;
   }
 
-  if (auto *PBD = dyn_cast<PatternBindingDecl>(D))
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+    if (PBD->getNumPatternEntries() < 1)
+      return nullptr;
+
     return PBD->getAnchoringVarDecl(0);
+  }
 
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(D))
     return OTD->getNamingDecl();

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1831,6 +1831,9 @@ namespace {
 
     void buildMethod(ConstantArrayBuilder &descriptors,
                      AbstractFunctionDecl *method) {
+      if (Lowering::shouldSkipLowering(method))
+        return;
+
       auto accessor = dyn_cast<AccessorDecl>(method);
       if (!accessor)
         return emitObjCMethodDescriptor(IGM, descriptors, method);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1568,7 +1568,9 @@ void IRGenerator::noteUseOfTypeGlobals(NominalTypeDecl *type,
                                        RequireMetadata_t requireMetadata) {
   if (!type)
     return;
-  
+
+  assert(!Lowering::shouldSkipLowering(type));
+
   // Force emission of ObjC protocol descriptors used by type refs.
   if (auto proto = dyn_cast<ProtocolDecl>(type)) {
     if (proto->isObjC()) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5486,6 +5486,8 @@ static Address getAddrOfSimpleVariable(IRGenModule &IGM,
 /// The result is always a GlobalValue.
 Address IRGenModule::getAddrOfFieldOffset(VarDecl *var,
                                           ForDefinition_t forDefinition) {
+  assert(!Lowering::shouldSkipLowering(var));
+
   LinkEntity entity = LinkEntity::forFieldOffset(var);
   return getAddrOfSimpleVariable(*this, GlobalVars, entity,
                                  forDefinition);
@@ -5493,6 +5495,8 @@ Address IRGenModule::getAddrOfFieldOffset(VarDecl *var,
 
 Address IRGenModule::getAddrOfEnumCase(EnumElementDecl *Case,
                                        ForDefinition_t forDefinition) {
+  assert(!Lowering::shouldSkipLowering(Case));
+
   LinkEntity entity = LinkEntity::forEnumCase(Case);
   auto addr = getAddrOfSimpleVariable(*this, GlobalVars, entity, forDefinition);
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6040,6 +6040,13 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
       continue;
     }
 
+    // For the purposes of memory layout, treat unavailable cases as if they do
+    // not have a payload.
+    if (Lowering::shouldSkipLowering(elt)) {
+      elementsWithNoPayload.push_back({elt, nullptr, nullptr});
+      continue;
+    }
+
     // If the payload is indirect, we can use the NativeObject type metadata
     // without recurring. The box won't affect loadability or fixed-ness.
     if (elt->isIndirect() || theEnum->isIndirect()) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -263,6 +263,9 @@ EnumImplStrategy::getTagIndex(EnumElementDecl *Case) const {
 static void emitResilientTagIndex(IRGenModule &IGM,
                                   const EnumImplStrategy *strategy,
                                   EnumElementDecl *Case) {
+  if (Lowering::shouldSkipLowering(Case))
+    return;
+
   auto resilientIdx = strategy->getTagIndex(Case);
   auto *global = cast<llvm::GlobalVariable>(
     IGM.getAddrOfEnumCase(Case, ForDefinition).getAddress());

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -856,8 +856,11 @@ private:
     if (hasPayload && (decl->isIndirect() || enumDecl->isIndirect()))
       flags.setIsIndirectCase();
 
-    addField(flags, decl->getArgumentInterfaceType(),
-             decl->getBaseIdentifier().str());
+    Type interfaceType = Lowering::shouldSkipLowering(decl)
+                             ? nullptr
+                             : decl->getArgumentInterfaceType();
+
+    addField(flags, interfaceType, decl->getBaseIdentifier().str());
   }
 
   void layoutEnum() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -36,6 +36,7 @@
 #include "swift/IRGen/ValueWitness.h"
 #include "swift/SIL/RuntimeEffect.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILModule.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Hashing.h"
@@ -455,6 +456,7 @@ public:
   }
 
   void noteLazyReemissionOfNominalTypeDescriptor(NominalTypeDecl *decl) {
+    assert(!Lowering::shouldSkipLowering(decl));
     LazilyReemittedTypeContextDescriptors.insert(decl);
   }
 
@@ -464,6 +466,7 @@ public:
   }
 
   void noteUseOfMetadataAccessor(NominalTypeDecl *decl) {
+    assert(!Lowering::shouldSkipLowering(decl));
     if (LazyMetadataAccessors.count(decl) == 0) {
       LazyMetadataAccessors.insert(decl);
     }

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -34,6 +34,7 @@
 #include "TupleMetadataVisitor.h"
 
 #include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILModule.h"
 #include "llvm/ADT/Optional.h"
 
 using namespace swift;

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -956,7 +956,7 @@ bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
   return theClass->getObjectModel() == ReferenceCounting::ObjC;
 }
 
-bool Lowering::shouldSkipLowering(Decl *D) {
+bool Lowering::shouldSkipLowering(const Decl *D) {
   if (D->getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
       UnavailableDeclOptimization::Complete)
     return false;
@@ -966,7 +966,7 @@ bool Lowering::shouldSkipLowering(Decl *D) {
   return D->getSemanticUnavailableAttr() != None;
 }
 
-bool Lowering::shouldLowerToUnavailableCodeStub(Decl *D) {
+bool Lowering::shouldLowerToUnavailableCodeStub(const Decl *D) {
   if (D->getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
       UnavailableDeclOptimization::Stub)
     return false;

--- a/test/IRGen/unavailable_decl_optimization_complete_enum.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_enum.swift
@@ -1,14 +1,27 @@
 // RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -enable-library-evolution %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP,CHECK-RESILIENT,CHECK-NO-STRIP-RESILIENT
 
 // RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -enable-library-evolution -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP,CHECK-RESILIENT,CHECK-STRIP-RESILIENT
 
 // CHECK: private constant [27 x i8] c"availableEnumAvailableCase\00"
 
 // FIXME: Should this reflection metadata for an unavailable case be stripped?
 // CHECK: private constant [29 x i8] c"availableEnumUnavailableCase\00"
 
+// CHECK-NO-STRIP-RESILIENT: @"$s4Test13AvailableEnumO09availableC34UnavailableCaseWithAssociatedValueyAcA0E6StructVcACmFWC" = {{.*}}constant
+// CHECK-STRIP-RESILIENT-NOT: @"$s4Test13AvailableEnumO09availableC34UnavailableCaseWithAssociatedValueyAcA0E6StructVcACmFWC" =
+
+// CHECK-RESILIENT: @"$s4Test13AvailableEnumO09availablecB4CaseyA2CmFWC" = {{.*}}constant
+
+// CHECK-NO-STRIP-RESILIENT: @"$s4Test13AvailableEnumO09availableC15UnavailableCaseyA2CmFWC" = {{.*}}constant
+// CHECK-STRIP-RESILIENT-NOT: @"$s4Test13AvailableEnumO09availableC15UnavailableCaseyA2CmFWC" =
+
 // CHECK-NO-STRIP: private constant [25 x i8] c"unavailableEnumFirstCase\00"
 // CHECK-STRIP-NOT: private constant [25 x i8] c"unavailableEnumFirstCase\00"
+
+// CHECK-NO-STRIP-RESILIENT: @"$s4Test15UnavailableEnumO011unavailableC9FirstCaseyA2CmFWC" = {{.*}}constant
+// CHECK-STRIP-RESILIENT-NOT: @"$s4Test15UnavailableEnumO011unavailableC9FirstCaseyA2CmFWC"
 
 @available(*, unavailable)
 public struct UnavailableStruct {}
@@ -38,15 +51,6 @@ public enum UnavailableEnum {
   // CHECK-NO-STRIP: s4Test15UnavailableEnumO6methodyyF
   // CHECK-STRIP-NOT: s4Test15UnavailableEnumO6methodyyF
   public func method() {}
-
-  // CHECK-NO-STRIP: s4Test15UnavailableEnumO21__derived_enum_equalsySbAC_ACtFZ
-  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO21__derived_enum_equalsySbAC_ACtFZ
-
-  // CHECK-NO-STRIP: s4Test15UnavailableEnumO4hash4intoys6HasherVz_tF
-  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO4hash4intoys6HasherVz_tF
-
-  // CHECK-NO-STRIP: s4Test15UnavailableEnumO9hashValueSivg
-  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO9hashValueSivg
 }
 
 // CHECK: s4Test13AvailableEnumOwug

--- a/test/IRGen/unavailable_decl_optimization_complete_enum.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_enum.swift
@@ -10,6 +10,8 @@
 // CHECK-NO-STRIP: private constant [25 x i8] c"unavailableEnumFirstCase\00"
 // CHECK-STRIP-NOT: private constant [25 x i8] c"unavailableEnumFirstCase\00"
 
+@available(*, unavailable)
+public struct UnavailableStruct {}
 
 public enum AvailableEnum {
   case availableEnumAvailableCase
@@ -17,15 +19,17 @@ public enum AvailableEnum {
   @available(*, unavailable)
   case availableEnumUnavailableCase
 
+  @available(*, unavailable)
+  case availableEnumUnavailableCaseWithAssociatedValue(UnavailableStruct)
+
   // CHECK-NO-STRIP: s4Test13AvailableEnumO17unavailableMethodyyF
   // CHECK-STRIP-NOT: s4Test13AvailableEnumO17unavailableMethodyyF
   @available(*, unavailable)
   public func unavailableMethod() {}
-
-  // CHECK: s4Test13AvailableEnumO21__derived_enum_equalsySbAC_ACtFZ
-  // CHECK: s4Test13AvailableEnumO4hash4intoys6HasherVz_tF
-  // CHECK: s4Test13AvailableEnumO9hashValueSivg
 }
+
+// CHECK-NO-STRIP: s4Test17UnavailableStructVMa
+// CHECK-STRIP-NOT: s4Test17UnavailableStructVMa
 
 @available(*, unavailable)
 public enum UnavailableEnum {

--- a/test/IRGen/unavailable_decl_optimization_complete_objc.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_objc.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+public class Class: NSObject {
+  // CHECK-NO-STRIP: define {{.*}} @"$s4Test5ClassC3fooyyF"
+  // CHECK-STRIP-NOT: define {{.*}} @"$s4Test5ClassC3fooyyF"
+
+  // CHECK-NO-STRIP: define {{.*}} @"$s4Test5ClassC3fooyyFTo"
+  // CHECK-STRIP-NOT: define {{.*}} @"$s4Test5ClassC3fooyyFTo"
+  @available(*, unavailable)
+  @objc public func foo() {}
+}

--- a/test/Interpreter/enum_unavailable_cases.swift
+++ b/test/Interpreter/enum_unavailable_cases.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Xfrontend -unavailable-decl-optimization=complete -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+@available(*, unavailable)
+class UnavailableClass {
+  var x: UInt8 = 0
+}
+
+enum SingletonTrivial {
+  @available(*, unavailable)
+  case unavailable(UInt8)
+}
+
+enum SingletonClass {
+  @available(*, unavailable)
+  case unavailable(UnavailableClass)
+}
+
+enum NoPayload {
+  case x
+  @available(*, unavailable)
+  case unavailable
+  case y
+}
+
+enum SinglePayloadTrivial {
+  case x
+  @available(*, unavailable)
+  case unavailable(UInt8)
+  case y
+}
+
+enum MultiPayloadTrivial {
+  case x(UInt8)
+  @available(*, unavailable)
+  case unavailable(UInt8, UInt8)
+  case y
+}
+
+enum MultiPayloadGeneric<T, U> {
+  case x(T)
+  @available(*, unavailable)
+  case unavailable(T, U)
+  case y
+}
+
+expectEqual(MemoryLayout<SingletonTrivial>.size, 0)
+expectEqual(MemoryLayout<SingletonClass>.size, 0)
+expectEqual(MemoryLayout<NoPayload>.size, 1)
+expectEqual(MemoryLayout<SinglePayloadTrivial>.size, 1)
+expectEqual(MemoryLayout<MultiPayloadTrivial>.size, 2)
+expectEqual(MemoryLayout<MultiPayloadGeneric<UInt8, UInt8>>.size, 2)
+expectEqual(MemoryLayout<MultiPayloadGeneric<UInt32, UInt32>>.size, 5)


### PR DESCRIPTION
* **Explanation**: Addresses several bugs in code generation that would cause compiler crashes or linker errors when the `-unavailable-decl-optimization=complete` flag is specified.
* **Scope**: Code generation for declarations marked unavailable with the `@available` attribute when the `-unavailable-decl-optimization=complete` flag is specified.
* **Issues**: rdar://107483852, rdar://109805050, rdar://109911571
* **Risk**: Low. The behavioral changes are staged behind a compiler flag.
* **Testing**: Regression tests added
* **Reviewers**: @aschwaighofer 
* **Main branch PRs**: https://github.com/apple/swift/pull/66069, https://github.com/apple/swift/pull/66157, https://github.com/apple/swift/pull/66232
