### PR TITLE
[5.9][sourcekitd] Allow client to enable use of dispatch barriers for open/edit/close on the message handling queue

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -90,16 +90,6 @@ class RequestTracker {
   }
 
 public:
-  /// Returns \c true if the request with the given \p CancellationToken has
-  /// already been cancelled.
-  bool isCancelled(SourceKitCancellationToken CancellationToken) {
-    if (!CancellationToken) {
-      return false;
-    }
-    llvm::sys::ScopedLock L(RequestsMtx);
-    return isCancelledImpl(CancellationToken);
-  }
-
   /// Adds a \p CancellationHandler that will be called when the request
   /// associated with the \p CancellationToken is cancelled.
   /// If that request has already been cancelled when this method is called,

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Service.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Service.h
@@ -45,6 +45,21 @@ void cancelRequest(SourceKitCancellationToken CancellationToken);
 
 void disposeCancellationToken(SourceKitCancellationToken CancellationToken);
 
+/// Returns \c true if \p Request is of a request kind that should be issued as
+/// a dispatch barrier of the message handling queue. In practice, this returns
+/// \c true for open, edit and close requets.
+///
+/// This does not check if dispatch barriers have been enabled by the sourckitd
+/// client.
+bool requestIsBarrier(sourcekitd_object_t Request);
+
+/// Returns \c true if this is a request to enable dispatch barriers in
+/// sourcekitd.
+bool requestIsEnableBarriers(sourcekitd_object_t Request);
+
+/// Send the response that request barriers have been enabled to \p Receiver.
+void sendBarriersEnabledResponse(ResponseReceiver Receiver);
+
 } // namespace sourcekitd
 
 #endif // LLVM_SOURCEKITD_SERVICE_H

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -405,6 +405,26 @@ void sourcekitd::disposeCancellationToken(
   getGlobalContext().getRequestTracker()->stopTracking(CancellationToken);
 }
 
+bool sourcekitd::requestIsBarrier(sourcekitd_object_t ReqObj) {
+  RequestDict Req(ReqObj);
+  sourcekitd_uid_t ReqUID = Req.getUID(KeyRequest);
+  return ReqUID == RequestEditorOpen || ReqUID == RequestEditorReplaceText ||
+         ReqUID == RequestEditorClose;
+}
+
+bool sourcekitd::requestIsEnableBarriers(sourcekitd_object_t ReqObj) {
+  RequestDict Req(ReqObj);
+  sourcekitd_uid_t ReqUID = Req.getUID(KeyRequest);
+  return ReqUID == RequestEnableRequestBarriers;
+}
+
+void sourcekitd::sendBarriersEnabledResponse(ResponseReceiver Receiver) {
+  ResponseBuilder RespBuilder;
+  auto Elem = RespBuilder.getDictionary();
+  Elem.setBool(KeyBarriersEnabled, true);
+  Receiver(RespBuilder.createResponse());
+}
+
 static std::unique_ptr<llvm::MemoryBuffer> getInputBufForRequest(
     Optional<StringRef> SourceFile, Optional<StringRef> SourceText,
     const Optional<VFSOptions> &vfsOptions, llvm::SmallString<64> &ErrBuf) {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -207,7 +207,8 @@ UID_KEYS = [
     # in this time. For cancellation testing purposes.
     KEY('SimulateLongRequest', 'key.simulate_long_request'),
     KEY('IsSynthesized', 'key.is_synthesized'),
-    KEY('BufferName', 'key.buffer_name')
+    KEY('BufferName', 'key.buffer_name'),
+    KEY('BarriersEnabled', 'key.barriers_enabled'),
 ]
 
 
@@ -272,6 +273,7 @@ UID_REQUESTS = [
     REQUEST('Diagnostics', 'source.request.diagnostics'),
     REQUEST('Compile', 'source.request.compile'),
     REQUEST('CompileClose', 'source.request.compile.close'),
+    REQUEST('EnableRequestBarriers', 'source.request.enable_request_barriers'),
 ]
 
 


### PR DESCRIPTION
* **Explanation**: Previously, we relied on the client to make sure any open/edit/close request has finished executing before sending semantic queries about that updated source file, implicitly relying on clients to provide synchronization guarantees. This enables a mode in which sourcekitd can provide those synchronization guarantees: 
By default, all behavior stays the same. After the client sends a `source.request.enable_request_barriers` request, `sourcekitd` will issue all open/edit/close requests as dispatch barriers. This makes sure that all requests after the open/edit/close will only start being handled *after* the open/edit/close has finished.
* **Scope**: No functionality change unless the new barrier mode is enabled
* **Risk**: While changing anything surrounding queues can be considered risky, this should be low-risk since there is no functionality change unless the new barrier behavior is explicitly enabled
* **Testing**: Ran unit test and SourceKit stress tester, both of which continue to use the code path that doesn’t use barriers
* **Issue**: rdar://91202327
* **Reviewer**:  @bnbarham and @rintaro on https://github.com/apple/swift/pull/66013
