### PR TITLE
[IRGen] Mask off metadata pack passed to DebugInfo

### DIFF
--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -210,10 +210,8 @@ static Address emitFixedSizeMetadataPackRef(IRGenFunction &IGF,
   return pack;
 }
 
-/// Use this to index into packs to correctly handle on-heap packs.
-static llvm::Value *loadMetadataAtIndex(IRGenFunction &IGF,
-                                        llvm::Value *patternPack,
-                                        llvm::Value *index) {
+llvm::Value *irgen::maskMetadataPackPointer(IRGenFunction &IGF,
+                                            llvm::Value *patternPack) {
   // If the pack is on the heap, the LSB is set, so mask it off.
   patternPack =
       IGF.Builder.CreatePtrToInt(patternPack, IGF.IGM.SizeTy);
@@ -221,6 +219,14 @@ static llvm::Value *loadMetadataAtIndex(IRGenFunction &IGF,
       IGF.Builder.CreateAnd(patternPack, llvm::ConstantInt::get(IGF.IGM.SizeTy, -2));
   patternPack =
       IGF.Builder.CreateIntToPtr(patternPack, IGF.IGM.TypeMetadataPtrPtrTy);
+  return patternPack;
+}
+
+/// Use this to index into packs to correctly handle on-heap packs.
+static llvm::Value *loadMetadataAtIndex(IRGenFunction &IGF,
+                                        llvm::Value *patternPack,
+                                        llvm::Value *index) {
+  patternPack = maskMetadataPackPointer(IGF, patternPack);
 
   Address patternPackAddress(patternPack, IGF.IGM.TypeMetadataPtrTy,
                              IGF.IGM.getPointerAlignment());

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -53,6 +53,10 @@ emitTypeMetadataPackRef(IRGenFunction &IGF,
                         CanPackType packType,
                         DynamicMetadataRequest request);
 
+/// Given a pointer to a potentially heap-allocated pack of metadata/wtables,
+/// mask off the bit that indicates whether it is heap allocated.
+llvm::Value *maskMetadataPackPointer(IRGenFunction &IGF, llvm::Value *);
+
 void bindOpenedElementArchetypesAtIndex(IRGenFunction &IGF,
                                         GenericEnvironment *env,
                                         llvm::Value *index);

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -19,6 +19,7 @@
 #include "Fulfillment.h"
 #include "GenMeta.h"
 #include "GenOpaque.h"
+#include "GenPack.h"
 #include "GenProto.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
@@ -349,6 +350,9 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
   auto name = typeParam->getName().str();
 
   llvm::Value *data = value.getMetadata();
+
+  if (key.Type->is<PackArchetypeType>())
+    data = maskMetadataPackPointer(IGF, data);
 
   // At -O0, create an alloca to keep the type alive. Not for async functions
   // though; see the comment in IRGenFunctionSIL::emitShadowCopyIfNeeded().

--- a/test/DebugInfo/variadic-generics.swift
+++ b/test/DebugInfo/variadic-generics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -o - \
-// RUN:    -parse-as-library -module-name a | %FileCheck %s
+// RUN:    -parse-as-library -module-name a | %IRGenFileCheck %s
 
 public func foo<each T>(args: repeat each T) {
   // CHECK: define {{.*}} @"$s1a3foo4argsyxxQp_tRvzlF"
@@ -8,9 +8,12 @@ public func foo<each T>(args: repeat each T) {
   // CHECK: call void @llvm.dbg.declare(metadata %swift.type*** %[[TYPE_PACK_ALLOCA]], metadata ![[TYPE_PACK_VAR:[0-9]+]], metadata !DIExpression())
   // CHECK: %[[ARGS_ALLOCA:.*]] = alloca %swift.opaque**
   // CHECK-DAG: call void @llvm.dbg.declare(metadata %swift.opaque*** %[[ARGS_ALLOCA]], metadata ![[ARGS_VAR:[0-9]+]], metadata !DIExpression(DW_OP_deref))
-  // CHECK-DAG: store %swift.type** %[[TYPE_PACK_ARG]], %swift.type*** %[[TYPE_PACK_ALLOCA]]
+  // CHECK-DAG: %[[TYPE_PACK_ARG_INT:[^,]+]] = ptrtoint %swift.type** %[[TYPE_PACK_ARG]] to [[INT]]
+  // CHECK-DAG: %[[TYPE_PACK_ARG_MASKED_INT:[^,]+]] = and [[INT]] %[[TYPE_PACK_ARG_INT]], -2
+  // CHECK-DAG: %[[TYPE_PACK_ARG_MASKED:[^,]+]] = inttoptr [[INT]] %[[TYPE_PACK_ARG_MASKED_INT]] to %swift.type**
+  // CHECK-DAG: store %swift.type** %[[TYPE_PACK_ARG_MASKED]], %swift.type*** %[[TYPE_PACK_ALLOCA]]
   // CHECK-DAG: store %swift.opaque** %0, %swift.opaque*** %[[ARGS_ALLOCA]]
-  // CHECK-DAG: ![[ARGS_VAR]] = !DILocalVariable(name: "args", arg: 1, {{.*}}line: [[@LINE-9]], type: ![[ARGS_LET_TY:[0-9]+]])
+  // CHECK-DAG: ![[ARGS_VAR]] = !DILocalVariable(name: "args", arg: 1, {{.*}}line: [[@LINE-12]], type: ![[ARGS_LET_TY:[0-9]+]])
   // CHECK-DAG: ![[ARGS_LET_TY]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[ARGS_TY:[0-9]+]])
   // CHECK-DAG: ![[ARGS_TY]] = !DICompositeType({{.*}}identifier: "$sxxQp_QSiD")
   // CHECK-DAG: ![[TYPE_PACK_VAR]] = !DILocalVariable(name: "$\CF\84_0_0", {{.*}}type: ![[TYPE_PACK_TYD:[0-9]+]], flags: DIFlagArtificial)

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) -parse-stdlib %S/../Inputs/print-shims-stdlib.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(PrintShims)
-// RUN: %target-build-swift -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim -Onone | %FileCheck %s --check-prefixes=CHECK-LL,CHECK-LL-UNOPT
+// RUN: %target-build-swift -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim -O | %FileCheck %s --check-prefixes=CHECK-LL,CHECK-LL-OPT
 // RUN: %target-build-swift -g -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
@@ -568,6 +569,7 @@ entry(%intIndex : $Builtin.Word):
 
 // Verify that we just gep into a parameter pack when that's all that the pack consists of.
 // CHECK-LL: define {{.*}}void @direct_access_from_parameter(i{{(32|64)}} [[INDEX:%[^,]+]], i{{(32|64)}} {{%[^,]+}}, %swift.type** [[PACK:%[^,]+]])
+// CHECK-LL-UNOPT:  [[PACK_ADDR_FOR_DI:%.*]] = ptrtoint %swift.type** [[PACK]] to i{{(32|64)}}
 // CHECK-LL:  [[PACK_ADDR:%.*]] = ptrtoint %swift.type** [[PACK]] to i{{(32|64)}}
 // CHECK-LL:  [[PACK_ADDR2:%.*]] = and i{{(32|64)}} [[PACK_ADDR]], -2
 // CHECK-LL:  [[PACK:%.*]] = inttoptr i{{(32|64)}} [[PACK_ADDR2]] to %swift.type**
@@ -591,6 +593,7 @@ entry(%intIndex : $Builtin.Word):
 // CHECK-LL-SAME:        i{{(32|64)}} {{%[^,]+}},
 // CHECK-LL-SAME:        %swift.type** [[METADATA_PACK:%[^,]+]],
 // CHECK-LL-SAME:        i8*** [[WTABLE_PACK:%[^,]+]])
+// CHECK-LL-UNOPT:   [[PACK_ADDR_FOR_DI:%.*]] = ptrtoint %swift.type** [[METADATA_PACK]] to i{{(32|64)}}
 // CHECK-LL:         [[PACK_ADDR:%.*]] = ptrtoint %swift.type** [[METADATA_PACK]] to i{{(32|64)}}
 // CHECK-LL:         [[PACK_ADDR2:%.*]] = and i{{(32|64)}} [[PACK_ADDR]], -2
 // CHECK-LL:         [[METADATA_PACK:%.*]] = inttoptr i{{(32|64)}} [[PACK_ADDR2]] to %swift.type**

--- a/test/IRGen/variadic_generic_outlining.sil
+++ b/test/IRGen/variadic_generic_outlining.sil
@@ -11,6 +11,7 @@ struct Wrapper<Value> {
 // an opened element type.
 //
 // CHECK-LABEL: define{{.*}}void @test_outlining
+// CHECK:       [[PACK_ADDR_FOR_DEBUGINFO:%.*]] = ptrtoint %swift.type** %"each T" to [[INT]]
 // CHECK:       [[PACK_ADDR:%.*]] = ptrtoint %swift.type** %"each T" to [[INT]]
 // CHECK-NEXT:  [[PACK_ADDR2:%.*]] = and [[INT]] [[PACK_ADDR]], -2
 // CHECK-NEXT:  [[PACK:%.*]] = inttoptr [[INT]] [[PACK_ADDR2]] to %swift.type**


### PR DESCRIPTION
When a metadata pack is heap allocated, the pointer's LSB is set. But lldb is expecting a real pointer.  So mask it off.

Companion PR has a test: https://github.com/apple/llvm-project/pull/6961

rdar://110195273
