### PR TITLE
Guard packIdx with #ifndef NDEBUG

### DIFF
--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -463,7 +463,9 @@ struct GenericSignatureLayout {
       }
     }
 
+#ifndef NDEBUG
     assert(packIdx == NumPacks);
+#endif
   }
 
   size_t sizeInWords() const {


### PR DESCRIPTION
To make builds work on environments where assert() isn't compiled out on release builds.