### PR TITLE
[Backtracing] Use stderr by default unless interactive.

### DIFF
--- a/include/swift/Runtime/Backtrace.h
+++ b/include/swift/Runtime/Backtrace.h
@@ -109,6 +109,7 @@ enum class SanitizePaths {
 };
 
 enum class OutputTo {
+  Auto = -1,
   Stdout = 0,
   Stderr = 2,
 };

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -123,7 +123,7 @@ SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings = {
   true,
 
   // outputTo,
-  OutputTo::Stdout,
+  OutputTo::Auto,
 
   // swiftBacktracePath
   NULL,
@@ -320,6 +320,13 @@ BacktraceInitializer::BacktraceInitializer() {
       _swift_backtraceSettings.preset = Preset::Friendly;
     else
       _swift_backtraceSettings.preset = Preset::Full;
+  }
+
+  if (_swift_backtraceSettings.outputTo == OutputTo::Auto) {
+    if (_swift_backtraceSettings.interactive == OnOffTty::On)
+      _swift_backtraceSettings.outputTo = OutputTo::Stdout;
+    else
+      _swift_backtraceSettings.outputTo = OutputTo::Stderr;
   }
 
 #if !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
@@ -648,7 +655,9 @@ _swift_processBacktracingSetting(llvm::StringRef key,
   } else if (key.equals_insensitive("cache")) {
     _swift_backtraceSettings.cache = parseBoolean(value);
   } else if (key.equals_insensitive("output-to")) {
-    if (value.equals_insensitive("stdout"))
+    if (value.equals_insensitive("auto"))
+      _swift_backtraceSettings.outputTo = OutputTo::Auto;
+    else if (value.equals_insensitive("stdout"))
       _swift_backtraceSettings.outputTo = OutputTo::Stdout;
     else if (value.equals_insensitive("stderr"))
       _swift_backtraceSettings.outputTo = OutputTo::Stderr;

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -617,6 +617,8 @@ const char *backtracer_argv[] = {
   "preset",                     // 26
   "--cache",                    // 27
   "true",                       // 28
+  "--output-to",                // 29
+  "stdout",                     // 30
   NULL
 };
 
@@ -766,6 +768,16 @@ run_backtracer(int memserver_fd)
     break;
   case SanitizePaths::On:
     backtracer_argv[26] = "true";
+    break;
+  }
+
+  switch (_swift_backtraceSettings.outputTo) {
+  case OutputTo::Stdout:
+    backtracer_argv[30] = "stdout";
+    break;
+  case OutputTo::Auto: // Shouldn't happen, but if it does pick stderr
+  case OutputTo::Stderr:
+    backtracer_argv[30] = "stderr";
     break;
   }
 

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -428,6 +428,7 @@ run_backtracer()
   case OutputTo::Stdout:
     backtracer_argv[30] = "stdout";
     break;
+  case OutputTo::Auto: // Shouldn't happen, but if it does pick stderr
   case OutputTo::Stderr:
     backtracer_argv[30] = "stderr";
     break;

--- a/test/Backtracing/Crash.swift
+++ b/test/Backtracing/Crash.swift
@@ -7,11 +7,11 @@
 // RUN: %target-codesign %t/CrashNoDebug
 // RUN: %target-codesign %t/CrashOpt
 // RUN: %target-codesign %t/CrashOptNoDebug
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Crash || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Crash 2>&1 || true) | %FileCheck %s
 // RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash || true) | %FileCheck %s --check-prefix FRIENDLY
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug || true) | %FileCheck %s --check-prefix NODEBUG
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt || true) | %FileCheck %s --check-prefix OPTIMIZED
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug || true) | %FileCheck %s --check-prefix OPTNODEBUG
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug 2>&1 || true) | %FileCheck %s --check-prefix NODEBUG
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt 2>&1 || true) | %FileCheck %s --check-prefix OPTIMIZED
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug 2>&1 || true) | %FileCheck %s --check-prefix OPTNODEBUG
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/Crash.swift
+++ b/test/Backtracing/Crash.swift
@@ -8,7 +8,7 @@
 // RUN: %target-codesign %t/CrashOpt
 // RUN: %target-codesign %t/CrashOptNoDebug
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Crash 2>&1 || true) | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Crash 2>&1 || true) | %FileCheck %s --check-prefix FRIENDLY
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashNoDebug 2>&1 || true) | %FileCheck %s --check-prefix NODEBUG
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt 2>&1 || true) | %FileCheck %s --check-prefix OPTIMIZED
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug 2>&1 || true) | %FileCheck %s --check-prefix OPTNODEBUG

--- a/test/Backtracing/CrashAsync.swift
+++ b/test/Backtracing/CrashAsync.swift
@@ -5,8 +5,8 @@
 // Demangling is disabled for now because older macOS can't demangle async
 // function names.  We test demangling elsewhere, so this is no big deal.
 
-// RUN: (env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync || true) | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: (env SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 || true) | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/CrashWithThunk.swift
+++ b/test/Backtracing/CrashWithThunk.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/CrashWithThunk
 // RUN: %target-codesign %t/CrashWithThunk
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk || true) | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk 2>&1 || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk 2>&1 || true) | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/Overflow.swift
+++ b/test/Backtracing/Overflow.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Overflow
 // RUN: %target-codesign %t/Overflow
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow || true) | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow 2>&1 || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow 2>&1 || true) | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/StackOverflow.swift
+++ b/test/Backtracing/StackOverflow.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/StackOverflow
 // RUN: %target-codesign %t/StackOverflow
-// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/StackOverflow || true) | %FileCheck %s
-// RUN: (env SWIFT_BACKTRACE=limit=17,top=5,enable=yes,cache=no %target-run %t/StackOverflow || true) | %FileCheck %s --check-prefix LIMITED
-// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/StackOverflow || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/StackOverflow 2>&1|| true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=limit=17,top=5,enable=yes,cache=no %target-run %t/StackOverflow 2>&1 || true) | %FileCheck %s --check-prefix LIMITED
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/StackOverflow 2>&1 || true) | %FileCheck %s --check-prefix FRIENDLY
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -494,7 +494,7 @@ if backtracing is not None:
 
 backtrace_on_crash = lit_config.params.get('backtrace_on_crash', None)
 if backtrace_on_crash is not None:
-    config.environment['SWIFT_BACKTRACE'] = 'enable=on,output-to=stderr'
+    config.environment['SWIFT_BACKTRACE'] = 'enable=on'
 
 config.available_features.add('lld_lto')
 


### PR DESCRIPTION
This means we don't need to specify `output-to` in CI.

rdar://110371557
