### PR TITLE
[ClosureSpecializer] Don't release trivial noescape apply argument twice.

### DIFF
--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -482,7 +482,8 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
     // If we passed in the original closure as @owned, then insert a release
     // right after NewAI. This is to balance the +1 from being an @owned
     // argument to AI.
-    if (CSDesc.isClosureConsumed() && CSDesc.closureHasRefSemanticContext())
+    if (CSDesc.isClosureConsumed() && !CSDesc.isTrivialNoEscapeParameter() &&
+        CSDesc.closureHasRefSemanticContext())
       Builder.createReleaseValue(Closure->getLoc(), Closure,
                                  Builder.getDefaultAtomicity());
 

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -702,6 +702,51 @@ bb0(%0 : $Int):
   return %empty : $()
 }
 
+sil @testClosureConvertHelper3 : $@convention(thin) (Int) -> Int
+sil [reabstraction_thunk] @reabstractionThunk3 : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+sil @testClosureThunkNoEscape3 : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out () {
+entry(%empty : $*(), %closure : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>):
+  %out = alloc_stack $Int
+  %ret = apply %closure(%out) : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  dealloc_stack %out : $*Int
+  store %ret to %empty : $*()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @reabstractionTest4 {{.*}} {
+// CHECK:         [[HELPER:%[^,]+]] = function_ref @testClosureConvertHelper3
+// CHECK:         [[SPECIALIZATION:%[^,]+]] = function_ref @$s25testClosureThunkNoEscape30aB14ConvertHelper3SiTf1nc_n
+// CHECK:         [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[HELPER]]
+// CHECK:         [[NOESCAPE_CLOSURE:%[^,]+]] = convert_escape_to_noescape [[CLOSURE]]
+// CHECK:         apply [[SPECIALIZATION]]{{.*}}
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK-LABEL: } // end sil function 'reabstractionTest4'
+sil @reabstractionTest4 : $(Int) -> () {
+bb0(%value : $Int):
+  %testThrowingClosureConvertHelper = function_ref @testClosureConvertHelper3 : $@convention(thin) (Int) -> Int
+  %closure = partial_apply [callee_guaranteed] %testThrowingClosureConvertHelper(%value) : $@convention(thin) (Int) -> Int
+  %noescapeClosure = convert_escape_to_noescape %closure : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  %thunk = function_ref @reabstractionThunk3 : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %appliedThunk = partial_apply [callee_guaranteed] [on_stack] %thunk(%noescapeClosure) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+  %dependency = mark_dependence %appliedThunk : $@noescape @callee_guaranteed () -> @out Int on %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  %generified = convert_function %dependency : $@noescape @callee_guaranteed () -> @out Int to $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %test = function_ref @testClosureThunkNoEscape3 : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out ()
+  strong_retain %generified : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %out = alloc_stack $()
+  %ret = apply %test(%out, %generified) : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out ()
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> Int
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> @out Int
+  %empty = tuple ()
+  return %empty : $()
+}
+
 sil @testThrowingClosureConvertHelper : $@convention(thin) (Int) -> (Int, @error any Error)
 sil [reabstraction_thunk] @reabstractionThunkThrowing : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
 


### PR DESCRIPTION
When a specialization is created, in the original function, releases are added in two different places:
(1) `ClosureSpecCloner::populateCloned`
(2) `rewriteApplyInst`

In the former, releases are added for closures which are guaranteed or trivial noescape (but with owned convention). In the latter, releases are added for closures that are owned.

Previously, when emitting releases at (2), whether the closure was trivial noescape wasn't considered.  The result was inserting the releases twice, an overrelease.

Here, fix (2) to recognize trivial noescape as not +1.

rdar://110115795
