### PR TITLE
[cxx-interop] Make a test work properly with optimizations

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -20,13 +20,9 @@ CxxSequenceTestSuite.test("SimpleCopyAwareSequence to Swift.Array") {
   copiesCount = 0
 
   let seq = SimpleCopyAwareSequence()
-
-  let seqCopy = seq
-  expectEqual(1, copiesCount) // make sure our copy tracking mechanism works
-
   let array = Array(seq)
 
-  expectEqual(1, copiesCount) // make sure we don't copy the C++ sequence value unnecessarily
+  expectEqual(0, copiesCount) // make sure we don't copy the C++ sequence value unnecessarily
 }
 #endif
 


### PR DESCRIPTION
The compiler might optimize away the first copy, so just make sure that no copies are happening during the actual initialization of Array.

rdar://110422053