### PR TITLE
[Test] Add test for already-fixed macro example.

### DIFF
--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -418,3 +418,10 @@ func testFreestandingClosureNesting() {
 func testLocalVarsFromDeclarationMacros() {
   #varValue
 }
+
+// Variadic macro
+@freestanding(declaration, names: arbitrary) macro emptyDecl(_: String...) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
+
+struct TakesVariadic {
+  #emptyDecl("foo", "bar")
+}


### PR DESCRIPTION
This used to cause a circular reference and crash. No more, but make sure we don't regress it. From rdar://109280926.
