### PR TITLE
IRGen: Avoid emitting Obj-C method metadata for unavailable methods

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -182,8 +182,12 @@ AvailabilityInference::parentDeclForInferredAvailability(const Decl *D) {
       return NTD;
   }
 
-  if (auto *PBD = dyn_cast<PatternBindingDecl>(D))
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+    if (PBD->getNumPatternEntries() < 1)
+      return nullptr;
+
     return PBD->getAnchoringVarDecl(0);
+  }
 
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(D))
     return OTD->getNamingDecl();

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1831,6 +1831,9 @@ namespace {
 
     void buildMethod(ConstantArrayBuilder &descriptors,
                      AbstractFunctionDecl *method) {
+      if (Lowering::shouldSkipLowering(method))
+        return;
+
       auto accessor = dyn_cast<AccessorDecl>(method);
       if (!accessor)
         return emitObjCMethodDescriptor(IGM, descriptors, method);

--- a/test/IRGen/unavailable_decl_optimization_complete_objc.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_objc.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+public class Class: NSObject {
+  // CHECK-NO-STRIP: define {{.*}} @"$s4Test5ClassC3fooyyF"
+  // CHECK-STRIP-NOT: define {{.*}} @"$s4Test5ClassC3fooyyF"
+
+  // CHECK-NO-STRIP: define {{.*}} @"$s4Test5ClassC3fooyyFTo"
+  // CHECK-STRIP-NOT: define {{.*}} @"$s4Test5ClassC3fooyyFTo"
+  @available(*, unavailable)
+  @objc public func foo() {}
+}


### PR DESCRIPTION
Additionally, fix a crash when querying availability for empty `PatternBindingDecls`.

Resolves rdar://109911571
