### PR TITLE
SIL: Don't skip lowering obsolete decls

### DIFF
--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -956,6 +956,13 @@ bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
   return theClass->getObjectModel() == ReferenceCounting::ObjC;
 }
 
+static bool isUnconditionallyUnavailable(const Decl *D) {
+  if (auto unavailableAttrAndDecl = D->getSemanticUnavailableAttr())
+    return unavailableAttrAndDecl->first->isUnconditionallyUnavailable();
+
+  return false;
+}
+
 bool Lowering::shouldSkipLowering(const Decl *D) {
   if (D->getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
       UnavailableDeclOptimization::Complete)
@@ -963,7 +970,7 @@ bool Lowering::shouldSkipLowering(const Decl *D) {
 
   // Unavailable declarations should be skipped if
   // -unavailable-decl-optimization=complete is specified.
-  return D->getSemanticUnavailableAttr() != None;
+  return isUnconditionallyUnavailable(D);
 }
 
 bool Lowering::shouldLowerToUnavailableCodeStub(const Decl *D) {
@@ -973,5 +980,5 @@ bool Lowering::shouldLowerToUnavailableCodeStub(const Decl *D) {
 
   // Unavailable declarations should trap at runtime if
   // -unavailable-decl-optimization=stub is specified.
-  return D->getSemanticUnavailableAttr() != None;
+  return isUnconditionallyUnavailable(D);
 }

--- a/test/SILGen/unavailable_decl_optimization_complete.swift
+++ b/test/SILGen/unavailable_decl_optimization_complete.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=none | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-emit-silgen -swift-version 5 -module-name Test -parse-as-library %s -verify | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-emit-silgen -swift-version 5 -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=none | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
 // RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=complete | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
 
 // CHECK-NO-STRIP: s4Test14globalConstant_Wz
@@ -17,6 +17,10 @@ public let globalConstant = true
 // CHECK-STRIP-NOT: s4Test15unavailableFuncyyF
 @available(*, unavailable)
 public func unavailableFunc() {}
+
+// CHECK: s4Test21funcObsoletedInSwift5yyF
+@available(swift, introduced: 4.2, obsoleted: 5)
+public func funcObsoletedInSwift5() {}
 
 @available(*, unavailable)
 public struct UnavailableStruct<T> {


### PR DESCRIPTION
When `-unavailable-decl-optimization=complete` is specified obsolete decls should be preserved because their symbols are still ABI since they are available to use when targeting deployment targets earlier than the obsoletion version.

Resolves rdar://110268649