### PR TITLE
5.9: [ClosureSpecializer] Don't release trivial noescape apply argument twice.

### DIFF
--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -482,7 +482,8 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
     // If we passed in the original closure as @owned, then insert a release
     // right after NewAI. This is to balance the +1 from being an @owned
     // argument to AI.
-    if (CSDesc.isClosureConsumed() && CSDesc.closureHasRefSemanticContext())
+    if (CSDesc.isClosureConsumed() && !CSDesc.isTrivialNoEscapeParameter() &&
+        CSDesc.closureHasRefSemanticContext())
       Builder.createReleaseValue(Closure->getLoc(), Closure,
                                  Builder.getDefaultAtomicity());
 

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -702,6 +702,51 @@ bb0(%0 : $Int):
   return %empty : $()
 }
 
+sil @testClosureConvertHelper3 : $@convention(thin) (Int) -> Int
+sil [reabstraction_thunk] @reabstractionThunk3 : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+sil @testClosureThunkNoEscape3 : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out () {
+entry(%empty : $*(), %closure : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>):
+  %out = alloc_stack $Int
+  %ret = apply %closure(%out) : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  dealloc_stack %out : $*Int
+  store %ret to %empty : $*()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @reabstractionTest4 {{.*}} {
+// CHECK:         [[HELPER:%[^,]+]] = function_ref @testClosureConvertHelper3
+// CHECK:         [[SPECIALIZATION:%[^,]+]] = function_ref @$s25testClosureThunkNoEscape30aB14ConvertHelper3SiTf1nc_n
+// CHECK:         [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[HELPER]]
+// CHECK:         [[NOESCAPE_CLOSURE:%[^,]+]] = convert_escape_to_noescape [[CLOSURE]]
+// CHECK:         apply [[SPECIALIZATION]]{{.*}}
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK-LABEL: } // end sil function 'reabstractionTest4'
+sil @reabstractionTest4 : $(Int) -> () {
+bb0(%value : $Int):
+  %testThrowingClosureConvertHelper = function_ref @testClosureConvertHelper3 : $@convention(thin) (Int) -> Int
+  %closure = partial_apply [callee_guaranteed] %testThrowingClosureConvertHelper(%value) : $@convention(thin) (Int) -> Int
+  %noescapeClosure = convert_escape_to_noescape %closure : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  %thunk = function_ref @reabstractionThunk3 : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %appliedThunk = partial_apply [callee_guaranteed] [on_stack] %thunk(%noescapeClosure) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+  %dependency = mark_dependence %appliedThunk : $@noescape @callee_guaranteed () -> @out Int on %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  %generified = convert_function %dependency : $@noescape @callee_guaranteed () -> @out Int to $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %test = function_ref @testClosureThunkNoEscape3 : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out ()
+  strong_retain %generified : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %out = alloc_stack $()
+  %ret = apply %test(%out, %generified) : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out ()
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> Int
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> @out Int
+  %empty = tuple ()
+  return %empty : $()
+}
+
 sil @testThrowingClosureConvertHelper : $@convention(thin) (Int) -> (Int, @error any Error)
 sil [reabstraction_thunk] @reabstractionThunkThrowing : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
 


### PR DESCRIPTION
Description: Analogous to https://github.com/apple/swift/pull/66274 but for `apply` instead of `try_apply`.

ClosureSpecializer creates releases for the closure passed as an parameter to a `apply` that is specialized.  These releases are created in (1) `ClosureSpecCloner::populateCloned` and (2) `rewriteApplyInst`, depending on the effective ownership of the closure: in (1) they are inserted for closures passed _without_ an increment of the retain count (done e.g. for closures passed as an `@guaranteed` parameter); in (2) they are inserted for closures passed _with_ an increment of the retain count (done e.g. for closures passed as an `@owned` parameter).

Among the closures that are passed without an increment of the retain count are those which are noescape (`SILFunctionType::isTrivialNoEscape`).  That is true even when the closure is passed as an `@owned` parameter.  The condition of (1) under which releases are added for the closure correctly included consideration of the `isTrivialNoEscape` predicate of the closure's type; consequently that code inserts releases in both of the `apply`'s destination blocks.  The condition of (2) under which releases were added for the closure incorrectly failed to consider the `isTrivialNoEscape` predicate; consequently, that code _also_ inserted releases in both of the destination blocks.  The result was adding two releases in each destination block, one of each of which was an overrelease.

The fix is just to consider the `isTrivialNoEscape` predicate in (2).
Risk: Low.  The patch adds a predicate to the bailout condition of (2) that complements an existing use of the same predicate in the condition of (1).
Scope: Narrow.  This only affects releases for noescape closures passed as owned arguments to `apply`s which are specialized.
Original PR: https://github.com/apple/swift/pull/66275
Reviewed By: Arnold Schwaigofer ( @aschwaighofer )
Testing: Added test that previously inserted double release is no longer present.
Resolves: rdar://110115795

