### PR TITLE
[5.9] tsan-ignores-arc-locks.swift: post process test binary on Darwin

### DIFF
--- a/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
+++ b/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
@@ -1,4 +1,5 @@
 // RUN: %target-build-swift -target %sanitizers-target-triple -sanitize=thread %s -o %t_binary
+// RUN: %target-codesign %t_binary
 // RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test
@@ -6,8 +7,6 @@
 // REQUIRES: foundation
 
 // Check that TSan ignores the retain count update locks in the runtime.
-
-// REQUIRES: rdar108188149
 
 import Foundation
 


### PR DESCRIPTION
This allows the `DYLD_LIBRARY_PATH` override to work as expected and avoid crashes when running.

*Scope:* change in a Swift validation test

*Issue:* rdar://110272079

*Risk:* Low -- other standard library tests are already using the same post process step

*Testing:* execute the toolchain PR job to exercise this test

(cherry picked from commit 44a40979e52be8e9344b8ca6069614a29aeff6cd,
 #66308)