### PR TITLE
IRGen: alloc_global and global_addr instructions need to agree on the storage

### DIFF
--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -54,3 +54,18 @@ extension A {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main(i32 %0, i8** %1) {{.*}} {
 // CHECK:      store  i64 {{.*}}, i64* getelementptr inbounds ([[INT]], [[INT]]* @"$s7globals2g0Sivp", i32 0, i32 0), align 8
 
+// CHECK:  [[BUF_PROJ:%.*]] = call {{.*}} @__swift_project_value_buffer({{.*}}s7globals1gQrvp
+// CHECK:  [[CAST:%.*]] = bitcast {{.*}} [[BUF_PROJ]]
+// CHECK:  [[CAST2:%.*]] = bitcast {{.*}} [[CAST]]
+// CHECK:  call void @llvm.memcpy{{.*}}({{.*}}[[CAST2]]
+
+
+public protocol Some {}
+
+public struct Implementer : Some {
+  var w = (0, 1, 2, 3, 4)
+
+  public init() { }
+}
+
+let g : some Some = Implementer()

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -disable-availability-checking -emit-ir | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: PTRSIZE=64


### PR DESCRIPTION
If the storage is opaque we need to project to the underlying buffer.

rdar://109636344

