### PR TITLE
NFC: Disable clang-format for inline bitfields

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -101,6 +101,7 @@ class DeclAttribute : public AttributeBase {
   friend class TypeAttributes;
 
 protected:
+  // clang-format off
   union {
     uint64_t OpaqueBits;
 
@@ -178,6 +179,7 @@ protected:
       isCategoryNameInvalid : 1
     );
   } Bits;
+  // clang-format on
 
   DeclAttribute *Next = nullptr;
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -139,6 +139,7 @@ class alignas(8) Expr : public ASTAllocated<Expr> {
   void operator=(const Expr&) = delete;
 
 protected:
+  // clang-format off
   union { uint64_t OpaqueBits;
 
   SWIFT_INLINE_BITFIELD_BASE(Expr, bitmax(NumExprKindBits,8)+1,
@@ -371,6 +372,7 @@ protected:
   );
 
   } Bits;
+  // clang-format on
 
 private:
   /// Ty - This is the type of the expression.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -63,6 +63,7 @@ class alignas(8) Stmt : public ASTAllocated<Stmt> {
   Stmt& operator=(const Stmt&) = delete;
 
 protected:
+  // clang-format off
   union { uint64_t OpaqueBits;
 
   SWIFT_INLINE_BITFIELD_BASE(Stmt, bitmax(NumStmtKindBits,8) + 1,
@@ -101,6 +102,7 @@ protected:
   );
 
   } Bits;
+  // clang-format on
 
   /// Return the given value for the 'implicit' flag if present, or if None,
   /// return true if the location is invalid.

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -60,6 +60,7 @@ class alignas(1 << TypeReprAlignInBits) TypeRepr
   void operator=(const TypeRepr&) = delete;
 
 protected:
+  // clang-format off
   union { uint64_t OpaqueBits;
 
   SWIFT_INLINE_BITFIELD_BASE(TypeRepr, bitmax(NumTypeReprKindBits,8)+1+1,
@@ -108,6 +109,7 @@ protected:
   );
 
   } Bits;
+  // clang-format on
 
   TypeRepr(TypeReprKind K) {
     Bits.OpaqueBits = 0;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -375,6 +375,8 @@ class alignas(1 << TypeAlignInBits) TypeBase
 protected:
   enum { NumAFTExtInfoBits = 11 };
   enum { NumSILExtInfoBits = 11 };
+
+  // clang-format off
   union { uint64_t OpaqueBits;
 
   SWIFT_INLINE_BITFIELD_BASE(TypeBase, bitmax(NumTypeKindBits,8) +
@@ -501,6 +503,7 @@ protected:
   );
 
   } Bits;
+  // clang-format on
 
 protected:
   TypeBase(TypeKind kind, const ASTContext *CanTypeCtx,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -95,6 +95,7 @@ class TypeInfo {
   friend class TypeConverter;
 
 protected:
+  // clang-format off
   union {
     uint64_t OpaqueBits;
 
@@ -143,6 +144,8 @@ protected:
       Size : 32
     );
   } Bits;
+  // clang-format on
+
   enum { InvalidSubclassKind = 0x7 };
 
   TypeInfo(llvm::Type *Type, Alignment A, IsTriviallyDestroyable_t pod,


### PR DESCRIPTION
clang-format tries to impose the wrong formatting on these, so let's disable it for these blocks.