### PR TITLE
Merge identical block copy/destroy helpers and descriptors

### DIFF
--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -364,7 +364,11 @@ public:
   virtual void getSchema(ExplosionSchema &schema) const = 0;
   virtual void destroy(IRGenFunction &IGF, Address addr, SILType T,
                        bool isOutlined) const = 0;
-
+  virtual std::string encodeDestroy(IRGenModule &IGM, Alignment alignment,
+                                    Size &offset, bool &outIsSupported) const {
+    outIsSupported = false;
+    return "";
+  }
   virtual void initializeFromParams(IRGenFunction &IGF, Explosion &params,
                                     Address dest, SILType T,
                                     bool isOutlined) const;
@@ -375,6 +379,13 @@ public:
                               SILType T, bool isOutlined) const = 0;
   virtual void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                                   SILType T, bool isOutlined) const = 0;
+  virtual std::string encodeInitializeWithCopy(IRGenModule &IGM,
+                                               Alignment alignment,
+                                               Size &offset,
+                                               bool &outIsSupported) const {
+    outIsSupported = false;
+    return "";
+  }
   virtual void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                                   SILType T, bool isOutlined) const = 0;
 

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -32,6 +32,13 @@ namespace irgen {
   class ForeignFunctionInfo;
   class IRGenFunction;
 
+  enum class BlockCaptureInitializeKind {
+    Store,
+  };
+
+  std::string
+  getBlockCaptureInitializeKindEncoding(BlockCaptureInitializeKind kind);
+
   /// Project the capture address from on-stack block storage.
   Address projectBlockStorageCapture(IRGenFunction &IGF,
                                      Address storageAddr,

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1244,12 +1244,10 @@ HelperGetObjCEncodingForType(const clang::ASTContext &Context,
                                             T, S, Extended);
 }
 
-static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
-                                               CanSILFunctionType fnType,
-                                               ArrayRef<SILParameterInfo> params,
-                                               StringRef fixedParamsString,
-                                               Size::int_type parmOffset,
-                                               bool useExtendedEncoding) {
+static std::string getObjCEncodingStringForTypes(
+    IRGenModule &IGM, CanSILFunctionType fnType,
+    ArrayRef<SILParameterInfo> params, StringRef fixedParamsString,
+    Size::int_type parmOffset, bool useExtendedEncoding) {
   auto resultType = fnType->getFormalCSemanticResult(IGM.getSILModule());
   auto &clangASTContext = IGM.getClangASTContext();
   
@@ -1259,7 +1257,7 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
   {
     auto clangType = IGM.getClangType(resultType.getASTType());
     if (clangType.isNull())
-      return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
+      return "";
     HelperGetObjCEncodingForType(clangASTContext, clangType, encodingString,
                                  useExtendedEncoding);
   }
@@ -1271,8 +1269,8 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
     auto clangType = IGM.getClangType(param.getArgumentType(
         IGM.getSILModule(), fnType, IGM.getMaximalTypeExpansionContext()));
     if (clangType.isNull())
-      return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
-    
+      return "";
+
     // TODO. Some stuff related to Array and Function type is missing.
     // TODO. Encode type qualifier, 'in', 'inout', etc. for the parameter.
     HelperGetObjCEncodingForType(clangASTContext, clangType, paramsString,
@@ -1285,6 +1283,19 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
   encodingString += llvm::itostr(parmOffset);
   encodingString += fixedParamsString;
   encodingString += paramsString;
+  return encodingString;
+}
+
+static llvm::Constant *
+getObjCEncodingForTypes(IRGenModule &IGM, CanSILFunctionType fnType,
+                        ArrayRef<SILParameterInfo> params,
+                        StringRef fixedParamsString, Size::int_type parmOffset,
+                        bool useExtendedEncoding) {
+  auto encodingString = getObjCEncodingStringForTypes(
+      IGM, fnType, params, fixedParamsString, parmOffset, useExtendedEncoding);
+  if (encodingString.empty()) {
+    return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
+  }
   return IGM.getAddrOfGlobalString(encodingString);
 }
 
@@ -1607,10 +1618,22 @@ irgen::getBlockTypeExtendedEncoding(IRGenModule &IGM,
   // Skip the storage pointer, which is encoded as '@?' to avoid the infinite
   // recursion of the usual '@?<...>' rule for blocks.
   auto paramTypes = invokeTy->getParameters().slice(1);
-  
-  return getObjCEncodingForTypes(IGM, invokeTy, paramTypes,
-                                 "@?0", IGM.getPointerSize().getValue(),
+
+  return getObjCEncodingForTypes(IGM, invokeTy, paramTypes, "@?0",
+                                 IGM.getPointerSize().getValue(),
                                  /*extended*/ true);
+}
+
+std::string
+irgen::getBlockTypeExtendedEncodingString(IRGenModule &IGM,
+                                          CanSILFunctionType invokeTy) {
+  // Skip the storage pointer, which is encoded as '@?' to avoid the infinite
+  // recursion of the usual '@?<...>' rule for blocks.
+  auto paramTypes = invokeTy->getParameters().slice(1);
+
+  return getObjCEncodingStringForTypes(IGM, invokeTy, paramTypes, "@?0",
+                                       IGM.getPointerSize().getValue(),
+                                       /*extended*/ true);
 }
 
 void irgen::emitObjCGetterDescriptor(IRGenModule &IGM,

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -178,7 +178,10 @@ namespace irgen {
   /// \returns the encoded type.
   llvm::Constant *getBlockTypeExtendedEncoding(IRGenModule &IGM,
                                                CanSILFunctionType invokeTy);
-  
+
+  std::string getBlockTypeExtendedEncodingString(IRGenModule &IGM,
+                                                 CanSILFunctionType invokeTy);
+
   /// Produces extended encoding of method type.
   /// \returns the encoded type.
   llvm::Constant *getMethodTypeExtendedEncoding(IRGenModule &IGM,

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -122,6 +122,16 @@ public:
     IGF.emitStrongRetain(value, asDerived().getReferenceCounting(), atomicity);
   }
 
+  bool supportsEncodingScalarRetain() const override { return true; }
+  std::string encodeScalarRetain(IRGenModule &IGM) const override {
+    return refcountingToString(asDerived().getReferenceCounting());
+  }
+  bool supportsEncodingScalarRelease() const override { return true; }
+  std::string encodeScalarRelease(IRGenModule &IGM) const override {
+    return refcountingToString(asDerived().getReferenceCounting());
+  }
+  Size getSizeForEncoding() const override { return super::getFixedSize(); }
+
   // Implement the primary retain/release operations of ReferenceTypeInfo
   // using basic reference counting.
   void strongRetain(IRGenFunction &IGF, Explosion &e,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -29,6 +29,8 @@
 #include "swift/AST/ReferenceCounting.h"
 #include "llvm/ADT/MapVector.h"
 
+#include <string>
+
 namespace llvm {
   class Constant;
   class Twine;
@@ -378,6 +380,22 @@ public:
                                   Address srcAddr, SILType T,
                                   bool isOutlined) const = 0;
 
+  /// Encode the behavior of initializeWithCopy into a string.
+  /// Subclasses that supports the encoding should set the out parameter
+  /// outIsSupported to true.
+  virtual std::string encodeInitializeWithCopy(IRGenModule &IGM,
+                                               Alignment alignment,
+                                               Size &offset,
+                                               bool &outIsSupported) const {
+    outIsSupported = false;
+    return "";
+  }
+  std::string encodeInitializeWithCopy(IRGenModule &IGM, Alignment alignment,
+                                       bool &outIsSupported) const {
+    Size offset;
+    return encodeInitializeWithCopy(IGM, alignment, offset, outIsSupported);
+  }
+
   /// Perform a copy-initialization from the given fixed-size buffer
   /// into an uninitialized fixed-size buffer, allocating the buffer if
   /// necessary.  Returns the address of the value inside the buffer.
@@ -400,6 +418,20 @@ public:
   /// Destroy an object of this type in memory.
   virtual void destroy(IRGenFunction &IGF, Address address, SILType T,
                        bool isOutlined) const = 0;
+
+  /// Encode the behavior of destroy into a string.
+  /// Subclasses that supports the encoding should set the out parameter
+  /// outIsSupported to true.
+  virtual std::string encodeDestroy(IRGenModule &IGM, Alignment alignment,
+                                    Size &offset, bool &outIsSupported) const {
+    outIsSupported = false;
+    return "";
+  }
+  std::string encodeDestroy(IRGenModule &IGM, Alignment alignment,
+                            bool &outIsSupported) const {
+    Size offset;
+    return encodeDestroy(IGM, alignment, offset, outIsSupported);
+  }
 
   /// Should optimizations be enabled which rely on the representation
   /// for this type being a single object pointer?

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -13,16 +13,17 @@
 #include "ConstantBuilder.h"
 #include "EnumPayload.h"
 #include "FixedTypeInfo.h"
-#include "GenOpaque.h"
-#include "IRGen.h"
 #include "GenEnum.h"
 #include "GenExistential.h"
+#include "GenOpaque.h"
 #include "GenericArguments.h"
+#include "IRGen.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "SwitchBuilder.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ReferenceCounting.h"
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/None.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -462,6 +463,10 @@ static std::string scalarToString(ScalarKind kind) {
   case ScalarKind::ExistentialReference: return "ExistentialReference";
   case ScalarKind::CustomReference: return "Custom";
   }
+}
+
+std::string swift::irgen::refcountingToString(ReferenceCounting refCounting) {
+  return scalarToString(refcountingToScalarKind(refCounting));
 }
 
 llvm::Function *createMetatypeAccessorFunction(IRGenModule &IGM, SILType ty,

--- a/lib/IRGen/TypeLayout.h
+++ b/lib/IRGen/TypeLayout.h
@@ -15,6 +15,7 @@
 
 #include "FixedTypeInfo.h"
 #include "TypeInfo.h"
+#include "swift/AST/ReferenceCounting.h"
 #include "swift/SIL/SILType.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/Debug.h"
@@ -56,6 +57,8 @@ enum class ScalarKind : uint8_t {
 
 /// Convert a ReferenceCounting into the appropriate Scalar reference
 ScalarKind refcountingToScalarKind(ReferenceCounting refCounting);
+
+std::string refcountingToString(ReferenceCounting refCounting);
 
 class TypeLayoutEntry {
 protected:

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -13,18 +13,18 @@ import gizmo
 
 // CHECK: [[BLOCK_ISA:@_NSConcreteStackBlock]] = external global {{(dllimport )?}}%objc_class
 // CHECK: [[VOID_BLOCK_SIGNATURE:@.*]] = private unnamed_addr constant {{.*}} c"v8@?0\00"
-// CHECK: [[TRIVIAL_BLOCK_DESCRIPTOR:@.*]] = internal constant { i64, i64, ptr } {
+// CHECK: [[TRIVIAL_BLOCK_DESCRIPTOR:@"block_descriptor_40_v8\\01\?0"]] = linkonce_odr hidden unnamed_addr constant { i64, i64, ptr } {
 // CHECK-SAME:   i64 0,
 // CHECK-SAME:   i64 40,
 // CHECK-SAME:   ptr [[VOID_BLOCK_SIGNATURE]]
 // CHECK-SAME: }
 // CHECK: [[BLOCK_PARAM_BLOCK_SIGNATURE:@.*]] = private unnamed_addr constant {{.*}} c"v16@?0@?<q@?q>8\00"
-// CHECK: [[BLOCK_PARAM_BLOCK_DESCRIPTOR:@.*]] = internal constant { {{.*}} } {
+// CHECK: [[BLOCK_PARAM_BLOCK_DESCRIPTOR:@"block_descriptor_40_v16\\01\?0\\01\?<q\\01\?q>8"]] = linkonce_odr hidden unnamed_addr constant { {{.*}} } {
 // CHECK:   i64 0,
 // CHECK:   i64 40,
 // CHECK:   ptr [[BLOCK_PARAM_BLOCK_SIGNATURE]]
 // CHECK: }
-// CHECK: [[NONTRIVIAL_BLOCK_DESCRIPTOR:@.*]] = internal constant { {{.*}} } {
+// CHECK: [[NONTRIVIAL_BLOCK_DESCRIPTOR:@"block_descriptor_40_8_0NativeStrongReferenceS_0NativeStrongReferencev8\\01\?0"]] = linkonce_odr hidden unnamed_addr constant { {{.*}} } {
 // CHECK:   i64 0,
 // CHECK:   i64 40,
 // CHECK:   ptr [[NONTRIVIAL_BLOCK_COPY:@[A-Za-z0-9_]+]],
@@ -32,7 +32,7 @@ import gizmo
 // CHECK:   ptr [[VOID_BLOCK_SIGNATURE]]
 // CHECK: }
 // CHECK: [[NSRECT_BLOCK_SIGNATURE:@.*]] = private unnamed_addr constant {{.*}} c"{NSRect={NSPoint=dd}{NSSize=dd}}8@?0\00"
-// CHECK: [[STRET_BLOCK_DESCRIPTOR:@.*]] = internal constant { {{.*}} } {
+// CHECK: [[STRET_BLOCK_DESCRIPTOR:@"block_descriptor_40_{NSRect={NSPoint=dd}{NSSize=dd}}8\\01\?0"]] = linkonce_odr hidden unnamed_addr constant { {{.*}} } {
 // CHECK:   i64 0,
 // CHECK:   i64 40,
 // CHECK:   ptr [[NSRECT_BLOCK_SIGNATURE]]
@@ -129,7 +129,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
   return %b : $@convention(block) () -> ()
 }
 
-// CHECK:       define internal void [[NONTRIVIAL_BLOCK_COPY]]
+// CHECK:       define linkonce_odr hidden void [[NONTRIVIAL_BLOCK_COPY]]
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %2 = getelementptr inbounds { %objc_block, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:    %3 = getelementptr inbounds { %objc_block, ptr }, ptr %1, i32 0, i32 1
@@ -138,7 +138,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 // CHECK-NEXT:    store ptr %4, ptr %2, align 8
 // CHECK-NEXT:    ret void
 
-// CHECK:       define internal void [[NONTRIVIAL_BLOCK_DISPOSE]]
+// CHECK:       define linkonce_odr hidden void [[NONTRIVIAL_BLOCK_DISPOSE]]
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds { %objc_block, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:    %toDestroy = load ptr, ptr %1, align 8


### PR DESCRIPTION
This patch is trying to merge identical block copy/destroy helpers and descriptors which is similar to [the patch for Clang](https://reviews.llvm.org/D50783).

Due to insufficient knowledge about the compiler, I don't know how to properly encode the capture type for copy/destroy helpers. For now the encoding is hardcoded. 

I am seeking help [on the forum](https://forums.swift.org/t/trying-to-merge-identical-block-copy-destroy-helpers-and-descriptors/65253), unfortunately there has been no response. So I decide to create the pull request to draw some attention on GitHub to anyone familiar with this field.