### PR TITLE
[move-only] Add memory verifier support for struct-deinit

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -416,6 +416,11 @@ void MemoryLifetimeVerifier::initDataflowInBlock(SILBasicBlock *block,
         }
         break;
       }
+      case SILInstructionKind::AllocStackInst: {
+        locations.genValueSelfBit(state.genSet, state.killSet,
+                                  cast<AllocStackInst>(&I));
+        break;
+      }
       case SILInstructionKind::DestroyAddrInst:
       case SILInstructionKind::DeallocStackInst:
         killBits(state, I.getOperand(0));
@@ -823,6 +828,10 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
           checkFuncArgument(bits, op, YI->getArgumentConventionForOperand(op),
                              &I);
         }
+        break;
+      }
+      case SILInstructionKind::AllocStackInst: {
+        locations.setValueSelfBit(bits, cast<AllocStackInst>(&I));
         break;
       }
       case SILInstructionKind::DeallocStackInst: {

--- a/test/SIL/memory_lifetime_moveonly.sil
+++ b/test/SIL/memory_lifetime_moveonly.sil
@@ -1,0 +1,78 @@
+// RUN: %target-sil-opt -o /dev/null %s
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// A non-trivial type
+class T {
+  init()
+}
+
+struct EmptyDeinit : ~Copyable {
+  deinit
+}
+
+struct PairDeinit : ~Copyable {
+  var a: T
+  var b: T
+
+  deinit
+}
+
+// The allocation implicitly initializes the empty value.
+sil [ossa] @testEmptyInit : $() -> () {
+bb0:
+  %addr = alloc_stack $EmptyDeinit
+  destroy_addr %addr : $*EmptyDeinit
+  dealloc_stack %addr : $*EmptyDeinit
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// The alloc_stack initialization implicitly initializes the aggregate.
+sil [ossa] @testPairInit : $(@owned T) -> () {
+bb0(%0 : @owned $T):
+  %addr = alloc_stack $PairDeinit
+  %2 = copy_value %0 : $T
+  %3 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.a
+  store %2 to [init] %3 : $*T
+  %5 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.b
+  store %0 to [init] %5 : $*T
+  destroy_addr %addr : $*PairDeinit
+  dealloc_stack %addr : $*PairDeinit
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// The aggregate is implicitly reinitialized by setting its fields.
+// The verifier does not yet ensure that all fields are reinitialized;
+// instead, we should add a mark_initialized instruction to SIL
+// to handle reinitialization of values with deinits.
+sil [ossa] @testPairInit : $(@owned T) -> () {
+bb0(%0 : @owned $T):
+  %addr = alloc_stack $PairDeinit
+
+  %2 = copy_value %0 : $T
+  %3 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.a
+  store %2 to [init] %3 : $*T
+  %5 = copy_value %0 : $T
+  %6 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.b
+  store %5 to [init] %6 : $*T
+  destroy_addr %addr : $*PairDeinit
+
+  %9 = copy_value %0 : $T
+  %10 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.a
+  store %9 to [init] %10 : $*T
+  %12 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.b
+  store %0 to [init] %12 : $*T
+  destroy_addr %addr : $*PairDeinit
+
+  dealloc_stack %addr : $*PairDeinit
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SIL/memory_lifetime_moveonly_failure.sil
+++ b/test/SIL/memory_lifetime_moveonly_failure.sil
@@ -1,0 +1,74 @@
+// RUN: %target-sil-opt -dont-abort-on-memory-lifetime-errors -o /dev/null %s 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// A non-trivial type
+class T {
+  init()
+}
+
+struct EmptyDeinit : ~Copyable {
+  deinit
+}
+
+struct PairDeinit : ~Copyable {
+  var a: T
+  var b: T
+
+  deinit
+}
+
+// The allocation implicitly initializes the empty value which must be
+// destroyed.
+//
+// CHECK: SIL memory lifetime failure in @testEmptyInit: memory is initialized, but shouldn't be
+sil [ossa] @testEmptyInit : $() -> () {
+bb0:
+  %addr = alloc_stack $EmptyDeinit
+  dealloc_stack %addr : $*EmptyDeinit
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// The field initialization implicitly initializes the aggregate,
+// which must be destroyed as a whole.
+//
+// CHECK: SIL memory lifetime failure in @testPairMemberDeinit: memory is initialized, but shouldn't be
+sil [ossa] @testPairMemberDeinit : $(@owned T) -> () {
+bb0(%0 : @owned $T):
+  %addr = alloc_stack $PairDeinit
+  %2 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.a
+  %3 = copy_value %0 : $T
+  store %3 to [init] %2 : $*T
+  %5 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.b
+  store %0 to [init] %5 : $*T
+  destroy_addr %2 : $*T
+  destroy_addr %5 : $*T
+  dealloc_stack %addr : $*PairDeinit
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// The aggregate cannot be destroyed after one of its fields is destroyed.
+//
+// CHECK: SIL memory lifetime failure in @testPairDoubleDeinit: memory is not initialized, but should be
+sil [ossa] @testPairDoubleDeinit : $(@owned T) -> () {
+bb0(%0 : @owned $T):
+  %addr = alloc_stack $PairDeinit
+  %2 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.a
+  %3 = copy_value %0 : $T
+  store %3 to [init] %2 : $*T
+  %5 = struct_element_addr %addr : $*PairDeinit, #PairDeinit.b
+  store %0 to [init] %5 : $*T
+  destroy_addr %2 : $*T
+  destroy_addr %addr : $*PairDeinit
+  dealloc_stack %addr : $*PairDeinit
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
When a value has a deinit, it cannot be memberwise destroyed. This verification catches cases where we fail to run the structs' deinit and cases where we incorrectly run a member's deinit more than once. It also handles structs that have a deinit but have only trivial members.

This fix adds an extra flag to the MemoryLocation but otherwise reuses the location's 'self' bit. This is not a good long term fix, but it solves an urgent problem of using the verifier with move-only types without adding any new SIL support.

Long-term, the verifier should instead use mark_uninitialized as the placeholder for value initialization, and DI should insert a new mark_initialized instruction for values with deinits after their members are initialized.