### PR TITLE
[stdlib] Change word order for clarity in Unicode handling doc

### DIFF
--- a/stdlib/public/core/NFC.swift
+++ b/stdlib/public/core/NFC.swift
@@ -128,7 +128,7 @@ extension Unicode._InternalNFC.Iterator: IteratorProtocol {
       // already NFD, so the last scalar in the buffer will have the highest
       // CCC value in this normalization segment.
       guard let lastBufferedNormData = buffer.last?.normData else {
-        // If we do not any have scalars in our buffer yet, then this step is
+        // If we do not have any scalars in our buffer yet, then this step is
         // trivial. Attempt to compose our current scalar with whatever composee
         // we're currently building up.
 


### PR DESCRIPTION
Hi, I noticed that the word order in a particular sentence in `NFC.swift` seemed to be incorrect, I'm not sure though.
Please review my changes. Thanks!