### PR TITLE
[IRGenDebugInfo] Look through pointer casts

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2813,6 +2813,7 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
     llvm::DIExpression *Expr, unsigned Line, unsigned Col,
     llvm::DILocalScope *Scope, const SILDebugScope *DS, bool InCoroContext,
     AddrDbgInstrKind AddrDInstKind) {
+  Storage = Storage->stripPointerCasts();
   // Set the location/scope of the intrinsic.
   auto *InlinedAt = createInlinedAt(DS);
   auto DL =

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -963,9 +963,13 @@ public:
   }
 
   bool shouldShadowStorage(llvm::Value *Storage) {
-    return !isa<llvm::AllocaInst>(Storage)
-      && !isa<llvm::UndefValue>(Storage)
-      && needsShadowCopy(Storage);
+    Storage = Storage->stripPointerCasts();
+    if (isa<llvm::UndefValue>(Storage))
+      return false;
+    if (auto *Alloca = dyn_cast<llvm::AllocaInst>(Storage);
+        Alloca && Alloca->isStaticAlloca())
+      return false;
+    return needsShadowCopy(Storage);
   }
 
   /// At -Onone, emit a shadow copy of an Address in an alloca, so the

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -28,17 +28,12 @@ bb0:
   // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":8:9, scope {{[0-9]+}})
   // CHECK-SIL-SAME         type $MyStruct, expr op_deref:op_fragment:#MyStruct.x
   debug_value %3 : $*Builtin.Int64, var, (name "my_struct", loc "file.swift":8:9, scope 1), type $MyStruct, expr op_deref:op_fragment:#MyStruct.x, loc "file.swift":9:17, scope 1
-  // CHECK: llvm.dbg.value(metadata {{.*}}* %[[FIELD_X]], metadata ![[VAR_DECL_MD]]
-  // CHECK-SAME:           !DIExpression(DW_OP_deref, DW_OP_LLVM_fragment, 0, 64)
-  // CHECK-NOT:           ), !dbg ![[VAR_DECL_MD]]
 
   %4 = alloc_stack $SmallStruct, var, name "small_struct", loc "file.swift":10:11, scope 1
   %5 = struct_element_addr %4 : $*SmallStruct, #SmallStruct.z, loc "file.swift":11:13, scope 1
   // CHECK: %[[FIELD_Z:.*]] = getelementptr {{.*}} %[[SMALL_STRUCT]]
   // If the fragment covers the whole struct, we're not generating the
   // DW_OP_LLVM_fragment part.
-  // CHECK: llvm.dbg.value(metadata {{.*}}* %[[FIELD_Z]], metadata ![[SMALL_VAR_DECL_MD]]
-  // CHECK-SAME:           !DIExpression(DW_OP_deref)
   debug_value %5 : $*Builtin.Int64, var, (name "small_struct", loc "file.swift":10:11, scope 1), type $SmallStruct, expr op_deref:op_fragment:#SmallStruct.z, loc "file.swift":11:13, scope 1
   dealloc_stack %4 : $*SmallStruct
 

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -44,15 +44,18 @@ public class C<R> {
 
   // SIL-LABEL: // C.f<A>(_:)
   // IR-LABEL: define {{.*}} @"$s1A1CC1fyyqd__lF"
+  // IR-SAME: nocapture %[[ARG_0:.*]], {{.*}} %[[ARG_S:.*]],
 #sourceLocation(file: "f.swift", line: 1)
   public func f<S>(_ s: S) {
     // SIL: debug_value %0 : $*S, let, name "s", argno 1, expr op_deref, {{.*}} scope [[F]]
     // SIL: function_ref {{.*}}yes{{.*}} scope [[F1G1]]
     // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H]]
-    // IR: dbg.value(metadata %swift.type* %S, metadata ![[MD_1_0:[0-9]+]]
-    // IR: dbg.value(metadata %swift.opaque* %0, metadata ![[S:[0-9]+]]
-    // IR: dbg.value(metadata %swift.opaque* %0, metadata ![[GS_T:[0-9]+]]
-    // IR: dbg.value(metadata %swift.opaque* %0, metadata ![[GS_U:[0-9]+]]
+    // IR: dbg.value(metadata %swift.type* %[[ARG_S]], metadata ![[MD_1_0:[0-9]+]]
+    // IR: %[[RS_PAIR:.*]] = alloca i8, i64 %
+    // IR: dbg.declare({{.*}} %[[RS_PAIR]], metadata ![[GRS_T:[0-9]+]],
+    // IR: dbg.value(metadata %swift.opaque* %[[ARG_0]], metadata ![[S:[0-9]+]]
+    // IR: dbg.value(metadata %swift.opaque* %[[ARG_0]], metadata ![[GS_T:[0-9]+]]
+    // IR: dbg.value(metadata %swift.opaque* %[[ARG_0]], metadata ![[GS_U:[0-9]+]]
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 2)
     g(s)
@@ -67,21 +70,19 @@ public class C<R> {
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 3)
     g(r)
-    // IR: dbg.value({{.*}}, metadata ![[GRS_T:[0-9]+]]
-    // IR: dbg.value({{.*}}, metadata ![[GRS_U:[0-9]+]]
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 4)
     g((r, s))
     // Note to maintainers: the relative order of the constant dbg.values here
     // seem to flip back and forth.
-    // IR: dbg.value({{.*}}, metadata ![[GI_U:[0-9]+]]
-    // IR: dbg.value({{.*}}, metadata ![[GI_T:[0-9]+]]
-    // IR: call {{.*}}3use
+    // IR: dbg.value(metadata i64 0, metadata ![[GI_U:[0-9]+]]
+    // IR: dbg.value(metadata i64 0, metadata ![[GI_T:[0-9]+]]
+    // IR: call {{.*}}3use{{.*}}(i64 0)
 #sourceLocation(file: "f.swift", line: 5)
     g(Int(0))
-    // IR: dbg.value({{.*}}, metadata ![[GB_U:[0-9]+]]
-    // IR: dbg.value({{.*}}, metadata ![[GB_T:[0-9]+]]
-    // IR: call {{.*}}3use
+    // IR: dbg.value(metadata i1 false, metadata ![[GB_U:[0-9]+]]
+    // IR: dbg.value(metadata i1 false, metadata ![[GB_T:[0-9]+]]
+    // IR: call {{.*}}3use{{.*}}(i1 false)
 #sourceLocation(file: "f.swift", line: 6)
     g(false)
   }
@@ -97,6 +98,10 @@ public class C<R> {
 // IR-DAG: ![[LET_TAU_0_0:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TAU_0_0]])
 // IR-DAG: ![[TAU_1_0:[0-9]+]] = {{.*}}DW_TAG_structure_type, name: "$sqd__D", file
 // IR-DAG: ![[MD_1_0]] = !DILocalVariable(name: "$\CF\84_1_0"
+// IR-DAG: ![[GRS_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GRS_T:[0-9]+]], {{.*}}type: ![[LET_TUPLE:[0-9]+]]
+// IR-DAG: ![[SP_GRS_T]] = {{.*}}linkageName: "$s1A1gyyxlFx_qd__t_Ti5"
+// IR-DAG: ![[LET_TUPLE]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TUPLE:[0-9]+]])
+// IR-DAG: ![[TUPLE]] = {{.*}}DW_TAG_structure_type, name: "$sx_qd__tD"
 // IR-DAG: ![[S]] = !DILocalVariable(name: "s", {{.*}} type: ![[LET_TAU_1_0:[0-9]+]]
 // IR-DAG: ![[LET_TAU_1_0]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TAU_1_0]])
 // IR-DAG: ![[GS_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GS_T:[0-9]+]], {{.*}} type: ![[LET_TAU_1_0]])
@@ -111,12 +116,6 @@ public class C<R> {
 
 // IR: ![[GR_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GR_U:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
 // IR: ![[SP_GR_U]] = {{.*}}linkageName: "$s1A1hyyxlF"
-// IR: ![[GRS_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GRS_T:[0-9]+]], {{.*}}type: ![[LET_TUPLE:[0-9]+]]
-// IR: ![[SP_GRS_T]] = {{.*}}linkageName: "$s1A1gyyxlFx_qd__t_Ti5"
-// IR: ![[LET_TUPLE]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[TUPLE:[0-9]+]])
-// IR: ![[TUPLE]] = {{.*}}DW_TAG_structure_type, name: "$sx_qd__tD"
-// IR: ![[GRS_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GRS_U:[0-9]+]], {{.*}}type: ![[LET_TUPLE]]
-// IR: ![[SP_GRS_U]] = {{.*}}linkageName: "$s1A1hyyxlFx_qd__t_Ti5"
 // IR-DAG: ![[GI_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GI_G:[0-9]+]], {{.*}}type: ![[LET_INT]])
 // IR-DAG: ![[SP_GI_G]] = {{.*}}linkageName: "$s1A1gyyxlFSi_Tg5"
 // IR-DAG: ![[GI_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GI_U:[0-9]+]], {{.*}}type: ![[LET_INT]])


### PR DESCRIPTION
This PR contains two commits, both fixing the same issue in different parts of the code base:  we fail to look through pointer casts when making codegen decisions. These were exposed by the opaque pointer work, since in this mode most pointer casts are gone.