### PR TITLE
[5.9][Macros] Don't apply member attribute macros to expanded members.

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -496,6 +496,10 @@ ArrayRef<unsigned> ExpandMemberAttributeMacros::evaluate(Evaluator &evaluator,
   if (decl->isImplicit())
     return { };
 
+  // Member attribute macros do not apply to macro-expanded members.
+  if (decl->isInMacroExpansionInContext())
+    return { };
+
   auto *parentDecl = decl->getDeclContext()->getAsDecl();
   if (!parentDecl || !isa<IterableDeclContext>(parentDecl))
     return { };

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1488,3 +1488,20 @@ public struct VarValueMacro: DeclarationMacro, PeerMacro {
     ]
   }
 }
+
+public struct SingleMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let member: DeclSyntax =
+      """
+      var expandedMember: Int = 10
+      """
+
+    return [
+      member,
+    ]
+  }
+}

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -123,3 +123,20 @@ class C2: P {
 
   var blah: Int { squareOfLength }
 }
+
+@attached(member, names: named(expandedMember))
+macro AddMember() = #externalMacro(module: "MacroDefinition", type: "SingleMemberMacro")
+
+@AddMember
+@wrapAllProperties
+struct TestExpansionOrder {
+  var originalMember: Int = 10
+}
+
+var expansionOrder = TestExpansionOrder()
+
+// CHECK-NOT: setting 27
+expansionOrder.expandedMember = 27
+
+// CHECK: setting 28
+expansionOrder.originalMember = 28


### PR DESCRIPTION
(cherry picked from commit 14e92b2678e32fb35a3e27d19719bb0f9997f110)

* **Explanation**: The attached macro proposal states:

> member attribute macros allow one to modify the member declarations that were explicitly written within the type or extension by adding new attributes to them

The implementation did not follow this, because it applied member attributes to other macro-expanded members. This change aligns the implementation with the proposal.
* **Scope**: Only impacts member-attribute macros that are composed with other macro roles that can add members to a type, e.g. member or peer macros.
* **Issue**: rdar://109217961
* **Risk**: Very low; this is a one-line change within the code path that expands member-attribute macros that checks whether the given member is in a macro expansion buffer relative to its parent.
* **Testing**: Added a test case.
* **Reviewer**: @ahoppen
* **Main branch PR**: https://github.com/apple/swift/pull/66258