### PR TITLE
[Runtime] Fix memory leak in -[__SwiftNativeNSError description] for large error values.

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -103,13 +103,16 @@ using namespace swift::hashable_support;
 - (id /* NSString */)description {
   auto error = (const SwiftError *)self;
   auto value = error->getValue();
+  auto type = error->type;
 
   // Copy the value, since it will be consumed by getDescription.
   ValueBuffer copyBuf;
-  auto copy = error->type->allocateBufferIn(&copyBuf);
+  auto copy = type->allocateBufferIn(&copyBuf);
   error->type->vw_initializeWithCopy(copy, const_cast<OpaqueValue *>(value));
 
-  return getDescription(copy, error->type);
+  auto description = getDescription(copy, type);
+  type->deallocateBufferIn(&copyBuf);
+  return description;
 }
 
 - (NSInteger)code {

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -863,6 +863,11 @@ struct SwiftError2: Error, CustomStringConvertible {
   var description: String
 }
 
+struct SwiftErrorLarge: Error, CustomStringConvertible {
+  var description: String
+  var makeItLarge = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+}
+
 ErrorBridgingTests.test("Swift Error description memory management") {
   func checkDescription() {
     // Generate a non-small, non-constant NSString bridged to String.
@@ -881,6 +886,15 @@ ErrorBridgingTests.test("Swift Error description memory management") {
     for _ in 0 ..< 10 {
       autoreleasepool {
         expectEqual(str, bridgedError.description)
+      }
+    }
+
+    // Make sure large structs also work.
+    let largeError = SwiftErrorLarge(description: str)
+    let largeBridgedError = largeError as NSError
+    for _ in 0 ..< 10 {
+      autoreleasepool {
+        expectEqual(str, largeBridgedError.description)
       }
     }
   }


### PR DESCRIPTION
Balance the call to allocateBufferIn with a call to deallocateBufferIn. When an error value is small, the missing deallocateBufferIn doesn't do anything. But when the error value is a larger struct that doesn't fit inline, we need deallocateBufferIn to avoid leaking the allocation.

rdar://109933822