### PR TITLE
Force linux builds off of base toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -918,6 +918,11 @@ mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts
     buildbot_linux_base
 
+extra-cmake-options=
+  -DCMAKE_C_FLAGS="--gcc-toolchain=/usr"
+  -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr"
+  -DCMAKE_Swift_FLAGS="-Xcc --gcc-toolchain=/usr -Xclang-linker --gcc-toolchain=/usr"
+
 [preset: buildbot_linux,no_assertions]
 mixin-preset=buildbot_linux_base
 


### PR DESCRIPTION
UBI9 installs the gcc-12 aligned toolchain as a dependency for clang. Clang picks up the gcc-12 aligned toolchain and symbols and adds a call to `glibcxx::__assert_fail`, which is not in the gcc-11 aligned libstdc++. To work with this when dynamically linking, the gcc-12 toolset contains a `libstdc++_noshared.a` static archive, which gets linked into the shared libraries and executables much like our compatibility libraries, and provides the missing symbols on top of the gcc-11 runtime that is already on UBI9 systems.

Of course, folks want to be able to statically link the stdlib into their binaries, and we avoid overlinking and symbol collisions by not linking the libstdc++_noshared.a static archive into the libswiftCore.a. Of course, this means that there is no definition for the symbol when it comes time to link the static stdlib on a base UBI9 image.

I've decided to just build the library against what is installed on the base system, so that we don't need to install anything additional to build and copy the binary to other systems running the same OS.

This should fix the linking issue in https://github.com/apple/swift/issues/65097
In theory, this should actually work for all of the Linux images and ensure that we're actually building the Linux toolchains based on what is actually available on the base system and not what is installed with the toolchain-build-dependencies.
