### PR TITLE
Require `switch` on a noncopyable-type binding to be explicitly `consumed`.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4616,6 +4616,9 @@ ERROR(unknown_case_multiple_patterns,none,
 ERROR(unknown_case_must_be_last,none,
       "'@unknown' can only be applied to the last case in a switch", ())
 
+WARNING(move_only_pattern_match_not_consumed,none,
+        "noncopyable binding being pattern-matched must have the 'consume' operator applied", ())
+
 WARNING(where_on_one_item, none,
         "'where' only applies to the second pattern match in this case", ())
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6152,6 +6152,11 @@ RValue RValueEmitter::visitConsumeExpr(ConsumeExpr *E, SGFContext C) {
     mv = SGF.B.createMoveValue(E, mv);
     // Set the flag so we check this.
     cast<MoveValueInst>(mv.getValue())->setAllowsDiagnostics(true);
+    if (subType.isMoveOnly()) {
+      // We need to move-only-check the moved value.
+      mv = SGF.B.createMarkMustCheckInst(E, mv,
+                         MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
+    }
     return RValue(SGF, {mv}, subType.getASTType());
   }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -133,12 +133,10 @@ bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
           }
         }
 
-        // Any time we have a lexical move_value, we can process it.
+        // Any time we have a move_value, we can process it.
         if (auto *mvi = dyn_cast<MoveValueInst>(mmci->getOperand())) {
-          if (mvi->isLexical()) {
-            moveIntroducersToProcess.insert(mmci);
-            continue;
-          }
+          moveIntroducersToProcess.insert(mmci);
+          continue;
         }
 
         if (auto *arg = dyn_cast<SILFunctionArgument>(mmci->getOperand())) {

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -526,6 +526,22 @@ static void replaceProjectBoxUsers(SILValue heapBox, SILValue stackBox) {
   }
 }
 
+static void replaceAllNonDebugUsesWith(SILValue value,
+                                       SILValue with) {
+  auto useI = value->use_begin();
+  while (useI != value->use_end()) {
+    Operand *op = *useI;
+    ++useI;
+    // Leave debug instructions on the original value.
+    if (op->getUser()->isDebugInstruction()) {
+      continue;
+    }
+    
+    // Rewrite all other uses.
+    op->set(with);
+  }
+}
+
 static void hoistMarkMustCheckInsts(SILValue stackBox,
                                     MarkMustCheckInst::CheckKind checkKind) {
   StackList<Operand *> worklist(stackBox->getFunction());
@@ -571,7 +587,9 @@ static void hoistMarkMustCheckInsts(SILValue stackBox,
   auto *undef = SILUndef::get(stackBox->getType(), *stackBox->getModule());
 
   auto *mmci = builder.createMarkMustCheckInst(loc, undef, checkKind);
-  stackBox->replaceAllUsesWith(mmci);
+  // Leave debug uses on the to-be-promoted box, but hoist all other uses to the
+  // new mark_must_check.
+  replaceAllNonDebugUsesWith(stackBox, mmci);
   mmci->setOperand(stackBox);
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -876,6 +876,7 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
   bool hadError = TypeChecker::typeCheckBinding(pattern, init, dc, patternType);
   elt.setPattern(pattern);
   elt.setInitializer(init);
+  
   isFalsable |= pattern->isRefutablePattern();
   return hadError;
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1741,10 +1741,10 @@ public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{missi
 public func enumPatternMatchIfLet1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1752,10 +1752,10 @@ public func enumPatternMatchIfLet1() {
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed here}}
         // expected-note @-1 {{consumed again here}}
         borrowVal(x)
     }
@@ -1765,7 +1765,7 @@ public func enumPatternMatchIfLet2() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed in a loop}}
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let EnumTy.klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1773,7 +1773,7 @@ public func enumPatternMatchIfLet2() {
 
 public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let EnumTy.klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1782,7 +1782,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{
 public func enumPatternMatchSwitch1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -1792,7 +1792,7 @@ public func enumPatternMatchSwitch1() {
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         borrowVal(x2)
@@ -1804,7 +1804,7 @@ public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {
 public func enumPatternMatchSwitch2() {
     var x2 = EnumTy.klass(Klass())
     x2 = EnumTy.klass(Klass())
-    switch x2 {
+    switch consume x2 {
     case let EnumTy.klass(k):
         borrowVal(k)
     case .int:
@@ -1813,7 +1813,7 @@ public func enumPatternMatchSwitch2() {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
     case .int:
@@ -1825,7 +1825,7 @@ public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {
 public func enumPatternMatchSwitch2WhereClause() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -1837,7 +1837,7 @@ public func enumPatternMatchSwitch2WhereClause() {
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -1851,7 +1851,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expec
 public func enumPatternMatchSwitch2WhereClause2() {
     var x2 = EnumTy.klass(Klass())
     x2 = EnumTy.klass(Klass())
-    switch x2 {
+    switch consume x2 {
     case let EnumTy.klass(k)
            where boolValue:
         borrowVal(k)
@@ -1863,7 +1863,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where boolValue:
         borrowVal(k)
@@ -3968,7 +3968,7 @@ func fieldSensitiveTestReinitFieldMultiBlock4() {
 func fieldSensitiveTestReinitEnumMultiBlock() {
     var e = NonTrivialEnum.first // expected-error {{'e' used after consume}}
     e = NonTrivialEnum.second(Klass())
-    switch e { // expected-note {{consumed here}}
+    switch consume e { // expected-note {{consumed here}}
     case .second:
         e = NonTrivialEnum.third(NonTrivialStruct())
     default:
@@ -3980,7 +3980,7 @@ func fieldSensitiveTestReinitEnumMultiBlock() {
 func fieldSensitiveTestReinitEnumMultiBlock1() {
     var e = NonTrivialEnum.first
     e = NonTrivialEnum.second(Klass())
-    switch e {
+    switch consume e {
     case .second:
         e = NonTrivialEnum.third(NonTrivialStruct())
     default:
@@ -3993,7 +3993,7 @@ func fieldSensitiveTestReinitEnumMultiBlock2() {
     var e = NonTrivialEnum.first
     e = NonTrivialEnum.second(Klass())
     if boolValue {
-        switch e {
+        switch consume e {
         case .second:
             e = NonTrivialEnum.third(NonTrivialStruct())
         default:
@@ -4398,54 +4398,54 @@ func borrow(_ x: borrowing MyEnum) {}
 
 func testMyEnum() {
   func test1(_ x: consuming MyEnum) {
-    if case let .first(y) = x {
+    if case let .first(y) = consume x {
       _ = y
     }
   }
 
   func test1a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .first(y) = x { // expected-note {{consumed here}}
+    if case let .first(y) = consume x { // expected-note {{consumed here}}
       _ = consume x // expected-note {{consumed again here}}
       _ = y
     }
   }
 
   func test1b(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .first(y) = x { // expected-note {{consumed here}}
+    if case let .first(y) = consume x { // expected-note {{consumed here}}
       _ = y
     }
     _ = consume x // expected-note {{consumed again here}}
   }
 
   func test2(_ x: consuming MyEnum) {
-    if case let .third(.first(y)) = x {
+    if case let .third(.first(y)) = consume x {
       _ = y
     }
   }
 
   func test2a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
+    if case let .third(.first(y)) = consume x { // expected-note {{consumed here}}
       _ = consume x // expected-note {{consumed again here}}
       _ = y
     }
   }
 
   func test2b(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
+    if case let .third(.first(y)) = consume x { // expected-note {{consumed here}}
       _ = y
     }
     _ = consume x // expected-note {{consumed again here}}
   }
 
   func test2c(_ x: consuming MyEnum) { // expected-error {{'x' used after consume}}
-    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
+    if case let .third(.first(y)) = consume x { // expected-note {{consumed here}}
       _ = y
     }
     borrow(x) // expected-note {{used here}}
   }
 
   func test3(_ x: consuming MyEnum) {
-    switch x {
+    switch consume x {
     case let .first(y):
       _ = y
       break
@@ -4455,7 +4455,7 @@ func testMyEnum() {
   }
 
   func test3a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    switch x { // expected-note {{consumed here}}
+    switch consume x { // expected-note {{consumed here}}
     case let .first(y):
       _ = y
       break
@@ -4466,7 +4466,7 @@ func testMyEnum() {
   }
 
   func test4(_ x: consuming MyEnum) {
-    switch x {
+    switch consume x {
     case let .third(.first(y)):
       _ = y
       break
@@ -4476,7 +4476,7 @@ func testMyEnum() {
   }
 
   func test4a(_ x: consuming MyEnum) { // expected-error {{'x' consumed more than once}}
-    switch x { // expected-note {{consumed here}}
+    switch consume x { // expected-note {{consumed here}}
     case let .third(.first(y)):
       _ = y
       break

--- a/test/SILOptimizer/moveonly_discard.swift
+++ b/test/SILOptimizer/moveonly_discard.swift
@@ -84,7 +84,7 @@ final class Wallet {
   }
 
   __consuming func inspect() { // expected-error {{'self' consumed more than once}}
-    switch self { // expected-note {{consumed here}}
+    switch consume self { // expected-note {{consumed here}}
     case .green, .yellow, .red:
       discard self // expected-note {{consumed again here}}
     default:

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2476,37 +2476,37 @@ public func enumAssignToVar5OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming Enu
 public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -2515,7 +2515,7 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
     let x2 = x // expected-error {{'x2' consumed in a loop}}
                // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -2523,7 +2523,7 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
 
 public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -2531,7 +2531,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-erro
 
 public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -2539,7 +2539,7 @@ public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-e
 
 public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -2548,7 +2548,7 @@ public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expecte
 public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consumed here}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -2558,7 +2558,7 @@ public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -2570,7 +2570,7 @@ public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-err
 }
 
 public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -2580,7 +2580,7 @@ public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-
 }
 
 public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -2591,7 +2591,7 @@ public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expect
 
 public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consumed here}}
-    switch x2 {
+    switch consume x2 {
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -2600,7 +2600,7 @@ public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -2609,7 +2609,7 @@ public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-err
 }
 
 public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -2618,7 +2618,7 @@ public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
 }
 
 public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -2630,7 +2630,7 @@ public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
 public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consumed here}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -2642,7 +2642,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expec
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -2654,7 +2654,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // e
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -2666,7 +2666,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -2679,7 +2679,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) 
 
 public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consumed here}}
-    switch x2 {
+    switch consume x2 {
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -2691,7 +2691,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expe
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -2703,7 +2703,7 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // 
 }
 
 public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -2715,7 +2715,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 }
 
 public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -4036,7 +4036,7 @@ enum EnumSwitchTests {
 func consumeVal(_ e: __owned EnumSwitchTests.E2) {}
 
 func enumSwitchTest1(_ e: __owned EnumSwitchTests.E) {
-    switch e {
+    switch consume e {
     case .first:
         break
     case .second(let x):
@@ -4057,7 +4057,7 @@ func enumSwitchTest1(_ e: __owned EnumSwitchTests.E) {
 }
 
 func enumSwitchTest2(_ e: consuming EnumSwitchTests.E) {
-    switch e {
+    switch consume e {
     case .first:
         break
     case .second(let x):
@@ -4262,13 +4262,13 @@ case third(MyEnum2)
 
 func testMyEnum() {
   func test1(_ x: borrowing MyEnum) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    if case let .first(y) = x { // expected-note {{consumed here}}
+    if case let .first(y) = consume x { // expected-note {{consumed here}}
       _ = y
     }
   }
 
   func test2(_ x: borrowing MyEnum) { // expected-error {{'x' is borrowed and cannot be consumed}}
-    if case let .third(.first(y)) = x { // expected-note {{consumed here}}
+    if case let .third(.first(y)) = consume x { // expected-note {{consumed here}}
       _ = y
     }
   }

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1020,10 +1020,10 @@ public func enumAssignToVar5Arg(_ x2: inout EnumTy) { // expected-error {{'x2' u
 public func enumPatternMatchIfLet1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1031,10 +1031,10 @@ public func enumPatternMatchIfLet1() {
 public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{missing reinitialization of inout parameter 'x2' after consume}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let EnumTy.klass(x) = x2 { // expected-note {{consumed here}}
+    if case let EnumTy.klass(x) = consume x2 { // expected-note {{consumed here}}
         // expected-note @-1 {{consumed again here}}
         borrowVal(x)
     }
@@ -1044,7 +1044,7 @@ public func enumPatternMatchIfLet2() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed in a loop}}
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let EnumTy.klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1052,7 +1052,7 @@ public func enumPatternMatchIfLet2() {
 
 public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
     for _ in 0..<1024 {
-        if case let EnumTy.klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let EnumTy.klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1062,7 +1062,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{
 public func enumPatternMatchSwitch1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -1074,7 +1074,7 @@ public func enumPatternMatchSwitch1() {
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -1088,7 +1088,7 @@ public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {
 public func enumPatternMatchSwitch2() {
     var x2 = EnumTy.klass(NonTrivialStruct())
     x2 = EnumTy.klass(NonTrivialStruct())
-    switch x2 {
+    switch consume x2 {
     case let EnumTy.klass(k):
         borrowVal(k)
     case .int:
@@ -1097,7 +1097,7 @@ public func enumPatternMatchSwitch2() {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k):
         borrowVal(k)
     case .int:
@@ -1109,7 +1109,7 @@ public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {
 public func enumPatternMatchSwitch2WhereClause() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -1121,7 +1121,7 @@ public func enumPatternMatchSwitch2WhereClause() {
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -1135,7 +1135,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expec
 public func enumPatternMatchSwitch2WhereClause2() {
     var x2 = EnumTy.klass(NonTrivialStruct())
     x2 = EnumTy.klass(NonTrivialStruct())
-    switch x2 {
+    switch consume x2 {
     case let EnumTy.klass(k)
            where boolValue:
         borrowVal(k)
@@ -1147,7 +1147,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expected-error {{missing reinitialization of inout parameter 'x2' after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let EnumTy.klass(k)
            where boolValue:
         borrowVal(k)

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1472,37 +1472,37 @@ public func enumAssignToVar5OwnedArg2(_ x: borrowing EnumTy, _ x2: consuming Enu
 public func enumPatternMatchIfLet1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consumed here}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x.i)
     }
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x.i)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed more than once}}
-    if case let .klass(x) = x2 { // expected-note {{consumed here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed here}}
         borrowVal(x)
     }
-    if case let .klass(x) = x2 { // expected-note {{consumed again here}}
+    if case let .klass(x) = consume x2 { // expected-note {{consumed again here}}
         borrowVal(x)
     }
 }
@@ -1511,7 +1511,7 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
     let x2 = x // expected-error {{'x2' consumed in a loop}}
                // expected-note @-1 {{consumed here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1519,7 +1519,7 @@ public func enumPatternMatchIfLet2(_ x: borrowing EnumTy) { // expected-error {{
 
 public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1527,7 +1527,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: borrowing EnumTy) { // expected-erro
 
 public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1535,7 +1535,7 @@ public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-e
 
 public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' consumed in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consumed here}}
+        if case let .klass(x) = consume x2 {  // expected-note {{consumed here}}
             borrowVal(x)
         }
     }
@@ -1544,7 +1544,7 @@ public func enumPatternMatchIfLet2OwnedArg2(_ x2: consuming EnumTy) { // expecte
 public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consumed here}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -1554,7 +1554,7 @@ public func enumPatternMatchSwitch1(_ x: borrowing EnumTy) { // expected-error {
 }
 
 public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
@@ -1566,7 +1566,7 @@ public func enumPatternMatchSwitch1Arg(_ x2: borrowing EnumTy) { // expected-err
 }
 
 public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -1576,7 +1576,7 @@ public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-
 }
 
 public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
         borrowVal(x2) // expected-note {{used here}}
@@ -1587,7 +1587,7 @@ public func enumPatternMatchSwitch1OwnedArg2(_ x2: consuming EnumTy) { // expect
 
 public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consumed here}}
-    switch x2 {
+    switch consume x2 {
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -1596,7 +1596,7 @@ public func enumPatternMatchSwitch2(_ x: borrowing EnumTy) { // expected-error {
 }
 
 public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -1605,7 +1605,7 @@ public func enumPatternMatchSwitch2Arg(_ x2: borrowing EnumTy) { // expected-err
 }
 
 public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -1614,7 +1614,7 @@ public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
 }
 
 public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k):
         borrowVal(k)
     case .int:
@@ -1626,7 +1626,7 @@ public func enumPatternMatchSwitch2OwnedArg2(_ x2: consuming EnumTy) {
 public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consumed here}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -1638,7 +1638,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: borrowing EnumTy) { // expec
 }
 
 public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething():
         borrowVal(k)
@@ -1650,7 +1650,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: borrowing EnumTy) { // e
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -1662,7 +1662,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
 }
 
 public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) { // expected-error {{'x2' used after consume}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where x2.doSomething(): // expected-note {{used here}}
         borrowVal(k)
@@ -1675,7 +1675,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg2(_ x2: consuming EnumTy) 
 
 public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expected-error {{'x' is borrowed and cannot be consumed}}
     let x2 = x // expected-note {{consumed here}}
-    switch x2 {
+    switch consume x2 {
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -1687,7 +1687,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: borrowing EnumTy) { // expe
 }
 
 public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // expected-error {{'x2' is borrowed and cannot be consumed}}
-    switch x2 { // expected-note {{consumed here}}
+    switch consume x2 { // expected-note {{consumed here}}
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -1699,7 +1699,7 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: borrowing EnumTy) { // 
 }
 
 public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k)
            where boolValue:
         borrowVal(k)
@@ -1711,7 +1711,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 }
 
 public func enumPatternMatchSwitch2WhereClause2OwnedArg2(_ x2: consuming EnumTy) {
-    switch x2 {
+    switch consume x2 {
     case let .klass(k)
            where boolValue:
         borrowVal(k)

--- a/test/Sema/discard.swift
+++ b/test/Sema/discard.swift
@@ -127,7 +127,7 @@ enum E: Error { case err }
   }
 
   __consuming func take() throws -> File {
-    if case let .valid(f) = self {
+    if case let .valid(f) = consume self {
       return f
     }
     discard self
@@ -136,7 +136,7 @@ enum E: Error { case err }
 
   var validFile: File {
     __consuming get {
-      if case let .valid(f) = self {
+      if case let .valid(f) = consume self {
         return f
       }
       discard self

--- a/test/Sema/moveonly_enum.swift
+++ b/test/Sema/moveonly_enum.swift
@@ -8,3 +8,231 @@ enum Foo {
 @_moveOnly
 enum Foo2 {
 }
+
+@_moveOnly
+struct Bar {
+    var x: Int
+}
+
+@_moveOnly
+enum Foo3 {
+    case foo(Int)
+    case bar(String)
+    case bas
+}
+
+func test_switch(x: consuming Foo3) {
+    switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
+    default:
+        break
+    }
+
+    switch consume x {
+    default:
+        break
+    }
+
+    switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
+    default:
+        break
+    }
+
+    switch (consume x) {
+    default:
+        break
+    }
+
+    let _: () -> () = {
+        switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
+        default:
+            break
+        }
+    }
+
+    let _: () -> () = {
+        switch consume x {
+        default:
+            break
+        }
+    }
+
+    let _: () -> () = {
+        switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
+        default:
+            break
+        }
+    }
+
+    let _: () -> () = {
+        switch (consume x) {
+        default:
+            break
+        }
+    }
+}
+
+func test_if_case(x: consuming Foo3) {
+    if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
+
+    guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
+    _ = y
+
+    if case .bar(let z) = consume x { _ = z }
+
+    guard case .bar(let z) = consume x else { return }
+    _ = z
+
+    if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
+
+    guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    _ = a
+
+    if case .bar(let b) = (consume x) { _ = b }
+
+    guard case .bar(let b) = (consume x) else { return }
+    _ = b
+
+    let _: () -> () = {
+        if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    }
+
+    let _: () -> () = {
+        guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
+        _ = y
+    }
+
+    let _: () -> () = {
+        if case .bar(let z) = consume x { _ = z }
+    }
+
+    let _: () -> () = {
+        guard case .bar(let z) = consume x else { return }
+        _ = z
+    }
+
+    let _: () -> () = {
+        if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
+    }
+
+    let _: () -> () = {
+        guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
+        _ = a
+    }
+
+    let _: () -> () = {
+        if case .bar(let b) = (consume x) { _ = b }
+    }
+
+    let _: () -> () = {
+        guard case .bar(let b) = (consume x) else { return }
+        _ = b
+    }
+}
+
+func test_switch_b(x: __owned Foo3) {
+    switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
+    default:
+        break
+    }
+
+    switch consume x {
+    default:
+        break
+    }
+
+    switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
+    default:
+        break
+    }
+
+    switch (consume x) {
+    default:
+        break
+    }
+
+    let _: () -> () = {
+        switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
+        default:
+            break
+        }
+    }
+
+    let _: () -> () = {
+        switch consume x {
+        default:
+            break
+        }
+    }
+
+    let _: () -> () = {
+        switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
+        default:
+            break
+        }
+    }
+
+    let _: () -> () = {
+        switch (consume x) {
+        default:
+            break
+        }
+    }
+}
+
+func test_if_case_b(x: __owned Foo3) {
+    if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
+
+    guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
+    _ = y
+
+    if case .bar(let z) = consume x { _ = z }
+
+    guard case .bar(let z) = consume x else { return }
+    _ = z
+
+    if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
+
+    guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    _ = a
+
+    if case .bar(let b) = (consume x) { _ = b }
+
+    guard case .bar(let b) = (consume x) else { return }
+    _ = b
+
+    let _: () -> () = {
+        if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    }
+
+    let _: () -> () = {
+        guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
+        _ = y
+    }
+
+    let _: () -> () = {
+        if case .bar(let z) = consume x { _ = z }
+    }
+
+    let _: () -> () = {
+        guard case .bar(let z) = consume x else { return }
+        _ = z
+    }
+
+    let _: () -> () = {
+        if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
+    }
+
+    let _: () -> () = {
+        guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
+        _ = a
+    }
+
+    let _: () -> () = {
+        if case .bar(let b) = (consume x) { _ = b }
+    }
+
+    let _: () -> () = {
+        guard case .bar(let b) = (consume x) else { return }
+        _ = b
+    }
+}


### PR DESCRIPTION
Pattern matching as currently implemented is consuming, but that's not necessarily what we want to be the default behavior when borrowing pattern matching is implemented. When a binding of noncopyable type is pattern-matched, require it to be annotated with the `consume` operator explicitly. That way, when we introduce borrowing pattern matching later, we have the option to make `switch x` do the right thing without subtly changing the behavior of existing code. rdar://110073984