### PR TITLE
5.9: [Mem2Reg] Recognize store_borrows for debug_value.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -292,6 +292,23 @@ replaceDestroy(DestroyAddrInst *dai, SILValue newValue, SILBuilderContext &ctx,
   prepareForDeletion(dai, instructionsToDelete);
 }
 
+/// Whether the specified debug_value's operand names the address at the
+/// indicated alloc_stack.
+///
+/// If it's a guaranteed alloc_stack (i.e. a store_borrow location), that
+/// includes the values produced by any store_borrows whose destinations are the
+/// alloc_stack since those values amount to aliases for the alloc_stack's
+/// storage.
+static bool isDebugValueOfAllocStack(DebugValueInst *dvi, AllocStackInst *asi) {
+  auto value = dvi->getOperand();
+  if (value == asi)
+    return true;
+  auto *sbi = dyn_cast<StoreBorrowInst>(value);
+  if (!sbi)
+    return false;
+  return sbi->getDest() == asi;
+}
+
 /// Promote a DebugValue w/ address value to a DebugValue of non-address value.
 static void promoteDebugValueAddr(DebugValueInst *dvai, SILValue value,
                                   SILBuilderContext &ctx,
@@ -979,7 +996,7 @@ SILInstruction *StackAllocationPromoter::promoteAllocationInBlock(
     // if we have a valid value to use at this point. Otherwise we'll
     // promote this when we deal with hooking up phis.
     if (auto *dvi = DebugValueInst::hasAddrVal(inst)) {
-      if (dvi->getOperand() == asi && runningVals)
+      if (isDebugValueOfAllocStack(dvi, asi) && runningVals)
         promoteDebugValueAddr(dvi, runningVals->value.replacement(asi, dvi),
                               ctx, deleter);
       continue;
@@ -1983,7 +2000,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     // Replace debug_value w/ address value with debug_value of
     // the promoted value.
     if (auto *dvi = DebugValueInst::hasAddrVal(inst)) {
-      if (dvi->getOperand() == asi) {
+      if (isDebugValueOfAllocStack(dvi, asi)) {
         if (runningVals) {
           promoteDebugValueAddr(dvi, runningVals->value.replacement(asi, dvi),
                                 ctx, deleter);

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -22,6 +22,12 @@ struct LargeCodesizeStruct {
   var s5: SmallCodesizeStruct
 }
 
+class C {}
+
+struct S {
+  var field: C
+}
+
 ///////////
 // Tests //
 ///////////
@@ -538,3 +544,67 @@ bb7:
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @debug_value_of_store_borrow_addr_multi_block : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         debug_value [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'debug_value_of_store_borrow_addr_multi_block'
+sil [ossa] @debug_value_of_store_borrow_addr_multi_block : $@convention(thin) (@owned S) -> () {
+entry(%instance : @owned $S):
+  br header
+
+header:
+  %lifetime = begin_borrow %instance : $S
+  %stack = alloc_stack $S
+  %stack_borrow = store_borrow %lifetime to %stack : $*S
+  debug_value %stack_borrow : $*S
+  br body
+
+body:
+  %field_addr = struct_element_addr %stack_borrow : $*S, #S.field
+  %field = load [copy] %field_addr : $*C
+  end_borrow %stack_borrow : $*S
+  dealloc_stack %stack : $*S
+  end_borrow %lifetime : $S
+  destroy_value %field : $C
+  cond_br undef, backedge, exit
+
+backedge:
+  br header
+
+exit:
+  destroy_value %instance : $S
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @debug_value_of_store_borrow_addr_single_block : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         debug_value [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'debug_value_of_store_borrow_addr_single_block'
+sil [ossa] @debug_value_of_store_borrow_addr_single_block : $@convention(thin) (@owned S) -> () {
+entry(%instance : @owned $S):
+  br header
+
+header:
+  %lifetime = begin_borrow %instance : $S
+  %stack = alloc_stack $S
+  %stack_borrow = store_borrow %lifetime to %stack : $*S
+  debug_value %stack_borrow : $*S
+  %field_addr = struct_element_addr %stack_borrow : $*S, #S.field
+  %field = load [copy] %field_addr : $*C
+  end_borrow %stack_borrow : $*S
+  dealloc_stack %stack : $*S
+  end_borrow %lifetime : $S
+  destroy_value %field : $C
+  cond_br undef, backedge, exit
+
+backedge:
+  br header
+
+exit:
+  destroy_value %instance : $S
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Description: Fix Mem2Reg's handling of `debug_value` instructions whose operands were `store_borrows`.

When `debug_value`s are visited, if their operand is the stack address, they are rewritten as `debug_value`s of the stored value, provided it is known.

Previously, the check for whether the operand is the stack address, however, just compared the `debug_value`'s operand with the `alloc_stack`.  For owned `alloc_stack`s, that was correct.  For guaranteed `alloc_stack`s, however, this failed to recognize the the values produced by the `store_borrow` instructions (which amount to aliases for the `alloc_stack`) as the stack address.

Here, this is fixed by checking whether the `debug_value`'s operand is either (1) the `alloc_stack` itself or (2) some `store_borrow` whose destination is the `alloc_stack`.
Risk: Low.  The fix is very simple, expanding an equality check to a simple predicate call in two places.
Scope: Narrow.  The fix only affects the Mem2Reg pass, only affects guaranteed `alloc_stack`s, and only affects the handling of `debug_value` instructions.
Original PR: https://github.com/apple/swift/pull/66303
Reviewed By: Meghana Gupta ( @meg-gupta )
Testing: Added new test cases for both the single block and multi block cases.
Resolves: rdar://109894792
