### PR TITLE
[Variadic Generics] drop requirement of .element for tuple expansion

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3679,7 +3679,7 @@ public:
 };
 
 /// An expression to materialize a pack from a tuple containing a pack
-/// expansion, spelled \c tuple.element.
+/// expansion.
 ///
 /// These nodes are created by CSApply and should only appear in a
 /// type-checked AST in the context of a \c PackExpansionExpr .
@@ -3687,7 +3687,7 @@ class MaterializePackExpr final : public Expr {
   /// The expression from which to materialize a pack.
   Expr *FromExpr;
 
-  /// The source location of \c .element
+  /// The source location of (deprecated) \c .element
   SourceLoc ElementLoc;
 
   MaterializePackExpr(Expr *fromExpr, SourceLoc elementLoc,
@@ -3711,7 +3711,7 @@ public:
   }
 
   SourceLoc getEndLoc() const {
-    return ElementLoc;
+    return ElementLoc.isInvalid() ? ElementLoc : FromExpr->getEndLoc();
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -324,6 +324,7 @@ IDENTIFIER(size)
 IDENTIFIER(speed)
 IDENTIFIER(unchecked)
 IDENTIFIER(unsafe)
+IDENTIFIER(element)
 
 // The singleton instance of TupleTypeDecl in the Builtin module
 IDENTIFIER(TheTupleType)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6100,6 +6100,8 @@ Type isPlaceholderVar(PatternBindingDecl *PB);
 /// Dump an anchor node for a constraint locator or contextual type.
 void dumpAnchor(ASTNode anchor, SourceManager *SM, raw_ostream &out);
 
+bool isSingleUnlabeledPackExpansionTuple(Type type);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -54,8 +54,7 @@ enum class OverloadChoiceKind : int {
   /// The overload choice selects a particular declaration that
   /// was found by unwrapping an optional context type.
   DeclViaUnwrappedOptional,
-  /// The overload choice materializes a pack from a tuple using
-  /// the \c .element syntax.
+  /// The overload choice materializes a pack from a tuple.
   MaterializePack,
   /// The overload choice indexes into a tuple. Index zero will
   /// have the value of this enumerator, index one will have the value of this

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5192,7 +5192,6 @@ void PrintAST::visitPackExpansionExpr(PackExpansionExpr *expr) {
 
 void PrintAST::visitMaterializePackExpr(MaterializePackExpr *expr) {
   visit(expr->getFromExpr());
-  Printer << ".element";
 }
 
 void PrintAST::visitPackElementExpr(PackElementExpr *expr) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3142,10 +3142,11 @@ namespace {
             if (type->is<ElementArchetypeType>() &&
                 CS.hasFixFor(CS.getConstraintLocator(declRef),
                              FixKind::IgnoreMissingEachKeyword)) {
-              Packs.push_back(PackElementExpr::create(CS.getASTContext(),
-                                                      /*eachLoc=*/SourceLoc(),
-                                                      declRef,
-                                                      /*implicit=*/true));
+              auto *packElementExpr =
+                  PackElementExpr::create(CS.getASTContext(),
+                                          /*eachLoc=*/{}, declRef,
+                                          /*implicit=*/true, type);
+              Packs.push_back(CS.cacheType(packElementExpr));
             }
           }
 
@@ -3224,8 +3225,17 @@ namespace {
     }
 
     Type visitPackElementExpr(PackElementExpr *expr) {
-      return openPackElement(CS.getType(expr->getPackRefExpr()),
-                             CS.getConstraintLocator(expr));
+      auto packType = CS.getType(expr->getPackRefExpr());
+
+      if (isSingleUnlabeledPackExpansionTuple(packType)) {
+        packType =
+            addMemberRefConstraints(expr, expr->getPackRefExpr(),
+                                    DeclNameRef(CS.getASTContext().Id_element),
+                                    FunctionRefKind::Unapplied, {});
+        CS.setType(expr->getPackRefExpr(), packType);
+      }
+
+      return openPackElement(packType, CS.getConstraintLocator(expr));
     }
 
     Type visitMaterializePackExpr(MaterializePackExpr *expr) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -127,6 +127,14 @@ static bool isPackExpansionType(Type type) {
   return false;
 }
 
+bool constraints::isSingleUnlabeledPackExpansionTuple(Type type) {
+  auto *tuple = type->getRValueType()->getAs<TupleType>();
+  // TODO: drop no name requirement
+  return tuple && (tuple->getNumElements() == 1) &&
+         isPackExpansionType(tuple->getElementType(0)) &&
+         !tuple->getElement(0).hasName();
+}
+
 static bool containsPackExpansionType(ArrayRef<AnyFunctionType::Param> params) {
   return llvm::any_of(params, [&](const auto &param) {
     return isPackExpansionType(param.getPlainType());
@@ -9150,6 +9158,16 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
       return SolutionKind::Solved;
   }
 
+  if (isSingleUnlabeledPackExpansionTuple(patternType)) {
+    auto *elementVar =
+        createTypeVariable(getConstraintLocator(locator), /*options=*/0);
+    addValueMemberConstraint(
+        patternType, DeclNameRef(getASTContext().Id_element), elementVar, DC,
+        FunctionRefKind::Unapplied, {},
+        getConstraintLocator(locator, {ConstraintLocator::Member}));
+    patternType = elementVar;
+  }
+
   // Let's try to resolve element type based on the pattern type.
   if (!patternType->hasTypeVariable()) {
     auto *loc = getConstraintLocator(locator);
@@ -9367,6 +9385,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     if (!memberName.isSpecial()) {
       StringRef nameStr = memberName.getBaseIdentifier().str();
       // Accessing `.element` on an abstract tuple materializes a pack.
+      // (deprecated behavior)
       if (nameStr == "element" && baseTuple->getNumElements() == 1 &&
           isPackExpansionType(baseTuple->getElementType(0))) {
         auto elementType = baseTuple->getElementType(0);
@@ -13339,6 +13358,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
 
     recordTypeVariablesAsHoles(shapeTy);
     return SolutionKind::Solved;
+  }
+
+  // Map element archetypes to the pack context to check for equality.
+  if (packTy->hasElementArchetype()) {
+    auto *packEnv = DC->getGenericEnvironmentOfContext();
+    packTy = packEnv->mapElementTypeIntoPackContext(packTy);
   }
 
   auto shape = packTy->getReducedShape();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3559,7 +3559,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     break;
 
   case OverloadChoiceKind::MaterializePack: {
-    // Since `.element` is only applicable to single element tuples at the
+    // Since pack expansion is only applicable to single element tuples at the
     // moment we can just look through l-value base to load it.
     //
     // In the future, _if_ the syntax allows for multiple expansions

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -131,14 +131,18 @@ func expansionOfNonPackType<T>(_ t: repeat each T) {}
 
 func tupleExpansion<each T, each U>(
   _ tuple1: (repeat each T),
-  _ tuple2: (repeat each U)
+  _ tuple2: (repeat each U),
+  _ tuple3: inout (repeat each T)
 ) {
-  _ = forward(repeat each tuple1.element)
+  _ = forward(repeat each tuple1)
 
-  _ = zip(repeat each tuple1.element, with: repeat each tuple1.element)
+  _ = zip(repeat each tuple1, with: repeat each tuple1)
+  _ = zip(repeat each tuple1, with: repeat each tuple1.element) // legacy syntax
 
-  _ = zip(repeat each tuple1.element, with: repeat each tuple2.element)
+  _ = zip(repeat each tuple1, with: repeat each tuple2)
   // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each T' and 'each U' have the same shape}}
+
+  _ = forward(repeat each tuple3)
 }
 
 protocol Generatable {
@@ -244,10 +248,10 @@ func test_pack_expansion_materialization_from_lvalue_base() {
 
     init() {
       self.data = (repeat Data<each T>())
-      _ = (repeat each data.element) // Ok
+      _ = (repeat each data) // Ok
 
       var tmp = (repeat Data<each T>()) // expected-warning {{never mutated}}
-      _ = (repeat each tmp.element) // Ok
+      _ = (repeat each tmp) // Ok
 
       // TODO: Add subscript test-case when syntax is supported.
     }
@@ -275,10 +279,9 @@ func packOutsideExpansion<each T>(_ t: repeat each T) {
 
   let tuple = (repeat each t)
 
-  _ = tuple.element
-  // expected-error@-1{{pack reference 'each T' can only appear in pack expansion}}
+  _ = tuple
 
-  _ = each tuple.element
+  _ = each tuple
   // expected-error@-1{{pack reference 'each T' can only appear in pack expansion}}
 }
 
@@ -482,7 +485,6 @@ do {
   func test_misplaced_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
     return (repeat each value.makeA())
     // expected-error@-1 {{value pack 'each T' must be referenced with 'each'}} {{25-25=(each }} {{30-30=)}}
-    // expected-error@-2 {{pack expansion requires that '()' and 'each T' have the same shape}}
   }
 }
 
@@ -538,5 +540,17 @@ do {
   func caller<each T1, each T2>(t1: repeat each T1, t2: repeat each T2) {
     test1(repeat each t1, repeat each t2) // Ok
     test2(repeat each t2, repeat each t1) // expected-error {{local function 'test2' requires that 'each T2' conform to 'RawRepresentable'}}
+  }
+}
+
+do {
+  func overloaded<each T>(_ a: Int, _ b: repeat each T) -> (repeat each T) {
+    return (repeat each b)
+  }
+
+  func overloaded() {}
+
+  func test<each T>(_ a: repeat each T) {
+    _ = (repeat overloaded(1, each a))
   }
 }

--- a/test/Interpreter/variadic_generic_tuples.swift
+++ b/test/Interpreter/variadic_generic_tuples.swift
@@ -57,7 +57,7 @@ func makeTuple<each Element>(
 
 func expandTupleElements<each T: Equatable>(_ value: repeat each T) {
   let values = makeTuple(repeat each value)
-  _ = (repeat expectEqual(each value, each values.element))
+  _ = (repeat expectEqual(each value, each values))
 }
 
 tuples.test("expandTuple") {

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -126,7 +126,7 @@ func wrapTupleElements<each T>(_ value: repeat each T) -> (repeat Wrapper<each T
   // CHECK: [[VAR:%.*]] = alloc_stack [lexical] $(repeat each T)
   let values = (repeat each value)
 
-  // Create a temporary for the 'values' in 'each values.element'
+  // Create a temporary for the 'values' in 'each values'
   // CHECK: bb3:
   // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $(repeat each T)
   // CHECK-NEXT: copy_addr [[VAR]] to [init] [[TEMP]] : $*(repeat each T)
@@ -158,7 +158,7 @@ func wrapTupleElements<each T>(_ value: repeat each T) -> (repeat Wrapper<each T
   // CHECK-NEXT: [[NEXT_INDEX:%.*]] = builtin "add_Word"([[INDEX]] : $Builtin.Word, [[ONE]] : $Builtin.Word) : $Builtin.Word
   // CHECK-NEXT: br bb4([[NEXT_INDEX]] : $Builtin.Word)
 
-  return (repeat Wrapper(value: each values.element))
+  return (repeat Wrapper(value: each values))
 
   // CHECK: destroy_addr [[TEMP]] : $*(repeat each T)
   // CHECK: dealloc_stack [[TEMP]] : $*(repeat each T)
@@ -306,7 +306,7 @@ struct FancyTuple<each T> {
   var x: (repeat each T)
 
   func makeTuple() -> (repeat each T) {
-    return (repeat each x.element)
+    return (repeat each x)
   }
 }
 


### PR DESCRIPTION
Explanation: This change drops the requirement for accessing a special case tuple label of "element" in order to expand a tuple containing a value pack, bringing our implementation in conformance with the language specification in [SE-0399](https://github.com/apple/swift-evolution/blob/main/proposals/0399-tuple-of-value-pack-expansion.md)
Scope: Only impacts variadic generics.
Issue: rdar://107160966
Risk: Low.
Testing: Added new tests for abstract tuple expansion to cover `inout` parameters and different directions of constraints.
Reviewer: @xedin @hborla 
Main branch PR: https://github.com/apple/swift/pull/66214