### PR TITLE
[stdlib] Fix calling convention mismatch for debugger utility functions

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -270,11 +270,11 @@ public func _debuggerTestingCheckExpect(_: String, _: String) { }
 
 // Utilities to get refcount(s) of class objects.
 public func _getRetainCount(_ Value: AnyObject) -> UInt {
-  return UInt(swift_retainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+  return UInt(bitPattern: swift_retainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
 }
 public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt {
-  return UInt(swift_unownedRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+  return UInt(bitPattern: swift_unownedRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
 }
 public func _getWeakRetainCount(_ Value: AnyObject) -> UInt {
-  return UInt(swift_weakRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+  return UInt(bitPattern: swift_weakRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
 }

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -269,9 +269,12 @@ public func _stringForPrintObject(_ value: Any) -> String {
 public func _debuggerTestingCheckExpect(_: String, _: String) { }
 
 // Utilities to get refcount(s) of class objects.
-@_silgen_name("swift_retainCount")
-public func _getRetainCount(_ Value: AnyObject) -> UInt
-@_silgen_name("swift_unownedRetainCount")
-public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt
-@_silgen_name("swift_weakRetainCount")
-public func _getWeakRetainCount(_ Value: AnyObject) -> UInt
+public func _getRetainCount(_ Value: AnyObject) -> UInt {
+  return UInt(swift_retainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+}
+public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt {
+  return UInt(swift_unownedRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+}
+public func _getWeakRetainCount(_ Value: AnyObject) -> UInt {
+  return UInt(swift_weakRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
+}


### PR DESCRIPTION
The functions `swift_retainCount`, `swift_unownedRetainCount`, and `swift_weakRetainCount` are declared in `HeapObject.h` as using the C calling convention, but the Swift declarations referenced them by `@_silgen_name`, which uses the Swift calling convention. This patch fixes the mismatch without any ABI/API breakage by calling the utility functions through C interop.

