### PR TITLE
Sema: Reword diagnostics to say 'without a type annotation' instead of 'without more context' [5.9]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -275,10 +275,10 @@ ERROR(no_candidates_match_argument_type,none,
       (StringRef, Type, unsigned))
 
 ERROR(cannot_infer_closure_parameter_type,none,
-      "unable to infer type of a closure parameter %0 in the current context",
+      "cannot infer type of closure parameter %0 without a type annotation",
        (StringRef))
 ERROR(cannot_infer_closure_type,none,
-      "unable to infer closure type in the current context", ())
+      "unable to infer closure type without a type annotation", ())
 ERROR(cannot_infer_empty_closure_result_type,none,
       "cannot infer return type of empty closure", ())
 ERROR(cannot_infer_closure_result_type,none,
@@ -4077,7 +4077,7 @@ ERROR(could_not_infer_placeholder,none,
       "could not infer type for placeholder", ())
 
 ERROR(type_of_expression_is_ambiguous,none,
-      "type of expression is ambiguous without more context", ())
+      "type of expression is ambiguous without a type annotation", ())
 
 ERROR(failed_to_produce_diagnostic,Fatal,
       "failed to produce diagnostic for expression; "

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -516,7 +516,7 @@ do {
   func set_via_closure<T, U>(_ closure: (inout T, U) -> ()) {} // expected-note {{in call to function 'set_via_closure'}}
   set_via_closure({ $0.number1 = $1 })
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
-  // expected-error@-2 {{unable to infer type of a closure parameter '$1' in the current context}}
+  // expected-error@-2 {{cannot infer type of closure parameter '$1' without a type annotation}}
 
   func f2<T>(_ item: T, _ update: (inout T) -> Void) {
     var x = item
@@ -1052,12 +1052,12 @@ overloaded_with_default_and_autoclosure { 42 } // Ok
 overloaded_with_default_and_autoclosure(42) // Ok
 
 /// https://github.com/apple/swift/issues/55261
-/// "error: type of expression is ambiguous without more context" in many cases
+/// "error: type of expression is ambiguous without a type annotation" in many cases
 /// where methods are missing.
 do {
   let _ = { a, b in }
-  // expected-error@-1 {{unable to infer type of a closure parameter 'a' in the current context}}
-  // expected-error@-2 {{unable to infer type of a closure parameter 'b' in the current context}}
+  // expected-error@-1 {{cannot infer type of closure parameter 'a' without a type annotation}}
+  // expected-error@-2 {{cannot infer type of closure parameter 'b' without a type annotation}}
 
   _ = .a { b in } // expected-error {{cannot infer contextual base in reference to member 'a'}}
 
@@ -1078,7 +1078,7 @@ let explicitUnboundResult2: (Array<Bool>) -> Array<Int> = {
 }
 // FIXME: Should we prioritize the contextual result type and infer Array<Int>
 // rather than using a type variable in these cases?
-// expected-error@+1 {{unable to infer closure type in the current context}}
+// expected-error@+1 {{unable to infer closure type without a type annotation}}
 let explicitUnboundResult3: (Array<Bool>) -> Array<Int> = {
   (arr: Array) -> Array in [true]
 }

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -154,7 +154,7 @@ extension S3 {
 let s3b = S3(maybe: s3a)
 
 // https://github.com/apple/swift/issues/47820
-// Erroneous diagnostic: type of expression is ambiguous without more context
+// Erroneous diagnostic: type of expression is ambiguous without a type annotation
 do {
   class C {
       struct S {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -297,7 +297,7 @@ func r18800223(_ i : Int) {
 }
 
 // <rdar://problem/21883806> Bogus "'_' can only appear in a pattern or on the left side of an assignment" is back
-_ = { $0 }  // expected-error {{unable to infer type of a closure parameter '$0' in the current context}}
+_ = { $0 }  // expected-error {{cannot infer type of closure parameter '$0' without a type annotation}}
 
 
 

--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -29,7 +29,7 @@ class C_45110: P_45110 {
 
 let _ = S_45110(arg: [C_45110()]) // expected-error {{extraneous argument label 'arg:' in call}}
 
-// rdar://problem/31898542 - Swift 4: 'type of expression is ambiguous without more context' errors, without a fixit
+// rdar://problem/31898542 - Swift 4: 'type of expression is ambiguous without a type annotation' errors, without a fixit
 
 enum R31898542<T> {
   case success(T) // expected-note {{'success' declared here}}

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -90,7 +90,7 @@ func testNil3(_ x: Bool) {
 }
 func testNil4(_ x: Bool) {
   // FIXME: Bad diagnostic (#63130)
-  let _: _? = if x { nil } else { 42 } // expected-error {{type of expression is ambiguous without more context}}
+  let _: _? = if x { nil } else { 42 } // expected-error {{type of expression is ambiguous without a type annotation}}
 }
 
 enum F<T> {
@@ -137,7 +137,7 @@ struct SQ : Q {
 
 func testAssociatedTypeReturn1() {
   func fn<T : Q>(_ fn: (T) -> T.X) {}
-  fn { x in // expected-error {{unable to infer type of a closure parameter 'x' in the current context}}
+  fn { x in // expected-error {{cannot infer type of closure parameter 'x' without a type annotation}}
     if .random() { "" } else { "" }
   }
   fn { (x: SQ) in

--- a/test/Constraints/one_way_closure_params.swift
+++ b/test/Constraints/one_way_closure_params.swift
@@ -3,6 +3,6 @@
 func testBasic() {
   let _: (Float) -> Float = { $0 + 1 }
 
-  let _ = { $0 + 1 } // expected-error{{unable to infer type of a closure parameter '$0' in the current context}}
+  let _ = { $0 + 1 } // expected-error{{cannot infer type of closure parameter '$0' without a type annotation}}
 }
 

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -284,7 +284,7 @@ func rdar60727310() {
 // FIXME: Bad diagnostic.
 func f_54877(_ e: Error) {
   func foo<T>(_ a: T, _ op: ((T, T) -> Bool)) {}
-  foo(e, ==) // expected-error {{type of expression is ambiguous without more context}}
+  foo(e, ==) // expected-error {{type of expression is ambiguous without a type annotation}}
 }
 
 // rdar://problem/62054241 - Swift compiler crashes when passing < as the sort function in sorted(by:) and the type of the array is not comparable

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -474,7 +474,7 @@ do {
   }
 }
 
-// rdar://107675464 - misplaced `each` results in `type of expression is ambiguous without more context`
+// rdar://107675464 - misplaced `each` results in `type of expression is ambiguous without a type annotation`
 do {
   func test_correct_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
     return (repeat (each value).makeA()) // Ok

--- a/test/Constraints/parameterized_existentials.swift
+++ b/test/Constraints/parameterized_existentials.swift
@@ -6,7 +6,7 @@ protocol P<A> {
 
 func f1(x: any P) -> any P<Int> {
   // FIXME: Bad diagnostic
-  return x // expected-error {{type of expression is ambiguous without more context}}
+  return x // expected-error {{type of expression is ambiguous without a type annotation}}
 }
 
 func f2(x: any P<Int>) -> any P {

--- a/test/Constraints/rdar106598067.swift
+++ b/test/Constraints/rdar106598067.swift
@@ -5,7 +5,7 @@ enum E: Error { case e }
 // rdar://106598067 – Make sure we don't crash.
 // FIXME: Bad diagnostic (the issue is that it should be written 'as', not 'as?')
 let fn = {
-  // expected-error@-1 {{unable to infer closure type in the current context}}
+  // expected-error@-1 {{unable to infer closure type without a type annotation}}
   do {} catch let x as? E {}
   // expected-warning@-1 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
 }

--- a/test/Constraints/rdar107724970.swift
+++ b/test/Constraints/rdar107724970.swift
@@ -8,7 +8,7 @@ func foo(_ x: E) {
   // FIXME: We need to handle pattern arguments in a bunch of places in argument
   // list diagnostic logic.
   // https://github.com/apple/swift/issues/65062
-  let fn = { // expected-error {{unable to infer closure type in the current context}}
+  let fn = { // expected-error {{unable to infer closure type without a type annotation}}
     switch x {
     case E.e(_, _):
       break

--- a/test/Constraints/rdar85263844_swift6.swift
+++ b/test/Constraints/rdar85263844_swift6.swift
@@ -32,5 +32,5 @@ extension S4 where T == (outer: Int, y: Int) {
 
 public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
   // FIXME: Bad error message.
-  S4(x.map { (inner: $0, y: $0) }) // expected-error {{type of expression is ambiguous without more context}}
+  S4(x.map { (inner: $0, y: $0) }) // expected-error {{type of expression is ambiguous without a type annotation}}
 }

--- a/test/Constraints/switch_expr.swift
+++ b/test/Constraints/switch_expr.swift
@@ -208,7 +208,7 @@ func testNil3(_ x: Bool) {
 }
 func testNil4(_ x: Bool) {
   // FIXME: Bad diagnostic (#63130)
-  let _: _? = switch x { case true: nil case false: 42 }  // expected-error {{type of expression is ambiguous without more context}}
+  let _: _? = switch x { case true: nil case false: 42 }  // expected-error {{type of expression is ambiguous without a type annotation}}
 }
 
 enum G<T> {

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -41,7 +41,7 @@ takesAnyObject()
 takesAnyObject(C(), C(), C())
 
 // FIXME: Bad diagnostic
-takesAnyObject(C(), S(), C())  // expected-error {{type of expression is ambiguous without more context}}
+takesAnyObject(C(), S(), C())  // expected-error {{type of expression is ambiguous without a type annotation}}
 
 // Same-type requirements
 

--- a/test/Interop/Cxx/foreign-reference/not-any-object.swift
+++ b/test/Interop/Cxx/foreign-reference/not-any-object.swift
@@ -26,4 +26,4 @@ import Test;
 public func test(_ _: AnyObject) {}
 
 // TODO: make this a better error.
-test(Empty.create()) // expected-error {{type of expression is ambiguous without more context}}
+test(Empty.create()) // expected-error {{type of expression is ambiguous without a type annotation}}

--- a/test/Interop/Cxx/namespace/inline-namespace-function-call-broken.swift
+++ b/test/Interop/Cxx/namespace/inline-namespace-function-call-broken.swift
@@ -22,5 +22,5 @@ import namespaces;
 
 // Swift's typechecker currently doesn't allow calling a function from inline namespace when it's referenced through the parent namespace.
 func test() {
-  Parent.functionInInlineChild() // expected-error {{type of expression is ambiguous without more context}}
+  Parent.functionInInlineChild() // expected-error {{type of expression is ambiguous without a type annotation}}
 }

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -97,7 +97,7 @@ macro genericDeclMacro<T: Numeric, U: Numeric>(_ x: T, _ y: U)
 
 func testDiags(a: Int, b: Int) {
   // FIXME: Bad diagnostic.
-  let s = #stringify<Int, Int>(a + b) // expected-error{{type of expression is ambiguous without more context}}
+  let s = #stringify<Int, Int>(a + b) // expected-error{{type of expression is ambiguous without a type annotation}}
 
   _ = #stringify()
   // expected-error@-1{{missing argument for parameter #1 in macro expansion}}

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -16,14 +16,14 @@ fe(.nope, .nyet) // expected-error {{type 'Int' has no member 'nope'}}
 // expected-error@-1 {{reference to member 'nyet' cannot be resolved without a contextual type}}
 
 func fg<T>(_ f: (T) -> T) -> Void {}
-fg({x in x}) // expected-error {{unable to infer type of a closure parameter 'x' in the current context}}
+fg({x in x}) // expected-error {{cannot infer type of closure parameter 'x' without a type annotation}}
 
 
 struct S {
   func f<T>(_ i: (T) -> T, _ j: Int) -> Void {}
   func f(_ d: (Double) -> Double) -> Void {}
   func test() -> Void {
-    f({x in x}, 2) // expected-error {{unable to infer type of a closure parameter 'x' in the current context}}
+    f({x in x}, 2) // expected-error {{cannot infer type of closure parameter 'x' without a type annotation}}
   }
   
   func g<T>(_ a: T, _ b: Int) -> Void {}

--- a/test/Sema/discard.swift
+++ b/test/Sema/discard.swift
@@ -97,7 +97,7 @@ enum E: Error { case err }
     discard (self) // expected-error {{cannot convert value of type 'File' to expected argument type 'Int'}}
 
     // FIXME: we should get an error about it being illegal to discard in a closure.
-    let _ = { // expected-error {{type of expression is ambiguous without more context}}
+    let _ = { // expected-error {{type of expression is ambiguous without a type annotation}}
       discard self
       return 0
     }()

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -147,15 +147,15 @@ let _ = [_].otherStaticMember.method()
 func f(x: Any, arr: [Int]) {
     // FIXME: Better diagnostics here. Maybe we should suggest replacing placeholders with 'Any'?
 
-    if x is _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-    if x is [_] {} // expected-error {{type of expression is ambiguous without more context}}
-    if x is () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    if let y = x as? _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-    if let y = x as? [_] {} // expected-error {{type of expression is ambiguous without more context}}
-    if let y = x as? () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    let y1 = x as! _ // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-    let y2 = x as! [_] // expected-error {{type of expression is ambiguous without more context}}
-    let y3 = x as! () -> _ // expected-error {{type of expression is ambiguous without more context}}
+    if x is _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without a type annotation}}
+    if x is [_] {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    if x is () -> _ {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    if let y = x as? _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without a type annotation}}
+    if let y = x as? [_] {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    if let y = x as? () -> _ {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    let y1 = x as! _ // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without a type annotation}}
+    let y2 = x as! [_] // expected-error {{type of expression is ambiguous without a type annotation}}
+    let y3 = x as! () -> _ // expected-error {{type of expression is ambiguous without a type annotation}}
 
     switch x {
     case is _: break // expected-error {{type placeholder not allowed here}}
@@ -166,15 +166,15 @@ func f(x: Any, arr: [Int]) {
     case let y as () -> _: break // expected-error {{type placeholder not allowed here}}
     }
 
-    if arr is _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-    if arr is [_] {} // expected-error {{type of expression is ambiguous without more context}}
-    if arr is () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    if let y = arr as? _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-    if let y = arr as? [_] {} // expected-error {{type of expression is ambiguous without more context}}
-    if let y = arr as? () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    let y1 = arr as! _ // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-    let y2 = arr as! [_] // expected-error {{type of expression is ambiguous without more context}}
-    let y3 = arr as! () -> _ // expected-error {{type of expression is ambiguous without more context}}
+    if arr is _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without a type annotation}}
+    if arr is [_] {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    if arr is () -> _ {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    if let y = arr as? _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without a type annotation}}
+    if let y = arr as? [_] {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    if let y = arr as? () -> _ {} // expected-error {{type of expression is ambiguous without a type annotation}}
+    let y1 = arr as! _ // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without a type annotation}}
+    let y2 = arr as! [_] // expected-error {{type of expression is ambiguous without a type annotation}}
+    let y3 = arr as! () -> _ // expected-error {{type of expression is ambiguous without a type annotation}}
 
     switch arr {
     case is _: break // expected-error {{type placeholder not allowed here}}

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -271,7 +271,7 @@ func testInvalidWrapperInference() {
   S<Int>.test({ $value in })
 
   func testGenericClosure<T>(_ closure: T) {}
-  // expected-error@+1 {{unable to infer type of a closure parameter '$value' in the current context}}
+  // expected-error@+1 {{cannot infer type of closure parameter '$value' without a type annotation}}
   testGenericClosure { $value in }
   testGenericClosure { ($value: ProjectionWrapper<Int>) in } // okay
 

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -864,7 +864,7 @@ do {
   // FIXME: Should GenericSignature::getConcreteType return the null type instead
   // of the error type here for Self.A, despite the broken conformance?
   let exist: any CompositionBrokenClassConformance_b & BadConformanceClass
-  exist.method(false) // expected-error {{type of expression is ambiguous without more context}}
+  exist.method(false) // expected-error {{type of expression is ambiguous without a type annotation}}
 }
 
 /// Covariant Associated Type Erasure

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -113,7 +113,7 @@ let _ : D<Int, Int, Float> = D(a: 1, b: 2)
 
 let _ : F = { (a : Int) -> Int in a }  // Infer the types of F
 
-let _ : F = { a in a } // expected-error {{unable to infer type of a closure parameter 'a' in the current context}}
+let _ : F = { a in a } // expected-error {{cannot infer type of closure parameter 'a' without a type annotation}}
 
 _ = MyType(a: "foo", b: 42)
 _ = A(a: "foo", b: 42)

--- a/test/decl/var/property_wrappers_invalid.swift
+++ b/test/decl/var/property_wrappers_invalid.swift
@@ -3,9 +3,9 @@
 // FIXME: This should produce a diagnostic with a proper
 // source location. Right now, we just get three useless errors:
 
-// <unknown>:0: error: type of expression is ambiguous without more context
-// <unknown>:0: error: type of expression is ambiguous without more context
-// <unknown>:0: error: type of expression is ambiguous without more context
+// <unknown>:0: error: type of expression is ambiguous without a type annotation
+// <unknown>:0: error: type of expression is ambiguous without a type annotation
+// <unknown>:0: error: type of expression is ambiguous without a type annotation
 
 // The actual problem is the type of the subscript declaration is wrong.
 

--- a/test/expr/closure/basic.swift
+++ b/test/expr/closure/basic.swift
@@ -26,7 +26,7 @@ func variadic() {
   _ = f(1, 2)
   _ = f(1, 3)
 
-  let D = { (Ss ...) in 1 } // expected-error{{'...' cannot be applied to a subpattern which is not explicitly typed}}, expected-error{{unable to infer type of a closure parameter 'Ss' in the current context}}
+  let D = { (Ss ...) in 1 } // expected-error{{'...' cannot be applied to a subpattern which is not explicitly typed}}, expected-error{{cannot infer type of closure parameter 'Ss' without a type annotation}}
 }
 
 // Closures with attributes in the parameter list.

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -117,7 +117,7 @@ assert(f0(1) == 1)
 
 // TODO(diagnostics): Bad diagnostic - should be `circular reference`
 var selfRef = { selfRef() }
-// expected-error@-1 {{unable to infer closure type in the current context}}
+// expected-error@-1 {{unable to infer closure type without a type annotation}}
 
 // TODO: should be an error `circular reference` but it's diagnosed via overlapped requests
 var nestedSelfRef = {

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -307,7 +307,7 @@ func test_pattern_matches_only_cases() {
   }
 }
 
-// rdar://91225620 - type of expression is ambiguous without more context in closure
+// rdar://91225620 - type of expression is ambiguous without a type annotation in closure
 func test_wrapped_var_without_initializer() {
   @propertyWrapper
   struct Wrapper {

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -504,7 +504,7 @@ do {
   // FIXME: The type error is likely due to not solving the conjunction before attempting default type var bindings.
   let _ = (if .random() { Int?.none } else { 1 as Int? })?.bitWidth
   // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-2 {{type of expression is ambiguous without more context}}
+  // expected-error@-2 {{type of expression is ambiguous without a type annotation}}
 }
 do {
   let _ = if .random() { Int?.none } else { 1 as Int? }!

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -44,7 +44,7 @@ struct B {
     }
 }
 func f3() {
-    B(v: "").f1(block: { _ in }).f2(keyPath: \B.v) // expected-error{{unable to infer type of a closure parameter '_' in the current context}}
+    B(v: "").f1(block: { _ in }).f2(keyPath: \B.v) // expected-error{{cannot infer type of closure parameter '_' without a type annotation}}
 }
 
 // https://github.com/apple/swift/issues/47949

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -662,7 +662,7 @@ do {
   // FIXME: The type error is likely due to not solving the conjunction before attempting default type var bindings.
   let _ = (switch Bool.random() { case true: Int?.none case false: 1 })?.bitWidth
   // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-2 {{type of expression is ambiguous without more context}}
+  // expected-error@-2 {{type of expression is ambiguous without a type annotation}}
 }
 do {
   let _ = switch Bool.random() { case true: Int?.none case false: 1 }!

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -88,5 +88,5 @@ func testPrimaries(
   takePrimaryCollections(setOfStrings, setOfInts)
   takePrimaryCollections(setOfStrings, arrayOfInts)
   _ = takeMatchedPrimaryCollections(arrayOfInts, setOfInts)
-  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without more context}}
+  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without a type annotation}}
 }

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -106,7 +106,7 @@ func testPrimaries(
   takePrimaryCollections(setOfStrings, setOfInts)
   takePrimaryCollections(setOfStrings, arrayOfInts)
   _ = takeMatchedPrimaryCollections(arrayOfInts, setOfInts)
-  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without more context}}
+  _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without a type annotation}}
 }
 
 


### PR DESCRIPTION
This is low priority but there's zero risk in taking this and so no reason not to cherry-pick it to 5.9.