### PR TITLE
Add implicit SPI import feature

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3304,6 +3304,14 @@ void SourceFile::lookupImportedSPIGroups(
   }
 }
 
+bool shouldImplicitImportAsSPI(ArrayRef<Identifier> spiGroups) {
+  for (auto group : spiGroups) {
+    if (group.empty())
+      return true;
+  }
+  return false;
+}
+
 bool SourceFile::isImportedAsSPI(const ValueDecl *targetDecl) const {
   auto targetModule = targetDecl->getModuleContext();
   llvm::SmallSetVector<Identifier, 4> importedSPIGroups;
@@ -3311,6 +3319,8 @@ bool SourceFile::isImportedAsSPI(const ValueDecl *targetDecl) const {
   // Objective-C SPIs are always imported implicitly.
   if (targetDecl->hasClangNode())
     return !targetDecl->getSPIGroups().empty();
+  if (shouldImplicitImportAsSPI(targetDecl->getSPIGroups()))
+    return true;
 
   lookupImportedSPIGroups(targetModule, importedSPIGroups);
   if (importedSPIGroups.empty())
@@ -3345,12 +3355,14 @@ bool SourceFile::importsModuleAsWeakLinked(const ModuleDecl *module) const {
 
 bool ModuleDecl::isImportedAsSPI(const SpecializeAttr *attr,
                                  const ValueDecl *targetDecl) const {
+  auto declSPIGroups = attr->getSPIGroups();
+  if (shouldImplicitImportAsSPI(declSPIGroups))
+    return true;
+
   auto targetModule = targetDecl->getModuleContext();
   llvm::SmallSetVector<Identifier, 4> importedSPIGroups;
   lookupImportedSPIGroups(targetModule, importedSPIGroups);
   if (importedSPIGroups.empty()) return false;
-
-  auto declSPIGroups = attr->getSPIGroups();
 
   for (auto declSPI : declSPIGroups)
     if (importedSPIGroups.count(declSPI))
@@ -3361,6 +3373,9 @@ bool ModuleDecl::isImportedAsSPI(const SpecializeAttr *attr,
 
 bool ModuleDecl::isImportedAsSPI(Identifier spiGroup,
                                  const ModuleDecl *fromModule) const {
+  if (shouldImplicitImportAsSPI({spiGroup}))
+    return true;
+
   llvm::SmallSetVector<Identifier, 4> importedSPIGroups;
   lookupImportedSPIGroups(fromModule, importedSPIGroups);
   if (importedSPIGroups.empty())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -916,7 +916,7 @@ bool Parser::parseSpecializeAttributeArguments(
         }
       }
       if (ParamLabel == "spi") {
-        if (!Tok.is(tok::identifier)) {
+        if (!Tok.isIdentifierOrUnderscore()) {
           diagnose(Tok.getLoc(), diag::attr_specialize_expected_spi_name);
           consumeToken();
           return false;
@@ -2842,7 +2842,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     SmallVector<Identifier, 4> spiGroups;
 
-    if (!Tok.is(tok::identifier) ||
+    if (!Tok.isIdentifierOrUnderscore() ||
         Tok.isContextualKeyword("set")) {
       diagnose(getEndOfPreviousLoc(), diag::attr_access_expected_spi_name);
       consumeToken();
@@ -2851,6 +2851,11 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     auto text = Tok.getText();
+    // An spi group name can be '_' as in @_spi(_), a specifier for implicit import of the SPI.
+    // '_' in source code is represented as an empty identifier in AST so match the behavior
+    // here for consistency
+    if (Tok.is(tok::kw__))
+      text = StringRef();
     spiGroups.push_back(Context.getIdentifier(text));
     consumeToken();
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2677,7 +2677,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       SmallVector<IdentifierID, 4> spis;
       for (auto spi : theAttr->getSPIGroups()) {
-        assert(!spi.empty() && "Empty SPI name");
+        // SPI group name in source code can be '_', a specifier that allows
+        // implicit import of the SPI. It gets converted to to an empty identifier
+        // during parsing to match the existing AST node representation. An empty
+        // identifier is printed as '_' at serialization.
         spis.push_back(S.addDeclBaseNameRef(spi));
       }
 

--- a/test/SPI/implicit_spi_import.swift
+++ b/test/SPI/implicit_spi_import.swift
@@ -1,0 +1,110 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -module-name Lib -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Lib.private.swiftinterface
+
+// RUN: %target-swift-frontend -typecheck -verify %t/ClientA.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/ClientB.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/ClientC.swift -I %t
+
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck -verify %t/ClientA.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/ClientB.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/ClientC.swift -I %t
+
+// RUN: %target-swift-frontend -emit-module %t/ClientA.swift \
+// RUN:   -module-name ClientA -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/ClientA.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/ClientA.private.swiftinterface
+// RUN: %FileCheck %s --check-prefix CHECK-A < %t/ClientA.private.swiftinterface
+// CHECK-A-NOT: @_spi(_) import Lib
+// CHECK-A: import Lib
+// CHECK-A: @_spi(_) public func useImplicit() -> Lib._Klass
+
+// RUN: %target-swift-frontend -emit-module %t/ClientB.swift \
+// RUN:   -module-name ClientB -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/ClientB.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/ClientB.private.swiftinterface
+// RUN: %FileCheck %s --check-prefix CHECK-B < %t/ClientB.private.swiftinterface
+// CHECK-B-NOT: @_spi(_) @_spi(core) import Lib
+// CHECK-B-NOT: @_spi(core) @_spi(_) import Lib
+// CHECK-B: @_spi(core) import Lib
+// CHECK-B: @_spi(_) public func useImplicit() -> Lib._Klass
+// CHECK-B: @_spi(core) public func useSPICore() -> Lib.CoreStruct
+
+// RUN: %target-swift-frontend -emit-module %t/ClientZ.swift \
+// RUN:   -module-name ClientZ -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/ClientZ.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/ClientZ.private.swiftinterface
+// RUN: %FileCheck %s --check-prefix CHECK-Z < %t/ClientZ.private.swiftinterface
+// CHECK-Z: @_spi(_) import Lib
+// CHECK-Z: @_spi(_) public func useImplicit() -> Lib._Klass
+
+
+//--- Lib.swift
+
+@_spi(core)
+public struct CoreStruct {
+  public init() {}
+}
+
+@_spi(_)
+public class _Klass {
+  public init() {}
+}
+
+public protocol APIProtocol {
+}
+
+
+//--- ClientA.swift
+
+import Lib
+
+@_spi(_)
+public func useImplicit() -> _Klass { return _Klass() }
+
+public func useMain() -> APIProtocol? { return nil }
+
+
+//--- ClientB.swift
+
+@_spi(core) import Lib
+
+@_spi(_)
+public func useImplicit() -> _Klass { return _Klass() }
+
+@_spi(core)
+public func useSPICore() -> CoreStruct { return CoreStruct() }
+
+public func useMain() -> APIProtocol? { return nil }
+
+
+//--- ClientC.swift
+
+import Lib
+
+public func useImplicit() -> _Klass { return _Klass() } // expected-error{{cannot use class '_Klass' here; it is an SPI imported from 'Lib'}}
+
+@_spi(core)
+public func useSPICore() -> CoreStruct { return CoreStruct() } // expected-error{{cannot find type 'CoreStruct' in scope}}
+
+public func useMain() -> APIProtocol? { return nil }
+
+
+//--- ClientZ.swift
+
+@_spi(_) import Lib
+
+@_spi(_)
+public func useImplicit() -> _Klass { return _Klass() }
+
+public func useMain() -> APIProtocol? { return nil }

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -9,7 +9,8 @@
 // SPI declarations
 @_spi(MySPI) public func spiFunc() {}
 @_spi(+) public func invalidSPIName() {} // expected-error {{expected an SPI identifier as subject of the '@_spi' attribute}}
-@_spi(🤔) public func emojiNamedSPI() {}
+@_spi(🤔) public func emojiNamedSPI() {} // OK
+@_spi(_) public func underscoreNamedSPI() {} // OK
 @_spi() public func emptyParensSPI() {} // expected-error {{expected an SPI identifier as subject of the '@_spi' attribute}}
 @_spi(set) public func keywordSPI() {} // expected-error {{expected an SPI identifier as subject of the '@_spi' attribute}}
 


### PR DESCRIPTION
API development sometimes requires a redesign while supporting early adopters. Currently this is done by adding @_spi(name) to the API but that requires adding the attribute in import statements as well, causing manual overhead of adding and then removing when the redesign is done.

This PR introduces a special spi group name '_' and allows an implicit spi import of a module containing API attributed with `@_spi(_)`

Resolves rdar://109797632
