### PR TITLE
Fix the swift-inspect dump-generic-metadata operation.

### DIFF
--- a/include/swift/RemoteInspection/GenericMetadataCacheEntry.h
+++ b/include/swift/RemoteInspection/GenericMetadataCacheEntry.h
@@ -1,0 +1,40 @@
+//===--- GenericMetadataCacheEntry.h ----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Declares a struct that mirrors the layout of GenericCacheEntry in
+// Metadata.cpp and use a static assert to check that the offset of
+// the member Value match between the two.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_REFLECTION_GENERICMETADATACACHEENTRY_H
+#define SWIFT_REFLECTION_GENERICMETADATACACHEENTRY_H
+
+#include <cstdint>
+
+namespace swift {
+
+template<typename StoredPointer>
+struct GenericMetadataCacheEntry {
+  StoredPointer TrackingInfo;
+  uint16_t NumKeyParameters;
+  uint16_t NumWitnessTables;
+  uint16_t NumPacks;
+  uint16_t NumShapeClasses;
+  StoredPointer PackShapeDescriptors;
+  uint32_t Hash;
+  StoredPointer Value;
+};
+
+} // namespace swift
+
+#endif // SWIFT_REFLECTION_GENERICMETADATACACHEENTRY_H

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -30,6 +30,7 @@
 #include "swift/Concurrency/Actor.h"
 #include "swift/Remote/MemoryReader.h"
 #include "swift/Remote/MetadataReader.h"
+#include "swift/RemoteInspection/GenericMetadataCacheEntry.h"
 #include "swift/RemoteInspection/Records.h"
 #include "swift/RemoteInspection/RuntimeInternals.h"
 #include "swift/RemoteInspection/TypeLowering.h"
@@ -1289,22 +1290,14 @@ public:
   StoredPointer allocationMetadataPointer(
     MetadataAllocation<Runtime> Allocation) {
     if (Allocation.Tag == GenericMetadataCacheTag) {
-        struct GenericMetadataCacheEntry {
-          StoredPointer LockedStorage;
-          uint8_t LockedStorageKind;
-          uint8_t TrackingInfo;
-          uint16_t NumKeyParameters;
-          uint16_t NumWitnessTables;
-          uint32_t Hash;
-          StoredPointer Value;
-        };
         auto AllocationBytes =
           getReader().readBytes(RemoteAddress(Allocation.Ptr),
                                               Allocation.Size);
         if (!AllocationBytes)
           return 0;
-        auto Entry = reinterpret_cast<const GenericMetadataCacheEntry *>(
-          AllocationBytes.get());
+        auto Entry =
+          reinterpret_cast<const GenericMetadataCacheEntry<StoredPointer> *>(
+            AllocationBytes.get());
         return Entry->Value;
     }
     return 0;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -28,6 +28,7 @@
 #include "swift/Basic/Range.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/RemoteInspection/GenericMetadataCacheEntry.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/ExistentialContainer.h"
@@ -426,6 +427,16 @@ namespace {
     }
   };
 } // end anonymous namespace
+
+namespace swift {
+  struct StaticAssertGenericMetadataCacheEntryValueOffset {
+    static_assert(
+      offsetof(GenericCacheEntry, Value) ==
+      offsetof(swift::GenericMetadataCacheEntry<InProcess::StoredPointer>,
+               Value),
+      "The generic metadata cache entry layout mismatch");
+  };
+}
 
 namespace {
   class GenericMetadataCache :

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -1583,6 +1583,8 @@ public:
   bool matchesKey(const MetadataCacheKey &key) const {
     return key == getKey();
   }
+
+  friend struct StaticAssertGenericMetadataCacheEntryValueOffset;
 };
 
 template <class EntryType, uint16_t Tag>


### PR DESCRIPTION
ReflectionContext::allocationMetadataPointer() was reading the metadata pointer from a wrong offset because of the out-of-sync struct layouts and dump-generic-metadata was not working correctly.

This change resync's the layouts and adds a static_assert to verify that the offsets match between GenericMetadataCacheEntry and GenericCacheEntry.
