### PR TITLE
[5.9] always use the argNames constructor for macro DeclNames

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4796,14 +4796,10 @@ public:
 
     // Resolve the name ids.
     DeclName name;
-    if (numArgNames > 0) {
-      SmallVector<Identifier, 2> argNames;
-      for (auto argNameID : argNameAndDependencyIDs.slice(0, numArgNames))
-        argNames.push_back(MF.getIdentifier(argNameID));
-      name = DeclName(ctx, baseName, argNames);
-    } else {
-      name = baseName;
-    }
+    SmallVector<Identifier, 2> argNames;
+    for (auto argNameID : argNameAndDependencyIDs.slice(0, numArgNames))
+      argNames.push_back(MF.getIdentifier(argNameID));
+    name = DeclName(ctx, baseName, argNames);
     PrettySupplementalDeclNameTrace trace(name);
 
     argNameAndDependencyIDs = argNameAndDependencyIDs.slice(numArgNames);

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -21,7 +21,7 @@ func test(a: Int, b: Int) {
 
 struct TestStruct {
   @myWrapper var x: Int
-  // expected-error@-1{{expansion of macro 'myWrapper' did not produce a non-observing accessor}}
+  // expected-error@-1{{expansion of macro 'myWrapper()' did not produce a non-observing accessor}}
 }
 
 @ArbitraryMembers

--- a/test/SourceKit/Refactoring/shorthand_shadow.swift
+++ b/test/SourceKit/Refactoring/shorthand_shadow.swift
@@ -32,7 +32,7 @@ func renameBuiltinMacroWithoutHash() {
     // RUN: not %sourcekitd-test -req=find-local-rename-ranges -pos=%(line+1):9 %s -- %s 2>&1 | %FileCheck %s --check-prefix=BUILTIN
     _ = file
   }
-  // BUILTIN: error: cannot rename system symbol 'file'
+  // BUILTIN: error: cannot rename system symbol 'file()'
 }
 
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
@@ -6,14 +6,32 @@
 // RUN: %target-swift-frontend -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name Macros -emit-module -emit-module-path %t/Macros.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %{python} -m json.tool %t/Macros.symbols.json %t/Macros.formatted.symbols.json
 
-// Make sure that the `= #externalMacro(...)` doesn't show up in declaration fragments and in names fragments.
+// Make sure that the `= #externalMacro(...)` doesn't show up in declaration fragments and in names
+// fragments, and also that macros with no parameters get the `()` in their name.
 
 // RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json --check-prefix NAMES
+// RUN: %FileCheck %s --input-file %t/Macros.formatted.symbols.json --check-prefix TITLE
 
+// Now do the same thing with a `swift-symbolgraph-extract`-processed symbol graph.
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/stringify_macro.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %target-swift-frontend -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name Macros -emit-module -emit-module-path %t/Macros.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name Macros -I %t -pretty-print -output-dir %t
+
+// RUN: %FileCheck %s --input-file %t/Macros.symbols.json
+// RUN: %FileCheck %s --input-file %t/Macros.symbols.json --check-prefix NAMES
+// RUN: %FileCheck %s --input-file %t/Macros.symbols.json --check-prefix TITLE
 
 @freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
+@freestanding(expression) public macro stringifySeven() -> (Int, String) = #stringify(7)
+
+// Note that type parameters don't have reference USRs when loading from serialized AST, so the
+// following declaration/names dumps are edited to handle both situations.
+
+// CHECK-LABEL: "precise": "s:6Macros9stringifyyx_SStxclufm",
 // CHECK:      "declarationFragments": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:         "kind": "attribute",
@@ -65,18 +83,16 @@
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:         "kind": "typeIdentifier",
-// CHECK-NEXT:         "spelling": "T",
-// CHECK-NEXT:         "preciseIdentifier": "s:6Macros1TL_xmfp"
-// CHECK-NEXT:     },
+// CHECK-NEXT:         "spelling": "T"
+// CHECK:          },
 // CHECK-NEXT:     {
 // CHECK-NEXT:         "kind": "text",
 // CHECK-NEXT:         "spelling": ") -> ("
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:         "kind": "typeIdentifier",
-// CHECK-NEXT:         "spelling": "T",
-// CHECK-NEXT:         "preciseIdentifier": "s:6Macros1TL_xmfp"
-// CHECK-NEXT:     },
+// CHECK-NEXT:         "spelling": "T"
+// CHECK:          },
 // CHECK-NEXT:     {
 // CHECK-NEXT:         "kind": "text",
 // CHECK-NEXT:         "spelling": ", "
@@ -92,6 +108,7 @@
 // CHECK-NEXT:     }
 // CHECK-NEXT: ],
 
+// NAMES-LABEL: "precise": "s:6Macros9stringifyyx_SStxclufm",
 // NAMES:      "names": {
 // NAMES-NEXT:     "title": "stringify(_:)",
 // NAMES-NEXT:     "subHeading": [
@@ -121,18 +138,16 @@
 // NAMES-NEXT:         },
 // NAMES-NEXT:         {
 // NAMES-NEXT:             "kind": "typeIdentifier",
-// NAMES-NEXT:             "spelling": "T",
-// NAMES-NEXT:             "preciseIdentifier": "s:6Macros1TL_xmfp"
-// NAMES-NEXT:         },
+// NAMES-NEXT:             "spelling": "T"
+// NAMES:              },
 // NAMES-NEXT:         {
 // NAMES-NEXT:             "kind": "text",
 // NAMES-NEXT:             "spelling": ") -> ("
 // NAMES-NEXT:         },
 // NAMES-NEXT:         {
 // NAMES-NEXT:             "kind": "typeIdentifier",
-// NAMES-NEXT:             "spelling": "T",
-// NAMES-NEXT:             "preciseIdentifier": "s:6Macros1TL_xmfp"
-// NAMES-NEXT:         },
+// NAMES-NEXT:             "spelling": "T"
+// NAMES:              },
 // NAMES-NEXT:         {
 // NAMES-NEXT:             "kind": "text",
 // NAMES-NEXT:             "spelling": ", "
@@ -148,3 +163,6 @@
 // NAMES-NEXT:         }
 // NAMES-NEXT:     ]
 // NAMES-NEXT: },
+
+// TITLE-LABEL: "precise": "s:6Macros14stringifySevenSi_SStycfm",
+// TITLE: "title": "stringifySeven()",


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66497

- **Explanation**: Macros with no parameters have an inconsistent DeclName based on whether they were loaded from source code or a built-module.
- **Scope**: Affects symbol graphs (and Swift-DocC documentation) for these macros.
- **Issue**: rdar://110179186
- **Risk**: Low. The deserialization logic that was removed was identical to the one that was left in its place, with the exception of which `DeclName` constructor is being used.
- **Testing**: A test has been added to ensure that a parameterless macro has the same name regardless of whether it's loaded from source code or a built module.
- **Reviewer**: @DougGregor 