### PR TITLE
5.9: [ClosureSpecializer] Don't release trivial noescape try_apply argument twice.

### DIFF
--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -460,7 +460,8 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
     // If we passed in the original closure as @owned, then insert a release
     // right after NewAI. This is to balance the +1 from being an @owned
     // argument to AI.
-    if (!CSDesc.isClosureConsumed() || !CSDesc.closureHasRefSemanticContext()) {
+    if (!CSDesc.isClosureConsumed() || CSDesc.isTrivialNoEscapeParameter() ||
+        !CSDesc.closureHasRefSemanticContext()) {
       break;
     }
 

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -702,6 +702,71 @@ bb0(%0 : $Int):
   return %empty : $()
 }
 
+sil @testThrowingClosureConvertHelper : $@convention(thin) (Int) -> (Int, @error any Error)
+sil [reabstraction_thunk] @reabstractionThunkThrowing : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
+
+sil @testClosureThunkNoEscapeThrowing : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>) -> (@out (), @error any Error) {
+entry(%empty : $*(), %closure : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>):
+  %out = alloc_stack $Int
+  try_apply %closure(%out) : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>, normal bb1, error bb2
+
+bb1(%ret : $()):
+  dealloc_stack %out : $*Int
+  store %ret to %empty : $*()
+  %retval = tuple ()
+  return %retval : $()
+
+bb2(%error : $any Error):
+  dealloc_stack %out : $*Int
+  throw %error : $any Error
+}
+
+// CHECK-LABEL: sil @reabstractionThrowing : $@convention(thin) (Int) -> ((), @error any Error) {
+// CHECK:         [[HELPER:%[^,]+]] = function_ref @testThrowingClosureConvertHelper
+// CHECK:         [[SPECIALIZATION:%[^,]+]] = function_ref @$s32testClosureThunkNoEscapeThrowing0afB13ConvertHelperSiTf1nc_n
+// CHECK:         [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[HELPER]]
+// CHECK:         [[NOESCAPE_CLOSURE:%[^,]+]] = convert_escape_to_noescape [[CLOSURE]]
+// CHECK:         try_apply [[SPECIALIZATION]]{{.*}}normal [[NORMAL_BLOCK:bb[0-9]+]], error [[ERROR_BLOCK:bb[0-9]+]]
+// CHECK:       [[NORMAL_BLOCK]]
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK:       [[ERROR_BLOCK]]
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK-LABEL: } // end sil function 'reabstractionThrowing'
+sil @reabstractionThrowing : $(Int) -> ((), @error any Error) {
+bb0(%value : $Int):
+  %testThrowingClosureConvertHelper = function_ref @testThrowingClosureConvertHelper : $@convention(thin) (Int) -> (Int, @error any Error)
+  %closure = partial_apply [callee_guaranteed] %testThrowingClosureConvertHelper(%value) : $@convention(thin) (Int) -> (Int, @error any Error)
+  %noescapeClosure = convert_escape_to_noescape %closure : $@callee_guaranteed () -> (Int, @error any Error) to $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  %thunk = function_ref @reabstractionThunkThrowing : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
+  %appliedThunk = partial_apply [callee_guaranteed] [on_stack] %thunk(%noescapeClosure) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
+
+  %dependency = mark_dependence %appliedThunk : $@noescape @callee_guaranteed () -> (@out Int, @error any Error) on %noescapeClosure : $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  %generified = convert_function %dependency : $@noescape @callee_guaranteed () -> (@out Int, @error any Error) to $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  %test = function_ref @testClosureThunkNoEscapeThrowing : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>) -> (@out (), @error any Error)
+  strong_retain %generified : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  %out = alloc_stack $()
+  try_apply %test(%out, %generified) : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>) -> (@out (), @error any Error), normal bb1, error bb2
+
+bb1(%ret : $()):
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> (Int, @error any Error)
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> (@out Int, @error any Error)
+  %empty = tuple ()
+  return %empty : $()
+
+bb2(%error : $any Error):
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> (Int, @error any Error)
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> (@out Int, @error any Error)
+  throw %error : $any Error
+}
+
 // Currently not supported cases.
 
 sil @testClosureThunk4 : $@convention(thin) (@owned @callee_guaranteed () -> @out Int) -> @out Int {


### PR DESCRIPTION
Description: ClosureSpecializer creates releases for the closure passed as an parameter to a `try_apply` that is specialized.  These releases are created in (1) `ClosureSpecCloner::populateCloned` and (2) `rewriteApplyInst`, depending on the effective ownership of the closure: in (1) they are inserted for closures passed _without_ an increment of the retain count (done e.g. for closures passed as an `@guaranteed` parameter); in (2) they are inserted for closures passed _with_ an increment of the retain count (done e.g. for closures passed as an `@owned` parameter).

Among the closures that are passed without an increment of the retain count are those which are noescape (`SILFunctionType::isTrivialNoEscape`).  That is true even when the closure is passed as an `@owned` parameter.  The condition of (1) under which releases are added for the closure correctly included consideration of the `isTrivialNoEscape` predicate of the closure's type; consequently that code inserts releases in both of the `try_apply`'s destination blocks.  The condition of (2) under which releases were added for the closure incorrectly failed to consider the `isTrivialNoEscape` predicate; consequently, that code _also_ inserted releases in both of the destination blocks.  The result was adding two releases in each destination block, one of each of which was an overrelease.

The fix is just to consider the `isTrivialNoEscape` predicate in (2).
Risk: Low.  The patch adds a predicate to the bailout condition of (2) that complements an existing use of the same predicate in the condition of (1).
Scope: Narrow.  This only affects releases for noescape closures passed as owned arguments to `try_apply`s which are specialized.
Original PR: https://github.com/apple/swift/pull/66263
Reviewed By: Erik Eckstein ( @eeckstein ), Arnold Schwaigofer ( @aschwaighofer )
Testing: Added test case that previously inserted double release.
Resolves: rdar://110058964
