### PR TITLE
[utils] Show the string value of `swift::Identifier` in LLDB

### DIFF
--- a/utils/lldb/lldbSwiftDataFormatters.py
+++ b/utils/lldb/lldbSwiftDataFormatters.py
@@ -20,6 +20,9 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand('type synthetic add --skip-references -w swift '
                            '-l lldbSwiftDataFormatters.DemangleNodeSynthProvider '
                            '-x "^swift::Demangle::Node$"')
+    debugger.HandleCommand('type summary add -w swift '
+                           '-s "${var.Pointer%S}" '
+                           'swift::Identifier')
 
 
 def SmallBitVectorSummaryProvider(valobj, internal_dict):


### PR DESCRIPTION
This adds a straightforward LLDB pretty printer for `swift::Identifier` which prints its string value.