### PR TITLE
[5.9] Macro refactorings and fixes

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/Mangler.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/Basic/TaggedUnion.h"
 
 namespace clang {
@@ -367,8 +368,7 @@ public:
   mangleRuntimeAttributeGeneratorEntity(const ValueDecl *decl, CustomAttr *attr,
                                         SymbolKind SKind = SymbolKind::Default);
 
-  std::string mangleMacroExpansion(const MacroExpansionExpr *expansion);
-  std::string mangleMacroExpansion(const MacroExpansionDecl *expansion);
+  std::string mangleMacroExpansion(const FreestandingMacroExpansion *expansion);
   std::string mangleAttachedMacroExpansion(
       const Decl *decl, CustomAttr *attr, MacroRole role);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8603,6 +8603,9 @@ public:
   /// Retrieve the definition of this macro.
   MacroDefinition getDefinition() const;
 
+  /// Set the definition of this macro
+  void setDefinition(MacroDefinition definition);
+
   /// Retrieve the parameter list of this macro.
   ParameterList *getParameterList() const { return parameterList; }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8639,8 +8639,9 @@ public:
     return getExpansionInfo()->getSourceRange();
   }
   SourceLoc getLocFromSource() const { return getExpansionInfo()->SigilLoc; }
-  using ExprOrStmtExpansionCallback = llvm::function_ref<void(ASTNode)>;
-  void forEachExpandedExprOrStmt(ExprOrStmtExpansionCallback) const;
+
+  /// Enumerate the nodes produced by expanding this macro expansion.
+  void forEachExpandedNode(llvm::function_ref<void(ASTNode)> callback) const;
 
   /// Returns a discriminator which determines this macro expansion's index
   /// in the sequence of macro expansions within the current function.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -26,6 +26,7 @@
 #include "swift/AST/DefaultArgumentKind.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/LayoutConstraint.h"
@@ -8618,69 +8619,28 @@ public:
   using Decl::getASTContext;
 };
 
-/// Information about a macro expansion that is common between macro
-/// expansion declarations and expressions.
-///
-/// Instances of these types will be shared among paired macro expansion
-/// declaration/expression nodes.
-struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
-  SourceLoc SigilLoc;
-  DeclNameRef MacroName;
-  DeclNameLoc MacroNameLoc;
-  SourceLoc LeftAngleLoc, RightAngleLoc;
-  ArrayRef<TypeRepr *> GenericArgs;
-  ArgumentList *ArgList;
-
-  /// The referenced macro.
-  ConcreteDeclRef macroRef;
-
-  MacroExpansionInfo(SourceLoc sigilLoc,
-                     DeclNameRef macroName,
-                     DeclNameLoc macroNameLoc,
-                     SourceLoc leftAngleLoc, SourceLoc rightAngleLoc,
-                     ArrayRef<TypeRepr *> genericArgs,
-                     ArgumentList *argList)
-    : SigilLoc(sigilLoc), MacroName(macroName), MacroNameLoc(macroNameLoc),
-      LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
-      GenericArgs(genericArgs), ArgList(argList) { }
-};
-
-class MacroExpansionDecl : public Decl {
-  MacroExpansionInfo *info;
+class MacroExpansionDecl : public Decl, public FreestandingMacroExpansion {
 
 public:
   enum : unsigned { InvalidDiscriminator = 0xFFFF };
 
   MacroExpansionDecl(DeclContext *dc, MacroExpansionInfo *info);
 
-  MacroExpansionDecl(DeclContext *dc, SourceLoc poundLoc, DeclNameRef macro,
-                     DeclNameLoc macroLoc,
-                     SourceLoc leftAngleLoc,
-                     ArrayRef<TypeRepr *> genericArgs,
-                     SourceLoc rightAngleLoc,
-                     ArgumentList *args);
+  static MacroExpansionDecl *create(DeclContext *dc, SourceLoc poundLoc,
+                                    DeclNameRef macro, DeclNameLoc macroLoc,
+                                    SourceLoc leftAngleLoc,
+                                    ArrayRef<TypeRepr *> genericArgs,
+                                    SourceLoc rightAngleLoc,
+                                    ArgumentList *args);
 
-  ArrayRef<TypeRepr *> getGenericArgs() const {
-    return info->GenericArgs;
+  DeclContext *getDeclContext() const { return Decl::getDeclContext(); }
+
+  SourceRange getSourceRange() const {
+    return getExpansionInfo()->getSourceRange();
   }
-
-  SourceRange getGenericArgsRange() const {
-    return SourceRange(info->LeftAngleLoc, info->RightAngleLoc);
-  }
-
-  SourceRange getSourceRange() const;
-  SourceLoc getLocFromSource() const { return info->SigilLoc; }
-  SourceLoc getPoundLoc() const { return info->SigilLoc; }
-  DeclNameLoc getMacroNameLoc() const { return info->MacroNameLoc; }
-  DeclNameRef getMacroName() const { return info->MacroName; }
-  ArgumentList *getArgs() const { return info->ArgList; }
-  void setArgs(ArgumentList *args) { info->ArgList = args; }
+  SourceLoc getLocFromSource() const { return getExpansionInfo()->SigilLoc; }
   using ExprOrStmtExpansionCallback = llvm::function_ref<void(ASTNode)>;
   void forEachExpandedExprOrStmt(ExprOrStmtExpansionCallback) const;
-  ConcreteDeclRef getMacroRef() const { return info->macroRef; }
-  void setMacroRef(ConcreteDeclRef ref) { info->macroRef = ref; }
-
-  MacroExpansionInfo *getExpansionInfo() const { return info; }
 
   /// Returns a discriminator which determines this macro expansion's index
   /// in the sequence of macro expansions within the current function.
@@ -8702,6 +8662,9 @@ public:
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::MacroExpansion;
+  }
+  static bool classof(const FreestandingMacroExpansion *expansion) {
+    return expansion->getFreestandingMacroKind() == FreestandingMacroKind::Decl;
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -913,7 +913,13 @@ public:
   ///
   /// Auxiliary declarations can be property wrapper backing variables,
   /// backing variables for 'lazy' vars, or peer macro expansions.
-  void visitAuxiliaryDecls(AuxiliaryDeclCallback callback) const;
+  ///
+  /// When \p visitFreestandingExpanded is true (the default), this will also
+  /// visit the declarations produced by a freestanding macro expansion.
+  void visitAuxiliaryDecls(
+      AuxiliaryDeclCallback callback,
+      bool visitFreestandingExpanded = true
+  ) const;
 
   using MacroCallback = llvm::function_ref<void(CustomAttr *, MacroDecl *)>;
 

--- a/include/swift/AST/FreestandingMacroExpansion.h
+++ b/include/swift/AST/FreestandingMacroExpansion.h
@@ -1,0 +1,113 @@
+//===--- FreestandingMacroExpansion.h ------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_FREESTANDING_MACRO_EXPANSION_H
+#define SWIFT_AST_FREESTANDING_MACRO_EXPANSION_H
+
+#include "swift/AST/ASTAllocated.h"
+#include "swift/AST/ASTNode.h"
+#include "swift/AST/ConcreteDeclRef.h"
+#include "swift/AST/DeclNameLoc.h"
+#include "swift/AST/Identifier.h"
+#include "swift/Basic/SourceLoc.h"
+
+namespace swift {
+class MacroExpansionDecl;
+class MacroExpansionExpr;
+class Expr;
+class Decl;
+class ArgumentList;
+
+/// Information about a macro expansion that is common between macro
+/// expansion declarations and expressions.
+///
+/// Instances of these types will be shared among paired macro expansion
+/// declaration/expression nodes.
+struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
+  SourceLoc SigilLoc;
+  DeclNameRef MacroName;
+  DeclNameLoc MacroNameLoc;
+  SourceLoc LeftAngleLoc, RightAngleLoc;
+  llvm::ArrayRef<TypeRepr *> GenericArgs;
+  ArgumentList *ArgList;
+
+  /// The referenced macro.
+  ConcreteDeclRef macroRef;
+
+  MacroExpansionInfo(SourceLoc sigilLoc, DeclNameRef macroName,
+                     DeclNameLoc macroNameLoc, SourceLoc leftAngleLoc,
+                     SourceLoc rightAngleLoc, ArrayRef<TypeRepr *> genericArgs,
+                     ArgumentList *argList)
+      : SigilLoc(sigilLoc), MacroName(macroName), MacroNameLoc(macroNameLoc),
+        LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
+        GenericArgs(genericArgs), ArgList(argList) {}
+
+  SourceLoc getLoc() const { return SigilLoc; }
+  SourceRange getGenericArgsRange() const {
+    return {LeftAngleLoc, RightAngleLoc};
+  }
+  SourceRange getSourceRange() const;
+};
+
+enum class FreestandingMacroKind {
+  Expr, // MacroExpansionExpr.
+  Decl, // MacroExpansionDecl.
+};
+
+/// A base class of either 'MacroExpansionExpr' or 'MacroExpansionDecl'.
+class FreestandingMacroExpansion {
+  llvm::PointerIntPair<MacroExpansionInfo *, 1, FreestandingMacroKind>
+      infoAndKind;
+
+protected:
+  FreestandingMacroExpansion(FreestandingMacroKind kind,
+                             MacroExpansionInfo *info)
+      : infoAndKind(info, kind) {}
+
+public:
+  MacroExpansionInfo *getExpansionInfo() const {
+    return infoAndKind.getPointer();
+  }
+  FreestandingMacroKind getFreestandingMacroKind() const {
+    return infoAndKind.getInt();
+  }
+
+  ASTNode getASTNode();
+
+  SourceLoc getPoundLoc() const { return getExpansionInfo()->SigilLoc; }
+
+  DeclNameLoc getMacroNameLoc() const {
+    return getExpansionInfo()->MacroNameLoc;
+  }
+  DeclNameRef getMacroName() const { return getExpansionInfo()->MacroName; }
+
+  ArrayRef<TypeRepr *> getGenericArgs() const {
+    return getExpansionInfo()->GenericArgs;
+  }
+  SourceRange getGenericArgsRange() const {
+    return getExpansionInfo()->getGenericArgsRange();
+  }
+
+  ArgumentList *getArgs() const { return getExpansionInfo()->ArgList; }
+  void setArgs(ArgumentList *args) { getExpansionInfo()->ArgList = args; }
+
+  ConcreteDeclRef getMacroRef() const { return getExpansionInfo()->macroRef; }
+  void setMacroRef(ConcreteDeclRef ref) { getExpansionInfo()->macroRef = ref; }
+
+  DeclContext *getDeclContext() const;
+  SourceRange getSourceRange() const;
+  unsigned getDiscriminator() const;
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_FREESTANDING_MACRO_EXPANSION_H

--- a/include/swift/AST/MacroDiscriminatorContext.h
+++ b/include/swift/AST/MacroDiscriminatorContext.h
@@ -22,12 +22,10 @@ namespace swift {
 /// Describes the context of a macro expansion for the purpose of
 /// computing macro expansion discriminators.
 struct MacroDiscriminatorContext
-    : public llvm::PointerUnion<DeclContext *, MacroExpansionExpr *,
-                                MacroExpansionDecl *> {
+    : public llvm::PointerUnion<DeclContext *, FreestandingMacroExpansion *> {
   using PointerUnion::PointerUnion;
 
-  static MacroDiscriminatorContext getParentOf(MacroExpansionExpr *expansion);
-  static MacroDiscriminatorContext getParentOf(MacroExpansionDecl *expansion);
+  static MacroDiscriminatorContext getParentOf(FreestandingMacroExpansion *expansion);
   static MacroDiscriminatorContext getParentOf(
       SourceLoc loc, DeclContext *origDC
   );

--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -18,11 +18,12 @@
 #ifndef SWIFT_PRETTYSTACKTRACE_H
 #define SWIFT_PRETTYSTACKTRACE_H
 
-#include "llvm/Support/PrettyStackTrace.h"
-#include "swift/Basic/SourceLoc.h"
 #include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
+#include "swift/Basic/SourceLoc.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 namespace clang {
   class Type;
@@ -93,7 +94,21 @@ public:
   virtual void print(llvm::raw_ostream &OS) const override;
 };
 
-void printExprDescription(llvm::raw_ostream &out, Expr *E,
+/// PrettyStackTraceFreestandingMacroExpansion -  Observe that we are
+/// processing a specific freestanding macro expansion.
+class PrettyStackTraceFreestandingMacroExpansion
+    : public llvm::PrettyStackTraceEntry {
+  const FreestandingMacroExpansion *Expansion;
+  const char *Action;
+
+public:
+  PrettyStackTraceFreestandingMacroExpansion(
+      const char *action, const FreestandingMacroExpansion *expansion)
+      : Expansion(expansion), Action(action) {}
+  virtual void print(llvm::raw_ostream &OS) const override;
+};
+
+void printExprDescription(llvm::raw_ostream &out, const Expr *E,
                           const ASTContext &Context, bool addNewline = true);
 
 /// PrettyStackTraceExpr - Observe that we are processing a specific

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3223,19 +3223,15 @@ public:
 
 class UnresolvedMacroReference {
 private:
-  llvm::PointerUnion<MacroExpansionDecl *, MacroExpansionExpr *, CustomAttr *>
+  llvm::PointerUnion<FreestandingMacroExpansion *, CustomAttr *>
     pointer;
 
 public:
-  UnresolvedMacroReference(MacroExpansionDecl *decl) : pointer(decl) {}
-  UnresolvedMacroReference(MacroExpansionExpr *expr) : pointer(expr) {}
+  UnresolvedMacroReference(FreestandingMacroExpansion *exp) : pointer(exp) {}
   UnresolvedMacroReference(CustomAttr *attr) : pointer(attr) {}
 
-  MacroExpansionDecl *getDecl() const {
-    return pointer.dyn_cast<MacroExpansionDecl *>();
-  }
-  MacroExpansionExpr *getExpr() const {
-    return pointer.dyn_cast<MacroExpansionExpr *>();
+  FreestandingMacroExpansion *getFreestanding() const {
+    return pointer.dyn_cast<FreestandingMacroExpansion *>();
   }
   CustomAttr *getAttr() const {
     return pointer.dyn_cast<CustomAttr *>();

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -578,6 +578,9 @@ public:
   void insertAfter(SourceManager &SM, SourceLoc Loc, StringRef Text, ArrayRef<NoteRegion> SubRegions = {});
   void accept(SourceManager &SM, Replacement Replacement) { accept(SM, RegionType::ActiveCode, {Replacement}); }
   void remove(SourceManager &SM, CharSourceRange Range);
+  void acceptMacroExpansionBuffer(SourceManager &SM, unsigned bufferID,
+                                  SourceFile *containingSF,
+                                  bool adjustExpansion, bool includeBufferName);
 };
 
 /// This helper stream inserts text into a SourceLoc by calling functions in

--- a/include/swift/IDETool/SyntacticMacroExpansion.h
+++ b/include/swift/IDETool/SyntacticMacroExpansion.h
@@ -1,0 +1,97 @@
+//===--- SyntacticMacroExpansion.h ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_SYNTACTICMACROEXPANSION_H
+#define SWIFT_IDE_SYNTACTICMACROEXPANSION_H
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/MacroDefinition.h"
+#include "swift/AST/PluginRegistry.h"
+#include "swift/Basic/Fingerprint.h"
+#include "swift/Frontend/Frontend.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+namespace swift {
+
+class ASTContext;
+class SourceFile;
+
+namespace ide {
+class SourceEditConsumer;
+
+/// Simple object to specify a syntactic macro expansion.
+struct MacroExpansionSpecifier {
+  unsigned offset;
+  swift::MacroRoles macroRoles;
+  swift::MacroDefinition macroDefinition;
+};
+
+/// Instance of a syntactic macro expansion context. This is created for each
+/// list of compiler arguments (i.e. 'argHash'), and reused as long as the
+/// compiler arguments are not changed.
+class SyntacticMacroExpansionInstance {
+  CompilerInvocation invocation;
+
+  SourceManager SourceMgr;
+  DiagnosticEngine Diags{SourceMgr};
+  std::unique_ptr<ASTContext> Ctx;
+  ModuleDecl *TheModule = nullptr;
+  llvm::StringMap<MacroDecl *> MacroDecls;
+
+  /// Create 'SourceFile' using the buffer.
+  swift::SourceFile *getSourceFile(llvm::MemoryBuffer *inputBuf);
+
+  /// Synthesize 'MacroDecl' AST object to use the expansion.
+  swift::MacroDecl *
+  getSynthesizedMacroDecl(swift::Identifier name,
+                          const MacroExpansionSpecifier &expansion);
+
+  /// Expand single 'expansion' in SF.
+  void expand(swift::SourceFile *SF,
+                    const MacroExpansionSpecifier &expansion,
+                    SourceEditConsumer &consumer);
+
+public:
+  SyntacticMacroExpansionInstance() {}
+
+  /// Setup the instance with \p args .
+  bool setup(StringRef SwiftExecutablePath, ArrayRef<const char *> args,
+             std::shared_ptr<PluginRegistry> plugins, std::string &error);
+
+  ASTContext &getASTContext() { return *Ctx; }
+
+  /// Expand all macros in \p inputBuf and send the edit results to \p consumer.
+  /// Expansions are specified by \p expansions .
+  void expandAll(llvm::MemoryBuffer *inputBuf,
+                     ArrayRef<MacroExpansionSpecifier> expansions,
+                     SourceEditConsumer &consumer);
+};
+
+/// Manager object to vend 'SyntacticMacroExpansionInstance'.
+class SyntacticMacroExpansion {
+  StringRef SwiftExecutablePath;
+  std::shared_ptr<PluginRegistry> Plugins;
+
+public:
+  SyntacticMacroExpansion(StringRef SwiftExecutablePath,
+                          std::shared_ptr<PluginRegistry> Plugins)
+      : SwiftExecutablePath(SwiftExecutablePath), Plugins(Plugins) {}
+
+  /// Get instance configured with the specified compiler arguments.
+  std::shared_ptr<SyntacticMacroExpansionInstance>
+  getInstance(ArrayRef<const char *> args, std::string &error);
+};
+
+} // namespace ide
+} // namespace swift
+
+#endif // SWIFT_IDE_SYNTACTICMACROEXPANSION_H

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -37,6 +37,7 @@ namespace swift {
   enum class DeclRefKind;
   class Expr;
   class ExtensionDecl;
+  class FreestandingMacroExpansion;
   class FunctionType;
   class LabeledConditionalStmt;
   class LookupResult;
@@ -355,6 +356,13 @@ namespace swift {
   SmallVector<std::pair<ValueDecl *, ValueDecl *>, 1>
   getShorthandShadows(LabeledConditionalStmt *CondStmt,
                       DeclContext *DC = nullptr);
+
+  SourceFile *evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
+                                        StringRef discriminator);
+
+  SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
+                                    CustomAttr *attr, bool passParentContext,
+                                    MacroRole role, StringRef discriminator);
 }
 
 #endif

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4033,26 +4033,23 @@ static StringRef getPrivateDiscriminatorIfNecessary(
   return discriminator.str();
 }
 
-std::string ASTMangler::mangleMacroExpansion(
-    const MacroExpansionExpr *expansion) {
-  beginMangling();
-  appendMacroExpansionContext(expansion->getLoc(), expansion->getDeclContext());
-  auto privateDiscriminator = getPrivateDiscriminatorIfNecessary(expansion);
-  if (!privateDiscriminator.empty()) {
-    appendIdentifier(privateDiscriminator);
-    appendOperator("Ll");
+static StringRef getPrivateDiscriminatorIfNecessary(
+    const FreestandingMacroExpansion *expansion) {
+  switch (expansion->getFreestandingMacroKind()) {
+  case FreestandingMacroKind::Expr:
+    return getPrivateDiscriminatorIfNecessary(
+        cast<MacroExpansionExpr>(expansion));
+  case FreestandingMacroKind::Decl:
+    return getPrivateDiscriminatorIfNecessary(
+        cast<Decl>(cast<MacroExpansionDecl>(expansion)));
   }
-  appendMacroExpansionOperator(
-      expansion->getMacroName().getBaseName().userFacingName(),
-      MacroRole::Expression,
-      expansion->getDiscriminator());
-  return finalize();
 }
 
-std::string ASTMangler::mangleMacroExpansion(
-    const MacroExpansionDecl *expansion) {
+std::string
+ASTMangler::mangleMacroExpansion(const FreestandingMacroExpansion *expansion) {
   beginMangling();
-  appendMacroExpansionContext(expansion->getLoc(), expansion->getDeclContext());
+  appendMacroExpansionContext(expansion->getPoundLoc(),
+                              expansion->getDeclContext());
   auto privateDiscriminator = getPrivateDiscriminatorIfNecessary(expansion);
   if (!privateDiscriminator.empty()) {
     appendIdentifier(privateDiscriminator);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -455,20 +455,20 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       else
         return true;
     }
+
     bool alreadyFailed = false;
     if (shouldWalkExpansion) {
       MED->forEachExpandedNode([&](ASTNode expandedNode) {
         if (alreadyFailed) return;
+
         if (auto *expr = expandedNode.dyn_cast<Expr *>()) {
-          if (!doIt(expr))
-            alreadyFailed = true;
+          alreadyFailed = doIt(expr) == nullptr;
         } else if (auto *stmt = expandedNode.dyn_cast<Stmt *>()) {
-          if (!doIt(stmt))
-            alreadyFailed = true;
+          alreadyFailed = doIt(stmt) == nullptr;
         } else {
           auto decl = expandedNode.get<Decl *>();
           if (!isa<VarDecl>(decl))
-            alreadyFailed = inherited::visit(decl);
+            alreadyFailed = doIt(decl);
         }
       });
     }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -458,12 +458,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     // Visit auxiliary decls, which may be decls from macro expansions.
     bool alreadyFailed = false;
     if (shouldWalkExpansion) {
-      MED->visitAuxiliaryDecls([&](Decl *decl) {
-        if (alreadyFailed) return;
-        if (!isa<VarDecl>(decl))
-          alreadyFailed = inherited::visit(decl);
-      });
-      MED->forEachExpandedExprOrStmt([&](ASTNode expandedNode) {
+      MED->forEachExpandedNode([&](ASTNode expandedNode) {
         if (alreadyFailed) return;
         if (auto *expr = expandedNode.dyn_cast<Expr *>()) {
           if (!doIt(expr))
@@ -471,6 +466,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         } else if (auto *stmt = expandedNode.dyn_cast<Stmt *>()) {
           if (!doIt(stmt))
             alreadyFailed = true;
+        } else {
+          auto decl = expandedNode.get<Decl *>();
+          if (!isa<VarDecl>(decl))
+            alreadyFailed = inherited::visit(decl);
         }
       });
     }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -455,7 +455,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       else
         return true;
     }
-    // Visit auxiliary decls, which may be decls from macro expansions.
     bool alreadyFailed = false;
     if (shouldWalkExpansion) {
       MED->forEachExpandedNode([&](ASTNode expandedNode) {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -50,6 +50,7 @@ add_swift_host_library(swiftAST STATIC
   ExtInfo.cpp
   FineGrainedDependencies.cpp
   FineGrainedDependencyFormat.cpp
+  FreestandingMacroExpansion.cpp
   FrontendSourceFileDepGraphFactory.cpp
   GenericEnvironment.cpp
   GenericParamList.cpp

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10680,8 +10680,9 @@ unsigned MacroExpansionDecl::getDiscriminator() const {
   return getRawDiscriminator();
 }
 
-void MacroExpansionDecl::forEachExpandedExprOrStmt(
-    ExprOrStmtExpansionCallback callback) const {
+void MacroExpansionDecl::forEachExpandedNode(
+    llvm::function_ref<void(ASTNode)> callback
+) const {
   auto mutableThis = const_cast<MacroExpansionDecl *>(this);
   auto bufferID = evaluateOrDefault(
       getASTContext().evaluator,
@@ -10693,8 +10694,7 @@ void MacroExpansionDecl::forEachExpandedExprOrStmt(
   auto startLoc = sourceMgr.getLocForBufferStart(*bufferID);
   auto *sourceFile = moduleDecl->getSourceFileContainingLocation(startLoc);
   for (auto node : sourceFile->getTopLevelItems())
-    if (node.is<Expr *>() || node.is<Stmt *>())
-      callback(node);
+    callback(node);
 }
 
 NominalTypeDecl *

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10640,37 +10640,27 @@ MacroDefinition MacroDefinition::forExpanded(
                                  ctx.AllocateCopy(replacements)};
 }
 
-MacroExpansionDecl::MacroExpansionDecl(
-    DeclContext *dc, MacroExpansionInfo *info
-) : Decl(DeclKind::MacroExpansion, dc), info(info) {
+MacroExpansionDecl::MacroExpansionDecl(DeclContext *dc,
+                                       MacroExpansionInfo *info)
+    : Decl(DeclKind::MacroExpansion, dc),
+      FreestandingMacroExpansion(FreestandingMacroKind::Decl, info) {
   Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;
 }
 
-MacroExpansionDecl::MacroExpansionDecl(
+MacroExpansionDecl *
+MacroExpansionDecl::create(
     DeclContext *dc, SourceLoc poundLoc, DeclNameRef macro,
     DeclNameLoc macroLoc, SourceLoc leftAngleLoc,
     ArrayRef<TypeRepr *> genericArgs, SourceLoc rightAngleLoc,
     ArgumentList *args
-) : Decl(DeclKind::MacroExpansion, dc) {
+) {
   ASTContext &ctx = dc->getASTContext();
-  info = new (ctx) MacroExpansionInfo{
+  MacroExpansionInfo *info = new (ctx) MacroExpansionInfo{
       poundLoc, macro, macroLoc,
       leftAngleLoc, rightAngleLoc, genericArgs,
       args ? args : ArgumentList::createImplicit(ctx, {})
   };
-  Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;
-}
-
-SourceRange MacroExpansionDecl::getSourceRange() const {
-  SourceLoc endLoc;
-  if (auto argsEndList = info->ArgList->getEndLoc())
-    endLoc = argsEndList;
-  else if (info->RightAngleLoc.isValid())
-    endLoc = info->RightAngleLoc;
-  else
-    endLoc = info->MacroNameLoc.getEndLoc();
-
-  return SourceRange(info->SigilLoc, endLoc);
+  return new (ctx) MacroExpansionDecl(dc, info);
 }
 
 unsigned MacroExpansionDecl::getDiscriminator() const {
@@ -10814,13 +10804,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
 }
 
 MacroDiscriminatorContext
-MacroDiscriminatorContext::getParentOf(MacroExpansionExpr *expansion) {
+MacroDiscriminatorContext::getParentOf(FreestandingMacroExpansion *expansion) {
   return getParentOf(
-      expansion->getLoc(), expansion->getDeclContext());
-}
-
-MacroDiscriminatorContext
-MacroDiscriminatorContext::getParentOf(MacroExpansionDecl *expansion) {
-  return getParentOf(
-      expansion->getLoc(), expansion->getDeclContext());
+      expansion->getPoundLoc(), expansion->getDeclContext());
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10629,6 +10629,11 @@ MacroDefinition MacroDecl::getDefinition() const {
       MacroDefinition::forUndefined());
 }
 
+void MacroDecl::setDefinition(MacroDefinition definition) {
+  getASTContext().evaluator.cacheOutput(MacroDefinitionRequest{this},
+                                        std::move(definition));
+}
+
 Optional<BuiltinMacroKind> MacroDecl::getBuiltinKind() const {
   auto def = getDefinition();
   if (def.kind != MacroDefinition::Kind::Builtin)

--- a/lib/AST/FreestandingMacroExpansion.cpp
+++ b/lib/AST/FreestandingMacroExpansion.cpp
@@ -1,0 +1,56 @@
+//===--- FreestandingMacroExpansion.cpp -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/FreestandingMacroExpansion.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+
+using namespace swift;
+
+SourceRange MacroExpansionInfo::getSourceRange() const {
+  SourceLoc endLoc;
+  if (ArgList && !ArgList->isImplicit())
+    endLoc = ArgList->getEndLoc();
+  else if (RightAngleLoc.isValid())
+    endLoc = RightAngleLoc;
+  else
+    endLoc = MacroNameLoc.getEndLoc();
+
+  return SourceRange(SigilLoc, endLoc);
+}
+
+#define FORWARD_VARIANT(NAME)                                                  \
+  switch (getFreestandingMacroKind()) {                                        \
+  case FreestandingMacroKind::Expr:                                            \
+    return cast<MacroExpansionExpr>(this)->NAME();                             \
+  case FreestandingMacroKind::Decl:                                            \
+    return cast<MacroExpansionDecl>(this)->NAME();                             \
+  }
+
+DeclContext *FreestandingMacroExpansion::getDeclContext() const {
+  FORWARD_VARIANT(getDeclContext);
+}
+SourceRange FreestandingMacroExpansion::getSourceRange() const {
+  FORWARD_VARIANT(getSourceRange);
+}
+unsigned FreestandingMacroExpansion::getDiscriminator() const {
+  FORWARD_VARIANT(getDiscriminator);
+}
+
+ASTNode FreestandingMacroExpansion::getASTNode() {
+  switch (getFreestandingMacroKind()) {
+  case FreestandingMacroKind::Expr:
+    return cast<MacroExpansionExpr>(this);
+  case FreestandingMacroKind::Decl:
+    return cast<MacroExpansionDecl>(this);
+  }
+}

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -133,6 +133,20 @@ void PrettyStackTraceAnyFunctionRef::print(llvm::raw_ostream &out) const {
   }
 }
 
+void PrettyStackTraceFreestandingMacroExpansion::print(
+    llvm::raw_ostream &out) const {
+  out << "While " << Action << ' ';
+  auto &Context = Expansion->getDeclContext()->getASTContext();
+  switch (Expansion->getFreestandingMacroKind()) {
+  case FreestandingMacroKind::Expr:
+    printExprDescription(out, cast<MacroExpansionExpr>(Expansion), Context);
+    break;
+  case FreestandingMacroKind::Decl:
+    printDeclDescription(out, cast<MacroExpansionDecl>(Expansion), Context);
+    break;
+  }
+}
+
 void PrettyStackTraceExpr::print(llvm::raw_ostream &out) const {
   out << "While " << Action << ' ';
   if (!TheExpr) {
@@ -142,7 +156,7 @@ void PrettyStackTraceExpr::print(llvm::raw_ostream &out) const {
   printExprDescription(out, TheExpr, Context);
 }
 
-void swift::printExprDescription(llvm::raw_ostream &out, Expr *E,
+void swift::printExprDescription(llvm::raw_ostream &out, const Expr *E,
                                  const ASTContext &Context, bool addNewline) {
   out << "expression at ";
   E->getSourceRange().print(out, Context.SourceMgr);

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1681,10 +1681,8 @@ void swift::simple_display(
 //----------------------------------------------------------------------------//
 
 DeclNameRef UnresolvedMacroReference::getMacroName() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getMacroName();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getMacroName();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getMacroName();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
     if (!identTypeRepr)
@@ -1695,20 +1693,16 @@ DeclNameRef UnresolvedMacroReference::getMacroName() const {
 }
 
 SourceLoc UnresolvedMacroReference::getSigilLoc() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getPoundLoc();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getLoc();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getPoundLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>())
     return attr->getRangeWithAt().Start;
   llvm_unreachable("Unhandled case");
 }
 
 DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getMacroNameLoc();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getMacroNameLoc();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getMacroNameLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
     if (!identTypeRepr)
@@ -1719,10 +1713,8 @@ DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
 }
 
 SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getGenericArgsRange();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getGenericArgsRange();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getGenericArgsRange();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *typeRepr = attr->getTypeRepr();
@@ -1737,10 +1729,8 @@ SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
 }
 
 ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getGenericArgs();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getGenericArgs();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getGenericArgs();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
     auto *typeRepr = attr->getTypeRepr();
@@ -1755,17 +1745,15 @@ ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
 }
 
 ArgumentList *UnresolvedMacroReference::getArgs() const {
-  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getArgs();
-  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
-    return mee->getArgs();
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getArgs();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>())
     return attr->getArgs();
   llvm_unreachable("Unhandled case");
 }
 
 MacroRoles UnresolvedMacroReference::getMacroRoles() const {
-  if (pointer.is<MacroExpansionExpr *>() || pointer.is<MacroExpansionDecl *>())
+  if (pointer.is<FreestandingMacroExpansion *>())
     return getFreestandingMacroRoles();
 
   if (pointer.is<CustomAttr *>())
@@ -1776,10 +1764,8 @@ MacroRoles UnresolvedMacroReference::getMacroRoles() const {
 
 void swift::simple_display(llvm::raw_ostream &out,
                            const UnresolvedMacroReference &ref) {
-  if (ref.getDecl())
-    out << "macro-expansion-decl";
-  else if (ref.getExpr())
-    out << "macro-expansion-expr";
+  if (ref.getFreestanding())
+    out << "freestanding-macro-expansion";
   else if (ref.getAttr())
     out << "custom-attr";
 }

--- a/lib/IDETool/CMakeLists.txt
+++ b/lib/IDETool/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_host_library(swiftIDETool STATIC
   CompilerInvocation.cpp
   IDEInspectionInstance.cpp
   DependencyChecking.cpp
+  SyntacticMacroExpansion.cpp
   )
 
 target_link_libraries(swiftIDETool PRIVATE

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -1,0 +1,471 @@
+//===--- SyntacticMacroExpansion.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IDETool/SyntacticMacroExpansion.h"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/MacroDefinition.h"
+#include "swift/AST/PluginLoader.h"
+#include "swift/AST/TypeRepr.h"
+#include "swift/Driver/FrontendUtil.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/IDE/Utils.h"
+#include "swift/Sema/IDETypeChecking.h"
+
+using namespace swift;
+using namespace ide;
+
+std::shared_ptr<SyntacticMacroExpansionInstance>
+SyntacticMacroExpansion::getInstance(ArrayRef<const char *> args,
+                                     std::string &error) {
+  // Create and configure a new instance.
+  auto instance = std::make_shared<SyntacticMacroExpansionInstance>();
+
+  bool failed = instance->setup(SwiftExecutablePath, args, Plugins, error);
+  if (failed)
+    return nullptr;
+
+  return instance;
+}
+
+bool SyntacticMacroExpansionInstance::setup(
+    StringRef SwiftExecutablePath, ArrayRef<const char *> args,
+    std::shared_ptr<PluginRegistry> plugins, std::string &error) {
+  SmallString<256> driverPath(SwiftExecutablePath);
+  llvm::sys::path::remove_filename(driverPath);
+  llvm::sys::path::append(driverPath, "swiftc");
+
+  // Setup CompilerInstance to configure the plugin search path correctly.
+  bool hadError = driver::getSingleFrontendInvocationFromDriverArguments(
+      driverPath, args, Diags,
+      [&](ArrayRef<const char *> frontendArgs) {
+        return invocation.parseArgs(
+            frontendArgs, Diags, /*ConfigurationFileBuffers=*/nullptr,
+            /*workingDirectory=*/{}, SwiftExecutablePath);
+      },
+      /*ForceNoOutput=*/true);
+  if (hadError) {
+    error = "failed to setup compiler invocation";
+    return true;
+  }
+
+  // Setup ASTContext.
+  Ctx.reset(ASTContext::get(
+      invocation.getLangOptions(), invocation.getTypeCheckerOptions(),
+      invocation.getSILOptions(), invocation.getSearchPathOptions(),
+      invocation.getClangImporterOptions(), invocation.getSymbolGraphOptions(),
+      SourceMgr, Diags));
+  registerParseRequestFunctions(Ctx->evaluator);
+  registerTypeCheckerRequestFunctions(Ctx->evaluator);
+
+  std::unique_ptr<PluginLoader> pluginLoader =
+      std::make_unique<PluginLoader>(*Ctx, /*DepTracker=*/nullptr);
+  pluginLoader->setRegistry(plugins.get());
+  Ctx->setPluginLoader(std::move(pluginLoader));
+
+  // Create a module where SourceFiles reside.
+  Identifier ID = Ctx->getIdentifier(invocation.getModuleName());
+  TheModule = ModuleDecl::create(ID, *Ctx);
+
+  return false;
+}
+
+SourceFile *
+SyntacticMacroExpansionInstance::getSourceFile(llvm::MemoryBuffer *inputBuf) {
+
+  // If there is a SourceFile with the same name and the content, use it.
+  // Note that this finds the generated source file that was created in the
+  // previous expansion requests.
+  if (auto bufID =
+          SourceMgr.getIDForBufferIdentifier(inputBuf->getBufferIdentifier())) {
+    if (inputBuf->getBuffer() == SourceMgr.getEntireTextForBuffer(*bufID)) {
+      SourceLoc bufLoc = SourceMgr.getLocForBufferStart(*bufID);
+      if (SourceFile *existing =
+              TheModule->getSourceFileContainingLocation(bufLoc)) {
+        return existing;
+      }
+    }
+  }
+
+  // Otherwise, create a new SourceFile.
+  SourceFile *SF = new (getASTContext()) SourceFile(
+      *TheModule, SourceFileKind::Main, SourceMgr.addMemBufferCopy(inputBuf));
+  SF->setImports({});
+  TheModule->addFile(*SF);
+
+  return SF;
+}
+
+MacroDecl *SyntacticMacroExpansionInstance::getSynthesizedMacroDecl(
+    Identifier name, const MacroExpansionSpecifier &expansion) {
+  auto &ctx = getASTContext();
+
+  std::string macroID;
+
+  switch (expansion.macroDefinition.kind) {
+  case MacroDefinition::Kind::External: {
+    // '<module name>.<type name>'
+    // It's safe to use without 'kind' because 'Expanded' always starts with a
+    // sigil '#' which can't be valid in a module name.
+    auto external = expansion.macroDefinition.getExternalMacro();
+    macroID += external.moduleName.str();
+    macroID += ".";
+    macroID += external.macroTypeName.str();
+    break;
+  }
+  case MacroDefinition::Kind::Expanded: {
+    auto expanded = expansion.macroDefinition.getExpanded();
+    macroID += expanded.getExpansionText();
+    break;
+  }
+  case MacroDefinition::Kind::Builtin:
+  case MacroDefinition::Kind::Invalid:
+  case MacroDefinition::Kind::Undefined:
+    assert(false && "invalid macro definition for syntactic expansion");
+    macroID += name.str();
+  }
+
+  // Reuse cached MacroDecl of the same name if it's already created.
+  MacroDecl *macro;
+  auto found = MacroDecls.find(macroID);
+  if (found != MacroDecls.end()) {
+    macro = found->second;
+  } else {
+    macro = new (ctx) MacroDecl(
+        /*macroLoc=*/{}, DeclName(name), /*nameLoc=*/{},
+        /*genericParams=*/nullptr, /*parameterList=*/nullptr,
+        /*arrowLoc=*/{}, /*resultType=*/nullptr,
+        /*definition=*/nullptr, /*parent=*/TheModule);
+    macro->setImplicit();
+    MacroDecls.insert({macroID, macro});
+  }
+
+  // Add missing role attributes to MacroDecl.
+  MacroRoles roles = expansion.macroRoles;
+  for (auto attr : macro->getAttrs().getAttributes<MacroRoleAttr>()) {
+    roles -= attr->getMacroRole();
+  }
+  for (MacroRole role : getAllMacroRoles()) {
+    if (!roles.contains(role))
+      continue;
+
+    MacroSyntax syntax = getFreestandingMacroRoles().contains(role)
+                             ? MacroSyntax::Freestanding
+                             : MacroSyntax::Attached;
+
+    auto *attr = MacroRoleAttr::create(ctx, /*atLoc=*/{}, /*range=*/{}, syntax,
+                                       /*lParenLoc=*/{}, role, /*names=*/{},
+                                       /*rParenLoc=*/{}, /*implicit=*/true);
+    macro->getAttrs().add(attr);
+  }
+
+  // Set the macro definition.
+  macro->setDefinition(expansion.macroDefinition);
+
+  return macro;
+}
+
+/// Create a unique name of the expansion. The result is *appended* to \p out.
+static void addExpansionDiscriminator(SmallString<32> &out,
+                                      const SourceFile *SF, SourceLoc loc,
+                                      Optional<SourceLoc> supplementalLoc = None,
+                                      Optional<MacroRole> role = None) {
+  SourceManager &SM = SF->getASTContext().SourceMgr;
+
+  StableHasher hasher = StableHasher::defaultHasher();
+
+  // Module name.
+  hasher.combine(SF->getParentModule()->getName().str());
+  hasher.combine(uint8_t{0});
+
+  // File base name.
+  // Do not use the full path because we want this hash stable.
+  hasher.combine(llvm::sys::path::filename(SF->getFilename()));
+  hasher.combine(uint8_t{0});
+
+  // Line/column.
+  auto lineColumn = SM.getLineAndColumnInBuffer(loc);
+  hasher.combine(lineColumn.first);
+  hasher.combine(lineColumn.second);
+
+  // Supplemental line/column.
+  if (supplementalLoc.has_value()) {
+    auto supLineColumn = SM.getLineAndColumnInBuffer(*supplementalLoc);
+    hasher.combine(supLineColumn.first);
+    hasher.combine(supLineColumn.second);
+  }
+
+  // Macro role.
+  if (role.has_value()) {
+    hasher.combine(*role);
+  }
+
+  Fingerprint hash(std::move(hasher));
+  out.append(hash.getRawValue());
+}
+
+/// Perform expansion of the specified freestanding macro using the 'MacroDecl'.
+static std::vector<unsigned>
+expandFreestandingMacro(MacroDecl *macro,
+                        FreestandingMacroExpansion *expansion) {
+  std::vector<unsigned> bufferIDs;
+
+  SmallString<32> discriminator;
+  discriminator.append("__syntactic_macro_");
+  addExpansionDiscriminator(discriminator,
+                            expansion->getDeclContext()->getParentSourceFile(),
+                            expansion->getPoundLoc());
+
+  expansion->setMacroRef(macro);
+
+  SourceFile *expandedSource =
+      swift::evaluateFreestandingMacro(expansion, discriminator);
+  if (expandedSource)
+    bufferIDs.push_back(*expandedSource->getBufferID());
+
+  return bufferIDs;
+}
+
+/// Perform expansion of the specified decl and the attribute using the
+/// 'MacroDecl'. If the macro has multiple roles, evaluate it for all macro
+/// roles.
+static std::vector<unsigned>
+expandAttachedMacro(MacroDecl *macro, CustomAttr *attr, Decl *attachedDecl) {
+
+  std::vector<unsigned> bufferIDs;
+  auto evaluate = [&](Decl *target, bool passParent, MacroRole role) {
+
+    SmallString<32> discriminator;
+    discriminator.append("macro_");
+    addExpansionDiscriminator(discriminator,
+                              target->getDeclContext()->getParentSourceFile(),
+                              target->getLoc(), attr->getLocation(), role);
+
+    SourceFile *expandedSource = swift::evaluateAttachedMacro(
+        macro, target, attr, passParent, role, discriminator);
+    if (expandedSource)
+      bufferIDs.push_back(*expandedSource->getBufferID());
+  };
+
+  MacroRoles roles = macro->getMacroRoles();
+  if (roles.contains(MacroRole::Accessor)) {
+    if (isa<AbstractStorageDecl>(attachedDecl))
+      evaluate(attachedDecl, /*passParent=*/false, MacroRole::Accessor);
+  }
+  if (roles.contains(MacroRole::MemberAttribute)) {
+    if (auto *idc = dyn_cast<IterableDeclContext>(attachedDecl)) {
+      for (auto *member : idc->getParsedMembers()) {
+        // 'VarDecl' in 'IterableDeclContext' are part of 'PatternBindingDecl'.
+        if (isa<VarDecl>(member))
+          continue;
+        evaluate(member, /*passParent=*/true, MacroRole::MemberAttribute);
+      }
+    }
+  }
+  if (roles.contains(MacroRole::Member)) {
+    if (isa<IterableDeclContext>(attachedDecl))
+      evaluate(attachedDecl, /*passParent=*/false, MacroRole::Member);
+  }
+  if (roles.contains(MacroRole::Peer)) {
+    evaluate(attachedDecl, /*passParent=*/false, MacroRole::Peer);
+  }
+  if (roles.contains(MacroRole::Conformance)) {
+    if (isa<NominalTypeDecl>(attachedDecl))
+      evaluate(attachedDecl, /*passParent=*/false, MacroRole::Conformance);
+  }
+  return bufferIDs;
+}
+
+/// Get the name of the custom attribute. This is used to create a dummy
+/// MacroDecl.
+static Identifier getCustomAttrName(ASTContext &ctx, const CustomAttr *attr) {
+  TypeRepr *tyR = attr->getTypeRepr();
+  if (auto ref = dyn_cast<DeclRefTypeRepr>(tyR)) {
+    return ref->getNameRef().getBaseIdentifier();
+  }
+
+  // If the attribute is not an identifier type, create an identifier with its
+  // textual representation. This is *not* expected to be reachable.
+  // The only case is like `@Foo?` where the client should not send the
+  // expansion request on this in the first place.
+  SmallString<32> name;
+  llvm::raw_svector_ostream OS(name);
+  tyR->print(OS);
+  return ctx.getIdentifier(name);
+}
+
+namespace {
+
+/// Find macro expansion i.e. '#foo' or '@foo' at the specified source location.
+/// If a freestanding expansion (i.e. #foo) is found, the result 'ExpansionNode'
+/// only has the node. If an attribute is found, the attribute and the attached
+/// decl object is returned.
+struct ExpansionNode {
+  CustomAttr *attribute;
+  ASTNode node;
+};
+class MacroExpansionFinder : public ASTWalker {
+  SourceManager &SM;
+  SourceLoc locToResolve;
+  llvm::Optional<ExpansionNode> result;
+
+  bool rangeContainsLocToResolve(SourceRange Range) const {
+    return SM.rangeContainsTokenLoc(Range, locToResolve);
+  }
+
+public:
+  MacroExpansionFinder(SourceManager &SM, SourceLoc locToResolve)
+      : SM(SM), locToResolve(locToResolve) {}
+
+  llvm::Optional<ExpansionNode> getResult() const { return result; }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::None;
+  }
+
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    // Visit all 'VarDecl' because 'getSourceRangeIncludingAttrs()' doesn't
+    // include its attribute ranges (because attributes are part of PBD.)
+    if (!isa<VarDecl>(D) &&
+        !rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
+      return Action::SkipChildren();
+    }
+
+    // Check the attributes.
+    for (DeclAttribute *attr : D->getAttrs()) {
+      if (auto customAttr = dyn_cast<CustomAttr>(attr)) {
+        SourceRange nameRange(customAttr->getRangeWithAt().Start,
+                              customAttr->getTypeExpr()->getEndLoc());
+        if (rangeContainsLocToResolve(nameRange)) {
+          result = ExpansionNode{customAttr, ASTNode(D)};
+          return Action::Stop();
+        }
+      }
+    }
+
+    // Check 'MacroExpansionDecl'.
+    if (auto med = dyn_cast<MacroExpansionDecl>(D)) {
+      SourceRange nameRange(med->getExpansionInfo()->SigilLoc,
+                            med->getMacroNameLoc().getEndLoc());
+      if (rangeContainsLocToResolve(nameRange)) {
+        result = ExpansionNode{nullptr, ASTNode(med)};
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue();
+  }
+
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+    if (!rangeContainsLocToResolve(E->getSourceRange())) {
+      return Action::SkipChildren(E);
+    }
+
+    // Check 'MacroExpansionExpr'.
+    if (auto mee = dyn_cast<MacroExpansionExpr>(E)) {
+      SourceRange nameRange(mee->getExpansionInfo()->SigilLoc,
+                            mee->getMacroNameLoc().getEndLoc());
+      if (rangeContainsLocToResolve(nameRange)) {
+        result = ExpansionNode{nullptr, ASTNode(mee)};
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue(E);
+  }
+
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+    if (!rangeContainsLocToResolve(S->getSourceRange())) {
+      return Action::SkipChildren(S);
+    }
+    return Action::Continue(S);
+  }
+  PreWalkResult<ArgumentList *>
+  walkToArgumentListPre(ArgumentList *AL) override {
+    if (!rangeContainsLocToResolve(AL->getSourceRange())) {
+      return Action::SkipChildren(AL);
+    }
+    return Action::Continue(AL);
+  }
+  PreWalkAction walkToParameterListPre(ParameterList *PL) override {
+    if (!rangeContainsLocToResolve(PL->getSourceRange())) {
+      return Action::SkipChildren();
+    }
+    return Action::Continue();
+  }
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+    // TypeRepr cannot have macro expansions in it.
+    return Action::SkipChildren();
+  }
+};
+} // namespace
+
+void SyntacticMacroExpansionInstance::expand(
+    SourceFile *SF, const MacroExpansionSpecifier &expansion,
+    SourceEditConsumer &consumer) {
+
+  // Find the expansion at 'expantion.offset'.
+  MacroExpansionFinder expansionFinder(
+      SourceMgr,
+      SourceMgr.getLocForOffset(*SF->getBufferID(), expansion.offset));
+  SF->walk(expansionFinder);
+  auto expansionNode = expansionFinder.getResult();
+  if (!expansionNode)
+    return;
+
+  // Expand the macro.
+  std::vector<unsigned> bufferIDs;
+  if (auto *attr = expansionNode->attribute) {
+    // Attached macros.
+    MacroDecl *macro = getSynthesizedMacroDecl(
+        getCustomAttrName(getASTContext(), attr), expansion);
+    auto *attachedTo = expansionNode->node.get<Decl *>();
+    bufferIDs = expandAttachedMacro(macro, attr, attachedTo);
+
+    // For an attached macro, remove the custom attribute; it's been fully
+    // subsumed by its expansions.
+    SourceRange range = attr->getRangeWithAt();
+    auto charRange = Lexer::getCharSourceRangeFromSourceRange(SourceMgr, range);
+    consumer.remove(SourceMgr, charRange);
+  } else {
+    // Freestanding macros.
+    FreestandingMacroExpansion *freestanding;
+    auto node = expansionNode->node;
+    if (node.is<Expr *>()) {
+      freestanding = cast<MacroExpansionExpr>(node.get<Expr *>());
+    } else {
+      freestanding = cast<MacroExpansionDecl>(node.get<Decl *>());
+    }
+
+    MacroDecl *macro = getSynthesizedMacroDecl(
+        freestanding->getMacroName().getBaseIdentifier(), expansion);
+    bufferIDs = expandFreestandingMacro(macro, freestanding);
+  }
+
+  // Send all edits to the consumer.
+  for (unsigned bufferID : bufferIDs) {
+    consumer.acceptMacroExpansionBuffer(SourceMgr, bufferID, SF,
+                                        /*adjust=*/false,
+                                        /*includeBufferName=*/false);
+  }
+}
+
+void SyntacticMacroExpansionInstance::expandAll(
+    llvm::MemoryBuffer *inputBuf, ArrayRef<MacroExpansionSpecifier> expansions,
+    SourceEditConsumer &consumer) {
+
+  // Create a source file.
+  SourceFile *SF = getSourceFile(inputBuf);
+
+  for (const auto &expansion : expansions) {
+    expand(SF, expansion, consumer);
+  }
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9940,7 +9940,7 @@ Parser::parseDeclMacroExpansion(ParseDeclOptions flags,
   if (!macroNameRef)
     return status;
 
-  auto *med = new (Context) MacroExpansionDecl(
+  auto *med = MacroExpansionDecl::create(
       CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
       Context.AllocateCopy(genericArgs), rightAngleLoc, argList);
   med->getAttrs() = attributes;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3472,12 +3472,11 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
 
   return makeParserResult(
       status,
-      new (Context) MacroExpansionExpr(
+      MacroExpansionExpr::create(
           CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
           Context.AllocateCopy(genericArgs), rightAngleLoc, argList,
-          CurDeclContext->isTypeContext()
-              ? MacroRole::Declaration
-              : getFreestandingMacroRoles()));
+          CurDeclContext->isTypeContext() ? MacroRole::Declaration
+                                          : getFreestandingMacroRoles()));
 }
 
 /// parseExprCollection - Parse a collection literal expression.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1621,11 +1621,13 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
 }
 
 void SILGenFunction::visitMacroExpansionDecl(MacroExpansionDecl *D) {
-  D->forEachExpandedExprOrStmt([&](ASTNode node) {
+  D->forEachExpandedNode([&](ASTNode node) {
     if (auto *expr = node.dyn_cast<Expr *>())
       emitIgnoredExpr(expr);
     else if (auto *stmt = node.dyn_cast<Stmt *>())
       emitStmt(stmt);
+    else
+      visit(node.get<Decl *>());
   });
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6298,11 +6298,13 @@ RValue RValueEmitter::visitMacroExpansionExpr(MacroExpansionExpr *E,
   }
   else if (auto *MED = E->getSubstituteDecl()) {
     Mangle::ASTMangler mangler;
-    MED->forEachExpandedExprOrStmt([&](ASTNode node) {
+    MED->forEachExpandedNode([&](ASTNode node) {
       if (auto *expr = node.dyn_cast<Expr *>())
         visit(expr, C);
       else if (auto *stmt = node.dyn_cast<Stmt *>())
         SGF.emitStmt(stmt);
+      else
+        SGF.visit(node.get<Decl *>());
     });
     return RValue();
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2937,7 +2937,7 @@ namespace {
 
         auto macro = cast<MacroDecl>(overload.choice.getDecl());
         ConcreteDeclRef macroRef = resolveConcreteDeclRef(macro, locator);
-        auto expansion = new (ctx) MacroExpansionExpr(
+        auto *expansion = MacroExpansionExpr::create(
             dc, expr->getStartLoc(), DeclNameRef(macro->getName()),
             DeclNameLoc(expr->getLoc()), SourceLoc(), {}, SourceLoc(), nullptr,
             MacroRole::Expression, /*isImplicit=*/true, expandedType);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2066,8 +2066,11 @@ public:
   void visitMacroExpansionDecl(MacroExpansionDecl *MED) {
     // Assign a discriminator.
     (void)MED->getDiscriminator();
-    // Decls in expansion already visited as auxiliary decls.
-    MED->forEachExpandedExprOrStmt([&](ASTNode node) {
+    MED->forEachExpandedNode([&](ASTNode node) {
+      // Decls in expansion already visited as auxiliary decls.
+      if (node.is<Decl *>())
+        return;
+
       TypeChecker::typeCheckASTNode(node, MED->getDeclContext());
     });
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1850,7 +1850,7 @@ public:
     if (!isa<ClassDecl>(decl->getDeclContext())) {
       decl->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
         this->visit(auxiliaryDecl);
-      });
+      }, /*visitFreestandingExpanded=*/false);
     }
 
     if (auto *Stats = getASTContext().Stats)
@@ -2067,10 +2067,6 @@ public:
     // Assign a discriminator.
     (void)MED->getDiscriminator();
     MED->forEachExpandedNode([&](ASTNode node) {
-      // Decls in expansion already visited as auxiliary decls.
-      if (node.is<Decl *>())
-        return;
-
       TypeChecker::typeCheckASTNode(node, MED->getDeclContext());
     });
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -39,6 +39,7 @@
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "swift/Subsystems.h"
 #include "llvm/Config/config.h"
 
@@ -861,7 +862,8 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
 
 /// Evaluate the given freestanding macro expansion.
 static SourceFile *
-evaluateFreestandingMacro(FreestandingMacroExpansion *expansion) {
+evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
+                          StringRef discriminatorStr = "") {
   auto *dc = expansion->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
   SourceLoc loc = expansion->getPoundLoc();
@@ -889,6 +891,8 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion) {
 
   /// The discriminator used for the macro.
   LazyValue<std::string> discriminator([&]() -> std::string {
+    if (!discriminatorStr.empty())
+      return discriminatorStr.str();
 #if SWIFT_SWIFT_PARSER
     Mangle::ASTMangler mangler;
     return mangler.mangleMacroExpansion(expansion);
@@ -983,7 +987,7 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion) {
 }
 
 Optional<unsigned> swift::expandMacroExpr(MacroExpansionExpr *mee) {
-  SourceFile *macroSourceFile = evaluateFreestandingMacro(mee);
+  SourceFile *macroSourceFile = ::evaluateFreestandingMacro(mee);
   if (!macroSourceFile)
     return None;
 
@@ -1043,7 +1047,7 @@ Optional<unsigned> swift::expandMacroExpr(MacroExpansionExpr *mee) {
 /// Expands the given macro expansion declaration.
 Optional<unsigned>
 swift::expandFreestandingMacro(MacroExpansionDecl *med) {
-  SourceFile *macroSourceFile = evaluateFreestandingMacro(med);
+  SourceFile *macroSourceFile = ::evaluateFreestandingMacro(med);
   if (!macroSourceFile)
     return None;
 
@@ -1065,9 +1069,10 @@ swift::expandFreestandingMacro(MacroExpansionDecl *med) {
   return *macroSourceFile->getBufferID();
 }
 
-static SourceFile *
-evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
-                      bool passParentContext, MacroRole role) {
+static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
+                                         CustomAttr *attr,
+                                         bool passParentContext, MacroRole role,
+                                         StringRef discriminatorStr = "") {
   DeclContext *dc;
   if (role == MacroRole::Peer) {
     dc = attachedTo->getDeclContext();
@@ -1117,6 +1122,8 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
 
   /// The discriminator used for the macro.
   LazyValue<std::string> discriminator([&]() -> std::string {
+    if (!discriminatorStr.empty())
+      return discriminatorStr.str();
 #if SWIFT_SWIFT_PARSER
     Mangle::ASTMangler mangler;
     return mangler.mangleAttachedMacroExpansion(attachedTo, attr, role);
@@ -1229,9 +1236,9 @@ Optional<unsigned> swift::expandAccessors(
     AbstractStorageDecl *storage, CustomAttr *attr, MacroDecl *macro
 ) {
   // Evaluate the macro.
-  auto macroSourceFile = evaluateAttachedMacro(macro, storage, attr,
-                                               /*passParentContext*/false,
-                                               MacroRole::Accessor);
+  auto macroSourceFile =
+      ::evaluateAttachedMacro(macro, storage, attr,
+                              /*passParentContext=*/false, MacroRole::Accessor);
   if (!macroSourceFile)
     return None;
 
@@ -1280,9 +1287,9 @@ ArrayRef<unsigned> ExpandAccessorMacros::evaluate(
 Optional<unsigned>
 swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member) {
   // Evaluate the macro.
-  auto macroSourceFile = evaluateAttachedMacro(macro, member, attr,
-                                               /*passParentContext*/true,
-                                               MacroRole::MemberAttribute);
+  auto macroSourceFile = ::evaluateAttachedMacro(macro, member, attr,
+                                                 /*passParentContext=*/true,
+                                                 MacroRole::MemberAttribute);
   if (!macroSourceFile)
     return None;
 
@@ -1305,9 +1312,9 @@ swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member) {
 Optional<unsigned>
 swift::expandMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl) {
   // Evaluate the macro.
-  auto macroSourceFile = evaluateAttachedMacro(macro, decl, attr,
-                                               /*passParentContext*/false,
-                                               MacroRole::Member);
+  auto macroSourceFile =
+      ::evaluateAttachedMacro(macro, decl, attr,
+                              /*passParentContext=*/false, MacroRole::Member);
   if (!macroSourceFile)
     return None;
 
@@ -1332,9 +1339,9 @@ swift::expandMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl) {
 
 Optional<unsigned>
 swift::expandPeers(CustomAttr *attr, MacroDecl *macro, Decl *decl) {
-  auto macroSourceFile = evaluateAttachedMacro(macro, decl, attr,
-                                               /*passParentContext*/false,
-                                               MacroRole::Peer);
+  auto macroSourceFile =
+      ::evaluateAttachedMacro(macro, decl, attr,
+                              /*passParentContext=*/false, MacroRole::Peer);
   if (!macroSourceFile)
     return None;
 
@@ -1358,10 +1365,9 @@ ExpandConformanceMacros::evaluate(Evaluator &evaluator,
 Optional<unsigned>
 swift::expandConformances(CustomAttr *attr, MacroDecl *macro,
                           NominalTypeDecl *nominal) {
-  auto macroSourceFile =
-      evaluateAttachedMacro(macro, nominal, attr,
-                            /*passParentContext*/false,
-                            MacroRole::Conformance);
+  auto macroSourceFile = ::evaluateAttachedMacro(macro, nominal, attr,
+                                                 /*passParentContext=*/false,
+                                                 MacroRole::Conformance);
 
   if (!macroSourceFile)
     return None;
@@ -1447,4 +1453,20 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   }
 
   return macroExpansion->getMacroRef();
+}
+
+// MARK: for IDE.
+
+SourceFile *swift::evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
+                                         CustomAttr *attr,
+                                         bool passParentContext, MacroRole role,
+                                         StringRef discriminator) {
+  return ::evaluateAttachedMacro(macro, attachedTo, attr, passParentContext,
+                                 role, discriminator);
+}
+
+SourceFile *
+swift::evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
+                                 StringRef discriminator) {
+  return ::evaluateFreestandingMacro(expansion, discriminator);
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -705,6 +705,159 @@ static std::string expandMacroDefinition(
   return expandedResult;
 }
 
+static GeneratedSourceInfo::Kind getGeneratedSourceInfoKind(MacroRole role) {
+  switch (role) {
+  case MacroRole::Expression:
+    return GeneratedSourceInfo::ExpressionMacroExpansion;
+  case MacroRole::Declaration:
+  case MacroRole::CodeItem:
+    return GeneratedSourceInfo::FreestandingDeclMacroExpansion;
+  case MacroRole::Accessor:
+    return GeneratedSourceInfo::AccessorMacroExpansion;
+  case MacroRole::MemberAttribute:
+    return GeneratedSourceInfo::MemberAttributeMacroExpansion;
+  case MacroRole::Member:
+    return GeneratedSourceInfo::MemberMacroExpansion;
+  case MacroRole::Peer:
+    return GeneratedSourceInfo::PeerMacroExpansion;
+  case MacroRole::Conformance:
+    return GeneratedSourceInfo::ConformanceMacroExpansion;
+  }
+  llvm_unreachable("unhandled MacroRole");
+}
+
+// If this storage declaration is a variable with an explicit initializer,
+// return the range from the `=` to the end of the explicit initializer.
+static Optional<SourceRange>
+getExplicitInitializerRange(AbstractStorageDecl *storage) {
+  auto var = dyn_cast<VarDecl>(storage);
+  if (!var)
+    return None;
+
+  auto pattern = var->getParentPatternBinding();
+  if (!pattern)
+    return None;
+
+  unsigned index = pattern->getPatternEntryIndexForVarDecl(var);
+  SourceLoc equalLoc = pattern->getEqualLoc(index);
+  SourceRange initRange = pattern->getOriginalInitRange(index);
+  if (equalLoc.isInvalid() || initRange.End.isInvalid())
+    return None;
+
+  return SourceRange(equalLoc, initRange.End);
+}
+
+static CharSourceRange getExpansionInsertionRange(MacroRole role,
+                                                  ASTNode target,
+                                                  SourceManager &sourceMgr) {
+  switch (role) {
+  case MacroRole::Accessor: {
+    auto storage = cast<AbstractStorageDecl>(target.get<Decl *>());
+    auto bracesRange = storage->getBracesRange();
+
+    // Compute the location where the accessors will be added.
+    if (bracesRange.Start.isValid()) {
+      // We have braces already, so insert them inside the leading '{'.
+      return CharSourceRange(
+          Lexer::getLocForEndOfToken(sourceMgr, bracesRange.Start), 0);
+    } else if (auto initRange = getExplicitInitializerRange(storage)) {
+      // The accessor had an initializer, so the initializer (including
+      // the `=`) is replaced by the accessors.
+      return Lexer::getCharSourceRangeFromSourceRange(sourceMgr, *initRange);
+    } else {
+      // The accessors go at the end.
+      SourceLoc endLoc = storage->getEndLoc();
+      if (auto var = dyn_cast<VarDecl>(storage)) {
+        if (auto pattern = var->getParentPattern())
+          endLoc = pattern->getEndLoc();
+      }
+
+      return CharSourceRange(Lexer::getLocForEndOfToken(sourceMgr, endLoc), 0);
+    }
+  }
+  case MacroRole::MemberAttribute: {
+    SourceLoc startLoc;
+    if (auto valueDecl = dyn_cast<ValueDecl>(target.get<Decl *>()))
+      startLoc = valueDecl->getAttributeInsertionLoc(/*forModifier=*/false);
+    else
+      startLoc = target.getStartLoc();
+
+    return CharSourceRange(startLoc, 0);
+  }
+  case MacroRole::Member: {
+    // Semantically, we insert members right before the closing brace.
+    SourceLoc rightBraceLoc;
+    if (auto nominal = dyn_cast<NominalTypeDecl>(target.get<Decl *>())) {
+      rightBraceLoc = nominal->getBraces().End;
+    } else {
+      auto ext = cast<ExtensionDecl>(target.get<Decl *>());
+      rightBraceLoc = ext->getBraces().End;
+    }
+
+    return CharSourceRange(rightBraceLoc, 0);
+  }
+  case MacroRole::Peer: {
+    SourceLoc afterDeclLoc =
+        Lexer::getLocForEndOfToken(sourceMgr, target.getEndLoc());
+    return CharSourceRange(afterDeclLoc, 0);
+    break;
+  }
+
+  case MacroRole::Conformance: {
+    SourceLoc afterDeclLoc =
+        Lexer::getLocForEndOfToken(sourceMgr, target.getEndLoc());
+    return CharSourceRange(afterDeclLoc, 0);
+  }
+
+  case MacroRole::Expression:
+  case MacroRole::Declaration:
+  case MacroRole::CodeItem:
+    return Lexer::getCharSourceRangeFromSourceRange(sourceMgr,
+                                                    target.getSourceRange());
+  }
+  llvm_unreachable("unhandled MacroRole");
+}
+
+static SourceFile *
+createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
+                      MacroRole role, ASTNode target, DeclContext *dc,
+                      CustomAttr *attr) {
+  ASTContext &ctx = dc->getASTContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
+
+  // Dump macro expansions to standard output, if requested.
+  if (ctx.LangOpts.DumpMacroExpansions) {
+    llvm::errs() << buffer->getBufferIdentifier()
+                 << "\n------------------------------\n"
+                 << buffer->getBuffer()
+                 << "\n------------------------------\n";
+  }
+
+  CharSourceRange generatedOriginalSourceRange =
+      getExpansionInsertionRange(role, target, sourceMgr);
+  GeneratedSourceInfo::Kind generatedSourceKind =
+      getGeneratedSourceInfoKind(role);
+
+  // Create a new source buffer with the contents of the expanded macro.
+  unsigned macroBufferID = sourceMgr.addNewSourceBuffer(std::move(buffer));
+  auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
+  GeneratedSourceInfo sourceInfo{generatedSourceKind,
+                                 generatedOriginalSourceRange,
+                                 macroBufferRange,
+                                 target.getOpaqueValue(),
+                                 dc,
+                                 attr};
+  sourceMgr.setGeneratedSourceInfo(macroBufferID, sourceInfo);
+
+  // Create a source file to hold the macro buffer. This is automatically
+  // registered with the enclosing module.
+  auto macroSourceFile = new (ctx) SourceFile(
+      *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
+      /*parsingOpts=*/{}, /*isPrimary=*/false);
+  macroSourceFile->setImports(dc->getParentSourceFile()->getImports());
+  return macroSourceFile;
+}
+
 Optional<unsigned>
 swift::expandMacroExpr(MacroExpansionExpr *mee) {
   DeclContext *dc = mee->getDeclContext();
@@ -810,36 +963,12 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
 #endif
   }
   }
+  SourceFile *macroSourceFile = createMacroSourceFile(
+      std::move(evaluatedSource), MacroRole::Expression, mee, dc,
+      /*attr=*/nullptr);
 
-  // Dump macro expansions to standard output, if requested.
-  if (ctx.LangOpts.DumpMacroExpansions) {
-    llvm::errs() << evaluatedSource->getBufferIdentifier() << " as "
-                 << expandedType.getString()
-                 << "\n------------------------------\n"
-                 << evaluatedSource->getBuffer()
-                 << "\n------------------------------\n";
-  }
-
-  // Create a new source buffer with the contents of the expanded macro.
-  unsigned macroBufferID =
-      sourceMgr.addNewSourceBuffer(std::move(evaluatedSource));
+  auto macroBufferID = *macroSourceFile->getBufferID();
   auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
-  GeneratedSourceInfo sourceInfo{
-    GeneratedSourceInfo::ExpressionMacroExpansion,
-    Lexer::getCharSourceRangeFromSourceRange(
-      sourceMgr, mee->getSourceRange()),
-    macroBufferRange,
-    ASTNode(mee).getOpaqueValue(),
-    dc
-  };
-  sourceMgr.setGeneratedSourceInfo(macroBufferID, sourceInfo);
-
-  // Create a source file to hold the macro buffer. This is automatically
-  // registered with the enclosing module.
-  auto macroSourceFile = new (ctx) SourceFile(
-      *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
-      /*parsingOpts=*/{}, /*isPrimary=*/false);
-  macroSourceFile->setImports(sourceFile->getImports());
 
   // Retrieve the parsed expression from the list of top-level items.
   auto topLevelItems = macroSourceFile->getTopLevelItems();
@@ -890,7 +1019,6 @@ Optional<unsigned>
 swift::expandFreestandingMacro(MacroExpansionDecl *med) {
   auto *dc = med->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
-  SourceManager &sourceMgr = ctx.SourceMgr;
 
   auto moduleDecl = dc->getParentModule();
   auto sourceFile = moduleDecl->getSourceFileContainingLocation(med->getLoc());
@@ -1004,34 +1132,9 @@ swift::expandFreestandingMacro(MacroExpansionDecl *med) {
   }
   }
 
-  // Dump macro expansions to standard output, if requested.
-  if (ctx.LangOpts.DumpMacroExpansions) {
-    llvm::errs() << evaluatedSource->getBufferIdentifier()
-                 << "\n------------------------------\n"
-                 << evaluatedSource->getBuffer()
-                 << "\n------------------------------\n";
-  }
-
-  // Create a new source buffer with the contents of the expanded macro.
-  unsigned macroBufferID =
-      sourceMgr.addNewSourceBuffer(std::move(evaluatedSource));
-  auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
-  GeneratedSourceInfo sourceInfo{
-      GeneratedSourceInfo::FreestandingDeclMacroExpansion,
-      Lexer::getCharSourceRangeFromSourceRange(
-        sourceMgr, med->getSourceRange()),
-      macroBufferRange,
-      ASTNode(med).getOpaqueValue(),
-      dc
-  };
-  sourceMgr.setGeneratedSourceInfo(macroBufferID, sourceInfo);
-
-  // Create a source file to hold the macro buffer. This is automatically
-  // registered with the enclosing module.
-  auto macroSourceFile = new (ctx) SourceFile(
-      *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
-      /*parsingOpts=*/{}, /*isPrimary=*/false);
-  macroSourceFile->setImports(sourceFile->getImports());
+  SourceFile *macroSourceFile = createMacroSourceFile(
+      std::move(evaluatedSource), MacroRole::Declaration, med, dc,
+      /*attr=*/nullptr);
 
   validateMacroExpansion(macroSourceFile, macro,
                          /*attachedTo*/nullptr,
@@ -1045,28 +1148,7 @@ swift::expandFreestandingMacro(MacroExpansionDecl *med) {
     if (auto *decl = item.dyn_cast<Decl *>())
       decl->setDeclContext(dc);
   }
-  return macroBufferID;
-}
-
-// If this storage declaration is a variable with an explicit initializer,
-// return the range from the `=` to the end of the explicit initializer.
-static Optional<SourceRange> getExplicitInitializerRange(
-    AbstractStorageDecl *storage) {
-  auto var = dyn_cast<VarDecl>(storage);
-  if (!var)
-    return None;
-
-  auto pattern = var->getParentPatternBinding();
-  if (!pattern)
-    return None;
-
-  unsigned index = pattern->getPatternEntryIndexForVarDecl(var);
-  SourceLoc equalLoc = pattern->getEqualLoc(index);
-  SourceRange initRange = pattern->getOriginalInitRange(index);
-  if (equalLoc.isInvalid() || initRange.End.isInvalid())
-    return None;
-
-  return SourceRange(equalLoc, initRange.End);
+  return *macroSourceFile->getBufferID();
 }
 
 static SourceFile *
@@ -1083,7 +1165,6 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
   }
 
   ASTContext &ctx = dc->getASTContext();
-  SourceManager &sourceMgr = ctx.SourceMgr;
 
   auto moduleDecl = dc->getParentModule();
 
@@ -1222,117 +1303,8 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
   }
   }
 
-  // Dump macro expansions to standard output, if requested.
-  if (ctx.LangOpts.DumpMacroExpansions) {
-    llvm::errs() << evaluatedSource->getBufferIdentifier()
-                 << "\n------------------------------\n"
-                 << evaluatedSource->getBuffer()
-                 << "\n------------------------------\n";
-  }
-
-  CharSourceRange generatedOriginalSourceRange;
-  GeneratedSourceInfo::Kind generatedSourceKind;
-  switch (role) {
-  case MacroRole::Accessor: {
-    generatedSourceKind = GeneratedSourceInfo::AccessorMacroExpansion;
-
-    // Compute the location where the accessors will be added.
-    auto storage = cast<AbstractStorageDecl>(attachedTo);
-    auto bracesRange = storage->getBracesRange();
-    if (bracesRange.Start.isValid()) {
-      // We have braces already, so insert them inside the leading '{'.
-      generatedOriginalSourceRange = CharSourceRange(
-         Lexer::getLocForEndOfToken(sourceMgr, bracesRange.Start), 0);
-    } else if (auto initRange = getExplicitInitializerRange(storage)) {
-      // The accessor had an initializer, so the initializer (including
-      // the `=`) is replaced by the accessors.
-      generatedOriginalSourceRange =
-          Lexer::getCharSourceRangeFromSourceRange(sourceMgr, *initRange);
-    } else {
-      // The accessors go at the end.
-      SourceLoc endLoc = storage->getEndLoc();
-      if (auto var = dyn_cast<VarDecl>(storage)) {
-        if (auto pattern = var->getParentPattern())
-          endLoc = pattern->getEndLoc();
-      }
-
-      generatedOriginalSourceRange = CharSourceRange(
-         Lexer::getLocForEndOfToken(sourceMgr, endLoc), 0);
-    }
-
-    break;
-  }
-
-  case MacroRole::MemberAttribute: {
-    generatedSourceKind = GeneratedSourceInfo::MemberAttributeMacroExpansion;
-    SourceLoc startLoc;
-    if (auto valueDecl = dyn_cast<ValueDecl>(attachedTo))
-      startLoc = valueDecl->getAttributeInsertionLoc(/*forModifier=*/false);
-    else
-      startLoc = attachedTo->getStartLoc();
-
-    generatedOriginalSourceRange = CharSourceRange(startLoc, 0);
-    break;
-  }
-
-  case MacroRole::Member: {
-    generatedSourceKind = GeneratedSourceInfo::MemberMacroExpansion;
-
-    // Semantically, we insert members right before the closing brace.
-    SourceLoc rightBraceLoc;
-    if (auto nominal = dyn_cast<NominalTypeDecl>(attachedTo)) {
-      rightBraceLoc = nominal->getBraces().End;
-    } else {
-      auto ext = cast<ExtensionDecl>(attachedTo);
-      rightBraceLoc = ext->getBraces().End;
-    }
-
-    generatedOriginalSourceRange = CharSourceRange(rightBraceLoc, 0);
-    break;
-  }
-
-  case MacroRole::Peer: {
-    generatedSourceKind = GeneratedSourceInfo::PeerMacroExpansion;
-    SourceLoc afterDeclLoc =
-        Lexer::getLocForEndOfToken(sourceMgr, attachedTo->getEndLoc());
-    generatedOriginalSourceRange = CharSourceRange(afterDeclLoc, 0);
-    break;
-  }
-
-  case MacroRole::Conformance: {
-    generatedSourceKind = GeneratedSourceInfo::ConformanceMacroExpansion;
-    SourceLoc afterDeclLoc =
-        Lexer::getLocForEndOfToken(sourceMgr, attachedTo->getEndLoc());
-    generatedOriginalSourceRange = CharSourceRange(afterDeclLoc, 0);
-    break;
-  }
-
-  case MacroRole::Expression:
-  case MacroRole::Declaration:
-  case MacroRole::CodeItem:
-    llvm_unreachable("freestanding macro in attached macro evaluation");
-  }
-
-  // Create a new source buffer with the contents of the expanded macro.
-  unsigned macroBufferID =
-      sourceMgr.addNewSourceBuffer(std::move(evaluatedSource));
-  auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
-  GeneratedSourceInfo sourceInfo{
-      generatedSourceKind,
-      generatedOriginalSourceRange,
-      macroBufferRange,
-      ASTNode(attachedTo).getOpaqueValue(),
-      dc,
-      attr
-  };
-  sourceMgr.setGeneratedSourceInfo(macroBufferID, sourceInfo);
-
-  // Create a source file to hold the macro buffer. This is automatically
-  // registered with the enclosing module.
-  auto macroSourceFile = new (ctx) SourceFile(
-      *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
-      /*parsingOpts=*/{}, /*isPrimary=*/false);
-  macroSourceFile->setImports(declSourceFile->getImports());
+  SourceFile *macroSourceFile = createMacroSourceFile(
+      std::move(evaluatedSource), role, attachedTo, dc, attr);
 
   validateMacroExpansion(macroSourceFile, macro,
                          dyn_cast<ValueDecl>(attachedTo), role);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/CASTBridging.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/PluginLoader.h"
@@ -858,24 +859,29 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
   return macroSourceFile;
 }
 
-Optional<unsigned>
-swift::expandMacroExpr(MacroExpansionExpr *mee) {
-  DeclContext *dc = mee->getDeclContext();
+/// Evaluate the given freestanding macro expansion.
+static SourceFile *
+evaluateFreestandingMacro(FreestandingMacroExpansion *expansion) {
+  auto *dc = expansion->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
-  SourceManager &sourceMgr = ctx.SourceMgr;
-  ConcreteDeclRef macroRef = mee->getMacroRef();
-  Type expandedType = mee->getType();
+  SourceLoc loc = expansion->getPoundLoc();
 
   auto moduleDecl = dc->getParentModule();
-  auto sourceFile = moduleDecl->getSourceFileContainingLocation(mee->getLoc());
+  auto sourceFile = moduleDecl->getSourceFileContainingLocation(loc);
   if (!sourceFile)
-    return None;
+    return nullptr;
 
-  MacroDecl *macro = cast<MacroDecl>(macroRef.getDecl());
+  MacroDecl *macro = cast<MacroDecl>(expansion->getMacroRef().getDecl());
+  auto macroRoles = macro->getMacroRoles();
+  assert(macroRoles.contains(MacroRole::Expression) ||
+         macroRoles.contains(MacroRole::Declaration) ||
+         macroRoles.contains(MacroRole::CodeItem));
 
-  if (isFromExpansionOfMacro(sourceFile, macro, MacroRole::Expression)) {
-    ctx.Diags.diagnose(mee->getLoc(), diag::macro_recursive, macro->getName());
-    return None;
+  if (isFromExpansionOfMacro(sourceFile, macro, MacroRole::Expression) ||
+      isFromExpansionOfMacro(sourceFile, macro, MacroRole::Declaration) ||
+      isFromExpansionOfMacro(sourceFile, macro, MacroRole::CodeItem)) {
+    ctx.Diags.diagnose(loc, diag::macro_recursive, macro->getName());
+    return nullptr;
   }
 
   // Evaluate the macro.
@@ -885,7 +891,7 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
   LazyValue<std::string> discriminator([&]() -> std::string {
 #if SWIFT_SWIFT_PARSER
     Mangle::ASTMangler mangler;
-    return mangler.mangleMacroExpansion(mee);
+    return mangler.mangleMacroExpansion(expansion);
 #else
     return "";
 #endif
@@ -896,21 +902,20 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
   case MacroDefinition::Kind::Undefined:
   case MacroDefinition::Kind::Invalid:
     // Already diagnosed as an error elsewhere.
-    return None;
+    return nullptr;
 
   case MacroDefinition::Kind::Builtin: {
     switch (macroDef.getBuiltinKind()) {
     case BuiltinMacroKind::ExternalMacro:
-      ctx.Diags.diagnose(
-          mee->getLoc(), diag::external_macro_outside_macro_definition);
-      return None;
+      ctx.Diags.diagnose(loc, diag::external_macro_outside_macro_definition);
+      return nullptr;
     }
   }
 
   case MacroDefinition::Kind::Expanded: {
     // Expand the definition with the given arguments.
-    auto result = expandMacroDefinition(
-        macroDef.getExpanded(), macro, mee->getArgs());
+    auto result = expandMacroDefinition(macroDef.getExpanded(), macro,
+                                        expansion->getArgs());
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         result, adjustMacroExpansionBufferName(*discriminator));
     break;
@@ -919,28 +924,33 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
   case MacroDefinition::Kind::External: {
     // Retrieve the external definition of the macro.
     auto external = macroDef.getExternalMacro();
-    ExternalMacroDefinitionRequest request{
-      &ctx, external.moduleName, external.macroTypeName
-    };
+    ExternalMacroDefinitionRequest request{&ctx, external.moduleName,
+                                           external.macroTypeName};
     auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
     if (!externalDef) {
-      ctx.Diags.diagnose(
-          mee->getLoc(), diag::external_macro_not_found,
-          external.moduleName.str(),
-          external.macroTypeName.str(),
-          macro->getName()
-      );
+      ctx.Diags.diagnose(loc, diag::external_macro_not_found,
+                         external.moduleName.str(),
+                         external.macroTypeName.str(), macro->getName());
       macro->diagnose(diag::decl_declared_here, macro->getName());
-      return None;
+      return nullptr;
+    }
+
+    // Code item macros require `CodeItemMacros` feature flag.
+    if (macroRoles.contains(MacroRole::CodeItem) &&
+        !ctx.LangOpts.hasFeature(Feature::CodeItemMacros)) {
+      ctx.Diags.diagnose(loc, diag::macro_experimental, "code item",
+                         "CodeItemMacros");
+      return nullptr;
     }
 
 #if SWIFT_SWIFT_PARSER
-    PrettyStackTraceExpr debugStack(ctx, "expanding macro", mee);
+    PrettyStackTraceFreestandingMacroExpansion debugStack(
+        "expanding freestanding macro", expansion);
 
     // Builtin macros are handled via ASTGen.
     auto *astGenSourceFile = sourceFile->getExportedSourceFile();
     if (!astGenSourceFile)
-      return None;
+      return nullptr;
 
     const char *evaluatedSourceAddress;
     ptrdiff_t evaluatedSourceLength;
@@ -948,24 +958,38 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
         &ctx.Diags, externalDef->opaqueHandle,
         static_cast<uint32_t>(externalDef->kind), discriminator->data(),
         discriminator->size(), astGenSourceFile,
-        mee->getStartLoc().getOpaquePointerValue(), &evaluatedSourceAddress,
-        &evaluatedSourceLength);
+        expansion->getSourceRange().Start.getOpaquePointerValue(),
+        &evaluatedSourceAddress, &evaluatedSourceLength);
     if (!evaluatedSourceAddress)
-      return None;
+      return nullptr;
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         {evaluatedSourceAddress, (size_t)evaluatedSourceLength},
         adjustMacroExpansionBufferName(*discriminator));
     free((void *)evaluatedSourceAddress);
     break;
 #else
-    ctx.Diags.diagnose(mee->getLoc(), diag::macro_unsupported);
-    return None;
+    ctx.Diags.diagnose(loc, diag::macro_unsupported);
+    return nullptr;
 #endif
   }
   }
-  SourceFile *macroSourceFile = createMacroSourceFile(
-      std::move(evaluatedSource), MacroRole::Expression, mee, dc,
-      /*attr=*/nullptr);
+
+  return createMacroSourceFile(std::move(evaluatedSource),
+                               isa<MacroExpansionDecl>(expansion)
+                                   ? MacroRole::Declaration
+                                   : MacroRole::Expression,
+                               expansion->getASTNode(), dc,
+                               /*attr=*/nullptr);
+}
+
+Optional<unsigned> swift::expandMacroExpr(MacroExpansionExpr *mee) {
+  SourceFile *macroSourceFile = evaluateFreestandingMacro(mee);
+  if (!macroSourceFile)
+    return None;
+
+  DeclContext *dc = mee->getDeclContext();
+  ASTContext &ctx = dc->getASTContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
 
   auto macroBufferID = *macroSourceFile->getBufferID();
   auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
@@ -988,6 +1012,8 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
         macroBufferRange.getStart(), diag::expected_macro_expansion_expr);
     return macroBufferID;
   }
+
+  auto expandedType = mee->getType();
 
   // Type-check the expanded expression.
   // FIXME: Would like to pass through type checking options like "discarded"
@@ -1017,124 +1043,12 @@ swift::expandMacroExpr(MacroExpansionExpr *mee) {
 /// Expands the given macro expansion declaration.
 Optional<unsigned>
 swift::expandFreestandingMacro(MacroExpansionDecl *med) {
-  auto *dc = med->getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
-
-  auto moduleDecl = dc->getParentModule();
-  auto sourceFile = moduleDecl->getSourceFileContainingLocation(med->getLoc());
-  if (!sourceFile)
+  SourceFile *macroSourceFile = evaluateFreestandingMacro(med);
+  if (!macroSourceFile)
     return None;
 
   MacroDecl *macro = cast<MacroDecl>(med->getMacroRef().getDecl());
-  auto macroRoles = macro->getMacroRoles();
-  assert(macroRoles.contains(MacroRole::Declaration) ||
-         macroRoles.contains(MacroRole::CodeItem));
-
-  if (isFromExpansionOfMacro(sourceFile, macro, MacroRole::Expression) ||
-      isFromExpansionOfMacro(sourceFile, macro, MacroRole::Declaration) ||
-      isFromExpansionOfMacro(sourceFile, macro, MacroRole::CodeItem)) {
-    med->diagnose(diag::macro_recursive, macro->getName());
-    return None;
-  }
-
-  // Evaluate the macro.
-  std::unique_ptr<llvm::MemoryBuffer> evaluatedSource;
-
-  /// The discriminator used for the macro.
-  LazyValue<std::string> discriminator([&]() -> std::string {
-#if SWIFT_SWIFT_PARSER
-    Mangle::ASTMangler mangler;
-    return mangler.mangleMacroExpansion(med);
-#else
-    return "";
-#endif
-  });
-
-  auto macroDef = macro->getDefinition();
-  switch (macroDef.kind) {
-  case MacroDefinition::Kind::Undefined:
-  case MacroDefinition::Kind::Invalid:
-    // Already diagnosed as an error elsewhere.
-    return None;
-
-  case MacroDefinition::Kind::Builtin: {
-    switch (macroDef.getBuiltinKind()) {
-    case BuiltinMacroKind::ExternalMacro:
-      // FIXME: Error here.
-      return None;
-    }
-  }
-
-  case MacroDefinition::Kind::Expanded: {
-    // Expand the definition with the given arguments.
-    auto result = expandMacroDefinition(
-        macroDef.getExpanded(), macro, med->getArgs());
-    evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
-        result, adjustMacroExpansionBufferName(*discriminator));
-    break;
-  }
-
-  case MacroDefinition::Kind::External: {
-    // Retrieve the external definition of the macro.
-    auto external = macroDef.getExternalMacro();
-    ExternalMacroDefinitionRequest request{
-        &ctx, external.moduleName, external.macroTypeName
-    };
-    auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
-    if (!externalDef) {
-      med->diagnose(diag::external_macro_not_found,
-                    external.moduleName.str(),
-                    external.macroTypeName.str(),
-                    macro->getName()
-      );
-      macro->diagnose(diag::decl_declared_here, macro->getName());
-      return None;
-    }
-
-    // Currently only expression macros are enabled by default. Declaration
-    // macros need the `FreestandingMacros` feature flag, and code item macros
-    // need both `FreestandingMacros` and `CodeItemMacros`.
-    if (!macroRoles.contains(MacroRole::Expression)) {
-      if (!macroRoles.contains(MacroRole::Declaration) &&
-          !ctx.LangOpts.hasFeature(Feature::CodeItemMacros)) {
-        med->diagnose(diag::macro_experimental, "code item", "CodeItemMacros");
-        return None;
-      }
-    }
-
-#if SWIFT_SWIFT_PARSER
-    PrettyStackTraceDecl debugStack("expanding declaration macro", med);
-
-    // Builtin macros are handled via ASTGen.
-    auto *astGenSourceFile = sourceFile->getExportedSourceFile();
-    if (!astGenSourceFile)
-      return None;
-
-    const char *evaluatedSourceAddress;
-    ptrdiff_t evaluatedSourceLength;
-    swift_ASTGen_expandFreestandingMacro(
-        &ctx.Diags, externalDef->opaqueHandle,
-        static_cast<uint32_t>(externalDef->kind), discriminator->data(),
-        discriminator->size(), astGenSourceFile,
-        med->getStartLoc().getOpaquePointerValue(), &evaluatedSourceAddress,
-        &evaluatedSourceLength);
-    if (!evaluatedSourceAddress)
-      return None;
-    evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
-        {evaluatedSourceAddress, (size_t)evaluatedSourceLength},
-        adjustMacroExpansionBufferName(*discriminator));
-    free((void *)evaluatedSourceAddress);
-    break;
-#else
-    med->diagnose(diag::macro_unsupported);
-    return None;
-#endif
-  }
-  }
-
-  SourceFile *macroSourceFile = createMacroSourceFile(
-      std::move(evaluatedSource), MacroRole::Declaration, med, dc,
-      /*attr=*/nullptr);
+  DeclContext *dc = med->getDeclContext();
 
   validateMacroExpansion(macroSourceFile, macro,
                          /*attachedTo*/nullptr,
@@ -1479,11 +1393,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
                                               DeclContext *dc) const {
   // Macro expressions and declarations have their own stored macro
   // reference. Use it if it's there.
-  if (auto *expr = macroRef.getExpr()) {
-    if (auto ref = expr->getMacroRef())
-      return ref;
-  } else if (auto decl = macroRef.getDecl()) {
-    if (auto ref = decl->getMacroRef())
+  if (auto *expansion = macroRef.getFreestanding()) {
+    if (auto ref = expansion->getMacroRef())
       return ref;
   }
 
@@ -1502,14 +1413,16 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   // If we already have a MacroExpansionExpr, use that. Otherwise,
   // create one.
   MacroExpansionExpr *macroExpansion;
-  if (auto *expr = macroRef.getExpr()) {
-    macroExpansion = expr;
-  } else if (auto *decl = macroRef.getDecl()) {
-    macroExpansion = new (ctx) MacroExpansionExpr(
-        dc, decl->getExpansionInfo(), roles);
+  if (auto *expansion = macroRef.getFreestanding()) {
+    if (auto *expr = dyn_cast<MacroExpansionExpr>(expansion)) {
+      macroExpansion = expr;
+    } else {
+      macroExpansion = new (ctx) MacroExpansionExpr(
+          dc, expansion->getExpansionInfo(), roles);
+    }
   } else {
     SourceRange genericArgsRange = macroRef.getGenericArgsRange();
-    macroExpansion = new (ctx) MacroExpansionExpr(
+    macroExpansion = MacroExpansionExpr::create(
       dc, macroRef.getSigilLoc(), macroRef.getMacroName(),
       macroRef.getMacroNameLoc(), genericArgsRange.Start,
       macroRef.getGenericArgs(), genericArgsRange.End,
@@ -1528,10 +1441,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   // reference. If we got a reference, store it there, too.
   // FIXME: This duplication of state is really unfortunate.
   if (auto ref = macroExpansion->getMacroRef()) {
-    if (auto *expr = macroRef.getExpr()) {
-      expr->setMacroRef(ref);
-    } else if (auto decl = macroRef.getDecl()) {
-      decl->setMacroRef(ref);
+    if (auto *expansion = macroRef.getFreestanding()) {
+      expansion->setMacroRef(ref);
     }
   }
 

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -1,27 +1,284 @@
+// REQUIRES: swift_swift_parser
+
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
-// REQUIRES: OS=macosx
+// RUN: split-file --leading-lines %s %t
 
+// Check that we index code expanded from macros, especially nested references
+// (ie. calls within an added function).
 
-@freestanding(expression) macro myLine() -> Int = #externalMacro(module: "MacroDefinition", type: "LineMacro")
-@freestanding(expression) macro myFilename<T: ExpressibleByStringLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "FileMacro")
-@freestanding(expression) macro myStringify<T>(_: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+// Create the plugin with various macros for testing
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(IndexMacros) -module-name=IndexMacros %t/IndexMacros.swift -g -no-toolchain-stdlib-rpath
 
-func test(x: Int) {
-  _ = #myLine
-  let _: String = #myFilename
-  _ = #myStringify(x + x)
+// Check indexed symbols
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/IndexTest.swift -load-plugin-library %t/%target-library-name(IndexMacros) -parse-as-library 2>&1 | tee %t/test.idx | %FileCheck %s
+
+//--- IndexTest.swift
+@freestanding(expression)
+macro freestandingExpr() = #externalMacro(module: "IndexMacros", type: "FreestandingExprMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | freestandingExpr() |  [[EXPR_USR:.*]] | Def
+
+@freestanding(declaration, names: named(TestFree))
+macro freestandingDecl() = #externalMacro(module: "IndexMacros", type: "FreestandingDeclMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | freestandingDecl() |  [[DECL_USR:.*]] | Def
+
+@attached(accessor)
+macro Accessor() = #externalMacro(module: "IndexMacros", type: "SomeAccessorMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | Accessor() |  [[ACCESSOR_USR:.*]] | Def
+
+@attached(conformance)
+macro Conformance() = #externalMacro(module: "IndexMacros", type: "SomeConformanceMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | Conformance() |  [[CONFORMANCE_USR:.*]] | Def
+
+@attached(member, names: named(memberFunc))
+macro Member() = #externalMacro(module: "IndexMacros", type: "SomeMemberMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | Member() |  [[MEMBER_USR:.*]] | Def
+
+@attached(memberAttribute)
+macro MemberAttribute() = #externalMacro(module: "IndexMacros", type: "SomeMemberAttributeMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | MemberAttribute() |  [[MEMBER_ATTRIBUTE_USR:.*]] | Def
+
+@attached(peer, names: named(TestPeer))
+macro Peer() = #externalMacro(module: "IndexMacros", type: "SomePeerMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | Peer() |  [[PEER_USR:.*]] | Def
+
+@attached(peer, names: named(peerMember))
+macro PeerMember() = #externalMacro(module: "IndexMacros", type: "SomePeerMemberMacro")
+// CHECK: [[@LINE-1]]:7 | macro/Swift | PeerMember() |  [[PEER_MEMBER_USR:.*]] | Def
+
+protocol TestProto {}
+// CHECK: [[@LINE-1]]:10 | protocol/Swift | TestProto | [[PROTO_USR:.*]] | Def
+
+func accessorLog() {}
+// CHECK: [[@LINE-1]]:6 | function/Swift | accessorLog() | [[ACC_LOG_USR:.*]] | Def
+func exprLog() {}
+// CHECK: [[@LINE-1]]:6 | function/Swift | exprLog() | [[EXPR_LOG_USR:.*]] | Def
+func freeLog() {}
+// CHECK: [[@LINE-1]]:6 | function/Swift | freeLog() | [[FREE_LOG_USR:.*]] | Def
+func memberLog() {}
+// CHECK: [[@LINE-1]]:6 | function/Swift | memberLog() | [[MEMBER_LOG_USR:.*]] | Def
+func peerLog() {}
+// CHECK: [[@LINE-1]]:6 | function/Swift | peerLog() | [[PEER_LOG_USR:.*]] | Def
+
+// CHECK: [[@LINE+2]]:8 | struct/Swift | AddOne | [[ADD_ONE_USR:.*]] | Def
+@propertyWrapper
+struct AddOne {
+  var value: Int = 1
+  var wrappedValue: Int {
+    get { value }
+    set { value = newValue + 1 }
+  }
+  init(wrappedValue: Int) {
+    self.wrappedValue = wrappedValue
+  }
 }
 
-// CHECK: 6:33 | macro/Swift | myLine() | s:14swift_ide_test6myLineSiycfm | Def | rel: 0
-// CHECK: 6:45 | struct/Swift | Int | s:Si | Ref | rel: 0
-// CHECK: 7:33 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycs26ExpressibleByStringLiteralRzlufm | Def | rel: 0
-// CHECK: 7:47 | protocol/Swift | ExpressibleByStringLiteral | s:s26ExpressibleByStringLiteralP | Ref | rel: 0
-// CHECK: 8:33 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxclufm | Def | rel: 0
+// Creates a `TestFree` struct with `freeFunc` calling `freeLog`
+#freestandingDecl
+// CHECK: [[@LINE-1]]:2 | macro/Swift | freestandingDecl() | [[DECL_USR]] | Ref
+// CHECK: [[@LINE-2]]:1 | struct/Swift | TestFree | [[FREE_STRUCT_USR:.*]] | Def,Impl
+// CHECK: [[@LINE-3]]:1 | instance-method/Swift | freeFunc() | [[FREE_FUNC_USR:.*]] | Def,Impl,RelChild
+// CHECK-NEXT: RelChild | struct/Swift | TestFree | [[FREE_STRUCT_USR]]
+// CHECK: [[@LINE-5]]:1 | function/Swift | freeLog() | [[FREE_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
+// CHECK-NEXT: RelCall,RelCont | instance-method/Swift | freeFunc() | [[FREE_FUNC_USR]]
 
-// CHECK: 11:8 | macro/Swift | myLine() | s:14swift_ide_test6myLineSiycfm | Ref,RelCont | rel: 1
-// CHECK: 12:20 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycs26ExpressibleByStringLiteralRzlufm | Ref,RelCont | rel: 1
-// CHECK: 13:8 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxclufm | Ref,RelCont | rel: 1
-// CHECK: 13:20 | param/Swift | x | s:14swift_ide_test0C01xySi_tFACL_Sivp | Ref,Read,RelCont | rel: 1
-// CHECK: 13:22 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelCall,RelCont | rel: 1
-// CHECK: 13:24 | param/Swift | x | s:14swift_ide_test0C01xySi_tFACL_Sivp | Ref,Read,RelCont | rel: 1
+// CHECK: [[@LINE+4]]:40 | macro/Swift | Peer() | [[PEER_USR]] | Ref
+// CHECK: [[@LINE+3]]:23 | macro/Swift | MemberAttribute() | [[MEMBER_ATTRIBUTE_USR]] | Ref
+// CHECK: [[@LINE+2]]:15 | macro/Swift | Member() | [[MEMBER_USR]] | Ref
+// CHECK: [[@LINE+1]]:2 | macro/Swift | Conformance() | [[CONFORMANCE_USR]] | Ref
+@Conformance @Member @MemberAttribute @Peer
+struct TestAttached {
+  var attachedMember: Int
+
+  @Accessor
+  var attachedMemberAccessors: Int
+}
+// `MemberAttribute` adds `@AddOne` to attachedMember
+// CHECK: [[@LINE-8]]:22 | struct/Swift | AddOne | [[ADD_ONE_USR]] | Ref,Impl,RelCont
+// CHECK-NEXT: RelCont | instance-property/Swift | attachedMember
+
+// `Accessor` adds getters/setters to `attachedMemberAccessors` that both call `accessorLog`
+// CHECK: [[@LINE-8]]:3 | function/Swift | accessorLog() | [[ACC_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
+// CHECK-NEXT: RelCall,RelCont | instance-method/acc-get/Swift | getter:attachedMemberAccessors
+
+// `Member` adds a new member `memberFunc` that calls `memberLog`
+// CHECK: [[@LINE-16]]:14 | instance-method/Swift | memberFunc() | [[MEMBER_FUNC_USR:.*]] | Def,Impl,RelChild
+// CHECK: [[@LINE-17]]:14 | function/Swift | memberLog() | [[MEMBER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
+// CHECK-NEXT: RelCall,RelCont | instance-method/Swift | memberFunc() | [[MEMBER_FUNC_USR]]
+
+// `Peer` adds a new inner type `TestPeer` that contains `peerFunc` with a call to `peerLog`
+// CHECK: [[@LINE-21]]:39 | struct/Swift | TestPeer | [[PEER_STRUCT_USR:.*]] | Def,Impl
+// CHECK: [[@LINE-22]]:39 | instance-method/Swift | peerFunc() | [[PEER_FUNC_USR:.*]] | Def,Impl,RelChild
+// CHECK-NEXT: RelChild | struct/Swift | TestPeer | [[PEER_STRUCT_USR]]
+// CHECK: [[@LINE-24]]:39 | function/Swift | peerLog() | [[PEER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
+// CHECK-NEXT: RelCall,RelCont | instance-method/Swift | peerFunc() | [[PEER_FUNC_USR]]
+
+// `Conformance` adds `TestProto` as a conformance on an extension of `TestAttached`
+// CHECK: [[@LINE-28]]:1 | extension/ext-struct/Swift | TestAttached | {{.*}} | Def,Impl
+// CHECK: [[@LINE-29]]:1 | protocol/Swift | TestProto | [[PROTO_USR]] | Ref,Impl,RelBase
+// CHECK-NEXT: RelBase | extension/ext-struct/Swift | TestAttached
+
+// CHECK: [[@LINE+1]]:8 | struct/Swift | Outer | [[OUTER_USR:.*]] | Def
+struct Outer {
+  // CHECK: [[@LINE+1]]:4 | macro/Swift | PeerMember() | [[PEER_MEMBER_USR]] | Ref
+  @PeerMember
+  var anyMember: Int
+  // `PeerMember` adds a new `peerMember`
+  // CHECK: [[@LINE-3]]:3 | instance-property/Swift | peerMember | {{.*}} | Def,Impl,RelChild
+  // CHECK-NEXT: RelChild | struct/Swift | Outer | [[OUTER_USR]]
+
+  // CHECK: [[@LINE+2]]:17 | macro/Swift | Member() | [[MEMBER_USR]] | Ref
+  // CHECK: [[@LINE+1]]:4 | macro/Swift | Conformance() | [[CONFORMANCE_USR]] | Ref
+  @Conformance @Member
+  struct TestInner {}
+}
+// `Member` adds a new member `memberFunc` that calls `memberLog`
+// CHECK: [[@LINE-4]]:16 | instance-method/Swift | memberFunc() | [[INNER_FUNC_USR:.*]] | Def,Impl
+// CHECK-NEXT: RelChild | struct/Swift | TestInner
+// CHECK: [[@LINE-6]]:16 | function/Swift | memberLog() | [[MEMBER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
+// CHECK-NEXT: RelCall,RelCont | instance-method/Swift | memberFunc() | [[INNER_FUNC_USR]]
+
+// `Conformance` adds `TestProto` as a conformance on an extension of `TestInner`
+// CHECK: [[@LINE-10]]:3 | extension/ext-struct/Swift | TestInner | {{.*}} | Def,Impl
+// CHECK: [[@LINE-11]]:3 | protocol/Swift | TestProto | [[PROTO_USR]] | Ref,Impl,RelBase
+// CHECK-NEXT: RelBase | extension/ext-struct/Swift | TestInner
+
+func testExpr() {
+  #freestandingExpr
+  // CHECK: [[@LINE-1]]:3 | function/Swift | exprLog() | [[EXPR_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
+  // CHECK-NEXT: RelCall,RelCont | function/Swift | testExpr()
+}
+
+//--- IndexMacros.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct FreestandingExprMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return "exprLog()"
+  }
+}
+
+public struct FreestandingDeclMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["""
+      struct TestFree {
+        func freeFunc() {
+          freeLog()
+        }
+      }
+      """]
+  }
+}
+
+public struct SomeAccessorMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    return [
+      """
+        get {
+          accessorLog()
+          return 1
+        }
+      """,
+      """
+        set {
+          accessorLog()
+        }
+      """,
+    ]
+  }
+}
+
+public struct SomeConformanceMacro: ConformanceMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingConformancesOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
+    let protocolName: TypeSyntax = "TestProto"
+    return [(protocolName, nil)]
+  }
+}
+
+public struct SomeMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let newFunc: DeclSyntax =
+      """
+      func memberFunc() {
+        memberLog()
+      }
+      """
+    return [
+      newFunc,
+    ]
+  }
+}
+
+public struct SomeMemberAttributeMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo parent: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    guard let varDecl = member.as(VariableDeclSyntax.self),
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+      identifier == "attachedMember"
+    else {
+      return []
+    }
+
+    return [AttributeSyntax(
+      attributeName: SimpleTypeIdentifierSyntax(
+        name: .identifier("AddOne")
+      )
+    )]
+  }
+}
+
+public struct SomePeerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      struct TestPeer {
+        func peerFunc() {
+          peerLog()
+        }
+      }
+      """
+    ]
+  }
+}
+
+public struct SomePeerMemberMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      var peerMember: Int
+      """
+    ]
+  }
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1449,23 +1449,22 @@ public struct SimpleCodeItemMacro: CodeItemMacro {
   ) throws -> [CodeBlockItemSyntax] {
     [
       .init(item: .decl("""
-
       struct \(context.makeUniqueName("foo")) {
         var x: Int
       }
       """)),
       .init(item: .stmt("""
-
       if true {
         print("from stmt")
         usedInExpandedStmt()
       }
+      """)),
+      .init(item: .stmt("""
       if false {
         print("impossible")
       }
       """)),
       .init(item: .expr("""
-
       print("from expr")
       """)),
     ]

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -299,18 +299,19 @@ public struct DefineDeclsWithKnownNamesMacro: DeclarationMacro {
   }
 }
 
-public struct VarDeclMacro: DeclarationMacro {
+public struct VarDeclMacro: CodeItemMacro {
   public static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
-  ) throws -> [DeclSyntax] {
+  ) throws -> [CodeBlockItemSyntax] {
+    let name = context.makeUniqueName("fromMacro")
     return [
+      "let \(name) = 23",
+      "use(\(name))",
       """
-      let fromMacro = 23
-      use(fromMacro)
       if true {
-        let fromMacro = "string"
-        use(fromMacro)
+        let \(name) = "string"
+        use(\(name))
       }
       """
     ]

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -299,6 +299,24 @@ public struct DefineDeclsWithKnownNamesMacro: DeclarationMacro {
   }
 }
 
+public struct VarDeclMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      let fromMacro = 23
+      use(fromMacro)
+      if true {
+        let fromMacro = "string"
+        use(fromMacro)
+      }
+      """
+    ]
+  }
+}
+
 public struct WarningMacro: ExpressionMacro {
    public static func expansion(
      of macro: some FreestandingMacroExpansionSyntax,

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -150,6 +150,13 @@ func testFileID(a: Int, b: Int) {
 
 testFileID(a: 1, b: 2)
 
+@freestanding(declaration, names: named(fromMacro)) macro varDecl() = #externalMacro(module: "MacroDefinition", type: "VarDeclMacro")
+
+func testVarDecl() {
+  func use<T>(_ t: T) {}
+  #varDecl()
+}
+
 @freestanding(expression) macro stringifyAndTry<T>(_ value: T) -> (T, String) =
     #externalMacro(module: "MacroDefinition", type: "StringifyAndTryMacro")
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -150,13 +150,6 @@ func testFileID(a: Int, b: Int) {
 
 testFileID(a: 1, b: 2)
 
-@freestanding(declaration, names: named(fromMacro)) macro varDecl() = #externalMacro(module: "MacroDefinition", type: "VarDeclMacro")
-
-func testVarDecl() {
-  func use<T>(_ t: T) {}
-  #varDecl()
-}
-
 @freestanding(expression) macro stringifyAndTry<T>(_ value: T) -> (T, String) =
     #externalMacro(module: "MacroDefinition", type: "StringifyAndTryMacro")
 

--- a/test/Macros/macro_expand_codeitems.swift
+++ b/test/Macros/macro_expand_codeitems.swift
@@ -33,3 +33,10 @@ func testFreestandingMacroExpansion() {
   #codeItems
 }
 testFreestandingMacroExpansion()
+
+@freestanding(codeItem) macro varDecl() = #externalMacro(module: "MacroDefinition", type: "VarDeclMacro")
+
+func testVarDecl() {
+  func use<T>(_ t: T) {}
+  #varDecl()
+}

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -50,7 +50,7 @@ func lookupGlobalFreestandingExpansion() {
 
 #anonymousTypes(public: true) { "hello" }
 
-// CHECK-SIL: sil @$s9MacroUser03$s9A71User33_082AE7CFEFA6960C804A9FE7366EB5A0Ll14anonymousTypesfMf0_4namefMu_C5helloSSyF
+// CHECK-SIL: sil @$s9MacroUser03$s9A70User33_082AE7CFEFA6960C804A9FE7366EB5A0Ll14anonymousTypesfMf_4namefMu_C5helloSSyF
 
 @main
 struct Main {

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -131,7 +131,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=57:1 %s -- ${COMPILER_ARGS[@]} -parse-as-library | %FileCheck -check-prefix=EXPAND_MACRO_DECL %s
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=57:2 %s -- ${COMPILER_ARGS[@]} -parse-as-library | %FileCheck -check-prefix=EXPAND_MACRO_DECL %s
 // EXPAND_MACRO_DECL: source.edit.kind.active:
-// EXPAND_MACRO_DECL-NEXT: 57:1-57:28 (@__swiftmacro_9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_.swift) "class $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu_ {
+// EXPAND_MACRO_DECL-NEXT: 57:1-57:28 (@__swiftmacro_9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf_.swift) "class $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf_4namefMu_ {
 // EXPAND_MACRO_DECL-NEXT:   func hello() -> String {
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
@@ -140,7 +140,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:      return Self.self
 // EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-NEXT: }
-// EXPAND_MACRO_DECL-NEXT: enum $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu0_ {
+// EXPAND_MACRO_DECL-NEXT: enum $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf_4namefMu0_ {
 // EXPAND_MACRO_DECL-NEXT:   case apple
 // EXPAND_MACRO_DECL-NEXT:   case banana
 // EXPAND_MACRO_DECL-EMPTY:
@@ -148,7 +148,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-NEXT: }
-// EXPAND_MACRO_DECL-NEXT: struct $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf0_4namefMu1_: Equatable {
+// EXPAND_MACRO_DECL-NEXT: struct $s9MacroUser33_70D4178875715FB9B8B50C58F66F8D53Ll14anonymousTypesfMf_4namefMu1_: Equatable {
 // EXPAND_MACRO_DECL-NEXT:   static func == (lhs: Self, rhs: Self) -> Bool {
 // EXPAND_MACRO_DECL-NEXT:     false
 // EXPAND_MACRO_DECL-NEXT:   }

--- a/test/SourceKit/Macros/syntactic_expansion.swift
+++ b/test/SourceKit/Macros/syntactic_expansion.swift
@@ -1,0 +1,82 @@
+//--- test.swift
+@DelegatedConformance
+@wrapAllProperties
+struct Generic<Element> {
+
+  @myPropertyWrapper
+  @otherAttr
+  var value: Int
+
+  func member() {}
+  var otherVal: Int = 1
+
+  #bitwidthNumberedStructs("blah")
+}
+
+//--- DelegatedConformance.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.conformance, source.lang.swift.macro_role.member],
+  key.modulename: "MacroDefinition",
+  key.typename: "DelegatedConformanceMacro",
+}
+
+//--- myPropertyWrapper.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.accessor, source.lang.swift.macro_role.peer],
+  key.modulename: "MacroDefinition",
+  key.typename: "PropertyWrapperMacro",
+}
+
+//--- wrapAllProperties.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.member_attribute],
+  key.modulename: "MacroDefinition",
+  key.typename: "WrapAllProperties",
+}
+
+//--- bitwidthNumberedStructs.json
+{
+  key.macro_roles: [source.lang.swift.macro_role.declaration],
+  key.modulename: "MacroDefinition",
+  key.typename: "DefineBitwidthNumberedStructsMacro",
+}
+
+//--- dummy.script
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/plugins
+// RUN: split-file %s %t
+
+//##-- Prepare the macro plugin.
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/plugins/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '### 1' \
+// RUN:   == \
+// RUN:   -req=syntactic-expandmacro \
+// RUN:   -req-opts=1:1:%t/DelegatedConformance.json \
+// RUN:   -req-opts=5:3:%t/myPropertyWrapper.json \
+// RUN:   -req-opts=2:1:%t/wrapAllProperties.json \
+// RUN:   -req-opts=12:3:%t/bitwidthNumberedStructs.json \
+// RUN:   %t/test.swift \
+// RUN:   -- \
+// RUN:   %t/test.swift \
+// RUN:   -plugin-path %t/plugins -Xfrontend -dump-macro-expansions \
+// RUN:   -module-name TestModule \
+// RUN:   == \
+// RUN:   -shell -- echo '### 2' \
+// RUN:   == \
+// RUN:   -req=syntactic-expandmacro \
+// RUN:   -req-opts=12:3:%t/bitwidthNumberedStructs.json \
+// RUN:   -req-opts=2:1:%t/wrapAllProperties.json \
+// RUN:   -req-opts=5:3:%t/myPropertyWrapper.json \
+// RUN:   -req-opts=1:1:%t/DelegatedConformance.json \
+// RUN:   %t/test.swift \
+// RUN:   -- \
+// RUN:   %t/test.swift \
+// RUN:   -plugin-path %t/plugins -Xfrontend -dump-macro-expansions \
+// RUN:   -module-name TestModule \
+// RUN:   | tee %t.response
+
+// RUN: diff -u %s.expected %t.response

--- a/test/SourceKit/Macros/syntactic_expansion.swift.expected
+++ b/test/SourceKit/Macros/syntactic_expansion.swift.expected
@@ -1,0 +1,108 @@
+### 1
+source.edit.kind.active:
+  1:1-1:22 ""
+source.edit.kind.active:
+  13:1-13:1 "static func requirement() where Element : P {
+  Element.requirement()
+}"
+source.edit.kind.active:
+  13:2-13:2 "extension Generic : P where Element: P {}"
+source.edit.kind.active:
+  5:3-5:21 ""
+source.edit.kind.active:
+  7:17-7:17 "{
+    get {
+            _value.wrappedValue
+      }
+
+    set {
+            _value.wrappedValue = newValue
+      }
+}"
+source.edit.kind.active:
+  7:12-7:12 "var _value: MyWrapperThingy<Int>"
+source.edit.kind.active:
+  2:1-2:19 ""
+source.edit.kind.active:
+  7:3-7:3 "@Wrapper"
+source.edit.kind.active:
+  10:3-10:3 "@Wrapper"
+source.edit.kind.active:
+  12:3-12:35 "struct blah8 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu0_() {
+  }
+}
+struct blah16 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu1_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu2_() {
+  }
+}
+struct blah32 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu3_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu4_() {
+  }
+}
+struct blah64 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu5_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu6_() {
+  }
+}"
+### 2
+source.edit.kind.active:
+  12:3-12:35 "struct blah8 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu0_() {
+  }
+}
+struct blah16 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu1_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu2_() {
+  }
+}
+struct blah32 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu3_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu4_() {
+  }
+}
+struct blah64 {
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu5_() {
+  }
+  func __syntactic_macro_a01f07de3e9ee8585adf794ccd6dec8c6methodfMu6_() {
+  }
+}"
+source.edit.kind.active:
+  2:1-2:19 ""
+source.edit.kind.active:
+  7:3-7:3 "@Wrapper"
+source.edit.kind.active:
+  10:3-10:3 "@Wrapper"
+source.edit.kind.active:
+  5:3-5:21 ""
+source.edit.kind.active:
+  7:17-7:17 "{
+    get {
+            _value.wrappedValue
+      }
+
+    set {
+            _value.wrappedValue = newValue
+      }
+}"
+source.edit.kind.active:
+  7:12-7:12 "var _value: MyWrapperThingy<Int>"
+source.edit.kind.active:
+  1:1-1:22 ""
+source.edit.kind.active:
+  13:1-13:1 "static func requirement() where Element : P {
+  Element.requirement()
+}"
+source.edit.kind.active:
+  13:2-13:2 "extension Generic : P where Element: P {}"

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -11,6 +11,7 @@ add_sourcekit_library(SourceKitSwiftLang
   SwiftLangSupport.cpp
   SwiftMangling.cpp
   SwiftSourceDocInfo.cpp
+  SwiftSyntacticMacroExpansion.cpp
   SwiftTypeContextInfo.cpp
     LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD}
       bitreader

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -29,6 +29,7 @@
 #include "swift/IDE/SyntaxModel.h"
 #include "swift/IDE/Utils.h"
 #include "swift/IDETool/IDEInspectionInstance.h"
+#include "swift/IDETool/SyntacticMacroExpansion.h"
 
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Preprocessor.h"
@@ -302,6 +303,9 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
 
   // By default, just use the in-memory cache.
   CCCache->inMemory = std::make_unique<ide::CodeCompletionCache>();
+
+  SyntacticMacroExpansions =
+      std::make_shared<SyntacticMacroExpansion>(SwiftExecutablePath, Plugins);
 
   // Provide a default file system provider.
   setFileSystemProvider("in-memory-vfs", std::make_unique<InMemoryFileSystemProvider>());

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -55,6 +55,7 @@ namespace ide {
   class IDEInspectionInstance;
   class OnDiskCodeCompletionCache;
   class SourceEditConsumer;
+  class SyntacticMacroExpansion;
   enum class CodeCompletionDeclKind : uint8_t;
   enum class SyntaxNodeKind : uint8_t;
   enum class SyntaxStructureKind : uint8_t;
@@ -366,6 +367,7 @@ class SwiftLangSupport : public LangSupport {
   llvm::StringMap<std::unique_ptr<FileSystemProvider>> FileSystemProviders;
   std::shared_ptr<swift::ide::IDEInspectionInstance> IDEInspectionInst;
   std::shared_ptr<compile::SessionManager> CompileManager;
+  std::shared_ptr<swift::ide::SyntacticMacroExpansion> SyntacticMacroExpansions;
 
 public:
   explicit SwiftLangSupport(SourceKit::Context &SKCtx);
@@ -755,6 +757,11 @@ public:
                                SourceKitCancellationToken CancellationToken,
                                ConformingMethodListConsumer &Consumer,
                                Optional<VFSOptions> vfsOptions) override;
+
+  void expandMacroSyntactically(llvm::MemoryBuffer *inputBuf,
+                                ArrayRef<const char *> args,
+                                ArrayRef<MacroExpansionInfo> expansions,
+                                CategorizedEditsReceiver receiver) override;
 
   void
   performCompile(StringRef Name, ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
@@ -1,0 +1,94 @@
+//===--- SwiftSyntaxMacro.cpp ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftLangSupport.h"
+#include "swift/AST/MacroDefinition.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/IDE/TypeContextInfo.h"
+#include "swift/IDETool/SyntacticMacroExpansion.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Comment.h"
+#include "clang/AST/Decl.h"
+
+using namespace SourceKit;
+using namespace swift;
+using namespace ide;
+
+void SwiftLangSupport::expandMacroSyntactically(
+    llvm::MemoryBuffer *inputBuf, ArrayRef<const char *> args,
+    ArrayRef<MacroExpansionInfo> reqExpansions,
+    CategorizedEditsReceiver receiver) {
+
+  std::string error;
+  auto instance = SyntacticMacroExpansions->getInstance(args, error);
+  if (!instance) {
+    return receiver(
+        RequestResult<ArrayRef<CategorizedEdits>>::fromError(error));
+  }
+  auto &ctx = instance->getASTContext();
+
+  // Convert 'SourceKit::MacroExpansionInfo' to 'ide::MacroExpansionSpecifier'.
+  SmallVector<ide::MacroExpansionSpecifier, 4> expansions;
+  for (auto &req : reqExpansions) {
+    unsigned offset = req.offset;
+
+    swift::MacroRoles macroRoles;
+    if (req.roles.contains(SourceKit::MacroRole::Expression))
+      macroRoles |= swift::MacroRole::Expression;
+    if (req.roles.contains(SourceKit::MacroRole::Declaration))
+      macroRoles |= swift::MacroRole::Declaration;
+    if (req.roles.contains(SourceKit::MacroRole::CodeItem))
+      macroRoles |= swift::MacroRole::CodeItem;
+    if (req.roles.contains(SourceKit::MacroRole::Accessor))
+      macroRoles |= swift::MacroRole::Accessor;
+    if (req.roles.contains(SourceKit::MacroRole::MemberAttribute))
+      macroRoles |= swift::MacroRole::MemberAttribute;
+    if (req.roles.contains(SourceKit::MacroRole::Member))
+      macroRoles |= swift::MacroRole::Member;
+    if (req.roles.contains(SourceKit::MacroRole::Peer))
+      macroRoles |= swift::MacroRole::Peer;
+    if (req.roles.contains(SourceKit::MacroRole::Conformance))
+      macroRoles |= swift::MacroRole::Conformance;
+
+    MacroDefinition definition = [&] {
+      if (auto *expanded =
+              std::get_if<MacroExpansionInfo::ExpandedMacroDefinition>(
+                  &req.macroDefinition)) {
+        SmallVector<ExpandedMacroReplacement, 2> replacements;
+        for (auto &reqReplacement : expanded->replacements) {
+          replacements.push_back(
+              {/*startOffset=*/reqReplacement.range.Offset,
+               /*endOffset=*/reqReplacement.range.Offset +
+                   reqReplacement.range.Length,
+               /*parameterIndex=*/reqReplacement.parameterIndex});
+        }
+        return MacroDefinition::forExpanded(ctx, expanded->expansionText,
+                                            replacements);
+      } else if (auto *externalRef =
+                     std::get_if<MacroExpansionInfo::ExternalMacroReference>(
+                         &req.macroDefinition)) {
+        return MacroDefinition::forExternal(
+            ctx.getIdentifier(externalRef->moduleName),
+            ctx.getIdentifier(externalRef->typeName));
+      } else {
+        return MacroDefinition::forUndefined();
+      }
+    }();
+
+    expansions.push_back({offset, macroRoles, definition});
+  }
+
+  RequestRefactoringEditConsumer consumer(receiver);
+  instance->expandAll(inputBuf, expansions, consumer);
+  // consumer automatically send the results on destruction.
+}

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -153,6 +153,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("diags", SourceKitRequest::Diagnostics)
         .Case("compile", SourceKitRequest::Compile)
         .Case("compile.close", SourceKitRequest::CompileClose)
+        .Case("syntactic-expandmacro", SourceKitRequest::SyntacticMacroExpansion)
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
 #include "swift/Refactoring/RefactoringKinds.def"
         .Default(SourceKitRequest::None);
@@ -203,6 +204,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                      << "- collect-type\n"
                      << "- global-config\n"
                      << "- dependency-updated\n"
+                     << "- syntactic-expandmacro\n"
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) << "- refactoring." #ID "\n"
 #include "swift/Refactoring/RefactoringKinds.def"
                         "\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -70,6 +70,7 @@ enum class SourceKitRequest {
   Diagnostics,
   Compile,
   CompileClose,
+  SyntacticMacroExpansion,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/Refactoring/RefactoringKinds.def"
 };

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -1824,6 +1824,134 @@ handleRequestDiagnostics(const RequestDict &Req,
   });
 }
 
+/// Expand macros in the specified source file syntactically.
+///
+/// Request would look like:
+///   {
+///     key.compilerargs: []
+///     key.sourcefile: <file name>
+///     key.sourcetext: <source text> (optional)
+///     key.expansions: [<expansion specifier>...]
+///   }
+/// 'compilerargs' is used for plugin search paths.
+/// 'expansion specifier' is
+///   {
+///     key.offset: <offset>
+///     key.modulename: <plugin module name>
+///     key.typename: <macro typename>
+///     key.macro_roles: [<macro role UID>...]
+///   }
+///
+/// Sends the results as a 'CategorizedEdits'. 
+/// Note that, unlike refactoring, each edit doesn't have 'key.buffer_name'.
+/// FIXME: Support nested expansion.
+static void handleRequestSyntacticMacroExpansion(
+    const RequestDict &req, SourceKitCancellationToken cancellationToken,
+    ResponseReceiver rec) {
+
+  Optional<VFSOptions> vfsOptions = getVFSOptions(req);
+  std::unique_ptr<llvm::MemoryBuffer> inputBuf =
+      getInputBufForRequestOrEmitError(req, vfsOptions, rec);
+  if (!inputBuf)
+    return;
+
+  SmallVector<const char *, 16> args;
+  if (getCompilerArgumentsForRequestOrEmitError(req, args, rec))
+    return;
+
+  // key.expansions: [
+  //   { key.offset: 42,
+  //     key.macro_roles: [source.lang.swift.macrorole.conformance,
+  //                      source.lang.swift.macrorole.member],
+  //     key.modulename: "MyMacroImpl",
+  //     key.typename: "StringifyMacro"},
+  //   { key.offset: 132,
+  //     key.sourceText: "foo(bar, baz)",
+  //     key.macro_roles: [source.lang.swift.macrorole.conformance,
+  //                      source.lang.swift.macrorole.member],
+  //     key.expandedmacro_replacements: [
+  //       {key.offset: 4, key.length: 3, key.argindex: 0},
+  //       {key.offset: 9, key.length: 3, key.argindex: 1}]}
+  // ]
+  std::vector<MacroExpansionInfo> expansions;
+  bool failed = req.dictionaryArrayApply(KeyExpansions, [&](RequestDict dict) {
+    // offset.
+    int64_t offset;
+    dict.getInt64(KeyOffset, offset, false);
+
+    // macro roles.
+    SmallVector<sourcekitd_uid_t, 1> macroRoleUIDs;
+    if (dict.getUIDArray(KeyMacroRoles, macroRoleUIDs, false)) {
+      rec(createErrorRequestInvalid(
+          "missing 'key.macro_roles' for expansion specifier"));
+      return true;
+    }
+    MacroRoles macroRoles;
+    for (auto uid : macroRoleUIDs) {
+      if (uid == KindMacroRoleExpression)
+        macroRoles |= MacroRole::Expression;
+      if (uid == KindMacroRoleDeclaration)
+        macroRoles |= MacroRole::Declaration;
+      if (uid == KindMacroRoleCodeItem)
+        macroRoles |= MacroRole::CodeItem;
+      if (uid == KindMacroRoleAccessor)
+        macroRoles |= MacroRole::Accessor;
+      if (uid == KindMacroRoleMemberAttribute)
+        macroRoles |= MacroRole::MemberAttribute;
+      if (uid == KindMacroRoleMember)
+        macroRoles |= MacroRole::Member;
+      if (uid == KindMacroRolePeer)
+        macroRoles |= MacroRole::Peer;
+      if (uid == KindMacroRoleConformance)
+        macroRoles |= MacroRole::Conformance;
+    }
+
+    // definition.
+    if (auto moduleName = dict.getString(KeyModuleName)) {
+      auto typeName = dict.getString(KeyTypeName);
+      if (!typeName) {
+        rec(createErrorRequestInvalid(
+            "missing 'key.typename' for external macro definition"));
+        return true;
+      }
+      MacroExpansionInfo::ExternalMacroReference definition(moduleName->str(),
+                                                            typeName->str());
+      expansions.emplace_back(offset, macroRoles, definition);
+    } else if (auto expandedText = dict.getString(KeySourceText)) {
+      MacroExpansionInfo::ExpandedMacroDefinition definition(*expandedText);
+      bool failed = dict.dictionaryArrayApply(
+          KeyExpandedMacroReplacements, [&](RequestDict dict) {
+            int64_t offset, length, paramIndex;
+            bool failed = false;
+            failed |= dict.getInt64(KeyOffset, offset, false);
+            failed |= dict.getInt64(KeyLength, length, false);
+            failed |= dict.getInt64(KeyArgIndex, paramIndex, false);
+            if (failed) {
+              rec(createErrorRequestInvalid(
+                  "macro replacement should have key.offset, key.length, and "
+                  "key.argindex"));
+              return true;
+            }
+            definition.replacements.emplace_back(
+                RawCharSourceRange{unsigned(offset), unsigned(length)},
+                paramIndex);
+            return false;
+          });
+      if (failed)
+        return true;
+      expansions.emplace_back(offset, macroRoles, definition);
+    }
+    return false;
+  });
+  if (failed)
+    return;
+
+  LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
+  Lang.expandMacroSyntactically(
+      inputBuf.get(), args, expansions,
+      [&](const auto &Result) { rec(createCategorizedEditsResponse(Result)); });
+}
+
 void handleRequestImpl(sourcekitd_object_t ReqObj,
                        SourceKitCancellationToken CancellationToken,
                        ResponseReceiver Rec) {
@@ -1927,6 +2055,8 @@ void handleRequestImpl(sourcekitd_object_t ReqObj,
   HANDLE_REQUEST(RequestRelatedIdents, handleRequestRelatedIdents)
   HANDLE_REQUEST(RequestActiveRegions, handleRequestActiveRegions)
   HANDLE_REQUEST(RequestDiagnostics, handleRequestDiagnostics)
+  HANDLE_REQUEST(RequestSyntacticMacroExpansion,
+                 handleRequestSyntacticMacroExpansion)
 
   {
     SmallString<64> ErrBuf;

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -209,6 +209,9 @@ UID_KEYS = [
     KEY('IsSynthesized', 'key.is_synthesized'),
     KEY('BufferName', 'key.buffer_name'),
     KEY('BarriersEnabled', 'key.barriers_enabled'),
+    KEY('Expansions', 'key.expansions'),
+    KEY('MacroRoles', 'key.macro_roles'),
+    KEY('ExpandedMacroReplacements', 'key.expanded_macro_replacements'),
 ]
 
 
@@ -274,6 +277,8 @@ UID_REQUESTS = [
     REQUEST('Compile', 'source.request.compile'),
     REQUEST('CompileClose', 'source.request.compile.close'),
     REQUEST('EnableRequestBarriers', 'source.request.enable_request_barriers'),
+    REQUEST('SyntacticMacroExpansion',
+            'source.request.syntactic_macro_expansion'),
 ]
 
 
@@ -491,4 +496,12 @@ UID_KINDS = [
     KIND('StatInstructionCount', 'source.statistic.instruction-count'),
     KIND('Swift', 'source.lang.swift'),
     KIND('ObjC', 'source.lang.objc'),
+    KIND('MacroRoleExpression', 'source.lang.swift.macro_role.expression'),
+    KIND('MacroRoleDeclaration', 'source.lang.swift.macro_role.declaration'),
+    KIND('MacroRoleCodeItem', 'source.lang.swift.macro_role.codeitem'),
+    KIND('MacroRoleAccessor', 'source.lang.swift.macro_role.accessor'),
+    KIND('MacroRoleMemberAttribute', 'source.lang.swift.macro_role.member_attribute'),
+    KIND('MacroRoleMember', 'source.lang.swift.macro_role.member'),
+    KIND('MacroRolePeer', 'source.lang.swift.macro_role.peer'),
+    KIND('MacroRoleConformance', 'source.lang.swift.macro_role.conformance'),
 ]


### PR DESCRIPTION
* Explanation: This contains a number of changes that depend on each other and would require a large chain of PRs otherwise:
  * 2 refactoring commits, which factors out `SourceFile` creation of macro expansions and unifies `MacroExpansionDecl` and `MacroExpansionExpr`
  * A fix for a crash where local variables introduced by a freestanding declaration macro would not get SIL emitted for them
  * An indexing fix to actually index peer and conformance expansions
  * A new SourceKit request to syntactically expand macros
* Scope: Macros
* Risk: Low. The main risk is in the refactoring, which we have enough test coverage for.
* Testing: New tests for the SILGen crash, indexing, and SK new request.
* Original PRs: https://github.com/apple/swift/pull/66233, https://github.com/apple/swift/pull/66296, https://github.com/apple/swift/pull/66387, https://github.com/apple/swift/pull/66421, and https://github.com/apple/swift/pull/66295