### PR TITLE
A couple of tiny variadic generic fixes [5.9]

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -418,6 +418,16 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
     // For the second step, we're looking into the requirement signature for
     // this protocol.
+    if (conformance.isPack()) {
+      auto pack = conformance.getPack();
+      conformance = ProtocolConformanceRef(
+          pack->getAssociatedConformance(step.first, step.second));
+      if (conformance.isInvalid())
+        return conformance;
+
+      continue;
+    }
+
     auto concrete = conformance.getConcrete();
     auto normal = concrete->getRootNormalConformance();
 

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -77,7 +77,9 @@ public:
                ProtocolConformanceRef(conformedProtocol),
                conformingReplacementType->getCanonicalType(),
                typeExpansionContext);
-      }, SubstFlags::SubstituteOpaqueArchetypes);
+      },
+      SubstFlags::SubstituteOpaqueArchetypes |
+      SubstFlags::PreservePackExpansionLevel);
   }
 
   // Substitute a function type.

--- a/test/SILGen/variadic_generic_conformances.swift
+++ b/test/SILGen/variadic_generic_conformances.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking
+
+protocol P {
+  associatedtype A: P
+}
+
+struct S: P {
+  typealias A = S
+}
+
+func f<each T: P>(_: repeat each T) -> (repeat each T.A.A.A.A) {}
+
+f(S(), S(), S())

--- a/validation-test/compiler_crashers_2_fixed/rdar110363503.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar110363503.swift
@@ -1,0 +1,54 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+struct ZipCollection<each C: Collection> {
+  let c: (repeat each C)
+}
+
+extension ZipCollection: Collection {
+  struct Element {
+    var elt: (repeat each C.Element)
+  }
+
+  struct Index {
+    let i: (repeat each C.Index)
+  }
+
+  var startIndex: Index {
+    Index(i: (repeat (each c).startIndex))
+  }
+
+  var endIndex: Index {
+    Index(i: (repeat (each c).endIndex))
+  }
+
+  func index(after i: Index) -> Index {
+    Index(i: (repeat (each c).index(after: each i.i)))
+  }
+
+  subscript(index: Index) -> Element {
+    Element(elt: (repeat (each c)[each index.i]))
+  }
+}
+
+extension ZipCollection.Index: Equatable {
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    var result = true
+    repeat result = ((each lhs.i) == (each rhs.i)) && result
+    return result
+  }
+}
+
+extension ZipCollection.Index: Comparable {
+  static func <(lhs: Self, rhs: Self) -> Bool {
+    var result: Bool? = nil
+    func check<T: Comparable>(_ x: T, _ y: T) {
+      if result == nil {
+        if x == y { return }
+        if x < y { result = true }
+        if x > y { result = false }
+      }
+    }
+    repeat check(each lhs.i, each rhs.i)
+    return result ?? false
+  }
+}


### PR DESCRIPTION
* Description: Implements a missing case in conformance path evaluation; we didn't handle pack conformances there at all, so the compiler would crash while substituting a type parameter pack whose conformance path had more than one step.

* Risk: Low, this only impacts variadic generics.

* Reviewed by: @hborla 

* Radar: rdar://110363503