### PR TITLE
[5.9][CMake] Allow install_name_tool to edit pure swift library load paths

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -141,6 +141,12 @@ function(add_pure_swift_host_library name)
   set_property(TARGET ${name}
     PROPERTY BUILD_WITH_INSTALL_RPATH YES)
 
+  if(APSHL_SHARED AND CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # Allow install_name_tool to update paths (for rdar://109473564)
+    set_property(TARGET ${name} APPEND_STRING PROPERTY
+                 LINK_FLAGS " -Xlinker -headerpad_max_install_names")
+  endif()
+
   # Respect LLVM_COMMON_DEPENDS if it is set.
   #
   # LLVM_COMMON_DEPENDS if a global variable set in ./lib that provides targets


### PR DESCRIPTION
* Explanation: `install_name_tool` is able to update install names as long as there's enough room. That sometimes happens to be the case (if eg. your path ends up being smaller/a similar size), but not always. Allow the maximum length so they can be updated to longer paths.
* Scope: Build
* Risk: Very low - sets `-headerpad_max_install_names` when linking Swift libraries. Either this links or doesn't.
* Testing: Builds and runs
* Original PR: https://github.com/apple/swift/pull/66385
