### PR TITLE
[Observation] Ensure type access is qualified to the module name

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -17,6 +17,22 @@ import SwiftSyntaxMacros
 @_implementationOnly import SwiftSyntaxBuilder
 
 public struct ObservableMacro {
+  static let moduleName = "_Observation"
+
+  static let conformanceName = "Observable"
+  static var qualifiedConformanceName: String {
+    return "\(moduleName).\(conformanceName)"
+  }
+
+  static var observableConformanceType: TypeSyntax {
+    "\(raw: qualifiedConformanceName)"
+  }
+
+  static let registrarTypeName = "ObservationRegistrar"
+  static var qualifiedRegistrarTypeName: String {
+    return "\(moduleName).\(registrarTypeName)"
+  }
+  
   static let trackedMacroName = "ObservationTracked"
   static let ignoredMacroName = "ObservationIgnored"
 
@@ -25,7 +41,7 @@ public struct ObservableMacro {
   static func registrarVariable(_ observableType: TokenSyntax) -> DeclSyntax {
     return
       """
-      @\(raw: ignoredMacroName) private let \(raw: registrarVariableName) = ObservationRegistrar()
+      @\(raw: ignoredMacroName) private let \(raw: registrarVariableName) = \(raw: qualifiedRegistrarTypeName)()
       """
   }
   
@@ -264,13 +280,13 @@ extension ObservableMacro: ConformanceMacro {
     
     if let inheritanceList {
       for inheritance in inheritanceList {
-        if inheritance.typeName.identifier == "Observable" {
+        if inheritance.typeName.identifier == ObservableMacro.conformanceName {
           return []
         }
       }
     }
     
-    return [("Observable", nil)]
+    return [(ObservableMacro.observableConformanceType, nil)]
   }
 }
 


### PR DESCRIPTION
Ensure type access is qualified to the module name. e.g. when an imported module ALSO defines `Observable` make sure the macros don't cause ambiguity.

Resolves: rdar://110324268