### PR TITLE
[GenPack] Always heapify metadata packs.

### DIFF
--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -210,10 +210,8 @@ static Address emitFixedSizeMetadataPackRef(IRGenFunction &IGF,
   return pack;
 }
 
-/// Use this to index into packs to correctly handle on-heap packs.
-static llvm::Value *loadMetadataAtIndex(IRGenFunction &IGF,
-                                        llvm::Value *patternPack,
-                                        llvm::Value *index) {
+llvm::Value *irgen::maskMetadataPackPointer(IRGenFunction &IGF,
+                                            llvm::Value *patternPack) {
   // If the pack is on the heap, the LSB is set, so mask it off.
   patternPack =
       IGF.Builder.CreatePtrToInt(patternPack, IGF.IGM.SizeTy);
@@ -221,6 +219,14 @@ static llvm::Value *loadMetadataAtIndex(IRGenFunction &IGF,
       IGF.Builder.CreateAnd(patternPack, llvm::ConstantInt::get(IGF.IGM.SizeTy, -2));
   patternPack =
       IGF.Builder.CreateIntToPtr(patternPack, IGF.IGM.TypeMetadataPtrPtrTy);
+  return patternPack;
+}
+
+/// Use this to index into packs to correctly handle on-heap packs.
+static llvm::Value *loadMetadataAtIndex(IRGenFunction &IGF,
+                                        llvm::Value *patternPack,
+                                        llvm::Value *index) {
+  patternPack = maskMetadataPackPointer(IGF, patternPack);
 
   Address patternPackAddress(patternPack, IGF.IGM.TypeMetadataPtrTy,
                              IGF.IGM.getPointerAlignment());

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -512,6 +512,11 @@ irgen::emitTypeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
   metadata = IGF.Builder.CreatePointerCast(
       metadata, IGF.IGM.TypeMetadataPtrTy->getPointerTo());
 
+  metadata = IGF.Builder.CreateCall(
+      IGF.IGM.getAllocateMetadataPackFunctionPointer(), {metadata, shape});
+
+  cleanupTypeMetadataPack(IGF, pack, shape);
+
   auto response = MetadataResponse::forComplete(metadata);
   IGF.setScopedLocalTypeMetadata(packType, response);
 
@@ -668,6 +673,11 @@ llvm::Value *irgen::emitWitnessTablePackRef(IRGenFunction &IGF,
   auto *result = pack.getAddress().getAddress();
   result = IGF.Builder.CreatePointerCast(
       result, IGF.IGM.WitnessTablePtrTy->getPointerTo());
+
+  result = IGF.Builder.CreateCall(
+      IGF.IGM.getAllocateWitnessTablePackFunctionPointer(), {result, shape});
+
+  cleanupWitnessTablePack(IGF, pack, shape);
 
   IGF.setScopedLocalTypeData(packType, localDataKind, result);
 

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -43,9 +43,8 @@ emitPackArchetypeMetadataRef(IRGenFunction &IGF,
                              CanPackArchetypeType type,
                              DynamicMetadataRequest request);
 
-StackAddress
-emitTypeMetadataPack(IRGenFunction &IGF,
-                     CanPackType packType,
+std::pair<StackAddress, llvm::Value *>
+emitTypeMetadataPack(IRGenFunction &IGF, CanPackType packType,
                      DynamicMetadataRequest request);
 
 MetadataResponse
@@ -68,18 +67,18 @@ emitTypeMetadataPackElementRef(IRGenFunction &IGF, CanPackType packType,
                                DynamicMetadataRequest request,
                                llvm::SmallVectorImpl<llvm::Value *> &wtables);
 
-void cleanupTypeMetadataPack(IRGenFunction &IGF,
-                             StackAddress pack,
-                             Optional<unsigned> elementCount);
+void cleanupTypeMetadataPack(IRGenFunction &IGF, StackAddress pack,
+                             llvm::Value *shape);
 
-StackAddress emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
-                                  PackConformance *conformance);
+std::pair<StackAddress, llvm::Value *>
+emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
+                     PackConformance *conformance);
 
 llvm::Value *emitWitnessTablePackRef(IRGenFunction &IGF, CanPackType packType,
                                      PackConformance *conformance);
 
 void cleanupWitnessTablePack(IRGenFunction &IGF, StackAddress pack,
-                             Optional<unsigned> elementCount);
+                             llvm::Value *shape);
 
 /// Emit the dynamic index of a particular structural component
 /// of the given pack type.  If the component is a pack expansion, this

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -53,6 +53,10 @@ emitTypeMetadataPackRef(IRGenFunction &IGF,
                         CanPackType packType,
                         DynamicMetadataRequest request);
 
+/// Given a pointer to a potentially heap-allocated pack of metadata/wtables,
+/// mask off the bit that indicates whether it is heap allocated.
+llvm::Value *maskMetadataPackPointer(IRGenFunction &IGF, llvm::Value *);
+
 void bindOpenedElementArchetypesAtIndex(IRGenFunction &IGF,
                                         GenericEnvironment *env,
                                         llvm::Value *index);

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -19,6 +19,7 @@
 #include "Fulfillment.h"
 #include "GenMeta.h"
 #include "GenOpaque.h"
+#include "GenPack.h"
 #include "GenProto.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
@@ -349,6 +350,9 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
   auto name = typeParam->getName().str();
 
   llvm::Value *data = value.getMetadata();
+
+  if (key.Type->is<PackArchetypeType>())
+    data = maskMetadataPackPointer(IGF, data);
 
   // At -O0, create an alloca to keep the type alive. Not for async functions
   // though; see the comment in IRGenFunctionSIL::emitShadowCopyIfNeeded().

--- a/test/DebugInfo/variadic-generics.swift
+++ b/test/DebugInfo/variadic-generics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -o - \
-// RUN:    -parse-as-library -module-name a | %FileCheck %s
+// RUN:    -parse-as-library -module-name a | %IRGenFileCheck %s
 
 public func foo<each T>(args: repeat each T) {
   // CHECK: define {{.*}} @"$s1a3foo4argsyxxQp_tRvzlF"
@@ -8,9 +8,12 @@ public func foo<each T>(args: repeat each T) {
   // CHECK: call void @llvm.dbg.declare(metadata %swift.type*** %[[TYPE_PACK_ALLOCA]], metadata ![[TYPE_PACK_VAR:[0-9]+]], metadata !DIExpression())
   // CHECK: %[[ARGS_ALLOCA:.*]] = alloca %swift.opaque**
   // CHECK-DAG: call void @llvm.dbg.declare(metadata %swift.opaque*** %[[ARGS_ALLOCA]], metadata ![[ARGS_VAR:[0-9]+]], metadata !DIExpression(DW_OP_deref))
-  // CHECK-DAG: store %swift.type** %[[TYPE_PACK_ARG]], %swift.type*** %[[TYPE_PACK_ALLOCA]]
+  // CHECK-DAG: %[[TYPE_PACK_ARG_INT:[^,]+]] = ptrtoint %swift.type** %[[TYPE_PACK_ARG]] to [[INT]]
+  // CHECK-DAG: %[[TYPE_PACK_ARG_MASKED_INT:[^,]+]] = and [[INT]] %[[TYPE_PACK_ARG_INT]], -2
+  // CHECK-DAG: %[[TYPE_PACK_ARG_MASKED:[^,]+]] = inttoptr [[INT]] %[[TYPE_PACK_ARG_MASKED_INT]] to %swift.type**
+  // CHECK-DAG: store %swift.type** %[[TYPE_PACK_ARG_MASKED]], %swift.type*** %[[TYPE_PACK_ALLOCA]]
   // CHECK-DAG: store %swift.opaque** %0, %swift.opaque*** %[[ARGS_ALLOCA]]
-  // CHECK-DAG: ![[ARGS_VAR]] = !DILocalVariable(name: "args", arg: 1, {{.*}}line: [[@LINE-9]], type: ![[ARGS_LET_TY:[0-9]+]])
+  // CHECK-DAG: ![[ARGS_VAR]] = !DILocalVariable(name: "args", arg: 1, {{.*}}line: [[@LINE-12]], type: ![[ARGS_LET_TY:[0-9]+]])
   // CHECK-DAG: ![[ARGS_LET_TY]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[ARGS_TY:[0-9]+]])
   // CHECK-DAG: ![[ARGS_TY]] = !DICompositeType({{.*}}identifier: "$sxxQp_QSiD")
   // CHECK-DAG: ![[TYPE_PACK_VAR]] = !DILocalVariable(name: "$\CF\84_0_0", {{.*}}type: ![[TYPE_PACK_TYD:[0-9]+]], flags: DIFlagArtificial)

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) -parse-stdlib %S/../Inputs/print-shims-stdlib.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(PrintShims)
-// RUN: %target-build-swift -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim -Onone | %FileCheck %s --check-prefixes=CHECK-LL,CHECK-LL-UNOPT
+// RUN: %target-build-swift -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim -O | %FileCheck %s --check-prefixes=CHECK-LL,CHECK-LL-OPT
 // RUN: %target-build-swift -g -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
@@ -568,6 +569,7 @@ entry(%intIndex : $Builtin.Word):
 
 // Verify that we just gep into a parameter pack when that's all that the pack consists of.
 // CHECK-LL: define {{.*}}void @direct_access_from_parameter(i{{(32|64)}} [[INDEX:%[^,]+]], i{{(32|64)}} {{%[^,]+}}, %swift.type** [[PACK:%[^,]+]])
+// CHECK-LL-UNOPT:  [[PACK_ADDR_FOR_DI:%.*]] = ptrtoint %swift.type** [[PACK]] to i{{(32|64)}}
 // CHECK-LL:  [[PACK_ADDR:%.*]] = ptrtoint %swift.type** [[PACK]] to i{{(32|64)}}
 // CHECK-LL:  [[PACK_ADDR2:%.*]] = and i{{(32|64)}} [[PACK_ADDR]], -2
 // CHECK-LL:  [[PACK:%.*]] = inttoptr i{{(32|64)}} [[PACK_ADDR2]] to %swift.type**
@@ -591,6 +593,7 @@ entry(%intIndex : $Builtin.Word):
 // CHECK-LL-SAME:        i{{(32|64)}} {{%[^,]+}},
 // CHECK-LL-SAME:        %swift.type** [[METADATA_PACK:%[^,]+]],
 // CHECK-LL-SAME:        i8*** [[WTABLE_PACK:%[^,]+]])
+// CHECK-LL-UNOPT:   [[PACK_ADDR_FOR_DI:%.*]] = ptrtoint %swift.type** [[METADATA_PACK]] to i{{(32|64)}}
 // CHECK-LL:         [[PACK_ADDR:%.*]] = ptrtoint %swift.type** [[METADATA_PACK]] to i{{(32|64)}}
 // CHECK-LL:         [[PACK_ADDR2:%.*]] = and i{{(32|64)}} [[PACK_ADDR]], -2
 // CHECK-LL:         [[METADATA_PACK:%.*]] = inttoptr i{{(32|64)}} [[PACK_ADDR2]] to %swift.type**

--- a/test/IRGen/variadic_generic_functions.sil
+++ b/test/IRGen/variadic_generic_functions.sil
@@ -32,10 +32,12 @@ struct Gen2<Fwd : Q> : Q {}
 // CHECK:         [[METADATA_ELEMENT_0:%[^,]+]] = getelementptr inbounds [1 x %swift.type*], [1 x %swift.type*]* [[METADATA_PACK]]
 // CHECK:         store %swift.type* bitcast {{.*}}$s26variadic_generic_functions3S_2VMf{{.*}}, %swift.type** [[METADATA_ELEMENT_0]]
 // CHECK:         [[METADATA_PACK_PTR:%[^,]+]] = bitcast [1 x %swift.type*]* [[METADATA_PACK]] to %swift.type**
+// CHECK:         [[HEAPIFIED_METADATA_PACK_PTR:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[METADATA_PACK_PTR]], i64 1)
 // CHECK:         [[WTABLE_ELEMENT_0:%[^,]+]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[WTABLE_PACK]]
 // CHECK:         store i8** getelementptr inbounds {{.*}}$s26variadic_generic_functions3S_2VAA1PAAWP{{.*}}, i8*** [[WTABLE_ELEMENT_0]]
-// CHECK:         [[WTABLE_PACK_ADDR:%[^,]+]] = bitcast [1 x i8**]* [[WTABLE_PACK]] to i8***
-// CHECK:         call swiftcc void @g([[INT]] 1, %swift.type** [[METADATA_PACK_PTR]], i8*** [[WTABLE_PACK_ADDR]])
+// CHECK:         [[WTABLE_PACK_PTR:%[^,]+]] = bitcast [1 x i8**]* [[WTABLE_PACK]] to i8***
+// CHECK:         [[HEAPIFIED_WTABLE_PACK_PTR:%[^%]+]] = call swiftcc i8*** @swift_allocateWitnessTablePack(i8*** [[WTABLE_PACK_PTR]], i64 1)
+// CHECK:         call swiftcc void @g([[INT]] 1, %swift.type** [[HEAPIFIED_METADATA_PACK_PTR]], i8*** [[HEAPIFIED_WTABLE_PACK_PTR]])
 sil @c : $() -> () {
   %g = function_ref @g : $@convention(thin) <each T : P> () -> ()
   apply %g<Pack{S_2}>() : $@convention(thin) <each T : P> () -> ()
@@ -89,9 +91,10 @@ sil @f1c : $<each T : PA where repeat each T.A : P> () -> () {}
 // CHECK-SAME:        i8*** %"each T.PA",
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q:%[^,]+]])
 // CHECK:         [[ASSOCIATEDTYPES:%[^,]+]] = alloca %swift.type*, [[INT]] [[SHAPE]]
+// CHECK:         [[HEAPIFIED_ASSOCIATEDTYPES:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[ASSOCIATEDTYPES]], i64 %0)
 // CHECK:         call swiftcc void @associatedtype_with_added_conformance_callee(
 // CHECK-SAME:        [[INT]] [[SHAPE]],
-// CHECK-SAME:        %swift.type** [[ASSOCIATEDTYPES]],
+// CHECK-SAME:        %swift.type** [[HEAPIFIED_ASSOCIATEDTYPES]],
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q]])
 sil @associatedtype_with_added_conformance : $<each T : PA where repeat each T.A : Q> () -> () {
     %callee = function_ref @associatedtype_with_added_conformance_callee : $@convention(thin) <each T : Q> () -> ()
@@ -109,9 +112,10 @@ sil @associatedtype_with_added_conformance_callee : $<each T : Q> () -> () {}
 // CHECK-SAME:        i8*** %"each T.A.QA",
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q:%[^,]+]])
 // CHECK:         [[ASSOCIATEDTYPES:%[^,]+]] = alloca %swift.type*, [[INT]] [[SHAPE]]
+// CHECK:         [[HEAPIFIED_ASSOCIATEDTYPES:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[ASSOCIATEDTYPES]], i64 [[SHAPE]])
 // CHECK:         call swiftcc void @associatedtype_with_added_conformance_2_callee(
 // CHECK-SAME:        [[INT]] [[SHAPE]],
-// CHECK-SAME:        %swift.type** [[ASSOCIATEDTYPES]],
+// CHECK-SAME:        %swift.type** [[HEAPIFIED_ASSOCIATEDTYPES]],
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q]])
 sil @associatedtype_with_added_conformance_2 : $<each T : PA where repeat each T.A : QA, repeat each T.A.A : R> () -> () {
     %j = function_ref @associatedtype_with_added_conformance_2_callee : $@convention(thin) <each T : R> () -> ()
@@ -127,11 +131,15 @@ sil @associatedtype_with_added_conformance_2_callee : $<each T : R> () -> () {}
 // CHECK-SAME:        %swift.type** %"each T",
 // CHECK-SAME:        i8*** %"each T.Q")
 // CHECK:             [[GEN2_TYPES:%[^,]+]] = alloca %swift.type*, [[INT]] [[SHAPE]]
+// CHECK:             [[HEAPIFIED_GEN2_TYPES:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[GEN2_TYPES]], i64 [[SHAPE]])
+// CHECK:             [[STORED_STACK_LOC:%[^,]+]] = call i8* @llvm.stacksave()
 // CHECK:             [[GEN2_CONFORMANCES_TO_Q:%[^,]+]] = alloca i8**, [[INT]] [[SHAPE]]
+// CHECK:             [[HEAPIFIED_GEN2_CONFORMANCES_TO_Q:%[^%]+]] = call swiftcc i8*** @swift_allocateWitnessTablePack(i8*** [[GEN2_CONFORMANCES_TO_Q]], i64 [[SHAPE]])
+// CHECK:             call void @llvm.stackrestore(i8* [[STORED_STACK_LOC]])
 // CHECK:             call swiftcc void @associatedtype_with_forwarded_conformance_1_callee(
 // CHECK-SAME:            [[INT]] [[SHAPE]],
-// CHECK-SAME:            %swift.type** [[GEN2_TYPES]],
-// CHECK-SAME:            i8*** [[GEN2_CONFORMANCES_TO_Q]])
+// CHECK-SAME:            %swift.type** [[HEAPIFIED_GEN2_TYPES]],
+// CHECK-SAME:            i8*** [[HEAPIFIED_GEN2_CONFORMANCES_TO_Q]])
 sil @associatedtype_with_forwarded_conformance_1 : $<each T : Q> () -> () {
     %i = function_ref @associatedtype_with_forwarded_conformance_1_callee : $@convention(thin) <each T : Q> () -> ()
     apply %i<Pack{repeat Gen2<each T>}>() : $@convention(thin) <each T : Q> () -> ()
@@ -148,11 +156,15 @@ sil @associatedtype_with_forwarded_conformance_1_callee : $<each T : Q> () -> ()
 // CHECK-SAME:        i8*** %"each T.PA",
 // CHECK-SAME:        i8*** %"each T.A.Q")
 // CHECK:         [[GEN1_TYPES:%[^,]+]] = alloca %swift.type*, [[INT]] [[SHAPE]]
+// CHECK:         [[HEAPIFIED_GEN1_TYPES:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[GEN1_TYPES]], i64 [[SHAPE]])
+// CHECK:         [[STORED_STACK_LOC:%[^,]+]] = call i8* @llvm.stacksave()
 // CHECK:         [[GEN1_CONFORMANCES_TO_PA:%[^,]+]] = alloca i8**, [[INT]] [[SHAPE]]
+// CHECK:         [[HEAPIFIED_GEN1_CONFORMANCES_TO_PA:%[^%]+]] = call swiftcc i8*** @swift_allocateWitnessTablePack(i8*** [[GEN1_CONFORMANCES_TO_PA]], i64 [[SHAPE]])
+// CHECK:         call void @llvm.stackrestore(i8* [[STORED_STACK_LOC]])
 // CHECK:         call swiftcc void @generictype_with_forwarded_conformance_2_callee(
 // CHECK-SAME:        [[INT]] [[SHAPE]],
-// CHECK-SAME:        %swift.type** [[GEN1_TYPES]],
-// CHECK-SAME:        i8*** [[GEN1_CONFORMANCES_TO_PA]],
+// CHECK-SAME:        %swift.type** [[HEAPIFIED_GEN1_TYPES]],
+// CHECK-SAME:        i8*** [[HEAPIFIED_GEN1_CONFORMANCES_TO_PA]],
 // CHECK-SAME:        i8*** %"each T.A.Q")
 sil @generictype_with_forwarded_conformance_2 : $<each T : PA where repeat each T.A : Q>() -> () {
     %callee = function_ref @generictype_with_forwarded_conformance_2_callee : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
@@ -169,11 +181,15 @@ sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where repea
 // CHECK-SAME:        i8*** %"each T.PA",
 // CHECK-SAME:        i8*** %"each T.A.Q")
 // CHECK:         [[GEN1_GEN1_TYPES:%[^,]+]] = alloca %swift.type*, [[INT]] [[SHAPE]]
+// CHECK:         [[HEAPIFIED_GEN1_GEN1_TYPES:%[^%]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[GEN1_GEN1_TYPES]], i64 [[SHAPE]])
+// CHECK:         [[STORED_STACK_LOC:%[^,]+]] = call i8* @llvm.stacksave()
 // CHECK:         [[GEN1_GEN1_CONFORMANCES_TO_PA:%[^,]+]] = alloca i8**, [[INT]] [[SHAPE]]
+// CHECK:         [[HEAPIFIED_GEN1_GEN1_CONFORMANCES_TO_PA:%[^%]+]] = call swiftcc i8*** @swift_allocateWitnessTablePack(i8*** [[GEN1_GEN1_CONFORMANCES_TO_PA]], i64 [[SHAPE]])
+// CHECK:         call void @llvm.stackrestore(i8* [[STORED_STACK_LOC]])
 // CHECK:         call swiftcc void @generic_with_forwarded_conformance_3_callee(
 // CHECK-SAME:        [[INT]] [[SHAPE]],
-// CHECK-SAME:        %swift.type** [[GEN1_GEN1_TYPES]],
-// CHECK-SAME:        i8*** [[GEN1_GEN1_CONFORMANCES_TO_PA]],
+// CHECK-SAME:        %swift.type** [[HEAPIFIED_GEN1_GEN1_TYPES]],
+// CHECK-SAME:        i8*** [[HEAPIFIED_GEN1_GEN1_CONFORMANCES_TO_PA]],
 // CHECK-SAME:        i8*** %"each T.A.Q")
 sil @generic_with_forwarded_conformance_3 : $<each T : PA where repeat each T.A : Q> () -> () {
     %callee = function_ref @generic_with_forwarded_conformance_3_callee : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()

--- a/test/IRGen/variadic_generic_outlining.sil
+++ b/test/IRGen/variadic_generic_outlining.sil
@@ -11,6 +11,7 @@ struct Wrapper<Value> {
 // an opened element type.
 //
 // CHECK-LABEL: define{{.*}}void @test_outlining
+// CHECK:       [[PACK_ADDR_FOR_DEBUGINFO:%.*]] = ptrtoint %swift.type** %"each T" to [[INT]]
 // CHECK:       [[PACK_ADDR:%.*]] = ptrtoint %swift.type** %"each T" to [[INT]]
 // CHECK-NEXT:  [[PACK_ADDR2:%.*]] = and [[INT]] [[PACK_ADDR]], -2
 // CHECK-NEXT:  [[PACK:%.*]] = inttoptr [[INT]] [[PACK_ADDR2]] to %swift.type**

--- a/validation-test/IRGen/pack_stack_metadata_alloc_loop.sil
+++ b/validation-test/IRGen/pack_stack_metadata_alloc_loop.sil
@@ -1,0 +1,79 @@
+// RUN: %target-run-simple-swift(-parse-sil)
+// RUN: %target-swift-frontend -parse-sil -emit-ir -primary-file %s | %IRGenFileCheck %s
+
+// REQUIRES: executable_test
+
+// Allocate metadata packs on the stack in a loop.  If these packs weren't
+// deallocated, the stack would be exhausted.
+
+import Builtin
+import Swift
+
+struct S {}
+
+sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %looper = function_ref @looper : $@convention(thin) <each T_1, each T_2> () -> ()
+  apply %looper<Pack{S, S, S}, Pack{S, S}>() : $@convention(thin) <each T_1, each T_2> () -> ()
+
+// If the stack were exhausted while looping, the apply of %looper would crash
+// and execution would never reach this point.
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}
+
+sil @callee : $@convention(thin) <each T> () -> () {
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: define {{.*}}@looper(
+// CHECK-SAME:      [[INT]] %0, [[INT]] %1, %swift.type** %"each T_1", %swift.type** %"each T_2") {{.*}} {
+// CHECK:       [[ENTRY:entry]]:
+// CHECK:         br label %[[HEADER:[^,]+]]
+// CHECK:       [[HEADER]]:
+// CHECK:         [[PREVIOUS:%[^,]+]] = phi i64 [ 10000000, %[[ENTRY]] ], [ [[REMAINING:%[^,]+]], %{{[^,]+}} ]
+// CHECK:         [[COMBINED_PACK_SIZE:%[^,]+]] = add [[INT]] %0, %1
+// CHECK:         [[STACK_BEFORE_FIRST_ALLOCA:%[^,]+]] = call i8* @llvm.stacksave()
+// CHECK:         [[FIRST_ALLOCA_METDATA_PACK:%[^,]+]] = alloca %swift.type*, [[INT]] [[COMBINED_PACK_SIZE]]
+// CHECK:         [[FIRST_HEAPIFIED_METADATA_PACK:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[FIRST_ALLOCA_METDATA_PACK]], [[INT]] [[COMBINED_PACK_SIZE]])
+// CHECK:         call void @llvm.stackrestore(i8* [[STACK_BEFORE_FIRST_ALLOCA]])
+// CHECK:         call swiftcc void @callee([[INT]] [[COMBINED_PACK_SIZE]], %swift.type** [[FIRST_HEAPIFIED_METADATA_PACK]])
+// CHECK:         [[COMBINED_PACK_SIZE_2:%[^,]+]] = add [[INT]] %1, %0
+// CHECK:         [[STACK_BEFORE_SECOND_ALLOCA:%[^,]+]] = call i8* @llvm.stacksave()
+// CHECK:         [[SECOND_ALLOCA_METDATA_PACK:%[^,]+]] = alloca %swift.type*, [[INT]] [[COMBINED_PACK_SIZE_2]]
+// CHECK:         [[SECOND_HEAPIFIED_METADATA_PACK:%[^,]+]] = call swiftcc %swift.type** @swift_allocateMetadataPack(%swift.type** [[SECOND_ALLOCA_METDATA_PACK]], [[INT]] [[COMBINED_PACK_SIZE_2]])
+// CHECK:         call void @llvm.stackrestore(i8* [[STACK_BEFORE_SECOND_ALLOCA]])
+// CHECK:         call swiftcc void @callee([[INT]] [[COMBINED_PACK_SIZE_2]], %swift.type** [[SECOND_HEAPIFIED_METADATA_PACK]])
+// CHECK:         [[REMAINING_AND_OVERFLOW:%[^,]+]] = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 [[PREVIOUS]], i64 1)
+// CHECK:         [[REMAINING]] = extractvalue { i64, i1 } [[REMAINING_AND_OVERFLOW]], 0
+// CHECK:         [[IS_ZERO:%[^,]+]] = icmp eq i64 [[REMAINING]], 0
+// CHECK:         br i1 [[IS_ZERO]], label %[[EXIT:[^,]+]], label %[[BACKEDGE:[^,]+]]
+// CHECK:       [[BACKEDGE]]:
+// CHECK:         br label %[[HEADER]]
+// CHECK:       [[EXIT]]:
+// CHECK:         ret void
+// CHECK:       }
+sil @looper : $@convention(thin) <each T_1, each T_2> () -> () {
+entry:
+  %callee = function_ref @callee : $@convention(thin) <each T> () -> ()
+  %initial = integer_literal $Builtin.Int64, 10000000
+  br header(%initial : $Builtin.Int64)
+header(%previous : $Builtin.Int64):
+  apply %callee<Pack{repeat each T_1, repeat each T_2}>() : $@convention(thin) <each T> () -> ()
+  apply %callee<Pack{repeat each T_2, repeat each T_1}>() : $@convention(thin) <each T> () -> ()
+  %offset = integer_literal $Builtin.Int64, 1
+  %flag = integer_literal $Builtin.Int1, -1
+  %remainingAndOverflow = builtin "ssub_with_overflow_Int64"(%previous : $Builtin.Int64, %offset : $Builtin.Int64, %flag : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %remaining = tuple_extract %remainingAndOverflow : $(Builtin.Int64, Builtin.Int1), 0
+  %zero = integer_literal $Builtin.Int64, 0
+  %isZero = builtin "cmp_eq_Int64"(%remaining : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+  cond_br %isZero, exit, backedge
+backedge:
+  br header(%remaining : $Builtin.Int64)
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Until the optimization to leave packs on-stack is in place.  Even then, we'll want to keep this as a fallback and for functions where leaving them on-stack can't be done.

rdar://110123679

