### PR TITLE
[Mem2Reg] Recognize store_borrows for debug_value.

### DIFF
--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -40,6 +40,12 @@ struct LargeCodesizeStruct {
   var s5: SmallCodesizeStruct
 }
 
+class C {}
+
+struct S {
+  var field: C
+}
+
 ///////////
 // Tests //
 ///////////
@@ -654,6 +660,71 @@ bb15:
 
 bb16:
   dealloc_stack %addr : $*FakeOptional<Klass>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @debug_value_of_store_borrow_addr_multi_block : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         debug_value [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'debug_value_of_store_borrow_addr_multi_block'
+sil [ossa] @debug_value_of_store_borrow_addr_multi_block : $@convention(thin) (@owned S) -> () {
+entry(%instance : @owned $S):
+  br header
+
+header:
+  %lifetime = begin_borrow %instance : $S
+  %stack = alloc_stack $S
+  %stack_borrow = store_borrow %lifetime to %stack : $*S
+  debug_value %stack_borrow : $*S
+  br body
+
+body:
+  %field_addr = struct_element_addr %stack_borrow : $*S, #S.field
+  %field = load [copy] %field_addr : $*C
+  end_borrow %stack_borrow : $*S
+  dealloc_stack %stack : $*S
+  end_borrow %lifetime : $S
+  destroy_value %field : $C
+  cond_br undef, backedge, exit
+
+backedge:
+  br header
+
+exit:
+  destroy_value %instance : $S
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @debug_value_of_store_borrow_addr_single_block : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         debug_value [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'debug_value_of_store_borrow_addr_single_block'
+sil [ossa] @debug_value_of_store_borrow_addr_single_block : $@convention(thin) (@owned S) -> () {
+entry(%instance : @owned $S):
+  br header
+
+header:
+  %lifetime = begin_borrow %instance : $S
+  %stack = alloc_stack $S
+  %stack_borrow = store_borrow %lifetime to %stack : $*S
+  debug_value %stack_borrow : $*S
+  %field_addr = struct_element_addr %stack_borrow : $*S, #S.field
+  %field = load [copy] %field_addr : $*C
+  end_borrow %stack_borrow : $*S
+  dealloc_stack %stack : $*S
+  end_borrow %lifetime : $S
+  destroy_value %field : $C
+  cond_br undef, backedge, exit
+
+backedge:
+  br header
+
+exit:
+  destroy_value %instance : $S
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
When `debug_value`s are visited, if their operand is the stack address, they are rewritten as `debug_value`s of the stored value, provided it is known.

Previously, the check for whether the operand is the stack address, however, just compared the `debug_value`'s operand with the `alloc_stack`.  For owned `alloc_stack`s (i.e. those that are not "store_borrow locations"), that was correct.  For guaranteed `alloc_stack`s (i.e. those that are "store_borrow locations"), however, this failed to recognize the the values produced by the `store_borrow` instructions (which amount to aliases for the `alloc_stack`) as the stack address.

Here, this is fixed by checking whether the `debug_value`'s operand is either (1) the `alloc_stack` itself or (2) some `store_borrow` whose destination is the `alloc_stack`.

rdar://109894792
