### PR TITLE
[Observation] Transition to peer macros instead of arbitrary members

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -202,16 +202,13 @@ extension ObservableMacro: MemberMacro {
     declaration.addIfNeeded(ObservableMacro.registrarVariable(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
-    
+
     let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
     for property in storedInstanceVariables {
       if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
       if property.initializer == nil {
         context.addDiagnostics(from: DiagnosticsError(syntax: property, message: "@Observable requires property '\(property.identifier?.text ?? "")' to have an initial value", id: .missingInitializer), node: property)
       }
-      let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
-      declaration.addIfNeeded(storage, to: &declarations)
-      
     }
 
     return declarations
@@ -327,8 +324,9 @@ extension ObservationTrackedMacro: PeerMacro {
           property.isValidForObservation else {
       return []
     }
-
-    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) {
+    
+    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) ||
+       property.hasMacroApplication(ObservableMacro.trackedMacroName) {
       return []
     }
     

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -16,7 +16,7 @@
 #if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
-@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation), arbitrary)
+@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation))
 @attached(memberAttribute)
 @attached(conformance)
 public macro Observable() = 
@@ -24,7 +24,7 @@ public macro Observable() =
 
 @available(SwiftStdlib 5.9, *)
 @attached(accessor)
-// @attached(peer, names: prefixed(_))
+@attached(peer, names: prefixed(_))
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 


### PR DESCRIPTION
This removes the arbitrary member emission from `@Observable` macro application and uses peer macros instead (but leaves member iteration to ensure initializers are satisfied till https://github.com/apple/swift/pull/66283 lands)

Resolves rdar://110327683