### PR TITLE
Add riscv64 as supported architecture on linux

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -465,6 +465,7 @@ function verify_host_is_supported() {
       | linux-powerpc           \
       | linux-powerpc64         \
       | linux-powerpc64le       \
+      | linux-riscv64           \
       | linux-s390x             \
       | macosx-x86_64           \
       | macosx-arm64            \

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -275,6 +275,7 @@ class StdlibDeploymentTarget(object):
         "powerpc",
         "powerpc64",
         "powerpc64le",
+        "riscv64",
         "s390x"])
 
     FreeBSD = Platform("freebsd", archs=["x86_64"])
@@ -361,6 +362,8 @@ class StdlibDeploymentTarget(object):
                 return StdlibDeploymentTarget.Linux.powerpc64
             elif machine == 'ppc64le':
                 return StdlibDeploymentTarget.Linux.powerpc64le
+            elif machine == 'riscv64':
+                return StdlibDeploymentTarget.Linux.riscv64
             elif machine == 's390x':
                 return StdlibDeploymentTarget.Linux.s390x
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Test Environment
OS = Ubuntu
Release = 22.04 / Jammy

When trying to build swift on a riscv64 linux system the following error occurs -
```bash
File "/home/build-user/swift/utils/swift_build_support/swift_build_support/targets.py", line 398, in host_target
    raise NotImplementedError('System "%s" with architecture "%s" is not '
NotImplementedError: System "Linux" with architecture "riscv64" is not supported
```

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/swift-riscv/swift-riscv64/issues/1

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
