### PR TITLE
Eliminate macro-generated operators from global operator lookup

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -35,8 +35,10 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/NameLookup.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/PotentialMacroExpansions.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeDeclFinder.h"
@@ -1318,6 +1320,25 @@ WitnessChecker::lookupValueWitnessesViaImplementsAttr(
   removeShadowedDecls(witnesses, DC);
 }
 
+/// Determine whether the given context may expand an operator with the given name.
+static bool contextMayExpandOperator(
+    DeclContext *dc, DeclBaseName operatorName
+) {
+  TypeOrExtensionDecl decl;
+  if (auto nominal = dyn_cast<NominalTypeDecl>(dc))
+    decl = nominal;
+  else if (auto ext = dyn_cast<ExtensionDecl>(dc))
+    decl = ext;
+  else
+    return false;
+
+  ASTContext &ctx = dc->getASTContext();
+  auto potentialExpansions = evaluateOrDefault(
+      ctx.evaluator, PotentialMacroExpansionsInContextRequest{decl},
+      PotentialMacroExpansions());
+  return potentialExpansions.shouldExpandForName(operatorName);
+}
+
 SmallVector<ValueDecl *, 4>
 WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   assert(!isa<AssociatedTypeDecl>(req) && "Not for lookup for type witnesses*");
@@ -1335,10 +1356,12 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   // An operator function is the only kind of witness that requires global
   // lookup. However, because global lookup doesn't enter local contexts,
   // an additional, qualified lookup is warranted when the conforming type
-  // is declared in a local context.
+  // is declared in a local context or when the operator could come from a
+  // macro expansion.
   const bool doUnqualifiedLookup = req->isOperator();
   const bool doQualifiedLookup =
-      !req->isOperator() || DC->getParent()->getLocalContext();
+      !req->isOperator() || DC->getParent()->getLocalContext() ||
+      contextMayExpandOperator(DC, req->getName().getBaseName());
 
   if (doUnqualifiedLookup) {
     auto lookup = TypeChecker::lookupUnqualified(DC->getModuleScopeContext(),

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -465,14 +465,42 @@ struct HasEqualsSelf3 {
 struct HasEqualsSelf4 {
 }
 
+protocol SelfEqualsBoolProto { // expected-note 4{{where 'Self' =}}
+  static func ==(lhs: Self, rhs: Bool) -> Bool
+}
+
+struct HasEqualsSelfP: SelfEqualsBoolProto {
+  #addSelfEqualsOperator
+}
+
+struct HasEqualsSelf2P: SelfEqualsBoolProto {
+  #addSelfEqualsOperatorArbitrary
+}
+
+@AddSelfEqualsMemberOperator
+struct HasEqualsSelf3P: SelfEqualsBoolProto {
+}
+
+@AddSelfEqualsMemberOperatorArbitrary
+struct HasEqualsSelf4P: SelfEqualsBoolProto {
+}
+
 func testHasEqualsSelf(
-  x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4
+  x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4,
+  xP: HasEqualsSelfP, yP: HasEqualsSelf2P, zP: HasEqualsSelf3P,
+  wP: HasEqualsSelf4P
 ) {
 #if TEST_DIAGNOSTICS
   // Global operator lookup doesn't find member operators introduced by macros.
-  _ = (x == true) // expected-error{{cannot convert value of type}}
-  _ = (y == true) // expected-error{{cannot convert value of type}}
-  _ = (z == true) // expected-error{{cannot convert value of type}}
-  _ = (w == true) // expected-error{{cannot convert value of type}}
+  _ = (x == true) // expected-error{{referencing operator function '=='}}
+  _ = (y == true) // expected-error{{referencing operator function '=='}}
+  _ = (z == true) // expected-error{{referencing operator function '=='}}
+  _ = (w == true) // expected-error{{referencing operator function '=='}}
   #endif
+
+  // These should be found through the protocol.
+  _ = (xP == true)
+  _ = (yP == true)
+  _ = (zP == true)
+  _ = (wP == true)
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -468,15 +468,11 @@ struct HasEqualsSelf4 {
 func testHasEqualsSelf(
   x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4
 ) {
-  _ = (x == true)
-  _ = (y == true)
 #if TEST_DIAGNOSTICS
-  // FIXME: This is technically a bug, because we should be able to find the
-  // == operator introduced through a member operator. However, we might
-  // want to change the rule rather than implement this.
-  _ = (z == true) // expected-error{{binary operator '==' cannot be applied to operands}}
-  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
-  _ = (w == true) // expected-error{{binary operator '==' cannot be applied to operands}}
-  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
+  // Global operator lookup doesn't find member operators introduced by macros.
+  _ = (x == true) // expected-error{{cannot convert value of type}}
+  _ = (y == true) // expected-error{{cannot convert value of type}}
+  _ = (z == true) // expected-error{{cannot convert value of type}}
+  _ = (w == true) // expected-error{{cannot convert value of type}}
   #endif
 }


### PR DESCRIPTION
The module-scope lookup tables use the same code for adding
module-scope declarations as for adding member operators, which are
found via "global" operator lookup. This requires us to expand macros
that can produce members of types, which violates the outside-in
expansion rule described in the proposals.

Stop recording member-producing macros, whether they are peer macros
applied to member declarations or are freestanding declaration macros
within a member context. This re-establishes the outside-in expansion
rule. It also means that member operators introduced by macro
expansion won't be found by global operator lookup, which is a
(necessary) semantic change.

To counteract this, when looking for an operator to satisfy a protocol requirement, we
currently depend on global operator lookup for everything except local
types. So, perform a member lookup for such cases in addition
to global operator lookup. This makes macro-provided operators visible
through protocol requirements they witness.