### PR TITLE
[Macros] Tighten restriction on non-expression macros not having return types

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4811,16 +4811,14 @@ void PrintAST::visitMacroDecl(MacroDecl *decl) {
       }
   );
 
-  {
+  if (decl->resultType.getTypeRepr() ||
+      !decl->getResultInterfaceType()->isVoid()) {
     Printer.printStructurePre(PrintStructureKind::DeclResultTypeClause);
     SWIFT_DEFER {
       Printer.printStructurePost(PrintStructureKind::DeclResultTypeClause);
     };
 
-    if (decl->parameterList)
-      Printer << " -> ";
-    else
-      Printer << ": ";
+    Printer << " -> ";
 
     TypeLoc resultTypeLoc(
         decl->resultType.getTypeRepr(), decl->getResultInterfaceType());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2072,11 +2072,10 @@ public:
     }
     }
 
-    // If the macro has a (non-Void) result type, it must have the freestanding
+    // If the macro has a result type, it must have the freestanding
     // expression role. Other roles cannot have result types.
     if (auto resultTypeRepr = MD->getResultTypeRepr()) {
-      if (!MD->getMacroRoles().contains(MacroRole::Expression) &&
-          !MD->getResultInterfaceType()->isEqual(Ctx.getVoidType())) {
+      if (!MD->getMacroRoles().contains(MacroRole::Expression)) {
         auto resultType = MD->getResultInterfaceType();
         Ctx.Diags.diagnose(
             MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType)

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2076,10 +2076,21 @@ public:
     // expression role. Other roles cannot have result types.
     if (auto resultTypeRepr = MD->getResultTypeRepr()) {
       if (!MD->getMacroRoles().contains(MacroRole::Expression)) {
-        auto resultType = MD->getResultInterfaceType();
-        Ctx.Diags.diagnose(
-            MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType)
-          .highlight(resultTypeRepr->getSourceRange());
+        auto resultType = MD->getResultInterfaceType(); {
+          auto diag = Ctx.Diags.diagnose(
+              MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType);
+          diag.highlight(resultTypeRepr->getSourceRange());
+
+          // In a .swiftinterface file, downgrade this diagnostic to a warning.
+          // This allows the compiler to process existing .swiftinterface
+          // files that contain this issue.
+          if (resultType->isVoid()) {
+            if (auto sourceFile = MD->getParentSourceFile())
+              if (sourceFile->Kind == SourceFileKind::Interface)
+                diag.limitBehavior(DiagnosticBehavior::Warning);
+          }
+        }
+
         Ctx.Diags.diagnose(MD->arrowLoc, diag::macro_make_freestanding_expression)
           .fixItInsert(MD->getAttributeInsertionLoc(false),
                        "@freestanding(expression)\n");

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -6,17 +6,17 @@
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'}}
 // expected-note@-2{{'m1()' declared here}}
 
-@attached(accessor) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
+@attached(accessor) macro m2(_: Int) = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2{{candidate has partially matching parameter list (Int)}}
 // expected-note@-3{{candidate expects value of type 'Int' for parameter #1 (got 'String')}}
 
-@attached(accessor) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
+@attached(accessor) macro m2(_: Double) = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2{{candidate has partially matching parameter list (Double)}}
 // expected-note@-3{{candidate expects value of type 'Double' for parameter #1 (got 'String')}}
 
-@attached(accessor) macro m3(message: String) -> Void = #externalMacro(module: "MyMacros", type: "Macro3")
+@attached(accessor) macro m3(message: String) = #externalMacro(module: "MyMacros", type: "Macro3")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro3' could not be found for macro 'm3(message:)'}}
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacros", type: "StringifyMacro")

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -211,6 +211,9 @@ struct SomeType {
 
 @freestanding(declaration) macro nonExpressionReturnsVoid<T>(_: T) -> Void = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type}}
+// expected-error@-2{{only a freestanding expression macro can produce a result of type 'Void'}}
+// expected-note@-3{{make this macro a freestanding expression macro}}{{1-1=@freestanding(expression)\n}}
+// expected-note@-4{{remove the result type if the macro does not produce a value}}{{68-76=}}
 
 
 @freestanding(expression)

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -51,7 +51,7 @@ macro am1()
   named, // expected-error{{introduced name kind 'named' requires a single argument '(name)'}}
   arbitrary(a) // expected-error{{introduced name kind 'arbitrary' must not have an argument}}
 )
-macro am2() -> Void
+macro am2()
 // expected-error@-1{{macro 'am2()' requires a definition}}
 
 #m1 + 1

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -30,14 +30,14 @@
 @freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "SomeModule", type: "Line")
 
 // CHECK: #if compiler(>=5.3) && $Macros
-// CHECK: @attached(accessor) public macro myWrapper() -> () = #externalMacro(module: "SomeModule", type: "Wrapper")
+// CHECK: @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 // CHECK-NEXT: #endif
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 // CHECK-NEXT: #endif
-@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 
 // CHECK-NOT: internalStringify
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")


### PR DESCRIPTION
There is no reason to special-case `Void` to permit it. Rather, make this a syntactic rule. Thanks to Alex Hoppen for the suggestion.
