### PR TITLE
[5.9] Fix String capacity growth tests for watchOS

### DIFF
--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2380,7 +2380,8 @@ StringTests.test("String.CoW.reserveCapacity") {
   let preGrowCapacity = str.capacity
   
   // Growth shouldn't be linear
-  str.append(contentsOf: String(repeating: "z", count: 20))
+  let newElementCount = (preGrowCapacity - str.count) + 10
+  str.append(contentsOf: String(repeating: "z", count: newElementCount))
   expectGE(str.capacity, preGrowCapacity * 2)
   
   // Capacity can shrink when copying, but not below the count
@@ -2407,7 +2408,6 @@ StringTests.test("NSString.CoW.reserveCapacity") {
   var copy2 = str2
   copy2.append(contentsOf: String(repeating: "z", count: 10))
   expectGE(copy2.capacity, 30)
-  expectLT(copy2.capacity, 40)
 #endif
 }
 


### PR DESCRIPTION
watchOS devices can have different allocation characteristics from other devices. This modifies the string capacity growth tests to be more flexible about measuring the growth in capacity, specifically when more is allocated than requested.

rdar://109895539