### PR TITLE
[lit] Repair tests for stdlib-only build

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -548,13 +548,14 @@ else:
         "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s"
         % (shell_quote(config.host_sdkroot), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
 
-# Parse the host triple.
-(host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
-
 if platform.system() == 'Darwin':
     host_build_extra_rpath=""
-else:
+elif config.host_triple:
+    # Parse the host triple.
+    (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
     host_build_extra_rpath="-Xlinker -rpath -Xlinker %s" % (make_path(config.swift_lib_dir, 'swift', host_os))
+else:
+    host_build_extra_rpath=""
 
 config.host_build_swift = (
     "%s -sdk %s -target %s -I %s -L %s %s" % (config.swiftc_driver, config.host_sdkroot, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir, host_build_extra_rpath))


### PR DESCRIPTION
`config.host_triple` can be None when no host tools are built

