### PR TITLE
[Backtracing][Linux] Use syscall() to call gettid().

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -296,6 +296,12 @@ getdents(int fd, void *buf, size_t bufsiz)
   return syscall(SYS_getdents64, fd, buf, bufsiz);
 }
 
+pid_t
+gettid()
+{
+  return (pid_t)syscall(SYS_gettid);
+}
+
 /* Stop all other threads in this process; we do this by establishing a
    signal handler for SIGPROF, then iterating through the threads sending
    SIGPROF.


### PR DESCRIPTION
Older versions of Linux don't have gettid() in their headers, so use syscall() to call it instead.

rdar://110417355
