### PR TITLE
[5.9][cxx-interop] add a SWIFT_MUTATING customization macro

### DIFF
--- a/lib/ClangImporter/bridging
+++ b/lib/ClangImporter/bridging
@@ -133,6 +133,13 @@
 #define SWIFT_COMPUTED_PROPERTY \
   __attribute__((swift_attr("import_computed_property")))
 
+/// Specifies that a specific **constant** C++ member function should be imported as
+/// `mutating` Swift method. This annotation should be added to constant C++ member functions
+/// that mutate `mutable` fields in a C++ object, to let Swift know that this function is still mutating
+/// and thus that it should become a `mutating` method in Swift.
+#define SWIFT_MUTATING \
+  __attribute__((swift_attr("mutating")))
+
 #else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 
 // Empty defines for compilers that don't support `attribute(swift_attr)`.
@@ -144,6 +151,7 @@
 #define SWIFT_NAME(_name)
 #define SWIFT_CONFORMS_TO_PROTOCOL(_moduleName_protocolName)
 #define SWIFT_COMPUTED_PROPERTY
+#define SWIFT_MUTATING
 
 #endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 

--- a/test/Interop/Cxx/class/Inputs/mutable-members.h
+++ b/test/Interop/Cxx/class/Inputs/mutable-members.h
@@ -1,10 +1,19 @@
 #ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MUTABLE_MEMBERS_H
 #define TEST_INTEROP_CXX_CLASS_INPUTS_MUTABLE_MEMBERS_H
 
+#ifdef USE_MUTATING
+// Note: in actuality, this will be included
+// as <swift/bridging>, but in this test we include
+// it directly.
+#include "bridging"
+#else
+#define SWIFT_MUTATING
+#endif
+
 struct HasPublicMutableMember {
   mutable int a = 0;
 
-  int foo() const {
+  int foo() const SWIFT_MUTATING {
     a++;
     return a;
   }
@@ -15,7 +24,7 @@ private:
   mutable int a = 0;
 
 public:
-  void bar() const { a++; }
+  void bar() const SWIFT_MUTATING { a++; }
 };
 
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_MUTABLE_MEMBERS_H

--- a/test/Interop/Cxx/class/mutable-members-with-mutating-annotation-module-interface.swift
+++ b/test/Interop/Cxx/class/mutable-members-with-mutating-annotation-module-interface.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -Xcc -DUSE_MUTATING -I %swift_src_root/lib/ClangImporter | %FileCheck %s
+
+// CHECK: struct HasPublicMutableMember {
+// CHECK:   mutating func foo() -> Int32
+// CHECK:   var a: Int32
+// CHECK: }
+
+// CHECK: struct HasPrivateMutableMember {
+// CHECK:   mutating func bar()
+// CHECK: }


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/66322

- Explanation:
This macro is needed to allow users to annotate constant C++ member functions that do mutate the object, e.g. using a mutable C++ field. This annotation makes Swift import them as `mutating` methods then. This allows users to call such constant functions from Swift without worrying about correctness of such a call invocation.
- Scope: Swift's and C++ interoperability, <swift/bridging> header
- Risk: Low. Additional only change.
- Testing: Swift unit tests.
- PR: https://github.com/apple/swift/pull/66374