### PR TITLE
Fix tests on Windows CI with VS2022

### DIFF
--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -28,7 +28,7 @@ for filePathPattern in sys.argv[2:]:
     # Support glob patterns if the shell did not expand them (like cmd.exe)
     if glob.escape(filePathPattern) == filePathPattern:
         # Not a glob pattern. We should touch that specific file.
-        filePaths = [ filePathPattern ]
+        filePaths = [filePathPattern]
     else:
         filePaths = glob.glob(filePathPattern)
 

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -26,6 +26,12 @@ timeVal = int(sys.argv[1])
 # From http://stackoverflow.com/a/1160227.
 for filePathPattern in sys.argv[2:]:
     # Support glob patterns if the shell did not expand them (like cmd.exe)
-    for filePath in glob.glob(filePathPattern):
+    if glob.escape(filePathPattern) == filePathPattern:
+        # Not a glob pattern. We should touch that specific file.
+        filePaths = [ filePathPattern ]
+    else:
+        filePaths = glob.glob(filePathPattern)
+
+    for filePath in filePaths:
         with open(filePath, 'a'):
             os.utime(filePath, (timeVal, timeVal))

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -15,6 +15,7 @@
 #
 # ----------------------------------------------------------------------------
 
+import glob
 import os
 import sys
 
@@ -23,6 +24,8 @@ timeVal = int(sys.argv[1])
 
 # Update the output file mtime, or create it if necessary.
 # From http://stackoverflow.com/a/1160227.
-for outputFile in sys.argv[2:]:
-    with open(outputFile, 'a'):
-        os.utime(outputFile, (timeVal, timeVal))
+for filePathPattern in sys.argv[2:]:
+    # Support glob patterns if the shell did not expand them (like cmd.exe)
+    for filePath in glob.glob(filePathPattern):
+        with open(filePath, 'a'):
+            os.utime(filePath, (timeVal, timeVal))

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -12,7 +12,9 @@
 // CHECK-FIRST-DAG: Produced master.swiftmodule
 
 // swift-driver checks existence of all outputs
-// RUN: touch -t 201401240006 %t/{main,other,master}.swift{module,doc,sourceinfo}
+// RUN: touch -t 201401240006 %t/*.swiftmodule
+// RUN: touch -t 201401240006 %t/*.swiftdoc
+// RUN: touch -t 201401240006 %t/*.swiftsourceinfo
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
-// RUN: touch -t 201401240005 %t/*
+// RUN: %{python} %S/Inputs/touch.py 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
@@ -12,9 +12,9 @@
 // CHECK-FIRST-DAG: Produced master.swiftmodule
 
 // swift-driver checks existence of all outputs
-// RUN: touch -t 201401240006 %t/*.swiftmodule
-// RUN: touch -t 201401240006 %t/*.swiftdoc
-// RUN: touch -t 201401240006 %t/*.swiftsourceinfo
+// RUN: %{python} %S/Inputs/touch.py 201401240006 %t/*.swiftmodule
+// RUN: %{python} %S/Inputs/touch.py 201401240006 %t/*.swiftdoc
+// RUN: %{python} %S/Inputs/touch.py 201401240006 %t/*.swiftsourceinfo
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 

--- a/test/ModuleInterface/ModuleCache/prefer-local-module-to-sdk-framework.swift
+++ b/test/ModuleInterface/ModuleCache/prefer-local-module-to-sdk-framework.swift
@@ -1,26 +1,26 @@
-// RUN: %empty-directory(%t/BuildDir/Lib.framework/Modules/Lib.swiftmodule)
-// RUN: %empty-directory(%t/SecondBuildDir/Lib.framework/Modules/Lib.swiftmodule)
+// RUN: %empty-directory(%t/Build1/Lib.framework/Modules/Lib.swiftmodule)
+// RUN: %empty-directory(%t/Build2/Lib.framework/Modules/Lib.swiftmodule)
 // RUN: %empty-directory(%t/ModuleCache)
 
 // RUN: echo 'public func showsUpInBothPlaces() {}' > %t/Lib.swift
 
 // 1. Create a .swiftinterface file containing just one API, and put it inside a second build dir (without a .swiftmodule)
-// RUN: %target-swift-frontend -typecheck %t/Lib.swift -emit-module-interface-path %t/SecondBuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name -module-name Lib
+// RUN: %target-swift-frontend -typecheck %t/Lib.swift -emit-module-interface-path %t/Build2/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name -module-name Lib
 
 // 2. Add a new API to the module, and compile just the serialized version in the build dir.
 // RUN: echo 'public func onlyInTheCompiledModule() {}' >> %t/Lib.swift
-// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftmodule-name -emit-module-interface-path %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name -module-name Lib
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/Build1/Lib.framework/Modules/Lib.swiftmodule/%target-swiftmodule-name -emit-module-interface-path %t/Build1/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name -module-name Lib
 
 // 3. Make sure when we compile this test file, we can access both APIs since we'll
 //    load the compiled .swiftmodule instead of the .swiftinterface in the SDK.
-// RUN: %target-swift-frontend -typecheck %s -F %t/BuildDir -F %t/SecondBuildDir -module-cache-path %t/ModuleCache
+// RUN: %target-swift-frontend -typecheck %s -F %t/Build1 -F %t/Build2 -module-cache-path %t/ModuleCache
 
 // 4. Make sure we didn't compile any .swiftinterfaces into the module cache.
 // RUN: ls %t/ModuleCache | not grep 'swiftmodule'
 
 // 5. This should also work if the swiftinterface isn't present in the first build dir.
-// RUN: rm %t/BuildDir/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name
-// RUN: %target-swift-frontend -typecheck %s -F %t/BuildDir -F %t/SecondBuildDir -module-cache-path %t/ModuleCache
+// RUN: rm %t/Build1/Lib.framework/Modules/Lib.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-frontend -typecheck %s -F %t/Build1 -F %t/Build2 -module-cache-path %t/ModuleCache
 
 // 6. Make sure we /still/ didn't compile any .swiftinterfaces into the module cache.
 // RUN: ls %t/ModuleCache | not grep 'swiftmodule'


### PR DESCRIPTION
While trying the migrate the CI to VS2022, some tests are failing. See https://ci-external.swift.org/job/win64-vs2022/1765/console

`test/Driver/Dependencies/one-way-merge-module-fine.swift`: is using bash file path wildcard syntax which is unreliable on Windows. We use bash from the git installation and it appears that not all versions will support this syntax. The fix is to expand them.

`test/ModuleInterface/ModuleCache/prefer-local-module-to-sdk-framework.swift`: is using extra long paths. The VS2022 CI is using a more recent version of Python where `os.path.realpath` expands substitute drives, which we were using to avoid running into `MAX_PATH` limitations. We may need to address this in `lit.py` but for here we can at least shorten some paths to see if we hit further issues.