### PR TITLE
Only inject macro-introduced operators into module scope

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1553,3 +1553,15 @@ public struct SelfAlwaysEqualOperator: DeclarationMacro {
     ]
   }
 }
+
+extension SelfAlwaysEqualOperator: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "static func ==(lhs: Self, rhs: Bool) -> Bool { true }",
+    ]
+  }
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1531,3 +1531,25 @@ public struct UseIdentifierMacro: DeclarationMacro {
     ]
   }
 }
+
+public struct StaticFooFuncMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "static func foo() {}",
+    ]
+  }
+}
+
+public struct SelfAlwaysEqualOperator: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "static func ==(lhs: Self, rhs: Bool) -> Bool { true }",
+    ]
+  }
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -425,3 +425,37 @@ func testLocalVarsFromDeclarationMacros() {
 struct TakesVariadic {
   #emptyDecl("foo", "bar")
 }
+
+// Funkiness with static functions introduced via macro expansions.
+@freestanding(declaration, names: named(foo())) public macro staticFooFunc() = #externalMacro(module: "MacroDefinition", type: "StaticFooFuncMacro")
+@freestanding(declaration, names: arbitrary) public macro staticFooFuncArbitrary() = #externalMacro(module: "MacroDefinition", type: "StaticFooFuncMacro")
+
+class HasAnExpandedStatic {
+  #staticFooFunc()
+}
+
+class HasAnExpandedStatic2 {
+  #staticFooFuncArbitrary()
+}
+
+func testHasAnExpandedStatic() {
+#if TEST_DIAGNOSTICS
+  foo() // expected-error{{cannot find 'foo' in scope}}
+#endif
+}
+
+@freestanding(declaration, names: named(==)) public macro addSelfEqualsOperator() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+@freestanding(declaration, names: arbitrary) public macro addSelfEqualsOperatorArbitrary() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+
+struct HasEqualsSelf {
+  #addSelfEqualsOperator
+}
+
+struct HasEqualsSelf2 {
+  #addSelfEqualsOperatorArbitrary
+}
+
+func testHasEqualsSelf(x: HasEqualsSelf, y: HasEqualsSelf2) {
+  _ = (x == true)
+  _ = (y == true)
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -446,6 +446,8 @@ func testHasAnExpandedStatic() {
 
 @freestanding(declaration, names: named(==)) public macro addSelfEqualsOperator() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
 @freestanding(declaration, names: arbitrary) public macro addSelfEqualsOperatorArbitrary() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+@attached(member, names: named(==)) public macro AddSelfEqualsMemberOperator() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+@attached(member, names: arbitrary) public macro AddSelfEqualsMemberOperatorArbitrary() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
 
 struct HasEqualsSelf {
   #addSelfEqualsOperator
@@ -455,7 +457,26 @@ struct HasEqualsSelf2 {
   #addSelfEqualsOperatorArbitrary
 }
 
-func testHasEqualsSelf(x: HasEqualsSelf, y: HasEqualsSelf2) {
+@AddSelfEqualsMemberOperator
+struct HasEqualsSelf3 {
+}
+
+@AddSelfEqualsMemberOperatorArbitrary
+struct HasEqualsSelf4 {
+}
+
+func testHasEqualsSelf(
+  x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4
+) {
   _ = (x == true)
   _ = (y == true)
+#if TEST_DIAGNOSTICS
+  // FIXME: This is technically a bug, because we should be able to find the
+  // == operator introduced through a member operator. However, we might
+  // want to change the rule rather than implement this.
+  _ = (z == true) // expected-error{{binary operator '==' cannot be applied to operands}}
+  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
+  _ = (w == true) // expected-error{{binary operator '==' cannot be applied to operands}}
+  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
+  #endif
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -418,3 +418,10 @@ func testFreestandingClosureNesting() {
 func testLocalVarsFromDeclarationMacros() {
   #varValue
 }
+
+// Variadic macro
+@freestanding(declaration, names: arbitrary) macro emptyDecl(_: String...) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
+
+struct TakesVariadic {
+  #emptyDecl("foo", "bar")
+}


### PR DESCRIPTION
Well, this is fun. Due to the use of the module-scope lookup table to
find operators, we need to carefully filter out any macro-introduced
declarations that *aren't* operators when forming the module-scope
lookup table. Otherwise, we can find macro-introduced static entities
within types... from completely unrelated scopes.

Fixes rdar://109219036.