### PR TITLE
[IRGen] Handle complex single payload enum cases

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -400,6 +400,16 @@ std::string IRGenMangler::mangleSymbolNameForMangledConformanceAccessorString(
   return finalize();
 }
 
+std::string IRGenMangler::mangleSymbolNameForMangledGetEnumTagForLayoutString(
+    CanType type) {
+  beginManglingWithoutPrefix();
+  Buffer << "get_enum_tag_for_layout_string"
+         << " ";
+
+  appendType(type, nullptr);
+  return finalize();
+}
+
 std::string IRGenMangler::mangleSymbolNameForUnderlyingTypeAccessorString(
     OpaqueTypeDecl *opaque, unsigned index) {
   beginManglingWithoutPrefix();

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -633,6 +633,8 @@ public:
                                            CanType type,
                                            ProtocolConformanceRef conformance);
 
+  std::string mangleSymbolNameForMangledGetEnumTagForLayoutString(CanType type);
+
   std::string
   mangleSymbolNameForUnderlyingTypeAccessorString(OpaqueTypeDecl *opaque,
                                                   unsigned index);

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -419,8 +419,12 @@ llvm::Function *createFixedEnumLoadTag(IRGenModule &IGM,
                                        const EnumTypeLayoutEntry &entry) {
   assert(entry.isFixedSize(IGM));
 
+  IRGenMangler mangler;
+  auto symbol = mangler.mangleSymbolNameForMangledGetEnumTagForLayoutString(
+      entry.ty.getASTType());
+
   auto helperFn = IGM.getOrCreateHelperFunction(
-      "", IGM.Int32Ty /*retTy*/, IGM.Int8PtrTy /*argTys*/,
+      symbol, IGM.Int32Ty /*retTy*/, IGM.Int8PtrTy /*argTys*/,
       [&](IRGenFunction &IGF) {
         auto enumPtr = IGF.collectParameters().claimNext();
         auto *typeInfo = *entry.fixedTypeInfo;

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -76,6 +76,8 @@ public:
     Existential = 0x0e,
     Resilient = 0x0f,
     SinglePayloadEnumSimple = 0x10,
+    SinglePayloadEnumFN = 0x11,
+    SinglePayloadEnumFNResolved = 0x12,
 
     Skip = 0x80,
     // We may use the MSB as flag that a count follows,
@@ -93,12 +95,19 @@ private:
     const TypeLayoutEntry *payload;
   };
 
+  struct SinglePayloadEnumFN {
+    llvm::Function *tagFn;
+    unsigned extraTagByteCount;
+    const TypeLayoutEntry *payload;
+  };
+
   struct RefCounting {
     RefCountingKind kind;
     union {
       size_t size;
       llvm::Function* metaTypeRef;
       SinglePayloadEnumSimple singlePayloadEnumSimple;
+      SinglePayloadEnumFN singlePayloadEnumFN;
     };
 
     RefCounting() = default;
@@ -129,6 +138,16 @@ public:
     op.singlePayloadEnumSimple.xiByteCount = xiByteCount;
     op.singlePayloadEnumSimple.xiOffset = xiOffset;
     op.singlePayloadEnumSimple.payload = payload;
+    refCountings.push_back(op);
+  }
+
+  void addSinglePayloadEnumFN(llvm::Function *tagFn, unsigned extraTagByteCount,
+                              const TypeLayoutEntry *payload) {
+    RefCounting op;
+    op.kind = RefCountingKind::SinglePayloadEnumFN;
+    op.singlePayloadEnumFN.tagFn = tagFn;
+    op.singlePayloadEnumSimple.extraTagByteCount = extraTagByteCount;
+    op.singlePayloadEnumFN.payload = payload;
     refCountings.push_back(op);
   }
 
@@ -224,6 +243,40 @@ public:
 
         skip += enumData.extraTagByteCount;
 
+        break;
+      }
+
+      case RefCountingKind::SinglePayloadEnumFN: {
+        uint64_t op = (static_cast<uint64_t>(refCounting.kind) << 56) | skip;
+        B.addInt64(op);
+
+        skip = 0;
+        size_t nestedRefCountBytes = 0;
+
+        auto enumData = refCounting.singlePayloadEnumFN;
+
+        B.addRelativeOffset(IGM.IntPtrTy, enumData.tagFn);
+
+        auto nestedRefCountBytesPlaceholder =
+            B.addPlaceholderWithSize(IGM.SizeTy);
+        auto skipBytesPlaceholder = B.addPlaceholderWithSize(IGM.SizeTy);
+
+        LayoutStringBuilder nestedBuilder{};
+        enumData.payload->refCountString(IGM, nestedBuilder, genericSig);
+        addRefCountings(IGM, B, genericSig, nestedBuilder.refCountings, skip,
+                        nestedRefCountBytes, flags);
+
+        auto nestedSkip = enumData.payload->fixedSize(IGM)->getValue() - skip;
+        B.fillPlaceholderWithInt(nestedRefCountBytesPlaceholder, IGM.SizeTy,
+                                 nestedRefCountBytes);
+        B.fillPlaceholderWithInt(skipBytesPlaceholder, IGM.SizeTy, nestedSkip);
+
+        refCountBytes += (sizeof(uint64_t)) +
+                         (3 * IGM.getPointerSize().getValue()) +
+                         nestedRefCountBytes;
+        skip += enumData.extraTagByteCount;
+
+        flags |= LayoutStringFlags::HasRelativePointers;
         break;
       }
 
@@ -357,6 +410,26 @@ llvm::Function *createMetatypeAccessorFunction(IRGenModule &IGM, SILType ty,
 
         auto ret = IGF.emitTypeMetadataRefForLayout(ty);
         IGF.Builder.CreateRet(ret);
+      });
+
+  return static_cast<llvm::Function *>(helperFn);
+}
+
+llvm::Function *createFixedEnumLoadTag(IRGenModule &IGM,
+                                       const EnumTypeLayoutEntry &entry) {
+  assert(entry.isFixedSize(IGM));
+
+  auto helperFn = IGM.getOrCreateHelperFunction(
+      "", IGM.Int32Ty /*retTy*/, IGM.Int8PtrTy /*argTys*/,
+      [&](IRGenFunction &IGF) {
+        auto enumPtr = IGF.collectParameters().claimNext();
+        auto *typeInfo = *entry.fixedTypeInfo;
+        auto enumType = typeInfo->getStorageType()->getPointerTo();
+        auto castEnumPtr = IGF.Builder.CreateBitCast(enumPtr, enumType);
+        auto enumAddr = typeInfo->getAddressForPointer(castEnumPtr);
+
+        auto tag = entry.getEnumTag(IGF, enumAddr);
+        IGF.Builder.CreateRet(tag);
       });
 
   return static_cast<llvm::Function *>(helperFn);
@@ -2069,6 +2142,7 @@ bool EnumTypeLayoutEntry::buildSinglePayloadRefCountString(
   uint64_t zeroTagValue = 0;
   unsigned xiBitCount = 0;
   unsigned xiOffset = 0;
+  bool isSimple = true;
 
   auto &payloadTI = **cases[0]->getFixedTypeInfo();
 
@@ -2088,12 +2162,12 @@ bool EnumTypeLayoutEntry::buildSinglePayloadRefCountString(
           (tzCount % toCount != 0)) {
         // We currently don't handle cases with non-contiguous or > 64 bits of
         // extra inhabitants
-        return false;
+        isSimple = false;
+      } else {
+        xiBitCount = std::min(64u, mask.countPopulation());
+        xiOffset = mask.countTrailingZeros();
+        zeroTagValue = lowValue.extractBitsAsZExtValue(xiBitCount, xiOffset);
       }
-
-      xiBitCount = std::min(64u, mask.countPopulation());
-      xiOffset = mask.countTrailingZeros();
-      zeroTagValue = lowValue.extractBitsAsZExtValue(xiBitCount, xiOffset);
     }
   }
 
@@ -2119,8 +2193,13 @@ bool EnumTypeLayoutEntry::buildSinglePayloadRefCountString(
     return false;
   }
 
-  B.addSinglePayloadEnumSimple(zeroTagValue, xiTagValues, extraTagByteCount,
-                               xiBitCount / 8, xiOffset, cases[0]);
+  if (isSimple) {
+    B.addSinglePayloadEnumSimple(zeroTagValue, xiTagValues, extraTagByteCount,
+                                 xiBitCount / 8, xiOffset, cases[0]);
+  } else {
+    auto tagFn = createFixedEnumLoadTag(IGM, *this);
+    B.addSinglePayloadEnumFN(tagFn, extraTagByteCount, cases[0]);
+  }
 
   return true;
 }

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -44,6 +44,8 @@ enum class RefCountingKind : uint8_t {
   Resilient = 0x0f,
 
   SinglePayloadEnumSimple = 0x10,
+  SinglePayloadEnumFN = 0x11,
+  SinglePayloadEnumFNResolved = 0x12,
 
   Skip = 0x80,
   // We may use the MSB as flag that a count follows,

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -442,6 +442,17 @@ public struct InternalEnumWrapper {
   }
 }
 
+public enum SinglePayloadEnumManyXI {
+    case empty0
+    case empty1
+    case empty2
+    case empty3
+    case empty4
+    case empty5
+    case empty6
+    case nonEmpty(Builtin.Int127, SimpleClass)
+}
+
 public struct PrespecializedStruct<T> {
     let y: Int = 0
     let x: T

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation -enable-layout-string-value-witnesses -enable-layout-string-value-witnesses-instantiation -enable-type-layout -enable-autolinking-runtime-compatibility-bytecode-layouts -emit-module -emit-module-path=%t/layout_string_witnesses_types.swiftmodule %S/Inputs/layout_string_witnesses_types.swift
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation -enable-layout-string-value-witnesses -enable-layout-string-value-witnesses-instantiation -enable-type-layout -enable-autolinking-runtime-compatibility-bytecode-layouts -parse-stdlib -emit-module -emit-module-path=%t/layout_string_witnesses_types.swiftmodule %S/Inputs/layout_string_witnesses_types.swift
 // RUN: %target-build-swift-dylib(%t/%target-library-name(layout_string_witnesses_types)) -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnessesInstantiation -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-layout-string-value-witnesses-instantiation -Xfrontend -enable-type-layout -Xfrontend -parse-stdlib -parse-as-library %S/Inputs/layout_string_witnesses_types.swift
 // RUN: %target-codesign %t/%target-library-name(layout_string_witnesses_types)
 // RUN: %target-swift-frontend -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation -enable-layout-string-value-witnesses -enable-layout-string-value-witnesses-instantiation -enable-library-evolution -enable-autolinking-runtime-compatibility-bytecode-layouts -emit-module -emit-module-path=%t/layout_string_witnesses_types_resilient.swiftmodule %S/Inputs/layout_string_witnesses_types_resilient.swift
 // RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnessesInstantiation -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-layout-string-value-witnesses-instantiation -Xfrontend -enable-library-evolution -c -parse-as-library -o %t/layout_string_witnesses_types_resilient.o %S/Inputs/layout_string_witnesses_types_resilient.swift
-// RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnessesInstantiation -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-layout-string-value-witnesses-instantiation -Xfrontend -enable-type-layout -Xfrontend -enable-autolinking-runtime-compatibility-bytecode-layouts -module-name layout_string_witnesses_dynamic -llayout_string_witnesses_types -L%t %t/layout_string_witnesses_types_resilient.o -I %t -o %t/main %s %target-rpath(%t)
+// RUN: %target-build-swift -g -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnesses -Xfrontend -enable-experimental-feature -Xfrontend LayoutStringValueWitnessesInstantiation -Xfrontend -enable-layout-string-value-witnesses -Xfrontend -enable-layout-string-value-witnesses-instantiation -Xfrontend -enable-type-layout -parse-stdlib -module-name layout_string_witnesses_dynamic -llayout_string_witnesses_types -L%t %t/layout_string_witnesses_types_resilient.o -I %t -o %t/main %s %target-rpath(%t)
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(layout_string_witnesses_types) | %FileCheck %s --check-prefix=CHECK -check-prefix=CHECK-%target-os
 
@@ -12,6 +12,7 @@
 
 // UNSUPPORTED: back_deployment_runtime
 
+import Swift
 import layout_string_witnesses_types
 import layout_string_witnesses_types_resilient
 
@@ -430,6 +431,34 @@ func testMixedEnumWrapperWrapperGeneric() {
 }
 
 testMixedEnumWrapperWrapperGeneric()
+
+func testGenericSinglePayloadEnumManyXI() {
+    let ptr = allocateInternalGenericPtr(of: SinglePayloadEnumManyXI.self)
+
+    do {
+        let x = SinglePayloadEnumManyXI.nonEmpty(Builtin.zeroInitializer(), SimpleClass(x: 23))
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = SinglePayloadEnumManyXI.nonEmpty(Builtin.zeroInitializer(), SimpleClass(x: 23))
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testGenericDestroy(ptr, of: SinglePayloadEnumManyXI.self)
+
+    ptr.deallocate()
+}
+
+testGenericSinglePayloadEnumManyXI()
 
 #if os(macOS)
 

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -542,6 +542,62 @@ func testSinglePayloadEnumExtraTagBytesWrapper() {
 
 testSinglePayloadEnumExtraTagBytesWrapper()
 
+func testSinglePayloadEnumManyXI() {
+    let ptr = UnsafeMutablePointer<SinglePayloadEnumManyXI>.allocate(capacity: 1)
+
+    do {
+        let x = SinglePayloadEnumManyXI.nonEmpty(Builtin.zeroInitializer(), SimpleClass(x: 23))
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = SinglePayloadEnumManyXI.nonEmpty(Builtin.zeroInitializer(), SimpleClass(x: 28))
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testSinglePayloadEnumManyXI()
+
+func testSinglePayloadEnumManyXIEmpty() {
+    let ptr = UnsafeMutablePointer<SinglePayloadEnumManyXI>.allocate(capacity: 1)
+
+    do {
+        let x = SinglePayloadEnumManyXI.empty0
+        testInit(ptr, to: x)
+    }
+
+    do {
+        let y = SinglePayloadEnumManyXI.empty1
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testSinglePayloadEnumManyXIEmpty()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
rdar://110138498

Handles single payload enum cases with more complex bit patterns (e.g. >64 bits or scattered) by storing a relative pointer to a function that reads the tag.
