### PR TITLE
prevent reinitialization of `self` after discard

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -778,6 +778,8 @@ ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
       (StringRef))
 ERROR(sil_movechecking_discard_missing_consume_self, none,
       "must consume 'self' before exiting method that discards self", ())
+ERROR(sil_movechecking_reinit_after_discard, none,
+      "cannot reinitialize 'self' after 'discard self'", ())
 
 NOTE(sil_movechecking_discard_self_here, none,
      "discarded self here", ())

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -191,6 +191,20 @@ void DiagnosticEmitter::emitCheckedMissedCopyError(SILInstruction *copyInst) {
            diag::sil_movechecking_bug_missed_copy);
 }
 
+void DiagnosticEmitter::emitReinitAfterDiscardError(SILInstruction *badReinit,
+                                                    SILInstruction *discard) {
+  assert(isa<DropDeinitInst>(discard));
+  assert(badReinit->getLoc() && "missing loc!");
+  assert(discard->getLoc() && "missing loc!");
+
+  diagnose(badReinit->getFunction()->getASTContext(),
+           badReinit,
+           diag::sil_movechecking_reinit_after_discard);
+
+  diagnose(discard->getFunction()->getASTContext(), discard,
+           diag::sil_movechecking_discard_self_here);
+}
+
 void DiagnosticEmitter::emitMissingConsumeInDiscardingContext(
     SILInstruction *leftoverDestroy,
     SILInstruction *discard) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -119,6 +119,11 @@ public:
   /// way to file a bug.
   void emitCheckedMissedCopyError(SILInstruction *copyInst);
 
+  /// Given a drop_deinit of self and an instruction reinitializing self,
+  /// emits an error saying that you cannot reinitialize self after a discard.
+  void emitReinitAfterDiscardError(SILInstruction *badReinit,
+                                   SILInstruction *dropDeinit);
+
   /// Assuming the given instruction represents the implicit destruction of
   /// 'self', emits an error saying that you needed to explicitly 'consume self'
   /// here because you're in a discarding context.


### PR DESCRIPTION
The value `self` is mutable (i.e., var-bound) in
a `consuming` method. Since you're allowed to
reinitialize a var after consuming, that means
you were also naturally allowed to reinitialize
self after `discard self`. But that capability was not intended; after you discard self you shouldn't be reinitializing it, as that's probably a mistake.

This change makes reinitialization of `self`
reachable from a `discard self` statement an error.

rdar://106098163