### PR TITLE
[LSan] Disable backtracing for the lsan builds.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1212,6 +1212,8 @@ sourcekit-lsp=0
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=RDA,test=no]
 build-subdir=buildbot_incremental_lsan
 
+swift-enable-backtracing=0
+
 # Reduce the size of the final toolchain, limit debug info
 extra-cmake-options=
    -DCMAKE_C_FLAGS="-gline-tables-only"
@@ -1226,6 +1228,8 @@ reconfigure
 
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=DA,test=no]
 build-subdir=buildbot_incremental_lsan
+
+swift-enable-backtracing=0
 
 # Reduce the size of the final toolchain, limit debug info
 extra-cmake-options=


### PR DESCRIPTION
We don't need or want it there, and it's causing dependency problems in our CMake build system.

rdar://110420951
