### PR TITLE
[5.9][Sema] InitAccessors: Don't synthesize default memberwise arg for ini…

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -144,6 +144,12 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   if (!var->getParentPattern()->getSingleVar())
     return;
 
+  // FIXME: Don't attempt to synthesize default arguments for init
+  //        accessor properties because there could be multiple properties
+  //        with default values they are going to initialize.
+  if (var->getAccessor(AccessorKind::Init))
+    return;
+
   // Whether we have explicit initialization.
   bool isExplicitlyInitialized = false;
   if (auto pbd = var->getParentPatternBinding()) {


### PR DESCRIPTION
…t accessor initializations

Cherry-pick of https://github.com/apple/swift/pull/66463

---

- Explanation:

Default arguments for `init accessors` are not fully supported at the moment, 
so we shouldn't attempt to synthesize them in Sema just to crash during linking.

- Scope: memberwise initializers with init accessor properties.

- Main Branch PR:  https://github.com/apple/swift/pull/66463

- Risk: Very Low (guarded by experimental feature flag)

- Reviewed By: @hborla 

- Testing:  Only manual testing until FIXME is resolved.

(cherry picked from commit 8c54d3d5604ac5c5d57ef7eceb4bfe61ee5a7216)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
