### PR TITLE
[Macros] Unify MacroExpansionDecl/MacroExpansionExpr expansion logic

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/Mangler.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/Basic/TaggedUnion.h"
 
 namespace clang {
@@ -367,8 +368,7 @@ public:
   mangleRuntimeAttributeGeneratorEntity(const ValueDecl *decl, CustomAttr *attr,
                                         SymbolKind SKind = SymbolKind::Default);
 
-  std::string mangleMacroExpansion(const MacroExpansionExpr *expansion);
-  std::string mangleMacroExpansion(const MacroExpansionDecl *expansion);
+  std::string mangleMacroExpansion(const FreestandingMacroExpansion *expansion);
   std::string mangleAttachedMacroExpansion(
       const Decl *decl, CustomAttr *attr, MacroRole role);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -26,6 +26,7 @@
 #include "swift/AST/DefaultArgumentKind.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/LayoutConstraint.h"
@@ -8584,69 +8585,28 @@ public:
   using Decl::getASTContext;
 };
 
-/// Information about a macro expansion that is common between macro
-/// expansion declarations and expressions.
-///
-/// Instances of these types will be shared among paired macro expansion
-/// declaration/expression nodes.
-struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
-  SourceLoc SigilLoc;
-  DeclNameRef MacroName;
-  DeclNameLoc MacroNameLoc;
-  SourceLoc LeftAngleLoc, RightAngleLoc;
-  ArrayRef<TypeRepr *> GenericArgs;
-  ArgumentList *ArgList;
-
-  /// The referenced macro.
-  ConcreteDeclRef macroRef;
-
-  MacroExpansionInfo(SourceLoc sigilLoc,
-                     DeclNameRef macroName,
-                     DeclNameLoc macroNameLoc,
-                     SourceLoc leftAngleLoc, SourceLoc rightAngleLoc,
-                     ArrayRef<TypeRepr *> genericArgs,
-                     ArgumentList *argList)
-    : SigilLoc(sigilLoc), MacroName(macroName), MacroNameLoc(macroNameLoc),
-      LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
-      GenericArgs(genericArgs), ArgList(argList) { }
-};
-
-class MacroExpansionDecl : public Decl {
-  MacroExpansionInfo *info;
+class MacroExpansionDecl : public Decl, public FreestandingMacroExpansion {
 
 public:
   enum : unsigned { InvalidDiscriminator = 0xFFFF };
 
   MacroExpansionDecl(DeclContext *dc, MacroExpansionInfo *info);
 
-  MacroExpansionDecl(DeclContext *dc, SourceLoc poundLoc, DeclNameRef macro,
-                     DeclNameLoc macroLoc,
-                     SourceLoc leftAngleLoc,
-                     ArrayRef<TypeRepr *> genericArgs,
-                     SourceLoc rightAngleLoc,
-                     ArgumentList *args);
+  static MacroExpansionDecl *create(DeclContext *dc, SourceLoc poundLoc,
+                                    DeclNameRef macro, DeclNameLoc macroLoc,
+                                    SourceLoc leftAngleLoc,
+                                    ArrayRef<TypeRepr *> genericArgs,
+                                    SourceLoc rightAngleLoc,
+                                    ArgumentList *args);
 
-  ArrayRef<TypeRepr *> getGenericArgs() const {
-    return info->GenericArgs;
+  DeclContext *getDeclContext() const { return Decl::getDeclContext(); }
+
+  SourceRange getSourceRange() const {
+    return getExpansionInfo()->getSourceRange();
   }
-
-  SourceRange getGenericArgsRange() const {
-    return SourceRange(info->LeftAngleLoc, info->RightAngleLoc);
-  }
-
-  SourceRange getSourceRange() const;
-  SourceLoc getLocFromSource() const { return info->SigilLoc; }
-  SourceLoc getPoundLoc() const { return info->SigilLoc; }
-  DeclNameLoc getMacroNameLoc() const { return info->MacroNameLoc; }
-  DeclNameRef getMacroName() const { return info->MacroName; }
-  ArgumentList *getArgs() const { return info->ArgList; }
-  void setArgs(ArgumentList *args) { info->ArgList = args; }
+  SourceLoc getLocFromSource() const { return getExpansionInfo()->SigilLoc; }
   using ExprOrStmtExpansionCallback = llvm::function_ref<void(ASTNode)>;
   void forEachExpandedExprOrStmt(ExprOrStmtExpansionCallback) const;
-  ConcreteDeclRef getMacroRef() const { return info->macroRef; }
-  void setMacroRef(ConcreteDeclRef ref) { info->macroRef = ref; }
-
-  MacroExpansionInfo *getExpansionInfo() const { return info; }
 
   /// Returns a discriminator which determines this macro expansion's index
   /// in the sequence of macro expansions within the current function.
@@ -8668,6 +8628,9 @@ public:
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::MacroExpansion;
+  }
+  static bool classof(const FreestandingMacroExpansion *expansion) {
+    return expansion->getFreestandingMacroKind() == FreestandingMacroKind::Decl;
   }
 };
 

--- a/include/swift/AST/FreestandingMacroExpansion.h
+++ b/include/swift/AST/FreestandingMacroExpansion.h
@@ -1,0 +1,113 @@
+//===--- FreestandingMacroExpansion.h ------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_FREESTANDING_MACRO_EXPANSION_H
+#define SWIFT_AST_FREESTANDING_MACRO_EXPANSION_H
+
+#include "swift/AST/ASTAllocated.h"
+#include "swift/AST/ASTNode.h"
+#include "swift/AST/ConcreteDeclRef.h"
+#include "swift/AST/DeclNameLoc.h"
+#include "swift/AST/Identifier.h"
+#include "swift/Basic/SourceLoc.h"
+
+namespace swift {
+class MacroExpansionDecl;
+class MacroExpansionExpr;
+class Expr;
+class Decl;
+class ArgumentList;
+
+/// Information about a macro expansion that is common between macro
+/// expansion declarations and expressions.
+///
+/// Instances of these types will be shared among paired macro expansion
+/// declaration/expression nodes.
+struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
+  SourceLoc SigilLoc;
+  DeclNameRef MacroName;
+  DeclNameLoc MacroNameLoc;
+  SourceLoc LeftAngleLoc, RightAngleLoc;
+  llvm::ArrayRef<TypeRepr *> GenericArgs;
+  ArgumentList *ArgList;
+
+  /// The referenced macro.
+  ConcreteDeclRef macroRef;
+
+  MacroExpansionInfo(SourceLoc sigilLoc, DeclNameRef macroName,
+                     DeclNameLoc macroNameLoc, SourceLoc leftAngleLoc,
+                     SourceLoc rightAngleLoc, ArrayRef<TypeRepr *> genericArgs,
+                     ArgumentList *argList)
+      : SigilLoc(sigilLoc), MacroName(macroName), MacroNameLoc(macroNameLoc),
+        LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
+        GenericArgs(genericArgs), ArgList(argList) {}
+
+  SourceLoc getLoc() const { return SigilLoc; }
+  SourceRange getGenericArgsRange() const {
+    return {LeftAngleLoc, RightAngleLoc};
+  }
+  SourceRange getSourceRange() const;
+};
+
+enum class FreestandingMacroKind {
+  Expr, // MacroExpansionExpr.
+  Decl, // MacroExpansionDecl.
+};
+
+/// A base class of either 'MacroExpansionExpr' or 'MacroExpansionDecl'.
+class FreestandingMacroExpansion {
+  llvm::PointerIntPair<MacroExpansionInfo *, 1, FreestandingMacroKind>
+      infoAndKind;
+
+protected:
+  FreestandingMacroExpansion(FreestandingMacroKind kind,
+                             MacroExpansionInfo *info)
+      : infoAndKind(info, kind) {}
+
+public:
+  MacroExpansionInfo *getExpansionInfo() const {
+    return infoAndKind.getPointer();
+  }
+  FreestandingMacroKind getFreestandingMacroKind() const {
+    return infoAndKind.getInt();
+  }
+
+  ASTNode getASTNode();
+
+  SourceLoc getPoundLoc() const { return getExpansionInfo()->SigilLoc; }
+
+  DeclNameLoc getMacroNameLoc() const {
+    return getExpansionInfo()->MacroNameLoc;
+  }
+  DeclNameRef getMacroName() const { return getExpansionInfo()->MacroName; }
+
+  ArrayRef<TypeRepr *> getGenericArgs() const {
+    return getExpansionInfo()->GenericArgs;
+  }
+  SourceRange getGenericArgsRange() const {
+    return getExpansionInfo()->getGenericArgsRange();
+  }
+
+  ArgumentList *getArgs() const { return getExpansionInfo()->ArgList; }
+  void setArgs(ArgumentList *args) { getExpansionInfo()->ArgList = args; }
+
+  ConcreteDeclRef getMacroRef() const { return getExpansionInfo()->macroRef; }
+  void setMacroRef(ConcreteDeclRef ref) { getExpansionInfo()->macroRef = ref; }
+
+  DeclContext *getDeclContext() const;
+  SourceRange getSourceRange() const;
+  unsigned getDiscriminator() const;
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_FREESTANDING_MACRO_EXPANSION_H

--- a/include/swift/AST/MacroDiscriminatorContext.h
+++ b/include/swift/AST/MacroDiscriminatorContext.h
@@ -22,12 +22,10 @@ namespace swift {
 /// Describes the context of a macro expansion for the purpose of
 /// computing macro expansion discriminators.
 struct MacroDiscriminatorContext
-    : public llvm::PointerUnion<DeclContext *, MacroExpansionExpr *,
-                                MacroExpansionDecl *> {
+    : public llvm::PointerUnion<DeclContext *, FreestandingMacroExpansion *> {
   using PointerUnion::PointerUnion;
 
-  static MacroDiscriminatorContext getParentOf(MacroExpansionExpr *expansion);
-  static MacroDiscriminatorContext getParentOf(MacroExpansionDecl *expansion);
+  static MacroDiscriminatorContext getParentOf(FreestandingMacroExpansion *expansion);
   static MacroDiscriminatorContext getParentOf(
       SourceLoc loc, DeclContext *origDC
   );

--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -18,11 +18,12 @@
 #ifndef SWIFT_PRETTYSTACKTRACE_H
 #define SWIFT_PRETTYSTACKTRACE_H
 
-#include "llvm/Support/PrettyStackTrace.h"
-#include "swift/Basic/SourceLoc.h"
 #include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
+#include "swift/Basic/SourceLoc.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 namespace clang {
   class Type;
@@ -93,7 +94,21 @@ public:
   virtual void print(llvm::raw_ostream &OS) const override;
 };
 
-void printExprDescription(llvm::raw_ostream &out, Expr *E,
+/// PrettyStackTraceFreestandingMacroExpansion -  Observe that we are
+/// processing a specific freestanding macro expansion.
+class PrettyStackTraceFreestandingMacroExpansion
+    : public llvm::PrettyStackTraceEntry {
+  const FreestandingMacroExpansion *Expansion;
+  const char *Action;
+
+public:
+  PrettyStackTraceFreestandingMacroExpansion(
+      const char *action, const FreestandingMacroExpansion *expansion)
+      : Expansion(expansion), Action(action) {}
+  virtual void print(llvm::raw_ostream &OS) const override;
+};
+
+void printExprDescription(llvm::raw_ostream &out, const Expr *E,
                           const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTraceExpr - Observe that we are processing a specific

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3204,19 +3204,15 @@ public:
 
 class UnresolvedMacroReference {
 private:
-  llvm::PointerUnion<MacroExpansionDecl *, MacroExpansionExpr *, CustomAttr *>
+  llvm::PointerUnion<FreestandingMacroExpansion *, CustomAttr *>
     pointer;
 
 public:
-  UnresolvedMacroReference(MacroExpansionDecl *decl) : pointer(decl) {}
-  UnresolvedMacroReference(MacroExpansionExpr *expr) : pointer(expr) {}
+  UnresolvedMacroReference(FreestandingMacroExpansion *exp) : pointer(exp) {}
   UnresolvedMacroReference(CustomAttr *attr) : pointer(attr) {}
 
-  MacroExpansionDecl *getDecl() const {
-    return pointer.dyn_cast<MacroExpansionDecl *>();
-  }
-  MacroExpansionExpr *getExpr() const {
-    return pointer.dyn_cast<MacroExpansionExpr *>();
+  FreestandingMacroExpansion *getFreestanding() const {
+    return pointer.dyn_cast<FreestandingMacroExpansion *>();
   }
   CustomAttr *getAttr() const {
     return pointer.dyn_cast<CustomAttr *>();

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -50,6 +50,7 @@ add_swift_host_library(swiftAST STATIC
   ExtInfo.cpp
   FineGrainedDependencies.cpp
   FineGrainedDependencyFormat.cpp
+  FreestandingMacroExpansion.cpp
   FrontendSourceFileDepGraphFactory.cpp
   GenericEnvironment.cpp
   GenericParamList.cpp

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10597,37 +10597,27 @@ MacroDefinition MacroDefinition::forExpanded(
                                  ctx.AllocateCopy(replacements)};
 }
 
-MacroExpansionDecl::MacroExpansionDecl(
-    DeclContext *dc, MacroExpansionInfo *info
-) : Decl(DeclKind::MacroExpansion, dc), info(info) {
+MacroExpansionDecl::MacroExpansionDecl(DeclContext *dc,
+                                       MacroExpansionInfo *info)
+    : Decl(DeclKind::MacroExpansion, dc),
+      FreestandingMacroExpansion(FreestandingMacroKind::Decl, info) {
   Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;
 }
 
-MacroExpansionDecl::MacroExpansionDecl(
+MacroExpansionDecl *
+MacroExpansionDecl::create(
     DeclContext *dc, SourceLoc poundLoc, DeclNameRef macro,
     DeclNameLoc macroLoc, SourceLoc leftAngleLoc,
     ArrayRef<TypeRepr *> genericArgs, SourceLoc rightAngleLoc,
     ArgumentList *args
-) : Decl(DeclKind::MacroExpansion, dc) {
+) {
   ASTContext &ctx = dc->getASTContext();
-  info = new (ctx) MacroExpansionInfo{
+  MacroExpansionInfo *info = new (ctx) MacroExpansionInfo{
       poundLoc, macro, macroLoc,
       leftAngleLoc, rightAngleLoc, genericArgs,
       args ? args : ArgumentList::createImplicit(ctx, {})
   };
-  Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;
-}
-
-SourceRange MacroExpansionDecl::getSourceRange() const {
-  SourceLoc endLoc;
-  if (auto argsEndList = info->ArgList->getEndLoc())
-    endLoc = argsEndList;
-  else if (info->RightAngleLoc.isValid())
-    endLoc = info->RightAngleLoc;
-  else
-    endLoc = info->MacroNameLoc.getEndLoc();
-
-  return SourceRange(info->SigilLoc, endLoc);
+  return new (ctx) MacroExpansionDecl(dc, info);
 }
 
 unsigned MacroExpansionDecl::getDiscriminator() const {
@@ -10771,13 +10761,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
 }
 
 MacroDiscriminatorContext
-MacroDiscriminatorContext::getParentOf(MacroExpansionExpr *expansion) {
+MacroDiscriminatorContext::getParentOf(FreestandingMacroExpansion *expansion) {
   return getParentOf(
-      expansion->getLoc(), expansion->getDeclContext());
-}
-
-MacroDiscriminatorContext
-MacroDiscriminatorContext::getParentOf(MacroExpansionDecl *expansion) {
-  return getParentOf(
-      expansion->getLoc(), expansion->getDeclContext());
+      expansion->getPoundLoc(), expansion->getDeclContext());
 }

--- a/lib/AST/FreestandingMacroExpansion.cpp
+++ b/lib/AST/FreestandingMacroExpansion.cpp
@@ -1,0 +1,56 @@
+//===--- FreestandingMacroExpansion.cpp -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/FreestandingMacroExpansion.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+
+using namespace swift;
+
+SourceRange MacroExpansionInfo::getSourceRange() const {
+  SourceLoc endLoc;
+  if (ArgList && !ArgList->isImplicit())
+    endLoc = ArgList->getEndLoc();
+  else if (RightAngleLoc.isValid())
+    endLoc = RightAngleLoc;
+  else
+    endLoc = MacroNameLoc.getEndLoc();
+
+  return SourceRange(SigilLoc, endLoc);
+}
+
+#define FORWARD_VARIANT(NAME)                                                  \
+  switch (getFreestandingMacroKind()) {                                        \
+  case FreestandingMacroKind::Expr:                                            \
+    return cast<MacroExpansionExpr>(this)->NAME();                             \
+  case FreestandingMacroKind::Decl:                                            \
+    return cast<MacroExpansionDecl>(this)->NAME();                             \
+  }
+
+DeclContext *FreestandingMacroExpansion::getDeclContext() const {
+  FORWARD_VARIANT(getDeclContext);
+}
+SourceRange FreestandingMacroExpansion::getSourceRange() const {
+  FORWARD_VARIANT(getSourceRange);
+}
+unsigned FreestandingMacroExpansion::getDiscriminator() const {
+  FORWARD_VARIANT(getDiscriminator);
+}
+
+ASTNode FreestandingMacroExpansion::getASTNode() {
+  switch (getFreestandingMacroKind()) {
+  case FreestandingMacroKind::Expr:
+    return cast<MacroExpansionExpr>(this);
+  case FreestandingMacroKind::Decl:
+    return cast<MacroExpansionDecl>(this);
+  }
+}

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -130,6 +130,20 @@ void PrettyStackTraceAnyFunctionRef::print(llvm::raw_ostream &out) const {
   }
 }
 
+void PrettyStackTraceFreestandingMacroExpansion::print(
+    llvm::raw_ostream &out) const {
+  out << "While " << Action << ' ';
+  auto &Context = Expansion->getDeclContext()->getASTContext();
+  switch (Expansion->getFreestandingMacroKind()) {
+  case FreestandingMacroKind::Expr:
+    printExprDescription(out, cast<MacroExpansionExpr>(Expansion), Context);
+    break;
+  case FreestandingMacroKind::Decl:
+    printDeclDescription(out, cast<MacroExpansionDecl>(Expansion), Context);
+    break;
+  }
+}
+
 void PrettyStackTraceExpr::print(llvm::raw_ostream &out) const {
   out << "While " << Action << ' ';
   if (!TheExpr) {
@@ -139,7 +153,7 @@ void PrettyStackTraceExpr::print(llvm::raw_ostream &out) const {
   printExprDescription(out, TheExpr, Context);
 }
 
-void swift::printExprDescription(llvm::raw_ostream &out, Expr *E,
+void swift::printExprDescription(llvm::raw_ostream &out, const Expr *E,
                                  const ASTContext &Context, bool addNewline) {
   out << "expression at ";
   E->getSourceRange().print(out, Context.SourceMgr);

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1681,10 +1681,8 @@ void swift::simple_display(
 //----------------------------------------------------------------------------//
 
 DeclNameRef UnresolvedMacroReference::getMacroName() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getMacroName();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getMacroName();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getMacroName();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
     if (!identTypeRepr)
@@ -1695,20 +1693,16 @@ DeclNameRef UnresolvedMacroReference::getMacroName() const {
 }
 
 SourceLoc UnresolvedMacroReference::getSigilLoc() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getPoundLoc();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getLoc();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getPoundLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>())
     return attr->getRangeWithAt().Start;
   llvm_unreachable("Unhandled case");
 }
 
 DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getMacroNameLoc();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getMacroNameLoc();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getMacroNameLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
     if (!identTypeRepr)
@@ -1719,10 +1713,8 @@ DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
 }
 
 SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getGenericArgsRange();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getGenericArgsRange();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getGenericArgsRange();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *typeRepr = attr->getTypeRepr();
@@ -1737,10 +1729,8 @@ SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
 }
 
 ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getGenericArgs();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getGenericArgs();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getGenericArgs();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *typeRepr = attr->getTypeRepr();
@@ -1755,17 +1745,15 @@ ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
 }
 
 ArgumentList *UnresolvedMacroReference::getArgs() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getArgs();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getArgs();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getArgs();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>())
     return attr->getArgs();
   llvm_unreachable("Unhandled case");
 }
 
 MacroRoles UnresolvedMacroReference::getMacroRoles() const {
-  if (pointer.is<MacroExpansionExpr *>() || pointer.is<MacroExpansionDecl *>())
+  if (pointer.is<FreestandingMacroExpansion *>())
     return getFreestandingMacroRoles();
 
   if (pointer.is<CustomAttr *>())
@@ -1776,10 +1764,8 @@ MacroRoles UnresolvedMacroReference::getMacroRoles() const {
 
 void swift::simple_display(llvm::raw_ostream &out,
                            const UnresolvedMacroReference &ref) {
-  if (ref.getDecl())
-    out << "macro-expansion-decl";
-  else if (ref.getExpr())
-    out << "macro-expansion-expr";
+  if (ref.getFreestanding())
+    out << "freestanding-macro-expansion";
   else if (ref.getAttr())
     out << "custom-attr";
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9911,7 +9911,7 @@ Parser::parseDeclMacroExpansion(ParseDeclOptions flags,
   if (!macroNameRef)
     return status;
 
-  auto *med = new (Context) MacroExpansionDecl(
+  auto *med = MacroExpansionDecl::create(
       CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
       Context.AllocateCopy(genericArgs), rightAngleLoc, argList);
   med->getAttrs() = attributes;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3472,12 +3472,11 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
 
   return makeParserResult(
       status,
-      new (Context) MacroExpansionExpr(
+      MacroExpansionExpr::create(
           CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
           Context.AllocateCopy(genericArgs), rightAngleLoc, argList,
-          CurDeclContext->isTypeContext()
-              ? MacroRole::Declaration
-              : getFreestandingMacroRoles()));
+          CurDeclContext->isTypeContext() ? MacroRole::Declaration
+                                          : getFreestandingMacroRoles()));
 }
 
 /// parseExprCollection - Parse a collection literal expression.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2937,7 +2937,7 @@ namespace {
 
         auto macro = cast<MacroDecl>(overload.choice.getDecl());
         ConcreteDeclRef macroRef = resolveConcreteDeclRef(macro, locator);
-        auto expansion = new (ctx) MacroExpansionExpr(
+        auto *expansion = MacroExpansionExpr::create(
             dc, expr->getStartLoc(), DeclNameRef(macro->getName()),
             DeclNameLoc(expr->getLoc()), SourceLoc(), {}, SourceLoc(), nullptr,
             MacroRole::Expression, /*isImplicit=*/true, expandedType);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/CASTBridging.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/PluginLoader.h"
@@ -858,24 +859,29 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
   return macroSourceFile;
 }
 
-Optional<unsigned>
-swift::expandMacroExpr(MacroExpansionExpr *mee) {
-  DeclContext *dc = mee->getDeclContext();
+/// Evaluate the given freestanding macro expansion.
+static SourceFile *
+evaluateFreestandingMacro(FreestandingMacroExpansion *expansion) {
+  auto *dc = expansion->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
-  SourceManager &sourceMgr = ctx.SourceMgr;
-  ConcreteDeclRef macroRef = mee->getMacroRef();
-  Type expandedType = mee->getType();
+  SourceLoc loc = expansion->getPoundLoc();
 
   auto moduleDecl = dc->getParentModule();
-  auto sourceFile = moduleDecl->getSourceFileContainingLocation(mee->getLoc());
+  auto sourceFile = moduleDecl->getSourceFileContainingLocation(loc);
   if (!sourceFile)
-    return None;
+    return nullptr;
 
-  MacroDecl *macro = cast<MacroDecl>(macroRef.getDecl());
+  MacroDecl *macro = cast<MacroDecl>(expansion->getMacroRef().getDecl());
+  auto macroRoles = macro->getMacroRoles();
+  assert(macroRoles.contains(MacroRole::Expression) ||
+         macroRoles.contains(MacroRole::Declaration) ||
+         macroRoles.contains(MacroRole::CodeItem));
 
-  if (isFromExpansionOfMacro(sourceFile, macro, MacroRole::Expression)) {
-    ctx.Diags.diagnose(mee->getLoc(), diag::macro_recursive, macro->getName());
-    return None;
+  if (isFromExpansionOfMacro(sourceFile, macro, MacroRole::Expression) ||
+      isFromExpansionOfMacro(sourceFile, macro, MacroRole::Declaration) ||
+      isFromExpansionOfMacro(sourceFile, macro, MacroRole::CodeItem)) {
+    ctx.Diags.diagnose(loc, diag::macro_recursive, macro->getName());
+    return nullptr;
   }
 
   // Evaluate the macro.
@@ -885,7 +891,7 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
   LazyValue<std::string> discriminator([&]() -> std::string {
 #if SWIFT_SWIFT_PARSER
     Mangle::ASTMangler mangler;
-    return mangler.mangleMacroExpansion(mee);
+    return mangler.mangleMacroExpansion(expansion);
 #else
     return "";
 #endif
@@ -896,21 +902,20 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
   case MacroDefinition::Kind::Undefined:
   case MacroDefinition::Kind::Invalid:
     // Already diagnosed as an error elsewhere.
-    return None;
+    return nullptr;
 
   case MacroDefinition::Kind::Builtin: {
     switch (macroDef.getBuiltinKind()) {
     case BuiltinMacroKind::ExternalMacro:
-      ctx.Diags.diagnose(
-          mee->getLoc(), diag::external_macro_outside_macro_definition);
-      return None;
+      ctx.Diags.diagnose(loc, diag::external_macro_outside_macro_definition);
+      return nullptr;
     }
   }
 
   case MacroDefinition::Kind::Expanded: {
     // Expand the definition with the given arguments.
-    auto result = expandMacroDefinition(
-        macroDef.getExpanded(), macro, mee->getArgs());
+    auto result = expandMacroDefinition(macroDef.getExpanded(), macro,
+                                        expansion->getArgs());
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         result, adjustMacroExpansionBufferName(*discriminator));
     break;
@@ -919,28 +924,33 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
   case MacroDefinition::Kind::External: {
     // Retrieve the external definition of the macro.
     auto external = macroDef.getExternalMacro();
-    ExternalMacroDefinitionRequest request{
-      &ctx, external.moduleName, external.macroTypeName
-    };
+    ExternalMacroDefinitionRequest request{&ctx, external.moduleName,
+                                           external.macroTypeName};
     auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
     if (!externalDef) {
-      ctx.Diags.diagnose(
-          mee->getLoc(), diag::external_macro_not_found,
-          external.moduleName.str(),
-          external.macroTypeName.str(),
-          macro->getName()
-      );
+      ctx.Diags.diagnose(loc, diag::external_macro_not_found,
+                         external.moduleName.str(),
+                         external.macroTypeName.str(), macro->getName());
       macro->diagnose(diag::decl_declared_here, macro->getName());
-      return None;
+      return nullptr;
+    }
+
+    // Code item macros require `CodeItemMacros` feature flag.
+    if (macroRoles.contains(MacroRole::CodeItem) &&
+        !ctx.LangOpts.hasFeature(Feature::CodeItemMacros)) {
+      ctx.Diags.diagnose(loc, diag::macro_experimental, "code item",
+                         "CodeItemMacros");
+      return nullptr;
     }
 
 #if SWIFT_SWIFT_PARSER
-    PrettyStackTraceExpr debugStack(ctx, "expanding macro", mee);
+    PrettyStackTraceFreestandingMacroExpansion debugStack(
+        "expanding freestanding macro", expansion);
 
     // Builtin macros are handled via ASTGen.
     auto *astGenSourceFile = sourceFile->getExportedSourceFile();
     if (!astGenSourceFile)
-      return None;
+      return nullptr;
 
     const char *evaluatedSourceAddress;
     ptrdiff_t evaluatedSourceLength;
@@ -948,24 +958,38 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
         &ctx.Diags, externalDef->opaqueHandle,
         static_cast<uint32_t>(externalDef->kind), discriminator->data(),
         discriminator->size(), astGenSourceFile,
-        mee->getStartLoc().getOpaquePointerValue(), &evaluatedSourceAddress,
-        &evaluatedSourceLength);
+        expansion->getSourceRange().Start.getOpaquePointerValue(),
+        &evaluatedSourceAddress, &evaluatedSourceLength);
     if (!evaluatedSourceAddress)
-      return None;
+      return nullptr;
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         {evaluatedSourceAddress, (size_t)evaluatedSourceLength},
         adjustMacroExpansionBufferName(*discriminator));
     free((void *)evaluatedSourceAddress);
     break;
 #else
-    ctx.Diags.diagnose(mee->getLoc(), diag::macro_unsupported);
-    return None;
+    ctx.Diags.diagnose(loc, diag::macro_unsupported);
+    return nullptr;
 #endif
   }
   }
-  SourceFile *macroSourceFile = createMacroSourceFile(
-      std::move(evaluatedSource), MacroRole::Expression, mee, dc,
-      /*attr=*/nullptr);
+
+  return createMacroSourceFile(std::move(evaluatedSource),
+                               isa<MacroExpansionDecl>(expansion)
+                                   ? MacroRole::Declaration
+                                   : MacroRole::Expression,
+                               expansion->getASTNode(), dc,
+                               /*attr=*/nullptr);
+}
+
+Optional<unsigned> swift::expandMacroExpr(MacroExpansionExpr *mee) {
+  SourceFile *macroSourceFile = evaluateFreestandingMacro(mee);
+  if (!macroSourceFile)
+    return None;
+
+  DeclContext *dc = mee->getDeclContext();
+  ASTContext &ctx = dc->getASTContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
 
   auto macroBufferID = *macroSourceFile->getBufferID();
   auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
@@ -988,6 +1012,8 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
         macroBufferRange.getStart(), diag::expected_macro_expansion_expr);
     return macroBufferID;
   }
+
+  auto expandedType = mee->getType();
 
   // Type-check the expanded expression.
   // FIXME: Would like to pass through type checking options like "discarded"
@@ -1017,124 +1043,12 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
 /// Expands the given macro expansion declaration.
 Optional<unsigned>
 swift::expandFreestandingMacro(MacroExpansionDecl *med) {
-  auto *dc = med->getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
-
-  auto moduleDecl = dc->getParentModule();
-  auto sourceFile = moduleDecl->getSourceFileContainingLocation(med->getLoc());
-  if (!sourceFile)
+  SourceFile *macroSourceFile = evaluateFreestandingMacro(med);
+  if (!macroSourceFile)
     return None;
 
   MacroDecl *macro = cast<MacroDecl>(med->getMacroRef().getDecl());
-  auto macroRoles = macro->getMacroRoles();
-  assert(macroRoles.contains(MacroRole::Declaration) ||
-         macroRoles.contains(MacroRole::CodeItem));
-
-  if (isFromExpansionOfMacro(sourceFile, macro, MacroRole::Expression) ||
-      isFromExpansionOfMacro(sourceFile, macro, MacroRole::Declaration) ||
-      isFromExpansionOfMacro(sourceFile, macro, MacroRole::CodeItem)) {
-    med->diagnose(diag::macro_recursive, macro->getName());
-    return None;
-  }
-
-  // Evaluate the macro.
-  std::unique_ptr<llvm::MemoryBuffer> evaluatedSource;
-
-  /// The discriminator used for the macro.
-  LazyValue<std::string> discriminator([&]() -> std::string {
-#if SWIFT_SWIFT_PARSER
-    Mangle::ASTMangler mangler;
-    return mangler.mangleMacroExpansion(med);
-#else
-    return "";
-#endif
-  });
-
-  auto macroDef = macro->getDefinition();
-  switch (macroDef.kind) {
-  case MacroDefinition::Kind::Undefined:
-  case MacroDefinition::Kind::Invalid:
-    // Already diagnosed as an error elsewhere.
-    return None;
-
-  case MacroDefinition::Kind::Builtin: {
-    switch (macroDef.getBuiltinKind()) {
-    case BuiltinMacroKind::ExternalMacro:
-      // FIXME: Error here.
-      return None;
-    }
-  }
-
-  case MacroDefinition::Kind::Expanded: {
-    // Expand the definition with the given arguments.
-    auto result = expandMacroDefinition(
-        macroDef.getExpanded(), macro, med->getArgs());
-    evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
-        result, adjustMacroExpansionBufferName(*discriminator));
-    break;
-  }
-
-  case MacroDefinition::Kind::External: {
-    // Retrieve the external definition of the macro.
-    auto external = macroDef.getExternalMacro();
-    ExternalMacroDefinitionRequest request{
-        &ctx, external.moduleName, external.macroTypeName
-    };
-    auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
-    if (!externalDef) {
-      med->diagnose(diag::external_macro_not_found,
-                    external.moduleName.str(),
-                    external.macroTypeName.str(),
-                    macro->getName()
-      );
-      macro->diagnose(diag::decl_declared_here, macro->getName());
-      return None;
-    }
-
-    // Currently only expression macros are enabled by default. Declaration
-    // macros need the `FreestandingMacros` feature flag, and code item macros
-    // need both `FreestandingMacros` and `CodeItemMacros`.
-    if (!macroRoles.contains(MacroRole::Expression)) {
-      if (!macroRoles.contains(MacroRole::Declaration) &&
-          !ctx.LangOpts.hasFeature(Feature::CodeItemMacros)) {
-        med->diagnose(diag::macro_experimental, "code item", "CodeItemMacros");
-        return None;
-      }
-    }
-
-#if SWIFT_SWIFT_PARSER
-    PrettyStackTraceDecl debugStack("expanding declaration macro", med);
-
-    // Builtin macros are handled via ASTGen.
-    auto *astGenSourceFile = sourceFile->getExportedSourceFile();
-    if (!astGenSourceFile)
-      return None;
-
-    const char *evaluatedSourceAddress;
-    ptrdiff_t evaluatedSourceLength;
-    swift_ASTGen_expandFreestandingMacro(
-        &ctx.Diags, externalDef->opaqueHandle,
-        static_cast<uint32_t>(externalDef->kind), discriminator->data(),
-        discriminator->size(), astGenSourceFile,
-        med->getStartLoc().getOpaquePointerValue(), &evaluatedSourceAddress,
-        &evaluatedSourceLength);
-    if (!evaluatedSourceAddress)
-      return None;
-    evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
-        {evaluatedSourceAddress, (size_t)evaluatedSourceLength},
-        adjustMacroExpansionBufferName(*discriminator));
-    free((void *)evaluatedSourceAddress);
-    break;
-#else
-    med->diagnose(diag::macro_unsupported);
-    return None;
-#endif
-  }
-  }
-
-  SourceFile *macroSourceFile = createMacroSourceFile(
-      std::move(evaluatedSource), MacroRole::Declaration, med, dc,
-      /*attr=*/nullptr);
+  DeclContext *dc = med->getDeclContext();
 
   validateMacroExpansion(macroSourceFile, macro,
                          /*attachedTo*/nullptr,
@@ -1478,11 +1392,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
                                               DeclContext *dc) const {
   // Macro expressions and declarations have their own stored macro
   // reference. Use it if it's there.
-  if (auto *expr = macroRef.getExpr()) {
-    if (auto ref = expr->getMacroRef())
-      return ref;
-  } else if (auto decl = macroRef.getDecl()) {
-    if (auto ref = decl->getMacroRef())
+  if (auto *expansion = macroRef.getFreestanding()) {
+    if (auto ref = expansion->getMacroRef())
       return ref;
   }
 
@@ -1501,14 +1412,16 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   // If we already have a MacroExpansionExpr, use that. Otherwise,
   // create one.
   MacroExpansionExpr *macroExpansion;
-  if (auto *expr = macroRef.getExpr()) {
-    macroExpansion = expr;
-  } else if (auto *decl = macroRef.getDecl()) {
-    macroExpansion = new (ctx) MacroExpansionExpr(
-        dc, decl->getExpansionInfo(), roles);
+  if (auto *expansion = macroRef.getFreestanding()) {
+    if (auto *expr = dyn_cast<MacroExpansionExpr>(expansion)) {
+      macroExpansion = expr;
+    } else {
+      macroExpansion = new (ctx) MacroExpansionExpr(
+          dc, expansion->getExpansionInfo(), roles);
+    }
   } else {
     SourceRange genericArgsRange = macroRef.getGenericArgsRange();
-    macroExpansion = new (ctx) MacroExpansionExpr(
+    macroExpansion = MacroExpansionExpr::create(
       dc, macroRef.getSigilLoc(), macroRef.getMacroName(),
       macroRef.getMacroNameLoc(), genericArgsRange.Start,
       macroRef.getGenericArgs(), genericArgsRange.End,
@@ -1527,10 +1440,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   // reference. If we got a reference, store it there, too.
   // FIXME: This duplication of state is really unfortunate.
   if (auto ref = macroExpansion->getMacroRef()) {
-    if (auto *expr = macroRef.getExpr()) {
-      expr->setMacroRef(ref);
-    } else if (auto decl = macroRef.getDecl()) {
-      decl->setMacroRef(ref);
+    if (auto *expansion = macroRef.getFreestanding()) {
+      expansion->setMacroRef(ref);
     }
   }
 


### PR DESCRIPTION
`MacroExpansionDecl` and `MacroExpansionExpr` have many common methods. Introduce a common base class `FreestandingMacroExpansion` that holds `MacroExpansionInfo`.

Factor out common expansion logic to `evaluateFreestandingMacro` function that resembles `evaluateAttachedMacro`.
