### PR TITLE
Allow protocols to be nested in non-generic contexts

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2215,9 +2215,12 @@ ERROR(unsupported_type_nested_in_protocol,none,
 ERROR(unsupported_type_nested_in_protocol_extension,none,
       "type %0 cannot be nested in protocol extension of %1",
       (const NominalTypeDecl *, const ProtocolDecl *))
-ERROR(unsupported_nested_protocol,none,
-      "protocol %0 cannot be nested inside another declaration",
+ERROR(unsupported_nested_protocol_in_generic,none,
+      "protocol %0 cannot be nested in a generic context",
       (const NominalTypeDecl *))
+ERROR(unsupported_nested_protocol_in_protocol,none,
+      "protocol %0 cannot be nested in protocol %1",
+      (const NominalTypeDecl *, const NominalTypeDecl *))
 ERROR(where_nongeneric_ctx,none,
       "'where' clause on non-generic member declaration requires a "
       "generic context", ())

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -37,7 +37,6 @@ public:
   }
   BAD_MEMBER(Extension)
   BAD_MEMBER(Import)
-  BAD_MEMBER(Protocol)
   BAD_MEMBER(TopLevelCode)
   BAD_MEMBER(Operator)
   BAD_MEMBER(PrecedenceGroup)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4929,11 +4929,10 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
   // If `decl` is a nested type, find the parent type.
   Type ParentTy;
   DeclContext *dc = decl->getDeclContext();
-  bool isObjCProtocol = isa<ProtocolDecl>(decl) && decl->hasClangNode();
+  bool isUnsupportedNestedProtocol =
+    isa<ProtocolDecl>(decl) && decl->getParent()->isGenericContext();
 
-  // Objective-C protocols, unlike Swift protocols, could be nested
-  // in other types.
-  if ((isObjCProtocol || !isa<ProtocolDecl>(decl)) && dc->isTypeContext()) {
+  if (!isUnsupportedNestedProtocol && dc->isTypeContext()) {
     switch (kind) {
     case DeclTypeKind::DeclaredType: {
       if (auto *nominal = dc->getSelfNominalTypeDecl())
@@ -4970,9 +4969,9 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
     }
 
     llvm_unreachable("Unhandled DeclTypeKind in switch.");
-  } else {
-    return NominalType::get(decl, ParentTy, ctx);
   }
+
+  return NominalType::get(decl, ParentTy, ctx);
 }
 
 Type NominalTypeDecl::getDeclaredType() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -132,6 +132,10 @@ void DeclContext::forEachGenericContext(
       if (auto genericCtx = decl->getAsGenericContext())
         if (auto *gpList = genericCtx->getGenericParams())
           fn(gpList);
+
+      // Protocols do not capture outer generic parameters.
+      if (isa<ProtocolDecl>(decl))
+        return;
     }
   } while ((dc = dc->getParentForLookup()));
 }
@@ -259,8 +263,8 @@ DeclContext *DeclContext::getInnermostSkippedFunctionContext() {
 }
 
 DeclContext *DeclContext::getParentForLookup() const {
-  if (isa<ProtocolDecl>(this) || isa<ExtensionDecl>(this)) {
-    // If we are inside a protocol or an extension, skip directly
+  if (isa<ExtensionDecl>(this)) {
+    // If we are inside an extension, skip directly
     // to the module scope context, without looking at any (invalid)
     // outer types.
     return getModuleScopeContext();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -269,6 +269,12 @@ DeclContext *DeclContext::getParentForLookup() const {
     // outer types.
     return getModuleScopeContext();
   }
+  if (isa<ProtocolDecl>(this) && getParent()->isGenericContext()) {
+    // Protocols in generic contexts must not look in to their parents,
+    // as the parents may contain types with inferred implicit
+    // generic parameters not present in the protocol's generic signature.
+    return getModuleScopeContext();
+  }
   if (isa<NominalTypeDecl>(this)) {
     // If we are inside a nominal type that is inside a protocol,
     // skip the protocol.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5594,7 +5594,6 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
     switch (member->getKind()) {
     case DeclKind::Import:
     case DeclKind::TopLevelCode:
-    case DeclKind::Protocol:
     case DeclKind::Extension:
     case DeclKind::InfixOperator:
     case DeclKind::PrefixOperator:
@@ -5649,6 +5648,9 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
       continue;
     case DeclKind::Class:
       emitClassDecl(cast<ClassDecl>(member));
+      continue;
+    case DeclKind::Protocol:
+      emitProtocolDecl(cast<ProtocolDecl>(member));
       continue;
     case DeclKind::MacroExpansion:
       // Expansion already visited as auxiliary decls.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9381,7 +9381,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
       ProtocolDecl(CurDeclContext, ProtocolLoc, NameLoc, ProtocolName,
                    Context.AllocateCopy(PrimaryAssociatedTypeNames),
                    Context.AllocateCopy(InheritedProtocols), TrailingWhere);
-  // No need to setLocalDiscriminator: protocols can't appear in local contexts.
+  recordLocalType(Proto);
 
   Proto->getAttrs() = Attributes;
   if (whereClauseHadCodeCompletion && CodeCompletionCallbacks)

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2674,30 +2674,30 @@ public:
         NTD->diagnose(diag::tuple_extension_nested_type, NTD);
         return;
       }
-    }
 
-    // We don't support protocols nested in generic contexts.
-    // This includes protocols nested in other protocols.
-    if (isa<ProtocolDecl>(NTD) && NTD->getParent()->isGenericContext()) {
-      if (auto *OuterPD = NTD->getParent()->getSelfProtocolDecl())
-        NTD->diagnose(diag::unsupported_nested_protocol_in_protocol, NTD,
-                      OuterPD);
-      else
-        NTD->diagnose(diag::unsupported_nested_protocol_in_generic, NTD);
+      // We don't support protocols nested in generic contexts.
+      // This includes protocols nested in other protocols.
+      if (isa<ProtocolDecl>(NTD) && DC->isGenericContext()) {
+        if (auto *OuterPD = DC->getSelfProtocolDecl())
+          NTD->diagnose(diag::unsupported_nested_protocol_in_protocol, NTD,
+                        OuterPD);
+        else
+          NTD->diagnose(diag::unsupported_nested_protocol_in_generic, NTD);
 
-      NTD->setInvalid();
-      return;
-    }
-
-    // We don't support nested types in protocols.
-    if (auto proto = dyn_cast<ProtocolDecl>(parentDecl)) {
-      if (DC->getExtendedProtocolDecl()) {
-        NTD->diagnose(diag::unsupported_type_nested_in_protocol_extension, NTD,
-                      proto);
-      } else {
-        NTD->diagnose(diag::unsupported_type_nested_in_protocol, NTD, proto);
+        NTD->setInvalid();
+        return;
       }
-      NTD->setInvalid();
+
+      // We don't support nested types in protocols.
+      if (auto proto = dyn_cast<ProtocolDecl>(parentDecl)) {
+        if (DC->getExtendedProtocolDecl()) {
+          NTD->diagnose(diag::unsupported_type_nested_in_protocol_extension, NTD,
+                        proto);
+        } else {
+          NTD->diagnose(diag::unsupported_type_nested_in_protocol, NTD, proto);
+        }
+        NTD->setInvalid();
+      }
     }
 
     // We don't support nested types in generic functions yet.
@@ -3188,15 +3188,6 @@ public:
     // Check that all named primary associated types are valid.
     if (!PD->getPrimaryAssociatedTypeNames().empty())
       (void) PD->getPrimaryAssociatedTypes();
-
-    // We cannot compute the requirement signature of a protocol
-    // in a generic context, because superclass constraints
-    // may include implicitly inferred generic arguments that are
-    // not part of the protocol's generic signature.
-    if (PD->getParent()->isGenericContext()) {
-      assert(PD->isInvalid());
-      return;
-    }
 
     // Explicitly compute the requirement signature to detect errors.
     // Do this before visiting members, to avoid a request cycle if

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -118,3 +118,60 @@ protocol Comprehensive {
 // CHECK-SAME:   %swift.protocol_requirement { i32 4, i32 0 },
 // CHECK-SAME:   %swift.protocol_requirement { i32 6, i32 0 }
 
+  struct ParentType {
+
+    // NESTED: [[NESTED_NAME:@.*]] = private constant [7 x i8] c"Nested\00"
+    // NESTED: [[NESTED_RETURNVALUE_NAME:@.*]] = private constant [12 x i8] c"ReturnValue\00"
+
+    // NESTED: @"$s17protocol_metadata10ParentTypeV6NestedMp" = hidden constant
+    // NESTED-SAME: i32 65603,
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeVMn"
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeV6NestedMp", i32 0, i32 1)
+    // NESTED-SAME: [7 x i8]* [[NESTED_NAME]]
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeV6NestedMp", i32 0, i32 2)
+    // NESTED-SAME: i32 0,
+    // NESTED-SAME: i32 2,
+    // NESTED-SAME: [12 x i8]* [[NESTED_RETURNVALUE_NAME]]
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeV6NestedMp", i32 0, i32 5)
+    // NESTED-SAME: %swift.protocol_requirement { i32 7, i32 0 },
+    // NESTED-SAME: %swift.protocol_requirement { i32 17, i32 0 }
+    protocol Nested {
+      associatedtype ReturnValue
+      func doSomething() -> ReturnValue
+    }
+  }
+
+  extension ParentType {
+
+    // NESTED: [[NESTEDVIAEXT_NAME:@.*]] = private constant [19 x i8] c"NestedViaExtension\00"
+
+    // NESTED: @"$s17protocol_metadata10ParentTypeV18NestedViaExtensionMp" = hidden constant
+    // NESTED-SAME: i32 65603,
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeVMn"
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeV18NestedViaExtensionMp", i32 0, i32 1)
+    // NESTED-SAME: [19 x i8]* [[NESTEDVIAEXT_NAME]]
+    // NESTED-SAME: @"$s17protocol_metadata10ParentTypeV18NestedViaExtensionMp", i32 0, i32 2)
+    // NESTED-SAME: i32 0,
+    // NESTED-SAME: i32 1,
+    // NESTED-SAME: i32 0,
+    // NESTED-SAME: %swift.protocol_requirement { i32 17, i32 0 }
+    protocol NestedViaExtension {
+      func foo()
+    }
+  }
+
+  func parentFunc() {
+    // NESTED: @"$s17protocol_metadata10parentFuncyyF6NestedL_Mp" = internal constant
+    // NESTED-SAME: i32 65603,
+    // NESTED-SAME: @"$s17protocol_metadata10parentFuncyyF6NestedL_PMXX"
+    // NESTED-SAME: @"$s17protocol_metadata10parentFuncyyF6NestedL_Mp", i32 0, i32 1)
+    // NESTED-SAME: [7 x i8]* [[NESTED_NAME]]
+    // NESTED-SAME: @"$s17protocol_metadata10parentFuncyyF6NestedL_Mp", i32 0, i32 2)
+    // NESTED-SAME: i32 0,
+    // NESTED-SAME: i32 1,
+    // NESTED-SAME: i32 0,
+    // NESTED-SAME: %swift.protocol_requirement { i32 17, i32 0 }
+    protocol Nested {
+      func foo()
+    }
+  }

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -409,6 +409,12 @@ class MyObject : NSObject {}
     @objc @objcMembers class DeeperIn {}
   }
 
+  // CHECK-LABEL: SWIFT_CLASS_NAMED("CustomNameInner")
+  // CHECK-NEXT: @interface MyInnerClass
+  // CHECK-NEXT: init
+  // CHECK-NEXT: @end
+  @objc(MyInnerClass) @objcMembers class CustomNameInner {}
+
   // CHECK-LABEL: @interface AnotherInner : A1
   // CHECK-NEXT: init
   // CHECK-NEXT: @end

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -137,6 +137,26 @@ extension NSString : A, ZZZ {}
   @objc optional func f()
 }
 
+// NESTED-LABEL: @interface ParentClass
+// NESTED-NEXT: @end
+@objc class ParentClass {
+
+  // NESTED-LABEL: @protocol Nested
+  // NESTED-NEXT: @end
+  @objc protocol Nested {}
+
+  // NESTED-LABEL: SWIFT_PROTOCOL_NAMED("Nested2")
+  // NESTED-NEXT: @protocol NestedInParent
+  // NESTED-NEXT: @end
+  @objc(NestedInParent) protocol Nested2 {}
+}
+
+extension ParentClass {
+  // NESTED-LABEL: @protocol NestedInExtensionOfParent
+  // NESTED-NEXT: @end
+  @objc protocol NestedInExtensionOfParent {}
+}
+
 // NEGATIVE-NOT: @protocol PrivateProto
 @objc private protocol PrivateProto {}
 

--- a/test/Runtime/nested-protocols.swift
+++ b/test/Runtime/nested-protocols.swift
@@ -1,0 +1,64 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+enum E {
+  protocol P {}
+}
+
+struct Conforms {}
+extension Conforms: E.P {}
+
+struct DoesNotConform {}
+
+struct S<T> {}
+extension S: E.P where T: E.P {}
+
+@inline(never)
+func castToNested(_ value: Any) -> (any E.P)? {
+    value as? any E.P
+}
+
+// Regular conformance.
+
+precondition(castToNested(Conforms()) != nil)
+precondition(castToNested(DoesNotConform()) == nil)
+
+// Conditional conformance.
+
+precondition(castToNested(S<Conforms>()) != nil)
+precondition(castToNested(S<DoesNotConform>()) == nil)
+
+// Verify that 'E.P' and a non-nested 'P' are different.
+
+protocol P {}
+
+@inline(never)
+func castToNonNested(_ value: Any) -> (any P)? {
+    value as? any P
+}
+
+precondition(castToNonNested(Conforms()) == nil)
+precondition(castToNonNested(S<Conforms>()) == nil)
+precondition(castToNonNested(DoesNotConform()) == nil)
+precondition(castToNonNested(S<DoesNotConform>()) == nil)
+
+// Local protocols.
+
+@inline(never)
+func f0(_ input: Any) -> (Any, inputConforms: Bool) {
+
+  protocol LocalProto { }
+  struct ConformsToLocal: LocalProto {}
+
+  if let input = input as? any LocalProto {
+    return (input, true)
+  } else {
+    return (ConformsToLocal(), false)
+  }
+}
+
+var result = f0(DoesNotConform())
+precondition(result.inputConforms == false)
+result = f0(result.0)
+precondition(result.inputConforms == true)

--- a/test/Serialization/Inputs/nested-protocols.swift
+++ b/test/Serialization/Inputs/nested-protocols.swift
@@ -1,0 +1,11 @@
+public struct Outer {
+  public protocol Inner {
+    func foo()
+  }
+}
+
+extension Outer {
+  public protocol InnerInExtension {
+    func bar()
+  }
+}

--- a/test/Serialization/nested-protocols.swift
+++ b/test/Serialization/nested-protocols.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -module-name nestedprotocolsource -emit-module-path %t/nestedprotocolsource.swiftmodule -primary-file %S/Inputs/nested-protocols.swift
-// RUN: %target-swift-frontend -emit-sil %s -I %t | Filecheck %s
+// RUN: %target-swift-frontend -emit-sil %s -I %t | %FileCheck %s
 import nestedprotocolsource
 
 // CHECK: usesNested<A>(_:)

--- a/test/Serialization/nested-protocols.swift
+++ b/test/Serialization/nested-protocols.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name nestedprotocolsource -emit-module-path %t/nestedprotocolsource.swiftmodule -primary-file %S/Inputs/nested-protocols.swift
+// RUN: %target-swift-frontend -emit-sil %s -I %t | Filecheck %s
+import nestedprotocolsource
+
+// CHECK: usesNested<A>(_:)
+// CHECK-NEXT: sil @$s4main10usesNestedyyx20nestedprotocolsource5OuterV5InnerRzlF :
+public func usesNested(_ x: some Outer.Inner) {}
+
+// CHECK: usesNestedInExtension<A>(_:)
+// CHECK-NEXT: sil @$s4main21usesNestedInExtensionyyx20nestedprotocolsource5OuterV05InnerdE0RzlF :
+public func usesNestedInExtension(_ x: some Outer.InnerInExtension) {}

--- a/test/decl/inherit/initializer.swift
+++ b/test/decl/inherit/initializer.swift
@@ -107,7 +107,7 @@ func testClassInGenericFunc<T>(t: T) {
   class A { init(t: T) {} } // expected-error {{type 'A' cannot be nested in generic function 'testClassInGenericFunc(t:)'}}
   class B : A {} // expected-error {{type 'B' cannot be nested in generic function 'testClassInGenericFunc(t:)'}}
 
-  _ = B(t: t)
+  _ = B(t: t) // expected-error {{'B' cannot be constructed because it has no accessible initializers}}
 }
 
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -1,38 +1,272 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library
 
-// Protocols cannot be nested inside other types, and types cannot
-// be nested inside protocols
+// Protocols can be nested inside non-generic types.
+
+protocol Delegate {}
+
+enum Table {
+  protocol Delegate {}
+}
+
+enum Button {
+  protocol Delegate {}
+}
+
+struct PlainDelegateConformer: Delegate {}
+struct TableDelegateConformer: Table.Delegate {}
+struct ButtonDelegateConformer: Button.Delegate {}
+
+func testDifferent() {
+  let plain = PlainDelegateConformer()
+  if plain is Delegate { print("ok (1)") } // expected-warning {{'is' test is always true}}
+  if plain is Table.Delegate { print("bad (2)") }
+  if plain is Button.Delegate { print("bad (3)") }
+
+  let tableDel = TableDelegateConformer()
+  if tableDel is Delegate { print("bad (4)") }
+  if tableDel is Table.Delegate { print("ok (5)") } // expected-warning {{'is' test is always true}}
+  if tableDel is Button.Delegate { print("bad (6)") }
+
+  let buttonDel = ButtonDelegateConformer()
+  if buttonDel is Delegate { print("bad (7)") }
+  if buttonDel is Table.Delegate { print("bad (8)") }
+  if buttonDel is Button.Delegate { print("ok (9)") } // expected-warning {{'is' test is always true}}
+}
+
+enum OuterEnum {
+  protocol C {}
+  case C(C) 
+  // expected-error@-1{{invalid redeclaration of 'C'}}
+  // expected-note@-3{{'C' previously declared here}}
+}
+
+class OuterClass {
+  protocol InnerProtocol : OuterClass { }
+}
+
+// Deeply nested.
+
+enum Level0 {
+  struct Level1 {
+    class Level2 {
+      actor Level3 {
+        struct Level4 {
+          class Level5 {
+            protocol DeeplyNested {
+              func someRequirement()
+            }
+            func lookupTest(_ input: some DeeplyNested) {}
+          }
+          func lookupTest(_ input: some Level5.DeeplyNested) {}
+        }
+        func lookupTest(_ input: some Level4.Level5.DeeplyNested) {}
+      }
+    }
+  }
+}
+
+func useDeeplyNested(_ input: some Level0.Level1.Level2.Level3.Level4.Level5.DeeplyNested) {
+  input.someRequirement()
+}
+
+// Add a nested protocol in an extension.
+
+extension Level0.Level1.Level2 {
+  protocol ModeratelyNested {
+    associatedtype ReturnValue
+    func anotherRequirement() -> ReturnValue
+  }
+
+  func lookupTest(_: some ModeratelyNested) { }
+}
+
+func useModeratelyNested<Input>(
+  _ input: Input
+) -> Input.ReturnValue where Input: Level0.Level1.Level2.ModeratelyNested {
+  input.anotherRequirement()
+}
+
+struct ModeratelyNestedConformer: Level0.Level1.Level2.ModeratelyNested {
+  func anotherRequirement() -> Int {
+    99
+  }
+}
+
+let _umn: Int = useModeratelyNested(ModeratelyNestedConformer())
+
+// Extend a nested protocol.
+
+extension Level0.Level1.Level2.ModeratelyNested {
+  func extensionMethod() -> ReturnValue {
+    anotherRequirement()
+  }
+}
+
+extension Level0.Level1.Level2.ModeratelyNested where ReturnValue == Int {
+  func extensionMethod() -> Int {
+    anotherRequirement() + 1
+  }
+}
+
+// Protocols may be nested inside non-generic functions.
+
+func someFunction_0() {
+  protocol Yes {}
+  struct Foo: Yes {}
+  struct Bar: Yes {}
+}
+
+func someFunction_1() {
+
+  struct HowAboutThis {
+    protocol AlsoYes {
+      associatedtype SomeType
+      func doSomething() -> SomeType
+    }
+  }
+
+  struct Conforms0: HowAboutThis.AlsoYes {
+    typealias SomeType = Int
+    func doSomething() -> SomeType { -99 }
+  }
+
+  struct Conforms1: HowAboutThis.AlsoYes {
+    typealias SomeType = String
+    func doSomething() -> SomeType { "works" }
+  }
+
+  func usesNested<T: HowAboutThis.AlsoYes>(_ input: T) -> T.SomeType {
+    input.doSomething()
+  }
+
+  let _: Int = usesNested(Conforms0())
+  let _: String = usesNested(Conforms1())
+}
+
+// Unqualified lookup searches parent scopes.
+
+struct Lookup_Parent {
+  protocol A {}
+  class SomeClass {}
+}
+
+extension Lookup_Parent {
+  protocol B: A {}
+  protocol C: SomeClass, B {
+    func doSomething(_: some A) -> SomeClass
+  }
+}
+
+// Protocols cannot be nested in generic types or other protocols.
 
 struct OuterGeneric<D> {
-  protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
+  protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested in a generic context}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: D) // expected-error{{cannot find type 'D' in scope}}
+    func flop(_ t: D)
   }
 }
 
 class OuterGenericClass<T> {
-  protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
+  protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested in a generic context}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: T) // expected-error{{cannot find type 'T' in scope}}
+    func flop(_ t: T)
   }
 }
 
 protocol OuterProtocol {
   associatedtype Hen
-  protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
+  protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested in protocol 'OuterProtocol'}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ h: Hen) // expected-error{{cannot find type 'Hen' in scope}}
+    func flop(_ h: Hen)
   }
+}
+
+extension OuterProtocol {
+  protocol DefinedInExtension {} // expected-error{{protocol 'DefinedInExtension' cannot be nested in protocol 'OuterProtocol'}}
 }
 
 struct ConformsToOuterProtocol : OuterProtocol {
   typealias Hen = Int
-
   func f() { let _ = InnerProtocol.self } // expected-error {{use of protocol 'InnerProtocol' as a type must be written 'any InnerProtocol'}}
 }
+
+extension OuterProtocol {
+  func f() {
+    protocol Invalid_0 {} // expected-error{{protocol 'Invalid_0' cannot be nested in a generic context}}
+
+    struct SomeType { // expected-error{{type 'SomeType' cannot be nested in generic function 'f()'}}
+      protocol Invalid_1 {} // expected-error{{protocol 'Invalid_1' cannot be nested in a generic context}}
+    }
+  }
+  func g<T>(_: T) {
+    protocol Invalid_2 {} // expected-error{{protocol 'Invalid_2' cannot be nested in a generic context}}
+  }
+}
+
+// 'InnerProtocol' does not inherit the generic parameters of
+// 'OtherGenericClass', so the occurrence of 'OtherGenericClass'
+// in 'InnerProtocol' is not "in context" with implicitly
+// inferred generic arguments <T, U>.
+class OtherGenericClass<T, U> {
+  protocol InnerProtocol : OtherGenericClass { }
+  // expected-error@-1{{protocol 'InnerProtocol' cannot be nested in a generic context}}
+}
+
+protocol InferredGenericTest {
+  associatedtype A
+}
+extension OtherGenericClass {
+  protocol P: InferredGenericTest where Self.A == T {} // expected-error {{protocol 'P' cannot be nested in a generic context}}
+}
+
+// A nested protocol does not satisfy an associated type requirement.
+
+protocol HasAssoc {
+  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+}
+struct ConformsToHasAssoc: HasAssoc { // expected-error {{type 'ConformsToHasAssoc' does not conform to protocol 'HasAssoc'}}
+  protocol A {}
+}
+
+// @usableFromInline.
+
+struct OuterForUFI {
+  @usableFromInline
+  protocol Inner {
+    func req()
+  }
+}
+
+extension OuterForUFI.Inner {
+  public func extMethod() {} // The 'public' puts this in a special path.
+}
+
+func testLookup(_ x: OuterForUFI.Inner) {
+  x.req()
+  x.extMethod()
+}
+
+func testLookup<T: OuterForUFI.Inner>(_ x: T) {
+  x.req()
+  x.extMethod()
+}
+
+// Protocols cannot be nested inside of generic functions.
+
+func invalidProtocolInGeneric<T>(_: T) {
+  protocol Test {} // expected-error{{protocol 'Test' cannot be nested in a generic context}}
+}
+
+struct NestedInGenericMethod<T> {
+  func someMethod() {
+    protocol AnotherTest {} // expected-error{{protocol 'AnotherTest' cannot be nested in a generic context}}
+  }
+}
+
+// Types cannot be nested inside of protocols.
 
 protocol Racoon {
   associatedtype Stripes
@@ -57,27 +291,6 @@ protocol SillyProtocol {
   // expected-note@-1 {{generic type 'InnerClass' declared here}}
 }
 
-// N.B. Redeclaration checks don't see this case because `protocol A` is invalid.
-enum OuterEnum {
-  protocol C {} // expected-error{{protocol 'C' cannot be nested inside another declaration}}
-  case C(C)
-}
-
-class OuterClass {
-  protocol InnerProtocol : OuterClass { }
-  // expected-error@-1{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
-}
-
-// 'InnerProtocol' does not inherit the generic parameters of
-// 'OtherGenericClass', so the occurrence of 'OtherGenericClass'
-// in 'InnerProtocol' is not "in context" with implicitly
-// inferred generic arguments <T, U>.
-class OtherGenericClass<T, U> { // expected-note {{generic type 'OtherGenericClass' declared here}}
-  protocol InnerProtocol : OtherGenericClass { }
-  // expected-error@-1{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
-  // expected-error@-2{{reference to generic type 'OtherGenericClass' requires arguments in <...>}}
-}
-
 protocol SelfDotTest {
   func f(_: Self.Class)
   class Class {}
@@ -86,44 +299,10 @@ protocol SelfDotTest {
 
 struct Outer {
   typealias E = NestedValidation.T
-  protocol NestedValidation { // expected-error {{protocol 'NestedValidation' cannot be nested inside another declaration}}
+  protocol NestedValidation {
     typealias T = A.B
     class A { // expected-error {{type 'A' cannot be nested in protocol 'NestedValidation'}}
       typealias B = Int
     }
   }
 }
-
-struct OuterForUFI {
-  @usableFromInline
-  protocol Inner { // expected-error {{protocol 'Inner' cannot be nested inside another declaration}}
-    func req()
-  }
-}
-
-extension OuterForUFI.Inner {
-  public func extMethod() {} // The 'public' puts this in a special path.
-}
-
-func testLookup(_ x: OuterForUFI.Inner) {
-  x.req()
-  x.extMethod()
-}
-
-func testLookup<T: OuterForUFI.Inner>(_ x: T) {
-  x.req()
-  x.extMethod()
-}
-
-// rdar://problem/113103854
-
-protocol Q {
-  associatedtype A
-}
-
-struct OuterNonGeneric {
-  protocol P: Q where Self.A == Int {}
-  // expected-error@-1 {{protocol 'P' cannot be nested inside another declaration}}
-}
-
-func usesProtoWithWhereClause<T: OuterNonGeneric.P>(_: T) {}

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -163,7 +163,7 @@ struct OuterGeneric<D> {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested in a generic context}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: D)
+    func flop(_ t: D) // expected-error {{cannot find type 'D' in scope}}
   }
 }
 
@@ -171,7 +171,7 @@ class OuterGenericClass<T> {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested in a generic context}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: T)
+    func flop(_ t: T) // expected-error {{cannot find type 'T' in scope}}
   }
 }
 
@@ -180,7 +180,7 @@ protocol OuterProtocol {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested in protocol 'OuterProtocol'}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ h: Hen)
+    func flop(_ h: Hen) // expected-error {{cannot find type 'Hen' in scope}}
   }
 }
 
@@ -195,14 +195,14 @@ struct ConformsToOuterProtocol : OuterProtocol {
 
 extension OuterProtocol {
   func f() {
-    protocol Invalid_0 {} // expected-error{{protocol 'Invalid_0' cannot be nested in a generic context}}
+    protocol Invalid_0 {} // expected-error{{type 'Invalid_0' cannot be nested in generic function 'f()'}}
 
     struct SomeType { // expected-error{{type 'SomeType' cannot be nested in generic function 'f()'}}
       protocol Invalid_1 {} // expected-error{{protocol 'Invalid_1' cannot be nested in a generic context}}
     }
   }
   func g<T>(_: T) {
-    protocol Invalid_2 {} // expected-error{{protocol 'Invalid_2' cannot be nested in a generic context}}
+    protocol Invalid_2 {} // expected-error{{type 'Invalid_2' cannot be nested in generic function 'g'}}
   }
 }
 
@@ -210,22 +210,25 @@ extension OuterProtocol {
 // 'OtherGenericClass', so the occurrence of 'OtherGenericClass'
 // in 'InnerProtocol' is not "in context" with implicitly
 // inferred generic arguments <T, U>.
-class OtherGenericClass<T, U> {
+class OtherGenericClass<T, U> { // expected-note {{generic type 'OtherGenericClass' declared here}}
   protocol InnerProtocol : OtherGenericClass { }
-  // expected-error@-1{{protocol 'InnerProtocol' cannot be nested in a generic context}}
+  // expected-error@-1 {{protocol 'InnerProtocol' cannot be nested in a generic context}}
+  // expected-error@-2 {{reference to generic type 'OtherGenericClass' requires arguments in <...>}}
 }
 
 protocol InferredGenericTest {
   associatedtype A
 }
 extension OtherGenericClass {
-  protocol P: InferredGenericTest where Self.A == T {} // expected-error {{protocol 'P' cannot be nested in a generic context}}
+  protocol P: InferredGenericTest where Self.A == T {}
+  // expected-error@-1 {{protocol 'P' cannot be nested in a generic context}}
+  // expected-error@-2 {{cannot find type 'T' in scope}}
 }
 
 // A nested protocol does not satisfy an associated type requirement.
 
 protocol HasAssoc {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+  associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
 }
 struct ConformsToHasAssoc: HasAssoc { // expected-error {{type 'ConformsToHasAssoc' does not conform to protocol 'HasAssoc'}}
   protocol A {}
@@ -257,12 +260,12 @@ func testLookup<T: OuterForUFI.Inner>(_ x: T) {
 // Protocols cannot be nested inside of generic functions.
 
 func invalidProtocolInGeneric<T>(_: T) {
-  protocol Test {} // expected-error{{protocol 'Test' cannot be nested in a generic context}}
+  protocol Test {} // expected-error{{type 'Test' cannot be nested in generic function 'invalidProtocolInGeneric'}}
 }
 
 struct NestedInGenericMethod<T> {
   func someMethod() {
-    protocol AnotherTest {} // expected-error{{protocol 'AnotherTest' cannot be nested in a generic context}}
+    protocol AnotherTest {} // expected-error{{type 'AnotherTest' cannot be nested in generic function 'someMethod()'}}
   }
 }
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -44,12 +44,19 @@ class OuterClass {
   protocol InnerProtocol : OuterClass { }
 }
 
+// Protocols can be nested in actors.
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+actor SomeActor {
+  protocol Proto {}
+}
+
 // Deeply nested.
 
 enum Level0 {
   struct Level1 {
     class Level2 {
-      actor Level3 {
+      enum Level3 {
         struct Level4 {
           class Level5 {
             protocol DeeplyNested {

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -549,10 +549,9 @@ enum E2_52486 {
   static func fn(_ x: @escaping () -> Bool) -> E2_52486 {} // Okay
 }
 
-// N.B. Redeclaration checks don't see this case because `protocol A` is invalid.
 enum E3_52486 {
-  protocol A {} //expected-error {{protocol 'A' cannot be nested inside another declaration}}
-  case A
+  protocol A {} // expected-note {{'A' previously declared here}}
+  case A // expected-error {{invalid redeclaration of 'A'}}
 }
 
 enum E4_52486 {
@@ -565,10 +564,9 @@ enum E5_52486 {
   case C // expected-error {{invalid redeclaration of 'C'}}
 }
 
-// N.B. Redeclaration checks don't see this case because `protocol D` is invalid.
 enum E6_52486 {
-  case D
-  protocol D {} //expected-error {{protocol 'D' cannot be nested inside another declaration}}
+  case D // expected-note {{'D' previously declared here}}
+  protocol D {} // expected-error {{invalid redeclaration of 'D'}}
 }
 
 enum E7_52486 {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Allows protocols to be nested in non-generic types/functions.

Gated behind flag `-enable-experimental-feature NestedProtocols`. SE proposal coming soon.

TODO:

- [ ] Test that ASTPrinter adds feature guards around uses of nested protocols
- [ ] IRGen tests
