### PR TITLE
Avoid emitting variable debug info for closure captures.  … @adrian-prantl

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -547,7 +547,7 @@ SILValue RValue::forwardAsSingleStorageValue(SILGenFunction &SGF,
   return SGF.emitConversionFromSemanticValue(l, result, storageType);
 }
 
-void RValue::forwardInto(SILGenFunction &SGF, SILLocation loc, 
+void RValue::forwardInto(SILGenFunction &SGF, SILLocation loc,
                          Initialization *I) && {
   assert(isComplete() && "rvalue is not complete");
   assert(isPlusOneOrTrivial(SGF) && "Can not forward borrowed RValues");

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1789,8 +1789,10 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
 
 InitializationPtr SILGenFunction::emitPatternBindingInitialization(
     Pattern *P, JumpDest failureDest, bool generateDebugInfo) {
-  return InitializationForPattern(*this, failureDest, generateDebugInfo)
-      .visit(P);
+  auto init =
+      InitializationForPattern(*this, failureDest, generateDebugInfo).visit(P);
+  init->setEmitDebugValueOnInit(generateDebugInfo);
+  return init;
 }
 
 /// Enter a cleanup to deallocate the given location.

--- a/test/DebugInfo/captures.swift
+++ b/test/DebugInfo/captures.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend %s -parse-as-library -module-name a -emit-sil -g -o - | %FileCheck %s
+struct S {}
+public class UIView {}
+public protocol View {}
+public final class Signal<Value> {
+    public func map<U>(_ transform: @escaping (Value) -> U) -> Signal<U> {
+        return Signal<U>()
+    }
+}
+public final class C<V: View, V1: View>: UIView {
+    private let t1: C<V, V1>? = nil
+    private let t2: C<V1, V>? = nil
+    func foo() -> Signal<(S, UIView)> {
+    // CHECK: sil {{.*}}s1a1CC3foo
+    // CHECK: debug_value {{.*}} name "self"
+    // CHECK-NOT: debug_value {{.*}} name "view"
+    // CHECK: return %
+	return (
+            Signal<S>()
+	    .map { [view = t1!] in ($0, view) },
+            Signal<S>()
+	    .map { [view = t2!] in ($0, view) }
+	).0
+    }
+}
+


### PR DESCRIPTION
Variable debug info is triggered by pattern bindings, however, inside a closure capture list, this should be avoided by setting the appropriate flag in the initializer object.

rdar://110329894
