### PR TITLE
[5.9] [Macros] Tighten declaration semantics and improve expansion of freestanding macros

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7060,6 +7060,8 @@ NOTE(macro_remove_result_type,none,
       ())
 NOTE(macro_make_freestanding_expression,none,
       "make this macro a freestanding expression macro", ())
+ERROR(macro_multiple_freestanding_roles,none,
+      "macro can only have a single freestanding role", ())
 ERROR(macro_expansion_missing_pound,none,
       "expansion of macro %0 requires leading '#'", (DeclName))
 ERROR(macro_expansion_missing_arguments,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7052,6 +7052,14 @@ ERROR(macro_in_nested,none,
 ERROR(macro_without_role,none,
       "macro %0 must declare its applicable roles via '@freestanding' or @attached'",
        (DeclName))
+ERROR(macro_result_type_cannot_be_used,none,
+      "only a freestanding expression macro can produce a result of type %0",
+      (Type))
+NOTE(macro_remove_result_type,none,
+      "remove the result type if the macro does not produce a value",
+      ())
+NOTE(macro_make_freestanding_expression,none,
+      "make this macro a freestanding expression macro", ())
 ERROR(macro_expansion_missing_pound,none,
       "expansion of macro %0 requires leading '#'", (DeclName))
 ERROR(macro_expansion_missing_arguments,none,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4780,16 +4780,14 @@ void PrintAST::visitMacroDecl(MacroDecl *decl) {
       }
   );
 
-  {
+  if (decl->resultType.getTypeRepr() ||
+      !decl->getResultInterfaceType()->isVoid()) {
     Printer.printStructurePre(PrintStructureKind::DeclResultTypeClause);
     SWIFT_DEFER {
       Printer.printStructurePost(PrintStructureKind::DeclResultTypeClause);
     };
 
-    if (decl->parameterList)
-      Printer << " -> ";
-    else
-      Printer << ": ";
+    Printer << " -> ";
 
     TypeLoc resultTypeLoc(
         decl->resultType.getTypeRepr(), decl->getResultInterfaceType());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3357,12 +3357,18 @@ TypeRepr *ValueDecl::getResultTypeRepr() const {
     returnRepr = FD->getResultTypeRepr();
   } else if (auto *SD = dyn_cast<SubscriptDecl>(this)) {
     returnRepr = SD->getElementTypeRepr();
+  } else if (auto *MD = dyn_cast<MacroDecl>(this)) {
+    returnRepr = MD->resultType.getTypeRepr();
   }
 
   return returnRepr;
 }
 
 TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
+  // FIXME: Macros don't allow opaque result types yet.
+  if (isa<MacroDecl>(this))
+    return nullptr;
+
   auto *returnRepr = this->getResultTypeRepr();
 
   auto *dc = getDeclContext();

--- a/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
@@ -20,6 +20,7 @@ internal enum HostToPluginMessage: Codable {
   /// Expand a '@freestanding' macro.
   case expandFreestandingMacro(
     macro: PluginMessage.MacroReference,
+    macroRole: PluginMessage.MacroRole? = nil,
     discriminator: String,
     syntax: PluginMessage.Syntax
   )
@@ -91,6 +92,7 @@ internal enum PluginToHostMessage: Codable {
     case member
     case peer
     case conformance
+    case codeItem
   }
 
   struct SourceLocation: Codable {

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -412,7 +412,7 @@ void SyntacticMacroExpansionInstance::expand(
     SourceFile *SF, const MacroExpansionSpecifier &expansion,
     SourceEditConsumer &consumer) {
 
-  // Find the expansion at 'expantion.offset'.
+  // Find the expansion at 'expansion.offset'.
   MacroExpansionFinder expansionFinder(
       SourceMgr,
       SourceMgr.getLocForOffset(*SF->getBufferID(), expansion.offset));

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2077,10 +2077,21 @@ public:
     // expression role. Other roles cannot have result types.
     if (auto resultTypeRepr = MD->getResultTypeRepr()) {
       if (!MD->getMacroRoles().contains(MacroRole::Expression)) {
-        auto resultType = MD->getResultInterfaceType();
-        Ctx.Diags.diagnose(
-            MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType)
-          .highlight(resultTypeRepr->getSourceRange());
+        auto resultType = MD->getResultInterfaceType(); {
+          auto diag = Ctx.Diags.diagnose(
+              MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType);
+          diag.highlight(resultTypeRepr->getSourceRange());
+
+          // In a .swiftinterface file, downgrade this diagnostic to a warning.
+          // This allows the compiler to process existing .swiftinterface
+          // files that contain this issue.
+          if (resultType->isVoid()) {
+            if (auto sourceFile = MD->getParentSourceFile())
+              if (sourceFile->Kind == SourceFileKind::Interface)
+                diag.limitBehavior(DiagnosticBehavior::Warning);
+          }
+        }
+
         Ctx.Diags.diagnose(MD->arrowLoc, diag::macro_make_freestanding_expression)
           .fixItInsert(MD->getAttributeInsertionLoc(false),
                        "@freestanding(expression)\n");

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2061,6 +2061,23 @@ public:
       break;
     }
     }
+
+    // If the macro has a (non-Void) result type, it must have the freestanding
+    // expression role. Other roles cannot have result types.
+    if (auto resultTypeRepr = MD->getResultTypeRepr()) {
+      if (!MD->getMacroRoles().contains(MacroRole::Expression) &&
+          !MD->getResultInterfaceType()->isEqual(Ctx.getVoidType())) {
+        auto resultType = MD->getResultInterfaceType();
+        Ctx.Diags.diagnose(
+            MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType)
+          .highlight(resultTypeRepr->getSourceRange());
+        Ctx.Diags.diagnose(MD->arrowLoc, diag::macro_make_freestanding_expression)
+          .fixItInsert(MD->getAttributeInsertionLoc(false),
+                       "@freestanding(expression)\n");
+        Ctx.Diags.diagnose(MD->arrowLoc, diag::macro_remove_result_type)
+          .fixItRemove(SourceRange(MD->arrowLoc, resultTypeRepr->getEndLoc()));
+      }
+    }
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *MED) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2073,11 +2073,10 @@ public:
     }
     }
 
-    // If the macro has a (non-Void) result type, it must have the freestanding
+    // If the macro has a result type, it must have the freestanding
     // expression role. Other roles cannot have result types.
     if (auto resultTypeRepr = MD->getResultTypeRepr()) {
-      if (!MD->getMacroRoles().contains(MacroRole::Expression) &&
-          !MD->getResultInterfaceType()->isEqual(Ctx.getVoidType())) {
+      if (!MD->getMacroRoles().contains(MacroRole::Expression)) {
         auto resultType = MD->getResultInterfaceType();
         Ctx.Diags.diagnose(
             MD->arrowLoc, diag::macro_result_type_cannot_be_used, resultType)

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -73,6 +73,26 @@ public struct StringifyMacro: ExpressionMacro {
   }
 }
 
+public struct ExprAndDeclMacro: ExpressionMacro, DeclarationMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.argumentList.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "(\(argument), \(StringLiteralExprSyntax(content: argument.description)))"
+  }
+
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> [DeclSyntax] {
+    return []
+  }
+}
+
 public struct StringifyAndTryMacro: ExpressionMacro {
   public static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -6,17 +6,17 @@
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'}}
 // expected-note@-2{{'m1()' declared here}}
 
-@attached(accessor) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
+@attached(accessor) macro m2(_: Int) = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2{{candidate has partially matching parameter list (Int)}}
 // expected-note@-3{{candidate expects value of type 'Int' for parameter #1 (got 'String')}}
 
-@attached(accessor) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
+@attached(accessor) macro m2(_: Double) = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2{{candidate has partially matching parameter list (Double)}}
 // expected-note@-3{{candidate expects value of type 'Double' for parameter #1 (got 'String')}}
 
-@attached(accessor) macro m3(message: String) -> Void = #externalMacro(module: "MyMacros", type: "Macro3")
+@attached(accessor) macro m3(message: String) = #externalMacro(module: "MyMacros", type: "Macro3")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro3' could not be found for macro 'm3(message:)'}}
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacros", type: "StringifyMacro")

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -509,3 +509,27 @@ func testHasEqualsSelf(
   _ = (zP == true)
   _ = (wP == true)
 }
+
+// Macro whose implementation is both an expression and declaration macro.
+@freestanding(declaration)
+macro AsDeclMacro<T>(_ value: T) = #externalMacro(module: "MacroDefinition", type: "ExprAndDeclMacro")
+
+@freestanding(expression)
+macro AsExprMacro<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "ExprAndDeclMacro")
+
+func testExpressionAndDeclarationMacro() {
+  #AsExprMacro(1 + 1) // expected-warning{{expression of type '(Int, String)' is unused}}
+  struct Inner {
+    #AsDeclMacro(1 + 1)
+  }
+  #AsDeclMacro(1 + 1)
+}
+
+// Expression macro implementation with declaration macro role
+@freestanding(declaration) macro stringifyAsDeclMacro<T>(_ value: T) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+func testExpressionAsDeclarationMacro() {
+#if TEST_DIAGNOSTICS
+  #stringifyAsDeclMacro(1+1)
+  // expected-error@-1{{macro implementation type 'StringifyMacro' doesn't conform to required protocol 'DeclarationMacro' (from macro 'stringifyAsDeclMacro')}}
+#endif
+}

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -23,9 +23,9 @@
 
 // CHECK: ->(plugin:[[#PID:]]) {"getCapability":{}}
 // CHECK: <-(plugin:[[#PID]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"testString","typeName":"TestStringMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":5,"offset":301},"source":"#testString(123)"}}}
+// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"testString","typeName":"TestStringMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":5,"offset":301},"source":"#testString(123)"}}}
 // CHECK: <-(plugin:[[#PID]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"\"123\"\n  +   \"foo  \""}}
-// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"testStringWithError","typeName":"TestStringWithErrorMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":336},"source":"#testStringWithError(321)"}}}
+// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"testStringWithError","typeName":"TestStringWithErrorMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":336},"source":"#testStringWithError(321)"}}}
 // CHECK: <-(plugin:[[#PID]]) {"expandFreestandingMacroResult":{"diagnostics":[{"fixIts":[],"highlights":[],"message":"message from plugin","notes":[],"position":{"fileName":"BUILD_DIR{{.*}}test.swift","offset":336},"severity":"error"}],"expandedSource":"\"bar\""}}
 
 //--- test.swift

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -23,12 +23,12 @@
 
 // CHECK: ->(plugin:[[#PID1:]]) {"getCapability":{}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":[[#]]},"source":"#fooMacro(1)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":[[#]]},"source":"#fooMacro(1)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"invalidResponse":{}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":8,"offset":[[#]]},"source":"#fooMacro(2)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":8,"offset":[[#]]},"source":"#fooMacro(2)"}}}
 // ^ This messages causes the mock plugin exit because there's no matching expected message.
 
-// CHECK: ->(plugin:[[#PID2:]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":10,"offset":[[#]]},"source":"#fooMacro(3)"}}}
+// CHECK: ->(plugin:[[#PID2:]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":10,"offset":[[#]]},"source":"#fooMacro(3)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2:]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"3.description"}}
 
 //--- test.swift

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -37,16 +37,16 @@
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
 // CHECK-NEXT: ->(plugin:[[#PID1]]) {"loadPluginLibrary":{"libraryPath":"BUILD_DIR{{.*}}plugins/libEvilMacros.dylib","moduleName":"EvilMacros"}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(a + b)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(a + b)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"(a + b, \"a + b\")"}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","macro":{"moduleName":"EvilMacros","name":"evil","typeName":"CrashingMacro"},"syntax":{"kind":"expression","location":{{{.+}}},"source":"#evil(42)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","macro":{"moduleName":"EvilMacros","name":"evil","typeName":"CrashingMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{{{.+}}},"source":"#evil(42)"}}}
 // ^ This crashes the plugin server.
 
 // CHECK-NEXT: ->(plugin:[[#PID2:]]) {"loadPluginLibrary":{"libraryPath":"BUILD_DIR{{.*}}plugins/libMacroDefinition.dylib","moduleName":"MacroDefinition"}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
 // CHECK-NEXT: ->(plugin:[[#PID2]]) {"loadPluginLibrary":{"libraryPath":"BUILD_DIR{{.*}}plugins/libEvilMacros.dylib","moduleName":"EvilMacros"}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"loadPluginLibraryResult":{"diagnostics":[],"loaded":true}}
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(b + a)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"${{.*}}","macro":{"moduleName":"MacroDefinition","name":"stringify","typeName":"StringifyMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{{{.+}}},"source":"#stringify(b + a)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"(b + a, \"b + a\")"}}
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -46,7 +46,7 @@ internal struct X { } // expected-note{{type declared here}}
 // expected-warning@-1{{external macro implementation type}}
 
 struct ZZZ {
-  macro m5() -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
+  macro m5() = #externalMacro(module: "BuiltinMacros", type: "Blah")
   // expected-error@-1{{macro 'm5()' can only be declared at file scope}}
   // expected-error@-2{{macro 'm5()' must declare its applicable roles}}
   // expected-warning@-3{{external macro implementation type}}
@@ -200,3 +200,14 @@ struct SomeType {
   // expected-error@-2{{use of protocol 'Hashable' as a type must be written 'any Hashable'}}
   // expected-error@-3{{external macro implementation type}}
 }
+
+
+
+@freestanding(declaration) macro nonExpressionReturnsInt<T>(_: T) -> Int = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}
+// expected-error@-2{{only a freestanding expression macro can produce a result of type 'Int'}}
+// expected-note@-3{{make this macro a freestanding expression macro}}{{1-1=@freestanding(expression)\n}}
+// expected-note@-4{{remove the result type if the macro does not produce a value}}{{67-74=}}
+
+@freestanding(declaration) macro nonExpressionReturnsVoid<T>(_: T) -> Void = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -211,6 +211,9 @@ struct SomeType {
 
 @freestanding(declaration) macro nonExpressionReturnsVoid<T>(_: T) -> Void = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type}}
+// expected-error@-2{{only a freestanding expression macro can produce a result of type 'Void'}}
+// expected-note@-3{{make this macro a freestanding expression macro}}{{1-1=@freestanding(expression)\n}}
+// expected-note@-4{{remove the result type if the macro does not produce a value}}{{68-76=}}
 
 
 @freestanding(expression)

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -211,3 +211,10 @@ struct SomeType {
 
 @freestanding(declaration) macro nonExpressionReturnsVoid<T>(_: T) -> Void = #externalMacro(module: "A", type: "B")
 // expected-warning@-1{{external macro implementation type}}
+
+
+@freestanding(expression)
+@freestanding(declaration)
+macro multipleFreestandingRoles<T>(_: T) -> Void = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type}}
+// expected-error@-2{{macro can only have a single freestanding role}}

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -35,6 +35,7 @@ protocol Q { associatedtype Assoc }
 @freestanding(expression) @freestanding(declaration, names: named(Foo)) @attached(accessor)
 macro m10(_: String) = #externalMacro(module: "A", type: "M4")
 // expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm10'}}
+// expected-error@-2{{macro can only have a single freestanding role}}
 
 @attached(
   accessor,

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -51,7 +51,7 @@ macro am1()
   named, // expected-error{{introduced name kind 'named' requires a single argument '(name)'}}
   arbitrary(a) // expected-error{{introduced name kind 'arbitrary' must not have an argument}}
 )
-macro am2() -> Void
+macro am2()
 // expected-error@-1{{macro 'am2()' requires a definition}}
 
 #m1 + 1

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -30,14 +30,14 @@
 @freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "SomeModule", type: "Line")
 
 // CHECK: #if compiler(>=5.3) && $Macros
-// CHECK: @attached(accessor) public macro myWrapper() -> () = #externalMacro(module: "SomeModule", type: "Wrapper")
+// CHECK: @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 // CHECK-NEXT: #endif
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 // CHECK-NEXT: #endif
-@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 
 // CHECK-NOT: internalStringify
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")


### PR DESCRIPTION
* **Explanation**: Implement missing-but-required declaration semantics for macro declarations, including diagnosing the presence of a result type on a macro that isn't a freestanding expression macro (it can't be used) and diagnosing multiple freestanding roles on a given macro declaration (SE-0397 requires this). While here, thread the intended freestanding macro role through to the macro expansion code, providing better diagnostics when there is a mismatch between the macro declaration and its implementations (previously, we would crash).
* **Scope**: Narrow; only affects validation of freestanding macro declarations and expansions.
* **Risk**: Low; narrow change to perform better validation when declaring and expanding freestanding macros.
* **Reviewed by**: @rintaro , @ahoppen 
* **Issue**: rdar://108871352, rdar://110418969, rdar://110178899
* **Original pull request**: https://github.com/apple/swift/pull/66504, https://github.com/apple/swift/pull/66509, https://github.com/apple/swift/pull/66526
