### PR TITLE
Add new backpressured APIs to Async[Throwing]Stream

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -228,6 +228,22 @@ public struct AsyncStream<Element> {
     }
   }
 
+  final class _Backing {
+    let storage: _BackPressuredStorage<Element, Never>
+
+    init(storage: _BackPressuredStorage<Element, Never>) {
+      self.storage = storage
+    }
+
+    deinit {
+        if #available(SwiftStdlib 9999, *) {
+          self.storage.sequenceDeinitialized()
+        } else {
+          fatalError("Internal inconsistency")
+        }
+    }
+  }
+
   final class _Context {
     let storage: _Storage?
     let produce: () async -> Element?
@@ -242,7 +258,14 @@ public struct AsyncStream<Element> {
     }
   }
 
-  let context: _Context
+  enum _Implementation {
+    /// This is the implementation based on the original proposal with the Continuation
+    case contextBased(_Context)
+    /// This is the implementation with backpressure based on the Source
+    case backpressured(_Backing)
+  }
+
+  let _implementation: _Implementation
   
 
   /// Constructs an asynchronous stream for an element type, using the
@@ -293,7 +316,7 @@ public struct AsyncStream<Element> {
     _ build: (Continuation) -> Void
   ) {
     let storage: _Storage = .create(limit: limit)
-    context = _Context(storage: storage, produce: storage.next)
+    self._implementation = .contextBased(_Context(storage: storage, produce: storage.next))
     build(Continuation(storage: storage))
   }
 
@@ -336,7 +359,7 @@ public struct AsyncStream<Element> {
   ) {
     let storage: _AsyncStreamCriticalStorage<Optional<() async -> Element?>>
       = .create(produce)
-    context = _Context {
+    self._implementation = .contextBased(_Context {
       return await withTaskCancellationHandler {
         guard let result = await storage.value?() else {
           storage.value = nil
@@ -347,7 +370,7 @@ public struct AsyncStream<Element> {
         storage.value = nil
         onCancel?()
       }
-    }
+    })
   }
 }
 
@@ -360,7 +383,34 @@ extension AsyncStream: AsyncSequence {
   /// concurrent context that contends with another such call, which
   /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
-    let context: _Context
+    final class _Backing {
+      let _storage: _BackPressuredStorage<Element, Never>
+
+      init(storage: _BackPressuredStorage<Element, Never>) {
+        self._storage = storage
+        self._storage.iteratorInitialized()
+      }
+
+      deinit {
+        if #available(SwiftStdlib 9999, *) {
+          self._storage.iteratorDeinitialized()
+        } else {
+          fatalError("Internal inconsistency")
+        }
+      }
+    }
+    enum _Implementation {
+      /// This is the implementation based on the original proposal with the Continuation
+      case contextBased(_Context)
+      /// This is the implementation with backpressure based on the Source
+      case backpressured(_Backing)
+    }
+
+    let _implementation: _Implementation
+
+    init(implementation: _Implementation) {
+      self._implementation = implementation
+    }
 
     /// The next value from the asynchronous stream.
     ///
@@ -375,14 +425,30 @@ extension AsyncStream: AsyncSequence {
     /// awaiting a value, the `AsyncStream` terminates. In this case, `next()`
     /// might return `nil` immediately, or return `nil` on subsequent calls.
     public mutating func next() async -> Element? {
-      await context.produce()
+      switch self._implementation {
+        case .contextBased(let context):
+          return await context.produce()
+        case .backpressured(let backing):
+        if #available(SwiftStdlib 9999, *) {
+          // The only error that can be thrown here is the `CancellationError` which we convert to nil
+          return try? await backing._storage.next()
+        } else {
+          fatalError("Internal inconsistency")
+        }
+      }
     }
   }
 
   /// Creates the asynchronous iterator that produces elements of this
   /// asynchronous sequence.
   public func makeAsyncIterator() -> Iterator {
-    return Iterator(context: context)
+    switch self._implementation {
+      case .contextBased(let context):
+        return Iterator(implementation: .contextBased(context))
+
+      case .backpressured(let backing):
+        return Iterator(implementation: .backpressured(.init(storage: backing.storage)))
+    }
   }
 }
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -229,9 +229,9 @@ public struct AsyncStream<Element> {
   }
 
   final class _Backing {
-    let storage: _BackPressuredStorage<Element, Never>
+    let storage: _BackpressuredStorage<Element, Never>
 
-    init(storage: _BackPressuredStorage<Element, Never>) {
+    init(storage: _BackpressuredStorage<Element, Never>) {
       self.storage = storage
     }
 
@@ -384,9 +384,9 @@ extension AsyncStream: AsyncSequence {
   /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
     final class _Backing {
-      let _storage: _BackPressuredStorage<Element, Never>
+      let _storage: _BackpressuredStorage<Element, Never>
 
-      init(storage: _BackPressuredStorage<Element, Never>) {
+      init(storage: _BackpressuredStorage<Element, Never>) {
         self._storage = storage
         self._storage.iteratorInitialized()
       }
@@ -429,12 +429,12 @@ extension AsyncStream: AsyncSequence {
         case .contextBased(let context):
           return await context.produce()
         case .backpressured(let backing):
-        if #available(SwiftStdlib 9999, *) {
-          // The only error that can be thrown here is the `CancellationError` which we convert to nil
-          return try? await backing._storage.next()
-        } else {
-          fatalError("Internal inconsistency")
-        }
+          if #available(SwiftStdlib 9999, *) {
+            // The only error that can be thrown here is the `CancellationError` which we convert to nil
+            return try? await backing._storage.next()
+          } else {
+            fatalError("Internal inconsistency")
+          }
       }
     }
   }

--- a/stdlib/public/Concurrency/AsyncStreamBackpressure.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBackpressure.swift
@@ -18,1944 +18,1961 @@ public struct AsyncStreamAlreadyFinishedError: Error {}
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream {
-    /// A mechanism to interface between producer code and an asynchronous stream.
-    ///
-    /// Use this source to provide elements to the stream by calling one of the `write` methods, then terminate the stream normally
-    /// by calling the `finish()` method.
+  /// A mechanism to interface between producer code and an asynchronous stream.
+  ///
+  /// Use this source to provide elements to the stream by calling one of the `write` methods, then terminate the stream normally
+  /// by calling the `finish()` method.
+  @available(SwiftStdlib 9999, *)
+  public struct Source: Sendable {
+    /// A strategy that handles the backpressure of the asynchronous stream.
     @available(SwiftStdlib 9999, *)
-    public struct Source: Sendable {
-        /// A strategy that handles the backpressure of the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public struct BackPressureStrategy: Sendable {
-            /// When the high watermark is reached producers will be suspended. All producers will be resumed again once
-            /// the low watermark is reached.
-            @available(SwiftStdlib 9999, *)
-            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
-                BackPressureStrategy(internalBackPressureStrategy: .watermark(.init(low: low, high: high)))
-            }
+    public struct BackpressureStrategy: Sendable {
+      /// When the high watermark is reached producers will be suspended. All producers will be resumed again once
+      /// the low watermark is reached.
+      @available(SwiftStdlib 9999, *)
+      public static func watermark(low: Int, high: Int) -> BackpressureStrategy {
+        BackpressureStrategy(internalBackpressureStrategy: .watermark(.init(low: low, high: high)))
+      }
 
-            private init(internalBackPressureStrategy: _InternalBackPressureStrategy) {
-                self._internalBackPressureStrategy = internalBackPressureStrategy
-            }
+      private init(internalBackpressureStrategy: _InternalBackpressureStrategy) {
+        self._internalBackpressureStrategy = internalBackpressureStrategy
+      }
 
-            fileprivate let _internalBackPressureStrategy: _InternalBackPressureStrategy
-        }
-
-        /// A type that indicates the result of writing elements to the source.
-        @available(SwiftStdlib 9999, *)
-        @frozen
-        public enum WriteResult: Sendable {
-            /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
-            /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.
-            public struct CallbackToken: Sendable {
-                let id: UInt
-            }
-
-            /// Indicates that more elements should be produced and written to the source.
-            case produceMore
-
-            /// Indicates that a callback should be enqueued.
-            ///
-            /// The associated token should be passed to the ``enqueueCallback(_:)`` method.
-            case enqueueCallback(CallbackToken)
-        }
-
-        /// Backing class for the source used to hook a deinit.
-        final class _Backing: Sendable {
-            let storage: _BackPressuredStorage<Element, Never>
-
-            init(storage: _BackPressuredStorage<Element, Never>) {
-                self.storage = storage
-            }
-
-            deinit {
-                self.storage.sourceDeinitialized()
-            }
-        }
-
-        /// A callback to invoke when the stream finished.
-        ///
-        /// The stream finishes and calls this closure in the following cases:
-        /// - No iterator was created and the sequence was deinited
-        /// - An iterator was created and deinited
-        /// - After ``finish(throwing:)`` was called and all elements have been consumed
-        /// - The consuming task got cancelled
-        @available(SwiftStdlib 9999, *)
-        public var onTermination: (@Sendable () -> Void)? {
-            set {
-                self._backing.storage.onTermination = newValue
-            }
-            get {
-                self._backing.storage.onTermination
-            }
-        }
-
-        private var _backing: _Backing
-
-        internal init(storage: _BackPressuredStorage<Element, Never>) {
-            self._backing = .init(storage: storage)
-        }
-
-        /// Writes new elements to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// - Parameter sequence: The elements to write to the asynchronous stream.
-        /// - Returns: The result that indicates if more elements should be produced at this time.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
-            let id = try self._backing.storage.write(contentsOf: sequence)
-
-            if let id {
-                return .enqueueCallback(.init(id: id))
-            } else {
-                return .produceMore
-            }
-        }
-
-        /// Write the element to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// provided element. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// - Parameter element: The element to write to the asynchronous stream.
-        /// - Returns: The result that indicates if more elements should be produced at this time.
-        @available(SwiftStdlib 9999, *)
-        public func write(_ element: Element) throws -> WriteResult {
-            let id = try self._backing.storage.write(contentsOf: CollectionOfOne(element))
-        
-            if let id {
-                return .enqueueCallback(.init(id: id))
-            } else {
-                return .produceMore
-            }
-        }
-
-        /// Enqueues a callback that will be invoked once more elements should be produced.
-        ///
-        /// Call this method after ``write(contentsOf:)`` or ``write(:)`` returned ``WriteResult/enqueueCallback(_:)``.
-        ///
-        /// - Important: Enqueueing the same token multiple times is not allowed.
-        ///
-        /// - Parameters:
-        ///   - callbackToken: The callback token.
-        ///   - onProduceMore: The callback which gets invoked once more elements should be produced.
-        @available(SwiftStdlib 9999, *)
-        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            self._backing.storage.enqueueProducer(callbackToken: callbackToken.id, onProduceMore: onProduceMore)
-        }
-
-        /// Cancel an enqueued callback.
-        ///
-        /// Call this method to cancel a callback enqueued by the ``enqueueCallback(callbackToken:onProduceMore:)`` method.
-        ///
-        /// - Note: This methods supports being called before ``enqueueCallback(callbackToken:onProduceMore:)`` is called and
-        /// will mark the passed `callbackToken` as cancelled.
-        ///
-        /// - Parameter callbackToken: The callback token.
-        @available(SwiftStdlib 9999, *)
-        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
-            self._backing.storage.cancelProducer(callbackToken: callbackToken.id)
-        }
-
-        /// Write new elements to the asynchronous stream and provide a callback which will be invoked once more elements should be produced.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// first element of the provided sequence. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
-        /// a `Result.failure`.
-        ///
-        /// - Parameters:
-        ///   - sequence: The elements to write to the asynchronous stream.
-        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
-        ///   invoked during the call to ``write(contentsOf:onProduceMore:)``.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
-            do {
-                let writeResult = try self.write(contentsOf: sequence)
-
-                switch writeResult {
-                case .produceMore:
-                    onProduceMore(Result<Void, Error>.success(()))
-
-                case .enqueueCallback(let callbackToken):
-                    self.enqueueCallback(callbackToken: callbackToken, onProduceMore: onProduceMore)
-                }
-            } catch {
-                onProduceMore(.failure(error))
-            }
-        }
-
-        /// Writes the element to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// provided element. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
-        /// a `Result.failure`.
-        ///
-        /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
-        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
-        ///   invoked during the call to ``write(_:onProduceMore:)``.
-        @available(SwiftStdlib 9999, *)
-        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            self.write(contentsOf: CollectionOfOne(element), onProduceMore: onProduceMore)
-        }
-
-        /// Write new elements to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// This method returns once more elements should be produced.
-        ///
-        /// - Parameters:
-        ///   - sequence: The elements to write to the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
-            let writeResult = try { try self.write(contentsOf: sequence) }()
-
-            switch writeResult {
-            case .produceMore:
-                return
-
-            case .enqueueCallback(let callbackToken):
-                try await withTaskCancellationHandler {
-                    try await withCheckedThrowingContinuation { continuation in
-                        self.enqueueCallback(callbackToken: callbackToken, onProduceMore: { result in
-                            switch result {
-                            case .success():
-                                continuation.resume(returning: ())
-                            case .failure(let error):
-                                continuation.resume(throwing: error)
-                            }
-                        })
-                    }
-                } onCancel: {
-                    self.cancelCallback(callbackToken: callbackToken)
-                }
-            }
-        }
-
-        /// Write new element to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// provided element. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// This method returns once more elements should be produced.
-        ///
-        /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public func write(_ element: Element) async throws {
-            try await self.write(contentsOf: CollectionOfOne(element))
-        }
-
-        /// Write the elements of the asynchronous sequence to the asynchronous stream.
-        ///
-        /// This method returns once the provided asynchronous sequence or the  the asynchronous stream finished.
-        ///
-        /// - Important: This method does not finish the source if consuming the upstream sequence terminated.
-        ///
-        /// - Parameters:
-        ///   - sequence: The elements to write to the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
-            for try await element in sequence {
-                try await self.write(contentsOf: CollectionOfOne(element))
-            }
-        }
-
-        /// Indicates that the production terminated.
-        ///
-        /// After all buffered elements are consumed the next iteration point will return `nil`.
-        ///
-        /// Calling this function more than once has no effect. After calling finish, the stream enters a terminal state and doesn't accept
-        /// new elements.
-        @available(SwiftStdlib 9999, *)
-        public func finish() {
-            self._backing.storage.finish(nil)
-        }
+      fileprivate let _internalBackpressureStrategy: _InternalBackpressureStrategy
     }
 
-    /// Initializes a new ``AsyncStream`` and an ``AsyncStream/Source``.
+    /// A type that indicates the result of writing elements to the source.
+    @available(SwiftStdlib 9999, *)
+    @frozen
+    public enum WriteResult: Sendable {
+      /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
+      /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.
+      public struct CallbackToken: Sendable {
+        let id: UInt64
+      }
+
+      /// Indicates that more elements should be produced and written to the source.
+      case produceMore
+
+      /// Indicates that a callback should be enqueued.
+      ///
+      /// The associated token should be passed to the ``enqueueCallback(_:)`` method.
+      case enqueueCallback(CallbackToken)
+    }
+
+    /// Backing class for the source used to hook a deinit.
+    final class _Backing: Sendable {
+      let storage: _BackpressuredStorage<Element, Never>
+
+      init(storage: _BackpressuredStorage<Element, Never>) {
+        self.storage = storage
+      }
+
+      deinit {
+        self.storage.sourceDeinitialized()
+      }
+    }
+
+    /// A callback to invoke when the stream finished.
+    ///
+    /// The stream finishes and calls this closure in the following cases:
+    /// - No iterator was created and the sequence was deinited
+    /// - An iterator was created and deinited
+    /// - After ``finish(throwing:)`` was called and all elements have been consumed
+    /// - The consuming task got cancelled
+    /// 
+    /// - Important: This callback is invoked exactly once when set before the stream is finished.
+    /// If set after the stream is finished the callback will be not set at all.
+    @available(SwiftStdlib 9999, *)
+    public var onTermination: (@Sendable () -> Void)? {
+      set {
+        self._backing.storage.onTermination = newValue
+      }
+      get {
+        self._backing.storage.onTermination
+      }
+    }
+
+    private var _backing: _Backing
+
+    internal init(storage: _BackpressuredStorage<Element, Never>) {
+      self._backing = .init(storage: storage)
+    }
+
+    /// Writes new elements to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// - Parameter sequence: The elements to write to the asynchronous stream.
+    /// - Returns: The result that indicates if more elements should be produced at this time.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+      let id = try self._backing.storage.write(contentsOf: sequence)
+
+      if let id {
+        return .enqueueCallback(.init(id: id))
+      } else {
+        return .produceMore
+      }
+    }
+
+    /// Write the element to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// provided element. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// - Parameter element: The element to write to the asynchronous stream.
+    /// - Returns: The result that indicates if more elements should be produced at this time.
+    @available(SwiftStdlib 9999, *)
+    public func write(_ element: Element) throws -> WriteResult {
+      let id = try self._backing.storage.write(contentsOf: CollectionOfOne(element))
+
+      if let id {
+        return .enqueueCallback(.init(id: id))
+      } else {
+        return .produceMore
+      }
+    }
+
+    /// Enqueues a callback that will be invoked once more elements should be produced.
+    ///
+    /// Call this method after ``write(contentsOf:)`` or ``write(:)`` returned ``WriteResult/enqueueCallback(_:)``.
+    ///
+    /// - Important: Enqueueing the same token multiple times is not allowed.
     ///
     /// - Parameters:
-    ///   - elementType: The element type of the stream.
-    ///   - backPressureStrategy: The backpressure strategy that the stream should use.
-    /// - Returns: A tuple containing the stream and its source. The source should be passed to the
-    ///   producer while the stream should be passed to the consumer.
+    ///   - token: The callback token.
+    ///   - onProduceMore: The callback which gets invoked once more elements should be produced.
     @available(SwiftStdlib 9999, *)
-    public static func makeStream(
-        of elementType: Element.Type = Element.self,
-        backPressureStrategy: Source.BackPressureStrategy
-    ) -> (`Self`, Source) {
-        let storage = _BackPressuredStorage<Element, Never>(
-            backPressureStrategy: backPressureStrategy._internalBackPressureStrategy
-        )
-        let source = Source(storage: storage)
-
-        return (.init(storage: storage), source)
+    public func enqueueCallback(token: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      self._backing.storage.enqueueProducer(callbackToken: token.id, onProduceMore: onProduceMore)
     }
 
-    init(storage: _BackPressuredStorage<Element, Never>) {
-        self._implementation = .backpressured(.init(storage: storage))
+    /// Cancel an enqueued callback.
+    ///
+    /// Call this method to cancel a callback enqueued by the ``enqueueCallback(token:onProduceMore:)`` method.
+    ///
+    /// - Note: This methods supports being called before ``enqueueCallback(token:onProduceMore:)`` is called and
+    /// will mark the passed `token` as cancelled.
+    ///
+    /// - Parameter token: The callback token.
+    @available(SwiftStdlib 9999, *)
+    public func cancelCallback(token: WriteResult.CallbackToken) {
+      self._backing.storage.cancelProducer(callbackToken: token.id)
     }
+
+    /// Write new elements to the asynchronous stream and provide a callback which will be invoked once more elements should be produced.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// first element of the provided sequence. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+    /// a `Result.failure`.
+    ///
+    /// - Parameters:
+    ///   - sequence: The elements to write to the asynchronous stream.
+    ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+    ///   invoked during the call to ``write(contentsOf:onProduceMore:)``.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+      do {
+        let writeResult = try self.write(contentsOf: sequence)
+
+        switch writeResult {
+        case .produceMore:
+          onProduceMore(Result<Void, Error>.success(()))
+
+        case .enqueueCallback(let callbackToken):
+          self.enqueueCallback(token: callbackToken, onProduceMore: onProduceMore)
+        }
+      } catch {
+        onProduceMore(.failure(error))
+      }
+    }
+
+    /// Writes the element to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// provided element. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+    /// a `Result.failure`.
+    ///
+    /// - Parameters:
+    ///   - sequence: The element to write to the asynchronous stream.
+    ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+    ///   invoked during the call to ``write(_:onProduceMore:)``.
+    @available(SwiftStdlib 9999, *)
+    public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      self.write(contentsOf: CollectionOfOne(element), onProduceMore: onProduceMore)
+    }
+
+    /// Write new elements to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// This method returns once more elements should be produced.
+    ///
+    /// - Parameters:
+    ///   - sequence: The elements to write to the asynchronous stream.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+      let writeResult = try { try self.write(contentsOf: sequence) }()
+
+      switch writeResult {
+      case .produceMore:
+        return
+
+      case .enqueueCallback(let callbackToken):
+        try await withTaskCancellationHandler {
+          try await withCheckedThrowingContinuation { continuation in
+            self.enqueueCallback(token: callbackToken, onProduceMore: { result in
+              switch result {
+              case .success():
+                continuation.resume(returning: ())
+              case .failure(let error):
+                continuation.resume(throwing: error)
+              }
+            })
+          }
+        } onCancel: {
+          self.cancelCallback(token: callbackToken)
+        }
+      }
+    }
+
+    /// Write new element to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// provided element. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// This method returns once more elements should be produced.
+    ///
+    /// - Parameters:
+    ///   - sequence: The element to write to the asynchronous stream.
+    @available(SwiftStdlib 9999, *)
+    public func write(_ element: Element) async throws {
+      try await self.write(contentsOf: CollectionOfOne(element))
+    }
+
+    /// Write the elements of the asynchronous sequence to the asynchronous stream.
+    ///
+    /// This method returns once the provided asynchronous sequence or the  the asynchronous stream finished.
+    ///
+    /// - Important: This method does not finish the source if consuming the upstream sequence terminated.
+    ///
+    /// - Parameters:
+    ///   - sequence: The elements to write to the asynchronous stream.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+      for try await element in sequence {
+        try await self.write(contentsOf: CollectionOfOne(element))
+      }
+    }
+
+    /// Indicates that the production terminated.
+    ///
+    /// After all buffered elements are consumed the next iteration point will return `nil`.
+    ///
+    /// Calling this function more than once has no effect. After calling finish, the stream enters a terminal state and doesn't accept
+    /// new elements.
+    @available(SwiftStdlib 9999, *)
+    public func finish() {
+      self._backing.storage.finish(nil)
+    }
+  }
+
+  /// Initializes a new ``AsyncStream`` and an ``AsyncStream/Source``.
+  ///
+  /// - Parameters:
+  ///   - elementType: The element type of the stream.
+  ///   - backpressureStrategy: The backpressure strategy that the stream should use.
+  /// - Returns: A tuple containing the stream and its source. The source should be passed to the
+  ///   producer while the stream should be passed to the consumer.
+  @available(SwiftStdlib 9999, *)
+  public static func makeStream(
+    of elementType: Element.Type = Element.self,
+    backpressureStrategy: Source.BackpressureStrategy
+  ) -> (`Self`, Source) {
+    let storage = _BackpressuredStorage<Element, Never>(
+      backpressureStrategy: backpressureStrategy._internalBackpressureStrategy
+    )
+    let source = Source(storage: storage)
+
+    return (.init(storage: storage), source)
+  }
+
+  init(storage: _BackpressuredStorage<Element, Never>) {
+    self._implementation = .backpressured(.init(storage: storage))
+  }
 }
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream {
-    /// A mechanism to interface between producer code and an asynchronous stream.
-    ///
-    /// Use this source to provide elements to the stream by calling one of the `write` methods, then terminate the stream normally
-    /// by calling the `finish()` method. You can also use the source's `finish(throwing:)` method to terminate the stream by
-    /// throwing an error.
+  /// A mechanism to interface between producer code and an asynchronous stream.
+  ///
+  /// Use this source to provide elements to the stream by calling one of the `write` methods, then terminate the stream normally
+  /// by calling the `finish()` method. You can also use the source's `finish(throwing:)` method to terminate the stream by
+  /// throwing an error.
+  @available(SwiftStdlib 9999, *)
+  public struct Source: Sendable {
+    /// A strategy that handles the backpressure of the asynchronous stream.
     @available(SwiftStdlib 9999, *)
-    public struct Source: Sendable {
-        /// A strategy that handles the backpressure of the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public struct BackPressureStrategy: Sendable {
-            /// When the high watermark is reached producers will be suspended. All producers will be resumed again once
-            /// the low watermark is reached.
-            @available(SwiftStdlib 9999, *)
-            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
-                BackPressureStrategy(internalBackPressureStrategy: .watermark(.init(low: low, high: high)))
-            }
+    public struct BackpressureStrategy: Sendable {
+      /// When the high watermark is reached producers will be suspended. All producers will be resumed again once
+      /// the low watermark is reached.
+      @available(SwiftStdlib 9999, *)
+      public static func watermark(low: Int, high: Int) -> BackpressureStrategy {
+        BackpressureStrategy(internalBackpressureStrategy: .watermark(.init(low: low, high: high)))
+      }
 
-            private init(internalBackPressureStrategy: _InternalBackPressureStrategy) {
-                self._internalBackPressureStrategy = internalBackPressureStrategy
-            }
+      private init(internalBackpressureStrategy: _InternalBackpressureStrategy) {
+        self._internalBackpressureStrategy = internalBackpressureStrategy
+      }
 
-            fileprivate let _internalBackPressureStrategy: _InternalBackPressureStrategy
-        }
-
-        /// A type that indicates the result of writing elements to the source.
-        @available(SwiftStdlib 9999, *)
-        @frozen
-        public enum WriteResult: Sendable {
-            /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
-            /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.
-            public struct CallbackToken: Sendable {
-                let id: UInt
-            }
-
-            /// Indicates that more elements should be produced and written to the source.
-            case produceMore
-
-            /// Indicates that a callback should be enqueued.
-            ///
-            /// The associated token should be passed to the ``enqueueCallback(_:)`` method.
-            case enqueueCallback(CallbackToken)
-        }
-
-        /// Backing class for the source used to hook a deinit.
-        final class _Backing: Sendable {
-            let storage: _BackPressuredStorage<Element, Failure>
-
-            init(storage: _BackPressuredStorage<Element, Failure>) {
-                self.storage = storage
-            }
-
-            deinit {
-                self.storage.sourceDeinitialized()
-            }
-        }
-
-        /// A callback to invoke when the stream finished.
-        ///
-        /// The stream finishes and calls this closure in the following cases:
-        /// - No iterator was created and the sequence was deinited
-        /// - An iterator was created and deinited
-        /// - After ``finish(throwing:)`` was called and all elements have been consumed
-        /// - The consuming task got cancelled
-        @available(SwiftStdlib 9999, *)
-        public var onTermination: (@Sendable () -> Void)? {
-            set {
-                self._backing.storage.onTermination = newValue
-            }
-            get {
-                self._backing.storage.onTermination
-            }
-        }
-
-        private var _backing: _Backing
-
-        internal init(storage: _BackPressuredStorage<Element, Failure>) {
-            self._backing = .init(storage: storage)
-        }
-
-        /// Writes new elements to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// - Parameter sequence: The elements to write to the asynchronous stream.
-        /// - Returns: The result that indicates if more elements should be produced at this time.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
-            let id = try self._backing.storage.write(contentsOf: sequence)
-
-            if let id {
-                return .enqueueCallback(.init(id: id))
-            } else {
-                return .produceMore
-            }
-        }
-
-        /// Write the element to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// provided element. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// - Parameter element: The element to write to the asynchronous stream.
-        /// - Returns: The result that indicates if more elements should be produced at this time.
-        @available(SwiftStdlib 9999, *)
-        public func write(_ element: Element) throws -> WriteResult {
-            let id = try self._backing.storage.write(contentsOf: CollectionOfOne(element))
-
-            if let id {
-                return .enqueueCallback(.init(id: id))
-            } else {
-                return .produceMore
-            }
-        }
-
-        /// Enqueues a callback that will be invoked once more elements should be produced.
-        ///
-        /// Call this method after ``write(contentsOf:)`` or ``write(:)`` returned ``WriteResult/enqueueCallback(_:)``.
-        ///
-        /// - Important: Enqueueing the same token multiple times is not allowed.
-        ///
-        /// - Parameters:
-        ///   - callbackToken: The callback token.
-        ///   - onProduceMore: The callback which gets invoked once more elements should be produced.
-        @available(SwiftStdlib 9999, *)
-        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            self._backing.storage.enqueueProducer(callbackToken: callbackToken.id, onProduceMore: onProduceMore)
-        }
-
-        /// Cancel an enqueued callback.
-        ///
-        /// Call this method to cancel a callback enqueued by the ``enqueueCallback(callbackToken:onProduceMore:)`` method.
-        ///
-        /// - Note: This methods supports being called before ``enqueueCallback(callbackToken:onProduceMore:)`` is called and
-        /// will mark the passed `callbackToken` as cancelled.
-        ///
-        /// - Parameter callbackToken: The callback token.
-        @available(SwiftStdlib 9999, *)
-        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
-            self._backing.storage.cancelProducer(callbackToken: callbackToken.id)
-        }
-
-        /// Write new elements to the asynchronous stream and provide a callback which will be invoked once more elements should be produced.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// first element of the provided sequence. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
-        /// a `Result.failure`.
-        ///
-        /// - Parameters:
-        ///   - sequence: The elements to write to the asynchronous stream.
-        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
-        ///   invoked during the call to ``write(contentsOf:onProduceMore:)``.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
-            do {
-                let writeResult = try self.write(contentsOf: sequence)
-
-                switch writeResult {
-                case .produceMore:
-                    onProduceMore(Result<Void, Error>.success(()))
-
-                case .enqueueCallback(let callbackToken):
-                    self.enqueueCallback(callbackToken: callbackToken, onProduceMore: onProduceMore)
-                }
-            } catch {
-                onProduceMore(.failure(error))
-            }
-        }
-
-        /// Writes the element to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// provided element. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
-        /// a `Result.failure`.
-        ///
-        /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
-        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
-        ///   invoked during the call to ``write(_:onProduceMore:)``.
-        @available(SwiftStdlib 9999, *)
-        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            self.write(contentsOf: CollectionOfOne(element), onProduceMore: onProduceMore)
-        }
-
-        /// Write new elements to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// This method returns once more elements should be produced.
-        ///
-        /// - Parameters:
-        ///   - sequence: The elements to write to the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
-            let writeResult = try { try self.write(contentsOf: sequence) }()
-
-            switch writeResult {
-            case .produceMore:
-                return
-
-            case .enqueueCallback(let callbackToken):
-                try await withTaskCancellationHandler {
-                    try await withCheckedThrowingContinuation { continuation in
-                        self.enqueueCallback(callbackToken: callbackToken, onProduceMore: { result in
-                            switch result {
-                            case .success():
-                                continuation.resume(returning: ())
-                            case .failure(let error):
-                                continuation.resume(throwing: error)
-                            }
-                        })
-                    }
-                } onCancel: {
-                    self.cancelCallback(callbackToken: callbackToken)
-                }
-            }
-        }
-
-        /// Write new element to the asynchronous stream.
-        ///
-        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
-        /// provided element. If the asynchronous stream already terminated then this method will throw an error
-        /// indicating the failure.
-        ///
-        /// This method returns once more elements should be produced.
-        ///
-        /// - Parameters:
-        ///   - sequence: The element to write to the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public func write(_ element: Element) async throws {
-            try await self.write(contentsOf: CollectionOfOne(element))
-        }
-
-        /// Write the elements of the asynchronous sequence to the asynchronous stream.
-        ///
-        /// This method returns once the provided asynchronous sequence or the  the asynchronous stream finished.
-        ///
-        /// - Important: This method does not finish the source if consuming the upstream sequence terminated.
-        ///
-        /// - Parameters:
-        ///   - sequence: The elements to write to the asynchronous stream.
-        @available(SwiftStdlib 9999, *)
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
-            for try await element in sequence {
-                try await self.write(contentsOf: CollectionOfOne(element))
-            }
-        }
-
-        /// Indicates that the production terminated.
-        ///
-        /// After all buffered elements are consumed the next iteration point will return `nil` or throw an error.
-        ///
-        /// Calling this function more than once has no effect. After calling finish, the stream enters a terminal state and doesn't accept
-        /// new elements.
-        ///
-        /// - Parameters:
-        ///   - error: The error to throw, or `nil`, to finish normally.
-        @available(SwiftStdlib 9999, *)
-        public func finish(throwing error: Failure?) {
-            self._backing.storage.finish(error)
-        }
+      fileprivate let _internalBackpressureStrategy: _InternalBackpressureStrategy
     }
 
-    /// Initializes a new ``AsyncThrowingStream`` and an ``AsyncThrowingStream/Source``.
+    /// A type that indicates the result of writing elements to the source.
+    @available(SwiftStdlib 9999, *)
+    @frozen
+    public enum WriteResult: Sendable {
+      /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
+      /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.
+      public struct CallbackToken: Sendable {
+        let id: UInt64
+      }
+
+      /// Indicates that more elements should be produced and written to the source.
+      case produceMore
+
+      /// Indicates that a callback should be enqueued.
+      ///
+      /// The associated token should be passed to the ``enqueueCallback(_:)`` method.
+      case enqueueCallback(CallbackToken)
+    }
+
+    /// Backing class for the source used to hook a deinit.
+    final class _Backing: Sendable {
+      let storage: _BackpressuredStorage<Element, Failure>
+
+      init(storage: _BackpressuredStorage<Element, Failure>) {
+        self.storage = storage
+      }
+
+      deinit {
+        self.storage.sourceDeinitialized()
+      }
+    }
+
+    /// A callback to invoke when the stream finished.
+    ///
+    /// The stream finishes and calls this closure in the following cases:
+    /// - No iterator was created and the sequence was deinited
+    /// - An iterator was created and deinited
+    /// - After ``finish(throwing:)`` was called and all elements have been consumed
+    /// - The consuming task got cancelled
+    /// 
+    /// - Important: This callback is invoked exactly once when set before the stream is finished.
+    /// If set after the stream is finished the callback will be not set at all.
+    @available(SwiftStdlib 9999, *)
+    public var onTermination: (@Sendable () -> Void)? {
+      set {
+        self._backing.storage.onTermination = newValue
+      }
+      get {
+        self._backing.storage.onTermination
+      }
+    }
+
+    private var _backing: _Backing
+
+    internal init(storage: _BackpressuredStorage<Element, Failure>) {
+      self._backing = .init(storage: storage)
+    }
+
+    /// Writes new elements to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// - Parameter sequence: The elements to write to the asynchronous stream.
+    /// - Returns: The result that indicates if more elements should be produced at this time.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+      let id = try self._backing.storage.write(contentsOf: sequence)
+
+      if let id {
+        return .enqueueCallback(.init(id: id))
+      } else {
+        return .produceMore
+      }
+    }
+
+    /// Write the element to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// provided element. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// - Parameter element: The element to write to the asynchronous stream.
+    /// - Returns: The result that indicates if more elements should be produced at this time.
+    @available(SwiftStdlib 9999, *)
+    public func write(_ element: Element) throws -> WriteResult {
+      let id = try self._backing.storage.write(contentsOf: CollectionOfOne(element))
+
+      if let id {
+        return .enqueueCallback(.init(id: id))
+      } else {
+        return .produceMore
+      }
+    }
+
+    /// Enqueues a callback that will be invoked once more elements should be produced.
+    ///
+    /// Call this method after ``write(contentsOf:)`` or ``write(:)`` returned ``WriteResult/enqueueCallback(_:)``.
+    ///
+    /// - Important: Enqueueing the same token multiple times is not allowed.
     ///
     /// - Parameters:
-    ///   - elementType: The element type of the stream.
-    ///   - failureType: The failure type of the stream.
-    ///   - backPressureStrategy: The backpressure strategy that the stream should use.
-    /// - Returns: A tuple containing the stream and its source. The source should be passed to the
-    ///   producer while the stream should be passed to the consumer.
+    ///   - token: The callback token.
+    ///   - onProduceMore: The callback which gets invoked once more elements should be produced.
     @available(SwiftStdlib 9999, *)
-    public static func makeStream(
-        of elementType: Element.Type = Element.self,
-        throwing failureType: Failure.Type = Failure.self,
-        backPressureStrategy: Source.BackPressureStrategy
-    ) -> (`Self`, Source) where Failure == Error {
-        let storage = _BackPressuredStorage<Element, Failure>(
-            backPressureStrategy: backPressureStrategy._internalBackPressureStrategy
-        )
-        let source = Source(storage: storage)
-
-        return (.init(storage: storage), source)
+    public func enqueueCallback(token: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      self._backing.storage.enqueueProducer(callbackToken: token.id, onProduceMore: onProduceMore)
     }
 
-    init(storage: _BackPressuredStorage<Element, Failure>) {
-        self._implementation = .backpressured(.init(storage: storage))
+    /// Cancel an enqueued callback.
+    ///
+    /// Call this method to cancel a callback enqueued by the ``enqueueCallback(token:onProduceMore:)`` method.
+    ///
+    /// - Note: This methods supports being called before ``enqueueCallback(token:onProduceMore:)`` is called and
+    /// will mark the passed `callbackToken` as cancelled.
+    ///
+    /// - Parameter callbackToken: The callback token.
+    @available(SwiftStdlib 9999, *)
+    public func cancelCallback(token: WriteResult.CallbackToken) {
+      self._backing.storage.cancelProducer(callbackToken: token.id)
     }
-}
 
-struct _WatermarkBackPressureStrategy {
-    /// The low watermark where demand should start.
-    private let _low: Int
-    /// The high watermark where demand should be stopped.
-    private let _high: Int
-
-    /// Initializes a new ``_WatermarkBackPressureStrategy``.
+    /// Write new elements to the asynchronous stream and provide a callback which will be invoked once more elements should be produced.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// first element of the provided sequence. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+    /// a `Result.failure`.
     ///
     /// - Parameters:
-    ///   - low: The low watermark where demand should start.
-    ///   - high: The high watermark where demand should be stopped.
-    init(low: Int, high: Int) {
-        precondition(low <= high)
-        self._low = low
-        self._high = high
+    ///   - sequence: The elements to write to the asynchronous stream.
+    ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+    ///   invoked during the call to ``write(contentsOf:onProduceMore:)``.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+      do {
+        let writeResult = try self.write(contentsOf: sequence)
+
+        switch writeResult {
+        case .produceMore:
+          onProduceMore(Result<Void, Error>.success(()))
+
+        case .enqueueCallback(let callbackToken):
+          self.enqueueCallback(token: callbackToken, onProduceMore: onProduceMore)
+        }
+      } catch {
+        onProduceMore(.failure(error))
+      }
     }
 
-    func didYield(bufferDepth: Int) -> Bool {
-        // We are demanding more until we reach the high watermark
-        return bufferDepth < self._high
+    /// Writes the element to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// provided element. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+    /// a `Result.failure`.
+    ///
+    /// - Parameters:
+    ///   - sequence: The element to write to the asynchronous stream.
+    ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+    ///   invoked during the call to ``write(_:onProduceMore:)``.
+    @available(SwiftStdlib 9999, *)
+    public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      self.write(contentsOf: CollectionOfOne(element), onProduceMore: onProduceMore)
     }
 
-    func didConsume(bufferDepth: Int) -> Bool {
-        // We start demanding again once we are below the low watermark
-        return bufferDepth < self._low
+    /// Write new elements to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// This method returns once more elements should be produced.
+    ///
+    /// - Parameters:
+    ///   - sequence: The elements to write to the asynchronous stream.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+      let writeResult = try { try self.write(contentsOf: sequence) }()
+
+      switch writeResult {
+      case .produceMore:
+        return
+
+      case .enqueueCallback(let callbackToken):
+        try await withTaskCancellationHandler {
+          try await withCheckedThrowingContinuation { continuation in
+            self.enqueueCallback(token: callbackToken, onProduceMore: { result in
+              switch result {
+              case .success():
+                continuation.resume(returning: ())
+              case .failure(let error):
+                continuation.resume(throwing: error)
+              }
+            })
+          }
+        } onCancel: {
+          self.cancelCallback(token: callbackToken)
+        }
+      }
     }
+
+    /// Write new element to the asynchronous stream.
+    ///
+    /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+    /// provided element. If the asynchronous stream already terminated then this method will throw an error
+    /// indicating the failure.
+    ///
+    /// This method returns once more elements should be produced.
+    ///
+    /// - Parameters:
+    ///   - sequence: The element to write to the asynchronous stream.
+    @available(SwiftStdlib 9999, *)
+    public func write(_ element: Element) async throws {
+      try await self.write(contentsOf: CollectionOfOne(element))
+    }
+
+    /// Write the elements of the asynchronous sequence to the asynchronous stream.
+    ///
+    /// This method returns once the provided asynchronous sequence or the  the asynchronous stream finished.
+    ///
+    /// - Important: This method does not finish the source if consuming the upstream sequence terminated.
+    ///
+    /// - Parameters:
+    ///   - sequence: The elements to write to the asynchronous stream.
+    @available(SwiftStdlib 9999, *)
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+      for try await element in sequence {
+        try await self.write(contentsOf: CollectionOfOne(element))
+      }
+    }
+
+    /// Indicates that the production terminated.
+    ///
+    /// After all buffered elements are consumed the next iteration point will return `nil` or throw an error.
+    ///
+    /// Calling this function more than once has no effect. After calling finish, the stream enters a terminal state and doesn't accept
+    /// new elements.
+    ///
+    /// - Parameters:
+    ///   - error: The error to throw, or `nil`, to finish normally.
+    @available(SwiftStdlib 9999, *)
+    public func finish(throwing error: Failure?) {
+      self._backing.storage.finish(error)
+    }
+  }
+
+  /// Initializes a new ``AsyncThrowingStream`` and an ``AsyncThrowingStream/Source``.
+  ///
+  /// - Parameters:
+  ///   - elementType: The element type of the stream.
+  ///   - backpressureStrategy: The backpressure strategy that the stream should use.
+  /// - Returns: A tuple containing the stream and its source. The source should be passed to the
+  ///   producer while the stream should be passed to the consumer.
+  @available(SwiftStdlib 9999, *)
+  public static func makeStream(
+    of elementType: Element.Type = Element.self,
+    backpressureStrategy: Source.BackpressureStrategy
+  ) -> (`Self`, Source) where Failure == Error {
+    let storage = _BackpressuredStorage<Element, Failure>(
+      backpressureStrategy: backpressureStrategy._internalBackpressureStrategy
+    )
+    let source = Source(storage: storage)
+
+    return (.init(storage: storage), source)
+  }
+
+  init(storage: _BackpressuredStorage<Element, Failure>) {
+    self._implementation = .backpressured(.init(storage: storage))
+  }
 }
 
-@available(SwiftStdlib 5.1, *)
-enum _InternalBackPressureStrategy {
-    case watermark(_WatermarkBackPressureStrategy)
+struct _WatermarkBackpressureStrategy {
+  /// The low watermark where demand should start.
+  private let _low: Int
+  /// The high watermark where demand should be stopped.
+  private let _high: Int
 
-    mutating func didYield(bufferDepth: Int) -> Bool {
-        switch self {
-        case .watermark(let strategy):
-            return strategy.didYield(bufferDepth: bufferDepth)
-        }
-    }
+  /// Initializes a new ``_WatermarkBackpressureStrategy``.
+  ///
+  /// - Parameters:
+  ///   - low: The low watermark where demand should start.
+  ///   - high: The high watermark where demand should be stopped.
+  init(low: Int, high: Int) {
+    precondition(low <= high)
+    precondition(low >= 0)
+    self._low = low
+    self._high = high
+  }
 
-    mutating func didConsume(bufferDepth: Int) -> Bool {
-        switch self {
-        case .watermark(let strategy):
-            return strategy.didConsume(bufferDepth: bufferDepth)
-        }
+  func didYield(bufferDepth: Int) -> Bool {
+    // We are demanding more until we reach the high watermark
+    return bufferDepth < self._high
+  }
+
+  func didConsume(bufferDepth: Int) -> Bool {
+    // We start demanding again once we are below the low watermark
+    return bufferDepth < self._low
+  }
+}
+
+enum _InternalBackpressureStrategy {
+  case watermark(_WatermarkBackpressureStrategy)
+
+  mutating func didYield(bufferDepth: Int) -> Bool {
+    switch self {
+    case .watermark(let strategy):
+      return strategy.didYield(bufferDepth: bufferDepth)
     }
+  }
+
+  mutating func didConsume(bufferDepth: Int) -> Bool {
+    switch self {
+    case .watermark(let strategy):
+      return strategy.didConsume(bufferDepth: bufferDepth)
+    }
+  }
 }
 
 // We are unchecked Sendable since we are protecting our state with a lock.
 @available(SwiftStdlib 5.1, *)
-final class _BackPressuredStorage<Element, Failure: Error>: @unchecked Sendable {
-    /// The state machine
-    var _stateMachine: _ManagedCriticalState<_StateMachine<Element, Failure>>
+final class _BackpressuredStorage<Element, Failure: Error>: @unchecked Sendable {
+  /// The state machine
+  var _stateMachine: _ManagedCriticalState<_StateMachine<Element, Failure>>
 
-    var onTermination: (@Sendable () -> Void)? {
-        set {
-            self._stateMachine.withCriticalRegion {
-                $0._onTermination = newValue
-            }
-        }
-        get {
-            self._stateMachine.withCriticalRegion {
-                $0._onTermination
-            }
-        }
+  var onTermination: (@Sendable () -> Void)? {
+    set {
+      self._stateMachine.withCriticalRegion {
+        $0._onTermination = newValue
+      }
+    }
+    get {
+      self._stateMachine.withCriticalRegion {
+        $0._onTermination
+      }
+    }
+  }
+
+  init(
+    backpressureStrategy: _InternalBackpressureStrategy
+  ) {
+    self._stateMachine = .init(.init(backpressureStrategy: backpressureStrategy))
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func sequenceDeinitialized() {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.sequenceDeinitialized()
     }
 
-    init(
-        backPressureStrategy: _InternalBackPressureStrategy
-    ) {
-        self._stateMachine = .init(.init(backPressureStrategy: backPressureStrategy))
+    switch action {
+    case .callOnTermination(let onTermination):
+      onTermination?()
+
+    case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+      for producerContinuation in producerContinuations {
+        producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+      }
+      onTermination?()
+
+    case .none:
+      break
+    }
+  }
+
+  func iteratorInitialized() {
+    self._stateMachine.withCriticalRegion {
+      $0.iteratorInitialized()
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func iteratorDeinitialized() {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.iteratorDeinitialized()
     }
 
-    @available(SwiftStdlib 9999, *)
-    func sequenceDeinitialized() {
+    switch action {
+    case .callOnTermination(let onTermination):
+      onTermination?()
+
+    case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+      for producerContinuation in producerContinuations {
+        producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+      }
+      onTermination?()
+
+    case .none:
+      break
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func sourceDeinitialized() {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.sourceDeinitialized()
+    }
+
+    switch action {
+    case .callOnTermination(let onTermination):
+      onTermination?()
+
+    case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+      for producerContinuation in producerContinuations {
+        producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+      }
+      onTermination?()
+
+    case .failProducers(let producerContinuations):
+      for producerContinuation in producerContinuations {
+        producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+      }
+
+    case .none:
+      break
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func write(
+    contentsOf sequence: some Sequence<Element>
+  ) throws -> UInt64? {
+    let action = self._stateMachine.withCriticalRegion {
+      return $0.write(sequence)
+    }
+
+    switch action {
+    case .returnProduceMore:
+      return nil
+
+    case .returnEnqueue(let callbackToken):
+      return callbackToken
+
+    case .resumeConsumerAndReturnProduceMore(let continuation, let element):
+      continuation.resume(returning: element)
+      return nil
+
+    case .resumeConsumerAndReturnEnqueue(let continuation, let element, let callbackToken):
+      continuation.resume(returning: element)
+      return callbackToken
+
+    case .throwFinishedError:
+      throw AsyncStreamAlreadyFinishedError()
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func enqueueProducer(callbackToken: UInt64, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.enqueueProducer(callbackToken: callbackToken, onProduceMore: onProduceMore)
+    }
+
+    switch action {
+    case .resumeProducer(let onProduceMore):
+      onProduceMore(Result<Void, Error>.success(()))
+
+    case .resumeProducerWithError(let onProduceMore, let error):
+      onProduceMore(Result<Void, Error>.failure(error))
+
+    case .none:
+      break
+    }
+  }
+
+  func cancelProducer(callbackToken: UInt64) {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.cancelProducer(callbackToken: callbackToken)
+    }
+
+    switch action {
+    case .resumeProducerWithCancellationError(let onProduceMore):
+      onProduceMore(Result<Void, Error>.failure(CancellationError()))
+
+    case .none:
+      break
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func finish(_ failure: Failure?) {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.finish(failure)
+    }
+
+    switch action {
+    case .callOnTermination(let onTermination):
+      onTermination?()
+
+    case .resumeConsumerAndCallOnTermination(let consumerContinuation, let failure, let onTermination):
+      switch failure {
+      case .some(let error):
+        consumerContinuation.resume(throwing: error)
+      case .none:
+        consumerContinuation.resume(returning: nil)
+      }
+
+      onTermination?()
+
+    case .resumeProducers(let producerContinuations):
+      for producerContinuation in producerContinuations {
+        producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+      }
+
+    case .none:
+      break
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func next() async throws -> Element? {
+    let action = self._stateMachine.withCriticalRegion {
+      $0.next()
+    }
+
+    switch action {
+    case .returnElement(let element):
+      return element
+
+    case .returnElementAndResumeProducers(let element, let producerContinuations):
+      for producerContinuation in producerContinuations {
+        producerContinuation(Result<Void, Error>.success(()))
+      }
+
+      return element
+
+    case .returnFailureAndCallOnTermination(let failure, let onTermination):
+      onTermination?()
+      switch failure {
+      case .some(let error):
+        throw error
+
+      case .none:
+        return nil
+      }
+
+    case .returnNil:
+      return nil
+
+    case .suspendTask:
+      return try await self.suspendNext()
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  func suspendNext() async throws -> Element? {
+    return try await withTaskCancellationHandler {
+      return try await withCheckedThrowingContinuation { continuation in
         let action = self._stateMachine.withCriticalRegion {
-            $0.sequenceDeinitialized()
+          $0.suspendNext(continuation: continuation)
         }
 
         switch action {
-        case .callOnTermination(let onTermination):
-            onTermination?()
+        case .resumeConsumerWithElement(let continuation, let element):
+          continuation.resume(returning: element)
 
-        case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
-            for producerContinuation in producerContinuations {
-                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
-            }
-            onTermination?()
+        case .resumeConsumerWithElementAndProducers(let continuation, let element, let producerContinuations):
+          continuation.resume(returning: element)
+          for producerContinuation in producerContinuations {
+            producerContinuation(Result<Void, Error>.success(()))
+          }
+
+        case .resumeConsumerWithFailureAndCallOnTermination(let continuation, let failure, let onTermination):
+          switch failure {
+          case .some(let error):
+            continuation.resume(throwing: error)
+
+          case .none:
+            continuation.resume(returning: nil)
+          }
+          onTermination?()
+
+        case .resumeConsumerWithNil(let continuation):
+          continuation.resume(returning: nil)
 
         case .none:
-            break
+          break
         }
+      }
+    } onCancel: {
+      let action = self._stateMachine.withCriticalRegion {
+        $0.cancelNext()
+      }
+
+      switch action {
+      case .resumeConsumerWithCancellationErrorAndCallOnTermination(let continuation, let onTermination):
+        continuation.resume(throwing: CancellationError())
+        onTermination?()
+
+      case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+        for producerContinuation in producerContinuations {
+          producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+        }
+        onTermination?()
+
+      case .none:
+        break
+      }
     }
-
-    func iteratorInitialized() {
-        self._stateMachine.withCriticalRegion {
-            $0.iteratorInitialized()
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func iteratorDeinitialized() {
-        let action = self._stateMachine.withCriticalRegion {
-            $0.iteratorDeinitialized()
-        }
-
-        switch action {
-        case .callOnTermination(let onTermination):
-            onTermination?()
-
-        case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
-            for producerContinuation in producerContinuations {
-                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
-            }
-            onTermination?()
-
-        case .none:
-            break
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func sourceDeinitialized() {
-        let action = self._stateMachine.withCriticalRegion {
-            $0.sourceDeinitialized()
-        }
-
-        switch action {
-        case .callOnTermination(let onTermination):
-            onTermination?()
-
-        case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
-            for producerContinuation in producerContinuations {
-                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
-            }
-            onTermination?()
-
-        case .failProducers(let producerContinuations):
-            for producerContinuation in producerContinuations {
-                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
-            }
-
-        case .none:
-            break
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func write(
-        contentsOf sequence: some Sequence<Element>
-    ) throws -> UInt? {
-        let action = self._stateMachine.withCriticalRegion {
-            return $0.write(sequence)
-        }
-
-        switch action {
-        case .returnProduceMore:
-            return nil
-
-        case .returnEnqueue(let callbackToken):
-            return callbackToken
-
-        case .resumeConsumerAndReturnProduceMore(let continuation, let element):
-            continuation.resume(returning: element)
-            return nil
-
-        case .resumeConsumerAndReturnEnqueue(let continuation, let element, let callbackToken):
-            continuation.resume(returning: element)
-            return callbackToken
-
-        case .throwFinishedError:
-            throw AsyncStreamAlreadyFinishedError()
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func enqueueProducer(callbackToken: UInt, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-        let action = self._stateMachine.withCriticalRegion {
-            $0.enqueueProducer(callbackToken: callbackToken, onProduceMore: onProduceMore)
-        }
-
-        switch action {
-        case .resumeProducer(let onProduceMore):
-            onProduceMore(Result<Void, Error>.success(()))
-
-        case .resumeProducerWithError(let onProduceMore, let error):
-            onProduceMore(Result<Void, Error>.failure(error))
-
-        case .none:
-            break
-        }
-    }
-
-    func cancelProducer(callbackToken: UInt) {
-        let action = self._stateMachine.withCriticalRegion {
-            $0.cancelProducer(callbackToken: callbackToken)
-        }
-
-        switch action {
-        case .resumeProducerWithCancellationError(let onProduceMore):
-            onProduceMore(Result<Void, Error>.failure(CancellationError()))
-
-        case .none:
-            break
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func finish(_ failure: Failure?) {
-        let action = self._stateMachine.withCriticalRegion {
-            $0.finish(failure)
-        }
-
-        switch action {
-        case .callOnTermination(let onTermination):
-            onTermination?()
-
-        case .resumeConsumerAndCallOnTermination(let consumerContinuation, let failure, let onTermination):
-            switch failure {
-            case .some(let error):
-                consumerContinuation.resume(throwing: error)
-            case .none:
-                consumerContinuation.resume(returning: nil)
-            }
-
-            onTermination?()
-
-        case .resumeProducers(let producerContinuations):
-            for producerContinuation in producerContinuations {
-                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
-            }
-
-        case .none:
-            break
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func next() async throws -> Element? {
-        let action = self._stateMachine.withCriticalRegion {
-            $0.next()
-        }
-
-        switch action {
-        case .returnElement(let element):
-            return element
-
-        case .returnElementAndResumeProducers(let element, let producerContinuations):
-            for producerContinuation in producerContinuations {
-                producerContinuation(Result<Void, Error>.success(()))
-            }
-
-            return element
-
-        case .returnFailureAndCallOnTermination(let failure, let onTermination):
-            onTermination?()
-            switch failure {
-            case .some(let error):
-                throw error
-
-            case .none:
-                return nil
-            }
-
-        case .returnNil:
-            return nil
-
-        case .suspendTask:
-            return try await self.suspendNext()
-        }
-    }
-
-    @available(SwiftStdlib 9999, *)
-    func suspendNext() async throws -> Element? {
-        return try await withTaskCancellationHandler {
-            return try await withCheckedThrowingContinuation { continuation in
-                let action = self._stateMachine.withCriticalRegion {
-                    $0.suspendNext(continuation: continuation)
-                }
-
-                switch action {
-                case .resumeConsumerWithElement(let continuation, let element):
-                    continuation.resume(returning: element)
-
-                case .resumeConsumerWithElementAndProducers(let continuation, let element, let producerContinuations):
-                    continuation.resume(returning: element)
-                    for producerContinuation in producerContinuations {
-                        producerContinuation(Result<Void, Error>.success(()))
-                    }
-
-                case .resumeConsumerWithFailureAndCallOnTermination(let continuation, let failure, let onTermination):
-                    switch failure {
-                    case .some(let error):
-                        continuation.resume(throwing: error)
-
-                    case .none:
-                        continuation.resume(returning: nil)
-                    }
-                    onTermination?()
-
-                case .resumeConsumerWithNil(let continuation):
-                    continuation.resume(returning: nil)
-
-                case .none:
-                    break
-                }
-            }
-        } onCancel: {
-            let action = self._stateMachine.withCriticalRegion {
-                $0.cancelNext()
-            }
-
-            switch action {
-            case .resumeConsumerWithCancellationErrorAndCallOnTermination(let continuation, let onTermination):
-                continuation.resume(throwing: CancellationError())
-                onTermination?()
-
-            case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
-                for producerContinuation in producerContinuations {
-                    producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
-                }
-                onTermination?()
-
-            case .none:
-                break
-            }
-        }
-    }
+  }
 }
 
 /// The state machine of the backpressured async stream.
 @available(SwiftStdlib 5.1, *)
 struct _StateMachine<Element, Failure: Error> {
-    enum _State {
-        struct Initial {
-            /// The backpressure strategy.
-            var backPressureStrategy: _InternalBackPressureStrategy
-            /// Indicates if the iterator was initialized.
-            var iteratorInitialized: Bool
-            /// The onTermination callback.
-            var onTermination: (@Sendable () -> Void)?
-        }
-
-        struct Streaming {
-            /// The backpressure strategy.
-            var backPressureStrategy: _InternalBackPressureStrategy
-            /// Indicates if the iterator was initialized.
-            var iteratorInitialized: Bool
-            /// The onTermination callback.
-            var onTermination: (@Sendable () -> Void)?
-            /// The buffer of elements.
-            var buffer: _Deque<Element>
-            /// The optional consumer continuation.
-            var consumerContinuation: CheckedContinuation<Element?, Error>?
-            /// The producer continuations.
-            var producerContinuations: _Deque<(UInt, (Result<Void, Error>) -> Void)>
-            /// The producers that have been cancelled.
-            var cancelledAsyncProducers: _Deque<UInt>
-            /// Indicates if we currently have outstanding demand.
-            var hasOutstandingDemand: Bool
-        }
-
-        struct SourceFinished {
-            /// Indicates if the iterator was initialized.
-            var iteratorInitialized: Bool
-            /// The buffer of elements.
-            var buffer: _Deque<Element>
-            /// The failure that should be thrown after the last element has been consumed.
-            var failure: Failure?
-            /// The onTermination callback.
-            var onTermination: (@Sendable () -> Void)?
-        }
-
-        case initial(Initial)
-        /// The state once either any element was yielded or `next()` was called.
-        case streaming(Streaming)
-        /// The state once the underlying source signalled that it is finished.
-        case sourceFinished(SourceFinished)
-
-        /// The state once there can be no outstanding demand. This can happen if:
-        /// 1. The iterator was deinited
-        /// 2. The underlying source finished and all buffered elements have been consumed
-        case finished(iteratorInitialized: Bool)
-
-        /// An intermediate state to avoid CoWs.
-        case modify
+  enum _State {
+    struct Initial {
+      /// The backpressure strategy.
+      var backpressureStrategy: _InternalBackpressureStrategy
+      /// Indicates if the iterator was initialized.
+      var iteratorInitialized: Bool
+      /// The onTermination callback.
+      var onTermination: (@Sendable () -> Void)?
     }
 
-    /// The state machine's current state.
-    var _state: _State
-
-    // The ID used for the next CallbackToken.
-    var nextCallbackTokenID: UInt = 0
-
-    var _onTermination: (@Sendable () -> Void)? {
-        set {
-            switch self._state {
-            case .initial(var initial):
-                initial.onTermination = newValue
-                self._state = .initial(initial)
-
-            case .streaming(var streaming):
-                streaming.onTermination = newValue
-                self._state = .streaming(streaming)
-
-            case .sourceFinished(var sourceFinished):
-                sourceFinished.onTermination = newValue
-                self._state = .sourceFinished(sourceFinished)
-
-            case .finished:
-                break
-
-            case .modify:
-                fatalError("AsyncStream internal inconsistency")
-            }
-        }
-        get {
-            switch self._state {
-            case .initial(let initial):
-                return initial.onTermination
-
-            case .streaming(let streaming):
-                return streaming.onTermination
-
-            case .sourceFinished(let sourceFinished):
-                return sourceFinished.onTermination
-
-            case .finished:
-                return nil
-
-            case .modify:
-                fatalError("AsyncStream internal inconsistency")
-            }
-        }
+    struct Streaming {
+      /// The backpressure strategy.
+      var backpressureStrategy: _InternalBackpressureStrategy
+      /// Indicates if the iterator was initialized.
+      var iteratorInitialized: Bool
+      /// The onTermination callback.
+      var onTermination: (@Sendable () -> Void)?
+      /// The buffer of elements.
+      var buffer: _Deque<Element>
+      /// The optional consumer continuation.
+      var consumerContinuation: CheckedContinuation<Element?, Error>?
+      /// The producer continuations.
+      var producerContinuations: _Deque<(UInt64, (Result<Void, Error>) -> Void)>
+      /// The producers that have been cancelled.
+      var cancelledAsyncProducers: _Deque<UInt64>
+      /// Indicates if we currently have outstanding demand.
+      var hasOutstandingDemand: Bool
     }
 
-    /// Initializes a new `StateMachine`.
-    ///
-    /// We are passing and holding the back-pressure strategy here because
-    /// it is a customizable extension of the state machine.
-    ///
-    /// - Parameter backPressureStrategy: The back-pressure strategy.
-    init(
-        backPressureStrategy: _InternalBackPressureStrategy
-    ) {
-        self._state = .initial(.init(
-            backPressureStrategy: backPressureStrategy,
-            iteratorInitialized: false,
-            onTermination: nil
+    struct SourceFinished {
+      /// Indicates if the iterator was initialized.
+      var iteratorInitialized: Bool
+      /// The buffer of elements.
+      var buffer: _Deque<Element>
+      /// The failure that should be thrown after the last element has been consumed.
+      var failure: Failure?
+      /// The onTermination callback.
+      var onTermination: (@Sendable () -> Void)?
+    }
+
+    case initial(Initial)
+    /// The state once either any element was yielded or `next()` was called.
+    case streaming(Streaming)
+    /// The state once the underlying source signalled that it is finished.
+    case sourceFinished(SourceFinished)
+
+    /// The state once there can be no outstanding demand. This can happen if:
+    /// 1. The iterator was deinited
+    /// 2. The underlying source finished and all buffered elements have been consumed
+    case finished(iteratorInitialized: Bool)
+
+    /// An intermediate state to avoid CoWs.
+    case modify
+  }
+
+  /// The state machine's current state.
+  var _state: _State
+
+  // The ID used for the next CallbackToken.
+  var nextCallbackTokenID: UInt64 = 0
+
+  var _onTermination: (@Sendable () -> Void)? {
+    set {
+      switch self._state {
+      case .initial(var initial):
+        self._state = .modify
+        initial.onTermination = newValue
+        self._state = .initial(initial)
+
+      case .streaming(var streaming):
+        self._state = .modify
+        streaming.onTermination = newValue
+        self._state = .streaming(streaming)
+
+      case .sourceFinished(var sourceFinished):
+        self._state = .modify
+        sourceFinished.onTermination = newValue
+        self._state = .sourceFinished(sourceFinished)
+
+      case .finished:
+        break
+
+      case .modify:
+        fatalError("AsyncStream internal inconsistency")
+      }
+    }
+    get {
+      switch self._state {
+      case .initial(let initial):
+        return initial.onTermination
+
+      case .streaming(let streaming):
+        return streaming.onTermination
+
+      case .sourceFinished(let sourceFinished):
+        return sourceFinished.onTermination
+
+      case .finished:
+        return nil
+
+      case .modify:
+        fatalError("AsyncStream internal inconsistency")
+      }
+    }
+  }
+
+  /// Initializes a new `StateMachine`.
+  ///
+  /// We are passing and holding the back-pressure strategy here because
+  /// it is a customizable extension of the state machine.
+  ///
+  /// - Parameter backpressureStrategy: The back-pressure strategy.
+  init(
+    backpressureStrategy: _InternalBackpressureStrategy
+  ) {
+    self._state = .initial(.init(
+      backpressureStrategy: backpressureStrategy,
+      iteratorInitialized: false,
+      onTermination: nil
+    ))
+  }
+
+  /// Generates the next callback token.
+  mutating func nextCallbackToken() -> UInt64 {
+    let id = self.nextCallbackTokenID
+    self.nextCallbackTokenID += 1
+    return id
+  }
+
+  /// Actions returned by `sequenceDeinitialized()`.
+  enum SequenceDeinitializedAction {
+    /// Indicates that `onTermination` should be called.
+    case callOnTermination((@Sendable () -> Void)?)
+    /// Indicates that  all producers should be failed and `onTermination` should be called.
+    case failProducersAndCallOnTermination(
+      [(Result<Void, Error>) -> Void],
+      (@Sendable () -> Void)?
+    )
+  }
+
+  mutating func sequenceDeinitialized() -> SequenceDeinitializedAction? {
+    switch self._state {
+    case .initial(let initial):
+      if initial.iteratorInitialized {
+        // An iterator was created and we deinited the sequence.
+        // This is an expected pattern and we just continue on normal.
+        return .none
+      } else {
+        // No iterator was created so we can transition to finished right away.
+        self._state = .finished(iteratorInitialized: false)
+
+        return .callOnTermination(initial.onTermination)
+      }
+
+    case .streaming(let streaming):
+      if streaming.iteratorInitialized {
+        // An iterator was created and we deinited the sequence.
+        // This is an expected pattern and we just continue on normal.
+        return .none
+      } else {
+        // No iterator was created so we can transition to finished right away.
+        self._state = .finished(iteratorInitialized: false)
+
+        return .failProducersAndCallOnTermination(
+          streaming.producerContinuations.map { $0.1 },
+          streaming.onTermination
+        )
+      }
+
+    case .sourceFinished(let sourceFinished):
+      if sourceFinished.iteratorInitialized {
+        // An iterator was created and we deinited the sequence.
+        // This is an expected pattern and we just continue on normal.
+        return .none
+      } else {
+        // No iterator was created so we can transition to finished right away.
+        self._state = .finished(iteratorInitialized: false)
+
+        return .callOnTermination(sourceFinished.onTermination)
+      }
+
+    case .finished:
+      // We are already finished so there is nothing left to clean up.
+      // This is just the references dropping afterwards.
+      return .none
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  mutating func iteratorInitialized() {
+    switch self._state {
+    case .initial(var initial):
+      self._state = .modify
+
+      if initial.iteratorInitialized {
+        // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+        fatalError("Only a single AsyncIterator can be created")
+      } else {
+        // The first and only iterator was initialized.
+        initial.iteratorInitialized = true
+        self._state = .initial(initial)
+      }
+
+    case .streaming(var streaming):
+      self._state = .modify
+  
+      if streaming.iteratorInitialized {
+        // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+        fatalError("Only a single AsyncIterator can be created")
+      } else {
+        // The first and only iterator was initialized.
+        streaming.iteratorInitialized = true
+        self._state = .streaming(streaming)
+      }
+
+    case .sourceFinished(var sourceFinished):
+      self._state = .modify
+
+      if sourceFinished.iteratorInitialized {
+        // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+        fatalError("Only a single AsyncIterator can be created")
+      } else {
+        // The first and only iterator was initialized.
+        sourceFinished.iteratorInitialized = true
+        self._state = .sourceFinished(sourceFinished)
+      }
+
+    case .finished(iteratorInitialized: true):
+      // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+      fatalError("Only a single AsyncIterator can be created")
+
+    case .finished(iteratorInitialized: false):
+      // It is strange that an iterator is created after we are finished
+      // but it can definitely happen, e.g.
+      // Sequence.init -> source.finish -> sequence.makeAsyncIterator
+      self._state = .finished(iteratorInitialized: true)
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  /// Actions returned by `iteratorDeinitialized()`.
+  enum IteratorDeinitializedAction {
+    /// Indicates that `onTermination` should be called.
+    case callOnTermination((@Sendable () -> Void)?)
+    /// Indicates that  all producers should be failed and `onTermination` should be called.
+    case failProducersAndCallOnTermination(
+      [(Result<Void, Error>) -> Void],
+      (@Sendable () -> Void)?
+    )
+  }
+
+  mutating func iteratorDeinitialized() -> IteratorDeinitializedAction? {
+    switch self._state {
+    case .initial(let initial):
+      if initial.iteratorInitialized {
+        // An iterator was created and deinited. Since we only support
+        // a single iterator we can now transition to finish.
+        self._state = .finished(iteratorInitialized: true)
+        return .callOnTermination(initial.onTermination)
+      } else {
+        // An iterator needs to be initialized before it can be deinitialized.
+        fatalError("AsyncStream internal inconsistency")
+      }
+
+    case .streaming(let streaming):
+      if streaming.iteratorInitialized {
+        // An iterator was created and deinited. Since we only support
+        // a single iterator we can now transition to finish.
+        self._state = .finished(iteratorInitialized: true)
+
+        return .failProducersAndCallOnTermination(
+          streaming.producerContinuations.map { $0.1 },
+          streaming.onTermination
+        )
+      } else {
+        // An iterator needs to be initialized before it can be deinitialized.
+        fatalError("AsyncStream internal inconsistency")
+      }
+
+    case .sourceFinished(let sourceFinished):
+      if sourceFinished.iteratorInitialized {
+        // An iterator was created and deinited. Since we only support
+        // a single iterator we can now transition to finish.
+        self._state = .finished(iteratorInitialized: true)
+        return .callOnTermination(sourceFinished.onTermination)
+      } else {
+        // An iterator needs to be initialized before it can be deinitialized.
+        fatalError("AsyncStream internal inconsistency")
+      }
+
+    case .finished:
+      // We are already finished so there is nothing left to clean up.
+      // This is just the references dropping afterwards.
+      return .none
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  /// Actions returned by `sourceDeinitialized()`.
+  enum SourceDeinitializedAction {
+    /// Indicates that `onTermination` should be called.
+    case callOnTermination((() -> Void)?)
+    /// Indicates that  all producers should be failed and `onTermination` should be called.
+    case failProducersAndCallOnTermination(
+      [(Result<Void, Error>) -> Void],
+      (@Sendable () -> Void)?
+    )
+    /// Indicates that all producers should be failed.
+    case failProducers([(Result<Void, Error>) -> Void])
+  }
+
+  mutating func sourceDeinitialized() -> SourceDeinitializedAction? {
+    switch self._state {
+    case .initial(let initial):
+      // The source got deinited before anything was written
+      self._state = .finished(iteratorInitialized: initial.iteratorInitialized)
+      return .callOnTermination(initial.onTermination)
+
+    case .streaming(let streaming):
+      if streaming.buffer.isEmpty {
+        // We can transition to finished right away since the buffer is empty now
+        self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+
+        return .failProducersAndCallOnTermination(
+          streaming.producerContinuations.map { $0.1 },
+          streaming.onTermination
+        )
+      } else {
+        // The continuation must be `nil` if the buffer has elements
+        precondition(streaming.consumerContinuation == nil)
+
+        self._state = .sourceFinished(.init(
+          iteratorInitialized: streaming.iteratorInitialized,
+          buffer: streaming.buffer,
+          failure: nil,
+          onTermination: streaming.onTermination
         ))
-    }
 
-    /// Generates the next callback token.
-    mutating func nextCallbackToken() -> UInt {
-        let id = self.nextCallbackTokenID
-        self.nextCallbackTokenID += 1
-        return id
-    }
-
-    /// Actions returned by `sequenceDeinitialized()`.
-    enum SequenceDeinitializedAction {
-        /// Indicates that `onTermination` should be called.
-        case callOnTermination((@Sendable () -> Void)?)
-        /// Indicates that  all producers should be failed and `onTermination` should be called.
-        case failProducersAndCallOnTermination(
-            [(Result<Void, Error>) -> Void],
-            (@Sendable () -> Void)?
+        return .failProducers(
+          streaming.producerContinuations.map { $0.1 }
         )
+      }
+
+    case .sourceFinished, .finished:
+      // This is normal and we just have to tolerate it
+      return .none
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
     }
+  }
 
-    mutating func sequenceDeinitialized() -> SequenceDeinitializedAction? {
-        switch self._state {
-        case .initial(let initial):
-            if initial.iteratorInitialized {
-                // An iterator was created and we deinited the sequence.
-                // This is an expected pattern and we just continue on normal.
-                return .none
-            } else {
-                // No iterator was created so we can transition to finished right away.
-                self._state = .finished(iteratorInitialized: false)
+  /// Actions returned by `write()`.
+  enum WriteAction {
+    /// Indicates that the producer should be notified to produce more.
+    case returnProduceMore
+    /// Indicates that the producer should be suspended to stop producing.
+    case returnEnqueue(
+      callbackToken: UInt64
+    )
+    /// Indicates that the consumer should be resumed and the producer should be notified to produce more.
+    case resumeConsumerAndReturnProduceMore(
+      continuation: CheckedContinuation<Element?, Error>,
+      element: Element
+    )
+    /// Indicates that the consumer should be resumed and the producer should be suspended.
+    case resumeConsumerAndReturnEnqueue(
+      continuation: CheckedContinuation<Element?, Error>,
+      element: Element,
+      callbackToken: UInt64
+    )
+    /// Indicates that the producer has been finished.
+    case throwFinishedError
 
-                return .callOnTermination(initial.onTermination)
-            }
+    init(
+      callbackToken: UInt64?,
+      continuationAndElement: (CheckedContinuation<Element?, Error>, Element)? = nil
+    ) {
+      switch (callbackToken, continuationAndElement) {
+      case (.none, .none):
+        self = .returnProduceMore
 
-        case .streaming(let streaming):
-            if streaming.iteratorInitialized {
-                // An iterator was created and we deinited the sequence.
-                // This is an expected pattern and we just continue on normal.
-                return .none
-            } else {
-                // No iterator was created so we can transition to finished right away.
-                self._state = .finished(iteratorInitialized: false)
+      case (.some(let callbackToken), .none):
+        self = .returnEnqueue(callbackToken: callbackToken)
 
-                return .failProducersAndCallOnTermination(
-                    Array(streaming.producerContinuations.map { $0.1 }),
-                    streaming.onTermination
-                )
-            }
-
-        case .sourceFinished(let sourceFinished):
-            if sourceFinished.iteratorInitialized {
-                // An iterator was created and we deinited the sequence.
-                // This is an expected pattern and we just continue on normal.
-                return .none
-            } else {
-                // No iterator was created so we can transition to finished right away.
-                self._state = .finished(iteratorInitialized: false)
-
-                return .callOnTermination(sourceFinished.onTermination)
-            }
-
-        case .finished:
-            // We are already finished so there is nothing left to clean up.
-            // This is just the references dropping afterwards.
-            return .none
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    mutating func iteratorInitialized() {
-        switch self._state {
-        case .initial(var initial):
-            if initial.iteratorInitialized {
-                // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
-                fatalError("Only a single AsyncIterator can be created")
-            } else {
-                // The first and only iterator was initialized.
-                initial.iteratorInitialized = true
-                self._state = .initial(initial)
-            }
-
-        case .streaming(var streaming):
-            if streaming.iteratorInitialized {
-                // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
-                fatalError("Only a single AsyncIterator can be created")
-            } else {
-                // The first and only iterator was initialized.
-                streaming.iteratorInitialized = true
-                self._state = .streaming(streaming)
-            }
-
-        case .sourceFinished(var sourceFinished):
-            if sourceFinished.iteratorInitialized {
-                // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
-                fatalError("Only a single AsyncIterator can be created")
-            } else {
-                // The first and only iterator was initialized.
-                sourceFinished.iteratorInitialized = true
-                self._state = .sourceFinished(sourceFinished)
-            }
-
-        case .finished(iteratorInitialized: true):
-            // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
-            fatalError("Only a single AsyncIterator can be created")
-
-        case .finished(iteratorInitialized: false):
-            // It is strange that an iterator is created after we are finished
-            // but it can definitely happen, e.g.
-            // Sequence.init -> source.finish -> sequence.makeAsyncIterator
-            self._state = .finished(iteratorInitialized: true)
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `iteratorDeinitialized()`.
-    enum IteratorDeinitializedAction {
-        /// Indicates that `onTermination` should be called.
-        case callOnTermination((@Sendable () -> Void)?)
-        /// Indicates that  all producers should be failed and `onTermination` should be called.
-        case failProducersAndCallOnTermination(
-            [(Result<Void, Error>) -> Void],
-            (@Sendable () -> Void)?
+      case (.none, .some((let continuation, let element))):
+        self = .resumeConsumerAndReturnProduceMore(
+          continuation: continuation,
+          element: element
         )
-    }
 
-    mutating func iteratorDeinitialized() -> IteratorDeinitializedAction? {
-        switch self._state {
-        case .initial(let initial):
-            if initial.iteratorInitialized {
-                // An iterator was created and deinited. Since we only support
-                // a single iterator we can now transition to finish.
-                self._state = .finished(iteratorInitialized: true)
-                return .callOnTermination(initial.onTermination)
-            } else {
-                // An iterator needs to be initialized before it can be deinitialized.
-                fatalError("AsyncStream internal inconsistency")
-            }
-
-        case .streaming(let streaming):
-            if streaming.iteratorInitialized {
-                // An iterator was created and deinited. Since we only support
-                // a single iterator we can now transition to finish.
-                self._state = .finished(iteratorInitialized: true)
-
-                return .failProducersAndCallOnTermination(
-                    Array(streaming.producerContinuations.map { $0.1 }),
-                    streaming.onTermination
-                )
-            } else {
-                // An iterator needs to be initialized before it can be deinitialized.
-                fatalError("AsyncStream internal inconsistency")
-            }
-
-        case .sourceFinished(let sourceFinished):
-            if sourceFinished.iteratorInitialized {
-                // An iterator was created and deinited. Since we only support
-                // a single iterator we can now transition to finish.
-                self._state = .finished(iteratorInitialized: true)
-                return .callOnTermination(sourceFinished.onTermination)
-            } else {
-                // An iterator needs to be initialized before it can be deinitialized.
-                fatalError("AsyncStream internal inconsistency")
-            }
-
-        case .finished:
-            // We are already finished so there is nothing left to clean up.
-            // This is just the references dropping afterwards.
-            return .none
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `sourceDeinitialized()`.
-    enum SourceDeinitializedAction {
-        /// Indicates that `onTermination` should be called.
-        case callOnTermination((() -> Void)?)
-        /// Indicates that  all producers should be failed and `onTermination` should be called.
-        case failProducersAndCallOnTermination(
-            [(Result<Void, Error>) -> Void],
-            (@Sendable () -> Void)?
+      case (.some(let callbackToken), .some((let continuation, let element))):
+        self = .resumeConsumerAndReturnEnqueue(
+          continuation: continuation,
+          element: element,
+          callbackToken: callbackToken
         )
-        /// Indicates that all producers should be failed.
-        case failProducers([(Result<Void, Error>) -> Void])
+      }
     }
+  }
 
-    mutating func sourceDeinitialized() -> SourceDeinitializedAction? {
-        switch self._state {
-        case .initial(let initial):
-            // The source got deinited before anything was written
-            self._state = .finished(iteratorInitialized: initial.iteratorInitialized)
-            return .callOnTermination(initial.onTermination)
+  mutating func write(_ sequence: some Sequence<Element>) -> WriteAction {
+    switch self._state {
+    case .initial(var initial):
+      self._state = .modify
 
-        case .streaming(let streaming):
-            if streaming.buffer.isEmpty {
-                // We can transition to finished right away since the buffer is empty now
-                self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+      var buffer = _Deque<Element>()
+      buffer.append(contentsOf: sequence)
 
-                return .failProducersAndCallOnTermination(
-                    Array(streaming.producerContinuations.map { $0.1 }),
-                    streaming.onTermination
-                )
-            } else {
-                // The continuation must be `nil` if the buffer has elements
-                precondition(streaming.consumerContinuation == nil)
+      let shouldProduceMore = initial.backpressureStrategy.didYield(bufferDepth: buffer.count)
+      let callbackToken = shouldProduceMore ? nil : self.nextCallbackToken()
 
-                self._state = .sourceFinished(.init(
-                    iteratorInitialized: streaming.iteratorInitialized,
-                    buffer: streaming.buffer,
-                    failure: nil,
-                    onTermination: streaming.onTermination
-                ))
+      self._state = .streaming(.init(
+        backpressureStrategy: initial.backpressureStrategy,
+        iteratorInitialized: initial.iteratorInitialized,
+        onTermination: initial.onTermination,
+        buffer: buffer,
+        consumerContinuation: nil,
+        producerContinuations: .init(),
+        cancelledAsyncProducers: .init(),
+        hasOutstandingDemand: shouldProduceMore
+      ))
 
-                return .failProducers(
-                    Array(streaming.producerContinuations.map { $0.1 })
-                )
-            }
+      return .init(callbackToken: callbackToken)
 
-        case .sourceFinished, .finished:
-            // This is normal and we just have to tolerate it
-            return .none
+    case .streaming(var streaming):
+      self._state = .modify
 
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
+      streaming.buffer.append(contentsOf: sequence)
+
+      // We have an element and can resume the continuation
+      let shouldProduceMore = streaming.backpressureStrategy.didYield(bufferDepth: streaming.buffer.count)
+      streaming.hasOutstandingDemand = shouldProduceMore
+      let callbackToken = shouldProduceMore ? nil : self.nextCallbackToken()
+
+      if let consumerContinuation = streaming.consumerContinuation {
+        guard let element = streaming.buffer.popFirst() else {
+          // We got a yield of an empty sequence. We just tolerate this.
+          self._state = .streaming(streaming)
+
+          return .init(callbackToken: callbackToken)
         }
-    }
 
-    /// Actions returned by `write()`.
-    enum WriteAction {
-        /// Indicates that the producer should be notified to produce more.
-        case returnProduceMore
-        /// Indicates that the producer should be suspended to stop producing.
-        case returnEnqueue(
-            callbackToken: UInt
+        // We got a consumer continuation and an element. We can resume the consumer now
+        streaming.consumerContinuation = nil
+        self._state = .streaming(streaming)
+        return .init(
+          callbackToken: callbackToken,
+          continuationAndElement: (consumerContinuation, element)
         )
-        /// Indicates that the consumer should be resumed and the producer should be notified to produce more.
-        case resumeConsumerAndReturnProduceMore(
-            continuation: CheckedContinuation<Element?, Error>,
-            element: Element
+      } else {
+        // We don't have a suspended consumer so we just buffer the elements
+        self._state = .streaming(streaming)
+        return .init(
+          callbackToken: callbackToken
         )
-        /// Indicates that the consumer should be resumed and the producer should be suspended.
-        case resumeConsumerAndReturnEnqueue(
-            continuation: CheckedContinuation<Element?, Error>,
-            element: Element,
-            callbackToken: UInt
+      }
+
+    case .sourceFinished, .finished:
+      // If the source has finished we are dropping the elements.
+      return .throwFinishedError
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  /// Actions returned by `enqueueProducer()`.
+  enum EnqueueProducerAction {
+    /// Indicates that the producer should be notified to produce more.
+    case resumeProducer((Result<Void, Error>) -> Void)
+    /// Indicates that the producer should be notified about an error.
+    case resumeProducerWithError((Result<Void, Error>) -> Void, Error)
+  }
+
+  @available(SwiftStdlib 9999, *)
+  mutating func enqueueProducer(callbackToken: UInt64, onProduceMore: @Sendable @escaping (Result<Void, Error>) -> Void) -> EnqueueProducerAction? {
+    switch self._state {
+    case .initial:
+      // We need to transition to streaming before we can suspend
+      // This is enforced because the CallbackToken has no public init so
+      // one must create it by calling `write` first.
+      fatalError("AsyncStream internal inconsistency")
+
+    case .streaming(var streaming):
+      self._state = .modify
+
+      if let index = streaming.cancelledAsyncProducers.firstIndex(of: callbackToken) {
+        // Our producer got marked as cancelled.
+        streaming.cancelledAsyncProducers.remove(at: index)
+        self._state = .streaming(streaming)
+
+        return .resumeProducerWithError(onProduceMore, CancellationError())
+      } else if streaming.hasOutstandingDemand {
+        // We hit an edge case here where we wrote but the consuming thread got interleaved
+        self._state = .streaming(streaming)
+        return .resumeProducer(onProduceMore)
+      } else {
+        streaming.producerContinuations.append((callbackToken, onProduceMore))
+
+        self._state = .streaming(streaming)
+        return .none
+      }
+
+    case .sourceFinished, .finished:
+      // Since we are unlocking between yielding and suspending the yield
+      // It can happen that the source got finished or the consumption fully finishes.
+      return .resumeProducerWithError(onProduceMore, AsyncStreamAlreadyFinishedError())
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  /// Actions returned by `cancelProducer()`.
+  enum CancelProducerAction {
+    /// Indicates that the producer should be notified about cancellation.
+    case resumeProducerWithCancellationError((Result<Void, Error>) -> Void)
+  }
+
+  mutating func cancelProducer(callbackToken: UInt64) -> CancelProducerAction? {
+    switch self._state {
+    case .initial:
+      // We need to transition to streaming before we can suspend
+      fatalError("AsyncStream internal inconsistency")
+
+    case .streaming(var streaming):
+      self._state = .modify
+
+      if let index = streaming.producerContinuations.firstIndex(where: { $0.0 == callbackToken }) {
+        // We have an enqueued producer that we need to resume now
+        let continuation = streaming.producerContinuations.remove(at: index).1
+        self._state = .streaming(streaming)
+
+        return .resumeProducerWithCancellationError(continuation)
+      } else {
+        // The task that yields was cancelled before yielding so the cancellation handler
+        // got invoked right away
+        streaming.cancelledAsyncProducers.append(callbackToken)
+        self._state = .streaming(streaming)
+
+        return .none
+      }
+
+    case .sourceFinished, .finished:
+      // Since we are unlocking between yielding and suspending the yield
+      // It can happen that the source got finished or the consumption fully finishes.
+      return .none
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  /// Actions returned by `finish()`.
+  enum FinishAction {
+    /// Indicates that `onTermination` should be called.
+    case callOnTermination((() -> Void)?)
+    /// Indicates that the consumer  should be resumed with the failure, the producers
+    /// should be resumed with an error and `onTermination` should be called.
+    case resumeConsumerAndCallOnTermination(
+      consumerContinuation: CheckedContinuation<Element?, Error>,
+      failure: Failure?,
+      onTermination: (() -> Void)?
+    )
+    /// Indicates that the producers should be resumed with an error.
+    case resumeProducers(
+      producerContinuations: Array<(Result<Void, Error>) -> Void>
+    )
+  }
+
+  @inlinable
+  mutating func finish(_ failure: Failure?) -> FinishAction? {
+    switch self._state {
+    case .initial(let initial):
+      // Nothing was yielded nor did anybody call next
+      // This means we can transition to sourceFinished and store the failure
+      self._state = .sourceFinished(.init(
+        iteratorInitialized: initial.iteratorInitialized,
+        buffer: .init(),
+        failure: failure,
+        onTermination: initial.onTermination
+      ))
+
+      return .callOnTermination(initial.onTermination)
+
+    case .streaming(let streaming):
+      if let consumerContinuation = streaming.consumerContinuation {
+        // We have a continuation, this means our buffer must be empty
+        // Furthermore, we can now transition to finished
+        // and resume the continuation with the failure
+        precondition(streaming.buffer.isEmpty, "Expected an empty buffer")
+        precondition(streaming.producerContinuations.isEmpty, "Expected no suspended producers")
+
+        self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+
+        return .resumeConsumerAndCallOnTermination(
+          consumerContinuation: consumerContinuation,
+          failure: failure,
+          onTermination: streaming.onTermination
         )
-        /// Indicates that the producer has been finished.
-        case throwFinishedError
+      } else {
+        self._state = .sourceFinished(.init(
+          iteratorInitialized: streaming.iteratorInitialized,
+          buffer: streaming.buffer,
+          failure: failure,
+          onTermination: streaming.onTermination
+        ))
 
-        init(
-            callbackToken: UInt?,
-            continuationAndElement: (CheckedContinuation<Element?, Error>, Element)? = nil
-        ) {
-            switch (callbackToken, continuationAndElement) {
-            case (.none, .none):
-                self = .returnProduceMore
+        return .resumeProducers(producerContinuations: streaming.producerContinuations.map { $0.1 })
+      }
 
-            case (.some(let callbackToken), .none):
-                self = .returnEnqueue(callbackToken: callbackToken)
+    case .sourceFinished, .finished:
+      // If the source has finished, finishing again has no effect.
+      return .none
 
-            case (.none, .some((let continuation, let element))):
-                self = .resumeConsumerAndReturnProduceMore(
-                    continuation: continuation,
-                    element: element
-                )
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
 
-            case (.some(let callbackToken), .some((let continuation, let element))):
-                self = .resumeConsumerAndReturnEnqueue(
-                    continuation: continuation,
-                    element: element,
-                    callbackToken: callbackToken
-                )
-            }
+  /// Actions returned by `next()`.
+  enum NextAction {
+    /// Indicates that the element should be returned to the caller.
+    case returnElement(Element)
+    /// Indicates that the element should be returned to the caller and that all producers should be called.
+    case returnElementAndResumeProducers(Element, [(Result<Void, Error>) -> Void])
+    /// Indicates that the `Failure` should be returned to the caller and that `onTermination` should be called.
+    case returnFailureAndCallOnTermination(Failure?, (() -> Void)?)
+    /// Indicates that the `nil` should be returned to the caller.
+    case returnNil
+    /// Indicates that the `Task` of the caller should be suspended.
+    case suspendTask
+  }
+
+  mutating func next() -> NextAction {
+    switch self._state {
+    case .initial(let initial):
+      // We are not interacting with the back-pressure strategy here because
+      // we are doing this inside `next(:)`
+      self._state = .streaming(.init(
+        backpressureStrategy: initial.backpressureStrategy,
+        iteratorInitialized: initial.iteratorInitialized,
+        onTermination: initial.onTermination,
+        buffer: _Deque<Element>(),
+        consumerContinuation: nil,
+        producerContinuations: .init(),
+        cancelledAsyncProducers: .init(),
+        hasOutstandingDemand: false // We set the outstanding demand to false initially
+      ))
+
+      return .suspendTask
+    case .streaming(var streaming):
+      self._state = .modify
+    
+      guard streaming.consumerContinuation == nil else {
+        // We have multiple AsyncIterators iterating the sequence
+        fatalError("AsyncStream internal inconsistency")
+      }
+
+      if let element = streaming.buffer.popFirst() {
+        // We have an element to fulfil the demand right away.
+        let shouldProduceMore = streaming.backpressureStrategy.didConsume(bufferDepth: streaming.buffer.count)
+        streaming.hasOutstandingDemand = shouldProduceMore
+
+        if shouldProduceMore {
+          // There is demand and we have to resume our producers
+          let producers = streaming.producerContinuations.map { $0.1 }
+          streaming.producerContinuations.removeAll()
+          self._state = .streaming(streaming)
+          return .returnElementAndResumeProducers(element, producers)
+        } else {
+          // We don't have any new demand, so we can just return the element.
+          self._state = .streaming(streaming)
+          return .returnElement(element)
         }
+      } else {
+        // There is nothing in the buffer to fulfil the demand so we need to suspend.
+        // We are not interacting with the back-pressure strategy here because
+        // we are doing this inside `suspendNext`
+        self._state = .streaming(streaming)
+
+        return .suspendTask
+      }
+
+    case .sourceFinished(var sourceFinished):
+      // Check if we have an element left in the buffer and return it
+      self._state = .modify
+
+      if let element = sourceFinished.buffer.popFirst() {
+        self._state = .sourceFinished(sourceFinished)
+
+        return .returnElement(element)
+      } else {
+        // We are returning the queued failure now and can transition to finished
+        self._state = .finished(iteratorInitialized: sourceFinished.iteratorInitialized)
+
+        return .returnFailureAndCallOnTermination(sourceFinished.failure, sourceFinished.onTermination)
+      }
+
+    case .finished:
+      return .returnNil
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
     }
+  }
 
-    mutating func write(_ sequence: some Sequence<Element>) -> WriteAction {
-        switch self._state {
-        case .initial(var initial):
-            var buffer = _Deque<Element>()
-            buffer.append(contentsOf: sequence)
+  /// Actions returned by `suspendNext()`.
+  enum SuspendNextAction {
+    /// Indicates that the consumer should be resumed.
+    case resumeConsumerWithElement(CheckedContinuation<Element?, Error>, Element)
+    /// Indicates that the consumer and all producers should be resumed.
+    case resumeConsumerWithElementAndProducers(CheckedContinuation<Element?, Error>, Element, [(Result<Void, Error>) -> Void])
+    /// Indicates that the consumer should be resumed with the failure and that `onTermination` should be called.
+    case resumeConsumerWithFailureAndCallOnTermination(CheckedContinuation<Element?, Error>, Failure?, (() -> Void)?)
+    /// Indicates that the consumer should be resumed with `nil`.
+    case resumeConsumerWithNil(CheckedContinuation<Element?, Error>)
+  }
 
-            let shouldProduceMore = initial.backPressureStrategy.didYield(bufferDepth: buffer.count)
-            let callbackToken = shouldProduceMore ? nil : self.nextCallbackToken()
+  mutating func suspendNext(continuation: CheckedContinuation<Element?, Error>) -> SuspendNextAction? {
+    switch self._state {
+    case .initial:
+      // We need to transition to streaming before we can suspend
+      preconditionFailure("AsyncStream internal inconsistency")
 
-            self._state = .streaming(.init(
-                backPressureStrategy: initial.backPressureStrategy,
-                iteratorInitialized: initial.iteratorInitialized,
-                onTermination: initial.onTermination,
-                buffer: buffer,
-                consumerContinuation: nil,
-                producerContinuations: .init(),
-                cancelledAsyncProducers: .init(),
-                hasOutstandingDemand: shouldProduceMore
-            ))
+    case .streaming(var streaming):
+      self._state = .modify
 
-            return .init(callbackToken: callbackToken)
+      guard streaming.consumerContinuation == nil else {
+        // We have multiple AsyncIterators iterating the sequence
+        fatalError("This should never happen since we only allow a single Iterator to be created")
+      }
 
-        case .streaming(var streaming):
-            self._state = .modify
+      // We have to check here again since we might have a producer interleave next and suspendNext
+      if let element = streaming.buffer.popFirst() {
+        // We have an element to fulfil the demand right away.
 
-            streaming.buffer.append(contentsOf: sequence)
+        let shouldProduceMore = streaming.backpressureStrategy.didConsume(bufferDepth: streaming.buffer.count)
+        streaming.hasOutstandingDemand = shouldProduceMore
 
-            // We have an element and can resume the continuation
-            let shouldProduceMore = streaming.backPressureStrategy.didYield(bufferDepth: streaming.buffer.count)
-            streaming.hasOutstandingDemand = shouldProduceMore
-            let callbackToken = shouldProduceMore ? nil : self.nextCallbackToken()
-
-            if let consumerContinuation = streaming.consumerContinuation {
-                guard let element = streaming.buffer.popFirst() else {
-                    // We got a yield of an empty sequence. We just tolerate this.
-                    self._state = .streaming(streaming)
-
-                    return .init(callbackToken: callbackToken)
-                }
-
-                // We got a consumer continuation and an element. We can resume the consumer now
-                streaming.consumerContinuation = nil
-                self._state = .streaming(streaming)
-                return .init(
-                    callbackToken: callbackToken,
-                    continuationAndElement: (consumerContinuation, element)
-                )
-            } else {
-                // We don't have a suspended consumer so we just buffer the elements
-                self._state = .streaming(streaming)
-                return .init(
-                    callbackToken: callbackToken
-                )
-            }
-
-        case .sourceFinished, .finished:
-            // If the source has finished we are dropping the elements.
-            return .throwFinishedError
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
+        if shouldProduceMore {
+          // There is demand and we have to resume our producers
+          let producers = streaming.producerContinuations.map { $0.1 }
+          streaming.producerContinuations.removeAll()
+          self._state = .streaming(streaming)
+          return .resumeConsumerWithElementAndProducers(continuation, element, producers)
+        } else {
+          // We don't have any new demand, so we can just return the element.
+          self._state = .streaming(streaming)
+          return .resumeConsumerWithElement(continuation, element)
         }
-    }
+      } else {
+        // There is nothing in the buffer to fulfil the demand so we to store the continuation.
+        streaming.consumerContinuation = continuation
+        self._state = .streaming(streaming)
 
-    /// Actions returned by `enqueueProducer()`.
-    enum EnqueueProducerAction {
-        /// Indicates that the producer should be notified to produce more.
-        case resumeProducer((Result<Void, Error>) -> Void)
-        /// Indicates that the producer should be notified about an error.
-        case resumeProducerWithError((Result<Void, Error>) -> Void, Error)
-    }
+        return .none
+      }
 
-    @available(SwiftStdlib 9999, *)
-    mutating func enqueueProducer(callbackToken: UInt, onProduceMore: @Sendable @escaping (Result<Void, Error>) -> Void) -> EnqueueProducerAction? {
-        switch self._state {
-        case .initial:
-            // We need to transition to streaming before we can suspend
-            // This is enforced because the CallbackToken has no public init so
-            // one must create it by calling `write` first.
-            fatalError("AsyncStream internal inconsistency")
+    case .sourceFinished(var sourceFinished):
+      // Check if we have an element left in the buffer and return it
+      self._state = .modify
 
-        case .streaming(var streaming):
-            if let index = streaming.cancelledAsyncProducers.firstIndex(of: callbackToken) {
-                // Our producer got marked as cancelled.
-                self._state = .modify
-                streaming.cancelledAsyncProducers.remove(at: index)
-                self._state = .streaming(streaming)
+      if let element = sourceFinished.buffer.popFirst() {
+        self._state = .sourceFinished(sourceFinished)
 
-                return .resumeProducerWithError(onProduceMore, CancellationError())
-            } else if streaming.hasOutstandingDemand {
-                // We hit an edge case here where we wrote but the consuming thread got interleaved
-                return .resumeProducer(onProduceMore)
-            } else {
-                self._state = .modify
-                streaming.producerContinuations.append((callbackToken, onProduceMore))
+        return .resumeConsumerWithElement(continuation, element)
+      } else {
+        // We are returning the queued failure now and can transition to finished
+        self._state = .finished(iteratorInitialized: sourceFinished.iteratorInitialized)
 
-                self._state = .streaming(streaming)
-                return .none
-            }
-
-        case .sourceFinished, .finished:
-            // Since we are unlocking between yielding and suspending the yield
-            // It can happen that the source got finished or the consumption fully finishes.
-            return .resumeProducerWithError(onProduceMore, AsyncStreamAlreadyFinishedError())
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `cancelProducer()`.
-    enum CancelProducerAction {
-        /// Indicates that the producer should be notified about cancellation.
-        case resumeProducerWithCancellationError((Result<Void, Error>) -> Void)
-    }
-
-    mutating func cancelProducer(callbackToken: UInt) -> CancelProducerAction? {
-        switch self._state {
-        case .initial:
-            // We need to transition to streaming before we can suspend
-            fatalError("AsyncStream internal inconsistency")
-
-        case .streaming(var streaming):
-            if let index = streaming.producerContinuations.firstIndex(where: { $0.0 == callbackToken }) {
-                // We have an enqueued producer that we need to resume now
-                self._state = .modify
-                let continuation = streaming.producerContinuations.remove(at: index).1
-                self._state = .streaming(streaming)
-
-                return .resumeProducerWithCancellationError(continuation)
-            } else {
-                // The task that yields was cancelled before yielding so the cancellation handler
-                // got invoked right away
-                self._state = .modify
-                streaming.cancelledAsyncProducers.append(callbackToken)
-                self._state = .streaming(streaming)
-
-                return .none
-            }
-
-        case .sourceFinished, .finished:
-            // Since we are unlocking between yielding and suspending the yield
-            // It can happen that the source got finished or the consumption fully finishes.
-            return .none
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `finish()`.
-    enum FinishAction {
-        /// Indicates that `onTermination` should be called.
-        case callOnTermination((() -> Void)?)
-        /// Indicates that the consumer  should be resumed with the failure, the producers
-        /// should be resumed with an error and `onTermination` should be called.
-        case resumeConsumerAndCallOnTermination(
-            consumerContinuation: CheckedContinuation<Element?, Error>,
-            failure: Failure?,
-            onTermination: (() -> Void)?
+        return .resumeConsumerWithFailureAndCallOnTermination(
+          continuation,
+          sourceFinished.failure,
+          sourceFinished.onTermination
         )
-        /// Indicates that the producers should be resumed with an error.
-        case resumeProducers(
-            producerContinuations: Array<(Result<Void, Error>) -> Void>
+      }
+
+    case .finished:
+      return .resumeConsumerWithNil(continuation)
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
+    }
+  }
+
+  /// Actions returned by `cancelNext()`.
+  enum CancelNextAction {
+    /// Indicates that the continuation should be resumed with a cancellation error, the producers should be finished and call onTermination.
+    case resumeConsumerWithCancellationErrorAndCallOnTermination(CheckedContinuation<Element?, Error>, (() -> Void)?)
+    /// Indicates that the producers should be finished and call onTermination.
+    case failProducersAndCallOnTermination([(Result<Void, Error>) -> Void], (() -> Void)?)
+  }
+
+  mutating func cancelNext() -> CancelNextAction? {
+    switch self._state {
+    case .initial:
+      // We need to transition to streaming before we can suspend
+      fatalError("AsyncStream internal inconsistency")
+
+    case .streaming(let streaming):
+      self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+
+      if let consumerContinuation = streaming.consumerContinuation {
+        precondition(streaming.producerContinuations.isEmpty, "Internal inconsistency. Unexpected producer continuations.")
+        return .resumeConsumerWithCancellationErrorAndCallOnTermination(
+          consumerContinuation,
+          streaming.onTermination
         )
+      } else {
+        return .failProducersAndCallOnTermination(
+          streaming.producerContinuations.map { $0.1 },
+          streaming.onTermination
+        )
+      }
+
+    case .sourceFinished, .finished:
+      return .none
+
+    case .modify:
+      fatalError("AsyncStream internal inconsistency")
     }
-
-    @inlinable
-    mutating func finish(_ failure: Failure?) -> FinishAction? {
-        switch self._state {
-        case .initial(let initial):
-            // Nothing was yielded nor did anybody call next
-            // This means we can transition to sourceFinished and store the failure
-            self._state = .sourceFinished(.init(
-                iteratorInitialized: initial.iteratorInitialized,
-                buffer: .init(),
-                failure: failure,
-                onTermination: initial.onTermination
-            ))
-
-            return .callOnTermination(initial.onTermination)
-
-        case .streaming(let streaming):
-            if let consumerContinuation = streaming.consumerContinuation {
-                // We have a continuation, this means our buffer must be empty
-                // Furthermore, we can now transition to finished
-                // and resume the continuation with the failure
-                precondition(streaming.buffer.isEmpty, "Expected an empty buffer")
-                precondition(streaming.producerContinuations.isEmpty, "Expected no suspended producers")
-
-                self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
-
-                return .resumeConsumerAndCallOnTermination(
-                    consumerContinuation: consumerContinuation,
-                    failure: failure,
-                    onTermination: streaming.onTermination
-                )
-            } else {
-                self._state = .sourceFinished(.init(
-                    iteratorInitialized: streaming.iteratorInitialized,
-                    buffer: streaming.buffer,
-                    failure: failure,
-                    onTermination: streaming.onTermination
-                ))
-
-                return .resumeProducers(producerContinuations: Array(streaming.producerContinuations.map { $0.1 }))
-            }
-
-        case .sourceFinished, .finished:
-            // If the source has finished, finishing again has no effect.
-            return .none
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `next()`.
-    enum NextAction {
-        /// Indicates that the element should be returned to the caller.
-        case returnElement(Element)
-        /// Indicates that the element should be returned to the caller and that all producers should be called.
-        case returnElementAndResumeProducers(Element, [(Result<Void, Error>) -> Void])
-        /// Indicates that the `Failure` should be returned to the caller and that `onTermination` should be called.
-        case returnFailureAndCallOnTermination(Failure?, (() -> Void)?)
-        /// Indicates that the `nil` should be returned to the caller.
-        case returnNil
-        /// Indicates that the `Task` of the caller should be suspended.
-        case suspendTask
-    }
-
-    mutating func next() -> NextAction {
-        switch self._state {
-        case .initial(let initial):
-            // We are not interacting with the back-pressure strategy here because
-            // we are doing this inside `next(:)`
-            self._state = .streaming(.init(
-                backPressureStrategy: initial.backPressureStrategy,
-                iteratorInitialized: initial.iteratorInitialized,
-                onTermination: initial.onTermination,
-                buffer: _Deque<Element>(),
-                consumerContinuation: nil,
-                producerContinuations: .init(),
-                cancelledAsyncProducers: .init(),
-                hasOutstandingDemand: false
-            ))
-
-            return .suspendTask
-        case .streaming(var streaming):
-            guard streaming.consumerContinuation == nil else {
-                // We have multiple AsyncIterators iterating the sequence
-                fatalError("AsyncStream internal inconsistency")
-            }
-
-            self._state = .modify
-
-            if let element = streaming.buffer.popFirst() {
-                // We have an element to fulfil the demand right away.
-                let shouldProduceMore = streaming.backPressureStrategy.didConsume(bufferDepth: streaming.buffer.count)
-                streaming.hasOutstandingDemand = shouldProduceMore
-
-                if shouldProduceMore {
-                    // There is demand and we have to resume our producers
-                    let producers = Array(streaming.producerContinuations.map { $0.1 })
-                    streaming.producerContinuations.removeAll()
-                    self._state = .streaming(streaming)
-                    return .returnElementAndResumeProducers(element, producers)
-                } else {
-                    // We don't have any new demand, so we can just return the element.
-                    self._state = .streaming(streaming)
-                    return .returnElement(element)
-                }
-            } else {
-                // There is nothing in the buffer to fulfil the demand so we need to suspend.
-                // We are not interacting with the back-pressure strategy here because
-                // we are doing this inside `suspendNext`
-                self._state = .streaming(streaming)
-
-                return .suspendTask
-            }
-
-        case .sourceFinished(var sourceFinished):
-            // Check if we have an element left in the buffer and return it
-            self._state = .modify
-
-            if let element = sourceFinished.buffer.popFirst() {
-                self._state = .sourceFinished(sourceFinished)
-
-                return .returnElement(element)
-            } else {
-                // We are returning the queued failure now and can transition to finished
-                self._state = .finished(iteratorInitialized: sourceFinished.iteratorInitialized)
-
-                return .returnFailureAndCallOnTermination(sourceFinished.failure, sourceFinished.onTermination)
-            }
-
-        case .finished:
-            return .returnNil
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `suspendNext()`.
-    enum SuspendNextAction {
-        /// Indicates that the consumer should be resumed.
-        case resumeConsumerWithElement(CheckedContinuation<Element?, Error>, Element)
-        /// Indicates that the consumer and all producers should be resumed.
-        case resumeConsumerWithElementAndProducers(CheckedContinuation<Element?, Error>, Element, [(Result<Void, Error>) -> Void])
-        /// Indicates that the consumer should be resumed with the failure and that `onTermination` should be called.
-        case resumeConsumerWithFailureAndCallOnTermination(CheckedContinuation<Element?, Error>, Failure?, (() -> Void)?)
-        /// Indicates that the consumer should be resumed with `nil`.
-        case resumeConsumerWithNil(CheckedContinuation<Element?, Error>)
-    }
-
-    mutating func suspendNext(continuation: CheckedContinuation<Element?, Error>) -> SuspendNextAction? {
-        switch self._state {
-        case .initial:
-            // We need to transition to streaming before we can suspend
-            preconditionFailure("AsyncStream internal inconsistency")
-
-        case .streaming(var streaming):
-            guard streaming.consumerContinuation == nil else {
-                // We have multiple AsyncIterators iterating the sequence
-                fatalError("This should never happen since we only allow a single Iterator to be created")
-            }
-
-            self._state = .modify
-
-            // We have to check here again since we might have a producer interleave next and suspendNext
-            if let element = streaming.buffer.popFirst() {
-                // We have an element to fulfil the demand right away.
-
-                let shouldProduceMore = streaming.backPressureStrategy.didConsume(bufferDepth: streaming.buffer.count)
-                streaming.hasOutstandingDemand = shouldProduceMore
-
-                if shouldProduceMore {
-                    // There is demand and we have to resume our producers
-                    let producers = Array(streaming.producerContinuations.map { $0.1 })
-                    streaming.producerContinuations.removeAll()
-                    self._state = .streaming(streaming)
-                    return .resumeConsumerWithElementAndProducers(continuation, element, producers)
-                } else {
-                    // We don't have any new demand, so we can just return the element.
-                    self._state = .streaming(streaming)
-                    return .resumeConsumerWithElement(continuation, element)
-                }
-            } else {
-                // There is nothing in the buffer to fulfil the demand so we to store the continuation.
-                streaming.consumerContinuation = continuation
-                self._state = .streaming(streaming)
-
-                return .none
-            }
-
-        case .sourceFinished(var sourceFinished):
-            // Check if we have an element left in the buffer and return it
-            self._state = .modify
-
-            if let element = sourceFinished.buffer.popFirst() {
-                self._state = .sourceFinished(sourceFinished)
-
-                return .resumeConsumerWithElement(continuation, element)
-            } else {
-                // We are returning the queued failure now and can transition to finished
-                self._state = .finished(iteratorInitialized: sourceFinished.iteratorInitialized)
-
-                return .resumeConsumerWithFailureAndCallOnTermination(
-                    continuation,
-                    sourceFinished.failure,
-                    sourceFinished.onTermination
-                )
-            }
-
-        case .finished:
-            return .resumeConsumerWithNil(continuation)
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
-
-    /// Actions returned by `cancelNext()`.
-    enum CancelNextAction {
-        /// Indicates that the continuation should be resumed with a cancellation error, the producers should be finished and call onTermination.
-        case resumeConsumerWithCancellationErrorAndCallOnTermination(CheckedContinuation<Element?, Error>, (() -> Void)?)
-        /// Indicates that the producers should be finished and call onTermination.
-        case failProducersAndCallOnTermination([(Result<Void, Error>) -> Void], (() -> Void)?)
-    }
-
-    mutating func cancelNext() -> CancelNextAction? {
-        switch self._state {
-        case .initial:
-            // We need to transition to streaming before we can suspend
-            fatalError("AsyncStream internal inconsistency")
-
-        case .streaming(let streaming):
-            self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
-
-            if let consumerContinuation = streaming.consumerContinuation {
-                precondition(streaming.producerContinuations.isEmpty, "Internal inconsistency. Unexpected producer continuations.")
-                return .resumeConsumerWithCancellationErrorAndCallOnTermination(
-                    consumerContinuation,
-                    streaming.onTermination
-                )
-            } else {
-                return .failProducersAndCallOnTermination(
-                    Array(streaming.producerContinuations.map { $0.1 }),
-                    streaming.onTermination
-                )
-            }
-
-        case .sourceFinished, .finished:
-            return .none
-
-        case .modify:
-            fatalError("AsyncStream internal inconsistency")
-        }
-    }
+  }
 }
 #else
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
 extension AsyncStream {
+  @available(SwiftStdlib 9999, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public struct Source: Sendable {
     @available(SwiftStdlib 9999, *)
     @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-    public struct Source: Sendable {
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public struct BackPressureStrategy: Sendable {
-            @available(SwiftStdlib 9999, *)
-            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
-                fatalError("Unavailable in task-to-thread concurrency model")
-            }
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public enum WriteResult: Sendable {
-            @available(SwiftStdlib 9999, *)
-            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-            public struct CallbackToken: Sendable {}
-            case produceMore
-            case enqueueCallback(CallbackToken)
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public var onTermination: (@Sendable () -> Void)? {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write(_ element: Element) throws -> WriteResult {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write(_ element: Element) async throws {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func finish() {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
+    public struct BackpressureStrategy: Sendable {
+      @available(SwiftStdlib 9999, *)
+      @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+      public static func watermark(low: Int, high: Int) -> BackpressureStrategy {
+        fatalError("Unavailable in task-to-thread concurrency model")
+      }
     }
 
     @available(SwiftStdlib 9999, *)
     @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-    public static func makeStream(
-        of elementType: Element.Type = Element.self,
-        backPressureStrategy: Source.BackPressureStrategy
-    ) -> (`Self`, Source) {
-            fatalError("Unavailable in task-to-thread concurrency model")
+    public enum WriteResult: Sendable {
+      @available(SwiftStdlib 9999, *)
+      @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+      public struct CallbackToken: Sendable {}
+      case produceMore
+      case enqueueCallback(CallbackToken)
     }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public var onTermination: (@Sendable () -> Void)? {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write(_: Element) throws -> WriteResult {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write(_: Element) async throws {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func finish() {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public static func makeStream(
+    of elementType: Element.Type = Element.self,
+    backpressureStrategy: Source.BackpressureStrategy
+  ) -> (`Self`, Source) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
 }
+
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
 extension AsyncThrowingStream {
+  @available(SwiftStdlib 9999, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public struct Source: Sendable {
     @available(SwiftStdlib 9999, *)
     @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-    public struct Source: Sendable {
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public struct BackPressureStrategy: Sendable {
-            @available(SwiftStdlib 9999, *)
-            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
-                fatalError("Unavailable in task-to-thread concurrency model")
-            }
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public enum WriteResult: Sendable {
-            @available(SwiftStdlib 9999, *)
-            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-            public struct CallbackToken: Sendable {}
-            case produceMore
-            case enqueueCallback(CallbackToken)
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public var onTermination: (@Sendable () -> Void)? {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write(_ element: Element) throws -> WriteResult {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write(_ element: Element) async throws {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
-
-        @available(SwiftStdlib 9999, *)
-        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-        public func finish(throwing error: Failure?) {
-            fatalError("Unavailable in task-to-thread concurrency model")
-        }
+    public struct BackpressureStrategy: Sendable {
+      @available(SwiftStdlib 9999, *)
+      @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+      public static func watermark(low: Int, high: Int) -> BackpressureStrategy {
+        fatalError("Unavailable in task-to-thread concurrency model")
+      }
     }
 
     @available(SwiftStdlib 9999, *)
     @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-    public static func makeStream(
-        of elementType: Element.Type = Element.self,
-        backPressureStrategy: Source.BackPressureStrategy
-    ) -> (`Self`, Source) {
-            fatalError("Unavailable in task-to-thread concurrency model")
+    public enum WriteResult: Sendable {
+      @available(SwiftStdlib 9999, *)
+      @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+      public struct CallbackToken: Sendable {}
+      case produceMore
+      case enqueueCallback(CallbackToken)
     }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public var onTermination: (@Sendable () -> Void)? {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write(_: Element) throws -> WriteResult {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write(_: Element) async throws {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public func finish(throwing error: Failure?) {
+      fatalError("Unavailable in task-to-thread concurrency model")
+    }
+  }
+
+  @available(SwiftStdlib 9999, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public static func makeStream(
+    of elementType: Element.Type = Element.self,
+    backpressureStrategy: Source.BackpressureStrategy
+  ) -> (`Self`, Source) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
 }
 #endif

--- a/stdlib/public/Concurrency/AsyncStreamBackpressure.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBackpressure.swift
@@ -1,0 +1,1961 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+@available(SwiftStdlib 9999, *)
+public struct AsyncStreamAlreadyFinishedError: Error {}
+
+@available(SwiftStdlib 5.1, *)
+extension AsyncStream {
+    /// A mechanism to interface between producer code and an asynchronous stream.
+    ///
+    /// Use this source to provide elements to the stream by calling one of the `write` methods, then terminate the stream normally
+    /// by calling the `finish()` method.
+    @available(SwiftStdlib 9999, *)
+    public struct Source: Sendable {
+        /// A strategy that handles the backpressure of the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public struct BackPressureStrategy: Sendable {
+            /// When the high watermark is reached producers will be suspended. All producers will be resumed again once
+            /// the low watermark is reached.
+            @available(SwiftStdlib 9999, *)
+            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
+                BackPressureStrategy(internalBackPressureStrategy: .watermark(.init(low: low, high: high)))
+            }
+
+            private init(internalBackPressureStrategy: _InternalBackPressureStrategy) {
+                self._internalBackPressureStrategy = internalBackPressureStrategy
+            }
+
+            fileprivate let _internalBackPressureStrategy: _InternalBackPressureStrategy
+        }
+
+        /// A type that indicates the result of writing elements to the source.
+        @available(SwiftStdlib 9999, *)
+        @frozen
+        public enum WriteResult: Sendable {
+            /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
+            /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.
+            public struct CallbackToken: Sendable {
+                let id: UInt
+            }
+
+            /// Indicates that more elements should be produced and written to the source.
+            case produceMore
+
+            /// Indicates that a callback should be enqueued.
+            ///
+            /// The associated token should be passed to the ``enqueueCallback(_:)`` method.
+            case enqueueCallback(CallbackToken)
+        }
+
+        /// Backing class for the source used to hook a deinit.
+        final class _Backing: Sendable {
+            let storage: _BackPressuredStorage<Element, Never>
+
+            init(storage: _BackPressuredStorage<Element, Never>) {
+                self.storage = storage
+            }
+
+            deinit {
+                self.storage.sourceDeinitialized()
+            }
+        }
+
+        /// A callback to invoke when the stream finished.
+        ///
+        /// The stream finishes and calls this closure in the following cases:
+        /// - No iterator was created and the sequence was deinited
+        /// - An iterator was created and deinited
+        /// - After ``finish(throwing:)`` was called and all elements have been consumed
+        /// - The consuming task got cancelled
+        @available(SwiftStdlib 9999, *)
+        public var onTermination: (@Sendable () -> Void)? {
+            set {
+                self._backing.storage.onTermination = newValue
+            }
+            get {
+                self._backing.storage.onTermination
+            }
+        }
+
+        private var _backing: _Backing
+
+        internal init(storage: _BackPressuredStorage<Element, Never>) {
+            self._backing = .init(storage: storage)
+        }
+
+        /// Writes new elements to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// - Parameter sequence: The elements to write to the asynchronous stream.
+        /// - Returns: The result that indicates if more elements should be produced at this time.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+            let id = try self._backing.storage.write(contentsOf: sequence)
+
+            if let id {
+                return .enqueueCallback(.init(id: id))
+            } else {
+                return .produceMore
+            }
+        }
+
+        /// Write the element to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// provided element. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// - Parameter element: The element to write to the asynchronous stream.
+        /// - Returns: The result that indicates if more elements should be produced at this time.
+        @available(SwiftStdlib 9999, *)
+        public func write(_ element: Element) throws -> WriteResult {
+            let id = try self._backing.storage.write(contentsOf: CollectionOfOne(element))
+        
+            if let id {
+                return .enqueueCallback(.init(id: id))
+            } else {
+                return .produceMore
+            }
+        }
+
+        /// Enqueues a callback that will be invoked once more elements should be produced.
+        ///
+        /// Call this method after ``write(contentsOf:)`` or ``write(:)`` returned ``WriteResult/enqueueCallback(_:)``.
+        ///
+        /// - Important: Enqueueing the same token multiple times is not allowed.
+        ///
+        /// - Parameters:
+        ///   - callbackToken: The callback token.
+        ///   - onProduceMore: The callback which gets invoked once more elements should be produced.
+        @available(SwiftStdlib 9999, *)
+        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            self._backing.storage.enqueueProducer(callbackToken: callbackToken.id, onProduceMore: onProduceMore)
+        }
+
+        /// Cancel an enqueued callback.
+        ///
+        /// Call this method to cancel a callback enqueued by the ``enqueueCallback(callbackToken:onProduceMore:)`` method.
+        ///
+        /// - Note: This methods supports being called before ``enqueueCallback(callbackToken:onProduceMore:)`` is called and
+        /// will mark the passed `callbackToken` as cancelled.
+        ///
+        /// - Parameter callbackToken: The callback token.
+        @available(SwiftStdlib 9999, *)
+        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
+            self._backing.storage.cancelProducer(callbackToken: callbackToken.id)
+        }
+
+        /// Write new elements to the asynchronous stream and provide a callback which will be invoked once more elements should be produced.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// first element of the provided sequence. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+        /// a `Result.failure`.
+        ///
+        /// - Parameters:
+        ///   - sequence: The elements to write to the asynchronous stream.
+        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+        ///   invoked during the call to ``write(contentsOf:onProduceMore:)``.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+            do {
+                let writeResult = try self.write(contentsOf: sequence)
+
+                switch writeResult {
+                case .produceMore:
+                    onProduceMore(Result<Void, Error>.success(()))
+
+                case .enqueueCallback(let callbackToken):
+                    self.enqueueCallback(callbackToken: callbackToken, onProduceMore: onProduceMore)
+                }
+            } catch {
+                onProduceMore(.failure(error))
+            }
+        }
+
+        /// Writes the element to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// provided element. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+        /// a `Result.failure`.
+        ///
+        /// - Parameters:
+        ///   - sequence: The element to write to the asynchronous stream.
+        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+        ///   invoked during the call to ``write(_:onProduceMore:)``.
+        @available(SwiftStdlib 9999, *)
+        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            self.write(contentsOf: CollectionOfOne(element), onProduceMore: onProduceMore)
+        }
+
+        /// Write new elements to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// This method returns once more elements should be produced.
+        ///
+        /// - Parameters:
+        ///   - sequence: The elements to write to the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+            let writeResult = try { try self.write(contentsOf: sequence) }()
+
+            switch writeResult {
+            case .produceMore:
+                return
+
+            case .enqueueCallback(let callbackToken):
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        self.enqueueCallback(callbackToken: callbackToken, onProduceMore: { result in
+                            switch result {
+                            case .success():
+                                continuation.resume(returning: ())
+                            case .failure(let error):
+                                continuation.resume(throwing: error)
+                            }
+                        })
+                    }
+                } onCancel: {
+                    self.cancelCallback(callbackToken: callbackToken)
+                }
+            }
+        }
+
+        /// Write new element to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// provided element. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// This method returns once more elements should be produced.
+        ///
+        /// - Parameters:
+        ///   - sequence: The element to write to the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public func write(_ element: Element) async throws {
+            try await self.write(contentsOf: CollectionOfOne(element))
+        }
+
+        /// Write the elements of the asynchronous sequence to the asynchronous stream.
+        ///
+        /// This method returns once the provided asynchronous sequence or the  the asynchronous stream finished.
+        ///
+        /// - Important: This method does not finish the source if consuming the upstream sequence terminated.
+        ///
+        /// - Parameters:
+        ///   - sequence: The elements to write to the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+            for try await element in sequence {
+                try await self.write(contentsOf: CollectionOfOne(element))
+            }
+        }
+
+        /// Indicates that the production terminated.
+        ///
+        /// After all buffered elements are consumed the next iteration point will return `nil`.
+        ///
+        /// Calling this function more than once has no effect. After calling finish, the stream enters a terminal state and doesn't accept
+        /// new elements.
+        @available(SwiftStdlib 9999, *)
+        public func finish() {
+            self._backing.storage.finish(nil)
+        }
+    }
+
+    /// Initializes a new ``AsyncStream`` and an ``AsyncStream/Source``.
+    ///
+    /// - Parameters:
+    ///   - elementType: The element type of the stream.
+    ///   - backPressureStrategy: The backpressure strategy that the stream should use.
+    /// - Returns: A tuple containing the stream and its source. The source should be passed to the
+    ///   producer while the stream should be passed to the consumer.
+    @available(SwiftStdlib 9999, *)
+    public static func makeStream(
+        of elementType: Element.Type = Element.self,
+        backPressureStrategy: Source.BackPressureStrategy
+    ) -> (`Self`, Source) {
+        let storage = _BackPressuredStorage<Element, Never>(
+            backPressureStrategy: backPressureStrategy._internalBackPressureStrategy
+        )
+        let source = Source(storage: storage)
+
+        return (.init(storage: storage), source)
+    }
+
+    init(storage: _BackPressuredStorage<Element, Never>) {
+        self._implementation = .backpressured(.init(storage: storage))
+    }
+}
+
+@available(SwiftStdlib 5.1, *)
+extension AsyncThrowingStream {
+    /// A mechanism to interface between producer code and an asynchronous stream.
+    ///
+    /// Use this source to provide elements to the stream by calling one of the `write` methods, then terminate the stream normally
+    /// by calling the `finish()` method. You can also use the source's `finish(throwing:)` method to terminate the stream by
+    /// throwing an error.
+    @available(SwiftStdlib 9999, *)
+    public struct Source: Sendable {
+        /// A strategy that handles the backpressure of the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public struct BackPressureStrategy: Sendable {
+            /// When the high watermark is reached producers will be suspended. All producers will be resumed again once
+            /// the low watermark is reached.
+            @available(SwiftStdlib 9999, *)
+            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
+                BackPressureStrategy(internalBackPressureStrategy: .watermark(.init(low: low, high: high)))
+            }
+
+            private init(internalBackPressureStrategy: _InternalBackPressureStrategy) {
+                self._internalBackPressureStrategy = internalBackPressureStrategy
+            }
+
+            fileprivate let _internalBackPressureStrategy: _InternalBackPressureStrategy
+        }
+
+        /// A type that indicates the result of writing elements to the source.
+        @available(SwiftStdlib 9999, *)
+        @frozen
+        public enum WriteResult: Sendable {
+            /// A token that is returned when the asynchronous stream's backpressure strategy indicated that production should
+            /// be suspended. Use this token to enqueue a callback by  calling the ``enqueueCallback(_:)`` method.
+            public struct CallbackToken: Sendable {
+                let id: UInt
+            }
+
+            /// Indicates that more elements should be produced and written to the source.
+            case produceMore
+
+            /// Indicates that a callback should be enqueued.
+            ///
+            /// The associated token should be passed to the ``enqueueCallback(_:)`` method.
+            case enqueueCallback(CallbackToken)
+        }
+
+        /// Backing class for the source used to hook a deinit.
+        final class _Backing: Sendable {
+            let storage: _BackPressuredStorage<Element, Failure>
+
+            init(storage: _BackPressuredStorage<Element, Failure>) {
+                self.storage = storage
+            }
+
+            deinit {
+                self.storage.sourceDeinitialized()
+            }
+        }
+
+        /// A callback to invoke when the stream finished.
+        ///
+        /// The stream finishes and calls this closure in the following cases:
+        /// - No iterator was created and the sequence was deinited
+        /// - An iterator was created and deinited
+        /// - After ``finish(throwing:)`` was called and all elements have been consumed
+        /// - The consuming task got cancelled
+        @available(SwiftStdlib 9999, *)
+        public var onTermination: (@Sendable () -> Void)? {
+            set {
+                self._backing.storage.onTermination = newValue
+            }
+            get {
+                self._backing.storage.onTermination
+            }
+        }
+
+        private var _backing: _Backing
+
+        internal init(storage: _BackPressuredStorage<Element, Failure>) {
+            self._backing = .init(storage: storage)
+        }
+
+        /// Writes new elements to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// - Parameter sequence: The elements to write to the asynchronous stream.
+        /// - Returns: The result that indicates if more elements should be produced at this time.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+            let id = try self._backing.storage.write(contentsOf: sequence)
+
+            if let id {
+                return .enqueueCallback(.init(id: id))
+            } else {
+                return .produceMore
+            }
+        }
+
+        /// Write the element to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// provided element. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// - Parameter element: The element to write to the asynchronous stream.
+        /// - Returns: The result that indicates if more elements should be produced at this time.
+        @available(SwiftStdlib 9999, *)
+        public func write(_ element: Element) throws -> WriteResult {
+            let id = try self._backing.storage.write(contentsOf: CollectionOfOne(element))
+
+            if let id {
+                return .enqueueCallback(.init(id: id))
+            } else {
+                return .produceMore
+            }
+        }
+
+        /// Enqueues a callback that will be invoked once more elements should be produced.
+        ///
+        /// Call this method after ``write(contentsOf:)`` or ``write(:)`` returned ``WriteResult/enqueueCallback(_:)``.
+        ///
+        /// - Important: Enqueueing the same token multiple times is not allowed.
+        ///
+        /// - Parameters:
+        ///   - callbackToken: The callback token.
+        ///   - onProduceMore: The callback which gets invoked once more elements should be produced.
+        @available(SwiftStdlib 9999, *)
+        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            self._backing.storage.enqueueProducer(callbackToken: callbackToken.id, onProduceMore: onProduceMore)
+        }
+
+        /// Cancel an enqueued callback.
+        ///
+        /// Call this method to cancel a callback enqueued by the ``enqueueCallback(callbackToken:onProduceMore:)`` method.
+        ///
+        /// - Note: This methods supports being called before ``enqueueCallback(callbackToken:onProduceMore:)`` is called and
+        /// will mark the passed `callbackToken` as cancelled.
+        ///
+        /// - Parameter callbackToken: The callback token.
+        @available(SwiftStdlib 9999, *)
+        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
+            self._backing.storage.cancelProducer(callbackToken: callbackToken.id)
+        }
+
+        /// Write new elements to the asynchronous stream and provide a callback which will be invoked once more elements should be produced.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// first element of the provided sequence. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+        /// a `Result.failure`.
+        ///
+        /// - Parameters:
+        ///   - sequence: The elements to write to the asynchronous stream.
+        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+        ///   invoked during the call to ``write(contentsOf:onProduceMore:)``.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+            do {
+                let writeResult = try self.write(contentsOf: sequence)
+
+                switch writeResult {
+                case .produceMore:
+                    onProduceMore(Result<Void, Error>.success(()))
+
+                case .enqueueCallback(let callbackToken):
+                    self.enqueueCallback(callbackToken: callbackToken, onProduceMore: onProduceMore)
+                }
+            } catch {
+                onProduceMore(.failure(error))
+            }
+        }
+
+        /// Writes the element to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// provided element. If the asynchronous stream already terminated then `onProduceMore` will be invoked with
+        /// a `Result.failure`.
+        ///
+        /// - Parameters:
+        ///   - sequence: The element to write to the asynchronous stream.
+        ///   - onProduceMore: The callback which gets invoked once more elements should be produced. This callback might be
+        ///   invoked during the call to ``write(_:onProduceMore:)``.
+        @available(SwiftStdlib 9999, *)
+        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            self.write(contentsOf: CollectionOfOne(element), onProduceMore: onProduceMore)
+        }
+
+        /// Write new elements to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// first element of the provided sequence. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// This method returns once more elements should be produced.
+        ///
+        /// - Parameters:
+        ///   - sequence: The elements to write to the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+            let writeResult = try { try self.write(contentsOf: sequence) }()
+
+            switch writeResult {
+            case .produceMore:
+                return
+
+            case .enqueueCallback(let callbackToken):
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        self.enqueueCallback(callbackToken: callbackToken, onProduceMore: { result in
+                            switch result {
+                            case .success():
+                                continuation.resume(returning: ())
+                            case .failure(let error):
+                                continuation.resume(throwing: error)
+                            }
+                        })
+                    }
+                } onCancel: {
+                    self.cancelCallback(callbackToken: callbackToken)
+                }
+            }
+        }
+
+        /// Write new element to the asynchronous stream.
+        ///
+        /// If there is a task consuming the stream and awaiting the next element then the task will get resumed with the
+        /// provided element. If the asynchronous stream already terminated then this method will throw an error
+        /// indicating the failure.
+        ///
+        /// This method returns once more elements should be produced.
+        ///
+        /// - Parameters:
+        ///   - sequence: The element to write to the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public func write(_ element: Element) async throws {
+            try await self.write(contentsOf: CollectionOfOne(element))
+        }
+
+        /// Write the elements of the asynchronous sequence to the asynchronous stream.
+        ///
+        /// This method returns once the provided asynchronous sequence or the  the asynchronous stream finished.
+        ///
+        /// - Important: This method does not finish the source if consuming the upstream sequence terminated.
+        ///
+        /// - Parameters:
+        ///   - sequence: The elements to write to the asynchronous stream.
+        @available(SwiftStdlib 9999, *)
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+            for try await element in sequence {
+                try await self.write(contentsOf: CollectionOfOne(element))
+            }
+        }
+
+        /// Indicates that the production terminated.
+        ///
+        /// After all buffered elements are consumed the next iteration point will return `nil` or throw an error.
+        ///
+        /// Calling this function more than once has no effect. After calling finish, the stream enters a terminal state and doesn't accept
+        /// new elements.
+        ///
+        /// - Parameters:
+        ///   - error: The error to throw, or `nil`, to finish normally.
+        @available(SwiftStdlib 9999, *)
+        public func finish(throwing error: Failure?) {
+            self._backing.storage.finish(error)
+        }
+    }
+
+    /// Initializes a new ``AsyncThrowingStream`` and an ``AsyncThrowingStream/Source``.
+    ///
+    /// - Parameters:
+    ///   - elementType: The element type of the stream.
+    ///   - failureType: The failure type of the stream.
+    ///   - backPressureStrategy: The backpressure strategy that the stream should use.
+    /// - Returns: A tuple containing the stream and its source. The source should be passed to the
+    ///   producer while the stream should be passed to the consumer.
+    @available(SwiftStdlib 9999, *)
+    public static func makeStream(
+        of elementType: Element.Type = Element.self,
+        throwing failureType: Failure.Type = Failure.self,
+        backPressureStrategy: Source.BackPressureStrategy
+    ) -> (`Self`, Source) where Failure == Error {
+        let storage = _BackPressuredStorage<Element, Failure>(
+            backPressureStrategy: backPressureStrategy._internalBackPressureStrategy
+        )
+        let source = Source(storage: storage)
+
+        return (.init(storage: storage), source)
+    }
+
+    init(storage: _BackPressuredStorage<Element, Failure>) {
+        self._implementation = .backpressured(.init(storage: storage))
+    }
+}
+
+struct _WatermarkBackPressureStrategy {
+    /// The low watermark where demand should start.
+    private let _low: Int
+    /// The high watermark where demand should be stopped.
+    private let _high: Int
+
+    /// Initializes a new ``_WatermarkBackPressureStrategy``.
+    ///
+    /// - Parameters:
+    ///   - low: The low watermark where demand should start.
+    ///   - high: The high watermark where demand should be stopped.
+    init(low: Int, high: Int) {
+        precondition(low <= high)
+        self._low = low
+        self._high = high
+    }
+
+    func didYield(bufferDepth: Int) -> Bool {
+        // We are demanding more until we reach the high watermark
+        return bufferDepth < self._high
+    }
+
+    func didConsume(bufferDepth: Int) -> Bool {
+        // We start demanding again once we are below the low watermark
+        return bufferDepth < self._low
+    }
+}
+
+@available(SwiftStdlib 5.1, *)
+enum _InternalBackPressureStrategy {
+    case watermark(_WatermarkBackPressureStrategy)
+
+    mutating func didYield(bufferDepth: Int) -> Bool {
+        switch self {
+        case .watermark(let strategy):
+            return strategy.didYield(bufferDepth: bufferDepth)
+        }
+    }
+
+    mutating func didConsume(bufferDepth: Int) -> Bool {
+        switch self {
+        case .watermark(let strategy):
+            return strategy.didConsume(bufferDepth: bufferDepth)
+        }
+    }
+}
+
+// We are unchecked Sendable since we are protecting our state with a lock.
+@available(SwiftStdlib 5.1, *)
+final class _BackPressuredStorage<Element, Failure: Error>: @unchecked Sendable {
+    /// The state machine
+    var _stateMachine: _ManagedCriticalState<_StateMachine<Element, Failure>>
+
+    var onTermination: (@Sendable () -> Void)? {
+        set {
+            self._stateMachine.withCriticalRegion {
+                $0._onTermination = newValue
+            }
+        }
+        get {
+            self._stateMachine.withCriticalRegion {
+                $0._onTermination
+            }
+        }
+    }
+
+    init(
+        backPressureStrategy: _InternalBackPressureStrategy
+    ) {
+        self._stateMachine = .init(.init(backPressureStrategy: backPressureStrategy))
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func sequenceDeinitialized() {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.sequenceDeinitialized()
+        }
+
+        switch action {
+        case .callOnTermination(let onTermination):
+            onTermination?()
+
+        case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+            for producerContinuation in producerContinuations {
+                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+            }
+            onTermination?()
+
+        case .none:
+            break
+        }
+    }
+
+    func iteratorInitialized() {
+        self._stateMachine.withCriticalRegion {
+            $0.iteratorInitialized()
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func iteratorDeinitialized() {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.iteratorDeinitialized()
+        }
+
+        switch action {
+        case .callOnTermination(let onTermination):
+            onTermination?()
+
+        case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+            for producerContinuation in producerContinuations {
+                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+            }
+            onTermination?()
+
+        case .none:
+            break
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func sourceDeinitialized() {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.sourceDeinitialized()
+        }
+
+        switch action {
+        case .callOnTermination(let onTermination):
+            onTermination?()
+
+        case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+            for producerContinuation in producerContinuations {
+                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+            }
+            onTermination?()
+
+        case .failProducers(let producerContinuations):
+            for producerContinuation in producerContinuations {
+                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+            }
+
+        case .none:
+            break
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func write(
+        contentsOf sequence: some Sequence<Element>
+    ) throws -> UInt? {
+        let action = self._stateMachine.withCriticalRegion {
+            return $0.write(sequence)
+        }
+
+        switch action {
+        case .returnProduceMore:
+            return nil
+
+        case .returnEnqueue(let callbackToken):
+            return callbackToken
+
+        case .resumeConsumerAndReturnProduceMore(let continuation, let element):
+            continuation.resume(returning: element)
+            return nil
+
+        case .resumeConsumerAndReturnEnqueue(let continuation, let element, let callbackToken):
+            continuation.resume(returning: element)
+            return callbackToken
+
+        case .throwFinishedError:
+            throw AsyncStreamAlreadyFinishedError()
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func enqueueProducer(callbackToken: UInt, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.enqueueProducer(callbackToken: callbackToken, onProduceMore: onProduceMore)
+        }
+
+        switch action {
+        case .resumeProducer(let onProduceMore):
+            onProduceMore(Result<Void, Error>.success(()))
+
+        case .resumeProducerWithError(let onProduceMore, let error):
+            onProduceMore(Result<Void, Error>.failure(error))
+
+        case .none:
+            break
+        }
+    }
+
+    func cancelProducer(callbackToken: UInt) {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.cancelProducer(callbackToken: callbackToken)
+        }
+
+        switch action {
+        case .resumeProducerWithCancellationError(let onProduceMore):
+            onProduceMore(Result<Void, Error>.failure(CancellationError()))
+
+        case .none:
+            break
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func finish(_ failure: Failure?) {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.finish(failure)
+        }
+
+        switch action {
+        case .callOnTermination(let onTermination):
+            onTermination?()
+
+        case .resumeConsumerAndCallOnTermination(let consumerContinuation, let failure, let onTermination):
+            switch failure {
+            case .some(let error):
+                consumerContinuation.resume(throwing: error)
+            case .none:
+                consumerContinuation.resume(returning: nil)
+            }
+
+            onTermination?()
+
+        case .resumeProducers(let producerContinuations):
+            for producerContinuation in producerContinuations {
+                producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+            }
+
+        case .none:
+            break
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func next() async throws -> Element? {
+        let action = self._stateMachine.withCriticalRegion {
+            $0.next()
+        }
+
+        switch action {
+        case .returnElement(let element):
+            return element
+
+        case .returnElementAndResumeProducers(let element, let producerContinuations):
+            for producerContinuation in producerContinuations {
+                producerContinuation(Result<Void, Error>.success(()))
+            }
+
+            return element
+
+        case .returnFailureAndCallOnTermination(let failure, let onTermination):
+            onTermination?()
+            switch failure {
+            case .some(let error):
+                throw error
+
+            case .none:
+                return nil
+            }
+
+        case .returnNil:
+            return nil
+
+        case .suspendTask:
+            return try await self.suspendNext()
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    func suspendNext() async throws -> Element? {
+        return try await withTaskCancellationHandler {
+            return try await withCheckedThrowingContinuation { continuation in
+                let action = self._stateMachine.withCriticalRegion {
+                    $0.suspendNext(continuation: continuation)
+                }
+
+                switch action {
+                case .resumeConsumerWithElement(let continuation, let element):
+                    continuation.resume(returning: element)
+
+                case .resumeConsumerWithElementAndProducers(let continuation, let element, let producerContinuations):
+                    continuation.resume(returning: element)
+                    for producerContinuation in producerContinuations {
+                        producerContinuation(Result<Void, Error>.success(()))
+                    }
+
+                case .resumeConsumerWithFailureAndCallOnTermination(let continuation, let failure, let onTermination):
+                    switch failure {
+                    case .some(let error):
+                        continuation.resume(throwing: error)
+
+                    case .none:
+                        continuation.resume(returning: nil)
+                    }
+                    onTermination?()
+
+                case .resumeConsumerWithNil(let continuation):
+                    continuation.resume(returning: nil)
+
+                case .none:
+                    break
+                }
+            }
+        } onCancel: {
+            let action = self._stateMachine.withCriticalRegion {
+                $0.cancelNext()
+            }
+
+            switch action {
+            case .resumeConsumerWithCancellationErrorAndCallOnTermination(let continuation, let onTermination):
+                continuation.resume(throwing: CancellationError())
+                onTermination?()
+
+            case .failProducersAndCallOnTermination(let producerContinuations, let onTermination):
+                for producerContinuation in producerContinuations {
+                    producerContinuation(.failure(AsyncStreamAlreadyFinishedError()))
+                }
+                onTermination?()
+
+            case .none:
+                break
+            }
+        }
+    }
+}
+
+/// The state machine of the backpressured async stream.
+@available(SwiftStdlib 5.1, *)
+struct _StateMachine<Element, Failure: Error> {
+    enum _State {
+        struct Initial {
+            /// The backpressure strategy.
+            var backPressureStrategy: _InternalBackPressureStrategy
+            /// Indicates if the iterator was initialized.
+            var iteratorInitialized: Bool
+            /// The onTermination callback.
+            var onTermination: (@Sendable () -> Void)?
+        }
+
+        struct Streaming {
+            /// The backpressure strategy.
+            var backPressureStrategy: _InternalBackPressureStrategy
+            /// Indicates if the iterator was initialized.
+            var iteratorInitialized: Bool
+            /// The onTermination callback.
+            var onTermination: (@Sendable () -> Void)?
+            /// The buffer of elements.
+            var buffer: _Deque<Element>
+            /// The optional consumer continuation.
+            var consumerContinuation: CheckedContinuation<Element?, Error>?
+            /// The producer continuations.
+            var producerContinuations: _Deque<(UInt, (Result<Void, Error>) -> Void)>
+            /// The producers that have been cancelled.
+            var cancelledAsyncProducers: _Deque<UInt>
+            /// Indicates if we currently have outstanding demand.
+            var hasOutstandingDemand: Bool
+        }
+
+        struct SourceFinished {
+            /// Indicates if the iterator was initialized.
+            var iteratorInitialized: Bool
+            /// The buffer of elements.
+            var buffer: _Deque<Element>
+            /// The failure that should be thrown after the last element has been consumed.
+            var failure: Failure?
+            /// The onTermination callback.
+            var onTermination: (@Sendable () -> Void)?
+        }
+
+        case initial(Initial)
+        /// The state once either any element was yielded or `next()` was called.
+        case streaming(Streaming)
+        /// The state once the underlying source signalled that it is finished.
+        case sourceFinished(SourceFinished)
+
+        /// The state once there can be no outstanding demand. This can happen if:
+        /// 1. The iterator was deinited
+        /// 2. The underlying source finished and all buffered elements have been consumed
+        case finished(iteratorInitialized: Bool)
+
+        /// An intermediate state to avoid CoWs.
+        case modify
+    }
+
+    /// The state machine's current state.
+    var _state: _State
+
+    // The ID used for the next CallbackToken.
+    var nextCallbackTokenID: UInt = 0
+
+    var _onTermination: (@Sendable () -> Void)? {
+        set {
+            switch self._state {
+            case .initial(var initial):
+                initial.onTermination = newValue
+                self._state = .initial(initial)
+
+            case .streaming(var streaming):
+                streaming.onTermination = newValue
+                self._state = .streaming(streaming)
+
+            case .sourceFinished(var sourceFinished):
+                sourceFinished.onTermination = newValue
+                self._state = .sourceFinished(sourceFinished)
+
+            case .finished:
+                break
+
+            case .modify:
+                fatalError("AsyncStream internal inconsistency")
+            }
+        }
+        get {
+            switch self._state {
+            case .initial(let initial):
+                return initial.onTermination
+
+            case .streaming(let streaming):
+                return streaming.onTermination
+
+            case .sourceFinished(let sourceFinished):
+                return sourceFinished.onTermination
+
+            case .finished:
+                return nil
+
+            case .modify:
+                fatalError("AsyncStream internal inconsistency")
+            }
+        }
+    }
+
+    /// Initializes a new `StateMachine`.
+    ///
+    /// We are passing and holding the back-pressure strategy here because
+    /// it is a customizable extension of the state machine.
+    ///
+    /// - Parameter backPressureStrategy: The back-pressure strategy.
+    init(
+        backPressureStrategy: _InternalBackPressureStrategy
+    ) {
+        self._state = .initial(.init(
+            backPressureStrategy: backPressureStrategy,
+            iteratorInitialized: false,
+            onTermination: nil
+        ))
+    }
+
+    /// Generates the next callback token.
+    mutating func nextCallbackToken() -> UInt {
+        let id = self.nextCallbackTokenID
+        self.nextCallbackTokenID += 1
+        return id
+    }
+
+    /// Actions returned by `sequenceDeinitialized()`.
+    enum SequenceDeinitializedAction {
+        /// Indicates that `onTermination` should be called.
+        case callOnTermination((@Sendable () -> Void)?)
+        /// Indicates that  all producers should be failed and `onTermination` should be called.
+        case failProducersAndCallOnTermination(
+            [(Result<Void, Error>) -> Void],
+            (@Sendable () -> Void)?
+        )
+    }
+
+    mutating func sequenceDeinitialized() -> SequenceDeinitializedAction? {
+        switch self._state {
+        case .initial(let initial):
+            if initial.iteratorInitialized {
+                // An iterator was created and we deinited the sequence.
+                // This is an expected pattern and we just continue on normal.
+                return .none
+            } else {
+                // No iterator was created so we can transition to finished right away.
+                self._state = .finished(iteratorInitialized: false)
+
+                return .callOnTermination(initial.onTermination)
+            }
+
+        case .streaming(let streaming):
+            if streaming.iteratorInitialized {
+                // An iterator was created and we deinited the sequence.
+                // This is an expected pattern and we just continue on normal.
+                return .none
+            } else {
+                // No iterator was created so we can transition to finished right away.
+                self._state = .finished(iteratorInitialized: false)
+
+                return .failProducersAndCallOnTermination(
+                    Array(streaming.producerContinuations.map { $0.1 }),
+                    streaming.onTermination
+                )
+            }
+
+        case .sourceFinished(let sourceFinished):
+            if sourceFinished.iteratorInitialized {
+                // An iterator was created and we deinited the sequence.
+                // This is an expected pattern and we just continue on normal.
+                return .none
+            } else {
+                // No iterator was created so we can transition to finished right away.
+                self._state = .finished(iteratorInitialized: false)
+
+                return .callOnTermination(sourceFinished.onTermination)
+            }
+
+        case .finished:
+            // We are already finished so there is nothing left to clean up.
+            // This is just the references dropping afterwards.
+            return .none
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    mutating func iteratorInitialized() {
+        switch self._state {
+        case .initial(var initial):
+            if initial.iteratorInitialized {
+                // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+                fatalError("Only a single AsyncIterator can be created")
+            } else {
+                // The first and only iterator was initialized.
+                initial.iteratorInitialized = true
+                self._state = .initial(initial)
+            }
+
+        case .streaming(var streaming):
+            if streaming.iteratorInitialized {
+                // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+                fatalError("Only a single AsyncIterator can be created")
+            } else {
+                // The first and only iterator was initialized.
+                streaming.iteratorInitialized = true
+                self._state = .streaming(streaming)
+            }
+
+        case .sourceFinished(var sourceFinished):
+            if sourceFinished.iteratorInitialized {
+                // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+                fatalError("Only a single AsyncIterator can be created")
+            } else {
+                // The first and only iterator was initialized.
+                sourceFinished.iteratorInitialized = true
+                self._state = .sourceFinished(sourceFinished)
+            }
+
+        case .finished(iteratorInitialized: true):
+            // Our sequence is a unicast sequence and does not support multiple AsyncIterator's
+            fatalError("Only a single AsyncIterator can be created")
+
+        case .finished(iteratorInitialized: false):
+            // It is strange that an iterator is created after we are finished
+            // but it can definitely happen, e.g.
+            // Sequence.init -> source.finish -> sequence.makeAsyncIterator
+            self._state = .finished(iteratorInitialized: true)
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `iteratorDeinitialized()`.
+    enum IteratorDeinitializedAction {
+        /// Indicates that `onTermination` should be called.
+        case callOnTermination((@Sendable () -> Void)?)
+        /// Indicates that  all producers should be failed and `onTermination` should be called.
+        case failProducersAndCallOnTermination(
+            [(Result<Void, Error>) -> Void],
+            (@Sendable () -> Void)?
+        )
+    }
+
+    mutating func iteratorDeinitialized() -> IteratorDeinitializedAction? {
+        switch self._state {
+        case .initial(let initial):
+            if initial.iteratorInitialized {
+                // An iterator was created and deinited. Since we only support
+                // a single iterator we can now transition to finish.
+                self._state = .finished(iteratorInitialized: true)
+                return .callOnTermination(initial.onTermination)
+            } else {
+                // An iterator needs to be initialized before it can be deinitialized.
+                fatalError("AsyncStream internal inconsistency")
+            }
+
+        case .streaming(let streaming):
+            if streaming.iteratorInitialized {
+                // An iterator was created and deinited. Since we only support
+                // a single iterator we can now transition to finish.
+                self._state = .finished(iteratorInitialized: true)
+
+                return .failProducersAndCallOnTermination(
+                    Array(streaming.producerContinuations.map { $0.1 }),
+                    streaming.onTermination
+                )
+            } else {
+                // An iterator needs to be initialized before it can be deinitialized.
+                fatalError("AsyncStream internal inconsistency")
+            }
+
+        case .sourceFinished(let sourceFinished):
+            if sourceFinished.iteratorInitialized {
+                // An iterator was created and deinited. Since we only support
+                // a single iterator we can now transition to finish.
+                self._state = .finished(iteratorInitialized: true)
+                return .callOnTermination(sourceFinished.onTermination)
+            } else {
+                // An iterator needs to be initialized before it can be deinitialized.
+                fatalError("AsyncStream internal inconsistency")
+            }
+
+        case .finished:
+            // We are already finished so there is nothing left to clean up.
+            // This is just the references dropping afterwards.
+            return .none
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `sourceDeinitialized()`.
+    enum SourceDeinitializedAction {
+        /// Indicates that `onTermination` should be called.
+        case callOnTermination((() -> Void)?)
+        /// Indicates that  all producers should be failed and `onTermination` should be called.
+        case failProducersAndCallOnTermination(
+            [(Result<Void, Error>) -> Void],
+            (@Sendable () -> Void)?
+        )
+        /// Indicates that all producers should be failed.
+        case failProducers([(Result<Void, Error>) -> Void])
+    }
+
+    mutating func sourceDeinitialized() -> SourceDeinitializedAction? {
+        switch self._state {
+        case .initial(let initial):
+            // The source got deinited before anything was written
+            self._state = .finished(iteratorInitialized: initial.iteratorInitialized)
+            return .callOnTermination(initial.onTermination)
+
+        case .streaming(let streaming):
+            if streaming.buffer.isEmpty {
+                // We can transition to finished right away since the buffer is empty now
+                self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+
+                return .failProducersAndCallOnTermination(
+                    Array(streaming.producerContinuations.map { $0.1 }),
+                    streaming.onTermination
+                )
+            } else {
+                // The continuation must be `nil` if the buffer has elements
+                precondition(streaming.consumerContinuation == nil)
+
+                self._state = .sourceFinished(.init(
+                    iteratorInitialized: streaming.iteratorInitialized,
+                    buffer: streaming.buffer,
+                    failure: nil,
+                    onTermination: streaming.onTermination
+                ))
+
+                return .failProducers(
+                    Array(streaming.producerContinuations.map { $0.1 })
+                )
+            }
+
+        case .sourceFinished, .finished:
+            // This is normal and we just have to tolerate it
+            return .none
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `write()`.
+    enum WriteAction {
+        /// Indicates that the producer should be notified to produce more.
+        case returnProduceMore
+        /// Indicates that the producer should be suspended to stop producing.
+        case returnEnqueue(
+            callbackToken: UInt
+        )
+        /// Indicates that the consumer should be resumed and the producer should be notified to produce more.
+        case resumeConsumerAndReturnProduceMore(
+            continuation: CheckedContinuation<Element?, Error>,
+            element: Element
+        )
+        /// Indicates that the consumer should be resumed and the producer should be suspended.
+        case resumeConsumerAndReturnEnqueue(
+            continuation: CheckedContinuation<Element?, Error>,
+            element: Element,
+            callbackToken: UInt
+        )
+        /// Indicates that the producer has been finished.
+        case throwFinishedError
+
+        init(
+            callbackToken: UInt?,
+            continuationAndElement: (CheckedContinuation<Element?, Error>, Element)? = nil
+        ) {
+            switch (callbackToken, continuationAndElement) {
+            case (.none, .none):
+                self = .returnProduceMore
+
+            case (.some(let callbackToken), .none):
+                self = .returnEnqueue(callbackToken: callbackToken)
+
+            case (.none, .some((let continuation, let element))):
+                self = .resumeConsumerAndReturnProduceMore(
+                    continuation: continuation,
+                    element: element
+                )
+
+            case (.some(let callbackToken), .some((let continuation, let element))):
+                self = .resumeConsumerAndReturnEnqueue(
+                    continuation: continuation,
+                    element: element,
+                    callbackToken: callbackToken
+                )
+            }
+        }
+    }
+
+    mutating func write(_ sequence: some Sequence<Element>) -> WriteAction {
+        switch self._state {
+        case .initial(var initial):
+            var buffer = _Deque<Element>()
+            buffer.append(contentsOf: sequence)
+
+            let shouldProduceMore = initial.backPressureStrategy.didYield(bufferDepth: buffer.count)
+            let callbackToken = shouldProduceMore ? nil : self.nextCallbackToken()
+
+            self._state = .streaming(.init(
+                backPressureStrategy: initial.backPressureStrategy,
+                iteratorInitialized: initial.iteratorInitialized,
+                onTermination: initial.onTermination,
+                buffer: buffer,
+                consumerContinuation: nil,
+                producerContinuations: .init(),
+                cancelledAsyncProducers: .init(),
+                hasOutstandingDemand: shouldProduceMore
+            ))
+
+            return .init(callbackToken: callbackToken)
+
+        case .streaming(var streaming):
+            self._state = .modify
+
+            streaming.buffer.append(contentsOf: sequence)
+
+            // We have an element and can resume the continuation
+            let shouldProduceMore = streaming.backPressureStrategy.didYield(bufferDepth: streaming.buffer.count)
+            streaming.hasOutstandingDemand = shouldProduceMore
+            let callbackToken = shouldProduceMore ? nil : self.nextCallbackToken()
+
+            if let consumerContinuation = streaming.consumerContinuation {
+                guard let element = streaming.buffer.popFirst() else {
+                    // We got a yield of an empty sequence. We just tolerate this.
+                    self._state = .streaming(streaming)
+
+                    return .init(callbackToken: callbackToken)
+                }
+
+                // We got a consumer continuation and an element. We can resume the consumer now
+                streaming.consumerContinuation = nil
+                self._state = .streaming(streaming)
+                return .init(
+                    callbackToken: callbackToken,
+                    continuationAndElement: (consumerContinuation, element)
+                )
+            } else {
+                // We don't have a suspended consumer so we just buffer the elements
+                self._state = .streaming(streaming)
+                return .init(
+                    callbackToken: callbackToken
+                )
+            }
+
+        case .sourceFinished, .finished:
+            // If the source has finished we are dropping the elements.
+            return .throwFinishedError
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `enqueueProducer()`.
+    enum EnqueueProducerAction {
+        /// Indicates that the producer should be notified to produce more.
+        case resumeProducer((Result<Void, Error>) -> Void)
+        /// Indicates that the producer should be notified about an error.
+        case resumeProducerWithError((Result<Void, Error>) -> Void, Error)
+    }
+
+    @available(SwiftStdlib 9999, *)
+    mutating func enqueueProducer(callbackToken: UInt, onProduceMore: @Sendable @escaping (Result<Void, Error>) -> Void) -> EnqueueProducerAction? {
+        switch self._state {
+        case .initial:
+            // We need to transition to streaming before we can suspend
+            // This is enforced because the CallbackToken has no public init so
+            // one must create it by calling `write` first.
+            fatalError("AsyncStream internal inconsistency")
+
+        case .streaming(var streaming):
+            if let index = streaming.cancelledAsyncProducers.firstIndex(of: callbackToken) {
+                // Our producer got marked as cancelled.
+                self._state = .modify
+                streaming.cancelledAsyncProducers.remove(at: index)
+                self._state = .streaming(streaming)
+
+                return .resumeProducerWithError(onProduceMore, CancellationError())
+            } else if streaming.hasOutstandingDemand {
+                // We hit an edge case here where we wrote but the consuming thread got interleaved
+                return .resumeProducer(onProduceMore)
+            } else {
+                self._state = .modify
+                streaming.producerContinuations.append((callbackToken, onProduceMore))
+
+                self._state = .streaming(streaming)
+                return .none
+            }
+
+        case .sourceFinished, .finished:
+            // Since we are unlocking between yielding and suspending the yield
+            // It can happen that the source got finished or the consumption fully finishes.
+            return .resumeProducerWithError(onProduceMore, AsyncStreamAlreadyFinishedError())
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `cancelProducer()`.
+    enum CancelProducerAction {
+        /// Indicates that the producer should be notified about cancellation.
+        case resumeProducerWithCancellationError((Result<Void, Error>) -> Void)
+    }
+
+    mutating func cancelProducer(callbackToken: UInt) -> CancelProducerAction? {
+        switch self._state {
+        case .initial:
+            // We need to transition to streaming before we can suspend
+            fatalError("AsyncStream internal inconsistency")
+
+        case .streaming(var streaming):
+            if let index = streaming.producerContinuations.firstIndex(where: { $0.0 == callbackToken }) {
+                // We have an enqueued producer that we need to resume now
+                self._state = .modify
+                let continuation = streaming.producerContinuations.remove(at: index).1
+                self._state = .streaming(streaming)
+
+                return .resumeProducerWithCancellationError(continuation)
+            } else {
+                // The task that yields was cancelled before yielding so the cancellation handler
+                // got invoked right away
+                self._state = .modify
+                streaming.cancelledAsyncProducers.append(callbackToken)
+                self._state = .streaming(streaming)
+
+                return .none
+            }
+
+        case .sourceFinished, .finished:
+            // Since we are unlocking between yielding and suspending the yield
+            // It can happen that the source got finished or the consumption fully finishes.
+            return .none
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `finish()`.
+    enum FinishAction {
+        /// Indicates that `onTermination` should be called.
+        case callOnTermination((() -> Void)?)
+        /// Indicates that the consumer  should be resumed with the failure, the producers
+        /// should be resumed with an error and `onTermination` should be called.
+        case resumeConsumerAndCallOnTermination(
+            consumerContinuation: CheckedContinuation<Element?, Error>,
+            failure: Failure?,
+            onTermination: (() -> Void)?
+        )
+        /// Indicates that the producers should be resumed with an error.
+        case resumeProducers(
+            producerContinuations: Array<(Result<Void, Error>) -> Void>
+        )
+    }
+
+    @inlinable
+    mutating func finish(_ failure: Failure?) -> FinishAction? {
+        switch self._state {
+        case .initial(let initial):
+            // Nothing was yielded nor did anybody call next
+            // This means we can transition to sourceFinished and store the failure
+            self._state = .sourceFinished(.init(
+                iteratorInitialized: initial.iteratorInitialized,
+                buffer: .init(),
+                failure: failure,
+                onTermination: initial.onTermination
+            ))
+
+            return .callOnTermination(initial.onTermination)
+
+        case .streaming(let streaming):
+            if let consumerContinuation = streaming.consumerContinuation {
+                // We have a continuation, this means our buffer must be empty
+                // Furthermore, we can now transition to finished
+                // and resume the continuation with the failure
+                precondition(streaming.buffer.isEmpty, "Expected an empty buffer")
+                precondition(streaming.producerContinuations.isEmpty, "Expected no suspended producers")
+
+                self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+
+                return .resumeConsumerAndCallOnTermination(
+                    consumerContinuation: consumerContinuation,
+                    failure: failure,
+                    onTermination: streaming.onTermination
+                )
+            } else {
+                self._state = .sourceFinished(.init(
+                    iteratorInitialized: streaming.iteratorInitialized,
+                    buffer: streaming.buffer,
+                    failure: failure,
+                    onTermination: streaming.onTermination
+                ))
+
+                return .resumeProducers(producerContinuations: Array(streaming.producerContinuations.map { $0.1 }))
+            }
+
+        case .sourceFinished, .finished:
+            // If the source has finished, finishing again has no effect.
+            return .none
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `next()`.
+    enum NextAction {
+        /// Indicates that the element should be returned to the caller.
+        case returnElement(Element)
+        /// Indicates that the element should be returned to the caller and that all producers should be called.
+        case returnElementAndResumeProducers(Element, [(Result<Void, Error>) -> Void])
+        /// Indicates that the `Failure` should be returned to the caller and that `onTermination` should be called.
+        case returnFailureAndCallOnTermination(Failure?, (() -> Void)?)
+        /// Indicates that the `nil` should be returned to the caller.
+        case returnNil
+        /// Indicates that the `Task` of the caller should be suspended.
+        case suspendTask
+    }
+
+    mutating func next() -> NextAction {
+        switch self._state {
+        case .initial(let initial):
+            // We are not interacting with the back-pressure strategy here because
+            // we are doing this inside `next(:)`
+            self._state = .streaming(.init(
+                backPressureStrategy: initial.backPressureStrategy,
+                iteratorInitialized: initial.iteratorInitialized,
+                onTermination: initial.onTermination,
+                buffer: _Deque<Element>(),
+                consumerContinuation: nil,
+                producerContinuations: .init(),
+                cancelledAsyncProducers: .init(),
+                hasOutstandingDemand: false
+            ))
+
+            return .suspendTask
+        case .streaming(var streaming):
+            guard streaming.consumerContinuation == nil else {
+                // We have multiple AsyncIterators iterating the sequence
+                fatalError("AsyncStream internal inconsistency")
+            }
+
+            self._state = .modify
+
+            if let element = streaming.buffer.popFirst() {
+                // We have an element to fulfil the demand right away.
+                let shouldProduceMore = streaming.backPressureStrategy.didConsume(bufferDepth: streaming.buffer.count)
+                streaming.hasOutstandingDemand = shouldProduceMore
+
+                if shouldProduceMore {
+                    // There is demand and we have to resume our producers
+                    let producers = Array(streaming.producerContinuations.map { $0.1 })
+                    streaming.producerContinuations.removeAll()
+                    self._state = .streaming(streaming)
+                    return .returnElementAndResumeProducers(element, producers)
+                } else {
+                    // We don't have any new demand, so we can just return the element.
+                    self._state = .streaming(streaming)
+                    return .returnElement(element)
+                }
+            } else {
+                // There is nothing in the buffer to fulfil the demand so we need to suspend.
+                // We are not interacting with the back-pressure strategy here because
+                // we are doing this inside `suspendNext`
+                self._state = .streaming(streaming)
+
+                return .suspendTask
+            }
+
+        case .sourceFinished(var sourceFinished):
+            // Check if we have an element left in the buffer and return it
+            self._state = .modify
+
+            if let element = sourceFinished.buffer.popFirst() {
+                self._state = .sourceFinished(sourceFinished)
+
+                return .returnElement(element)
+            } else {
+                // We are returning the queued failure now and can transition to finished
+                self._state = .finished(iteratorInitialized: sourceFinished.iteratorInitialized)
+
+                return .returnFailureAndCallOnTermination(sourceFinished.failure, sourceFinished.onTermination)
+            }
+
+        case .finished:
+            return .returnNil
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `suspendNext()`.
+    enum SuspendNextAction {
+        /// Indicates that the consumer should be resumed.
+        case resumeConsumerWithElement(CheckedContinuation<Element?, Error>, Element)
+        /// Indicates that the consumer and all producers should be resumed.
+        case resumeConsumerWithElementAndProducers(CheckedContinuation<Element?, Error>, Element, [(Result<Void, Error>) -> Void])
+        /// Indicates that the consumer should be resumed with the failure and that `onTermination` should be called.
+        case resumeConsumerWithFailureAndCallOnTermination(CheckedContinuation<Element?, Error>, Failure?, (() -> Void)?)
+        /// Indicates that the consumer should be resumed with `nil`.
+        case resumeConsumerWithNil(CheckedContinuation<Element?, Error>)
+    }
+
+    mutating func suspendNext(continuation: CheckedContinuation<Element?, Error>) -> SuspendNextAction? {
+        switch self._state {
+        case .initial:
+            // We need to transition to streaming before we can suspend
+            preconditionFailure("AsyncStream internal inconsistency")
+
+        case .streaming(var streaming):
+            guard streaming.consumerContinuation == nil else {
+                // We have multiple AsyncIterators iterating the sequence
+                fatalError("This should never happen since we only allow a single Iterator to be created")
+            }
+
+            self._state = .modify
+
+            // We have to check here again since we might have a producer interleave next and suspendNext
+            if let element = streaming.buffer.popFirst() {
+                // We have an element to fulfil the demand right away.
+
+                let shouldProduceMore = streaming.backPressureStrategy.didConsume(bufferDepth: streaming.buffer.count)
+                streaming.hasOutstandingDemand = shouldProduceMore
+
+                if shouldProduceMore {
+                    // There is demand and we have to resume our producers
+                    let producers = Array(streaming.producerContinuations.map { $0.1 })
+                    streaming.producerContinuations.removeAll()
+                    self._state = .streaming(streaming)
+                    return .resumeConsumerWithElementAndProducers(continuation, element, producers)
+                } else {
+                    // We don't have any new demand, so we can just return the element.
+                    self._state = .streaming(streaming)
+                    return .resumeConsumerWithElement(continuation, element)
+                }
+            } else {
+                // There is nothing in the buffer to fulfil the demand so we to store the continuation.
+                streaming.consumerContinuation = continuation
+                self._state = .streaming(streaming)
+
+                return .none
+            }
+
+        case .sourceFinished(var sourceFinished):
+            // Check if we have an element left in the buffer and return it
+            self._state = .modify
+
+            if let element = sourceFinished.buffer.popFirst() {
+                self._state = .sourceFinished(sourceFinished)
+
+                return .resumeConsumerWithElement(continuation, element)
+            } else {
+                // We are returning the queued failure now and can transition to finished
+                self._state = .finished(iteratorInitialized: sourceFinished.iteratorInitialized)
+
+                return .resumeConsumerWithFailureAndCallOnTermination(
+                    continuation,
+                    sourceFinished.failure,
+                    sourceFinished.onTermination
+                )
+            }
+
+        case .finished:
+            return .resumeConsumerWithNil(continuation)
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+
+    /// Actions returned by `cancelNext()`.
+    enum CancelNextAction {
+        /// Indicates that the continuation should be resumed with a cancellation error, the producers should be finished and call onTermination.
+        case resumeConsumerWithCancellationErrorAndCallOnTermination(CheckedContinuation<Element?, Error>, (() -> Void)?)
+        /// Indicates that the producers should be finished and call onTermination.
+        case failProducersAndCallOnTermination([(Result<Void, Error>) -> Void], (() -> Void)?)
+    }
+
+    mutating func cancelNext() -> CancelNextAction? {
+        switch self._state {
+        case .initial:
+            // We need to transition to streaming before we can suspend
+            fatalError("AsyncStream internal inconsistency")
+
+        case .streaming(let streaming):
+            self._state = .finished(iteratorInitialized: streaming.iteratorInitialized)
+
+            if let consumerContinuation = streaming.consumerContinuation {
+                precondition(streaming.producerContinuations.isEmpty, "Internal inconsistency. Unexpected producer continuations.")
+                return .resumeConsumerWithCancellationErrorAndCallOnTermination(
+                    consumerContinuation,
+                    streaming.onTermination
+                )
+            } else {
+                return .failProducersAndCallOnTermination(
+                    Array(streaming.producerContinuations.map { $0.1 }),
+                    streaming.onTermination
+                )
+            }
+
+        case .sourceFinished, .finished:
+            return .none
+
+        case .modify:
+            fatalError("AsyncStream internal inconsistency")
+        }
+    }
+}
+#else
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+extension AsyncStream {
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public struct Source: Sendable {
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public struct BackPressureStrategy: Sendable {
+            @available(SwiftStdlib 9999, *)
+            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
+                fatalError("Unavailable in task-to-thread concurrency model")
+            }
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public enum WriteResult: Sendable {
+            @available(SwiftStdlib 9999, *)
+            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+            public struct CallbackToken: Sendable {}
+            case produceMore
+            case enqueueCallback(CallbackToken)
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public var onTermination: (@Sendable () -> Void)? {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write(_ element: Element) throws -> WriteResult {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write(_ element: Element) async throws {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func finish() {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public static func makeStream(
+        of elementType: Element.Type = Element.self,
+        backPressureStrategy: Source.BackPressureStrategy
+    ) -> (`Self`, Source) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+    }
+}
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+extension AsyncThrowingStream {
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public struct Source: Sendable {
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public struct BackPressureStrategy: Sendable {
+            @available(SwiftStdlib 9999, *)
+            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+            public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
+                fatalError("Unavailable in task-to-thread concurrency model")
+            }
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public enum WriteResult: Sendable {
+            @available(SwiftStdlib 9999, *)
+            @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+            public struct CallbackToken: Sendable {}
+            case produceMore
+            case enqueueCallback(CallbackToken)
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public var onTermination: (@Sendable () -> Void)? {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S) throws -> WriteResult where Element == S.Element, S: Sequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write(_ element: Element) throws -> WriteResult {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func enqueueCallback(callbackToken: WriteResult.CallbackToken, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func cancelCallback(callbackToken: WriteResult.CallbackToken) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) where Element == S.Element, S: Sequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write(_ element: Element, onProduceMore: @escaping @Sendable (Result<Void, Error>) -> Void) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: Sequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write(_ element: Element) async throws {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func write<S>(contentsOf sequence: S) async throws where Element == S.Element, S: AsyncSequence {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+
+        @available(SwiftStdlib 9999, *)
+        @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+        public func finish(throwing error: Failure?) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+        }
+    }
+
+    @available(SwiftStdlib 9999, *)
+    @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+    public static func makeStream(
+        of elementType: Element.Type = Element.self,
+        backPressureStrategy: Source.BackPressureStrategy
+    ) -> (`Self`, Source) {
+            fatalError("Unavailable in task-to-thread concurrency model")
+    }
+}
+#endif

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -252,6 +252,22 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     }
   }
 
+  final class _Backing {
+    let storage: _BackPressuredStorage<Element, Failure>
+
+    init(storage: _BackPressuredStorage<Element, Failure>) {
+      self.storage = storage
+    }
+
+    deinit {
+        if #available(SwiftStdlib 9999, *) {
+          self.storage.sequenceDeinitialized()
+        } else {
+          fatalError("Internal inconsistency")
+        }
+    }
+  }
+
   final class _Context {
     let storage: _Storage?
     let produce: () async throws -> Element?
@@ -266,7 +282,14 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     }
   }
 
-  let context: _Context
+  enum _Implementation {
+    /// This is the implementation based on the original proposal with the Continuation
+    case contextBased(_Context)
+    /// This is the implementation with backpressure based on the Source
+    case backpressured(_Backing)
+  }
+
+  let _implementation: _Implementation
 
   /// Constructs an asynchronous stream for an element type, using the
   /// specified buffering policy and element-producing closure.
@@ -328,7 +351,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     _ build: (Continuation) -> Void
   ) where Failure == Error {
     let storage: _Storage = .create(limit: limit)
-    context = _Context(storage: storage, produce: storage.next)
+    self._implementation = .contextBased(_Context(storage: storage, produce: storage.next))
     build(Continuation(storage: storage))
   }
   
@@ -374,7 +397,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   ) where Failure == Error {
     let storage: _AsyncStreamCriticalStorage<Optional<() async throws -> Element?>>
       = .create(produce)
-    context = _Context {
+    self._implementation = .contextBased(_Context {
       return try await withTaskCancellationHandler {
         guard let result = try await storage.value?() else {
           storage.value = nil
@@ -384,7 +407,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       } onCancel: {
         storage.value = nil
       }
-    }
+    })
   }
 }
 
@@ -397,7 +420,34 @@ extension AsyncThrowingStream: AsyncSequence {
   /// concurrent context that contends with another such call, which
   /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
-    let context: _Context
+    final class _Backing {
+      let _storage: _BackPressuredStorage<Element, Failure>
+
+      init(storage: _BackPressuredStorage<Element, Failure>) {
+        self._storage = storage
+        self._storage.iteratorInitialized()
+      }
+
+      deinit {
+        if #available(SwiftStdlib 9999, *) {
+          self._storage.iteratorDeinitialized()
+        } else {
+          fatalError("Internal inconsistency")
+        }
+      }
+    }
+    enum _Implementation {
+      /// This is the implementation based on the original proposal with the Continuation
+      case contextBased(_Context)
+      /// This is the implementation with backpressure based on the Source
+      case backpressured(_Backing)
+    }
+
+    let _implementation: _Implementation
+
+    init(implementation: _Implementation) {
+      self._implementation = implementation
+    }
 
     /// The next value from the asynchronous stream.
     ///
@@ -413,14 +463,29 @@ extension AsyncThrowingStream: AsyncSequence {
     /// `next()` may return `nil` immediately, or else return `nil` on
     /// subsequent calls.
     public mutating func next() async throws -> Element? {
-      return try await context.produce()
+      switch self._implementation {
+        case .contextBased(let context):
+          return try await context.produce()
+        case .backpressured(let backing):
+        if #available(SwiftStdlib 9999, *) {
+          return try await backing._storage.next()
+        } else {
+          fatalError("Internal inconsistency")
+        }
+      }
     }
   }
 
   /// Creates the asynchronous iterator that produces elements of this
   /// asynchronous sequence.
   public func makeAsyncIterator() -> Iterator {
-    return Iterator(context: context)
+    switch self._implementation {
+      case .contextBased(let context):
+        return Iterator(implementation: .contextBased(context))
+
+      case .backpressured(let backing):
+        return Iterator(implementation: .backpressured(.init(storage: backing.storage)))
+    }
   }
 }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -253,9 +253,9 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   }
 
   final class _Backing {
-    let storage: _BackPressuredStorage<Element, Failure>
+    let storage: _BackpressuredStorage<Element, Failure>
 
-    init(storage: _BackPressuredStorage<Element, Failure>) {
+    init(storage: _BackpressuredStorage<Element, Failure>) {
       self.storage = storage
     }
 
@@ -421,9 +421,9 @@ extension AsyncThrowingStream: AsyncSequence {
   /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
     final class _Backing {
-      let _storage: _BackPressuredStorage<Element, Failure>
+      let _storage: _BackpressuredStorage<Element, Failure>
 
-      init(storage: _BackPressuredStorage<Element, Failure>) {
+      init(storage: _BackpressuredStorage<Element, Failure>) {
         self._storage = storage
         self._storage.iteratorInitialized()
       }

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -122,7 +122,9 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   TaskSleep.swift
   ThreadingError.cpp
   TracingSignpost.cpp
+  Locking.swift
   AsyncStreamBuffer.swift
+  AsyncStreamBackpressure.swift
   AsyncStream.swift
   AsyncThrowingStream.swift
   AsyncStream.cpp

--- a/stdlib/public/Concurrency/Locking.swift
+++ b/stdlib/public/Concurrency/Locking.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+internal struct _ManagedCriticalState<State> {
+  final private class LockedBuffer: ManagedBuffer<State, UnsafeRawPointer> { }
+
+  private let buffer: ManagedBuffer<State, UnsafeRawPointer>
+
+  internal init(_ buffer: ManagedBuffer<State, UnsafeRawPointer>) {
+    self.buffer = buffer
+  }
+  
+  internal init(_ initial: State) {
+    let roundedSize = (_lockWordCount() + MemoryLayout<UnsafeRawPointer>.size - 1) / MemoryLayout<UnsafeRawPointer>.size 
+    self.init(LockedBuffer.create(minimumCapacity: Swift.max(roundedSize, 1)) { buffer in
+      buffer.withUnsafeMutablePointerToElements { _lockInit(UnsafeRawPointer($0)) }
+      return initial
+    })
+  }
+
+  internal func withCriticalRegion<R>(
+    _ critical: (inout State) throws -> R
+  ) rethrows -> R {
+    try buffer.withUnsafeMutablePointers { header, lock in
+      _lock(UnsafeRawPointer(lock))
+      defer {
+        _unlock(UnsafeRawPointer(lock))
+      }
+      return try critical(&header.pointee)
+    }
+  }
+}
+
+extension _ManagedCriticalState: @unchecked Sendable where State: Sendable { }
+
+extension _ManagedCriticalState: Identifiable {
+  internal var id: ObjectIdentifier {
+    ObjectIdentifier(buffer)
+  }
+}
+

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -29,7 +29,7 @@ var tests = TestSuite("AsyncStream")
         continuation.yield("hello")
 
         var iterator = stream.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
+        await expectEqual(iterator.next(), "hello")
       }
 
       tests.test("throwing factory method") {
@@ -38,7 +38,7 @@ var tests = TestSuite("AsyncStream")
 
         var iterator = stream.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "hello")
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -61,7 +61,7 @@ var tests = TestSuite("AsyncStream")
           continuation.yield("hello")
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
+        await expectEqual(iterator.next(), "hello")
       }
 
       tests.test("yield with awaiting next throwing") {
@@ -70,7 +70,7 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "hello")
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -82,8 +82,8 @@ var tests = TestSuite("AsyncStream")
           continuation.yield("world")
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
-        expectEqual(await iterator.next(), "world")
+        await expectEqual(iterator.next(), "hello")
+        await expectEqual(iterator.next(), "world")
       }
 
       tests.test("yield with awaiting next 2 throwing") {
@@ -93,8 +93,8 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -107,9 +107,9 @@ var tests = TestSuite("AsyncStream")
           continuation.finish()
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
-        expectEqual(await iterator.next(), "world")
-        expectEqual(await iterator.next(), nil)
+        await expectEqual(iterator.next(), "hello")
+        await expectEqual(iterator.next(), "world")
+        await expectEqual(iterator.next(), nil)
       }
 
       tests.test("yield with awaiting next 2 and finish throwing") {
@@ -120,9 +120,9 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
-          expectEqual(try await iterator.next(), nil)
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
+          try await expectEqual(iterator.next(), nil)
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -137,8 +137,8 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
           _ = try await iterator.next()
           expectUnreachable("expected thrown error")
         } catch {
@@ -173,7 +173,7 @@ var tests = TestSuite("AsyncStream")
           }
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
+        await expectEqual(iterator.next(), "hello")
       }
 
       tests.test("yield with awaiting next detached throwing") {
@@ -184,7 +184,7 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "hello")
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -198,8 +198,8 @@ var tests = TestSuite("AsyncStream")
           }
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
-        expectEqual(await iterator.next(), "world")
+        await expectEqual(iterator.next(), "hello")
+        await expectEqual(iterator.next(), "world")
       }
 
       tests.test("yield with awaiting next 2 detached throwing") {
@@ -211,8 +211,8 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -227,9 +227,9 @@ var tests = TestSuite("AsyncStream")
           }
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
-        expectEqual(await iterator.next(), "world")
-        expectEqual(await iterator.next(), nil)
+        await expectEqual(iterator.next(), "hello")
+        await expectEqual(iterator.next(), "world")
+        await expectEqual(iterator.next(), nil)
       }
 
       tests.test("yield with awaiting next 2 and finish detached throwing") {
@@ -242,9 +242,9 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
-          expectEqual(try await iterator.next(), nil)
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
+          try await expectEqual(iterator.next(), nil)
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -261,8 +261,8 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
           _ = try await iterator.next()
           expectUnreachable("expected thrown error")
         } catch {
@@ -284,10 +284,10 @@ var tests = TestSuite("AsyncStream")
           }
         }
         var iterator = series.makeAsyncIterator()
-        expectEqual(await iterator.next(), "hello")
-        expectEqual(await iterator.next(), "world")
-        expectEqual(await iterator.next(), nil)
-        expectEqual(await iterator.next(), nil)
+        await expectEqual(iterator.next(), "hello")
+        await expectEqual(iterator.next(), "world")
+        await expectEqual(iterator.next(), nil)
+        await expectEqual(iterator.next(), nil)
       }
 
       tests.test("yield with awaiting next 2 and finish detached with value after finish throwing") {
@@ -301,10 +301,10 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
-          expectEqual(try await iterator.next(), nil)
-          expectEqual(try await iterator.next(), nil)
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
+          try await expectEqual(iterator.next(), nil)
+          try await expectEqual(iterator.next(), nil)
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -322,10 +322,10 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
-          expectEqual(try await iterator.next(), nil)
-          expectEqual(try await iterator.next(), nil)
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
+          try await expectEqual(iterator.next(), nil)
+          try await expectEqual(iterator.next(), nil)
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -341,10 +341,10 @@ var tests = TestSuite("AsyncStream")
         }
         var iterator = series.makeAsyncIterator()
         do {
-          expectEqual(try await iterator.next(), "hello")
-          expectEqual(try await iterator.next(), "world")
-          expectEqual(try await iterator.next(), nil)
-          expectEqual(try await iterator.next(), nil)
+          try await expectEqual(iterator.next(), "hello")
+          try await expectEqual(iterator.next(), "world")
+          try await expectEqual(iterator.next(), nil)
+          try await expectEqual(iterator.next(), nil)
         } catch {
           expectUnreachable("unexpected error thrown")
         }
@@ -358,7 +358,7 @@ var tests = TestSuite("AsyncStream")
             continuation.onTermination = { @Sendable _ in expectation.fulfilled = true }
           }
         }
-        
+
         scopedLifetime(expectation)
 
         expectTrue(expectation.fulfilled)
@@ -373,7 +373,7 @@ var tests = TestSuite("AsyncStream")
             continuation.finish()
           }
         }
-        
+
         scopedLifetime(expectation)
 
         expectTrue(expectation.fulfilled)
@@ -393,7 +393,7 @@ var tests = TestSuite("AsyncStream")
             }
           }
         }
-        
+
         scopedLifetime(expectation)
 
         expectTrue(expectation.fulfilled)
@@ -413,7 +413,7 @@ var tests = TestSuite("AsyncStream")
             }
           }
         }
-        
+
         scopedLifetime(expectation)
 
         expectTrue(expectation.fulfilled)
@@ -422,167 +422,166 @@ var tests = TestSuite("AsyncStream")
       // Backpressure tests
       tests.test("SequenceDeinitialized when no iterator") {
         var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 5, high: 10)
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 5, high: 10)
         )
 
         let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
         source.onTermination = {
-            onTerminationContinuation.finish()
+          onTerminationContinuation.finish()
         }
 
         await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                while !Task.isCancelled {
-                    onTerminationContinuation.yield()
-                    try await Task.sleep(for: .seconds(0.2))
-                }
+          group.addTask {
+            while !Task.isCancelled {
+              onTerminationContinuation.yield()
+              try await Task.sleep(for: .seconds(0.2))
             }
+          }
 
-            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-            _ = await onTerminationIterator.next()
+          var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+          _ = await onTerminationIterator.next()
 
-            withExtendedLifetime(stream) {}
-            stream = nil
+          withExtendedLifetime(stream) {}
+          stream = nil
 
-            let terminationResult: Void? = await onTerminationIterator.next()
-            expectNil(terminationResult)
+          let terminationResult: Void? = await onTerminationIterator.next()
+          expectNil(terminationResult)
 
-            do {
-                _ = try { try source.write(2) }()
-                expectUnreachable("Expected an error to be thrown")
-            } catch {
-                expectTrue(error is AsyncStreamAlreadyFinishedError)
-            }
+          do {
+            _ = try { try source.write(2) }()
+            expectUnreachable("Expected an error to be thrown")
+          } catch {
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
 
-            group.cancelAll()
+          group.cancelAll()
         }
       }
 
       tests.test("SequenceDeinitialized when iterator") {
         do {
           var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           var iterator = stream?.makeAsyncIterator()
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
-              }
-
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
-
-              try withExtendedLifetime(stream) {
-                  let writeResult = try source.write(1)
-                  writeResult.assertIsProducerMore()
-              }
-
-              stream = nil
-
-              do {
-                  let writeResult = try { try source.write(2) }()
-                  writeResult.assertIsProducerMore()
-              } catch {
-                print(error)
-                  expectUnreachable("Expected no error to be thrown")
-              }
-
-              let element1 = try await iterator?.next()
-              expectEqual(element1, 1)
-              let element2 = try await iterator?.next()
-              expectEqual(element2, 2)
-
-              group.cancelAll()
-          }
-        } catch {
-            expectUnreachable("Expected no error to be thrown")
-        }
-      }
-
-      tests.test("SequenceDeinitialized when finished") {
-        var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 5, high: 10)
-        )
-
-        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
-        source.onTermination = {
-            onTerminationContinuation.finish()
-        }
-
-        await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                while !Task.isCancelled {
-                    onTerminationContinuation.yield()
-                    try await Task.sleep(for: .seconds(0.2))
-                }
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
+              }
             }
 
             var onTerminationIterator = onTerminationStream.makeAsyncIterator()
             _ = await onTerminationIterator.next()
 
-            withExtendedLifetime(stream) {
-                source.finish(throwing: nil)
+            try withExtendedLifetime(stream) {
+              let writeResult = try source.write(1)
+              writeResult.assertIsProducerMore()
             }
 
             stream = nil
 
-            let terminationResult: Void? = await onTerminationIterator.next()
-            expectNil(terminationResult)
-
             do {
-                _ = try { try source.write(1) }()
-                expectUnreachable("Expected an error to be thrown")
+              let writeResult = try { try source.write(2) }()
+              writeResult.assertIsProducerMore()
             } catch {
-                expectTrue(error is AsyncStreamAlreadyFinishedError)
+              expectUnreachable("Expected no error to be thrown")
             }
 
+            let element1 = try await iterator?.next()
+            expectEqual(element1, 1)
+            let element2 = try await iterator?.next()
+            expectEqual(element2, 2)
+
             group.cancelAll()
+          }
+        } catch {
+          expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SequenceDeinitialized when finished") {
+        var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+        source.onTermination = {
+          onTerminationContinuation.finish()
+        }
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+          group.addTask {
+            while !Task.isCancelled {
+              onTerminationContinuation.yield()
+              try await Task.sleep(for: .seconds(0.2))
+            }
+          }
+
+          var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+          _ = await onTerminationIterator.next()
+
+          withExtendedLifetime(stream) {
+            source.finish(throwing: nil)
+          }
+
+          stream = nil
+
+          let terminationResult: Void? = await onTerminationIterator.next()
+          expectNil(terminationResult)
+
+          do {
+            _ = try { try source.write(1) }()
+            expectUnreachable("Expected an error to be thrown")
+          } catch {
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
+
+          group.cancelAll()
         }
       }
 
       tests.test("SequenceDeinitialized when streaming and suspended producer") {
         do {
           var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 2)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 2)
           )
 
           _ = try { try source.write(1) }()
 
           do {
-              try await withCheckedThrowingContinuation { continuation in
-                  source.write(1) { result in
-                      continuation.resume(with: result)
-                  }
-
-                  stream = nil
-                  _ = stream?.makeAsyncIterator()
+            try await withCheckedThrowingContinuation { continuation in
+              source.write(1) { result in
+                continuation.resume(with: result)
               }
+
+              stream = nil
+              _ = stream?.makeAsyncIterator()
+            }
           } catch {
-              expectTrue(error is AsyncStreamAlreadyFinishedError)
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorInitialized when initial") {
         let (stream, _) = AsyncThrowingStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 5, high: 10)
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 5, high: 10)
         )
 
         _ = stream.makeAsyncIterator()
@@ -591,8 +590,8 @@ var tests = TestSuite("AsyncStream")
       tests.test("IteratorInitialized when streaming") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           try await source.write(1)
@@ -601,15 +600,15 @@ var tests = TestSuite("AsyncStream")
           let element = try await iterator.next()
           expectEqual(element, 1)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorInitialized when source finished") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           try await source.write(1)
@@ -621,187 +620,187 @@ var tests = TestSuite("AsyncStream")
           let element2 = try await iterator.next()
           expectNil(element2)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorInitialized when finished") {
         do {
-        let (stream, source) = AsyncThrowingStream.makeStream(
+          let (stream, source) = AsyncThrowingStream.makeStream(
             of: Int.self,
-            backPressureStrategy: .watermark(low: 5, high: 10)
-        )
+            backpressureStrategy: .watermark(low: 5, high: 10)
+          )
 
-        source.finish(throwing: nil)
+          source.finish(throwing: nil)
 
-        var iterator = stream.makeAsyncIterator()
-        let element = try await iterator.next()
-        expectNil(element)
+          var iterator = stream.makeAsyncIterator()
+          let element = try await iterator.next()
+          expectNil(element)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorDeinitialized when initial") {
         do {
           var (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
+            group.addTask {
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
               }
+            }
 
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
 
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              iterator = nil
-              _ = try await iterator?.next()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            iterator = nil
+            _ = try await iterator?.next()
 
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorDeinitialized when streaming") {
         do {
           var (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await source.write(1)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
+            group.addTask {
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
               }
+            }
 
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
 
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              iterator = nil
-              _ = try await iterator?.next()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            iterator = nil
+            _ = try await iterator?.next()
 
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorDeinitialized when source finished") {
         do {
           var (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await source.write(1)
           source.finish(throwing: nil)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
+            group.addTask {
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
               }
+            }
 
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
 
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              iterator = nil
-              _ = try await iterator?.next()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            iterator = nil
+            _ = try await iterator?.next()
 
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorDeinitialized when finished") {
         do {
           var (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           source.finish(throwing: nil)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
+            group.addTask {
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
               }
+            }
 
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
 
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              iterator = nil
-              _ = try await iterator?.next()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            iterator = nil
+            _ = try await iterator?.next()
 
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("IteratorDeinitialized when streaming and suspended producer") {
         do {
           var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 2)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 2)
           )
 
           var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream?.makeAsyncIterator()
@@ -810,51 +809,51 @@ var tests = TestSuite("AsyncStream")
           _ = try { try source.write(1) }()
 
           do {
-              try await withCheckedThrowingContinuation { continuation in
-                  source.write(1) { result in
-                      continuation.resume(with: result)
-                  }
-
-                  iterator = nil
+            try await withCheckedThrowingContinuation { continuation in
+              source.write(1) { result in
+                continuation.resume(with: result)
               }
+
+              iterator = nil
+            }
           } catch {
-              expectTrue(error is AsyncStreamAlreadyFinishedError)
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
           }
 
           _ = try await iterator?.next()
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("SourceDeinitialized when initial") {
         var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 5, high: 10)
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 5, high: 10)
         )
 
         let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
         source?.onTermination = {
-            onTerminationContinuation.finish()
+          onTerminationContinuation.finish()
         }
 
         await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                while !Task.isCancelled {
-                    onTerminationContinuation.yield()
-                    try await Task.sleep(for: .seconds(0.2))
-                }
+          group.addTask {
+            while !Task.isCancelled {
+              onTerminationContinuation.yield()
+              try await Task.sleep(for: .seconds(0.2))
             }
+          }
 
-            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-            _ = await onTerminationIterator.next()
+          var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+          _ = await onTerminationIterator.next()
 
-            source = nil
+          source = nil
 
-            let terminationResult: Void? = await onTerminationIterator.next()
-            expectNil(terminationResult)
+          let terminationResult: Void? = await onTerminationIterator.next()
+          expectNil(terminationResult)
 
-            group.cancelAll()
+          group.cancelAll()
         }
 
         withExtendedLifetime(stream) {}
@@ -863,99 +862,99 @@ var tests = TestSuite("AsyncStream")
       tests.test("SourceDeinitialized when streaming and empty buffer") {
         do {
           var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source?.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await source?.write(1)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
+            group.addTask {
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
               }
+            }
 
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
 
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              _ = try await iterator?.next()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            _ = try await iterator?.next()
 
-              source = nil
+            source = nil
 
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("SourceDeinitialized when streaming and not empty buffer") {
         do {
           var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source?.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await source?.write(1)
           try await source?.write(2)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
+            group.addTask {
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
               }
+            }
 
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
 
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              _ = try await iterator?.next()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            _ = try await iterator?.next()
 
-              source = nil
+            source = nil
 
-              _ = await onTerminationIterator.next()
+            _ = await onTerminationIterator.next()
 
-              _ = try await iterator?.next()
-              _ = try await iterator?.next()
+            _ = try await iterator?.next()
+            _ = try await iterator?.next()
 
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("SourceDeinitialized when source finished") {
         do {
           var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 5, high: 10)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 5, high: 10)
           )
 
           let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
           source?.onTermination = {
-              onTerminationContinuation.finish()
+            onTerminationContinuation.finish()
           }
 
           try await source?.write(1)
@@ -963,105 +962,105 @@ var tests = TestSuite("AsyncStream")
           source?.finish(throwing: nil)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while !Task.isCancelled {
-                      onTerminationContinuation.yield()
-                      try await Task.sleep(for: .seconds(0.2))
-                  }
-              }
-
-              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
-              _ = await onTerminationIterator.next()
-
-              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
-              _ = try await iterator?.next()
-
-              source = nil
-
-              _ = await onTerminationIterator.next()
-
-              _ = try await iterator?.next()
-              _ = try await iterator?.next()
-
-              let terminationResult: Void? = await onTerminationIterator.next()
-              expectNil(terminationResult)
-
-              group.cancelAll()
-          }
-        } catch {
-            expectUnreachable("Expected no error to be thrown")
-        }
-      }
-
-      tests.test("SourceDeinitialized when finished") {
-        var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 5, high: 10)
-        )
-
-        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
-        source?.onTermination = {
-            onTerminationContinuation.finish()
-        }
-
-        source?.finish(throwing: nil)
-
-        await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                while !Task.isCancelled {
-                    onTerminationContinuation.yield()
-                    try await Task.sleep(for: .seconds(0.2))
-                }
+              while !Task.isCancelled {
+                onTerminationContinuation.yield()
+                try await Task.sleep(for: .seconds(0.2))
+              }
             }
 
             var onTerminationIterator = onTerminationStream.makeAsyncIterator()
             _ = await onTerminationIterator.next()
 
-            _ = stream.makeAsyncIterator()
+            var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+            _ = try await iterator?.next()
 
             source = nil
 
             _ = await onTerminationIterator.next()
 
+            _ = try await iterator?.next()
+            _ = try await iterator?.next()
+
             let terminationResult: Void? = await onTerminationIterator.next()
             expectNil(terminationResult)
 
             group.cancelAll()
+          }
+        } catch {
+          expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SourceDeinitialized when finished") {
+        var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+        source?.onTermination = {
+          onTerminationContinuation.finish()
+        }
+
+        source?.finish(throwing: nil)
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+          group.addTask {
+            while !Task.isCancelled {
+              onTerminationContinuation.yield()
+              try await Task.sleep(for: .seconds(0.2))
+            }
+          }
+
+          var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+          _ = await onTerminationIterator.next()
+
+          _ = stream.makeAsyncIterator()
+
+          source = nil
+
+          _ = await onTerminationIterator.next()
+
+          let terminationResult: Void? = await onTerminationIterator.next()
+          expectNil(terminationResult)
+
+          group.cancelAll()
         }
       }
 
       tests.test("SourceDeinitialized when streaming and suspended producer") {
         do {
           var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 0, high: 0)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 0, high: 0)
           )
           let (producerStream, producerContinuation) = AsyncThrowingStream<Void, Error>.makeStream()
           var iterator = stream.makeAsyncIterator()
 
           source?.write(1) {
-              producerContinuation.yield(with: $0)
+            producerContinuation.yield(with: $0)
           }
 
           _ = try await iterator.next()
           source = nil
 
           do {
-              try await producerStream.first { _ in true }
-              expectUnreachable("We expected to throw here")
+            try await producerStream.first { _ in true }
+            expectUnreachable("We expected to throw here")
           } catch {
-              expectTrue(error is AsyncStreamAlreadyFinishedError)
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Write when initial") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 5)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 5)
           )
 
           try await source.write(1)
@@ -1070,15 +1069,15 @@ var tests = TestSuite("AsyncStream")
           let element = try await iterator.next()
           expectEqual(element, 1)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Write when streaming and no consumer") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 5)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 5)
           )
 
           try await source.write(1)
@@ -1090,445 +1089,445 @@ var tests = TestSuite("AsyncStream")
           let element2 = try await iterator.next()
           expectEqual(element2, 2)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Write when streaming and suspended consumer") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 5)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 5)
           )
 
           try await withThrowingTaskGroup(of: Int?.self) { group in
-              group.addTask {
-                  return try await stream.first { _ in true }
-              }
+            group.addTask {
+              return try await stream.first { _ in true }
+            }
 
-              // This is always going to be a bit racy since we need the call to next() suspend
-              try await Task.sleep(for: .seconds(0.5))
+            // This is always going to be a bit racy since we need the call to next() suspend
+            try await Task.sleep(for: .seconds(0.5))
 
-              try await source.write(1)
-              let element = try await group.next()
-              expectEqual(element, 1)
+            try await source.write(1)
+            let element = try await group.next()
+            expectEqual(element, 1)
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Write when streaming and suspended consumer and empty sequence") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 5)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 5)
           )
 
           try await withThrowingTaskGroup(of: Int?.self) { group in
-              group.addTask {
-                  return try await stream.first { _ in true }
-              }
+            group.addTask {
+              return try await stream.first { _ in true }
+            }
 
-              // This is always going to be a bit racy since we need the call to next() suspend
-              try await Task.sleep(for: .seconds(0.5))
+            // This is always going to be a bit racy since we need the call to next() suspend
+            try await Task.sleep(for: .seconds(0.5))
 
-              try await source.write(contentsOf: [])
-              try await source.write(contentsOf: [1])
-              let element = try await group.next()
-              expectEqual(element, 1)
+            try await source.write(contentsOf: [])
+            try await source.write(contentsOf: [1])
+            let element = try await group.next()
+            expectEqual(element, 1)
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("EnqueueProducer when streaming and cancelled") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 2)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 2)
           )
 
           let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
 
           try await source.write(1)
 
-          let writeResult =  try { try source.write(2) }()
+          let writeResult = try { try source.write(2) }()
 
           switch writeResult {
           case .produceMore:
-              preconditionFailure()
+            preconditionFailure()
           case .enqueueCallback(let callbackToken):
-              source.cancelCallback(callbackToken: callbackToken)
+            source.cancelCallback(token: callbackToken)
 
-              source.enqueueCallback(callbackToken: callbackToken) { result in
-                  producerSource.yield(with: result)
-              }
+            source.enqueueCallback(token: callbackToken) { result in
+              producerSource.yield(with: result)
+            }
           }
 
           do {
-              _ = try await producerStream.first { _ in true }
-              expectUnreachable("Expected an error to be thrown")
+            _ = try await producerStream.first { _ in true }
+            expectUnreachable("Expected an error to be thrown")
           } catch {
-              expectTrue(error is CancellationError)
+            expectTrue(error is CancellationError)
           }
 
           let element = try await stream.first { _ in true }
           expectEqual(element, 1)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("EnqueueProducer when streaming and cancelled and async") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 2)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 2)
           )
 
           try await source.write(1)
 
           await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  try await source.write(2)
-              }
+            group.addTask {
+              try await source.write(2)
+            }
 
-              group.cancelAll()
-              do {
-                  try await group.next()
-                  expectUnreachable("Expected an error to be thrown")
-              } catch {
-                  expectTrue(error is CancellationError)
-              }
+            group.cancelAll()
+            do {
+              try await group.next()
+              expectUnreachable("Expected an error to be thrown")
+            } catch {
+              expectTrue(error is CancellationError)
+            }
           }
 
           let element = try await stream.first { _ in true }
           expectEqual(element, 1)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("EnqueueProducer when streaming and interleaving") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 1)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 1)
           )
           var iterator = stream.makeAsyncIterator()
 
           let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
 
-          let writeResult =  try { try source.write(1) }()
+          let writeResult = try { try source.write(1) }()
 
           switch writeResult {
           case .produceMore:
-              preconditionFailure()
+            preconditionFailure()
           case .enqueueCallback(let callbackToken):
-              let element = try await iterator.next()
-              expectEqual(element, 1)
+            let element = try await iterator.next()
+            expectEqual(element, 1)
 
-              source.enqueueCallback(callbackToken: callbackToken) { result in
-                  producerSource.yield(with: result)
-              }
+            source.enqueueCallback(token: callbackToken) { result in
+              producerSource.yield(with: result)
+            }
           }
 
           do {
-              _ = try await producerStream.first { _ in true }
+            _ = try await producerStream.first { _ in true }
           } catch {
-              expectUnreachable("Expected no error to be thrown")
+            expectUnreachable("Expected no error to be thrown")
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("EnqueueProducer when streaming and suspending") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 1)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 1)
           )
           var iterator = stream.makeAsyncIterator()
 
           let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
 
-          let writeResult =  try { try source.write(1) }()
+          let writeResult = try { try source.write(1) }()
 
           switch writeResult {
           case .produceMore:
-              preconditionFailure()
+            preconditionFailure()
           case .enqueueCallback(let callbackToken):
-              source.enqueueCallback(callbackToken: callbackToken) { result in
-                  producerSource.yield(with: result)
-              }
+            source.enqueueCallback(token: callbackToken) { result in
+              producerSource.yield(with: result)
+            }
           }
 
           let element = try await iterator.next()
           expectEqual(element, 1)
 
           do {
-              _ = try await producerStream.first { _ in true }
+            _ = try await producerStream.first { _ in true }
           } catch {
-              expectUnreachable("Expected no error to be thrown")
+            expectUnreachable("Expected no error to be thrown")
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("EnqueueProducer when finished") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 1)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 1)
           )
           var iterator = stream.makeAsyncIterator()
 
           let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
 
-          let writeResult =  try { try source.write(1) }()
+          let writeResult = try { try source.write(1) }()
 
           switch writeResult {
           case .produceMore:
-              preconditionFailure()
+            preconditionFailure()
           case .enqueueCallback(let callbackToken):
-              source.finish(throwing: nil)
+            source.finish(throwing: nil)
 
-              source.enqueueCallback(callbackToken: callbackToken) { result in
-                  producerSource.yield(with: result)
-              }
+            source.enqueueCallback(token: callbackToken) { result in
+              producerSource.yield(with: result)
+            }
           }
 
           let element = try await iterator.next()
           expectEqual(element, 1)
 
           do {
-              _ = try await producerStream.first { _ in true }
-              expectUnreachable("Expected an error to be thrown")
+            _ = try await producerStream.first { _ in true }
+            expectUnreachable("Expected an error to be thrown")
           } catch {
-              expectTrue(error is AsyncStreamAlreadyFinishedError)
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("CancelProducer when streaming") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 2)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 2)
           )
 
           let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
 
           try await source.write(1)
 
-          let writeResult =  try { try source.write(2) }()
+          let writeResult = try { try source.write(2) }()
 
           switch writeResult {
           case .produceMore:
-              preconditionFailure()
+            preconditionFailure()
           case .enqueueCallback(let callbackToken):
-              source.enqueueCallback(callbackToken: callbackToken) { result in
-                  producerSource.yield(with: result)
-              }
+            source.enqueueCallback(token: callbackToken) { result in
+              producerSource.yield(with: result)
+            }
 
-              source.cancelCallback(callbackToken: callbackToken)
+            source.cancelCallback(token: callbackToken)
           }
 
           do {
-              _ = try await producerStream.first { _ in true }
-              expectUnreachable("Expected an error to be thrown")
+            _ = try await producerStream.first { _ in true }
+            expectUnreachable("Expected an error to be thrown")
           } catch {
-              expectTrue(error is CancellationError)
+            expectTrue(error is CancellationError)
           }
 
           let element = try await stream.first { _ in true }
           expectEqual(element, 1)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("CancelProducer when source finished") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 2)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 2)
           )
 
           let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
 
           try await source.write(1)
 
-          let writeResult =  try { try source.write(2) }()
+          let writeResult = try { try source.write(2) }()
 
           switch writeResult {
           case .produceMore:
-              preconditionFailure()
+            preconditionFailure()
           case .enqueueCallback(let callbackToken):
-              source.enqueueCallback(callbackToken: callbackToken) { result in
-                  producerSource.yield(with: result)
-              }
+            source.enqueueCallback(token: callbackToken) { result in
+              producerSource.yield(with: result)
+            }
 
-              source.finish(throwing: nil)
+            source.finish(throwing: nil)
 
-              source.cancelCallback(callbackToken: callbackToken)
+            source.cancelCallback(token: callbackToken)
           }
 
           do {
-              _ = try await producerStream.first { _ in true }
-              expectUnreachable("Expected an error to be thrown")
+            _ = try await producerStream.first { _ in true }
+            expectUnreachable("Expected an error to be thrown")
           } catch {
-              expectTrue(error is AsyncStreamAlreadyFinishedError)
+            expectTrue(error is AsyncStreamAlreadyFinishedError)
           }
 
           let element = try await stream.first { _ in true }
           expectEqual(element, 1)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Finish when streaming and consumer suspended") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 1, high: 1)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 1, high: 1)
           )
 
           try await withThrowingTaskGroup(of: Int?.self) { group in
-              group.addTask {
-                  return try await stream.first { $0 == 2 }
-              }
+            group.addTask {
+              return try await stream.first { $0 == 2 }
+            }
 
-              // This is always going to be a bit racy since we need the call to next() suspend
-              try await Task.sleep(for: .seconds(0.5))
+            // This is always going to be a bit racy since we need the call to next() suspend
+            try await Task.sleep(for: .seconds(0.5))
 
-              source.finish(throwing: nil)
-              let element = try await group.next()
-              expectEqual(element, .some(nil))
+            source.finish(throwing: nil)
+            let element = try await group.next()
+            expectEqual(element, .some(nil))
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Finish when initial") {
         let (stream, source) = AsyncThrowingStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 1, high: 1)
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 1, high: 1)
         )
 
         source.finish(throwing: CancellationError())
 
         do {
-            for try await _ in stream {}
-            expectUnreachable("Expected an error to be thrown")
+          for try await _ in stream {}
+          expectUnreachable("Expected an error to be thrown")
         } catch {
-            expectTrue(error is CancellationError)
+          expectTrue(error is CancellationError)
         }
       }
 
       tests.test("Backpressure async") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 4)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 4)
           )
 
-          let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+          let (backpressureEventStream, backpressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  while true {
-                      backPressureEventContinuation.yield(())
-                      try await source.write(contentsOf: [1])
-                  }
+            group.addTask {
+              while true {
+                backpressureEventContinuation.yield(())
+                try await source.write(contentsOf: [1])
               }
+            }
 
-              var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
-              var iterator = stream.makeAsyncIterator()
+            var backpressureEventIterator = backpressureEventStream.makeAsyncIterator()
+            var iterator = stream.makeAsyncIterator()
 
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
 
-              _ = try await iterator.next()
-              _ = try await iterator.next()
-              _ = try await iterator.next()
+            _ = try await iterator.next()
+            _ = try await iterator.next()
+            _ = try await iterator.next()
 
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
 
-              group.cancelAll()
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Backpressure sync") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 4)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 4)
           )
 
-          let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+          let (backpressureEventStream, backpressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
 
           try await withThrowingTaskGroup(of: Void.self) { group in
-              group.addTask {
-                  @Sendable func yield() {
-                      backPressureEventContinuation.yield(())
-                      source.write(contentsOf: [1]) { result in
-                          switch result {
-                          case .success:
-                              yield()
+            group.addTask {
+              @Sendable func yield() {
+                backpressureEventContinuation.yield(())
+                source.write(contentsOf: [1]) { result in
+                  switch result {
+                  case .success:
+                    yield()
 
-                          case .failure:
-                              break
-                          }
-                      }
+                  case .failure:
+                    break
                   }
-
-                  yield()
+                }
               }
 
-              var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
-              var iterator = stream.makeAsyncIterator()
+              yield()
+            }
 
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
+            var backpressureEventIterator = backpressureEventStream.makeAsyncIterator()
+            var iterator = stream.makeAsyncIterator()
 
-              _ = try await iterator.next()
-              _ = try await iterator.next()
-              _ = try await iterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
 
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
-              await backPressureEventIterator.next()
+            _ = try await iterator.next()
+            _ = try await iterator.next()
+            _ = try await iterator.next()
 
-              group.cancelAll()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+            await backpressureEventIterator.next()
+
+            group.cancelAll()
           }
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("Throws error") {
         do {
           let (stream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 4)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 4)
           )
 
           try await source.write(1)
@@ -1539,19 +1538,19 @@ var tests = TestSuite("AsyncStream")
           var iterator = stream.makeAsyncIterator()
 
           do {
-              while let element = try await iterator.next() {
-                  elements.append(element)
-              }
-              expectUnreachable("Expected an error to be thrown")
+            while let element = try await iterator.next() {
+              elements.append(element)
+            }
+            expectUnreachable("Expected an error to be thrown")
           } catch {
-              expectTrue(error is CancellationError)
-              expectEqual(elements, [1, 2])
+            expectTrue(error is CancellationError)
+            expectEqual(elements, [1, 2])
           }
 
           let element = try await iterator.next()
           expectNil(element)
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
@@ -1559,8 +1558,8 @@ var tests = TestSuite("AsyncStream")
         do {
           let (stream, continuation) = AsyncStream<Int>.makeStream()
           let (backpressuredStream, source) = AsyncThrowingStream.makeStream(
-              of: Int.self,
-              backPressureStrategy: .watermark(low: 2, high: 4)
+            of: Int.self,
+            backpressureStrategy: .watermark(low: 2, high: 4)
           )
 
           continuation.yield(1)
@@ -1573,99 +1572,99 @@ var tests = TestSuite("AsyncStream")
           let elements = try await backpressuredStream.collect()
           expectEqual(elements, [1, 2])
         } catch {
-            expectUnreachable("Expected no error to be thrown")
+          expectUnreachable("Expected no error to be thrown")
         }
       }
 
       tests.test("AsyncStream backpressure async") {
         let (stream, source) = AsyncStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 2, high: 4)
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 2, high: 4)
         )
 
-        let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+        let (backpressureEventStream, backpressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
 
         await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                @Sendable func yield() {
-                    backPressureEventContinuation.yield(())
-                    source.write(contentsOf: [1]) { result in
-                        switch result {
-                        case .success:
-                            yield()
+          group.addTask {
+            @Sendable func yield() {
+              backpressureEventContinuation.yield(())
+              source.write(contentsOf: [1]) { result in
+                switch result {
+                case .success:
+                  yield()
 
-                        case .failure:
-                            break
-                        }
-                    }
+                case .failure:
+                  break
                 }
-
-                yield()
+              }
             }
 
-            var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
-            var iterator = stream.makeAsyncIterator()
+            yield()
+          }
 
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
+          var backpressureEventIterator = backpressureEventStream.makeAsyncIterator()
+          var iterator = stream.makeAsyncIterator()
 
-            _ = await iterator.next()
-            _ = await iterator.next()
-            _ = await iterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
 
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
+          _ = await iterator.next()
+          _ = await iterator.next()
+          _ = await iterator.next()
 
-            group.cancelAll()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+
+          group.cancelAll()
         }
       }
 
       tests.test("Backpressure sync") {
         let (stream, source) = AsyncStream.makeStream(
-            of: Int.self,
-            backPressureStrategy: .watermark(low: 2, high: 4)
+          of: Int.self,
+          backpressureStrategy: .watermark(low: 2, high: 4)
         )
 
-        let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+        let (backpressureEventStream, backpressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
 
         await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                @Sendable func yield() {
-                    backPressureEventContinuation.yield(())
-                    source.write(contentsOf: [1]) { result in
-                        switch result {
-                        case .success:
-                            yield()
+          group.addTask {
+            @Sendable func yield() {
+              backpressureEventContinuation.yield(())
+              source.write(contentsOf: [1]) { result in
+                switch result {
+                case .success:
+                  yield()
 
-                        case .failure:
-                            break
-                        }
-                    }
+                case .failure:
+                  break
                 }
-
-                yield()
+              }
             }
 
-            var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
-            var iterator = stream.makeAsyncIterator()
+            yield()
+          }
 
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
+          var backpressureEventIterator = backpressureEventStream.makeAsyncIterator()
+          var iterator = stream.makeAsyncIterator()
 
-            _ = await iterator.next()
-            _ = await iterator.next()
-            _ = await iterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
 
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
-            await backPressureEventIterator.next()
+          _ = await iterator.next()
+          _ = await iterator.next()
+          _ = await iterator.next()
 
-            group.cancelAll()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+          await backpressureEventIterator.next()
+
+          group.cancelAll()
         }
       }
 
@@ -1675,34 +1674,32 @@ var tests = TestSuite("AsyncStream")
 }
 
 extension AsyncSequence {
-    /// Collect all elements in the sequence into an array.
-    fileprivate func collect() async rethrows -> [Element] {
-        try await self.reduce(into: []) { accumulated, next in
-            accumulated.append(next)
-        }
+  /// Collect all elements in the sequence into an array.
+  fileprivate func collect() async rethrows -> [Element] {
+    try await self.reduce(into: []) { accumulated, next in
+      accumulated.append(next)
     }
+  }
 }
 
 extension AsyncThrowingStream.Source.WriteResult {
-    func assertIsProducerMore() {
-        switch self {
-        case .produceMore:
-            return
+  func assertIsProducerMore() {
+    switch self {
+    case .produceMore:
+      return
 
-        case .enqueueCallback:
-            expectUnreachable("Expected produceMore")
-        }
+    case .enqueueCallback:
+      expectUnreachable("Expected produceMore")
     }
+  }
 
-    func assertIsEnqueueCallback() {
-        switch self {
-        case .produceMore:
-            expectUnreachable("Expected enqueueCallback")
+  func assertIsEnqueueCallback() {
+    switch self {
+    case .produceMore:
+      expectUnreachable("Expected enqueueCallback")
 
-        case .enqueueCallback:
-            return
-        }
+    case .enqueueCallback:
+      return
     }
+  }
 }
-
-

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -419,9 +419,1290 @@ var tests = TestSuite("AsyncStream")
         expectTrue(expectation.fulfilled)
       }
 
+      // Backpressure tests
+      tests.test("SequenceDeinitialized when no iterator") {
+        var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+        source.onTermination = {
+            onTerminationContinuation.finish()
+        }
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while !Task.isCancelled {
+                    onTerminationContinuation.yield()
+                    try await Task.sleep(for: .seconds(0.2))
+                }
+            }
+
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
+
+            withExtendedLifetime(stream) {}
+            stream = nil
+
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
+
+            do {
+                _ = try { try source.write(2) }()
+                expectUnreachable("Expected an error to be thrown")
+            } catch {
+                expectTrue(error is AsyncStreamAlreadyFinishedError)
+            }
+
+            group.cancelAll()
+        }
+      }
+
+      tests.test("SequenceDeinitialized when iterator") {
+        do {
+          var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          var iterator = stream?.makeAsyncIterator()
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              try withExtendedLifetime(stream) {
+                  let writeResult = try source.write(1)
+                  writeResult.assertIsProducerMore()
+              }
+
+              stream = nil
+
+              do {
+                  let writeResult = try { try source.write(2) }()
+                  writeResult.assertIsProducerMore()
+              } catch {
+                print(error)
+                  expectUnreachable("Expected no error to be thrown")
+              }
+
+              let element1 = try await iterator?.next()
+              expectEqual(element1, 1)
+              let element2 = try await iterator?.next()
+              expectEqual(element2, 2)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SequenceDeinitialized when finished") {
+        var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+        source.onTermination = {
+            onTerminationContinuation.finish()
+        }
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while !Task.isCancelled {
+                    onTerminationContinuation.yield()
+                    try await Task.sleep(for: .seconds(0.2))
+                }
+            }
+
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
+
+            withExtendedLifetime(stream) {
+                source.finish(throwing: nil)
+            }
+
+            stream = nil
+
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
+
+            do {
+                _ = try { try source.write(1) }()
+                expectUnreachable("Expected an error to be thrown")
+            } catch {
+                expectTrue(error is AsyncStreamAlreadyFinishedError)
+            }
+
+            group.cancelAll()
+        }
+      }
+
+      tests.test("SequenceDeinitialized when streaming and suspended producer") {
+        do {
+          var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 2)
+          )
+
+          _ = try { try source.write(1) }()
+
+          do {
+              try await withCheckedThrowingContinuation { continuation in
+                  source.write(1) { result in
+                      continuation.resume(with: result)
+                  }
+
+                  stream = nil
+                  _ = stream?.makeAsyncIterator()
+              }
+          } catch {
+              expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorInitialized when initial") {
+        let (stream, _) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        _ = stream.makeAsyncIterator()
+      }
+
+      tests.test("IteratorInitialized when streaming") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          try await source.write(1)
+
+          var iterator = stream.makeAsyncIterator()
+          let element = try await iterator.next()
+          expectEqual(element, 1)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorInitialized when source finished") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          try await source.write(1)
+          source.finish(throwing: nil)
+
+          var iterator = stream.makeAsyncIterator()
+          let element1 = try await iterator.next()
+          expectEqual(element1, 1)
+          let element2 = try await iterator.next()
+          expectNil(element2)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorInitialized when finished") {
+        do {
+        let (stream, source) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        source.finish(throwing: nil)
+
+        var iterator = stream.makeAsyncIterator()
+        let element = try await iterator.next()
+        expectNil(element)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorDeinitialized when initial") {
+        do {
+          var (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              iterator = nil
+              _ = try await iterator?.next()
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorDeinitialized when streaming") {
+        do {
+          var (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await source.write(1)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              iterator = nil
+              _ = try await iterator?.next()
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorDeinitialized when source finished") {
+        do {
+          var (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await source.write(1)
+          source.finish(throwing: nil)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              iterator = nil
+              _ = try await iterator?.next()
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorDeinitialized when finished") {
+        do {
+          var (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          source.finish(throwing: nil)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              iterator = nil
+              _ = try await iterator?.next()
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("IteratorDeinitialized when streaming and suspended producer") {
+        do {
+          var (stream, source): (AsyncThrowingStream?, AsyncThrowingStream.Source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 2)
+          )
+
+          var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream?.makeAsyncIterator()
+          stream = nil
+
+          _ = try { try source.write(1) }()
+
+          do {
+              try await withCheckedThrowingContinuation { continuation in
+                  source.write(1) { result in
+                      continuation.resume(with: result)
+                  }
+
+                  iterator = nil
+              }
+          } catch {
+              expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
+
+          _ = try await iterator?.next()
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SourceDeinitialized when initial") {
+        var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+        source?.onTermination = {
+            onTerminationContinuation.finish()
+        }
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while !Task.isCancelled {
+                    onTerminationContinuation.yield()
+                    try await Task.sleep(for: .seconds(0.2))
+                }
+            }
+
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
+
+            source = nil
+
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
+
+            group.cancelAll()
+        }
+
+        withExtendedLifetime(stream) {}
+      }
+
+      tests.test("SourceDeinitialized when streaming and empty buffer") {
+        do {
+          var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source?.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await source?.write(1)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              _ = try await iterator?.next()
+
+              source = nil
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SourceDeinitialized when streaming and not empty buffer") {
+        do {
+          var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source?.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await source?.write(1)
+          try await source?.write(2)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              _ = try await iterator?.next()
+
+              source = nil
+
+              _ = await onTerminationIterator.next()
+
+              _ = try await iterator?.next()
+              _ = try await iterator?.next()
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SourceDeinitialized when source finished") {
+        do {
+          var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 5, high: 10)
+          )
+
+          let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+          source?.onTermination = {
+              onTerminationContinuation.finish()
+          }
+
+          try await source?.write(1)
+          try await source?.write(2)
+          source?.finish(throwing: nil)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while !Task.isCancelled {
+                      onTerminationContinuation.yield()
+                      try await Task.sleep(for: .seconds(0.2))
+                  }
+              }
+
+              var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+              _ = await onTerminationIterator.next()
+
+              var iterator: AsyncThrowingStream<Int, Error>.AsyncIterator? = stream.makeAsyncIterator()
+              _ = try await iterator?.next()
+
+              source = nil
+
+              _ = await onTerminationIterator.next()
+
+              _ = try await iterator?.next()
+              _ = try await iterator?.next()
+
+              let terminationResult: Void? = await onTerminationIterator.next()
+              expectNil(terminationResult)
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("SourceDeinitialized when finished") {
+        var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 5, high: 10)
+        )
+
+        let (onTerminationStream, onTerminationContinuation) = AsyncStream<Void>.makeStream()
+        source?.onTermination = {
+            onTerminationContinuation.finish()
+        }
+
+        source?.finish(throwing: nil)
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while !Task.isCancelled {
+                    onTerminationContinuation.yield()
+                    try await Task.sleep(for: .seconds(0.2))
+                }
+            }
+
+            var onTerminationIterator = onTerminationStream.makeAsyncIterator()
+            _ = await onTerminationIterator.next()
+
+            _ = stream.makeAsyncIterator()
+
+            source = nil
+
+            _ = await onTerminationIterator.next()
+
+            let terminationResult: Void? = await onTerminationIterator.next()
+            expectNil(terminationResult)
+
+            group.cancelAll()
+        }
+      }
+
+      tests.test("SourceDeinitialized when streaming and suspended producer") {
+        do {
+          var (stream, source): (AsyncThrowingStream, AsyncThrowingStream.Source?) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 0, high: 0)
+          )
+          let (producerStream, producerContinuation) = AsyncThrowingStream<Void, Error>.makeStream()
+          var iterator = stream.makeAsyncIterator()
+
+          source?.write(1) {
+              producerContinuation.yield(with: $0)
+          }
+
+          _ = try await iterator.next()
+          source = nil
+
+          do {
+              try await producerStream.first { _ in true }
+              expectUnreachable("We expected to throw here")
+          } catch {
+              expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Write when initial") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 5)
+          )
+
+          try await source.write(1)
+
+          var iterator = stream.makeAsyncIterator()
+          let element = try await iterator.next()
+          expectEqual(element, 1)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Write when streaming and no consumer") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 5)
+          )
+
+          try await source.write(1)
+          try await source.write(2)
+
+          var iterator = stream.makeAsyncIterator()
+          let element1 = try await iterator.next()
+          expectEqual(element1, 1)
+          let element2 = try await iterator.next()
+          expectEqual(element2, 2)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Write when streaming and suspended consumer") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 5)
+          )
+
+          try await withThrowingTaskGroup(of: Int?.self) { group in
+              group.addTask {
+                  return try await stream.first { _ in true }
+              }
+
+              // This is always going to be a bit racy since we need the call to next() suspend
+              try await Task.sleep(for: .seconds(0.5))
+
+              try await source.write(1)
+              let element = try await group.next()
+              expectEqual(element, 1)
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Write when streaming and suspended consumer and empty sequence") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 5)
+          )
+
+          try await withThrowingTaskGroup(of: Int?.self) { group in
+              group.addTask {
+                  return try await stream.first { _ in true }
+              }
+
+              // This is always going to be a bit racy since we need the call to next() suspend
+              try await Task.sleep(for: .seconds(0.5))
+
+              try await source.write(contentsOf: [])
+              try await source.write(contentsOf: [1])
+              let element = try await group.next()
+              expectEqual(element, 1)
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("EnqueueProducer when streaming and cancelled") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 2)
+          )
+
+          let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
+
+          try await source.write(1)
+
+          let writeResult =  try { try source.write(2) }()
+
+          switch writeResult {
+          case .produceMore:
+              preconditionFailure()
+          case .enqueueCallback(let callbackToken):
+              source.cancelCallback(callbackToken: callbackToken)
+
+              source.enqueueCallback(callbackToken: callbackToken) { result in
+                  producerSource.yield(with: result)
+              }
+          }
+
+          do {
+              _ = try await producerStream.first { _ in true }
+              expectUnreachable("Expected an error to be thrown")
+          } catch {
+              expectTrue(error is CancellationError)
+          }
+
+          let element = try await stream.first { _ in true }
+          expectEqual(element, 1)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("EnqueueProducer when streaming and cancelled and async") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 2)
+          )
+
+          try await source.write(1)
+
+          await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  try await source.write(2)
+              }
+
+              group.cancelAll()
+              do {
+                  try await group.next()
+                  expectUnreachable("Expected an error to be thrown")
+              } catch {
+                  expectTrue(error is CancellationError)
+              }
+          }
+
+          let element = try await stream.first { _ in true }
+          expectEqual(element, 1)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("EnqueueProducer when streaming and interleaving") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 1)
+          )
+          var iterator = stream.makeAsyncIterator()
+
+          let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
+
+          let writeResult =  try { try source.write(1) }()
+
+          switch writeResult {
+          case .produceMore:
+              preconditionFailure()
+          case .enqueueCallback(let callbackToken):
+              let element = try await iterator.next()
+              expectEqual(element, 1)
+
+              source.enqueueCallback(callbackToken: callbackToken) { result in
+                  producerSource.yield(with: result)
+              }
+          }
+
+          do {
+              _ = try await producerStream.first { _ in true }
+          } catch {
+              expectUnreachable("Expected no error to be thrown")
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("EnqueueProducer when streaming and suspending") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 1)
+          )
+          var iterator = stream.makeAsyncIterator()
+
+          let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
+
+          let writeResult =  try { try source.write(1) }()
+
+          switch writeResult {
+          case .produceMore:
+              preconditionFailure()
+          case .enqueueCallback(let callbackToken):
+              source.enqueueCallback(callbackToken: callbackToken) { result in
+                  producerSource.yield(with: result)
+              }
+          }
+
+          let element = try await iterator.next()
+          expectEqual(element, 1)
+
+          do {
+              _ = try await producerStream.first { _ in true }
+          } catch {
+              expectUnreachable("Expected no error to be thrown")
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("EnqueueProducer when finished") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 1)
+          )
+          var iterator = stream.makeAsyncIterator()
+
+          let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
+
+          let writeResult =  try { try source.write(1) }()
+
+          switch writeResult {
+          case .produceMore:
+              preconditionFailure()
+          case .enqueueCallback(let callbackToken):
+              source.finish(throwing: nil)
+
+              source.enqueueCallback(callbackToken: callbackToken) { result in
+                  producerSource.yield(with: result)
+              }
+          }
+
+          let element = try await iterator.next()
+          expectEqual(element, 1)
+
+          do {
+              _ = try await producerStream.first { _ in true }
+              expectUnreachable("Expected an error to be thrown")
+          } catch {
+              expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("CancelProducer when streaming") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 2)
+          )
+
+          let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
+
+          try await source.write(1)
+
+          let writeResult =  try { try source.write(2) }()
+
+          switch writeResult {
+          case .produceMore:
+              preconditionFailure()
+          case .enqueueCallback(let callbackToken):
+              source.enqueueCallback(callbackToken: callbackToken) { result in
+                  producerSource.yield(with: result)
+              }
+
+              source.cancelCallback(callbackToken: callbackToken)
+          }
+
+          do {
+              _ = try await producerStream.first { _ in true }
+              expectUnreachable("Expected an error to be thrown")
+          } catch {
+              expectTrue(error is CancellationError)
+          }
+
+          let element = try await stream.first { _ in true }
+          expectEqual(element, 1)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("CancelProducer when source finished") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 2)
+          )
+
+          let (producerStream, producerSource) = AsyncThrowingStream<Void, Error>.makeStream()
+
+          try await source.write(1)
+
+          let writeResult =  try { try source.write(2) }()
+
+          switch writeResult {
+          case .produceMore:
+              preconditionFailure()
+          case .enqueueCallback(let callbackToken):
+              source.enqueueCallback(callbackToken: callbackToken) { result in
+                  producerSource.yield(with: result)
+              }
+
+              source.finish(throwing: nil)
+
+              source.cancelCallback(callbackToken: callbackToken)
+          }
+
+          do {
+              _ = try await producerStream.first { _ in true }
+              expectUnreachable("Expected an error to be thrown")
+          } catch {
+              expectTrue(error is AsyncStreamAlreadyFinishedError)
+          }
+
+          let element = try await stream.first { _ in true }
+          expectEqual(element, 1)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Finish when streaming and consumer suspended") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 1, high: 1)
+          )
+
+          try await withThrowingTaskGroup(of: Int?.self) { group in
+              group.addTask {
+                  return try await stream.first { $0 == 2 }
+              }
+
+              // This is always going to be a bit racy since we need the call to next() suspend
+              try await Task.sleep(for: .seconds(0.5))
+
+              source.finish(throwing: nil)
+              let element = try await group.next()
+              expectEqual(element, .some(nil))
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Finish when initial") {
+        let (stream, source) = AsyncThrowingStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 1, high: 1)
+        )
+
+        source.finish(throwing: CancellationError())
+
+        do {
+            for try await _ in stream {}
+            expectUnreachable("Expected an error to be thrown")
+        } catch {
+            expectTrue(error is CancellationError)
+        }
+      }
+
+      tests.test("Backpressure async") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 4)
+          )
+
+          let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  while true {
+                      backPressureEventContinuation.yield(())
+                      try await source.write(contentsOf: [1])
+                  }
+              }
+
+              var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
+              var iterator = stream.makeAsyncIterator()
+
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+
+              _ = try await iterator.next()
+              _ = try await iterator.next()
+              _ = try await iterator.next()
+
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Backpressure sync") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 4)
+          )
+
+          let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+
+          try await withThrowingTaskGroup(of: Void.self) { group in
+              group.addTask {
+                  @Sendable func yield() {
+                      backPressureEventContinuation.yield(())
+                      source.write(contentsOf: [1]) { result in
+                          switch result {
+                          case .success:
+                              yield()
+
+                          case .failure:
+                              break
+                          }
+                      }
+                  }
+
+                  yield()
+              }
+
+              var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
+              var iterator = stream.makeAsyncIterator()
+
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+
+              _ = try await iterator.next()
+              _ = try await iterator.next()
+              _ = try await iterator.next()
+
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+              await backPressureEventIterator.next()
+
+              group.cancelAll()
+          }
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("Throws error") {
+        do {
+          let (stream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 4)
+          )
+
+          try await source.write(1)
+          try await source.write(2)
+          source.finish(throwing: CancellationError())
+
+          var elements = [Int]()
+          var iterator = stream.makeAsyncIterator()
+
+          do {
+              while let element = try await iterator.next() {
+                  elements.append(element)
+              }
+              expectUnreachable("Expected an error to be thrown")
+          } catch {
+              expectTrue(error is CancellationError)
+              expectEqual(elements, [1, 2])
+          }
+
+          let element = try await iterator.next()
+          expectNil(element)
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("AsyncSequence write") {
+        do {
+          let (stream, continuation) = AsyncStream<Int>.makeStream()
+          let (backpressuredStream, source) = AsyncThrowingStream.makeStream(
+              of: Int.self,
+              backPressureStrategy: .watermark(low: 2, high: 4)
+          )
+
+          continuation.yield(1)
+          continuation.yield(2)
+          continuation.finish()
+
+          try await source.write(contentsOf: stream)
+          source.finish(throwing: nil)
+
+          let elements = try await backpressuredStream.collect()
+          expectEqual(elements, [1, 2])
+        } catch {
+            expectUnreachable("Expected no error to be thrown")
+        }
+      }
+
+      tests.test("AsyncStream backpressure async") {
+        let (stream, source) = AsyncStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 2, high: 4)
+        )
+
+        let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                @Sendable func yield() {
+                    backPressureEventContinuation.yield(())
+                    source.write(contentsOf: [1]) { result in
+                        switch result {
+                        case .success:
+                            yield()
+
+                        case .failure:
+                            break
+                        }
+                    }
+                }
+
+                yield()
+            }
+
+            var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
+            var iterator = stream.makeAsyncIterator()
+
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+
+            _ = await iterator.next()
+            _ = await iterator.next()
+            _ = await iterator.next()
+
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+
+            group.cancelAll()
+        }
+      }
+
+      tests.test("Backpressure sync") {
+        let (stream, source) = AsyncStream.makeStream(
+            of: Int.self,
+            backPressureStrategy: .watermark(low: 2, high: 4)
+        )
+
+        let (backPressureEventStream, backPressureEventContinuation) = AsyncStream.makeStream(of: Void.self)
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                @Sendable func yield() {
+                    backPressureEventContinuation.yield(())
+                    source.write(contentsOf: [1]) { result in
+                        switch result {
+                        case .success:
+                            yield()
+
+                        case .failure:
+                            break
+                        }
+                    }
+                }
+
+                yield()
+            }
+
+            var backPressureEventIterator = backPressureEventStream.makeAsyncIterator()
+            var iterator = stream.makeAsyncIterator()
+
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+
+            _ = await iterator.next()
+            _ = await iterator.next()
+            _ = await iterator.next()
+
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+            await backPressureEventIterator.next()
+
+            group.cancelAll()
+        }
+      }
+
       await runAllTestsAsync()
     }
   }
+}
+
+extension AsyncSequence {
+    /// Collect all elements in the sequence into an array.
+    fileprivate func collect() async rethrows -> [Element] {
+        try await self.reduce(into: []) { accumulated, next in
+            accumulated.append(next)
+        }
+    }
+}
+
+extension AsyncThrowingStream.Source.WriteResult {
+    func assertIsProducerMore() {
+        switch self {
+        case .produceMore:
+            return
+
+        case .enqueueCallback:
+            expectUnreachable("Expected produceMore")
+        }
+    }
+
+    func assertIsEnqueueCallback() {
+        switch self {
+        case .produceMore:
+            expectUnreachable("Expected enqueueCallback")
+
+        case .enqueueCallback:
+            return
+        }
+    }
 }
 
 


### PR DESCRIPTION
# Motivation

https://github.com/apple/swift-evolution/pull/2077

# Modification
This PR adds support for the new backpressured interfaces of `Async[Throwing]Stream`