### PR TITLE
[5.9][cxx-interop] evaluate default constructor's unevaluated exception sp…

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3282,11 +3282,9 @@ llvm::CallBase *swift::irgen::emitCXXConstructorCall(
     IRGenFunction &IGF, const clang::CXXConstructorDecl *ctor,
     llvm::FunctionType *ctorFnType, llvm::Constant *ctorAddress,
     llvm::ArrayRef<llvm::Value *> args) {
-  bool canThrow = IGF.IGM.isForeignExceptionHandlingEnabled();
-  if (auto *fpt = ctor->getType()->getAs<clang::FunctionProtoType>()) {
-    if (fpt->isNothrow())
-      canThrow = false;
-  }
+  bool canThrow =
+      IGF.IGM.isForeignExceptionHandlingEnabled() &&
+      !IGF.IGM.isCxxNoThrow(const_cast<clang::CXXConstructorDecl *>(ctor));
   if (!canThrow)
     return IGF.Builder.CreateCall(ctorFnType, ctorAddress, args);
   llvm::CallBase *result;

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -720,11 +720,8 @@ namespace {
       }
       bool canThrow = false;
       if (IGF.IGM.isForeignExceptionHandlingEnabled()) {
-        if (auto *fpt =
-                destructor->getType()->getAs<clang::FunctionProtoType>()) {
-          if (!fpt->isNothrow())
-            canThrow = true;
-        }
+        if (!IGF.IGM.isCxxNoThrow(destructor, /*defaultNoThrow=*/true))
+          canThrow = true;
       }
       if (canThrow) {
         IGF.createExceptionTrapScope([&](llvm::BasicBlock *invokeNormalDest,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1829,6 +1829,9 @@ public:
 
   bool isForeignExceptionHandlingEnabled() const;
 
+  /// Returns true if the given Clang function does not throw exceptions.
+  bool isCxxNoThrow(clang::FunctionDecl *fd, bool defaultNoThrow = false);
+
 private:
   llvm::Constant *
   getAddrOfSharedContextDescriptor(LinkEntity entity,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2887,12 +2887,10 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
   FunctionPointer fp =
       FunctionPointer::forDirect(fpKind, value, secondaryValue, sig);
   // Update the foreign no-throw information if needed.
-  if (const auto *cd = fn->getClangDecl()) {
+  if (auto *cd = fn->getClangDecl()) {
     if (auto *cfd = dyn_cast<clang::FunctionDecl>(cd)) {
-      if (auto *cft = cfd->getType()->getAs<clang::FunctionProtoType>()) {
-        if (cft->isNothrow())
-          fp.setForeignNoThrow();
-      }
+      if (IGM.isCxxNoThrow(const_cast<clang::FunctionDecl *>(cfd)))
+        fp.setForeignNoThrow();
     }
     if (IGM.emittedForeignFunctionThunksWithExceptionTraps.count(fnPtr))
       fp.setForeignCallCatchesExceptionInThunk();

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -131,6 +131,33 @@ public:
   inline ClassWithNoThrowingConstructor() noexcept {}
 };
 
+struct StructWithDefaultConstructor {
+  StructWithDefaultConstructor() = default;
+
+  int m = 0;
+};
+
+
+struct NonTrivial {
+  ~NonTrivial() {}
+};
+
+struct StructWithDefaultCopyConstructor {
+  StructWithDefaultCopyConstructor() noexcept {}
+  StructWithDefaultCopyConstructor(const StructWithDefaultCopyConstructor &) = default;
+
+  int m = 0;
+  NonTrivial _nonTrivialPoison;
+};
+
+struct StructWithDefaultDestructor {
+  StructWithDefaultDestructor() noexcept {}
+  ~StructWithDefaultDestructor() = default;
+
+  int m = 0;
+  NonTrivial _nonTrivialPoison;
+};
+
 //--- test.swift
 
 import CxxModule
@@ -227,6 +254,22 @@ func testClassWithNoThrowingConstructor() -> CInt {
   return obj.m
 }
 
+func testStructWithDefaultConstructor() -> StructWithDefaultConstructor {
+  return StructWithDefaultConstructor()
+}
+
+func testStructWithDefaultCopyConstructor() -> CInt {
+  var s = StructWithDefaultCopyConstructor()
+  let copy = s
+  return s.m
+}
+
+func testStructWithDefaultDestructor() -> CInt {
+  let s = StructWithDefaultDestructor()
+  let result = s.m
+  return result
+}
+
 let _ = testFreeFunctionNoThrowOnly()
 let _ = testFreeFunctionCalls()
 let _ = testMethodCalls()
@@ -241,6 +284,9 @@ let _ = testClassWithCopyConstructor()
 let _ = testClassWithThrowingCopyConstructor()
 let _ = testClassWithThrowingConstructor()
 let _ = testClassWithNoThrowingConstructor()
+let _ = testStructWithDefaultConstructor()
+let _ = testStructWithDefaultCopyConstructor()
+let _ = testStructWithDefaultDestructor()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :
@@ -390,6 +436,18 @@ let _ = testClassWithNoThrowingConstructor()
 // CHECK-NEXT: unreachable
 
 // CHECK: define {{.*}} @"$s4test0A30ClassWithNoThrowingConstructors5Int32VyF"() #[[#SWIFTMETA]]
+// CHECK-NOT: invoke
+// CHECK: }
+
+// CHECK: define {{.*}} @"$s4test0A28StructWithDefaultConstructorSo0bcdE0VyF"() #[[#SWIFTMETA]] {
+// CHECK-NOT: invoke
+// CHECK: }
+
+// CHECK: define {{.*}} @"$s4test0A32StructWithDefaultCopyConstructors5Int32VyF"() #[[#SWIFTMETA]] {
+// CHECK-NOT: invoke
+// CHECK: }
+
+// CHECK: define {{.*}} @"$s4test0A27StructWithDefaultDestructors5Int32VyF"() #[[#SWIFTMETA]] {
 // CHECK-NOT: invoke
 // CHECK: }
 


### PR DESCRIPTION
…ec if needed when emitting C++ constructor call

Fixes https://github.com/apple/swift/issues/65891

- Explanation:
Swift needs to understand if C++ functions are `noexcept` to elide exception traps. Some C++ class members, like the implicit default constructor, delay the evaluation of exception specifier. This delay causes Swift to crash on an unevaluated exception specifier. The fix forces Swift to evaluate unevaluated exception specifier for a C++ function that has such an unevaluated specifier.
- Scope: Swift's IRGen, C++ interoperability
- Risk: Low, these checks are only done when C++ interoperability is enabled , and exceptions are not disabled
- Testing: Swift unit tests.
- PR: https://github.com/apple/swift/pull/65922