### PR TITLE
[NFC] TypeCheckDeclPrimary.cpp: remove unused `isGenericType`

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -472,7 +472,6 @@ static void checkGenericParams(GenericContext *ownerCtx) {
     return;
 
   auto *decl = ownerCtx->getAsDecl();
-  bool isGenericType = isa<NominalTypeDecl>(decl);
   bool hasPack = false;
 
   for (auto gp : *genericParams) {


### PR DESCRIPTION
This change fixes a warning encountered when compiling this file:

```
swift/lib/Sema/TypeCheckDeclPrimary.cpp:475:8: warning: unused variable 'isGenericType' [-Wunused-variable]
  bool isGenericType = isa<NominalTypeDecl>(decl);
```
