### PR TITLE
[Build] Read all shell output as UTF-8

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -228,8 +228,10 @@ def run(*args, **kwargs):
     my_pipe = subprocess.Popen(
         *args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         universal_newlines=True,
+        encoding='utf-8',
         **kwargs)
     (output, _) = my_pipe.communicate()
+    output = output.encode(encoding='ascii', errors='replace')
     ret = my_pipe.wait()
 
     if lock:


### PR DESCRIPTION
Encodes the output back into ASCII as there's been issues with printing UTF-8 in the past.