### PR TITLE
[Observation] Refinements for init, peer macros, and qualified type emissions

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -17,6 +17,22 @@ import SwiftSyntaxMacros
 @_implementationOnly import SwiftSyntaxBuilder
 
 public struct ObservableMacro {
+  static let moduleName = "Observation"
+
+  static let conformanceName = "Observable"
+  static var qualifiedConformanceName: String {
+    return "\(moduleName).\(conformanceName)"
+  }
+
+  static var observableConformanceType: TypeSyntax {
+    "\(raw: qualifiedConformanceName)"
+  }
+
+  static let registrarTypeName = "ObservationRegistrar"
+  static var qualifiedRegistrarTypeName: String {
+    return "\(moduleName).\(registrarTypeName)"
+  }
+  
   static let trackedMacroName = "ObservationTracked"
   static let ignoredMacroName = "ObservationIgnored"
 
@@ -25,7 +41,7 @@ public struct ObservableMacro {
   static func registrarVariable(_ observableType: TokenSyntax) -> DeclSyntax {
     return
       """
-      @\(raw: ignoredMacroName) private let \(raw: registrarVariableName) = ObservationRegistrar()
+      @\(raw: ignoredMacroName) private let \(raw: registrarVariableName) = \(raw: qualifiedRegistrarTypeName)()
       """
   }
   
@@ -264,13 +280,13 @@ extension ObservableMacro: ConformanceMacro {
     
     if let inheritanceList {
       for inheritance in inheritanceList {
-        if inheritance.typeName.identifier == "Observable" {
+        if inheritance.typeName.identifier == ObservableMacro.conformanceName {
           return []
         }
       }
     }
     
-    return [("Observable", nil)]
+    return [(ObservableMacro.observableConformanceType, nil)]
   }
 }
 

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -218,17 +218,6 @@ extension ObservableMacro: MemberMacro {
     declaration.addIfNeeded(ObservableMacro.registrarVariable(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
-    
-    let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
-    for property in storedInstanceVariables {
-      if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
-      if property.initializer == nil {
-        context.addDiagnostics(from: DiagnosticsError(syntax: property, message: "@Observable requires property '\(property.identifier?.text ?? "")' to have an initial value", id: .missingInitializer), node: property)
-      }
-      let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
-      declaration.addIfNeeded(storage, to: &declarations)
-      
-    }
 
     return declarations
   }
@@ -343,8 +332,9 @@ extension ObservationTrackedMacro: PeerMacro {
           property.isValidForObservation else {
       return []
     }
-
-    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) {
+    
+    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) ||
+       property.hasMacroApplication(ObservableMacro.trackedMacroName) {
       return []
     }
     

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -298,6 +298,14 @@ public struct ObservationTrackedMacro: AccessorMacro {
       return []
     }
 
+    let initAccessor: AccessorDeclSyntax = {
+      """
+      init(initialValue) initializes(_\(identifier)) {
+        _\(identifier) = initialValue
+      }
+      """
+    }
+
     let getAccessor: AccessorDeclSyntax =
       """
       get {
@@ -315,7 +323,7 @@ public struct ObservationTrackedMacro: AccessorMacro {
       }
       """
 
-    return [getAccessor, setAccessor]
+    return [initAccessor, getAccessor, setAccessor]
   }
 }
 

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -16,7 +16,7 @@
 #if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
-@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation), arbitrary)
+@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation))
 @attached(memberAttribute)
 @attached(conformance)
 public macro Observable() = 
@@ -24,7 +24,7 @@ public macro Observable() =
 
 @available(SwiftStdlib 5.9, *)
 @attached(accessor)
-// @attached(peer, names: prefixed(_))
+@attached(peer, names: prefixed(_))
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 


### PR DESCRIPTION
Includes fixes for the following:

Ensure type access is qualified to the module name. e.g. when an imported module ALSO defines `Observable` make sure the macros don't cause ambiguity.

 Transition to peer macros instead of arbitrary member. This removes the arbitrary member emission from using `@Observable` and favors the peer macro instead.
 
 Lift the initializer requirement by utilizing init accessors for fully formed definite initialization. This removes the error case where types need fully defined initialization of properties. This is dependent upon https://github.com/apple/swift/pull/66283