### PR TITLE
Macro operators without global operator lookup 5.9

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -35,8 +35,10 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/NameLookup.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/PotentialMacroExpansions.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeDeclFinder.h"
@@ -1314,6 +1316,25 @@ WitnessChecker::lookupValueWitnessesViaImplementsAttr(
   removeShadowedDecls(witnesses, DC);
 }
 
+/// Determine whether the given context may expand an operator with the given name.
+static bool contextMayExpandOperator(
+    DeclContext *dc, DeclBaseName operatorName
+) {
+  TypeOrExtensionDecl decl;
+  if (auto nominal = dyn_cast<NominalTypeDecl>(dc))
+    decl = nominal;
+  else if (auto ext = dyn_cast<ExtensionDecl>(dc))
+    decl = ext;
+  else
+    return false;
+
+  ASTContext &ctx = dc->getASTContext();
+  auto potentialExpansions = evaluateOrDefault(
+      ctx.evaluator, PotentialMacroExpansionsInContextRequest{decl},
+      PotentialMacroExpansions());
+  return potentialExpansions.shouldExpandForName(operatorName);
+}
+
 SmallVector<ValueDecl *, 4>
 WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   assert(!isa<AssociatedTypeDecl>(req) && "Not for lookup for type witnesses*");
@@ -1331,10 +1352,12 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   // An operator function is the only kind of witness that requires global
   // lookup. However, because global lookup doesn't enter local contexts,
   // an additional, qualified lookup is warranted when the conforming type
-  // is declared in a local context.
+  // is declared in a local context or when the operator could come from a
+  // macro expansion.
   const bool doUnqualifiedLookup = req->isOperator();
   const bool doQualifiedLookup =
-      !req->isOperator() || DC->getParent()->getLocalContext();
+      !req->isOperator() || DC->getParent()->getLocalContext() ||
+      contextMayExpandOperator(DC, req->getName().getBaseName());
 
   if (doUnqualifiedLookup) {
     auto lookup = TypeChecker::lookupUnqualified(DC->getModuleScopeContext(),

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1553,3 +1553,15 @@ public struct SelfAlwaysEqualOperator: DeclarationMacro {
     ]
   }
 }
+
+extension SelfAlwaysEqualOperator: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "static func ==(lhs: Self, rhs: Bool) -> Bool { true }",
+    ]
+  }
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1531,3 +1531,25 @@ public struct UseIdentifierMacro: DeclarationMacro {
     ]
   }
 }
+
+public struct StaticFooFuncMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "static func foo() {}",
+    ]
+  }
+}
+
+public struct SelfAlwaysEqualOperator: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "static func ==(lhs: Self, rhs: Bool) -> Bool { true }",
+    ]
+  }
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1505,3 +1505,29 @@ public struct SingleMemberMacro: MemberMacro {
     ]
   }
 }
+
+public struct UseIdentifierMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let argument = node.argumentList.first?.expression.as(StringLiteralExprSyntax.self) else {
+      fatalError("boom")
+    }
+    return [
+      """
+      func \(context.makeUniqueName("name"))() {
+        _ = \(raw: argument.segments.first!)
+      }
+      """,
+      """
+      struct Foo {
+        var \(context.makeUniqueName("name")): Int {
+          _ = \(raw: argument.segments.first!)
+          return 0
+        }
+      }
+      """
+    ]
+  }
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -445,6 +445,8 @@ func testHasAnExpandedStatic() {
 
 @freestanding(declaration, names: named(==)) public macro addSelfEqualsOperator() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
 @freestanding(declaration, names: arbitrary) public macro addSelfEqualsOperatorArbitrary() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+@attached(member, names: named(==)) public macro AddSelfEqualsMemberOperator() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+@attached(member, names: arbitrary) public macro AddSelfEqualsMemberOperatorArbitrary() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
 
 struct HasEqualsSelf {
   #addSelfEqualsOperator
@@ -454,7 +456,26 @@ struct HasEqualsSelf2 {
   #addSelfEqualsOperatorArbitrary
 }
 
-func testHasEqualsSelf(x: HasEqualsSelf, y: HasEqualsSelf2) {
+@AddSelfEqualsMemberOperator
+struct HasEqualsSelf3 {
+}
+
+@AddSelfEqualsMemberOperatorArbitrary
+struct HasEqualsSelf4 {
+}
+
+func testHasEqualsSelf(
+  x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4
+) {
   _ = (x == true)
   _ = (y == true)
+#if TEST_DIAGNOSTICS
+  // FIXME: This is technically a bug, because we should be able to find the
+  // == operator introduced through a member operator. However, we might
+  // want to change the rule rather than implement this.
+  _ = (z == true) // expected-error{{binary operator '==' cannot be applied to operands}}
+  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
+  _ = (w == true) // expected-error{{binary operator '==' cannot be applied to operands}}
+  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
+  #endif
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -24,7 +24,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -emit-ir -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-IR %s
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5 -g -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -g -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -Xfrontend -emit-dependencies-path -Xfrontend %t/main.d -Xfrontend -emit-reference-dependencies-path -Xfrontend %t/main.swiftdeps
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -467,15 +467,11 @@ struct HasEqualsSelf4 {
 func testHasEqualsSelf(
   x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4
 ) {
-  _ = (x == true)
-  _ = (y == true)
 #if TEST_DIAGNOSTICS
-  // FIXME: This is technically a bug, because we should be able to find the
-  // == operator introduced through a member operator. However, we might
-  // want to change the rule rather than implement this.
-  _ = (z == true) // expected-error{{binary operator '==' cannot be applied to operands}}
-  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
-  _ = (w == true) // expected-error{{binary operator '==' cannot be applied to operands}}
-  // expected-note@-1{{overloads for '==' exist with these partially matching parameter lists}}
+  // Global operator lookup doesn't find member operators introduced by macros.
+  _ = (x == true) // expected-error{{cannot convert value of type}}
+  _ = (y == true) // expected-error{{cannot convert value of type}}
+  _ = (z == true) // expected-error{{cannot convert value of type}}
+  _ = (w == true) // expected-error{{cannot convert value of type}}
   #endif
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -464,14 +464,42 @@ struct HasEqualsSelf3 {
 struct HasEqualsSelf4 {
 }
 
+protocol SelfEqualsBoolProto { // expected-note 4{{where 'Self' =}}
+  static func ==(lhs: Self, rhs: Bool) -> Bool
+}
+
+struct HasEqualsSelfP: SelfEqualsBoolProto {
+  #addSelfEqualsOperator
+}
+
+struct HasEqualsSelf2P: SelfEqualsBoolProto {
+  #addSelfEqualsOperatorArbitrary
+}
+
+@AddSelfEqualsMemberOperator
+struct HasEqualsSelf3P: SelfEqualsBoolProto {
+}
+
+@AddSelfEqualsMemberOperatorArbitrary
+struct HasEqualsSelf4P: SelfEqualsBoolProto {
+}
+
 func testHasEqualsSelf(
-  x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4
+  x: HasEqualsSelf, y: HasEqualsSelf2, z: HasEqualsSelf3, w: HasEqualsSelf4,
+  xP: HasEqualsSelfP, yP: HasEqualsSelf2P, zP: HasEqualsSelf3P,
+  wP: HasEqualsSelf4P
 ) {
 #if TEST_DIAGNOSTICS
   // Global operator lookup doesn't find member operators introduced by macros.
-  _ = (x == true) // expected-error{{cannot convert value of type}}
-  _ = (y == true) // expected-error{{cannot convert value of type}}
-  _ = (z == true) // expected-error{{cannot convert value of type}}
-  _ = (w == true) // expected-error{{cannot convert value of type}}
+  _ = (x == true) // expected-error{{referencing operator function '=='}}
+  _ = (y == true) // expected-error{{referencing operator function '=='}}
+  _ = (z == true) // expected-error{{referencing operator function '=='}}
+  _ = (w == true) // expected-error{{referencing operator function '=='}}
   #endif
+
+  // These should be found through the protocol.
+  _ = (xP == true)
+  _ = (yP == true)
+  _ = (zP == true)
+  _ = (wP == true)
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -424,3 +424,37 @@ func testLocalVarsFromDeclarationMacros() {
 struct TakesVariadic {
   #emptyDecl("foo", "bar")
 }
+
+// Funkiness with static functions introduced via macro expansions.
+@freestanding(declaration, names: named(foo())) public macro staticFooFunc() = #externalMacro(module: "MacroDefinition", type: "StaticFooFuncMacro")
+@freestanding(declaration, names: arbitrary) public macro staticFooFuncArbitrary() = #externalMacro(module: "MacroDefinition", type: "StaticFooFuncMacro")
+
+class HasAnExpandedStatic {
+  #staticFooFunc()
+}
+
+class HasAnExpandedStatic2 {
+  #staticFooFuncArbitrary()
+}
+
+func testHasAnExpandedStatic() {
+#if TEST_DIAGNOSTICS
+  foo() // expected-error{{cannot find 'foo' in scope}}
+#endif
+}
+
+@freestanding(declaration, names: named(==)) public macro addSelfEqualsOperator() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+@freestanding(declaration, names: arbitrary) public macro addSelfEqualsOperatorArbitrary() = #externalMacro(module: "MacroDefinition", type: "SelfAlwaysEqualOperator")
+
+struct HasEqualsSelf {
+  #addSelfEqualsOperator
+}
+
+struct HasEqualsSelf2 {
+  #addSelfEqualsOperatorArbitrary
+}
+
+func testHasEqualsSelf(x: HasEqualsSelf, y: HasEqualsSelf2) {
+  _ = (x == true)
+  _ = (y == true)
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -417,3 +417,10 @@ func testFreestandingClosureNesting() {
 func testLocalVarsFromDeclarationMacros() {
   #varValue
 }
+
+// Variadic macro
+@freestanding(declaration, names: arbitrary) macro emptyDecl(_: String...) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
+
+struct TakesVariadic {
+  #emptyDecl("foo", "bar")
+}

--- a/test/Macros/macro_expand_primary.swift
+++ b/test/Macros/macro_expand_primary.swift
@@ -85,3 +85,13 @@ final class Dog: Observable {
 func test() {
   observeDog()
 }
+
+
+@freestanding(declaration, names: named(Foo)) macro useIdentifier(_ value: String) = #externalMacro(module: "MacroDefinition", type: "UseIdentifierMacro")
+
+#if false
+#useIdentifier("totallyNotDefined")
+#else
+let hello = "Hello"
+#useIdentifier("hello")
+#endif


### PR DESCRIPTION
* **Explanation**: Module-scope name lookup tables are used for global operator lookup, which involves that code walking into the members of types to find member operators. This code also unintentionally expanded macros (both peer and freestanding) at member scope, violating the outside-in rule for macro expansion and caused various assertions and circular reference errors. Prevent module-scope lookup from expanding any macros that produce members, so we don't violate this rule. However, this means that member operators introduced via macros won't be found---so make sure they can be found by witness matching, at least.
* **Scope**: Narrow; only affects module-scope and global operator lookup involving types with macros that can produce members.
* **Risk**: Low; narrow change to the code that builds macros and performs witness matching for types/extensions that have macros.
* **Reviewed by**: @hborla 
* **Issue**:  rdar://109219036
* **Original pull request**: https://github.com/apple/swift/pull/66317, https://github.com/apple/swift/pull/66320
