### PR TITLE
[5.9][SourceKit] Highlight `consuming` and `borrowing` as keywords

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4573,6 +4573,7 @@ Parser::parseTypeAttributeListPresent(ParamDecl::Specifier &Specifier,
     }
 
     if (Tok.isContextualKeyword("_const")) {
+      Tok.setKind(tok::contextual_keyword);
       ConstLoc = consumeToken();
       continue;
     }
@@ -4595,6 +4596,7 @@ Parser::parseTypeAttributeListPresent(ParamDecl::Specifier &Specifier,
         }
       }
     }
+    Tok.setKind(tok::contextual_keyword);
     SpecifierLoc = consumeToken();
   }
 

--- a/test/SourceKit/SyntaxMapData/consuming_borrowing.swift
+++ b/test/SourceKit/SyntaxMapData/consuming_borrowing.swift
@@ -1,0 +1,60 @@
+func foo(a: consuming Int, b: borrowing Int, c: _const Int) {}
+
+// RUN: %sourcekitd-test -req=syntax-map %s | %FileCheck %s
+
+// CHECK: key.syntaxmap: [
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.keyword,
+// CHECK-NEXT:   key.offset: 0,
+// CHECK-NEXT:   key.length: 4
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.identifier,
+// CHECK-NEXT:   key.offset: 5,
+// CHECK-NEXT:   key.length: 3
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.identifier,
+// CHECK-NEXT:   key.offset: 9,
+// CHECK-NEXT:   key.length: 1
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.keyword,
+// CHECK-NEXT:   key.offset: 12,
+// CHECK-NEXT:   key.length: 9
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.typeidentifier,
+// CHECK-NEXT:   key.offset: 22,
+// CHECK-NEXT:   key.length: 3
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.identifier,
+// CHECK-NEXT:   key.offset: 27,
+// CHECK-NEXT:   key.length: 1
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.keyword,
+// CHECK-NEXT:   key.offset: 30,
+// CHECK-NEXT:   key.length: 9
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.typeidentifier,
+// CHECK-NEXT:   key.offset: 40,
+// CHECK-NEXT:   key.length: 3
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.identifier,
+// CHECK-NEXT:   key.offset: 45,
+// CHECK-NEXT:   key.length: 1
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.keyword,
+// CHECK-NEXT:   key.offset: 48,
+// CHECK-NEXT:   key.length: 6
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   key.kind: source.lang.swift.syntaxtype.typeidentifier,
+// CHECK-NEXT:   key.offset: 55,
+// CHECK-NEXT:   key.length: 3
+// CHECK-NEXT: },


### PR DESCRIPTION
* **Explanation**: `consuming` and `borrowing` were not highlighted as keywords by sourcekitd. Fix that
* **Scope**: Syntax highlighting provided by sourcekitd
* **Risk**: Very low
* **Testing**: Added a test case 
* **Issue**: rdar://110421891
* **Reviewer**:  @rintaro and @bnbarham on https://github.com/apple/swift/pull/66458