### PR TITLE
[5.9] SILGen: Don't copy a borrowed noncopyable address-only base of a computed property access.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1171,6 +1171,11 @@ namespace {
       assert(base
              && base.getType().isAddress()
              && "should have an address base to borrow from");
+      // If the base value is address-only then we can borrow from the
+      // address in-place.
+      if (!base.getType().isLoadable(SGF.F)) {
+        return base;
+      }
       auto result = SGF.B.createLoadBorrow(loc, base.getValue());
       return SGF.emitFormalEvaluationManagedBorrowedRValueWithCleanup(loc,
          base.getValue(), result);

--- a/test/ModuleInterface/moveonly_user.swift
+++ b/test/ModuleInterface/moveonly_user.swift
@@ -5,16 +5,12 @@
 // RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
 
 // >> now again with library evolution; we expect the same result.
-// FIXME: move checker doesn't like it when you specify library evolution
 // RUN: %target-swift-frontend -DSYNTHESIZE_ACCESSORS -enable-library-evolution -emit-module -o %t/Hello.swiftmodule %S/Inputs/moveonly_api.swift
 // RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
 
 // FIXME: ideally this would also try executing the program rather than just generating SIL
 
 // FIXME: make this test work when we're not synthesizing the accessors
-
-// rdar://106164128
-// XFAIL: *
 
 import Hello
 

--- a/test/SILGen/moveonly_addressonly_computed_property.swift
+++ b/test/SILGen/moveonly_addressonly_computed_property.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// rdar://109161396
+
+public protocol P {}
+
+@_moveOnly
+public struct M {
+   private var x: P
+   var other: CInt { 0 }
+
+   var otherMoveOnly: M {
+       _read {
+           yield self
+       }
+   }
+
+   @_silgen_name("no")
+   init()
+}
+
+// CHECK-LABEL: sil [ossa] @${{.*}}4test3mut
+// CHECK: [[CHECK:%.*]] = mark_must_check [consumable_and_assignable] %0
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[CHECK]]
+// CHECK: [[RESULT:%.*]] = apply {{.*}}([[ACCESS]])
+// CHECK; end_access [[ACCESS]]
+// CHECK: return [[RESULT]]
+public func test(mut: inout M) -> CInt {
+  return mut.other
+}
+
+// CHECK-LABEL: sil [ossa] @${{.*}}4test6borrow
+// CHECK: [[CHECK:%.*]] = mark_must_check [no_consume_or_assign] %0
+// CHECK: [[RESULT:%.*]] = apply {{.*}}([[CHECK]])
+// CHECK: return [[RESULT]]
+public func test(borrow: borrowing M) -> CInt {
+  return borrow.other
+}
+
+// CHECK-LABEL: sil [ossa] @${{.*}}4test7consume
+// CHECK: [[BOX:%.*]] = project_box
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX]]
+// CHECK: [[CHECK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+// CHECK: [[RESULT:%.*]] = apply {{.*}}([[CHECK]])
+// CHECK; end_access [[ACCESS]]
+// CHECK: return [[RESULT]]
+public func test(consume: consuming M) -> CInt {
+  return consume.other
+}
+
+// CHECK-LABEL: sil [ossa] @${{.*}}4test3own
+// CHECK: [[CHECK:%.*]] = mark_must_check [consumable_and_assignable] %0
+// CHECK: [[RESULT:%.*]] = apply {{.*}}([[CHECK]])
+// CHECK: return [[RESULT]]
+public func test(own: __owned M) -> CInt {
+  return own.other
+}
+
+func use(_: CInt, andMutate _: inout M) {}
+func use(_: CInt, andConsume _: consuming M) {}
+func borrow(_: borrowing M, andMutate _: inout M) {}
+func borrow(_: borrowing M, andConsume _: consuming M) {}
+
+public func testNoInterferenceGet(mut: inout M, extra: consuming M) {
+    // This should not cause exclusivity interference, since the result of
+    // the getter can have an independent lifetime from the borrow.
+    use(mut.other, andMutate: &mut)
+    use(mut.other, andConsume: mut)
+    mut = extra
+}
+
+public func testInterferenceRead(mut: inout M, extra: consuming M) {
+    // This should cause exclusivity interference, since in order to borrow
+    // the yielded result from the `_read`, we need to keep the borrow of
+    // the base going.
+    borrow(mut.otherMoveOnly, andMutate: &mut) // expected-error{{}} expected-note{{}}
+    borrow(mut.otherMoveOnly, andConsume: mut) // expected-error{{}} expected-note{{}}
+    mut = extra
+}


### PR DESCRIPTION
Issue: rdar://109161396
• Explanation: Accessing a computed property on an "address-only" noncopyable type would crash the compiler and/or raise a spurious "borrowed value cannot be consumed" error trying to consume the base.
• Scope of Issue: Fixes a compiler crash and reject-valid bug.
• Origination: Noncopyable types feature work.
• Risk: Low. The fix targets a specific code pattern only when using noncopyable types, for code that currently crashes the compiler. Potential miscompiles ought to be diagnosed by the move-only checker, so that they do not lead to accidentally successful compiles.
• Reviewed By: @gottesmm 
• Automated Testing: Swift CI
• Dependencies: None
• Builder Impact: Not applicable
• Directions for QE: None