### PR TITLE
Requestify `AbstractStorageDecl::hasStorage()`.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5295,10 +5295,7 @@ public:
 
   /// Overwrite the registered implementation-info.  This should be
   /// used carefully.
-  void setImplInfo(StorageImplInfo implInfo) {
-    LazySemanticInfo.ImplInfoComputed = 1;
-    ImplInfo = implInfo;
-  }
+  void setImplInfo(StorageImplInfo implInfo);
 
   ReadImplKind getReadImpl() const {
     return getImplInfo().getReadImpl();
@@ -5313,9 +5310,7 @@ public:
 
   /// Return true if this is a VarDecl that has storage associated with
   /// it.
-  bool hasStorage() const {
-    return getImplInfo().hasStorage();
-  }
+  bool hasStorage() const;
 
   /// Return true if this storage has the basic accessors/capability
   /// to be mutated.  This is generally constant after the accessors are

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5297,6 +5297,9 @@ public:
   /// used carefully.
   void setImplInfo(StorageImplInfo implInfo);
 
+  /// Cache the implementation-info, for use by the request-evaluator.
+  void cacheImplInfo(StorageImplInfo implInfo);
+
   ReadImplKind getReadImpl() const {
     return getImplInfo().getReadImpl();
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7095,6 +7095,10 @@ ERROR(invalid_macro_role_for_macro_syntax,none,
       (unsigned))
 ERROR(macro_cannot_introduce_names,none,
       "'%0' macros are not allowed to introduce names", (StringRef))
+ERROR(macro_accessor_missing_from_expansion,none,
+      "expansion of macro %0 did not produce a %select{non-|}1observing "
+      "accessor",
+      (DeclName, bool))
 
 ERROR(macro_resolve_circular_reference, none,
       "circular reference resolving %select{freestanding|attached}0 macro %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7099,6 +7099,9 @@ ERROR(macro_accessor_missing_from_expansion,none,
       "expansion of macro %0 did not produce a %select{non-|}1observing "
       "accessor",
       (DeclName, bool))
+ERROR(macro_init_accessor_not_documented,none,
+      "expansion of macro %0 produced an unexpected 'init' accessor",
+      (DeclName))
 
 ERROR(macro_resolve_circular_reference, none,
       "circular reference resolving %select{freestanding|attached}0 macro %1",

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -316,6 +316,12 @@ public:
     cache.insert<Request>(request, std::move(output));
   }
 
+  template<typename Request,
+           typename std::enable_if<!Request::hasExternalCache>::type* = nullptr>
+  bool hasCachedResult(const Request &request) {
+    return cache.find_as(request) != cache.end<Request>();
+  }
+
   /// Do not introduce new callers of this function.
   template<typename Request,
            typename std::enable_if<!Request::hasExternalCache>::type* = nullptr>

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -555,6 +555,13 @@ void forEachPotentialResolvedMacro(
     llvm::function_ref<void(MacroDecl *, const MacroRoleAttr *)> body
 );
 
+/// For each macro with the given role that might be attached to the given
+/// declaration, call the body.
+void forEachPotentialAttachedMacro(
+    Decl *decl, MacroRole role,
+    llvm::function_ref<void(MacroDecl *macro, const MacroRoleAttr *)> body
+);
+
 } // end namespace namelookup
 
 /// Describes an inherited nominal entry.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1686,6 +1686,26 @@ private:
   ArrayRef<VarDecl *>
   evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
 
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+class HasStorageRequest :
+    public SimpleRequest<HasStorageRequest,
+                         bool(AbstractStorageDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
+
 public:
   bool isCached() const { return true; }
 };

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -302,6 +302,9 @@ SWIFT_REQUEST(TypeChecker, SelfAccessKindRequest, SelfAccessKind(FuncDecl *),
 SWIFT_REQUEST(TypeChecker, StorageImplInfoRequest,
               StorageImplInfo(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, HasStorageRequest,
+              bool(AbstractStorageDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, StoredPropertiesAndMissingMembersRequest,
               ArrayRef<Decl *>(NominalTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, StoredPropertiesRequest,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1627,7 +1627,7 @@ void namelookup::forEachPotentialResolvedMacro(
 
 /// For each macro with the given role that might be attached to the given
 /// declaration, call the body.
-static void forEachPotentialAttachedMacro(
+void namelookup::forEachPotentialAttachedMacro(
     Decl *decl, MacroRole role,
     llvm::function_ref<void(MacroDecl *macro, const MacroRoleAttr *)> body
 ) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -687,7 +687,7 @@ StorageImplInfoRequest::getCachedResult() const {
 
 void StorageImplInfoRequest::cacheResult(StorageImplInfo value) const {
   auto *storage = std::get<0>(getStorage());
-  storage->setImplInfo(value);
+  storage->cacheImplInfo(value);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -34,6 +34,7 @@
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Platform.h"
@@ -5042,6 +5043,7 @@ cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
     out->setIsObjC(var->isObjC());
     out->setIsDynamic(var->isDynamic());
     out->copyFormalAccessFrom(var);
+    out->getASTContext().evaluator.cacheOutput(HasStorageRequest{out}, false);
     out->setAccessors(SourceLoc(),
                       makeBaseClassMemberAccessors(newContext, out, var),
                       SourceLoc());

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -126,6 +126,7 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
                                                  AccessorDecl *getter,
                                                  AccessorDecl *setter) {
   assert(getter);
+  storage->getASTContext().evaluator.cacheOutput(HasStorageRequest{storage}, false);
   if (setter) {
     storage->setImplInfo(StorageImplInfo::getMutableComputed());
     storage->setAccessors(SourceLoc(), {getter, setter}, SourceLoc());

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -890,6 +890,10 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
                     SourceLoc(), C.Id_hashValue, parentDC);
   hashValueDecl->setInterfaceType(intType);
   hashValueDecl->setSynthesized();
+  hashValueDecl->setImplicit();
+  hashValueDecl->setImplInfo(StorageImplInfo::getImmutableComputed());
+  hashValueDecl->copyFormalAccessFrom(derived.Nominal,
+                                      /*sourceIsParentContext*/ true);
 
   ParameterList *params = ParameterList::createEmpty(C);
 
@@ -908,12 +912,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
                                    /*sourceIsParentContext*/ true);
 
   // Finish creating the property.
-  hashValueDecl->setImplicit();
-  hashValueDecl->setInterfaceType(intType);
-  hashValueDecl->setImplInfo(StorageImplInfo::getImmutableComputed());
   hashValueDecl->setAccessors(SourceLoc(), {getterDecl}, SourceLoc());
-  hashValueDecl->copyFormalAccessFrom(derived.Nominal,
-                                      /*sourceIsParentContext*/ true);
 
   // The derived hashValue of an actor must be nonisolated.
   if (!addNonIsolatedToSynthesized(derived.Nominal, hashValueDecl) &&

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -82,6 +82,11 @@ Optional<unsigned> expandConformances(CustomAttr *attr, MacroDecl *macro,
 bool accessorMacroOnlyIntroducesObservers(
     MacroDecl *macro, const MacroRoleAttr *attr);
 
+/// Determine whether an accessor macro (defined with the given role attribute)
+/// introduces an init accessor.
+bool accessorMacroIntroducesInitAccessor(
+    MacroDecl *macro, const MacroRoleAttr *attr);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKMACROS_H */

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -77,6 +77,11 @@ Optional<unsigned> expandPeers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
 Optional<unsigned> expandConformances(CustomAttr *attr, MacroDecl *macro,
                                       NominalTypeDecl *nominal);
 
+/// Determine whether an accessor macro with the given attribute only
+/// introduces observers like willSet and didSet.
+bool accessorMacroOnlyIntroducesObservers(
+    MacroDecl *macro, const MacroRoleAttr *attr);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKMACROS_H */

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1403,7 +1403,7 @@ synthesizeTrivialGetterBody(AccessorDecl *getter, TargetImpl target,
 /// underlying storage.
 static std::pair<BraceStmt *, bool>
 synthesizeTrivialGetterBody(AccessorDecl *getter, ASTContext &ctx) {
-  assert(getter->getStorage()->hasStorage());
+  assert(getter->getStorage()->getImplInfo().hasStorage());
   return synthesizeTrivialGetterBody(getter, TargetImpl::Storage, ctx);
 }
 
@@ -3444,6 +3444,73 @@ static StorageImplInfo classifyWithHasStorageAttr(VarDecl *var) {
   return StorageImplInfo(ReadImplKind::Stored, writeImpl, readWriteImpl);
 }
 
+bool HasStorageRequest::evaluate(Evaluator &evaluator,
+                                 AbstractStorageDecl *storage) const {
+  // Parameters are always stored.
+  if (isa<ParamDecl>(storage))
+    return true;
+
+  // Only variables can be stored.
+  auto *var = dyn_cast<VarDecl>(storage);
+  if (!var)
+    return false;
+
+  // @_hasStorage implies that it... has storage.
+  if (var->getAttrs().hasAttribute<HasStorageAttr>())
+    return true;
+
+  // Protocol requirements never have storage.
+  if (isa<ProtocolDecl>(storage->getDeclContext()))
+    return false;
+
+  // lazy declarations do not have storage.
+  if (storage->getAttrs().hasAttribute<LazyAttr>())
+    return false;
+
+  // @NSManaged attributes don't have storage
+  if (storage->getAttrs().hasAttribute<NSManagedAttr>())
+    return false;
+
+  // Any accessors that read or write imply that there is no storage.
+  if (storage->getParsedAccessor(AccessorKind::Get) ||
+      storage->getParsedAccessor(AccessorKind::Read) ||
+      storage->getParsedAccessor(AccessorKind::Address) ||
+      storage->getParsedAccessor(AccessorKind::Set) ||
+      storage->getParsedAccessor(AccessorKind::Modify) ||
+      storage->getParsedAccessor(AccessorKind::MutableAddress))
+    return false;
+
+  // willSet or didSet in an overriding property imply that there is no storage.
+  if ((storage->getParsedAccessor(AccessorKind::WillSet) ||
+       storage->getParsedAccessor(AccessorKind::DidSet)) &&
+      storage->getAttrs().hasAttribute<OverrideAttr>())
+    return false;
+
+  // The presence of a property wrapper implies that there is no storage.
+  if (var->hasAttachedPropertyWrapper())
+    return false;
+
+  // Look for any accessor macros that might make this property computed.
+  bool hasStorage = true;
+  namelookup::forEachPotentialAttachedMacro(
+      var, MacroRole::Accessor,
+      [&](MacroDecl *macro, const MacroRoleAttr *attr) {
+        // Will this macro introduce observers?
+        bool foundObserver = accessorMacroOnlyIntroducesObservers(macro, attr);
+
+        // If it's not (just) introducing observers, it's making the property
+        // computed.
+        if (!foundObserver)
+          hasStorage = false;
+
+        // If it will introduce observers, and there is an "override",
+        // the property doesn't have storage.
+        if (foundObserver && storage->getAttrs().hasAttribute<OverrideAttr>())
+          hasStorage = false;
+      });
+  return hasStorage;
+}
+
 StorageImplInfo
 StorageImplInfoRequest::evaluate(Evaluator &evaluator,
                                  AbstractStorageDecl *storage) const {
@@ -3603,6 +3670,8 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   StorageImplInfo info(readImpl, writeImpl, readWriteImpl);
   finishStorageImplInfo(storage, info);
 
+  assert(info.hasStorage() == storage->hasStorage() ||
+         storage->getASTContext().Diags.hadAnyError());
   return info;
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2795,15 +2795,17 @@ void ModuleFile::configureStorage(AbstractStorageDecl *decl,
   auto readWriteImpl = getActualReadWriteImplKind(rawReadWriteImplKind);
   if (!readWriteImpl) return;
 
+  auto implInfo = StorageImplInfo(*readImpl, *writeImpl, *readWriteImpl);
+  decl->setImplInfo(implInfo);
+
+  decl->getASTContext().evaluator.cacheOutput(HasStorageRequest{decl}, implInfo.hasStorage());
+
   SmallVector<AccessorDecl*, 8> accessors;
   for (DeclID id : rawIDs.IDs) {
     auto accessor = dyn_cast_or_null<AccessorDecl>(getDecl(id));
     if (!accessor) return;
     accessors.push_back(accessor);
   }
-
-  auto implInfo = StorageImplInfo(*readImpl, *writeImpl, *readWriteImpl);
-  decl->setImplInfo(implInfo);
 
   if (implInfo.isSimpleStored() && accessors.empty())
     return;
@@ -3421,6 +3423,9 @@ public:
     var->setIsSetterMutating(isSetterMutating);
     declOrOffset = var;
 
+    MF.configureStorage(var, opaqueReadOwnership,
+                        readImpl, writeImpl, readWriteImpl, accessors);
+
     auto interfaceTypeOrError = MF.getTypeChecked(interfaceTypeID);
     if (!interfaceTypeOrError)
       return interfaceTypeOrError.takeError();
@@ -3432,8 +3437,6 @@ public:
       AddAttribute(
           new (ctx) ReferenceOwnershipAttr(referenceStorage->getOwnership()));
 
-    MF.configureStorage(var, opaqueReadOwnership,
-                        readImpl, writeImpl, readWriteImpl, accessors);
     auto accessLevel = getActualAccessLevel(rawAccessLevel);
     if (!accessLevel)
       return MF.diagnoseFatal();

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -23,11 +23,11 @@
 #endif
 @attached(memberAttribute)
 @attached(conformance)
-public macro Observable() = 
+public macro Observable() =
   #externalMacro(module: "ObservationMacros", type: "ObservableMacro")
 
 @available(SwiftStdlib 5.9, *)
-@attached(accessor)
+@attached(accessor, names: named(init), named(get), named(set))
 #if OBSERVATION_SUPPORTS_PEER_MACROS
 @attached(peer, names: prefixed(_))
 #endif

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -35,7 +35,7 @@ public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 
 @available(SwiftStdlib 5.9, *)
-@attached(accessor)
+@attached(accessor, names: named(willSet))
 public macro ObservationIgnored() =
   #externalMacro(module: "ObservationMacros", type: "ObservationIgnoredMacro")
 

--- a/test/Macros/accessor_has_storage_cycle.swift
+++ b/test/Macros/accessor_has_storage_cycle.swift
@@ -1,0 +1,21 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -swift-version 5
+
+struct Predicate<T> { }
+
+@freestanding(expression)
+macro Predicate<T>(_ body: (T) -> Void) -> Predicate<T> = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{could not be found}}
+
+@attached(accessor)
+@attached(peer)
+macro Foo<T>(filter: Predicate<T>) = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{could not be found}}
+// expected-note@-2 2{{declared here}}
+
+struct Content {
+  @Foo(filter: #Predicate<Bool> { $0 == true }) var foo: Bool = true
+  //expected-error@-1 2{{could not be found for macro}}
+  // expected-warning@-2{{result of operator '==' is unused}}
+}

--- a/test/ModuleInterface/Observable.swift
+++ b/test/ModuleInterface/Observable.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-host-lib-dir/plugins -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-host-lib-dir/plugins -disable-availability-checking -enable-experimental-feature InitAccessors
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library -disable-availability-checking
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -21,6 +21,7 @@ func test(a: Int, b: Int) {
 
 struct TestStruct {
   @myWrapper var x: Int
+  // expected-error@-1{{expansion of macro 'myWrapper' did not produce a non-observing accessor}}
 }
 
 @ArbitraryMembers

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -33,7 +33,7 @@ func validateMemberwiseInitializers() {
 @Observable
 struct DefiniteInitialization {
   var field: Int
-  
+
   init(field: Int) {
     self.field = field
   }
@@ -60,21 +60,21 @@ class ContainsIUO {
 }
 
 class NonObservable {
-  
+
 }
 
 @Observable
 class InheritsFromNonObservable: NonObservable {
-  
+
 }
 
 protocol NonObservableProtocol {
-  
+
 }
 
 @Observable
 class ConformsToNonObservableProtocol: NonObservableProtocol {
-  
+
 }
 
 struct NonObservableContainer {
@@ -89,19 +89,19 @@ class ImplementsAccessAndMutation {
   var field = 3
   let accessCalled: (PartialKeyPath<ImplementsAccessAndMutation>) -> Void
   let withMutationCalled: (PartialKeyPath<ImplementsAccessAndMutation>) -> Void
-  
+
   init(accessCalled: @escaping (PartialKeyPath<ImplementsAccessAndMutation>) -> Void, withMutationCalled: @escaping (PartialKeyPath<ImplementsAccessAndMutation>) -> Void) {
     self.accessCalled = accessCalled
     self.withMutationCalled = withMutationCalled
   }
-  
+
   internal func access<Member>(
       keyPath: KeyPath<ImplementsAccessAndMutation , Member>
   ) {
     accessCalled(keyPath)
     _$observationRegistrar.access(self, keyPath: keyPath)
   }
-  
+
   internal func withMutation<Member, T>(
     keyPath: KeyPath<ImplementsAccessAndMutation , Member>,
     _ mutation: () throws -> T
@@ -126,7 +126,7 @@ class Entity {
 class Person : Entity {
   var firstName = ""
   var lastName = ""
-  
+
   var friends = [Person]()
 
   var fullName: String { firstName + " " + lastName }
@@ -163,7 +163,7 @@ class HasIntermediaryConformance: Intermediary { }
 
 class CapturedState<State>: @unchecked Sendable {
   var state: State
-  
+
   init(state: State) {
     self.state = state
   }


### PR DESCRIPTION
* **Explanation**: The `hasStorage()` computation is used in many places to determine the signatures of other declarations. It currently needs to expand accessor macros, which causes a number of cyclic references. Provide a simplified request to determine `hasStorage` without expanding or resolving macros, breaking a common pattern of cycles when using macros. This requires some level of additional documentation for accessor macros to say what accessors they could generate, because we need to know whether a given accessor macro will make a property computed (or not) without expanding it. There is a small-but-necessary language adjustment to be paired with this.
* **Scope**: Fairly broad: the `hasStorage()` computation is core to determining whether a particular property is stored or not. Its value was determined based on a heavier-weight computation of the access pattern for the property, which required creating all accessors in advance.
* **Risk**: Moderate: it is plausible that the `hasStorage` computation could be out-of-sync with the access-pattern computation in some corner case not exercised by any code we've tested, causing a regression. The `hasStorage` computation is so central to everything in the compiler that this seems unlikely.
* **Reviewed by**: @hborla 
* **Issue**: rdar://109668383
* **Original pull request**: https://github.com/apple/swift/pull/66482