### PR TITLE
[Sema] Unify typeEraseExistential Functions

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2013,6 +2013,7 @@ public:
   friend class ConjunctionElement;
   friend class RequirementFailure;
   friend class MissingMemberFailure;
+  friend class AddExplicitExistentialCoercion;
   friend struct ClosureIsolatedByPreconcurrency;
 
   class SolverScope;
@@ -4136,6 +4137,15 @@ public:
         [](const ClosureExpr *closure) {
           return closure->isIsolatedByPreconcurrency();
         });
+  
+  /// Type-erase occurrences of covariant 'Self'-rooted type parameters to their
+  /// most specific non-dependent bounds throughout the given type, using
+  /// \p baseTy as the existential base object type.
+  ///
+  /// \note If a 'Self'-rooted type parameter is bound to a concrete type, this
+  /// routine will recurse into the concrete type.
+  static Type typeEraseExistentialSelfReferences(Type refTy,  OpenedArchetypeType *baseTy,
+                                                 TypePosition outermostPosition);
 
   /// Given the opened type and a pile of information about a member reference,
   /// determine the reference type of the member reference.
@@ -5577,7 +5587,7 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// Given a type that includes an existential type that has been opened to
 /// the given type variable, type-erase occurrences of that opened type
 /// variable and anything that depends on it to their non-dependent bounds.
-Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
+Type typeEraseOpenedExistentialReference(Type type, OpenedArchetypeType *existentialBaseType,
                                          TypeVariableType *openedTypeVar,
                                          TypePosition outermostPosition);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -524,7 +524,7 @@ Type TypeBase::typeEraseOpenedArchetypesWithRoot(
     return type;
 
   const auto sig = root->getASTContext().getOpenedExistentialSignature(
-      root->getExistentialType(), useDC->getGenericSignatureOfContext());
+      root->getExistentialType(), useDC->getGenericSignatureOfContext()/*GenericSignature()*/);
 
   unsigned metatypeDepth = 0;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -867,13 +867,15 @@ namespace {
 
       if (!force && record.Depth < ExprStack.size() - 1)
         return false;
-
       // If we had a return type of 'Self', erase it.
       Type resultTy;
       resultTy = cs.getType(result);
       if (resultTy->hasOpenedExistentialWithRoot(record.Archetype)) {
-        Type erasedTy = resultTy->typeEraseOpenedArchetypesWithRoot(
-            record.Archetype, dc);
+      Type erasedTy = ConstraintSystem::typeEraseExistentialSelfReferences(resultTy,
+                                                                            record.Archetype,TypePosition::Covariant);
+//      Type erasedTy = resultTy->typeEraseOpenedArchetypesWithRoot(
+//             record.Archetype, dc);
+
         auto range = result->getSourceRange();
         result = coerceToType(result, erasedTy, locator);
         // FIXME: Implement missing tuple-to-tuple conversion
@@ -1585,7 +1587,7 @@ namespace {
           containerTy = containerTy->typeEraseOpenedArchetypesWithRoot(
               knownOpened->second, dc);
           selfTy = containerTy;
-        }
+        } 
       }
 
       // References to properties with accessors and storage usually go

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2479,16 +2479,18 @@ bool AddExplicitExistentialCoercion::isRequired(
 
     ConstraintSystem &cs;
     ExistentialTypeFinder GetExistentialType;
+    ConstraintLocatorBuilder Locator;
 
     CoercionChecker(ConstraintSystem &cs,
-                    ExistentialTypeFinder getExistentialType)
-        : cs(cs), GetExistentialType(getExistentialType) {}
+                    ExistentialTypeFinder getExistentialType, ConstraintLocatorBuilder locator)
+        : cs(cs), GetExistentialType(getExistentialType), Locator(locator) {}
 
     Action walkToTypePre(Type componentTy) override {
       // In cases where result references a member type, we need to check
       // whether such type would is resolved to concrete or not.
       if (auto *member = componentTy->getAs<DependentMemberType>()) {
         auto memberBaseTy = getBaseTypeOfDependentMemberChain(member);
+        
 
         auto typeVar = memberBaseTy->getAs<TypeVariableType>();
         if (!typeVar)
@@ -2502,9 +2504,11 @@ bool AddExplicitExistentialCoercion::isRequired(
         auto existentialType = GetExistentialType(typeVar);
         if (!existentialType)
           return Action::SkipChildren;
+        
+        auto openedArchetype = cs.OpenedExistentialTypes.lookup(cs.getConstraintLocator(Locator));
 
         auto erasedMemberTy = typeEraseOpenedExistentialReference(
-            Type(member), *existentialType, typeVar, TypePosition::Covariant);
+            Type(member), openedArchetype, typeVar, TypePosition::Covariant);
 
         // If result is an existential type and the base has `where` clauses
         // associated with its associated types, the call needs a coercion.
@@ -2677,7 +2681,7 @@ bool AddExplicitExistentialCoercion::isRequired(
       return false;
   }
 
-  CoercionChecker check(cs, findExistentialType);
+  CoercionChecker check(cs, findExistentialType, locator);
   resultTy.walk(check);
 
   return check.RequiresCoercion;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1912,7 +1912,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
           !cs.isArgumentGenericFunction(argTy, argExpr)) {
         for (const auto &opened : openedExistentials) {
           paramTy = typeEraseOpenedExistentialReference(
-              paramTy, opened.second->getExistentialType(), opened.first,
+              paramTy, opened.second, opened.first,
               TypePosition::Contravariant);
         }
       }
@@ -12903,7 +12903,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (result2->hasTypeVariable() && !openedExistentials.empty()) {
       for (const auto &opened : openedExistentials) {
         result2 = typeEraseOpenedExistentialReference(
-            result2, opened.second->getExistentialType(), opened.first,
+            result2, opened.second, opened.first,
             TypePosition::Covariant);
       }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -369,3 +369,48 @@ func testPrimaryAssocReturn(p: any P4<Int>) {
 func testPrimaryAssocCollection(p: any P4<Float>) {
   let _: any Collection<Float> = p.returnAssocTypeCollection()
 }
+
+protocol P5<X> {
+  associatedtype X = Void
+}
+
+struct K<T>: P5 {
+  typealias X = T
+}
+
+extension P5 {
+  func foo() -> some P<X>{
+    K<X>()
+  }
+  func bar(_ handler: @escaping (X) -> Void) -> some P<X> {
+    K<X>()
+  }
+}
+
+func test<T>(_ p: any P5<Result<T, Error>>) {
+  p.bar { _ in }
+}
+
+func testFoo<T,U>(_ p: any P5<Result<U, Error>>) -> any P5<T> {
+  p.foo() //expected-error {{cannot convert return expression of type 'T' to return type 'Result<U, any Error>'}} {{7-7=as! Result<U, any Error>)}}
+}
+
+func testBar<U>(_ p: any P5<Result<U, Error>>) -> any P5 {
+  p.bar { _ in }
+}
+
+enum Node<T> {
+  case e(any P5)
+  case f(any P5<Result<T, Error>>)
+}
+
+struct S<T, U> {
+  func foo(_ elt: Node<U>) -> Node<T>? {
+    switch elt {
+    case let .e(p):
+      return .e(p)
+    case let .f(p):
+      return .e(p.bar { _ in })
+    }
+  }
+}


### PR DESCRIPTION
Combine typeEraseExistentialSelfReferences function and typeEraseOpenedArchetypesWithRoot function. Both functions erase an existential to its nondepdendent upper bound. 

The difference is the type used to compute the upper bound: one function uses the opened archetype type and the other uses  the existential type. In theory we should be always be able rely on the open archetype type to erase to an existential type's upper bound.