### PR TITLE
Remove #ifndef on skipVarDeclAssert in SILBuilder::createAllocBox signature

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -480,14 +480,14 @@ public:
                                Optional<SILDebugVariable> Var = None,
                                bool hasDynamicLifetime = false,
                                bool reflection = false,
-                               bool usesMoveableValueDebugInfo = false
-#ifndef NDEBUG
-                               ,
+                               bool usesMoveableValueDebugInfo = false,
                                bool skipVarDeclAssert = false,
-#endif
                                bool hasPointerEscape = false) {
     llvm::SmallString<4> Name;
     Loc.markAsPrologue();
+#if defined(NDEBUG)
+    (void) skipVarDeclAssert;
+#endif
     assert((skipVarDeclAssert ||
             !dyn_cast_or_null<VarDecl>(Loc.getAsASTNode<Decl>()) || Var) &&
            "location is a VarDecl, but SILDebugVariable is empty");

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -955,11 +955,9 @@ SILCloner<ImplClass>::visitAllocBoxInst(AllocBoxInst *Inst) {
       Inst,
       getBuilder().createAllocBox(
           Loc, this->getOpType(Inst->getType()).template castTo<SILBoxType>(),
-          VarInfo, false, false, false
-#ifndef NDEBUG
-          ,
-          true
-#endif
+          VarInfo, /*hasDynamicLifetime*/ false,
+          /*reflection*/ false,
+          /*usesMoveableValueDebugInfo*/ false, /*skipVarDeclAssert*/ true
           ));
 }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -519,12 +519,10 @@ public:
     Optional<SILDebugVariable> DbgVar;
     if (generateDebugInfo)
       DbgVar = SILDebugVariable(decl->isLet(), ArgNo);
-    Box = SGF.B.createAllocBox(decl, boxType, DbgVar, false, false, false
-#ifndef NDEBUG
-                               ,
-                               !generateDebugInfo
-#endif
-    );
+    Box = SGF.B.createAllocBox(
+        decl, boxType, DbgVar, /*hasDynamicLifetime*/ false,
+        /*reflection*/ false, /*usesMoveableValueDebugInfo*/ false,
+        !generateDebugInfo);
 
     // Mark the memory as uninitialized, so DI will track it for us.
     if (kind)


### PR DESCRIPTION
Follow up for https://github.com/apple/swift/pull/66187