### PR TITLE
[Backtracing][IRGen] Add a semantic attribute to force frame pointer.

### DIFF
--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -144,5 +144,8 @@ SEMANTICS_ATTR(NO_PERFORMANCE_ANALYSIS, "no_performance_analysis")
 // that may cause the user to think there is a bug in the compiler.
 SEMANTICS_ATTR(NO_MOVEONLY_DIAGNOSTICS, "sil.optimizer.moveonly.diagnostic.ignore")
 
+// Force the use of the frame pointer for the specified function
+SEMANTICS_ATTR(USE_FRAME_POINTER, "use_frame_pointer")
+
 #undef SEMANTICS_ATTR
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/ExternalUnion.h"
@@ -1834,6 +1835,11 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
       CurFn->addFnAttr(llvm::Attribute::SanitizeThread);
     }
   }
+
+  // If we have @_semantics("use_frame_pointer"), force the use of a
+  // frame pointer for this function.
+  if (f->hasSemanticsAttr(semantics::USE_FRAME_POINTER))
+    CurFn->addFnAttr("frame-pointer", "all");
 
   // Disable inlining of coroutine functions until we split.
   if (f->getLoweredFunctionType()->isCoroutine()) {


### PR DESCRIPTION
The Swift backtracer's frame pointer unwinder cannot work on Linux without this change, because the compiler omits the frame pointer from the function in libSwift_Backtracing that actually captures the stack.

rdar://110260855
