### PR TITLE
Enable IRGen/protocol_metadata test on Apple Silicon

### DIFF
--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
 
-// REQUIRES: CPU=x86_64
+// REQUIRES: PTRSIZE=64
 
 protocol A { func a() }
 protocol B { func b() }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This requirement seems to be too restrictive. The test works for me as-is on an M2 Max (removing the REQUIRES line, of course).

I assume the intention is to limit this to 64-bit architectures, and I think `PTRSIZE=64` is the right way to do that?

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
