### PR TITLE
[5.9][CSApply] Preserve primary associated types during type erasure

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4136,6 +4136,15 @@ public:
         [](const ClosureExpr *closure) {
           return closure->isIsolatedByPreconcurrency();
         });
+  
+  /// Type-erase occurrences of covariant 'Self'-rooted type parameters to their
+  /// most specific non-dependent bounds throughout the given type, using
+  /// \p baseTy as the existential base object type.
+  ///
+  /// \note If a 'Self'-rooted type parameter is bound to a concrete type, this
+  /// routine will recurse into the concrete type.
+  static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
+                                                 TypePosition outermostPosition);
 
   /// Given the opened type and a pile of information about a member reference,
   /// determine the reference type of the member reference.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -867,13 +867,13 @@ namespace {
 
       if (!force && record.Depth < ExprStack.size() - 1)
         return false;
-
       // If we had a return type of 'Self', erase it.
       Type resultTy;
       resultTy = cs.getType(result);
       if (resultTy->hasOpenedExistentialWithRoot(record.Archetype)) {
-        Type erasedTy = resultTy->typeEraseOpenedArchetypesWithRoot(
-            record.Archetype, dc);
+          Type erasedTy = ConstraintSystem::typeEraseExistentialSelfReferences(resultTy, record.Archetype->getExistentialType(),
+                                                             TypePosition::Covariant);
+
         auto range = result->getSourceRange();
         result = coerceToType(result, erasedTy, locator);
         // FIXME: Implement missing tuple-to-tuple conversion

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2047,14 +2047,7 @@ static bool isMainDispatchQueueMember(ConstraintLocator *locator) {
   return true;
 }
 
-/// Type-erase occurrences of covariant 'Self'-rooted type parameters to their
-/// most specific non-dependent bounds throughout the given type, using
-/// \p baseTy as the existential base object type.
-///
-/// \note If a 'Self'-rooted type parameter is bound to a concrete type, this
-/// routine will recurse into the concrete type.
-static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
-                                               TypePosition outermostPosition) {
+Type ConstraintSystem::typeEraseExistentialSelfReferences(Type refTy, Type baseTy, TypePosition outermostPosition) {
   assert(baseTy->isExistentialType());
   if (!refTy->hasTypeParameter()) {
     return refTy;
@@ -2190,7 +2183,7 @@ Type constraints::typeEraseOpenedExistentialReference(
   });
 
   // Then, type-erase occurrences of covariant 'Self'-rooted type parameters.
-  type = typeEraseExistentialSelfReferences(type, existentialBaseType,
+  type = ConstraintSystem::typeEraseExistentialSelfReferences(type, existentialBaseType,
                                             outermostPosition);
 
   // Finally, swap the 'Self'-corresponding type variable back in.
@@ -2299,7 +2292,6 @@ Type ConstraintSystem::getMemberReferenceTypeFromOpenedType(
 
     type = typeEraseOpenedExistentialReference(type, baseObjTy, openedTypeVar,
                                                TypePosition::Covariant);
-
     Type contextualTy;
 
     if (auto *anchor = getAsExpr(simplifyLocatorToAnchor(locator))) {

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -369,3 +369,48 @@ func testPrimaryAssocReturn(p: any P4<Int>) {
 func testPrimaryAssocCollection(p: any P4<Float>) {
   let _: any Collection<Float> = p.returnAssocTypeCollection()
 }
+
+protocol P5<X> {
+  associatedtype X = Void
+}
+
+struct K<T>: P5 {
+  typealias X = T
+}
+
+extension P5 {
+  func foo() -> some P<X>{
+    K<X>()
+  }
+  func bar(_ handler: @escaping (X) -> Void) -> some P<X> {
+    K<X>()
+  }
+}
+
+func test<T>(_ p: any P5<Result<T, Error>>) {
+  p.bar { _ in }
+}
+
+func testFoo<T,U>(_ p: any P5<Result<U, Error>>) -> any P5<T> {
+  p.foo() //expected-error {{cannot convert return expression of type 'T' to return type 'Result<U, any Error>'}} {{7-7=as! Result<U, any Error>)}}
+}
+
+func testBar<U>(_ p: any P5<Result<U, Error>>) -> any P5 {
+  p.bar { _ in }
+}
+
+enum Node<T> {
+  case e(any P5)
+  case f(any P5<Result<T, Error>>)
+}
+
+struct S<T, U> {
+  func foo(_ elt: Node<U>) -> Node<T>? {
+    switch elt {
+    case let .e(p):
+      return .e(p)
+    case let .f(p):
+      return .e(p.bar { _ in })
+    }
+  }
+}


### PR DESCRIPTION
Now that typeEraseExistentialSelfReferences function preserves primary associated types during existential type erasure, we should use this function in CSApply instead of typeEraseOpenedArchetypesWithRoot.

