### PR TITLE
[Test] Remove five second delay in swift-reflection-test startup.

### DIFF
--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -764,10 +764,6 @@ int doDumpHeapInstance(const char *BinaryFilename) {
       exit(status);
     }
     default: { // Parent
-      for (int i = 5; i > 1; i--) {
-	fprintf(stderr, "%d\n", i);
-	sleep(1);
-      }
       close(PipeMemoryReader_getChildReadFD(&Pipe));
       close(PipeMemoryReader_getChildWriteFD(&Pipe));
       SwiftReflectionContextRef RC =


### PR DESCRIPTION
This was added in ea54c3ba40447b165e108df7ec7ce8d36a9a55cb, presumably inadvertently.