### PR TITLE
[cxx-interop] Initializing a Swift.Array from CxxConvertibleToCollection should not copy the collection

### DIFF
--- a/stdlib/public/Cxx/CxxConvertibleToCollection.swift
+++ b/stdlib/public/Cxx/CxxConvertibleToCollection.swift
@@ -56,7 +56,7 @@ extension RangeReplaceableCollection {
   ///   be true for certain C++ types, e.g. those with a custom copy
   ///   constructor that performs additional logic.
   @inlinable
-  public init<C: CxxConvertibleToCollection>(_ elements: C)
+  public init<C: CxxConvertibleToCollection>(_ elements: __shared C)
     where C.RawIterator.Pointee == Element {
 
     self.init()
@@ -74,7 +74,7 @@ extension SetAlgebra {
   ///   be true for certain C++ types, e.g. those with a custom copy
   ///   constructor that performs additional logic.
   @inlinable
-  public init<C: CxxConvertibleToCollection>(_ elements: C)
+  public init<C: CxxConvertibleToCollection>(_ elements: __shared C)
     where C.RawIterator.Pointee == Element {
 
     self.init()

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -14,6 +14,16 @@ struct SimpleSequenceWithOutOfLineEqualEqual {
   ConstIteratorOutOfLineEq end() const { return ConstIteratorOutOfLineEq(5); }
 };
 
+static int copiesCount = 0;
+
+struct SimpleCopyAwareSequence {
+  ConstIterator begin() const { return ConstIterator(1); }
+  ConstIterator end() const { return ConstIterator(5); }
+
+  SimpleCopyAwareSequence() {}
+  SimpleCopyAwareSequence(const SimpleCopyAwareSequence &other) { copiesCount++; }
+};
+
 struct SimpleArrayWrapper {
 private:
   int a[5] = {10, 20, 30, 40, 50};

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -15,6 +15,21 @@ CxxSequenceTestSuite.test("SimpleSequence to Swift.Array") {
   expectEqual([1, 2, 3, 4] as [Int32], array)
 }
 
+#if !os(Linux) // this test crashes on Linux (https://github.com/apple/swift/issues/66363)
+CxxSequenceTestSuite.test("SimpleCopyAwareSequence to Swift.Array") {
+  copiesCount = 0
+
+  let seq = SimpleCopyAwareSequence()
+
+  let seqCopy = seq
+  expectEqual(1, copiesCount) // make sure our copy tracking mechanism works
+
+  let array = Array(seq)
+
+  expectEqual(1, copiesCount) // make sure we don't copy the C++ sequence value unnecessarily
+}
+#endif
+
 CxxSequenceTestSuite.test("SimpleSequenceWithOutOfLineEqualEqual to Swift.Array") {
   let seq = SimpleSequenceWithOutOfLineEqualEqual()
   let array = Array(seq)


### PR DESCRIPTION
This makes the `CxxConvertibleToCollection` parameter shared, preventing the unnecessary copy of the C++ value.

rdar://110110376