### PR TITLE
[5.9] Tests: disable AutoDiff/compiler_crashers_fixed/issue-55852-tangent-value-category-mismatch.swift on linux

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/issue-55852-tangent-value-category-mismatch.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-55852-tangent-value-category-mismatch.swift
@@ -4,6 +4,9 @@
 // Semantic member getter pullback generation crash due to tangent value
 // category mismatch
 
+// Sometimes the linker crashes on linux
+// UNSUPPORTED: OS=linux-gnu
+
 import _Differentiation
 
 struct Dense: Differentiable {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/65249

