### PR TITLE
Fix drop_deinit side effects.

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -461,8 +461,15 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // effects relative to other OSSA values like copy_value.
   SINGLE_VALUE_INST(MoveValueInst, move_value, SingleValueInstruction, None,
                     DoesNotRelease)
-  SINGLE_VALUE_INST(DropDeinitInst, drop_deinit, SingleValueInstruction, None,
-                    DoesNotRelease)
+  // A drop_deinit has no user-level side effects. It does, however, change the
+  // information about the owenership of its operand, and therefore cannot be
+  // arbitrarily deleted. It effectively wraps the type of the operand so that
+  // the resulting value is an equivalent type without a user-defined deinit.
+  //
+  // TODO: Add an OwnershipEffect type of side effect for instructions like
+  // drop_deinit to indicate their ownership effects.
+  SINGLE_VALUE_INST(DropDeinitInst, drop_deinit, SingleValueInstruction,
+                    MayHaveSideEffects, DoesNotRelease)
   // A canary value inserted by a SIL generating frontend to signal to the move
   // checker to check a specific value.  Valid only in Raw SIL. The relevant
   // checkers should remove the mark_must_check instruction after successfully

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2698,6 +2698,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::DeinitExistentialValueInst:
   case SILInstructionKind::DestroyAddrInst:
   case SILInstructionKind::DestroyValueInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::EndAccessInst:
   case SILInstructionKind::EndApplyInst:
   case SILInstructionKind::EndBorrowInst:

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -18,6 +18,11 @@ struct CAndBit {
     var bit: Int1
 }
 
+@_moveOnly
+struct MO {
+    deinit
+}
+
 sil @dummy : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [ossa] @dead1 :
@@ -406,4 +411,24 @@ exit:
   destroy_value %instance : $C
   %retval = tuple ()
   return %retval : $()
+}
+
+// Test that DCE does not eliminate a drop_deinit.
+//
+// rdar://109863801 ([move-only] DCE removes drop_deinit, so
+// user-defined deinitializers call themselves recursively at -O)
+//
+// CHECK-LABEL: sil hidden [ossa] @testDropDeinit : $@convention(method) (@owned MO) -> () {
+// CHECK: [[DROP:%.*]] = drop_deinit %0 : $MO
+// CHECK: end_lifetime [[DROP]] : $MO
+// CHECK-LABEL: } // end sil function 'testDropDeinit'
+//
+// MO.deinit
+sil hidden [ossa] @testDropDeinit : $@convention(method) (@owned MO) -> () {
+bb0(%0 : @owned $MO):
+  debug_value %0 : $MO, let, name "self", argno 1, implicit
+  %61 = drop_deinit %0 : $MO
+  end_lifetime %61 : $MO
+  %63 = tuple ()
+  return %63 : $()
 }


### PR DESCRIPTION
rdar://109863801 ([move-only] DCE removes drop_deinit, so user-defined deinitializers call themselves recursively at -O)
