### PR TITLE
[Test] Fix FileCheck lines for 32bit in test.

### DIFF
--- a/test/IRGen/pack_metadata_marker_inserter.sil
+++ b/test/IRGen/pack_metadata_marker_inserter.sil
@@ -82,7 +82,7 @@ entry:
 // CHECK-LLVM-SAME:      [[INT]] [[SHAPE:%[^,]+]], 
 // CHECK-LLVM-SAME:      %swift.type** [[PACK:%[^,]+]]) {{.*}} {
 // CHECK-LLVM:         call swiftcc void @takeTypePack(
-// CHECK-LLVM-SAME:        i64 [[SHAPE]], 
+// CHECK-LLVM-SAME:        [[INT]] [[SHAPE]],
 // CHECK-LLVM-SAME:        %swift.type** [[PACK]])
 // CHECK-LLVM:       }
 sil @forward_type_pack : $<each T>() -> () {
@@ -105,7 +105,6 @@ sil @forward_type_pack : $<each T>() -> () {
 // CHECK-LLVM:         [[PACK_ADDR:%[^,]+]] = alloca [3 x %swift.type*]
 // CHECK-LLVM:         [[LIFETIME_START_CAST:%[^,]+]] = bitcast [3 x %swift.type*]* [[PACK_ADDR]] to i8*
 // CHECK-LLVM:         call void @llvm.lifetime.start.p0i8(
-// CHECK-LLVM-SAME:        [[INT]] 24, 
 // CHECK-LLVM-SAME:        i8* [[LIFETIME_START_CAST]])
 // CHECK-LLVM:         [[LIFETIME_END_CAST:%[^,]+]] = bitcast [3 x %swift.type*]* [[PACK_ADDR]] to i8*
 // CHECK-LLVM:         call void @llvm.lifetime.end.p0i8(


### PR DESCRIPTION
The `IRGen/pack_metadata_marker_inserter.sil` test was expecting 64-bit specific values in a couple of places.  Fix those check lines.
