### PR TITLE
🍒[cxx-interop] Initializing a Swift.Array from CxxConvertibleToCollection should not copy the collection

### DIFF
--- a/stdlib/public/Cxx/CxxConvertibleToCollection.swift
+++ b/stdlib/public/Cxx/CxxConvertibleToCollection.swift
@@ -56,7 +56,7 @@ extension RangeReplaceableCollection {
   ///   be true for certain C++ types, e.g. those with a custom copy
   ///   constructor that performs additional logic.
   @inlinable
-  public init<C: CxxConvertibleToCollection>(_ elements: C)
+  public init<C: CxxConvertibleToCollection>(_ elements: __shared C)
     where C.RawIterator.Pointee == Element {
 
     self.init()
@@ -74,7 +74,7 @@ extension SetAlgebra {
   ///   be true for certain C++ types, e.g. those with a custom copy
   ///   constructor that performs additional logic.
   @inlinable
-  public init<C: CxxConvertibleToCollection>(_ elements: C)
+  public init<C: CxxConvertibleToCollection>(_ elements: __shared C)
     where C.RawIterator.Pointee == Element {
 
     self.init()

--- a/stdlib/public/Cxx/CxxConvertibleToCollection.swift
+++ b/stdlib/public/Cxx/CxxConvertibleToCollection.swift
@@ -55,6 +55,7 @@ extension RangeReplaceableCollection {
   ///   container when each element is copied in O(1). Note that this might not
   ///   be true for certain C++ types, e.g. those with a custom copy
   ///   constructor that performs additional logic.
+  @inlinable
   public init<C: CxxConvertibleToCollection>(_ elements: C)
     where C.RawIterator.Pointee == Element {
 
@@ -72,6 +73,7 @@ extension SetAlgebra {
   ///   container when each element is copied in O(1). Note that this might not
   ///   be true for certain C++ types, e.g. those with a custom copy
   ///   constructor that performs additional logic.
+  @inlinable
   public init<C: CxxConvertibleToCollection>(_ elements: C)
     where C.RawIterator.Pointee == Element {
 

--- a/stdlib/public/Cxx/CxxSet.swift
+++ b/stdlib/public/Cxx/CxxSet.swift
@@ -18,6 +18,7 @@ public protocol CxxSet<Element> {
 }
 
 extension CxxSet {
+  @inlinable
   public func contains(_ element: Element) -> Bool {
     return count(element) > 0
   }

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -14,6 +14,16 @@ struct SimpleSequenceWithOutOfLineEqualEqual {
   ConstIteratorOutOfLineEq end() const { return ConstIteratorOutOfLineEq(5); }
 };
 
+static int copiesCount = 0;
+
+struct SimpleCopyAwareSequence {
+  ConstIterator begin() const { return ConstIterator(1); }
+  ConstIterator end() const { return ConstIterator(5); }
+
+  SimpleCopyAwareSequence() {}
+  SimpleCopyAwareSequence(const SimpleCopyAwareSequence &other) { copiesCount++; }
+};
+
 struct SimpleArrayWrapper {
 private:
   int a[5] = {10, 20, 30, 40, 50};

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -15,6 +15,21 @@ CxxSequenceTestSuite.test("SimpleSequence to Swift.Array") {
   expectEqual([1, 2, 3, 4] as [Int32], array)
 }
 
+#if !os(Linux) // this test crashes on Linux (https://github.com/apple/swift/issues/66363)
+CxxSequenceTestSuite.test("SimpleCopyAwareSequence to Swift.Array") {
+  copiesCount = 0
+
+  let seq = SimpleCopyAwareSequence()
+
+  let seqCopy = seq
+  expectEqual(1, copiesCount) // make sure our copy tracking mechanism works
+
+  let array = Array(seq)
+
+  expectEqual(1, copiesCount) // make sure we don't copy the C++ sequence value unnecessarily
+}
+#endif
+
 CxxSequenceTestSuite.test("SimpleSequenceWithOutOfLineEqualEqual to Swift.Array") {
   let seq = SimpleSequenceWithOutOfLineEqualEqual()
   let array = Array(seq)


### PR DESCRIPTION
**Explanation**: This improves the performance of initializing a Swift Collection such as `Swift.Array` from a C++ container by avoiding excessive copies of the C++ container.
**Scope**: This adds attributes to two initializers declared in the `Cxx` module, which is only visible when C++ interop is enabled.
**Risk**: Low, this only has an effect when C++ interop is enabled.

rdar://110110376