### PR TITLE
🍒[Observation] Add property definite initialization support

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -218,16 +218,13 @@ extension ObservableMacro: MemberMacro {
     declaration.addIfNeeded(ObservableMacro.registrarVariable(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
-    
+
     let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
     for property in storedInstanceVariables {
       if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
       if property.initializer == nil {
         context.addDiagnostics(from: DiagnosticsError(syntax: property, message: "@Observable requires property '\(property.identifier?.text ?? "")' to have an initial value", id: .missingInitializer), node: property)
       }
-      let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
-      declaration.addIfNeeded(storage, to: &declarations)
-      
     }
 
     return declarations
@@ -343,8 +340,9 @@ extension ObservationTrackedMacro: PeerMacro {
           property.isValidForObservation else {
       return []
     }
-
-    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) {
+    
+    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) ||
+       property.hasMacroApplication(ObservableMacro.trackedMacroName) {
       return []
     }
     

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -219,6 +219,15 @@ extension ObservableMacro: MemberMacro {
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
 
+#if !OBSERVATION_SUPPORTS_PEER_MACROS
+    let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
+    for property in storedInstanceVariables {
+       if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
+       let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
+       declaration.addIfNeeded(storage, to: &declarations)
+    }
+#endif
+
     return declarations
   }
 }

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -219,14 +219,6 @@ extension ObservableMacro: MemberMacro {
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
 
-    let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
-    for property in storedInstanceVariables {
-      if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
-      if property.initializer == nil {
-        context.addDiagnostics(from: DiagnosticsError(syntax: property, message: "@Observable requires property '\(property.identifier?.text ?? "")' to have an initial value", id: .missingInitializer), node: property)
-      }
-    }
-
     return declarations
   }
 }
@@ -306,6 +298,13 @@ public struct ObservationTrackedMacro: AccessorMacro {
       return []
     }
 
+    let initAccessor: AccessorDeclSyntax =
+      """
+      init(initialValue) initializes(_\(identifier)) {
+        _\(identifier) = initialValue
+      }
+      """
+
     let getAccessor: AccessorDeclSyntax =
       """
       get {
@@ -323,7 +322,7 @@ public struct ObservationTrackedMacro: AccessorMacro {
       }
       """
 
-    return [getAccessor, setAccessor]
+    return [initAccessor, getAccessor, setAccessor]
   }
 }
 

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -16,7 +16,11 @@
 #if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
+#if OBSERVATION_SUPPORTS_PEER_MACROS
 @attached(member, names: named(_$observationRegistrar), named(access), named(withMutation))
+#else
+@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation), arbitrary)
+#endif
 @attached(memberAttribute)
 @attached(conformance)
 public macro Observable() = 
@@ -24,7 +28,9 @@ public macro Observable() =
 
 @available(SwiftStdlib 5.9, *)
 @attached(accessor)
+#if OBSERVATION_SUPPORTS_PEER_MACROS
 @attached(peer, names: prefixed(_))
+#endif
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -16,7 +16,7 @@
 #if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
-@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation), arbitrary)
+@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation))
 @attached(memberAttribute)
 @attached(conformance)
 public macro Observable() = 
@@ -24,7 +24,7 @@ public macro Observable() =
 
 @available(SwiftStdlib 5.9, *)
 @attached(accessor)
-// @attached(peer, names: prefixed(_))
+@attached(peer, names: prefixed(_))
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -22,6 +22,24 @@ struct Structure {
 }
 
 @Observable
+struct MemberwiseInitializers {
+  var field: Int
+}
+
+func validateMemberwiseInitializers() {
+  _ = MemberwiseInitializers(field: 3)
+}
+
+@Observable
+struct DefiniteInitialization {
+  var field: Int
+  
+  init(field: Int) {
+    self.field = field
+  }
+}
+
+@Observable
 class ContainsWeak {
   weak var obj: AnyObject? = nil
 }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
 
 // REQUIRES: observation
 // REQUIRES: concurrency


### PR DESCRIPTION
This adds definite initialization support for `@Observable` types. This lifts the requirement for observable types needing all properties to be initialized with default values.

Resolves: rdar://110378123