### PR TITLE
[5.9][cxx-interop][driver] make '-emit-clang-header-path' a fully supporte…

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -626,7 +626,7 @@ def emit_clang_header_nonmodular_includes : Flag<["-"], "emit-clang-header-nonmo
   HelpText<"Augment emitted Objective-C header with textual imports for every included modular import">;
 
 def emit_clang_header_path : Separate<["-"], "emit-clang-header-path">,
-  Flags<[FrontendOption, NoDriverOption, NoInteractiveOption, ArgumentIsPath,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
          SupplementaryOutput]>,
   HelpText<"Emit an Objective-C and C++ header file to <path>">,
   Alias<emit_objc_header_path>;


### PR DESCRIPTION
…d driver flag

This will let other build systems call it without relying on the frontend flag

- Explanation:
The `-emit-clang-header-path` flag is only a frontend option. Make it a driver option, so we can advise CMake / other build systems to emit a header using a Swift invocation, and not a Swift frontend invocation.
- Scope: Swift's driver options
- Risk: Low. 
- Testing: Swift driver unit tests.
- PR: https://github.com/apple/swift/pull/66418