### PR TITLE
[IRGen] Include extra tag bytes in offset in layout strings

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -221,6 +221,9 @@ public:
         refCountBytes += (3 * sizeof(uint64_t)) +
                          (4 * IGM.getPointerSize().getValue()) +
                          nestedRefCountBytes;
+
+        skip += enumData.extraTagByteCount;
+
         break;
       }
 

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -350,6 +350,27 @@ public struct MixedEnumWrapperWrapperGeneric<T> {
     }
 }
 
+public struct SinglePayloadEnumExtraTagBytesWrapper {
+    let x: SinglePayloadEnumExtraTagBytes
+    let y: SimpleClass
+
+    public init(x: SinglePayloadEnumExtraTagBytes, y: SimpleClass) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public enum SinglePayloadEnumExtraTagBytes {
+    case empty0
+    case empty1
+    case empty2
+    case empty3
+    case empty4
+    case empty5
+    case empty6
+    case nonEmpty(WeakNativeWrapper)
+}
+
 public struct ComplexNesting<A, B, C, D> {
     let pre: Filler = Filler()
     let a: NestedA<A>

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -513,6 +513,35 @@ func testInternalEnumWrapper() {
 
 testInternalEnumWrapper()
 
+func testSinglePayloadEnumExtraTagBytesWrapper() {
+    let ptr = UnsafeMutablePointer<SinglePayloadEnumExtraTagBytesWrapper>.allocate(capacity: 1)
+
+    do {
+        let x = SinglePayloadEnumExtraTagBytesWrapper(x: .empty0, y: SimpleClass(x: 23))
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = SinglePayloadEnumExtraTagBytesWrapper(x: .empty0, y: SimpleClass(x: 28))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testSinglePayloadEnumExtraTagBytesWrapper()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
rdar://110088270

When extra tag bytes are used in single payload enums, the generated layout string does not include the tag bytes in its offset after the enum payload. This causes subsequent ref count operations to use the wrong memory location.
