### PR TITLE
[borrowing/consuming] Be sure to visit boxes with trivial @moveonly types.

### DIFF
--- a/test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -verify
+// RUN: %target-swift-frontend -emit-sil %s -verify -sil-verify-all
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -verify
+// RUN: %target-swift-frontend -emit-sil %s -verify -sil-verify-all
 
 ////////////////////////
 // MARK: Declarations //


### PR DESCRIPTION
This was not caught on main since I wasn't the tests with -sil-verify-all
enabled... but it seems that it was caught by the verifier on 5.9. I have since
enabled sil-verify-all by default on both of those tests
(noimplicitcopy_consuming_parameter.swift and
noimplicitcopy_borrowing_parameter.swift).

rdar://110364874