### PR TITLE
Support required inits in @objcImpl

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1663,6 +1663,11 @@ ERROR(objc_implementation_type_mismatch,none,
       "header",
       (DescriptiveDeclKind, ValueDecl *, Type, Type))
 
+ERROR(objc_implementation_required_attr_mismatch,none,
+      "%0 %1 %select{should not|should}2 be 'required' to match %0 declared by "
+      "the header",
+      (DescriptiveDeclKind, ValueDecl *, bool))
+
 ERROR(objc_implementation_wrong_objc_name,none,
       "selector %0 for %1 %2 not found in header; did you mean %3?",
       (ObjCSelector, DescriptiveDeclKind, ValueDecl *, ObjCSelector))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2717,7 +2717,7 @@ void AttributeChecker::visitRequiredAttr(RequiredAttr *attr) {
     // The constructor must be declared within the class itself.
     // FIXME: Allow an SDK overlay to add a required initializer to a class
     // defined in Objective-C
-    if (!isa<ClassDecl>(ctor->getDeclContext()) &&
+    if (!isa<ClassDecl>(ctor->getDeclContext()->getImplementedObjCContext()) &&
         !isObjCClassExtensionInOverlay(ctor->getDeclContext())) {
       diagnose(ctor, diag::required_initializer_in_extension, parentTy)
         .highlight(attr->getLocation());

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3015,6 +3015,7 @@ private:
     WrongDeclKind,
     WrongType,
     WrongWritability,
+    WrongRequiredAttr,
 
     Match,
     MatchWithExplicitObjCName,
@@ -3312,6 +3313,10 @@ private:
             !cast<AbstractStorageDecl>(cand)->isSettable(nullptr))
         return MatchOutcome::WrongWritability;
 
+    if (auto reqCtor = dyn_cast<ConstructorDecl>(req))
+      if (reqCtor->isRequired() != cast<ConstructorDecl>(cand)->isRequired())
+        return MatchOutcome::WrongRequiredAttr;
+
     // If we got here, everything matched. But at what quality?
     if (explicitObjCName)
       return MatchOutcome::MatchWithExplicitObjCName;
@@ -3399,6 +3404,22 @@ private:
       diagnose(cand, diag::objc_implementation_must_be_settable,
                cand->getDescriptiveKind(), cand, req->getDescriptiveKind());
       return;
+
+    case MatchOutcome::WrongRequiredAttr: {
+      bool shouldBeRequired = cast<ConstructorDecl>(req)->isRequired();
+
+      auto diag =
+        diagnose(cand, diag::objc_implementation_required_attr_mismatch,
+                 cand->getDescriptiveKind(), cand, shouldBeRequired);
+      
+      if (shouldBeRequired)
+        diag.fixItInsert(cand->getAttributeInsertionLoc(/*forModifier=*/true),
+                         "required ");
+      else
+        diag.fixItRemove(cand->getAttrs().getAttribute<RequiredAttr>()
+                             ->getLocation());
+      return;
+    }
     }
 
     llvm_unreachable("Unknown MatchOutcome");

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -12,7 +12,16 @@
 
 @end
 
-@interface ObjCClass : ObjCBaseClass
+@protocol ObjCProto
+
+- (instancetype)initFromProtocol1:(int)param;
+- (instancetype)initFromProtocol2:(int)param;
+
+@end
+
+@interface ObjCClass : ObjCBaseClass <ObjCProto>
+
+- (instancetype)initNotFromProtocol:(int)param;
 
 - (void)methodFromHeader1:(int)param;
 - (void)methodFromHeader2:(int)param;

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -145,6 +145,21 @@
     // OK
   }
 
+  @objc(initFromProtocol1:)
+  required public init?(fromProtocol1: CInt) {
+    // OK
+  }
+
+  @objc(initFromProtocol2:)
+  public init?(fromProtocol2: CInt) {
+    // expected-error@-1 {{initializer 'init(fromProtocol2:)' should be 'required' to match initializer declared by the header}} {{3-3=required }}
+  }
+
+  @objc(initNotFromProtocol:)
+  required public init?(notFromProtocol: CInt) {
+    // expected-error@-1 {{initializer 'init(notFromProtocol:)' should not be 'required' to match initializer declared by the header}} {{3-12=}}
+  }
+
   class func classMethod1(_: CInt) {
     // OK
   }

--- a/test/decl/ext/objc_implementation_conflicts.swift
+++ b/test/decl/ext/objc_implementation_conflicts.swift
@@ -146,6 +146,24 @@ import objc_implementation_private
     super.init(fromSuperclass2: v)
   }
 
+  @objc(initFromProtocol1:)
+  required public init?(fromProtocol1 v: CInt) {
+    // OK
+    super.init(fromSuperclass: v)
+  }
+
+  @objc(initFromProtocol2:)
+  required public init?(fromProtocol2 v: CInt) {
+    // OK
+    super.init(fromSuperclass: v)
+  }
+
+  @objc(initNotFromProtocol:)
+  public init?(notFromProtocol v: CInt) {
+    // OK
+    super.init(fromSuperclass: v)
+  }
+
   class func classMethod1(_: CInt) {}
   class func classMethod2(_: CInt) {}
   class func classMethod3(_: CInt) {}


### PR DESCRIPTION
* Allow `required init`s in @objcImpl extensions of a class’s main body
* Validate that the presence or absence of a `required` modifier matches the imported header declaration.

Fixes rdar://110016760.
