### PR TITLE
[Serialization] Display contextual notes on deserialization errors and misconfigurations

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -143,7 +143,7 @@ namespace swift {
       StringRef StringVal;
       DeclNameRef IdentifierVal;
       ObjCSelector ObjCSelectorVal;
-      ValueDecl *TheValueDecl;
+      const ValueDecl *TheValueDecl;
       Type TypeVal;
       TypeRepr *TyR;
       FullyQualified<Type> FullyQualifiedTypeVal;
@@ -194,7 +194,7 @@ namespace swift {
       : Kind(DiagnosticArgumentKind::ObjCSelector), ObjCSelectorVal(S) {
     }
 
-    DiagnosticArgument(ValueDecl *VD)
+    DiagnosticArgument(const ValueDecl *VD)
       : Kind(DiagnosticArgumentKind::ValueDecl), TheValueDecl(VD) {
     }
 
@@ -305,7 +305,7 @@ namespace swift {
       return ObjCSelectorVal;
     }
 
-    ValueDecl *getAsValueDecl() const {
+    const ValueDecl *getAsValueDecl() const {
       assert(Kind == DiagnosticArgumentKind::ValueDecl);
       return TheValueDecl;
     }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -873,18 +873,54 @@ ERROR(need_hermetic_seal_to_import_module,none,
       (Identifier))
 
 ERROR(modularization_issue_decl_moved,Fatal,
-      "reference to %select{top-level|type}0 %1 broken by a context change; "
+      "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
       "%1 was expected to be in %2, but now a candidate is found only in %3",
       (bool, DeclName, const ModuleDecl*, const ModuleDecl*))
 ERROR(modularization_issue_decl_type_changed,Fatal,
-      "reference to %select{top-level|type}0 %1 broken by a context change; "
+      "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
       "the declaration kind of %1 %select{from %2|}5 changed since building '%3'"
       "%select{|, it was in %2 and is now a candidate is found only in %4}5",
       (bool, DeclName, const ModuleDecl*, StringRef, const ModuleDecl*, bool))
 ERROR(modularization_issue_decl_not_found,Fatal,
-      "reference to %select{top-level|type}0 %1 broken by a context change; "
+      "reference to %select{top-level declaration|type}0 %1 broken by a context change; "
       "%1 is not found, it was expected to be in %2",
       (bool, DeclName, const ModuleDecl*))
+
+NOTE(modularization_issue_note_expected,none,
+     "the %select{declaration|type}0 was expected to be found in module %1 at '%2'",
+     (bool, const ModuleDecl*, StringRef))
+NOTE(modularization_issue_note_expected_underlying,none,
+     "or expected to be found in the underlying module '%0' defined at '%1'",
+     (StringRef, StringRef))
+NOTE(modularization_issue_note_found,none,
+     "the %select{declaration|type}0 was actually found in module %1 at '%2'",
+     (bool, const ModuleDecl*, StringRef))
+
+NOTE(modularization_issue_stale_module,none,
+     "the module %0 has enabled library-evolution; "
+     "the following file may need to be deleted if the SDK was modified: '%1'",
+     (const ModuleDecl *, StringRef))
+NOTE(modularization_issue_swift_version,none,
+     "the module %0 was built with a Swift language version set to %1 "
+     "while the current invocation uses %2; "
+     "APINotes may change how clang declarations are imported",
+     (const ModuleDecl *, llvm::VersionTuple, llvm::VersionTuple))
+NOTE(modularization_issue_audit_headers,none,
+     "declarations in the %select{underlying|}0 clang module %1 "
+     "may be hidden by clang project settings",
+     (bool, const ModuleDecl*))
+NOTE(modularization_issue_layering_expected_local,none,
+     "the distributed module %0 refers to the local module %1; "
+     "this may be caused by clang project settings",
+     (const ModuleDecl*, const ModuleDecl*))
+NOTE(modularization_issue_layering_found_local,none,
+     "the reference may break layering; the candidate was found in "
+     "the local module %1 for a reference from the distributed module %0",
+     (const ModuleDecl*, const ModuleDecl*))
+NOTE(modularization_issue_related_modules,none,
+     "the %select{declaration|type}0 %1 moved between related modules; "
+     "clang project settings may affect headers shared between these modules",
+     (bool, DeclName))
 
 NOTE(modularization_issue_side_effect_extension_error,none,
      "could not deserialize extension",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -875,16 +875,16 @@ ERROR(need_hermetic_seal_to_import_module,none,
 ERROR(modularization_issue_decl_moved,Fatal,
       "reference to %select{top-level|type}0 %1 broken by a context change; "
       "%1 was expected to be in %2, but now a candidate is found only in %3",
-      (bool, DeclName, Identifier, Identifier))
+      (bool, DeclName, const ModuleDecl*, const ModuleDecl*))
 ERROR(modularization_issue_decl_type_changed,Fatal,
       "reference to %select{top-level|type}0 %1 broken by a context change; "
       "the declaration kind of %1 %select{from %2|}5 changed since building '%3'"
-      "%select{|, it was in %2 and is now found in %4}5",
-      (bool, DeclName, Identifier, StringRef, Identifier, bool))
+      "%select{|, it was in %2 and is now a candidate is found only in %4}5",
+      (bool, DeclName, const ModuleDecl*, StringRef, const ModuleDecl*, bool))
 ERROR(modularization_issue_decl_not_found,Fatal,
       "reference to %select{top-level|type}0 %1 broken by a context change; "
       "%1 is not found, it was expected to be in %2",
-      (bool, DeclName, Identifier))
+      (bool, DeclName, const ModuleDecl*))
 
 NOTE(modularization_issue_side_effect_extension_error,none,
      "could not deserialize extension",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -893,9 +893,10 @@ NOTE(modularization_issue_side_effect_type_error,none,
      "could not deserialize type for %0",
      (DeclName))
 
-WARNING(modularization_issue_worked_around,none,
-        "attempting forced recovery enabled by -experimental-force-workaround-broken-modules",
-        ())
+NOTE(modularization_issue_worked_around,none,
+     "attempting forced recovery enabled by "
+     "-experimental-force-workaround-broken-modules",
+     ())
 
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -907,11 +907,11 @@ NOTE(modularization_issue_swift_version,none,
      (const ModuleDecl *, llvm::VersionTuple, llvm::VersionTuple))
 NOTE(modularization_issue_audit_headers,none,
      "declarations in the %select{underlying|}0 clang module %1 "
-     "may be hidden by clang project settings",
+     "may be hidden by clang preprocessor macros",
      (bool, const ModuleDecl*))
 NOTE(modularization_issue_layering_expected_local,none,
      "the distributed module %0 refers to the local module %1; "
-     "this may be caused by clang project settings",
+     "this may be caused by header maps or search paths",
      (const ModuleDecl*, const ModuleDecl*))
 NOTE(modularization_issue_layering_found_local,none,
      "the reference may break layering; the candidate was found in "
@@ -919,7 +919,7 @@ NOTE(modularization_issue_layering_found_local,none,
      (const ModuleDecl*, const ModuleDecl*))
 NOTE(modularization_issue_related_modules,none,
      "the %select{declaration|type}0 %1 moved between related modules; "
-     "clang project settings may affect headers shared between these modules",
+     "clang preprocessor macros may affect headers shared between these modules",
      (bool, DeclName))
 
 NOTE(modularization_issue_side_effect_extension_error,none,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2059,13 +2059,13 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     if (getContext().LangOpts.ForceWorkaroundBrokenModules &&
         errorKind == ModularizationError::Kind::DeclMoved &&
         !values.empty()) {
-      // Print the error as a remark and notify of the recovery attempt.
-      getContext().Diags.diagnose(getSourceLoc(),
-                                  diag::modularization_issue_worked_around);
+      // Print the error as a warning and notify of the recovery attempt.
       llvm::handleAllErrors(std::move(error),
         [&](const ModularizationError &modularError) {
-          modularError.diagnose(this, DiagnosticBehavior::Note);
+          modularError.diagnose(this, DiagnosticBehavior::Warning);
         });
+      getContext().Diags.diagnose(getSourceLoc(),
+                                  diag::modularization_issue_worked_around);
     } else {
       return std::move(error);
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -189,6 +189,21 @@ SourceLoc ModuleFile::getSourceLoc() const {
   return SourceMgr.getLocForBufferStart(*bufferID);
 }
 
+SourceLoc ModularizationError::getSourceLoc() const {
+  auto &SourceMgr = referenceModule->getContext().Diags.SourceMgr;
+  auto filename = referenceModule->getModuleFilename();
+
+  // Synthesize some context. We don't have an actual decl here
+  // so try to print a simple representation of the reference.
+  std::string S;
+  llvm::raw_string_ostream OS(S);
+  OS << expectedModule->getName() << "." << name;
+
+  // If we enable these remarks by default we may want to reuse these buffers.
+  auto bufferID = SourceMgr.addMemBufferCopy(S, filename);
+  return SourceMgr.getLocForBufferStart(bufferID);
+}
+
 void
 ModularizationError::diagnose(const ModuleFile *MF,
                               DiagnosticBehavior limit) const {

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -355,40 +355,47 @@ private:
   DeclName name;
   bool declIsType;
   Kind errorKind;
-  Identifier expectedModuleName;
-  StringRef referencedFromModuleName;
-  Identifier foundModuleName;
+
+  /// Module targeted by the reference that should define the decl.
+  const ModuleDecl *expectedModule;
+
+  /// Binary module file with the outgoing reference.
+  const ModuleFile *referenceModule;
+
+  /// Module where the compiler did find the decl, if any.
+  const ModuleDecl *foundModule;
+
   XRefTracePath path;
 
 public:
   explicit ModularizationError(DeclName name, bool declIsType, Kind errorKind,
-                               Identifier expectedModuleName,
-                               StringRef referencedFromModuleName,
-                               Identifier foundModuleName,
+                               const ModuleDecl *expectedModule,
+                               const ModuleFile *referenceModule,
+                               const ModuleDecl *foundModule,
                                XRefTracePath path):
     name(name), declIsType(declIsType), errorKind(errorKind),
-    expectedModuleName(expectedModuleName),
-    referencedFromModuleName(referencedFromModuleName),
-    foundModuleName(foundModuleName), path(path) {}
+    expectedModule(expectedModule),
+    referenceModule(referenceModule),
+    foundModule(foundModule), path(path) {}
 
   void diagnose(const ModuleFile *MF,
                 DiagnosticBehavior limit = DiagnosticBehavior::Fatal) const;
 
   void log(raw_ostream &OS) const override {
     OS << "modularization issue on '" << name << "', reference from '";
-    OS << referencedFromModuleName << "' not resolvable: ";
+    OS << referenceModule->getName() << "' not resolvable: ";
     switch (errorKind) {
       case Kind::DeclMoved:
-        OS << "expected in '" << expectedModuleName << "' but found in '";
-        OS << foundModuleName << "'";
+        OS << "expected in '" << expectedModule->getName() << "' but found in '";
+        OS << foundModule->getName() << "'";
         break;
       case Kind::DeclKindChanged:
         OS << "decl details changed between what was imported from '";
-        OS << expectedModuleName << "' and what is now imported from '";
-        OS << foundModuleName << "'";
+        OS << expectedModule->getName() << "' and what is now imported from '";
+        OS << foundModule->getName() << "'";
         break;
       case Kind::DeclNotFound:
-        OS << "not found, expected in '" << expectedModuleName << "'";
+        OS << "not found, expected in '" << expectedModule->getName() << "'";
         break;
     }
     OS << "\n";

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -402,6 +402,8 @@ public:
     path.print(OS);
   }
 
+  SourceLoc getSourceLoc() const;
+
   std::error_code convertToErrorCode() const override {
     return llvm::inconvertibleErrorCode();
   }

--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -15,6 +15,43 @@
 
 /// Main error downgraded to a remark.
 // CHECK-MOVED: LibWithXRef.swiftmodule:1:1: remark: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
+
+/// Contextual notes about the modules involved.
+// CHECK-MOVED: <unknown>:0: note: the type was expected to be found in module 'A' at '
+// CHECK-MOVED-SAME: A.swiftmodule'
+// CHECK-MOVED: <unknown>:0: note: or expected to be found in the underlying module 'A' defined at '
+// CHECK-MOVED-SAME: module.modulemap'
+// CHECK-MOVED: <unknown>:0: note: the type was actually found in module 'A_related' at '
+// CHECK-MOVED-SAME: A_related.swiftmodule'
+
+/// More notes depending on the context
+// CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' was built with a Swift language version set to 5
+// CHECK-MOVED-SAME: while the current invocation uses 4
+
+// CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: '
+// CHECK-MOVED-SAME: LibWithXRef.swiftmodule'
+// CHECK-MOVED: <unknown>:0: note: declarations in the underlying clang module 'A' may be hidden by clang project settings
+// CHECK-MOVED: <unknown>:0: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by clang project settings
+// CHECK-MOVED: <unknown>:0: note: the type 'MyType' moved between related modules; clang project settings may affect headers shared between these modules
+// CHECK-MOVED: LibWithXRef.swiftmodule:1:1: note: could not deserialize type for 'foo()'
+// CHECK-MOVED: error: cannot find 'foo' in scope
+
+/// Move A to the SDK, triggering a different note about layering.
+// RUN: mv %t/A.swiftmodule %t/sdk/A.swiftmodule
+// RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK-LAYERING-FOUND %s
+// CHECK-LAYERING-FOUND: <unknown>:0: note: the reference may break layering; the candidate was found in the local module 'A_related' for a reference from the distributed module 'LibWithXRef'
+// CHECK-LAYERING-FOUND: error: cannot find 'foo' in scope
+
+/// Delete A, keep only the underlying clangmodule for notes about clang modules.
+// RUN: rm %t/sdk/A.swiftmodule
+// RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related
+// RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
+// RUN:   | %FileCheck --check-prefixes CHECK-CLANG %s
+// CHECK-CLANG: <unknown>:0: note: declarations in the clang module 'A' may be hidden by clang project settings
+// CHECK-CLANG: error: cannot find 'foo' in scope
+
+
 //--- module.modulemap
 module A {
     header "A.h"

--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -30,9 +30,9 @@
 
 // CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: '
 // CHECK-MOVED-SAME: LibWithXRef.swiftmodule'
-// CHECK-MOVED: <unknown>:0: note: declarations in the underlying clang module 'A' may be hidden by clang project settings
-// CHECK-MOVED: <unknown>:0: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by clang project settings
-// CHECK-MOVED: <unknown>:0: note: the type 'MyType' moved between related modules; clang project settings may affect headers shared between these modules
+// CHECK-MOVED: <unknown>:0: note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
+// CHECK-MOVED: <unknown>:0: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
+// CHECK-MOVED: <unknown>:0: note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
 // CHECK-MOVED: LibWithXRef.swiftmodule:1:1: note: could not deserialize type for 'foo()'
 // CHECK-MOVED: error: cannot find 'foo' in scope
 
@@ -48,7 +48,7 @@
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-CLANG %s
-// CHECK-CLANG: <unknown>:0: note: declarations in the clang module 'A' may be hidden by clang project settings
+// CHECK-CLANG: <unknown>:0: note: declarations in the clang module 'A' may be hidden by clang preprocessor macros
 // CHECK-CLANG: error: cannot find 'foo' in scope
 
 

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -18,8 +18,8 @@
 // RUN: %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t \
 // RUN:   -experimental-force-workaround-broken-modules 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-WORKAROUND %s
-// CHECK-WORKAROUND: warning: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
-// CHECK-WORKAROUND: note: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
+// CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
+// CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
 // CHECK-WORKAROUND: func foo() -> some Proto
 
 /// Change MyType into a function.

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -34,7 +34,7 @@
 // RUN: %target-swift-frontend %t/LibTypeChanged.swift -emit-module-path %t/B.swiftmodule -module-name B
 // RUN: not %target-swift-frontend -emit-sil %t/LibWithXRef.swiftmodule -module-name LibWithXRef -I %t 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK,CHECK-KIND-CHANGED-AND-MOVED %s
-// CHECK-KIND-CHANGED-AND-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the declaration kind of 'MyType' changed since building 'LibWithXRef', it was in 'A' and is now found in 'B'
+// CHECK-KIND-CHANGED-AND-MOVED: LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; the declaration kind of 'MyType' changed since building 'LibWithXRef', it was in 'A' and is now a candidate is found only in 'B'
 
 /// Remove MyType from all imported modules.
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A.swiftmodule -module-name A

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -19,7 +19,13 @@
 // RUN:   -experimental-force-workaround-broken-modules 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-WORKAROUND %s
 // CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
-// CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
+// CHECK-WORKAROUND-NEXT: A.MyType
+// CHECK-WORKAROUND-NEXT: ^
+// CHECK-WORKAROUND: <unknown>:0: note: the type was expected to be found in module 'A' at '
+// CHECK-WORKAROUND-SAME: A.swiftmodule'
+// CHECK-WORKAROUND: <unknown>:0: note: the type was actually found in module 'B' at '
+// CHECK-WORKAROUND-SAME: B.swiftmodule'
+// CHECK-WORKAROUND: <unknown>:0: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
 // CHECK-WORKAROUND: func foo() -> some Proto
 
 /// Change MyType into a function.


### PR DESCRIPTION
Since #65713 the Swift compiler raises a proper error instead of crashing when hitting a deserialization issue likely caused by broken modularization or project settings. This PR makes these diagnostics more helpful by providing contextual information:

- Paths to the modules involved (up to 4 modules): the loaded swiftmodule with the broken outgoing reference, the path to the module where the decl was expected, the path to the underlying clang module, and the path to the module where the decl was found. This information should prevent us from having to ask for a different log with `-Rmodule-loading`.
- Hint to delete the swiftmodule files when the module is library-evolution enabled.
- Hint that clang settings affect clang modules involved in this scenario.
- Pointing out when a decl moved between two modules with a similar name (where one name is a prefix of the other). This is a common issue when headers are shared between a clang framework's public and private modules.
- Pointing out layering issues when an SDK module imports a local module.
- Pointing out Swift language version mismatch which may lead to the compiler viewing the same clang decls differently when they are modified by APINotes files.

These notes are also display with `-Rmodule-recovery` (#66139) and when `-experimental-force-workaround-broken-modules` triggers and shows a warning (#66186).

---

There is room to improve those diagnostics further. We're considering bubbling up decls marked invalid instead of passing up errors in deserialization, this would allow for more complete synthesized decl when pointing to the final effect of the failure. We may also need to prioritize diagnosing these errors at a few sites where the compiler would still crash. We could also added services to the diagnostics engine to support one-line diagnostics pointing to binary files, without showing source code or the `:1:1`.