### PR TITLE
SILGen: Fix emission of class allocating init with pack expansion parameters

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -910,19 +910,25 @@ static void makeArgument(Type ty, ParamDecl *decl,
                          SmallVectorImpl<SILValue> &args, SILGenFunction &SGF) {
   assert(ty && "no type?!");
   
-  // Destructure tuple value arguments.
-  if (TupleType *tupleTy = decl->isInOut() ? nullptr : ty->getAs<TupleType>()) {
-    for (auto fieldType : tupleTy->getElementTypes())
-      makeArgument(fieldType, decl, args, SGF);
-  } else {
-    auto loweredTy = SGF.getLoweredTypeForFunctionArgument(ty);
-    if (decl->isInOut())
-      loweredTy = SILType::getPrimitiveAddressType(loweredTy.getASTType());
-    auto arg = SGF.F.begin()->createFunctionArgument(loweredTy, decl);
-    args.push_back(arg);
+  if (ty->is<PackExpansionType>()) {
+    ty = PackType::get(SGF.getASTContext(), {ty});
   }
-}
 
+  // Destructure tuple value arguments.
+  if (!decl->isInOut()) {
+    if (TupleType *tupleTy = ty->getAs<TupleType>()) {
+      for (auto fieldType : tupleTy->getElementTypes())
+        makeArgument(fieldType, decl, args, SGF);
+      return;
+    }
+  }
+
+  auto loweredTy = SGF.getLoweredTypeForFunctionArgument(ty);
+  if (decl->isInOut())
+    loweredTy = SILType::getPrimitiveAddressType(loweredTy.getASTType());
+  auto arg = SGF.F.begin()->createFunctionArgument(loweredTy, decl);
+  args.push_back(arg);
+}
 
 void SILGenFunction::bindParameterForForwarding(ParamDecl *param,
                                      SmallVectorImpl<SILValue> &parameters) {

--- a/test/SILGen/variadic_generic_allocating_init.swift
+++ b/test/SILGen/variadic_generic_allocating_init.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen %s -disable-availability-checking | %FileCheck %s
+
+class C<each T> {
+  var values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s32variadic_generic_allocating_init1CC9fromTupleACyxxQp_QPGxxQp_t_tcfC : $@convention(method) <each T> (@pack_owned Pack{repeat each T}, @thick C<repeat each T>.Type) -> @owned C<repeat each T> {
+  // CHECK: bb0(%0 : $*Pack{repeat each T}, %1 : $@thick C<repeat each T>.Type):
+  init(fromTuple: (repeat each T)) {
+    self.values = fromTuple
+  }
+
+  // CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s32variadic_generic_allocating_init1CC8fromPackACyxxQp_QPGxxQp_tcfC : $@convention(method) <each T> (@pack_owned Pack{repeat each T}, @thick C<repeat each T>.Type) -> @owned C<repeat each T> {
+  // CHECK: bb0(%0 : $*Pack{repeat each T}, %1 : $@thick C<repeat each T>.Type):
+  init(fromPack: repeat each T) {
+    self.values = (repeat each fromPack)
+  }
+}


### PR DESCRIPTION
Fixes rdar://110099644.