### PR TITLE
[5.9] [Parser] Add local type declarations to the outermost enclosing source file

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5100,7 +5100,7 @@ void Parser::recordLocalType(TypeDecl *TD) {
     return;
 
   if (!InInactiveClauseEnvironment)
-    SF.LocalTypeDecls.insert(TD);
+    SF.getOutermostParentSourceFile()->LocalTypeDecls.insert(TD);
 }
 
 /// Set the original declaration in `@differentiable` attributes.

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -234,11 +234,17 @@ func testStringifyWithThrows() throws {
 
     // CHECK-DIAGS: @__swiftmacro_9MacroUser23testStringifyWithThrowsyyKF9stringifyfMf1_.swift:1:2: error: call can throw but is not marked with 'try'
 #endif
-  
+
   // The macro adds the 'try' for us.
   _ = #stringifyAndTry(maybeThrowing())
 }
 
+func testStringifyWithLocalType() throws {
+  _ =  #stringify({
+    struct QuailError: Error {}
+    throw QuailError()
+    })
+}
 
 @freestanding(expression) macro addBlocker<T>(_ value: T) -> T = #externalMacro(module: "MacroDefinition", type: "AddBlocker")
 
@@ -495,7 +501,7 @@ func testHasEqualsSelf(
   _ = (y == true) // expected-error{{referencing operator function '=='}}
   _ = (z == true) // expected-error{{referencing operator function '=='}}
   _ = (w == true) // expected-error{{referencing operator function '=='}}
-  #endif
+#endif
 
   // These should be found through the protocol.
   _ = (xP == true)


### PR DESCRIPTION
The parser is currently responsible for adding local type declarations to a `SourceFile`, which IR generation later queries. However, IRGen never sees the source files associated with macro expansion buffers, so local types introduced there don't get recorded.

In time, this approach of using the parser to record semantic information should be replaced with something more "pull" oriented. For now, however, record local type declarations in the outermost enclosing source file... so we see the ones produced by macro expansions, too.

Fixes rdar://109370309.

(cherry picked from commit e964d1290fe27225376e4ce691215274a22098ce)
