### PR TITLE
Macro tests for fixed bugs

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1505,3 +1505,29 @@ public struct SingleMemberMacro: MemberMacro {
     ]
   }
 }
+
+public struct UseIdentifierMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let argument = node.argumentList.first?.expression.as(StringLiteralExprSyntax.self) else {
+      fatalError("boom")
+    }
+    return [
+      """
+      func \(context.makeUniqueName("name"))() {
+        _ = \(raw: argument.segments.first!)
+      }
+      """,
+      """
+      struct Foo {
+        var \(context.makeUniqueName("name")): Int {
+          _ = \(raw: argument.segments.first!)
+          return 0
+        }
+      }
+      """
+    ]
+  }
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -24,7 +24,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -emit-ir -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-IR %s
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5 -g -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -g -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -Xfrontend -emit-dependencies-path -Xfrontend %t/main.d -Xfrontend -emit-reference-dependencies-path -Xfrontend %t/main.swiftdeps
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Macros/macro_expand_primary.swift
+++ b/test/Macros/macro_expand_primary.swift
@@ -85,3 +85,13 @@ final class Dog: Observable {
 func test() {
   observeDog()
 }
+
+
+@freestanding(declaration, names: named(Foo)) macro useIdentifier(_ value: String) = #externalMacro(module: "MacroDefinition", type: "UseIdentifierMacro")
+
+#if false
+#useIdentifier("totallyNotDefined")
+#else
+let hello = "Hello"
+#useIdentifier("hello")
+#endif


### PR DESCRIPTION
Add tests for already-fixed bugs with macros:
* Crash while emitting reference dependencies (rdar://108300632)
* Expanding macros in unvisited `#if` blocks (rdar://110083415), thanks to @rxwei 