### PR TITLE
[Variadic Generics] correct a logical inversion typo in MaterializePa…

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3711,7 +3711,7 @@ public:
   }
 
   SourceLoc getEndLoc() const {
-    return ElementLoc.isInvalid() ? ElementLoc : FromExpr->getEndLoc();
+    return ElementLoc.isValid() ? ElementLoc : FromExpr->getEndLoc();
   }
 
   static bool classof(const Expr *E) {


### PR DESCRIPTION
…ckExpr::getEndLoc (introduced in 0594efc0c)

Practically speaking, in the current implementation, both branches of this conditional yield the same value, so the fix does not change behavior, but does correct a glaring reversal of intention.