### PR TITLE
Fix two problems with statically initialized enums

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -63,6 +63,7 @@ let initializeStaticGlobalsPass = FunctionPass(name: "initialize-static-globals"
 
   context.erase(instruction: allocInst)
   context.erase(instruction: storeToGlobal)
+  context.removeTriviallyDeadInstructionsIgnoringDebugUses(in: function)
 }
 
 /// Analyses the global initializer function and returns the `alloc_global` and `store`

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -336,7 +336,7 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
     return llvm::ConstantExpr::getIntToPtr(val, sTy);
 
   } else if (auto *CFI = dyn_cast<ConvertFunctionInst>(operand)) {
-    return emitConstantValue(IGM, CFI->getOperand()).claimNextConstant();
+    return emitConstantValue(IGM, CFI->getOperand());
 
   } else if (auto *T2TFI = dyn_cast<ThinToThickFunctionInst>(operand)) {
     SILType type = operand->getType();
@@ -349,7 +349,12 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
     auto *context = llvm::ConstantExpr::getBitCast(
         llvm::ConstantPointerNull::get(IGM.OpaquePtrTy),
         sTy->getTypeAtIndex((unsigned)1));
-    
+
+    if (flatten) {
+      Explosion out;
+      out.add({function, context});
+      return out;
+    }
     return llvm::ConstantStruct::get(sTy, {function, context});
 
   } else if (auto *FRI = dyn_cast<FunctionRefInst>(operand)) {

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -161,6 +161,16 @@ func getStringGen(_ s: StringGen) -> String {
   }
 }
 
+public enum R {
+    case success(Int)
+    case failure(Error)
+}
+
+public let success: R = .success(27)
+
+// CHECK-LABEL: sil_global hidden @$s4test10optSuccessAA1ROSgvp : $Optional<R> = {
+var optSuccess: R? = success
+
 // CHECK-LABEL: sil_global private @$s4test9createArrSaySiSgGyFTv_ : $_ContiguousArrayStorage<Optional<Int>> = {
 @inline(never)
 func createArr() -> [Int?] {
@@ -234,6 +244,8 @@ struct Main {
     print("stringGen2: \(getStringGen(sg2))")
     // CHECK-OUTPUT: stringGen3: str
     print("stringGen3: \(getStringGen(sg3))")
+    // CHECK-OUTPUT: optSuccess: Optional(test.R.success(27))
+    print("optSuccess:", optSuccess as Any)
   }
 }
 

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -130,6 +130,37 @@ var outer: Outer? = Outer(i: Inner(x: 2, y: 3), z: 4)
 // CHECK-LABEL: sil_global hidden @$s4test8optionalSiSgvp : $Optional<Int> = {
 var optional: Int? = Optional(42)
 
+struct StringGen {
+  enum E {
+    case none
+    case str(String)
+    case gen(() -> String)
+  }
+
+  var source: E
+}
+
+// CHECK-LABEL: sil_global hidden @$s4test3sg1AA9StringGenVvp : $StringGen = {
+var sg1 = StringGen(source: .gen({ "gen" }))
+
+// CHECK-LABEL: sil_global hidden @$s4test3sg2AA9StringGenVvp : $StringGen = {
+var sg2 = StringGen(source: .none)
+
+// CHECK-LABEL: sil_global hidden @$s4test3sg3AA9StringGenVvp : $StringGen = {
+var sg3 = StringGen(source: .str("str"))
+
+@inline(never)
+func getStringGen(_ s: StringGen) -> String {
+  switch s.source {
+    case .gen(let f):
+      return f()
+    case .str(let s):
+      return s
+    case .none:
+      return "none"
+  }
+}
+
 // CHECK-LABEL: sil_global private @$s4test9createArrSaySiSgGyFTv_ : $_ContiguousArrayStorage<Optional<Int>> = {
 @inline(never)
 func createArr() -> [Int?] {
@@ -197,6 +228,12 @@ struct Main {
     print("optional:", optional as Any)
     // CHECK-OUTPUT: createArr: [Optional(27), Optional(42), nil, Optional(103)]
     print("createArr:", createArr())
+    // CHECK-OUTPUT: stringGen1: gen
+    print("stringGen1: \(getStringGen(sg1))")
+    // CHECK-OUTPUT: stringGen2: none
+    print("stringGen2: \(getStringGen(sg2))")
+    // CHECK-OUTPUT: stringGen3: str
+    print("stringGen3: \(getStringGen(sg3))")
   }
 }
 

--- a/validation-test/SILOptimizer/static_enums_fuzzing.swift
+++ b/validation-test/SILOptimizer/static_enums_fuzzing.swift
@@ -22,7 +22,7 @@ func createTestfile() {
 
   print()
 
-  for (idx, t) in globals.enumerated() {
+  for (idx, _) in globals.enumerated() {
     print("""
           @inline(never) func printGlobal\(idx)() {
             print("global\(idx)var: \", global\(idx)var as Any)
@@ -78,6 +78,10 @@ var typeDefinitions: String {
       case B(V)
       case C
     }
+
+    public func fn() {}
+
+    public typealias Func = () -> ()
 
   """
 }
@@ -149,6 +153,16 @@ struct LargeString : Value {
   func getType() -> String { "String" }
   func getInitValue() -> String  { "\"large string which exceeds the inline buffer\"" }
   func getRuntimeTypeName(topLevel: Bool) -> String { topLevel ? "String" : "Swift.String" }
+}
+
+struct Function : Value {
+
+  init(generator: inout RandomGenerator, depth: Int) {}
+
+  func getType() -> String { "Func" }
+  func getInitValue() -> String  { "fn" }
+  func getRuntimeTypeName(topLevel: Bool) -> String { "() -> ()" }
+  func getExpectedOutput(topLevel: Bool) -> String { "(Function)" }
 }
 
 struct OptionalValue : Value {
@@ -340,23 +354,19 @@ struct RandomGenerator : RandomNumberGenerator {
     }
   }
 
-  private static let allValueTypes: [any Value.Type] = [
-    SmallInt.self,
-    LargeInt.self,
-    SmallString.self,
-    LargeString.self,
-    Enum.self,
-    OptionalValue.self,
-    Struct.self,
-    MultiPayloadEnum.self
-  ]
-
   private static let allTerminalTypes: [any Value.Type] = [
     SmallInt.self,
     LargeInt.self,
     SmallString.self,
     LargeString.self,
+    Function.self,
     Enum.self
   ]
+  private static let allValueTypes: [any Value.Type] = allTerminalTypes + [
+    OptionalValue.self,
+    Struct.self,
+    MultiPayloadEnum.self
+  ]
+
 }
 


### PR DESCRIPTION
* IRGen: fix generation of static enums with function payloads

fixes a compiler crash
rdar://109999583

* InitializeStaticGlobals: remove dead instructions in global initializer

After removing the store it's required to remove the remaining dead instructions to avoid ownership verifier errors.
rdar://109999674