### PR TITLE
[SourceKit] Add request to expand macros syntactically

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8601,6 +8601,9 @@ public:
   /// Retrieve the definition of this macro.
   MacroDefinition getDefinition() const;
 
+  /// Set the definition of this macro
+  void setDefinition(MacroDefinition definition);
+
   /// Retrieve the parameter list of this macro.
   ParameterList *getParameterList() const { return parameterList; }
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -578,6 +578,9 @@ public:
   void insertAfter(SourceManager &SM, SourceLoc Loc, StringRef Text, ArrayRef<NoteRegion> SubRegions = {});
   void accept(SourceManager &SM, Replacement Replacement) { accept(SM, RegionType::ActiveCode, {Replacement}); }
   void remove(SourceManager &SM, CharSourceRange Range);
+  void acceptMacroExpansionBuffer(SourceManager &SM, unsigned bufferID,
+                                  SourceFile *containingSF,
+                                  bool adjustExpansion, bool includeBufferName);
 };
 
 /// This helper stream inserts text into a SourceLoc by calling functions in

--- a/include/swift/IDETool/SyntacticMacroExpansion.h
+++ b/include/swift/IDETool/SyntacticMacroExpansion.h
@@ -1,0 +1,97 @@
+//===--- SyntacticMacroExpansion.h ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_SYNTACTICMACROEXPANSION_H
+#define SWIFT_IDE_SYNTACTICMACROEXPANSION_H
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/MacroDefinition.h"
+#include "swift/AST/PluginRegistry.h"
+#include "swift/Basic/Fingerprint.h"
+#include "swift/Frontend/Frontend.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+namespace swift {
+
+class ASTContext;
+class SourceFile;
+
+namespace ide {
+class SourceEditConsumer;
+
+/// Simple object to specify a syntactic macro expansion.
+struct MacroExpansionSpecifier {
+  unsigned offset;
+  swift::MacroRoles macroRoles;
+  swift::MacroDefinition macroDefinition;
+};
+
+/// Instance of a syntactic macro expansion context. This is created for each
+/// list of compiler arguments (i.e. 'argHash'), and reused as long as the
+/// compiler arguments are not changed.
+class SyntacticMacroExpansionInstance {
+  CompilerInvocation invocation;
+
+  SourceManager SourceMgr;
+  DiagnosticEngine Diags{SourceMgr};
+  std::unique_ptr<ASTContext> Ctx;
+  ModuleDecl *TheModule = nullptr;
+  llvm::StringMap<MacroDecl *> MacroDecls;
+
+  /// Create 'SourceFile' using the buffer.
+  swift::SourceFile *getSourceFile(llvm::MemoryBuffer *inputBuf);
+
+  /// Synthesize 'MacroDecl' AST object to use the expansion.
+  swift::MacroDecl *
+  getSynthesizedMacroDecl(swift::Identifier name,
+                          const MacroExpansionSpecifier &expansion);
+
+  /// Expand single 'expansion' in SF.
+  void expand(swift::SourceFile *SF,
+                    const MacroExpansionSpecifier &expansion,
+                    SourceEditConsumer &consumer);
+
+public:
+  SyntacticMacroExpansionInstance() {}
+
+  /// Setup the instance with \p args .
+  bool setup(StringRef SwiftExecutablePath, ArrayRef<const char *> args,
+             std::shared_ptr<PluginRegistry> plugins, std::string &error);
+
+  ASTContext &getASTContext() { return *Ctx; }
+
+  /// Expand all macros in \p inputBuf and send the edit results to \p consumer.
+  /// Expansions are specified by \p expansions .
+  void expandAll(llvm::MemoryBuffer *inputBuf,
+                     ArrayRef<MacroExpansionSpecifier> expansions,
+                     SourceEditConsumer &consumer);
+};
+
+/// Manager object to vend 'SyntacticMacroExpansionInstance'.
+class SyntacticMacroExpansion {
+  StringRef SwiftExecutablePath;
+  std::shared_ptr<PluginRegistry> Plugins;
+
+public:
+  SyntacticMacroExpansion(StringRef SwiftExecutablePath,
+                          std::shared_ptr<PluginRegistry> Plugins)
+      : SwiftExecutablePath(SwiftExecutablePath), Plugins(Plugins) {}
+
+  /// Get instance configured with the specified compiler arguments.
+  std::shared_ptr<SyntacticMacroExpansionInstance>
+  getInstance(ArrayRef<const char *> args, std::string &error);
+};
+
+} // namespace ide
+} // namespace swift
+
+#endif // SWIFT_IDE_SYNTACTICMACROEXPANSION_H

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -37,6 +37,7 @@ namespace swift {
   enum class DeclRefKind;
   class Expr;
   class ExtensionDecl;
+  class FreestandingMacroExpansion;
   class FunctionType;
   class LabeledConditionalStmt;
   class LookupResult;
@@ -355,6 +356,13 @@ namespace swift {
   SmallVector<std::pair<ValueDecl *, ValueDecl *>, 1>
   getShorthandShadows(LabeledConditionalStmt *CondStmt,
                       DeclContext *DC = nullptr);
+
+  SourceFile *evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
+                                        StringRef discriminator);
+
+  SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
+                                    CustomAttr *attr, bool passParentContext,
+                                    MacroRole role, StringRef discriminator);
 }
 
 #endif

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10632,6 +10632,11 @@ MacroDefinition MacroDecl::getDefinition() const {
       MacroDefinition::forUndefined());
 }
 
+void MacroDecl::setDefinition(MacroDefinition definition) {
+  getASTContext().evaluator.cacheOutput(MacroDefinitionRequest{this},
+                                        std::move(definition));
+}
+
 Optional<BuiltinMacroKind> MacroDecl::getBuiltinKind() const {
   auto def = getDefinition();
   if (def.kind != MacroDefinition::Kind::Builtin)

--- a/lib/IDETool/CMakeLists.txt
+++ b/lib/IDETool/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_host_library(swiftIDETool STATIC
   CompilerInvocation.cpp
   IDEInspectionInstance.cpp
   DependencyChecking.cpp
+  SyntacticMacroExpansion.cpp
   )
 
 target_link_libraries(swiftIDETool PRIVATE

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -1,0 +1,471 @@
+//===--- SyntacticMacroExpansion.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IDETool/SyntacticMacroExpansion.h"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/MacroDefinition.h"
+#include "swift/AST/PluginLoader.h"
+#include "swift/AST/TypeRepr.h"
+#include "swift/Driver/FrontendUtil.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/IDE/Utils.h"
+#include "swift/Sema/IDETypeChecking.h"
+
+using namespace swift;
+using namespace ide;
+
+std::shared_ptr<SyntacticMacroExpansionInstance>
+SyntacticMacroExpansion::getInstance(ArrayRef<const char *> args,
+                                     std::string &error) {
+  // Create and configure a new instance.
+  auto instance = std::make_shared<SyntacticMacroExpansionInstance>();
+
+  bool failed = instance->setup(SwiftExecutablePath, args, Plugins, error);
+  if (failed)
+    return nullptr;
+
+  return instance;
+}
+
+bool SyntacticMacroExpansionInstance::setup(
+    StringRef SwiftExecutablePath, ArrayRef<const char *> args,
+    std::shared_ptr<PluginRegistry> plugins, std::string &error) {
+  SmallString<256> driverPath(SwiftExecutablePath);
+  llvm::sys::path::remove_filename(driverPath);
+  llvm::sys::path::append(driverPath, "swiftc");
+
+  // Setup CompilerInstance to configure the plugin search path correctly.
+  bool hadError = driver::getSingleFrontendInvocationFromDriverArguments(
+      driverPath, args, Diags,
+      [&](ArrayRef<const char *> frontendArgs) {
+        return invocation.parseArgs(
+            frontendArgs, Diags, /*ConfigurationFileBuffers=*/nullptr,
+            /*workingDirectory=*/{}, SwiftExecutablePath);
+      },
+      /*ForceNoOutput=*/true);
+  if (hadError) {
+    error = "failed to setup compiler invocation";
+    return true;
+  }
+
+  // Setup ASTContext.
+  Ctx.reset(ASTContext::get(
+      invocation.getLangOptions(), invocation.getTypeCheckerOptions(),
+      invocation.getSILOptions(), invocation.getSearchPathOptions(),
+      invocation.getClangImporterOptions(), invocation.getSymbolGraphOptions(),
+      SourceMgr, Diags));
+  registerParseRequestFunctions(Ctx->evaluator);
+  registerTypeCheckerRequestFunctions(Ctx->evaluator);
+
+  std::unique_ptr<PluginLoader> pluginLoader =
+      std::make_unique<PluginLoader>(*Ctx, /*DepTracker=*/nullptr);
+  pluginLoader->setRegistry(plugins.get());
+  Ctx->setPluginLoader(std::move(pluginLoader));
+
+  // Create a module where SourceFiles reside.
+  Identifier ID = Ctx->getIdentifier(invocation.getModuleName());
+  TheModule = ModuleDecl::create(ID, *Ctx);
+
+  return false;
+}
+
+SourceFile *
+SyntacticMacroExpansionInstance::getSourceFile(llvm::MemoryBuffer *inputBuf) {
+
+  // If there is a SourceFile with the same name and the content, use it.
+  // Note that this finds the generated source file that was created in the
+  // previous expansion requests.
+  if (auto bufID =
+          SourceMgr.getIDForBufferIdentifier(inputBuf->getBufferIdentifier())) {
+    if (inputBuf->getBuffer() == SourceMgr.getEntireTextForBuffer(*bufID)) {
+      SourceLoc bufLoc = SourceMgr.getLocForBufferStart(*bufID);
+      if (SourceFile *existing =
+              TheModule->getSourceFileContainingLocation(bufLoc)) {
+        return existing;
+      }
+    }
+  }
+
+  // Otherwise, create a new SourceFile.
+  SourceFile *SF = new (getASTContext()) SourceFile(
+      *TheModule, SourceFileKind::Main, SourceMgr.addMemBufferCopy(inputBuf));
+  SF->setImports({});
+  TheModule->addFile(*SF);
+
+  return SF;
+}
+
+MacroDecl *SyntacticMacroExpansionInstance::getSynthesizedMacroDecl(
+    Identifier name, const MacroExpansionSpecifier &expansion) {
+  auto &ctx = getASTContext();
+
+  std::string macroID;
+
+  switch (expansion.macroDefinition.kind) {
+  case MacroDefinition::Kind::External: {
+    // '<module name>.<type name>'
+    // It's safe to use without 'kind' because 'Expanded' always starts with a
+    // sigil '#' which can't be valid in a module name.
+    auto external = expansion.macroDefinition.getExternalMacro();
+    macroID += external.moduleName.str();
+    macroID += ".";
+    macroID += external.macroTypeName.str();
+    break;
+  }
+  case MacroDefinition::Kind::Expanded: {
+    auto expanded = expansion.macroDefinition.getExpanded();
+    macroID += expanded.getExpansionText();
+    break;
+  }
+  case MacroDefinition::Kind::Builtin:
+  case MacroDefinition::Kind::Invalid:
+  case MacroDefinition::Kind::Undefined:
+    assert(false && "invalid macro definition for syntactic expansion");
+    macroID += name.str();
+  }
+
+  // Reuse cached MacroDecl of the same name if it's already created.
+  MacroDecl *macro;
+  auto found = MacroDecls.find(macroID);
+  if (found != MacroDecls.end()) {
+    macro = found->second;
+  } else {
+    macro = new (ctx) MacroDecl(
+        /*macroLoc=*/{}, DeclName(name), /*nameLoc=*/{},
+        /*genericParams=*/nullptr, /*parameterList=*/nullptr,
+        /*arrowLoc=*/{}, /*resultType=*/nullptr,
+        /*definition=*/nullptr, /*parent=*/TheModule);
+    macro->setImplicit();
+    MacroDecls.insert({macroID, macro});
+  }
+
+  // Add missing role attributes to MacroDecl.
+  MacroRoles roles = expansion.macroRoles;
+  for (auto attr : macro->getAttrs().getAttributes<MacroRoleAttr>()) {
+    roles -= attr->getMacroRole();
+  }
+  for (MacroRole role : getAllMacroRoles()) {
+    if (!roles.contains(role))
+      continue;
+
+    MacroSyntax syntax = getFreestandingMacroRoles().contains(role)
+                             ? MacroSyntax::Freestanding
+                             : MacroSyntax::Attached;
+
+    auto *attr = MacroRoleAttr::create(ctx, /*atLoc=*/{}, /*range=*/{}, syntax,
+                                       /*lParenLoc=*/{}, role, /*names=*/{},
+                                       /*rParenLoc=*/{}, /*implicit=*/true);
+    macro->getAttrs().add(attr);
+  }
+
+  // Set the macro definition.
+  macro->setDefinition(expansion.macroDefinition);
+
+  return macro;
+}
+
+/// Create a unique name of the expansion. The result is *appended* to \p out.
+static void addExpansionDiscriminator(SmallString<32> &out,
+                                      const SourceFile *SF, SourceLoc loc,
+                                      Optional<SourceLoc> supplementalLoc = None,
+                                      Optional<MacroRole> role = None) {
+  SourceManager &SM = SF->getASTContext().SourceMgr;
+
+  StableHasher hasher = StableHasher::defaultHasher();
+
+  // Module name.
+  hasher.combine(SF->getParentModule()->getName().str());
+  hasher.combine(uint8_t{0});
+
+  // File base name.
+  // Do not use the full path because we want this hash stable.
+  hasher.combine(llvm::sys::path::filename(SF->getFilename()));
+  hasher.combine(uint8_t{0});
+
+  // Line/column.
+  auto lineColumn = SM.getLineAndColumnInBuffer(loc);
+  hasher.combine(lineColumn.first);
+  hasher.combine(lineColumn.second);
+
+  // Supplemental line/column.
+  if (supplementalLoc.has_value()) {
+    auto supLineColumn = SM.getLineAndColumnInBuffer(*supplementalLoc);
+    hasher.combine(supLineColumn.first);
+    hasher.combine(supLineColumn.second);
+  }
+
+  // Macro role.
+  if (role.has_value()) {
+    hasher.combine(*role);
+  }
+
+  Fingerprint hash(std::move(hasher));
+  out.append(hash.getRawValue());
+}
+
+/// Perform expansion of the specified freestanding macro using the 'MacroDecl'.
+static std::vector<unsigned>
+expandFreestandingMacro(MacroDecl *macro,
+                        FreestandingMacroExpansion *expansion) {
+  std::vector<unsigned> bufferIDs;
+
+  SmallString<32> discriminator;
+  discriminator.append("__syntactic_macro_");
+  addExpansionDiscriminator(discriminator,
+                            expansion->getDeclContext()->getParentSourceFile(),
+                            expansion->getPoundLoc());
+
+  expansion->setMacroRef(macro);
+
+  SourceFile *expandedSource =
+      swift::evaluateFreestandingMacro(expansion, discriminator);
+  if (expandedSource)
+    bufferIDs.push_back(*expandedSource->getBufferID());
+
+  return bufferIDs;
+}
+
+/// Perform expansion of the specified decl and the attribute using the
+/// 'MacroDecl'. If the macro has multiple roles, evaluate it for all macro
+/// roles.
+static std::vector<unsigned>
+expandAttachedMacro(MacroDecl *macro, CustomAttr *attr, Decl *attachedDecl) {
+
+  std::vector<unsigned> bufferIDs;
+  auto evaluate = [&](Decl *target, bool passParent, MacroRole role) {
+
+    SmallString<32> discriminator;
+    discriminator.append("macro_");
+    addExpansionDiscriminator(discriminator,
+                              target->getDeclContext()->getParentSourceFile(),
+                              target->getLoc(), attr->getLocation(), role);
+
+    SourceFile *expandedSource = swift::evaluateAttachedMacro(
+        macro, target, attr, passParent, role, discriminator);
+    if (expandedSource)
+      bufferIDs.push_back(*expandedSource->getBufferID());
+  };
+
+  MacroRoles roles = macro->getMacroRoles();
+  if (roles.contains(MacroRole::Accessor)) {
+    if (isa<AbstractStorageDecl>(attachedDecl))
+      evaluate(attachedDecl, /*passParent=*/false, MacroRole::Accessor);
+  }
+  if (roles.contains(MacroRole::MemberAttribute)) {
+    if (auto *idc = dyn_cast<IterableDeclContext>(attachedDecl)) {
+      for (auto *member : idc->getParsedMembers()) {
+        // 'VarDecl' in 'IterableDeclContext' are part of 'PatternBindingDecl'.
+        if (isa<VarDecl>(member))
+          continue;
+        evaluate(member, /*passParent=*/true, MacroRole::MemberAttribute);
+      }
+    }
+  }
+  if (roles.contains(MacroRole::Member)) {
+    if (isa<IterableDeclContext>(attachedDecl))
+      evaluate(attachedDecl, /*passParent=*/false, MacroRole::Member);
+  }
+  if (roles.contains(MacroRole::Peer)) {
+    evaluate(attachedDecl, /*passParent=*/false, MacroRole::Peer);
+  }
+  if (roles.contains(MacroRole::Conformance)) {
+    if (isa<NominalTypeDecl>(attachedDecl))
+      evaluate(attachedDecl, /*passParent=*/false, MacroRole::Conformance);
+  }
+  return bufferIDs;
+}
+
+/// Get the name of the custom attribute. This is used to create a dummy
+/// MacroDecl.
+static Identifier getCustomAttrName(ASTContext &ctx, const CustomAttr *attr) {
+  TypeRepr *tyR = attr->getTypeRepr();
+  if (auto ref = dyn_cast<DeclRefTypeRepr>(tyR)) {
+    return ref->getNameRef().getBaseIdentifier();
+  }
+
+  // If the attribute is not an identifier type, create an identifier with its
+  // textual representation. This is *not* expected to be reachable.
+  // The only case is like `@Foo?` where the client should not send the
+  // expansion request on this in the first place.
+  SmallString<32> name;
+  llvm::raw_svector_ostream OS(name);
+  tyR->print(OS);
+  return ctx.getIdentifier(name);
+}
+
+namespace {
+
+/// Find macro expansion i.e. '#foo' or '@foo' at the specified source location.
+/// If a freestanding expansion (i.e. #foo) is found, the result 'ExpansionNode'
+/// only has the node. If an attribute is found, the attribute and the attached
+/// decl object is returned.
+struct ExpansionNode {
+  CustomAttr *attribute;
+  ASTNode node;
+};
+class MacroExpansionFinder : public ASTWalker {
+  SourceManager &SM;
+  SourceLoc locToResolve;
+  llvm::Optional<ExpansionNode> result;
+
+  bool rangeContainsLocToResolve(SourceRange Range) const {
+    return SM.rangeContainsTokenLoc(Range, locToResolve);
+  }
+
+public:
+  MacroExpansionFinder(SourceManager &SM, SourceLoc locToResolve)
+      : SM(SM), locToResolve(locToResolve) {}
+
+  llvm::Optional<ExpansionNode> getResult() const { return result; }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::None;
+  }
+
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    // Visit all 'VarDecl' because 'getSourceRangeIncludingAttrs()' doesn't
+    // include its attribute ranges (because attributes are part of PBD.)
+    if (!isa<VarDecl>(D) &&
+        !rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
+      return Action::SkipChildren();
+    }
+
+    // Check the attributes.
+    for (DeclAttribute *attr : D->getAttrs()) {
+      if (auto customAttr = dyn_cast<CustomAttr>(attr)) {
+        SourceRange nameRange(customAttr->getRangeWithAt().Start,
+                              customAttr->getTypeExpr()->getEndLoc());
+        if (rangeContainsLocToResolve(nameRange)) {
+          result = ExpansionNode{customAttr, ASTNode(D)};
+          return Action::Stop();
+        }
+      }
+    }
+
+    // Check 'MacroExpansionDecl'.
+    if (auto med = dyn_cast<MacroExpansionDecl>(D)) {
+      SourceRange nameRange(med->getExpansionInfo()->SigilLoc,
+                            med->getMacroNameLoc().getEndLoc());
+      if (rangeContainsLocToResolve(nameRange)) {
+        result = ExpansionNode{nullptr, ASTNode(med)};
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue();
+  }
+
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+    if (!rangeContainsLocToResolve(E->getSourceRange())) {
+      return Action::SkipChildren(E);
+    }
+
+    // Check 'MacroExpansionExpr'.
+    if (auto mee = dyn_cast<MacroExpansionExpr>(E)) {
+      SourceRange nameRange(mee->getExpansionInfo()->SigilLoc,
+                            mee->getMacroNameLoc().getEndLoc());
+      if (rangeContainsLocToResolve(nameRange)) {
+        result = ExpansionNode{nullptr, ASTNode(mee)};
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue(E);
+  }
+
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+    if (!rangeContainsLocToResolve(S->getSourceRange())) {
+      return Action::SkipChildren(S);
+    }
+    return Action::Continue(S);
+  }
+  PreWalkResult<ArgumentList *>
+  walkToArgumentListPre(ArgumentList *AL) override {
+    if (!rangeContainsLocToResolve(AL->getSourceRange())) {
+      return Action::SkipChildren(AL);
+    }
+    return Action::Continue(AL);
+  }
+  PreWalkAction walkToParameterListPre(ParameterList *PL) override {
+    if (!rangeContainsLocToResolve(PL->getSourceRange())) {
+      return Action::SkipChildren();
+    }
+    return Action::Continue();
+  }
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+    // TypeRepr cannot have macro expansions in it.
+    return Action::SkipChildren();
+  }
+};
+} // namespace
+
+void SyntacticMacroExpansionInstance::expand(
+    SourceFile *SF, const MacroExpansionSpecifier &expansion,
+    SourceEditConsumer &consumer) {
+
+  // Find the expansion at 'expantion.offset'.
+  MacroExpansionFinder expansionFinder(
+      SourceMgr,
+      SourceMgr.getLocForOffset(*SF->getBufferID(), expansion.offset));
+  SF->walk(expansionFinder);
+  auto expansionNode = expansionFinder.getResult();
+  if (!expansionNode)
+    return;
+
+  // Expand the macro.
+  std::vector<unsigned> bufferIDs;
+  if (auto *attr = expansionNode->attribute) {
+    // Attached macros.
+    MacroDecl *macro = getSynthesizedMacroDecl(
+        getCustomAttrName(getASTContext(), attr), expansion);
+    auto *attachedTo = expansionNode->node.get<Decl *>();
+    bufferIDs = expandAttachedMacro(macro, attr, attachedTo);
+
+    // For an attached macro, remove the custom attribute; it's been fully
+    // subsumed by its expansions.
+    SourceRange range = attr->getRangeWithAt();
+    auto charRange = Lexer::getCharSourceRangeFromSourceRange(SourceMgr, range);
+    consumer.remove(SourceMgr, charRange);
+  } else {
+    // Freestanding macros.
+    FreestandingMacroExpansion *freestanding;
+    auto node = expansionNode->node;
+    if (node.is<Expr *>()) {
+      freestanding = cast<MacroExpansionExpr>(node.get<Expr *>());
+    } else {
+      freestanding = cast<MacroExpansionDecl>(node.get<Decl *>());
+    }
+
+    MacroDecl *macro = getSynthesizedMacroDecl(
+        freestanding->getMacroName().getBaseIdentifier(), expansion);
+    bufferIDs = expandFreestandingMacro(macro, freestanding);
+  }
+
+  // Send all edits to the consumer.
+  for (unsigned bufferID : bufferIDs) {
+    consumer.acceptMacroExpansionBuffer(SourceMgr, bufferID, SF,
+                                        /*adjust=*/false,
+                                        /*includeBufferName=*/false);
+  }
+}
+
+void SyntacticMacroExpansionInstance::expandAll(
+    llvm::MemoryBuffer *inputBuf, ArrayRef<MacroExpansionSpecifier> expansions,
+    SourceEditConsumer &consumer) {
+
+  // Create a source file.
+  SourceFile *SF = getSourceFile(inputBuf);
+
+  for (const auto &expansion : expansions) {
+    expand(SF, expansion, consumer);
+  }
+}

--- a/test/SourceKit/Macros/syntactic_expansion.swift
+++ b/test/SourceKit/Macros/syntactic_expansion.swift
@@ -1,0 +1,82 @@
+//--- test.swift
+@DelegatedConformance
+@wrapAllProperties
+struct Generic<Element> {
+
+  @myPropertyWrapper
+  @otherAttr
+  var value: Int
+
+  func member() {}
+  var otherVal: Int = 1
+
+  #bitwidthNumberedStructs("blah")
+}
+
+//--- DelegatedConformance.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.conformance, source.lang.swift.macro_role.member],
+  key.modulename: "MacroDefinition",
+  key.typename: "DelegatedConformanceMacro",
+}
+
+//--- myPropertyWrapper.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.accessor, source.lang.swift.macro_role.peer],
+  key.modulename: "MacroDefinition",
+  key.typename: "PropertyWrapperMacro",
+}
+
+//--- wrapAllProperties.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.member_attribute],
+  key.modulename: "MacroDefinition",
+  key.typename: "WrapAllProperties",
+}
+
+//--- bitwidthNumberedStructs.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.declaration],
+  key.modulename: "MacroDefinition",
+  key.typename: "DefineBitwidthNumberedStructsMacro",
+}
+
+//--- dummy.script
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/plugins
+// RUN: split-file %s %t
+
+//##-- Prepare the macro plugin.
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/plugins/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '### 1' \
+// RUN:   == \
+// RUN:   -req=syntactic-expandmacro \
+// RUN:   -req-opts=1:1:%t/DelegatedConformance.json \
+// RUN:   -req-opts=5:3:%t/myPropertyWrapper.json \
+// RUN:   -req-opts=2:1:%t/wrapAllProperties.json \
+// RUN:   -req-opts=12:3:%t/bitwidthNumberedStructs.json \
+// RUN:   %t/test.swift \
+// RUN:   -- \
+// RUN:   %t/test.swift \
+// RUN:   -plugin-path %t/plugins -Xfrontend -dump-macro-expansions \
+// RUN:   -module-name TestModule \
+// RUN:   == \
+// RUN:   -shell -- echo '### 2' \
+// RUN:   == \
+// RUN:   -req=syntactic-expandmacro \
+// RUN:   -req-opts=12:3:%t/bitwidthNumberedStructs.json \
+// RUN:   -req-opts=2:1:%t/wrapAllProperties.json \
+// RUN:   -req-opts=5:3:%t/myPropertyWrapper.json \
+// RUN:   -req-opts=1:1:%t/DelegatedConformance.json \
+// RUN:   %t/test.swift \
+// RUN:   -- \
+// RUN:   %t/test.swift \
+// RUN:   -plugin-path %t/plugins -Xfrontend -dump-macro-expansions \
+// RUN:   -module-name TestModule \
+// RUN:   | tee %t.response
+
+// RUN: diff -u %s.expected %t.response

--- a/test/SourceKit/Macros/syntactic_expansion.swift.expected
+++ b/test/SourceKit/Macros/syntactic_expansion.swift.expected
@@ -1,0 +1,108 @@
+### 1
+source.edit.kind.active:
+  1:1-1:22 ""
+source.edit.kind.active:
+  13:1-13:1 "static func requirement() where Element : P {
+  Element.requirement()
+}"
+source.edit.kind.active:
+  13:2-13:2 "extension Generic : P where Element: P {}"
+source.edit.kind.active:
+  5:3-5:21 ""
+source.edit.kind.active:
+  7:17-7:17 "{
+    get {
+            _value.wrappedValue
+      }
+
+    set {
+            _value.wrappedValue = newValue
+      }
+}"
+source.edit.kind.active:
+  7:12-7:12 "var _value: MyWrapperThingy<Int>"
+source.edit.kind.active:
+  2:1-2:19 ""
+source.edit.kind.active:
+  7:3-7:3 "@Wrapper"
+source.edit.kind.active:
+  10:3-10:3 "@Wrapper"
+source.edit.kind.active:
+  12:3-12:35 "struct blah8 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu0_() {
+  }
+}
+struct blah16 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu1_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu2_() {
+  }
+}
+struct blah32 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu3_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu4_() {
+  }
+}
+struct blah64 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu5_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu6_() {
+  }
+}"
+### 2
+source.edit.kind.active:
+  12:3-12:35 "struct blah8 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu0_() {
+  }
+}
+struct blah16 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu1_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu2_() {
+  }
+}
+struct blah32 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu3_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu4_() {
+  }
+}
+struct blah64 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu5_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu6_() {
+  }
+}"
+source.edit.kind.active:
+  2:1-2:19 ""
+source.edit.kind.active:
+  7:3-7:3 "@Wrapper"
+source.edit.kind.active:
+  10:3-10:3 "@Wrapper"
+source.edit.kind.active:
+  5:3-5:21 ""
+source.edit.kind.active:
+  7:17-7:17 "{
+    get {
+            _value.wrappedValue
+      }
+
+    set {
+            _value.wrappedValue = newValue
+      }
+}"
+source.edit.kind.active:
+  7:12-7:12 "var _value: MyWrapperThingy<Int>"
+source.edit.kind.active:
+  1:1-1:22 ""
+source.edit.kind.active:
+  13:1-13:1 "static func requirement() where Element : P {
+  Element.requirement()
+}"
+source.edit.kind.active:
+  13:2-13:2 "extension Generic : P where Element: P {}"

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -11,6 +11,7 @@ add_sourcekit_library(SourceKitSwiftLang
   SwiftLangSupport.cpp
   SwiftMangling.cpp
   SwiftSourceDocInfo.cpp
+  SwiftSyntacticMacroExpansion.cpp
   SwiftTypeContextInfo.cpp
     LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD}
       bitreader

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -29,6 +29,7 @@
 #include "swift/IDE/SyntaxModel.h"
 #include "swift/IDE/Utils.h"
 #include "swift/IDETool/IDEInspectionInstance.h"
+#include "swift/IDETool/SyntacticMacroExpansion.h"
 
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Preprocessor.h"
@@ -302,6 +303,9 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
 
   // By default, just use the in-memory cache.
   CCCache->inMemory = std::make_unique<ide::CodeCompletionCache>();
+
+  SyntacticMacroExpansions =
+      std::make_shared<SyntacticMacroExpansion>(SwiftExecutablePath, Plugins);
 
   // Provide a default file system provider.
   setFileSystemProvider("in-memory-vfs", std::make_unique<InMemoryFileSystemProvider>());

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -55,6 +55,7 @@ namespace ide {
   class IDEInspectionInstance;
   class OnDiskCodeCompletionCache;
   class SourceEditConsumer;
+  class SyntacticMacroExpansion;
   enum class CodeCompletionDeclKind : uint8_t;
   enum class SyntaxNodeKind : uint8_t;
   enum class SyntaxStructureKind : uint8_t;
@@ -366,6 +367,7 @@ class SwiftLangSupport : public LangSupport {
   llvm::StringMap<std::unique_ptr<FileSystemProvider>> FileSystemProviders;
   std::shared_ptr<swift::ide::IDEInspectionInstance> IDEInspectionInst;
   std::shared_ptr<compile::SessionManager> CompileManager;
+  std::shared_ptr<swift::ide::SyntacticMacroExpansion> SyntacticMacroExpansions;
 
 public:
   explicit SwiftLangSupport(SourceKit::Context &SKCtx);
@@ -755,6 +757,11 @@ public:
                                SourceKitCancellationToken CancellationToken,
                                ConformingMethodListConsumer &Consumer,
                                Optional<VFSOptions> vfsOptions) override;
+
+  void expandMacroSyntactically(llvm::MemoryBuffer *inputBuf,
+                                ArrayRef<const char *> args,
+                                ArrayRef<MacroExpansionInfo> expansions,
+                                CategorizedEditsReceiver receiver) override;
 
   void
   performCompile(StringRef Name, ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
@@ -1,0 +1,94 @@
+//===--- SwiftSyntaxMacro.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftLangSupport.h"
+#include "swift/AST/MacroDefinition.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/IDE/TypeContextInfo.h"
+#include "swift/IDETool/SyntacticMacroExpansion.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Comment.h"
+#include "clang/AST/Decl.h"
+
+using namespace SourceKit;
+using namespace swift;
+using namespace ide;
+
+void SwiftLangSupport::expandMacroSyntactically(
+    llvm::MemoryBuffer *inputBuf, ArrayRef<const char *> args,
+    ArrayRef<MacroExpansionInfo> reqExpansions,
+    CategorizedEditsReceiver receiver) {
+
+  std::string error;
+  auto instance = SyntacticMacroExpansions->getInstance(args, error);
+  if (!instance) {
+    return receiver(
+        RequestResult<ArrayRef<CategorizedEdits>>::fromError(error));
+  }
+  auto &ctx = instance->getASTContext();
+
+  // Convert 'SourceKit::MacroExpansionInfo' to 'ide::MacroExpansionSpecifier'.
+  SmallVector<ide::MacroExpansionSpecifier, 4> expansions;
+  for (auto &req : reqExpansions) {
+    unsigned offset = req.offset;
+
+    swift::MacroRoles macroRoles;
+    if (req.roles.contains(SourceKit::MacroRole::Expression))
+      macroRoles |= swift::MacroRole::Expression;
+    if (req.roles.contains(SourceKit::MacroRole::Declaration))
+      macroRoles |= swift::MacroRole::Declaration;
+    if (req.roles.contains(SourceKit::MacroRole::CodeItem))
+      macroRoles |= swift::MacroRole::CodeItem;
+    if (req.roles.contains(SourceKit::MacroRole::Accessor))
+      macroRoles |= swift::MacroRole::Accessor;
+    if (req.roles.contains(SourceKit::MacroRole::MemberAttribute))
+      macroRoles |= swift::MacroRole::MemberAttribute;
+    if (req.roles.contains(SourceKit::MacroRole::Member))
+      macroRoles |= swift::MacroRole::Member;
+    if (req.roles.contains(SourceKit::MacroRole::Peer))
+      macroRoles |= swift::MacroRole::Peer;
+    if (req.roles.contains(SourceKit::MacroRole::Conformance))
+      macroRoles |= swift::MacroRole::Conformance;
+
+    MacroDefinition definition = [&] {
+      if (auto *expanded =
+              std::get_if<MacroExpansionInfo::ExpandedMacroDefinition>(
+                  &req.macroDefinition)) {
+        SmallVector<ExpandedMacroReplacement, 2> replacements;
+        for (auto &reqReplacement : expanded->replacements) {
+          replacements.push_back(
+              {/*startOffset=*/reqReplacement.range.Offset,
+               /*endOffset=*/reqReplacement.range.Offset +
+                   reqReplacement.range.Length,
+               /*parameterIndex=*/reqReplacement.parameterIndex});
+        }
+        return MacroDefinition::forExpanded(ctx, expanded->expansionText,
+                                            replacements);
+      } else if (auto *externalRef =
+                     std::get_if<MacroExpansionInfo::ExternalMacroReference>(
+                         &req.macroDefinition)) {
+        return MacroDefinition::forExternal(
+            ctx.getIdentifier(externalRef->moduleName),
+            ctx.getIdentifier(externalRef->typeName));
+      } else {
+        return MacroDefinition::forUndefined();
+      }
+    }();
+
+    expansions.push_back({offset, macroRoles, definition});
+  }
+
+  RequestRefactoringEditConsumer consumer(receiver);
+  instance->expandAll(inputBuf, expansions, consumer);
+  // consumer automatically send the results on destruction.
+}

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -153,6 +153,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("diags", SourceKitRequest::Diagnostics)
         .Case("compile", SourceKitRequest::Compile)
         .Case("compile.close", SourceKitRequest::CompileClose)
+        .Case("syntactic-expandmacro", SourceKitRequest::SyntacticMacroExpansion)
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
 #include "swift/Refactoring/RefactoringKinds.def"
         .Default(SourceKitRequest::None);
@@ -203,6 +204,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                      << "- collect-type\n"
                      << "- global-config\n"
                      << "- dependency-updated\n"
+                     << "- syntactic-expandmacro\n"
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) << "- refactoring." #ID "\n"
 #include "swift/Refactoring/RefactoringKinds.def"
                         "\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -70,6 +70,7 @@ enum class SourceKitRequest {
   Diagnostics,
   Compile,
   CompileClose,
+  SyntacticMacroExpansion,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/Refactoring/RefactoringKinds.def"
 };

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -1824,6 +1824,134 @@ handleRequestDiagnostics(const RequestDict &Req,
   });
 }
 
+/// Expand macros in the specified source file syntactically.
+///
+/// Request would look like:
+///   {
+///     key.compilerargs: []
+///     key.sourcefile: <file name>
+///     key.sourcetext: <source text> (optional)
+///     key.expansions: [<expansion specifier>...]
+///   }
+/// 'compilerargs' is used for plugin search paths.
+/// 'expansion specifier' is
+///   {
+///     key.offset: <offset>
+///     key.modulename: <plugin module name>
+///     key.typename: <macro typename>
+///     key.macro_roles: [<macro role UID>...]
+///   }
+///
+/// Sends the results as a 'CategorizedEdits'. 
+/// Note that, unlike refactoring, each edit doesn't have 'key.buffer_name'.
+/// FIXME: Support nested expansion.
+static void handleRequestSyntacticMacroExpansion(
+    const RequestDict &req, SourceKitCancellationToken cancellationToken,
+    ResponseReceiver rec) {
+
+  Optional<VFSOptions> vfsOptions = getVFSOptions(req);
+  std::unique_ptr<llvm::MemoryBuffer> inputBuf =
+      getInputBufForRequestOrEmitError(req, vfsOptions, rec);
+  if (!inputBuf)
+    return;
+
+  SmallVector<const char *, 16> args;
+  if (getCompilerArgumentsForRequestOrEmitError(req, args, rec))
+    return;
+
+  // key.expansions: [
+  //   { key.offset: 42,
+  //     key.macro_roles: [source.lang.swift.macrorole.conformance,
+  //                      source.lang.swift.macrorole.member],
+  //     key.modulename: "MyMacroImpl",
+  //     key.typename: "StringifyMacro"},
+  //   { key.offset: 132,
+  //     key.sourceText: "foo(bar, baz)",
+  //     key.macro_roles: [source.lang.swift.macrorole.conformance,
+  //                      source.lang.swift.macrorole.member],
+  //     key.expandedmacro_replacements: [
+  //       {key.offset: 4, key.length: 3, key.argindex: 0},
+  //       {key.offset: 9, key.length: 3, key.argindex: 1}]}
+  // ]
+  std::vector<MacroExpansionInfo> expansions;
+  bool failed = req.dictionaryArrayApply(KeyExpansions, [&](RequestDict dict) {
+    // offset.
+    int64_t offset;
+    dict.getInt64(KeyOffset, offset, false);
+
+    // macro roles.
+    SmallVector<sourcekitd_uid_t, 1> macroRoleUIDs;
+    if (dict.getUIDArray(KeyMacroRoles, macroRoleUIDs, false)) {
+      rec(createErrorRequestInvalid(
+          "missing 'key.macro_roles' for expansion specifier"));
+      return true;
+    }
+    MacroRoles macroRoles;
+    for (auto uid : macroRoleUIDs) {
+      if (uid == KindMacroRoleExpression)
+        macroRoles |= MacroRole::Expression;
+      if (uid == KindMacroRoleDeclaration)
+        macroRoles |= MacroRole::Declaration;
+      if (uid == KindMacroRoleCodeItem)
+        macroRoles |= MacroRole::CodeItem;
+      if (uid == KindMacroRoleAccessor)
+        macroRoles |= MacroRole::Accessor;
+      if (uid == KindMacroRoleMemberAttribute)
+        macroRoles |= MacroRole::MemberAttribute;
+      if (uid == KindMacroRoleMember)
+        macroRoles |= MacroRole::Member;
+      if (uid == KindMacroRolePeer)
+        macroRoles |= MacroRole::Peer;
+      if (uid == KindMacroRoleConformance)
+        macroRoles |= MacroRole::Conformance;
+    }
+
+    // definition.
+    if (auto moduleName = dict.getString(KeyModuleName)) {
+      auto typeName = dict.getString(KeyTypeName);
+      if (!typeName) {
+        rec(createErrorRequestInvalid(
+            "missing 'key.typename' for external macro definition"));
+        return true;
+      }
+      MacroExpansionInfo::ExternalMacroReference definition(moduleName->str(),
+                                                            typeName->str());
+      expansions.emplace_back(offset, macroRoles, definition);
+    } else if (auto expandedText = dict.getString(KeySourceText)) {
+      MacroExpansionInfo::ExpandedMacroDefinition definition(*expandedText);
+      bool failed = dict.dictionaryArrayApply(
+          KeyExpandedMacroReplacements, [&](RequestDict dict) {
+            int64_t offset, length, paramIndex;
+            bool failed = false;
+            failed |= dict.getInt64(KeyOffset, offset, false);
+            failed |= dict.getInt64(KeyLength, length, false);
+            failed |= dict.getInt64(KeyArgIndex, paramIndex, false);
+            if (failed) {
+              rec(createErrorRequestInvalid(
+                  "macro replacement should have key.offset, key.length, and "
+                  "key.argindex"));
+              return true;
+            }
+            definition.replacements.emplace_back(
+                RawCharSourceRange{unsigned(offset), unsigned(length)},
+                paramIndex);
+            return false;
+          });
+      if (failed)
+        return true;
+      expansions.emplace_back(offset, macroRoles, definition);
+    }
+    return false;
+  });
+  if (failed)
+    return;
+
+  LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
+  Lang.expandMacroSyntactically(
+      inputBuf.get(), args, expansions,
+      [&](const auto &Result) { rec(createCategorizedEditsResponse(Result)); });
+}
+
 void handleRequestImpl(sourcekitd_object_t ReqObj,
                        SourceKitCancellationToken CancellationToken,
                        ResponseReceiver Rec) {
@@ -1927,6 +2055,8 @@ void handleRequestImpl(sourcekitd_object_t ReqObj,
   HANDLE_REQUEST(RequestRelatedIdents, handleRequestRelatedIdents)
   HANDLE_REQUEST(RequestActiveRegions, handleRequestActiveRegions)
   HANDLE_REQUEST(RequestDiagnostics, handleRequestDiagnostics)
+  HANDLE_REQUEST(RequestSyntacticMacroExpansion,
+                 handleRequestSyntacticMacroExpansion)
 
   {
     SmallString<64> ErrBuf;

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -209,6 +209,9 @@ UID_KEYS = [
     KEY('IsSynthesized', 'key.is_synthesized'),
     KEY('BufferName', 'key.buffer_name'),
     KEY('BarriersEnabled', 'key.barriers_enabled'),
+    KEY('Expansions', 'key.expansions'),
+    KEY('MacroRoles', 'key.macro_roles'),
+    KEY('ExpandedMacroReplacements', 'key.expanded_macro_replacements'),
 ]
 
 
@@ -274,6 +277,8 @@ UID_REQUESTS = [
     REQUEST('Compile', 'source.request.compile'),
     REQUEST('CompileClose', 'source.request.compile.close'),
     REQUEST('EnableRequestBarriers', 'source.request.enable_request_barriers'),
+    REQUEST('SyntacticMacroExpansion',
+            'source.request.syntactic_macro_expansion'),
 ]
 
 
@@ -491,4 +496,12 @@ UID_KINDS = [
     KIND('StatInstructionCount', 'source.statistic.instruction-count'),
     KIND('Swift', 'source.lang.swift'),
     KIND('ObjC', 'source.lang.objc'),
+    KIND('MacroRoleExpression', 'source.lang.swift.macro_role.expression'),
+    KIND('MacroRoleDeclaration', 'source.lang.swift.macro_role.declaration'),
+    KIND('MacroRoleCodeItem', 'source.lang.swift.macro_role.codeitem'),
+    KIND('MacroRoleAccessor', 'source.lang.swift.macro_role.accessor'),
+    KIND('MacroRoleMemberAttribute', 'source.lang.swift.macro_role.member_attribute'),
+    KIND('MacroRoleMember', 'source.lang.swift.macro_role.member'),
+    KIND('MacroRolePeer', 'source.lang.swift.macro_role.peer'),
+    KIND('MacroRoleConformance', 'source.lang.swift.macro_role.conformance'),
 ]


### PR DESCRIPTION
Expand macros in the specified source file syntactically (without any module imports, nor typechecking).
 
Request would look like:
```
{
  key.compilerargs: [...]
  key.sourcefile: <file name>
  key.sourcetext: <source text> (optional)
  key.expansions: [<expansion specifier>...]
}
```
`key.compilerargs` are used for getting plugins search paths. If `key.sourcetext` is not specified, it's loaded from the file system.
Each `<expansion sepecifier>` is
```
{
  key.offset: <offset>
  key.modulename: <plugin module name>
  key.typename: <macro typename>
  key.macro_roles: [<macro role UID>...]
}
```
Clients have to provide the module and type names because that's semantic.

Response is a  `CategorizedEdits` just like (semantic) "ExpandMacro" refactoring. But without `key.buffer_name`. Nested expansions are not supported at this point.