### PR TITLE
[5.9][move-only] Fix SIL representation and SILOptimizer to preserve value deinits.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -40,6 +40,12 @@ SILValue stripCastsWithoutMarkDependence(SILValue V);
 /// begin_borrow instructions.
 SILValue lookThroughOwnershipInsts(SILValue v);
 
+/// Reverse of lookThroughOwnershipInsts.
+///
+/// Return true if \p visitor returned true for all uses.
+bool visitNonOwnershipUses(SILValue value,
+                           function_ref<bool(Operand *)> visitor);
+
 /// Return the underlying SILValue after looking through all copy_value
 /// instructions.
 SILValue lookThroughCopyValueInsts(SILValue v);

--- a/include/swift/SIL/SILMoveOnlyDeinit.h
+++ b/include/swift/SIL/SILMoveOnlyDeinit.h
@@ -61,7 +61,10 @@ public:
 
   NominalTypeDecl *getNominalDecl() const { return nominalDecl; }
 
-  SILFunction *getImplementation() const { return funcImpl; }
+  SILFunction *getImplementation() const {
+    assert(funcImpl);
+    return funcImpl;
+  }
 
   IsSerialized_t isSerialized() const {
     return serialized ? IsSerialized : IsNotSerialized;

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -463,8 +463,15 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // effects relative to other OSSA values like copy_value.
   SINGLE_VALUE_INST(MoveValueInst, move_value, SingleValueInstruction, None,
                     DoesNotRelease)
-  SINGLE_VALUE_INST(DropDeinitInst, drop_deinit, SingleValueInstruction, None,
-                    DoesNotRelease)
+  // A drop_deinit has no user-level side effects. It does, however, change the
+  // information about the owenership of its operand, and therefore cannot be
+  // arbitrarily deleted. It effectively wraps the type of the operand so that
+  // the resulting value is an equivalent type without a user-defined deinit.
+  //
+  // TODO: Add an OwnershipEffect type of side effect for instructions like
+  // drop_deinit to indicate their ownership effects.
+  SINGLE_VALUE_INST(DropDeinitInst, drop_deinit, SingleValueInstruction,
+                    MayHaveSideEffects, DoesNotRelease)
   // A canary value inserted by a SIL generating frontend to signal to the move
   // checker to check a specific value.  Valid only in Raw SIL. The relevant
   // checkers should remove the mark_must_check instruction after successfully

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -462,7 +462,7 @@ PASS(PartialApplySimplification, "partial-apply-simplification",
      "Transform partial_apply instructions into explicit closure box constructions")
 PASS(MovedAsyncVarDebugInfoPropagator, "sil-moved-async-var-dbginfo-propagator",
      "Propagate debug info from moved async vars after coroutine funclet boundaries")
-PASS(MoveOnlyDeinitInsertion, "sil-move-only-deinit-insertion",
+PASS(MoveOnlyDeinitDevirtualization, "sil-move-only-deinit-devirtualization",
      "After running move only checking, convert last destroy_values to deinit calls")
 PASS(MoveOnlyBorrowToDestructureTransform,
      "sil-move-only-borrow-to-destructure",

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -381,8 +381,10 @@ ignore_expect_uses(ValueBase *value) {
 /// operations from it. These can be simplified and removed.
 bool simplifyUsers(SingleValueInstruction *inst);
 
-///  True if a type can be expanded
-/// without a significant increase to code size.
+/// True if a type can be expanded without a significant increase to code size.
+///
+/// False if expanding a type is invalid. For example, expanding a
+/// struct-with-deinit drops the deinit.
 bool shouldExpand(SILModule &module, SILType ty);
 
 /// Check if the value of value is computed by means of a simple initialization.

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -141,6 +141,16 @@ void collectUsesOfValue(SILValue V,
 /// value itself)
 void eraseUsesOfValue(SILValue value);
 
+/// Return true if \p type is a value type (struct/enum) that requires
+/// deinitialization beyond destruction of its members.
+bool hasValueDeinit(SILType type);
+
+/// Return true if \p value has a value type (struct/enum) that requires
+/// deinitialization beyond destruction of its members.
+inline bool hasValueDeinit(SILValue value) {
+  return hasValueDeinit(value->getType());
+}
+
 /// Gets the concrete value which is stored in an existential box.
 /// Returns %value in following pattern:
 ///

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1249,8 +1249,7 @@ public:
     setLoweredExplosion(i, e);
   }
   void visitDropDeinitInst(DropDeinitInst *i) {
-    auto e = getLoweredExplosion(i->getOperand());
-    setLoweredExplosion(i, e);
+    llvm_unreachable("only valid in ownership SIL");
   }
   void visitMarkMustCheckInst(MarkMustCheckInst *i) {
     llvm_unreachable("Invalid in Lowered SIL");

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1575,6 +1575,19 @@ namespace {
       return B.createStruct(loc, getLoweredType(), values);
     }
 
+    void
+    emitLoweredDestroyValue(SILBuilder &B, SILLocation loc, SILValue aggValue,
+                            TypeExpansionKind loweringStyle) const override {
+      // A value type with a deinit cannot be memberwise destroyed.
+      if (auto *nominal = getLoweredType().getNominalOrBoundGenericNominal()) {
+        if (nominal->getValueTypeDestructor()) {
+          emitDestroyValue(B, loc, aggValue);
+          return;
+        }
+      }
+      Super::emitLoweredDestroyValue(B, loc, aggValue, loweringStyle);
+    }
+
   private:
     void lowerChildren(TypeConverter &TC,
                        SmallVectorImpl<Child> &children) const override {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2698,6 +2698,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::DeinitExistentialValueInst:
   case SILInstructionKind::DestroyAddrInst:
   case SILInstructionKind::DestroyValueInst:
+  case SILInstructionKind::DropDeinitInst:
   case SILInstructionKind::EndAccessInst:
   case SILInstructionKind::EndApplyInst:
   case SILInstructionKind::EndBorrowInst:

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -262,7 +262,7 @@ void SILGenFunction::emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd) {
   // Clean up our members, consuming our +1 self value as we do it.
   emitMoveOnlyMemberDestruction(selfValue,
                                 dd->getDeclContext()->getSelfNominalTypeDecl(),
-                                cleanupLoc, nullptr);
+                                cleanupLoc);
 
   // Return.
   B.createReturn(loc, emitEmptyTuple(loc));
@@ -497,113 +497,59 @@ void SILGenFunction::emitClassMemberDestruction(ManagedValue selfValue,
 
 void SILGenFunction::emitMoveOnlyMemberDestruction(SILValue selfValue,
                                                    NominalTypeDecl *nom,
-                                                   CleanupLocation cleanupLoc,
-                                                   SILBasicBlock *finishBB) {
-  // drop_deinit must be used to invalidate any user-defined struct/enum deinit
-  // before the individual members can be destroyed.
+                                                   CleanupLocation cleanupLoc) {
+  // drop_deinit invalidates any user-defined struct/enum deinit
+  // before the individual members are destroyed.
   selfValue = B.createDropDeinit(cleanupLoc, selfValue);
-  if (selfValue->getType().isAddress()) {
-    if (auto *structDecl = dyn_cast<StructDecl>(nom)) {
-      for (VarDecl *vd : nom->getStoredProperties()) {
-        const TypeLowering &ti = getTypeLowering(vd->getType());
-        if (ti.isTrivial())
-          continue;
+  if (selfValue->getType().isObject()) {
+    // A destroy value that uses the result of a drop_deinit implicitly performs
+    // memberwise destruction.
+    B.emitDestroyValueOperation(cleanupLoc, selfValue);
+    return;
+  }
+  if (auto *structDecl = dyn_cast<StructDecl>(nom)) {
+    for (VarDecl *vd : nom->getStoredProperties()) {
+      const TypeLowering &ti = getTypeLowering(vd->getType());
+      if (ti.isTrivial())
+        continue;
 
-        SILValue addr = B.createStructElementAddr(
-            cleanupLoc, selfValue, vd, ti.getLoweredType().getAddressType());
-        addr = B.createBeginAccess(cleanupLoc, addr, SILAccessKind::Deinit,
-                                   SILAccessEnforcement::Static,
-                                   false /*noNestedConflict*/,
-                                   false /*fromBuiltin*/);
-        B.createDestroyAddr(cleanupLoc, addr);
-        B.createEndAccess(cleanupLoc, addr, false /*is aborting*/);
-      }
-    } else {
-      auto *origBlock = B.getInsertionBB();
-      auto *enumDecl = cast<EnumDecl>(nom);
-      SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 8>
-          caseCleanups;
-      auto *contBlock = createBasicBlock();
-
-      for (auto *enumElt : enumDecl->getAllElements()) {
-        auto *enumBlock = createBasicBlock();
-        SILBuilder builder(enumBlock, enumBlock->begin());
-
-        if (enumElt->hasAssociatedValues()) {
-          auto *take = builder.createUncheckedTakeEnumDataAddr(
-              cleanupLoc, selfValue, enumElt);
-          builder.createDestroyAddr(cleanupLoc, take);
-        }
-
-        // Branch to the continue trampoline block.
-        builder.createBranch(cleanupLoc, contBlock);
-        caseCleanups.emplace_back(enumElt, enumBlock);
-
-        // Set the insertion point to after this enum block so we insert the
-        // next new block after this block.
-        B.setInsertionPoint(enumBlock);
-      }
-
-      B.setInsertionPoint(origBlock);
-      B.createSwitchEnumAddr(cleanupLoc, selfValue, nullptr, caseCleanups);
-      B.setInsertionPoint(contBlock);
+      SILValue addr = B.createStructElementAddr(
+          cleanupLoc, selfValue, vd, ti.getLoweredType().getAddressType());
+      addr = B.createBeginAccess(
+          cleanupLoc, addr, SILAccessKind::Deinit, SILAccessEnforcement::Static,
+          false /*noNestedConflict*/, false /*fromBuiltin*/);
+      B.createDestroyAddr(cleanupLoc, addr);
+      B.createEndAccess(cleanupLoc, addr, false /*is aborting*/);
     }
   } else {
-    if (auto *sd = dyn_cast<StructDecl>(nom)) {
-      if (llvm::any_of(sd->getStoredProperties(),
-                       [&](VarDecl *vd) {
-                         auto &lowering = getTypeLowering(vd->getType());
-                         return !lowering.isTrivial();
-                       })) {
-        auto *d = B.createDestructureStruct(cleanupLoc, selfValue,
-                                            OwnershipKind::Owned);
-        for (auto result : d->getResults()) {
-          B.emitDestroyValueOperation(cleanupLoc, result);
-        }
-      } else {
-        // If we only contain trivial uses, we don't have anything to cleanup,
-        // so just insert an end_lifetime.
-        B.createEndLifetime(cleanupLoc, selfValue);
-      }
-    } else {
-      auto *origBlock = B.getInsertionBB();
-      auto *enumDecl = dyn_cast<EnumDecl>(nom);
-      SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 8>
-          caseCleanups;
-      auto *contBlock = createBasicBlock();
+    auto *origBlock = B.getInsertionBB();
+    auto *enumDecl = cast<EnumDecl>(nom);
+    SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 8> caseCleanups;
+    auto *contBlock = createBasicBlock();
 
-      for (auto *enumElt : enumDecl->getAllElements()) {
-        auto *enumBlock = createBasicBlock();
-        SILBuilder builder(enumBlock, enumBlock->begin());
+    for (auto *enumElt : enumDecl->getAllElements()) {
+      auto *enumBlock = createBasicBlock();
+      SILBuilder builder(enumBlock, enumBlock->begin());
 
-        if (enumElt->hasAssociatedValues()) {
-          auto caseType = selfValue->getType().getEnumElementType(
-              enumElt, enumBlock->getParent());
-          auto *phiArg =
-              enumBlock->createPhiArgument(caseType, OwnershipKind::Owned);
-          builder.emitDestroyValueOperation(cleanupLoc, phiArg);
-        }
-
-        // Branch to the continue trampoline block.
-        builder.createBranch(cleanupLoc, contBlock);
-        caseCleanups.emplace_back(enumElt, enumBlock);
-
-        // Set the insertion point to after this enum block so we insert the
-        // next new block after this block.
-        B.setInsertionPoint(enumBlock);
+      if (enumElt->hasAssociatedValues()) {
+        auto *take = builder.createUncheckedTakeEnumDataAddr(
+            cleanupLoc, selfValue, enumElt);
+        builder.createDestroyAddr(cleanupLoc, take);
       }
 
-      B.setInsertionPoint(origBlock);
-      B.createSwitchEnum(cleanupLoc, selfValue, nullptr, caseCleanups);
-      B.setInsertionPoint(contBlock);
+      // Branch to the continue trampoline block.
+      builder.createBranch(cleanupLoc, contBlock);
+      caseCleanups.emplace_back(enumElt, enumBlock);
+
+      // Set the insertion point to after this enum block so we insert the
+      // next new block after this block.
+      B.setInsertionPoint(enumBlock);
     }
+
+    B.setInsertionPoint(origBlock);
+    B.createSwitchEnumAddr(cleanupLoc, selfValue, nullptr, caseCleanups);
+    B.setInsertionPoint(contBlock);
   }
-
-  if (finishBB)
-    B.createBranch(cleanupLoc, finishBB);
-
-  if (finishBB)
-    B.emitBlock(finishBB);
 }
 
 void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -499,6 +499,8 @@ void SILGenFunction::emitMoveOnlyMemberDestruction(SILValue selfValue,
                                                    NominalTypeDecl *nom,
                                                    CleanupLocation cleanupLoc,
                                                    SILBasicBlock *finishBB) {
+  // drop_deinit must be used to invalidate any user-defined struct/enum deinit
+  // before the individual members can be destroyed.
   selfValue = B.createDropDeinit(cleanupLoc, selfValue);
   if (selfValue->getType().isAddress()) {
     if (auto *structDecl = dyn_cast<StructDecl>(nom)) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -815,12 +815,8 @@ public:
   ///
   /// \param selfValue The 'self' value.
   /// \param nd The nominal declaration whose members are being destroyed.
-  /// \param finishBB If set, used as the basic block after members have been
-  ///                 destroyed, and we're ready to perform final cleanups
-  ///                 before returning.
   void emitMoveOnlyMemberDestruction(SILValue selfValue, NominalTypeDecl *nd,
-                                     CleanupLocation cleanupLoc,
-                                     SILBasicBlock *finishBB);
+                                     CleanupLocation cleanupLoc);
 
   /// Generates code to destroy linearly recursive data structures, without
   /// building up the call stack.

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -795,8 +795,7 @@ void StmtEmitter::visitDiscardStmt(DiscardStmt *S) {
     }
   }
 
-  SGF.emitMoveOnlyMemberDestruction(selfValue.forward(SGF), nominal, loc,
-                                    nullptr);
+  SGF.emitMoveOnlyMemberDestruction(selfValue.forward(SGF), nominal, loc);
 }
 
 void StmtEmitter::visitYieldStmt(YieldStmt *S) {

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -71,6 +71,8 @@ class DeadFunctionAndGlobalElimination {
     }
 
     /// Adds an implementation of the method in a specific conformance.
+    ///
+    /// \p Conf is null for default implementations and move-only deinits
     void addWitnessFunction(SILFunction *F, RootProtocolConformance *Conf) {
       assert(isWitnessMethod);
       implementingFunctions.push_back(FuncImpl(F, Conf));
@@ -615,6 +617,14 @@ class DeadFunctionAndGlobalElimination {
         ensureAlive(dw.getJVP());
       if (dw.getVJP())
         ensureAlive(dw.getVJP());
+    }
+
+    // Collect move-only deinit methods.
+    //
+    // TODO: Similar to addWitnessFunction, track the associated
+    // struct/enum decl to allow DCE of unused deinits.
+    for (auto *deinit : Module->getMoveOnlyDeinits()) {
+      makeAlive(deinit->getImplementation());
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -28,7 +28,6 @@ target_sources(swiftSILOptimizer PRIVATE
   MoveOnlyBorrowToDestructureTester.cpp
   MoveOnlyBorrowToDestructureUtils.cpp
   MoveOnlyChecker.cpp
-  MoveOnlyDeinitInsertion.cpp
   MoveOnlyDiagnostics.cpp
   MoveOnlyObjectCheckerTester.cpp
   MoveOnlyObjectCheckerUtils.cpp

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -135,6 +135,8 @@ struct OwnershipModelEliminatorVisitor
   bool visitCopyValueInst(CopyValueInst *cvi);
   bool visitExplicitCopyValueInst(ExplicitCopyValueInst *cvi);
   bool visitExplicitCopyAddrInst(ExplicitCopyAddrInst *cai);
+
+  void splitDestroy(DestroyValueInst *destroy);
   bool visitDestroyValueInst(DestroyValueInst *dvi);
   bool visitLoadBorrowInst(LoadBorrowInst *lbi);
   bool visitMoveValueInst(MoveValueInst *mvi) {
@@ -142,8 +144,8 @@ struct OwnershipModelEliminatorVisitor
     return true;
   }
   bool visitDropDeinitInst(DropDeinitInst *ddi) {
-    eraseInstructionAndRAUW(ddi, ddi->getOperand());
-    return true;
+    instructionsToSimplify.insert(ddi);
+    return false;
   }
   bool visitBeginBorrowInst(BeginBorrowInst *bbi) {
     eraseInstructionAndRAUW(bbi, bbi->getOperand());
@@ -481,6 +483,57 @@ done_rewriting:
   return false;
 }
 
+// Destroy all nontrivial members of the struct or enum destroyed by \p destroy
+// ignoring any user-defined deinit.
+//
+// See also splitDestructure().
+void OwnershipModelEliminatorVisitor::splitDestroy(DestroyValueInst *destroy) {
+  SILModule &module = destroy->getModule();
+  SILFunction *function = destroy->getFunction();
+  auto loc = destroy->getLoc();
+  auto operand = destroy->getOperand();
+  auto operandTy = operand->getType();
+  NominalTypeDecl *nominalDecl = operandTy.getNominalOrBoundGenericNominal();
+
+  if (auto *sd = dyn_cast<StructDecl>(nominalDecl)) {
+    withBuilder<void>(destroy, [&](SILBuilder &builder, SILLocation loc) {
+      llvm::SmallVector<Projection, 8> projections;
+      Projection::getFirstLevelProjections(
+        operandTy, module, TypeExpansionContext(*function), projections);
+      for (Projection &projection : projections) {
+        auto *projectedValue =
+          projection.createObjectProjection(builder, loc, operand).get();
+        builder.emitDestroyValueOperation(loc, projectedValue);
+      }
+    });
+    return;
+  }
+
+  // "Destructure" an enum.
+  auto *enumDecl = dyn_cast<EnumDecl>(nominalDecl);
+  SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 8> caseCleanups;
+  auto *destroyBlock = destroy->getParent();
+  auto *contBlock = destroyBlock->split(std::next(destroy->getIterator()));
+
+  for (auto *enumElt : enumDecl->getAllElements()) {
+    auto *enumBlock = function->createBasicBlockBefore(contBlock);
+    SILBuilder builder(enumBlock, enumBlock->begin());
+    if (enumElt->hasAssociatedValues()) {
+      auto caseType = operandTy.getEnumElementType(enumElt, function);
+      auto *phiArg =
+        enumBlock->createPhiArgument(caseType, OwnershipKind::Owned);
+      SILBuilderWithScope(enumBlock, builderCtx, destroy->getDebugScope())
+        .emitDestroyValueOperation(loc, phiArg);
+    }
+    // Branch to the continue block.
+    builder.createBranch(loc, contBlock);
+    caseCleanups.emplace_back(enumElt, enumBlock);
+  }
+  SILBuilderWithScope switchBuilder(destroyBlock, builderCtx,
+                                    destroy->getDebugScope());
+  switchBuilder.createSwitchEnum(loc, operand, nullptr, caseCleanups);
+}
+
 bool OwnershipModelEliminatorVisitor::visitDestroyValueInst(
     DestroyValueInst *dvi) {
   // Nonescaping closures are represented ultimately as trivial pointers to
@@ -502,12 +555,15 @@ bool OwnershipModelEliminatorVisitor::visitDestroyValueInst(
       return true;
     }
   }
-    
-  // A destroy_value of an address-only type cannot be replaced.
-  //
-  // TODO: When LowerAddresses runs before this, we can remove this case.
-  if (operandTy.isAddressOnly(*dvi->getFunction()))
-    return false;
+
+  // A drop_deinit eliminates any user-defined deinit. Its destroy does not
+  // lower to a release. If any members require deinitialization, they must be
+  // destructured and individually destroyed.
+  if (isa<DropDeinitInst>(lookThroughOwnershipInsts(operand))) {
+    splitDestroy(dvi);
+    eraseInstruction(dvi);
+    return true;
+  }
 
   // Now that we have set the unqualified ownership flag,
   // emitDestroyValueOperation will insert the appropriate instruction.
@@ -564,6 +620,7 @@ bool OwnershipModelEliminatorVisitor::visitSwitchEnumInst(
   return true;
 }
 
+// See also splitDestroy().
 void OwnershipModelEliminatorVisitor::splitDestructure(
     SILInstruction *destructureInst, SILValue destructureOperand) {
   assert((isa<DestructureStructInst>(destructureInst) ||
@@ -640,12 +697,11 @@ static bool stripOwnership(SILFunction &func) {
       arg->setOwnershipKind(OwnershipKind::None);
     }
 
-    for (auto ii = block.begin(), ie = block.end(); ii != ie;) {
-      // Since we are going to be potentially removing instructions, we need
-      // to make sure to increment our iterator before we perform any
-      // visits.
+    // This loop may erase instructions and split basic blocks.
+    for (auto ii = block.begin(); ii != block.end(); ++ii) {
       SILInstruction *inst = &*ii;
-      ++ii;
+      if (inst->isDeleted())
+        continue;
 
       madeChange |= visitor.visit(inst);
     }
@@ -665,6 +721,12 @@ static bool stripOwnership(SILFunction &func) {
     auto value = visitor.instructionsToSimplify.pop_back_val();
     if (!value.has_value())
       continue;
+
+    if (auto dropDeinit = dyn_cast<DropDeinitInst>(*value)) {
+      visitor.eraseInstructionAndRAUW(dropDeinit, dropDeinit->getOperand());
+      madeChange = true;
+      continue;
+    }
     auto callbacks =
         InstModCallbacks().onDelete([&](SILInstruction *instToErase) {
           visitor.eraseInstruction(instToErase);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -156,8 +156,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
 
   // Check noImplicitCopy and move only types for objects and addresses.
   P.addMoveOnlyChecker();
-  // Convert last destroy_value to deinits.
-  P.addMoveOnlyDeinitDevirtualization();
   // Lower move only wrapped trivial types.
   P.addTrivialMoveOnlyTypeEliminator();
   // Check no uses after consume operator of a value in an address.

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -157,7 +157,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // Check noImplicitCopy and move only types for objects and addresses.
   P.addMoveOnlyChecker();
   // Convert last destroy_value to deinits.
-  P.addMoveOnlyDeinitInsertion();
+  P.addMoveOnlyDeinitDevirtualization();
   // Lower move only wrapped trivial types.
   P.addTrivialMoveOnlyTypeEliminator();
   // Check no uses after consume operator of a value in an address.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1084,6 +1084,10 @@ SILInstruction *SILCombiner::visitReleaseValueInst(ReleaseValueInst *RVI) {
   SILValue Operand = RVI->getOperand();
   SILType OperandTy = Operand->getType();
 
+  // Do not remove a release that calls a value deinit.
+  if (hasValueDeinit(OperandTy))
+    return nullptr;
+
   // Destroy value of an enum with a trivial payload or no-payload is a no-op.
   if (auto *EI = dyn_cast<EnumInst>(Operand)) {
     if (!EI->hasOperand() ||

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1092,7 +1092,7 @@ SILInstruction *SILCombiner::visitReleaseValueInst(ReleaseValueInst *RVI) {
 
     // retain_value of an enum_inst where we know that it has a payload can be
     // reduced to a retain_value on the payload.
-    if (EI->hasOperand()) {
+    if (EI->hasOperand() && !hasValueDeinit(EI)) {
       return Builder.createReleaseValue(RVI->getLoc(), EI->getOperand(),
                                         RVI->getAtomicity());
     }

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(swiftSILOptimizer PRIVATE
   DifferentiabilityWitnessDevirtualizer.cpp
   EagerSpecializer.cpp
   GenericSpecializer.cpp
+  MoveOnlyDeinitDevirtualization.cpp
   Outliner.cpp
   ObjectOutliner.cpp
   AssemblyVisionRemarkGenerator.cpp

--- a/lib/SILOptimizer/Transforms/MoveOnlyDeinitDevirtualization.cpp
+++ b/lib/SILOptimizer/Transforms/MoveOnlyDeinitDevirtualization.cpp
@@ -1,4 +1,4 @@
-//===--- MoveOnlyDeinitInsertion.cpp --------------------------------------===//
+//===--- MoveOnlyDeinitDevirtualization.cpp --------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -143,7 +143,7 @@ static bool performTransform(SILFunction &fn) {
 
 namespace {
 
-class SILMoveOnlyDeinitInsertionPass : public SILFunctionTransform {
+class SILMoveOnlyDeinitDevirtualizationPass : public SILFunctionTransform {
   void run() override {
     auto *fn = getFunction();
 
@@ -153,7 +153,7 @@ class SILMoveOnlyDeinitInsertionPass : public SILFunctionTransform {
 
     assert(fn->getModule().getStage() == SILStage::Raw &&
            "Should only run on Raw SIL");
-    LLVM_DEBUG(llvm::dbgs() << "===> MoveOnly Deinit Insertion. Visiting: "
+    LLVM_DEBUG(llvm::dbgs() << "===> MoveOnly Deinit Devirtualization. Visiting: "
                             << fn->getName() << '\n');
     if (performTransform(*fn)) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::CallsAndInstructions);
@@ -163,6 +163,6 @@ class SILMoveOnlyDeinitInsertionPass : public SILFunctionTransform {
 
 } // anonymous namespace
 
-SILTransform *swift::createMoveOnlyDeinitInsertion() {
-  return new SILMoveOnlyDeinitInsertionPass();
+SILTransform *swift::createMoveOnlyDeinitDevirtualization() {
+  return new SILMoveOnlyDeinitDevirtualizationPass();
 }

--- a/lib/SILOptimizer/Transforms/MoveOnlyDeinitDevirtualization.cpp
+++ b/lib/SILOptimizer/Transforms/MoveOnlyDeinitDevirtualization.cpp
@@ -15,6 +15,13 @@
 /// This pass runs after move only checking has occurred and transforms last
 /// destroy_value of move only types into a call to the move only types deinit.
 ///
+/// TODO: This pass is disabled because it hides bugs in the common case in
+/// which optimization passes incorrectly remove the deinit, for example, by
+/// destructuring the aggregate rather than destroying it as a whole. Consider
+/// reeabling this pass later in the pipeline, after all other OSSA function
+/// passes have run. Also consider removing bailouts from this pass. If it's
+/// possible to devirtualize, then it should do it.
+///
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-move-only-checker"

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -309,6 +309,15 @@ void swift::eraseUsesOfValue(SILValue v) {
   }
 }
 
+bool swift::hasValueDeinit(SILType type) {
+  // Do not look inside an aggregate type that has a user-deinit, for which
+  // memberwise-destruction is not equivalent to aggregate destruction.
+  if (auto *nominal = type.getNominalOrBoundGenericNominal()) {
+    return nominal->getValueTypeDestructor() != nullptr;
+  }
+  return false;
+}
+
 SILValue swift::
 getConcreteValueOfExistentialBox(AllocExistentialBoxInst *existentialBox,
                                   SILInstruction *ignoreUser) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1109,13 +1109,23 @@ bool swift::simplifyUsers(SingleValueInstruction *inst) {
   return changed;
 }
 
-/// True if a type can be expanded without a significant increase to code size.
+// True if a type can be expanded without a significant increase to code size.
+//
+// False if expanding a type is invalid. For example, expanding a
+// struct-with-deinit drops the deinit.
 bool swift::shouldExpand(SILModule &module, SILType ty) {
   // FIXME: Expansion
   auto expansion = TypeExpansionContext::minimal();
 
   if (module.Types.getTypeLowering(ty, expansion).isAddressOnly()) {
     return false;
+  }
+  // A move-only-with-deinit type cannot be SROA.
+  //
+  // TODO: we could loosen this requirement if all paths lead to a drop_deinit.
+  if (auto *nominalTy = ty.getNominalOrBoundGenericNominal()) {
+    if (nominalTy->getValueTypeDestructor())
+      return false;
   }
   if (EnableExpandAll) {
     return true;

--- a/test/SILGen/discard.swift
+++ b/test/SILGen/discard.swift
@@ -25,10 +25,16 @@ func invokedDeinit() {}
   // CHECK:    [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_REF]] : $*MaybeFile
   // CHECK:    [[SELF_VAL:%.*]] = load [copy] [[SELF_MMC]] : $*MaybeFile
   // CHECK:    [[DD:%.*]] = drop_deinit [[SELF_VAL]] : $MaybeFile
-  // CHECK:    switch_enum [[DD]] : $MaybeFile, case #MaybeFile.some!enumelt: bb1, case #MaybeFile.none!enumelt: bb2
+  // CHECK:    destroy_value [[DD]] : $MaybeFile
+
+  // CHECK-SIL-LABEL: sil hidden @$s4test9MaybeFileOAASivg
+  // CHECK-SIL:    [[SELF_STACK:%.*]] = alloc_stack $MaybeFile, let, name "self", argno 1
+  // CHECK-SIL:    store {{.*}}
+  // CHECK-SIL:    [[SELF_VAL:%.*]] = load [[SELF_STACK]] : $*MaybeFile
+  // CHECK-SIL:    switch_enum [[SELF_VAL]] : $MaybeFile, case #MaybeFile.some!enumelt: bb1, case #MaybeFile.none!enumelt: bb2
   //
-  // CHECK:  bb1([[FILE:%.*]] : @owned $File):
-  // CHECK:    destroy_value [[FILE]] : $File
+  // CHECK-SIL:  bb1([[FILE:%.*]] : $File):
+  // CHECK-SIL:    release_value [[FILE]] : $File
 }
 
 @_moveOnly struct File {
@@ -54,7 +60,7 @@ func invokedDeinit() {}
   // CHECK:  [[SELF_MMC:%.*]] = mark_must_check [no_consume_or_assign] [[SELF_REF]] : $*File
   // CHECK:  [[SELF_VAL:%.*]] = load [copy] [[SELF_MMC]] : $*File
   // CHECK:  [[DD:%.*]] = drop_deinit [[SELF_VAL]] : $File
-  // CHECK:  end_lifetime [[DD]] : $File
+  // CHECK:  destroy_value [[DD]] : $File
 
   deinit {
     invokedDeinit()
@@ -90,7 +96,7 @@ func invokedDeinit() {}
 // CHECK:     [[COPIED_SELF:%.*]] = load [copy] [[MMC]] : $*PointerTree
 // CHECK:     end_access [[ACCESS]] : $*PointerTree
 // CHECK:     [[DD:%.*]] = drop_deinit [[COPIED_SELF]]
-// CHECK:     end_lifetime [[DD]]
+// CHECK:     destroy_value [[DD]]
 // CHECK:     br bb3
 //
 // CHECK:   bb2:
@@ -116,9 +122,7 @@ func invokedDeinit() {}
 // CHECK-SIL:     br bb3
 //
 // CHECK-SIL:  bb2:
-// CHECK-SIL:     [[TREE_DEINIT:%.*]] = function_ref @$s4test11PointerTreeVfD : $@convention(method) (@owned PointerTree) -> ()
-// CHECK-SIL:     [[SELF_VAL:%.*]] = load {{.*}} : $*PointerTree
-// CHECK-SIL:     apply [[TREE_DEINIT]]([[SELF_VAL]]) : $@convention(method) (@owned PointerTree) -> ()
+// CHECK-SIL:     destroy_addr %{{.*}} : $*PointerTree
 // CHECK-SIL:     br bb3
 //
 // CHECK-SIL:  bb3:
@@ -159,13 +163,24 @@ final class Wallet {
   // CHECK:    [[SELF_COPY:%.*]] = load [copy] [[SELF_MMC]] : $*Ticket
   // CHECK:    end_access [[SELF_ACCESS:%.*]] : $*Ticket
   // CHECK:    [[DD:%.*]] = drop_deinit [[SELF_COPY]] : $Ticket
-  // CHECK:    switch_enum [[DD]] : $Ticket, case #Ticket.empty!enumelt: [[TICKET_EMPTY:bb[0-9]+]], case #Ticket.within!enumelt: [[TICKET_WITHIN:bb[0-9]+]]
-  // CHECK:  [[TICKET_EMPTY]]:
-  // CHECK:    br [[JOIN_POINT:bb[0-9]+]]
-  // CHECK:  [[TICKET_WITHIN]]([[PREV_SELF_WALLET:%.*]] : @owned $Wallet):
-  // CHECK:    destroy_value [[PREV_SELF_WALLET]] : $Wallet
-  // CHECK:    br [[JOIN_POINT]]
-  // CHECK:  [[JOIN_POINT]]:
+  // CHECK:    destroy_value [[DD]] : $Ticket
+
+  // CHECK-SIL-LABEL: sil hidden @$s4test6TicketO06changeB08inWalletyAA0E0CSg_tF : $@convention(method) (@guaranteed Optional<Wallet>, @owned Ticket) -> () {
+  // CHECK-SIL:    [[SELF_REF:%.*]] = alloc_stack [lexical] $Ticket, var, name "self", implicit 
+  // CHECK-SIL:    switch_enum {{.*}} : $Optional<Wallet>, case #Optional.some!enumelt: {{.*}}, case #Optional.none!enumelt: [[NO_WALLET_BB:bb[0-9]+]]
+  //
+  // >> now we begin the destruction sequence, which involves pattern matching on self to destroy its innards
+  // CHECK-SIL:  [[NO_WALLET_BB]]
+  // CHECK-SIL:    [[SELF_ACCESS:%.*]] = begin_access [modify] [static] {{%.*}} : $*Ticket
+  // CHECK-SIL:    [[SELF_COPY:%.*]] = load [[SELF_ACCESS]] : $*Ticket
+  // CHECK-SIL:    end_access [[SELF_ACCESS:%.*]] : $*Ticket
+  // CHECK-SIL:    switch_enum [[SELF_COPY]] : $Ticket, case #Ticket.empty!enumelt: [[TICKET_EMPTY:bb[0-9]+]], case #Ticket.within!enumelt: [[TICKET_WITHIN:bb[0-9]+]]
+  // CHECK-SIL:  [[TICKET_EMPTY]]:
+  // CHECK-SIL:    br [[JOIN_POINT:bb[0-9]+]]
+  // CHECK-SIL:  [[TICKET_WITHIN]]([[PREV_SELF_WALLET:%.*]] : $Wallet):
+  // CHECK-SIL:    strong_release [[PREV_SELF_WALLET]] : $Wallet
+  // CHECK-SIL:    br [[JOIN_POINT]]
+  // CHECK-SIL:  [[JOIN_POINT]]:
 
   deinit {
     print("destroying ticket")

--- a/test/SILGen/discard.swift
+++ b/test/SILGen/discard.swift
@@ -1,6 +1,12 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyEnumDeinits -module-name test %s | %FileCheck %s --enable-var-scope
 // RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyEnumDeinits -module-name test -sil-verify-all %s | %FileCheck %s --check-prefix CHECK-SIL --enable-var-scope
 
+// UNSUPPORTED: OS=windows-msvc
+//
+// On Windows, the struct_extract instructions are not fully cleaned up:
+// CHECK-SIL-NOT: struct_extract
+// It likely has to do with the lazy property.
+
 func invokedDeinit() {}
 
 @_moveOnly enum MaybeFile {

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -66,16 +66,14 @@ var value: Bool { false }
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 // SILGEN:   [[DD:%.*]] = drop_deinit [[MARK]]
-// SILGEN:   ([[LHS:%.*]], [[RHS:%.*]]) = destructure_struct [[DD]]
-// SILGEN:   destroy_value [[LHS]]
-// SILGEN:   destroy_value [[RHS]]
+// SILGEN:   destroy_value [[DD]]
 // SILGEN: } // end sil function '$s16moveonly_deinits19KlassPairWithDeinitVfD'
 
 // SILGEN-LABEL: sil hidden [ossa] @$s16moveonly_deinits17IntPairWithDeinitVfD : $@convention(method) (@owned IntPairWithDeinit) -> () {
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARKED:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 // SILGEN:   [[DD:%.*]] = drop_deinit [[MARKED]]
-// SILGEN:   end_lifetime [[DD]]
+// SILGEN:   destroy_value [[DD]]
 // SILGEN: } // end sil function '$s16moveonly_deinits17IntPairWithDeinitVfD'
 
 ////////////////////////
@@ -165,11 +163,7 @@ public func testIntPairWithoutDeinit() {
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits17IntPairWithDeinitVfD : $@convention(method) (@owned IntPairWithDeinit) -> ()
-// SIL:   [[VALUE:%.*]] = load [[STACK]]
-// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntPairWithDeinit) -> ()
-// SIL-NOT: apply
-// SIL-NOT: destroy_addr
+// SIL:   destroy_addr [[STACK]] : $*IntPairWithDeinit 
 // SIL:   br bb3
 //
 // SIL: bb3:
@@ -266,11 +260,7 @@ public func testKlassPairWithoutDeinit() {
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits19KlassPairWithDeinitVfD : $@convention(method) (@owned KlassPairWithDeinit) -> ()
-// SIL:   [[VALUE:%.*]] = load [[STACK]]
-// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassPairWithDeinit) -> ()
-// SIL-NOT: apply
-// SIL-NOT: destroy_addr
+// SIL:   destroy_addr [[STACK]] : $*KlassPairWithDeinit
 // SIL:   br bb3
 //
 // SIL: bb3:
@@ -332,17 +322,7 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 // SILGEN:   [[DD:%.*]] = drop_deinit [[MARK]]
-// SILGEN:   switch_enum [[DD]] : $KlassEnumPairWithDeinit, case #KlassEnumPairWithDeinit.lhs!enumelt: [[BB_LHS:bb[0-9]+]], case #KlassEnumPairWithDeinit.rhs!enumelt: [[BB_RHS:bb[0-9]+]]
-//
-// SILGEN: [[BB_LHS]]([[ARG:%.*]] :
-// SILGEN-NEXT: destroy_value [[ARG]]
-// SILGEN-NEXT: br [[BB_CONT:bb[0-9]+]]
-//
-// SILGEN: [[BB_RHS]]([[ARG:%.*]] :
-// SILGEN-NEXT: destroy_value [[ARG]]
-// SILGEN-NEXT: br [[BB_CONT]]
-//
-// SILGEN: [[BB_CONT]]:
+// SILGEN:   destroy_value [[DD]] : $KlassEnumPairWithDeinit
 // SILGEN-NEXT: tuple ()
 // SILGEN-NEXT: return
 // SILGEN: } // end sil function '$s16moveonly_deinits23KlassEnumPairWithDeinitOfD'
@@ -351,15 +331,7 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 // SILGEN: bb0([[ARG:%.*]] :
 // SILGEN:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 // SILGEN:   [[DD:%.*]] = drop_deinit [[MARK]]
-// SILGEN:   switch_enum [[DD]] : $IntEnumPairWithDeinit, case #IntEnumPairWithDeinit.lhs!enumelt: [[BB_LHS:bb[0-9]+]], case #IntEnumPairWithDeinit.rhs!enumelt: [[BB_RHS:bb[0-9]+]]
-//
-// SILGEN: [[BB_LHS]]([[ARG:%.*]] :
-// SILGEN-NEXT: br [[BB_CONT:bb[0-9]+]]
-//
-// SILGEN: [[BB_RHS]]([[ARG:%.*]] :
-// SILGEN-NEXT: br [[BB_CONT]]
-//
-// SILGEN: [[BB_CONT]]:
+// SILGEN:   destroy_value [[DD]] : $IntEnumPairWithDeinit
 // SILGEN-NEXT: tuple ()
 // SILGEN-NEXT: return
 // SILGEN: } // end sil function '$s16moveonly_deinits21IntEnumPairWithDeinitOfD'
@@ -449,11 +421,7 @@ public func testIntEnumPairWithoutDeinit() {
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits21IntEnumPairWithDeinitOfD : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
-// SIL:   [[VALUE:%.*]] = load [[STACK]]
-// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
-// SIL-NOT: apply
-// SIL-NOT: destroy_addr
+// SIL:   destroy_addr [[STACK]] : $*IntEnumPairWithDeinit
 // SIL:   br bb3
 //
 // SIL: bb3:
@@ -547,11 +515,7 @@ public func testKlassEnumPairWithoutDeinit() {
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits23KlassEnumPairWithDeinitOfD : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
-// SIL:   [[VALUE:%.*]] = load [[STACK]]
-// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
-// SIL-NOT: apply
-// SIL-NOT: destroy_addr
+// SIL:   destroy_addr [[STACK]] : $*KlassEnumPairWithDeinit
 // SIL:   br bb3
 //
 // SIL: bb3:

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -18,6 +18,11 @@ struct CAndBit {
     var bit: Int1
 }
 
+@_moveOnly
+struct MO {
+    deinit
+}
+
 sil @dummy : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [ossa] @dead1 :
@@ -406,4 +411,24 @@ exit:
   destroy_value %instance : $C
   %retval = tuple ()
   return %retval : $()
+}
+
+// Test that DCE does not eliminate a drop_deinit.
+//
+// rdar://109863801 ([move-only] DCE removes drop_deinit, so
+// user-defined deinitializers call themselves recursively at -O)
+//
+// CHECK-LABEL: sil hidden [ossa] @testDropDeinit : $@convention(method) (@owned MO) -> () {
+// CHECK: [[DROP:%.*]] = drop_deinit %0 : $MO
+// CHECK: end_lifetime [[DROP]] : $MO
+// CHECK-LABEL: } // end sil function 'testDropDeinit'
+//
+// MO.deinit
+sil hidden [ossa] @testDropDeinit : $@convention(method) (@owned MO) -> () {
+bb0(%0 : @owned $MO):
+  debug_value %0 : $MO, let, name "self", argno 1, implicit
+  %61 = drop_deinit %0 : $MO
+  end_lifetime %61 : $MO
+  %63 = tuple ()
+  return %63 : $()
 }

--- a/test/SILOptimizer/earlycodemotion_moveonly.sil
+++ b/test/SILOptimizer/earlycodemotion_moveonly.sil
@@ -1,0 +1,38 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -early-codemotion -retain-sinking -enable-experimental-feature MoveOnlyEnumDeinits | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+struct FileDescriptor: ~Copyable {
+  var fd: Builtin.Int64
+
+  init(fd: Builtin.Int64)
+  deinit
+}
+
+enum MaybeFileDescriptor: ~Copyable {
+  case some(FileDescriptor)
+  case nothing
+
+  consuming func discard() { discard self }
+
+  deinit
+}
+
+
+// Test that a release_value is not replaced for a enum-with-deinit.
+// Doing so would forget the deinit.
+//
+// CHECK-LABEL: sil hidden [noinline] @testEnumDeinit : $@convention(thin) () -> () {
+// CHECK:   release_value %{{.*}} : $MaybeFileDescriptor
+// CHECK-LABEL: } // end sil function 'testEnumDeinit'
+sil hidden [noinline] @testEnumDeinit : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %26 = struct $FileDescriptor (%0 : $Builtin.Int64)
+  %38 = enum $MaybeFileDescriptor, #MaybeFileDescriptor.some!enumelt, %26 : $FileDescriptor
+  release_value %38 : $MaybeFileDescriptor
+  %42 = tuple ()
+  return %42 : $()
+}

--- a/test/SILOptimizer/late_release_hoisting.sil
+++ b/test/SILOptimizer/late_release_hoisting.sil
@@ -31,6 +31,15 @@ class HasHasObj {
   var ho : HasObj
 }
 
+public final class C {}
+
+@_moveOnly
+struct FD {
+  var c = C()
+
+  deinit {}
+}
+
 sil @$s4test8HasInt64CfD : $@convention(method) (@owned HasInt64) -> () {
 [%0: noescape **]
 }
@@ -307,4 +316,17 @@ bb0(%0 : $Int64, %1 : $HasObj):
   %o = load %oadr : $*AnyObject
   strong_release %lo : $HasHasInt64
   return %o : $AnyObject
+}
+
+// Test that a struct-with-deinit is not RC-identical to its single member.
+//
+// CHECK-LABEL: sil hidden @fdDeinit : $@convention(method) (@owned FD) -> () {
+// CHECK:         strong_release %{{.*}} : $C
+// CHECK-LABEL: } // end sil function 'fdDeinit'
+sil hidden @fdDeinit : $@convention(method) (@owned FD) -> () {
+bb0(%0 : $FD):
+  %2 = struct_extract %0 : $FD, #FD.c
+  strong_release %2 : $C
+  %4 = tuple ()
+  return %4 : $()
 }

--- a/test/SILOptimizer/loweraggregateinstrs_moveonly.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_moveonly.sil
@@ -1,0 +1,34 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -lower-aggregate-instrs %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+struct S : ~Copyable {
+  deinit {}
+}
+struct S2 : ~Copyable {
+  var s1 = S()
+  var s2 = S()
+}
+
+// Test that a struct-with-deinit is preserved on both members s1 and s2.
+//
+// public func testDeinitTwo() {
+//   var s = S2()
+// }
+//
+// CHECK-LABEL: sil @testDeinitTwo : $@convention(thin) () -> () {
+// CHECK: struct_extract [[S2:%.*]] : $S2, #S2.s1
+// CHECK: release_value %{{.*}} : $S
+// CHECK: struct_extract [[S2]] : $S2, #S2.s2
+// CHECK: release_value %{{.*}} : $S
+// CHECK-LABEL: } // end sil function 'testDeinitTwo'
+sil @testDeinitTwo : $@convention(thin) () -> () {
+bb0:
+  %0 = struct $S ()
+  %1 = struct $S2 (%0 : $S, %0 : $S)
+  release_value %1 : $S2
+  %5 = tuple ()
+  return %5 : $()
+}

--- a/test/SILOptimizer/moveonly_deinit_devirtualization.sil
+++ b/test/SILOptimizer/moveonly_deinit_devirtualization.sil
@@ -19,6 +19,13 @@ struct TrivialStruct {
 }
 
 @_moveOnly
+struct StructDeinit {
+  var i: Builtin.Int32
+
+  deinit
+}
+
+@_moveOnly
 struct SingleFieldNonTrivial {
   var k: Klass
 }
@@ -69,14 +76,14 @@ bb0(%0 : @owned $Klass):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @trivialStructTest : $@convention(thin) (@owned TrivialStruct) -> () {
-// CHECK: bb0([[ARG:%.*]] : @owned $TrivialStruct):
-// CHECK:   [[FUNC:%.*]] = function_ref @$s4main13TrivialStructVfD :
+// CHECK-LABEL: sil [ossa] @structDeinitTest : $@convention(thin) (@owned StructDeinit) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $StructDeinit):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main12StructDeinitVfD :
 // CHECK:   apply [[FUNC]]([[ARG]])
-// CHECK: } // end sil function 'trivialStructTest'
-sil [ossa] @trivialStructTest : $@convention(thin) (@owned TrivialStruct) -> () {
-bb0(%0 : @owned $TrivialStruct):
-  destroy_value %0 : $TrivialStruct
+// CHECK: } // end sil function 'structDeinitTest'
+sil [ossa] @structDeinitTest : $@convention(thin) (@owned StructDeinit) -> () {
+bb0(%0 : @owned $StructDeinit):
+  destroy_value %0 : $StructDeinit
   %9999 = tuple()
   return %9999 : $()
 }
@@ -125,15 +132,15 @@ bb0(%0 : @owned $NonTrivialMoveOnlyEnum):
 //                                 Var Tests
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: sil [ossa] @trivialStructAddrTest : $@convention(thin) (@in TrivialStruct) -> () {
-// CHECK: bb0([[ARG:%.*]] : $*TrivialStruct):
-// CHECK:   [[FUNC:%.*]] = function_ref @$s4main13TrivialStructVfD :
+// CHECK-LABEL: sil [ossa] @trivialStructAddrTest : $@convention(thin) (@in StructDeinit) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*StructDeinit):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s4main12StructDeinitVfD :
 // CHECK:   [[LOADED_VALUE:%.*]] = load [take] [[ARG]]
 // CHECK:   apply [[FUNC]]([[LOADED_VALUE]])
 // CHECK: } // end sil function 'trivialStructAddrTest'
-sil [ossa] @trivialStructAddrTest : $@convention(thin) (@in TrivialStruct) -> () {
-bb0(%0 : $*TrivialStruct):
-  destroy_addr %0 : $*TrivialStruct
+sil [ossa] @trivialStructAddrTest : $@convention(thin) (@in StructDeinit) -> () {
+bb0(%0 : $*StructDeinit):
+  destroy_addr %0 : $*StructDeinit
   %9999 = tuple()
   return %9999 : $()
 }
@@ -216,12 +223,13 @@ bb0(%0 : $*ThreeNonTrivialNoDeinit):
 //                                Destructors
 //===----------------------------------------------------------------------===//
 
-sil hidden [ossa] @$s4main13TrivialStructVfD : $@convention(method) (@owned TrivialStruct) -> () {
-bb0(%0 : @owned $TrivialStruct):
-  debug_value %0 : $TrivialStruct, let, name "self", argno 1, implicit
-  %2 = destructure_struct %0 : $TrivialStruct
-  %3 = tuple ()
-  return %3 : $()
+sil hidden [ossa] @$s4main12StructDeinitVfD : $@convention(method) (@owned StructDeinit) -> () {
+bb0(%0 : @owned $StructDeinit):
+  debug_value %0 : $StructDeinit, let, name "self", argno 1, implicit
+  %2 = drop_deinit %0 : $StructDeinit
+  %3 = destructure_struct %2 : $StructDeinit
+  %4 = tuple ()
+  return %4 : $()
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main21SingleFieldNonTrivialVfD : $@convention(method) (@owned SingleFieldNonTrivial) -> () {
@@ -313,40 +321,40 @@ bb6:
 //                              drop_deinit Tests
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK-LABEL: sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned StructDeinit) -> () {
 // CHECK:         %1 = drop_deinit %0
 // CHECK-NEXT:    destroy_value %1
 // CHECK:       } // end sil function 'dropDeinitOnStruct'
-sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned TrivialStruct) -> () {
-bb0(%0 : @owned $TrivialStruct):
-  %1 = drop_deinit %0 : $TrivialStruct
-  destroy_value %1 : $TrivialStruct
+sil [ossa] @dropDeinitOnStruct : $@convention(thin) (@owned StructDeinit) -> () {
+bb0(%0 : @owned $StructDeinit):
+  %1 = drop_deinit %0 : $StructDeinit
+  destroy_value %1 : $StructDeinit
   %9999 = tuple()
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned TrivialStruct) -> () {
+// CHECK-LABEL: sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned StructDeinit) -> () {
 // CHECK:         %1 = drop_deinit %0
 // CHECK-NEXT:    %2 = move_value %1
 // CHECK-NEXT:    destroy_value %2
 // CHECK:       } // end sil function 'dropDeinitOnMovedStruct'
-sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned TrivialStruct) -> () {
-bb0(%0 : @owned $TrivialStruct):
-  %1 = drop_deinit %0 : $TrivialStruct
-  %2 = move_value %1 : $TrivialStruct
-  destroy_value %2 : $TrivialStruct
+sil [ossa] @dropDeinitOnMovedStruct : $@convention(thin) (@owned StructDeinit) -> () {
+bb0(%0 : @owned $StructDeinit):
+  %1 = drop_deinit %0 : $StructDeinit
+  %2 = move_value %1 : $StructDeinit
+  destroy_value %2 : $StructDeinit
   %9999 = tuple()
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in TrivialStruct) -> () {
+// CHECK-LABEL: sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in StructDeinit) -> () {
 // CHECK:         %1 = drop_deinit %0
 // CHECK-NEXT:    destroy_addr %1
 // CHECK:       } // end sil function 'dropDeinitOnIndirectStruct'
-sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in TrivialStruct) -> () {
-bb0(%0 : $*TrivialStruct):
-  %1 = drop_deinit %0 : $*TrivialStruct
-  destroy_addr %1 : $*TrivialStruct
+sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in StructDeinit) -> () {
+bb0(%0 : $*StructDeinit):
+  %1 = drop_deinit %0 : $*StructDeinit
+  destroy_addr %1 : $*StructDeinit
   %9999 = tuple()
   return %9999 : $()
 }
@@ -359,8 +367,8 @@ sil_moveonlydeinit Klass {
   @$s4main5KlassCfD
 }
 
-sil_moveonlydeinit TrivialStruct {
-  @$s4main13TrivialStructVfD	// TrivialStruct.deinit
+sil_moveonlydeinit StructDeinit {
+  @$s4main12StructDeinitVfD	// StructDeinit.deinit
 }
 
 sil_moveonlydeinit SingleFieldNonTrivial {

--- a/test/SILOptimizer/moveonly_deinit_devirtualization.sil
+++ b/test/SILOptimizer/moveonly_deinit_devirtualization.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name main -enable-sil-verify-all -sil-move-only-deinit-insertion -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name main -enable-sil-verify-all -sil-move-only-deinit-devirtualization -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyEnumDeinits %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -19,9 +19,6 @@ struct MoveOnlyStruct {
         y = self
         // expected-note @-1 {{consumed here}}
         // expected-note @-2 {{consumed again here}}
-        // We get an infinite recursion since we are going to call our own
-        // deinit here. We are just testing diagnostics here though.
-        // expected-warning @-6 {{function call causes an infinite recursion}}
         _ = y
         // expected-note @-1 {{consumed here}}
         let z = y // expected-note {{consumed again here}}
@@ -45,9 +42,6 @@ enum MoveOnlyEnum {
         var y = MoveOnlyEnum.lhs(Klass())
         y = self // expected-note {{consumed here}}
         // expected-note @-1 {{consumed again here}}
-        // We get an infinite recursion since we are going to call our own
-        // deinit here. We are just testing diagnostics here though.
-        // expected-warning @-5 {{function call causes an infinite recursion}}
         _ = y 
         globalMoveOnlyEnum = self // expected-note {{consumed here}}
         // expected-note @-1 {{consumed again here}}

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -38,9 +38,7 @@ func something()
 // CHECK:         apply [[BORROW_C]]([[INSTANCE]])
 //
 // TODO: Once we maximize lifetimes this should be below something.
-// CHECK:         [[DESTROY_C:%[^,]+]] = function_ref @$s17moveonly_lifetime1CVfD
-// CHECK:         [[INSTANCE:%.*]] = load [take] [[STACK]]
-// CHECK:         apply [[DESTROY_C]]([[INSTANCE]])
+// CHECK:         destroy_addr [[STACK]]
 //
 // CHECK:         [[SOMETHING:%[^,]+]] = function_ref @something
 // CHECK:         apply [[SOMETHING]]

--- a/test/SILOptimizer/sil_combine_moveonly.sil
+++ b/test/SILOptimizer/sil_combine_moveonly.sil
@@ -1,28 +1,73 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-experimental-feature MoveOnlyEnumDeinits -enable-sil-verify-all -sil-combine %s | %FileCheck %s
 
- sil_stage canonical
+sil_stage canonical
 
- import Builtin
+import Builtin
 
- struct S : ~Copyable {
-   deinit {}
- }
+struct S : ~Copyable {
+  deinit {}
+}
 
- // Test that a release_value is not removed for a struct-with-deinit.
- // Doing so would forget the deinit.
- //
- // public func testStructDeinit() {
- //   var s = S()
- // }
- //
- // CHECK-LABEL: sil @testStructDeinit : $@convention(thin) () -> () {
- // CHECK:         release_value %{{.*}} : $S
- // CHECK-LABEL: } // end sil function 'testStructDeinit'
- sil @testStructDeinit : $@convention(thin) () -> () {
- bb0:
-   %0 = struct $S ()
-   release_value %0 : $S
-   %5 = tuple ()
-   return %5 : $()
- }
- 
+struct FileDescriptor: ~Copyable {
+  var fd: Builtin.Int64
+
+  init(fd: Builtin.Int64)
+  deinit
+}
+
+enum MaybeFileDescriptor: ~Copyable {
+  case some(FileDescriptor)
+  case nothing
+
+  consuming func discard() { discard self }
+
+  deinit
+}
+
+// Test that a release_value is not removed for a struct-with-deinit.
+// Doing so would forget the deinit.
+//
+// public func testStructDeinit() {
+//   var s = S()
+// }
+//
+// CHECK-LABEL: sil @testStructDeinit : $@convention(thin) () -> () {
+// CHECK:         release_value %{{.*}} : $S
+// CHECK-LABEL: } // end sil function 'testStructDeinit'
+sil @testStructDeinit : $@convention(thin) () -> () {
+bb0:
+  %0 = struct $S ()
+  release_value %0 : $S
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// Test that a release_value is not replaced for a enum-with-deinit.
+// Doing so would forget the deinit.
+//
+// CHECK-LABEL: sil hidden [noinline] @testEnumDeinit : $@convention(thin) () -> () {
+// CHECK:   release_value %{{.*}} : $MaybeFileDescriptor
+// CHECK-LABEL: } // end sil function 'testEnumDeinit'
+sil hidden [noinline] @testEnumDeinit : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %26 = struct $FileDescriptor (%0 : $Builtin.Int64)
+  %38 = enum $MaybeFileDescriptor, #MaybeFileDescriptor.some!enumelt, %26 : $FileDescriptor
+  release_value %38 : $MaybeFileDescriptor
+  %42 = tuple ()
+  return %42 : $()
+}
+
+// Test that a release of a trivial payload is not removed.
+//
+// CHECK-LABEL: sil hidden [noinline] @testEnumDeinitTrivialPayload : $@convention(thin) () -> () {
+// CHECK:   release_value %{{.*}} : $MaybeFileDescriptor
+// CHECK-LABEL: } // end sil function 'testEnumDeinitTrivialPayload'
+sil hidden [noinline] @testEnumDeinitTrivialPayload : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $MaybeFileDescriptor, #MaybeFileDescriptor.nothing!enumelt // users: %2, %1
+  debug_value %0 : $MaybeFileDescriptor, var, name "maybe" // id: %1
+  release_value %0 : $MaybeFileDescriptor
+  %9 = tuple ()
+  return %9 : $()
+}


### PR DESCRIPTION
--- CCC ---

Explanation:

Many basic SIL passes were silently deleting the struct and enum deinits:

- SROA
- Mem2Reg
- RLE
- DSE
- FunctionSignatureOpts
- LowerAggregates
- SILCombine
- EarlyCodeMotion
- ReleaseHoisting
- many passes that rely on ARC analysis (RCIndentity)

Major Changes:

- add SIL verification for drop_deinit
- fix ownership lowering to handle drop_deinit
- disable deinit devirtualization (until the optimizer is tested)
- fix 'shouldExpand' to recognize value deinits; impacts many passes
- fix dead function elimination to collect and preserve value deinits
- fix RCIdentity to recognize value deinits; impacts many passes
- fix SILCombine special cases to preserve value deinits
- fix TypeLowering to preserve value deinits; mainly fixes LowerAggregates

Scope of Issue: In some cases, deinitialization would run recursively, hanging the system. In other cases, a struct's deinit would silently fail to run when the struct was a member within another type. In the most trivial cases, with no type composition, and earlier MoveOnlyDeinitInsertion pass was hiding the problem.

Risk: Low risk to regular copyable code. And non-copyable was already broken.

PR to main: [move-only] Fix SIL representation and SILOptimizer to preserve value deinits #66314
https://github.com/apple/swift/pull/66314

Reviewed By: Erik Eckstein and Joe Groff

Resolves:

rdar://109849028 ([move-only] LowerAggregateInstrs eliminates struct deinitialization)

rdar://109863801 ([move-only] DCE removes drop_deinit, so user-defined deinitializers call themselves recursively at -O)

rdar://110079028 ([move-only] Finish SIL support for drop_deinit)
