### PR TITLE
🍒[cxx-interop] Do not treat `std::pair<UnsafeType, T>` as safe

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6566,6 +6566,17 @@ static bool hasDestroyTypeOperations(const clang::CXXRecordDecl *decl) {
   return false;
 }
 
+static bool hasCustomCopyOrMoveConstructor(const clang::CXXRecordDecl *decl) {
+  // std::pair and std::tuple might have copy and move constructors, but that
+  // doesn't mean they are safe to use from Swift, e.g. std::pair<UnsafeType, T>
+  if (decl->isInStdNamespace() &&
+      (decl->getName() == "pair" || decl->getName() == "tuple")) {
+    return false;
+  }
+  return decl->hasUserDeclaredCopyConstructor() ||
+         decl->hasUserDeclaredMoveConstructor();
+}
+
 static bool isSwiftClassType(const clang::CXXRecordDecl *decl) {
   // Swift type must be annotated with external_source_symbol attribute.
   auto essAttr = decl->getAttr<clang::ExternalSourceSymbolAttr>();
@@ -6633,8 +6644,7 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
     return CxxRecordSemanticsKind::Iterator;
   }
   
-  if (!cxxDecl->hasUserDeclaredCopyConstructor() &&
-      !cxxDecl->hasUserDeclaredMoveConstructor() &&
+  if (!hasCustomCopyOrMoveConstructor(cxxDecl) &&
       hasPointerInSubobjects(cxxDecl)) {
     return CxxRecordSemanticsKind::UnsafePointerMember;
   }
@@ -6722,8 +6732,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return true;
         }
 
-        if (!cxxRecordReturnType->hasUserDeclaredCopyConstructor() &&
-            !cxxRecordReturnType->hasUserDeclaredMoveConstructor() &&
+        if (!hasCustomCopyOrMoveConstructor(cxxRecordReturnType) &&
             !hasOwnedValueAttr(cxxRecordReturnType) &&
             hasPointerInSubobjects(cxxRecordReturnType)) {
           return false;

--- a/test/Interop/Cxx/stdlib/Inputs/std-pair.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-pair.h
@@ -23,3 +23,17 @@ using PairStructInt = std::pair<StructInPair, int>;
 inline PairStructInt getPairStructInt(int x) {
     return { { x * 2, -x}, x };
 }
+
+struct UnsafeStruct {
+    int *ptr;
+};
+
+struct __attribute__((swift_attr("import_iterator"))) Iterator {};
+
+using PairUnsafeStructInt = std::pair<UnsafeStruct, int>;
+using PairIteratorInt = std::pair<Iterator, int>;
+
+struct HasMethodThatReturnsUnsafePair {
+    PairUnsafeStructInt getUnsafePair() const { return {}; }
+    PairIteratorInt getIteratorPair() const { return {}; }
+};

--- a/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+import StdPair
+
+let u = HasMethodThatReturnsUnsafePair()
+u.getUnsafePair() // expected-error {{value of type 'HasMethodThatReturnsUnsafePair' has no member 'getUnsafePair'}}
+u.getIteratorPair() // expected-error {{value of type 'HasMethodThatReturnsUnsafePair' has no member 'getIteratorPair'}}


### PR DESCRIPTION
**Explanation**: If a C++ types has a copy constructor, we assume that it is safe to use from Swift. Unfortunately this means that types such as `std::pair<UnsafeType, T>` are treated as safe. This is a larger issue that needs to be addressed, but for now let's make sure we handle `std::pair` and `std::tuple` correctly: treat them as safe only if their templated parameters are safe.
**Scope**: This changes the way Swift imports C++ methods that return `std::pair<A, B>` where either A or B is unsafe in Swift.
**Risk**: Low, this only takes effect when C++ interop is enabled.


rdar://109529750
(cherry picked from commit f2771584dff50b1c42faec23c12d5ffa0e5e7994)