### PR TITLE
Allow @_silgen_name to be used on globals and add a @_silgen_name(raw: ...) version that skips mangling

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -856,14 +856,15 @@ By default, SourceKit hides underscored protocols from the generated
 swiftinterface (for all modules, not just the standard library), but this
 attribute can be used to override that behavior for the standard library.
 
-## `@_silgen_name("cName")`
+## `@_silgen_name([raw: ]"cName")`
 
-Changes the symbol name for a function, similar to an ASM label in C,
-except that the platform symbol mangling (leading underscore on Darwin)
-is maintained.
+Changes the symbol name for a function or a global, similar to an ASM label in
+C. Unlike ASM labels in C, the platform symbol mangling (leading underscore on
+Darwin) is maintained, unless "raw:" is used, in which case the name provided is
+expected to already be mangled.
 
 Since this has label-like behavior, it may not correspond to any declaration;
-if so, it is assumed that the function is implemented in C.
+if so, it is assumed that the function/global is implemented in C.
 
 A function defined by `@_silgen_name` is assumed to use the Swift ABI.
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -491,15 +491,18 @@ public:
 /// Defines the @_silgen_name attribute.
 class SILGenNameAttr : public DeclAttribute {
 public:
-  SILGenNameAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+  SILGenNameAttr(StringRef Name, bool Raw, SourceLoc AtLoc, SourceRange Range, bool Implicit)
     : DeclAttribute(DAK_SILGenName, AtLoc, Range, Implicit),
-      Name(Name) {}
+      Name(Name), Raw(Raw) {}
 
-  SILGenNameAttr(StringRef Name, bool Implicit)
-    : SILGenNameAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
+  SILGenNameAttr(StringRef Name, bool Raw, bool Implicit)
+    : SILGenNameAttr(Name, Raw, SourceLoc(), SourceRange(), Implicit) {}
 
   /// The symbol name.
   const StringRef Name;
+
+  /// If true, the name is not to be mangled (underscore prefix on Darwin)
+  bool Raw;
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_SILGenName;

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -340,8 +340,8 @@ ERROR(performance_unknown_callees,none,
       "called function is not known at compile time and can have unpredictable performance", ())
 ERROR(performance_callee_unavailable,none,
       "called function is not available in this module and can have unpredictable performance", ())
-ERROR(section_attr_on_non_const_global,none,
-      "global variable must be a compile-time constant to use @_section attribute", ())
+ERROR(bad_attr_on_non_const_global,none,
+      "global variable must be a compile-time constant to use %0 attribute", (StringRef))
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6861,6 +6861,9 @@ bool VarDecl::isLazilyInitializedGlobal() const {
   if (isDebuggerVar())
     return false;
 
+  if (getAttrs().hasAttribute<SILGenNameAttr>())
+    return false;
+
   // Top-level global variables in the main source file and in the REPL are not
   // lazily initialized.
   return !isTopLevelGlobal();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2893,6 +2893,15 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       ParseSymbolName = consumeIf(tok::comma);
     }
 
+    bool Raw = false;
+    if (DK == DAK_SILGenName) {
+      if (Tok.is(tok::identifier) && Tok.getText() == "raw") {
+        consumeToken(tok::identifier);
+        consumeToken(tok::colon);
+        Raw = true;
+      }
+    }
+
     llvm::Optional<StringRef> AsmName;
     if (ParseSymbolName) {
       if (Tok.isNot(tok::string_literal)) {
@@ -2928,7 +2937,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     if (!DiscardAttribute) {
       if (DK == DAK_SILGenName)
-        Attributes.add(new (Context) SILGenNameAttr(AsmName.value(), AtLoc,
+        Attributes.add(new (Context) SILGenNameAttr(AsmName.value(), Raw, AtLoc,
                                                 AttrRange, /*Implicit=*/false));
       else if (DK == DAK_CDecl)
         Attributes.add(new (Context) CDeclAttr(AsmName.value(), AtLoc,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1446,7 +1446,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
         {}, /*async*/ false, /*throws*/ false, {}, emptyParams,
         getASTContext().getNeverType(), moduleDecl);
     drainQueueFuncDecl->getAttrs().add(new (getASTContext()) SILGenNameAttr(
-        "swift_task_asyncMainDrainQueue", /*implicit*/ true));
+        "swift_task_asyncMainDrainQueue", /*raw*/ false, /*implicit*/ true));
   }
 
   SILFunction *drainQueueSILFunc = SGM.getFunction(

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -50,6 +50,9 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
 
   if (gDecl->getAttrs().hasAttribute<SILGenNameAttr>()) {
     silLinkage = SILLinkage::DefaultForDeclaration;
+    if (! gDecl->hasInitialValue()) {
+      forDef = NotForDefinition;
+    }
   }
 
   // Check if it is already created, and update linkage if necessary.

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -31,6 +31,9 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
     auto SILGenName = gDecl->getAttrs().getAttribute<SILGenNameAttr>();
     if (SILGenName && !SILGenName->Name.empty()) {
       mangledName = SILGenName->Name.str();
+      if (SILGenName->Raw) {
+        mangledName = "\1" + mangledName;
+      }
     } else {
       Mangle::ASTMangler NewMangler;
       mangledName = NewMangler.mangleGlobalVariableFull(gDecl);
@@ -44,6 +47,10 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
   else
     formalLinkage = getDeclLinkage(gDecl);
   auto silLinkage = getSILLinkage(formalLinkage, forDef);
+
+  if (gDecl->getAttrs().hasAttribute<SILGenNameAttr>()) {
+    silLinkage = SILLinkage::DefaultForDeclaration;
+  }
 
   // Check if it is already created, and update linkage if necessary.
   if (auto gv = M.lookUpGlobalVariable(mangledName)) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1373,8 +1373,8 @@ SILValue SILGenFunction::emitMainExecutor(SILLocation loc) {
         ctx.TheExecutorType,
         getModule().getSwiftModule());
     getMainExecutorFuncDecl->getAttrs().add(
-        new (ctx)
-            SILGenNameAttr("swift_task_getMainExecutor", /*implicit*/ true));
+        new (ctx) SILGenNameAttr("swift_task_getMainExecutor", /*raw*/ false,
+                                 /*implicit*/ true));
   }
 
   auto fn = SGM.getFunction(

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2315,6 +2315,9 @@ public:
         if (!var->hasStorage())
           return;
 
+        if (var->getAttrs().hasAttribute<SILGenNameAttr>())
+          return;
+
         if (var->isInvalid() || PBD->isInvalid())
           return;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5361,7 +5361,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         bool isImplicit;
         serialization::decls_block::SILGenNameDeclAttrLayout::readRecord(
             scratch, isImplicit);
-        Attr = new (ctx) SILGenNameAttr(blobData, isImplicit);
+        Attr = new (ctx) SILGenNameAttr(blobData, /*raw*/ false, isImplicit);
         break;
       }
 

--- a/test/IRGen/linker_set_low_level.swift
+++ b/test/IRGen/linker_set_low_level.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers %s -emit-ir -parse-as-library | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+@_used
+@_section("__TEXT,__mysection")
+let my_global1: Int = 42
+
+@_used
+@_section("__TEXT,__mysection")
+let my_global2: Int = 46
+
+@_silgen_name(raw: "section$start$__TEXT$__mysection")
+var mysection_start: Int
+
+@_silgen_name(raw: "section$end$__TEXT$__mysection")
+var mysection_end: Int
+
+// CHECK: @"$s20linker_set_low_level10my_global1Sivp" = {{.*}}constant %TSi <{ {{(i64|i32)}} 42 }>, section "__TEXT,__mysection
+// CHECK: @"$s20linker_set_low_level10my_global2Sivp" = {{.*}}constant %TSi <{ {{(i64|i32)}} 46 }>, section "__TEXT,__mysection
+// CHECK: @"\01section$start$__TEXT$__mysection" = {{.*}}global %TSi
+// CHECK: @"\01section$end$__TEXT$__mysection" = {{.*}}global %TSi

--- a/test/IRGen/linker_set_low_level_exec.swift
+++ b/test/IRGen/linker_set_low_level_exec.swift
@@ -4,17 +4,33 @@
 // REQUIRES: swift_in_compiler
 
 @_used
+#if canImport(Darwin)
 @_section("__TEXT,__mysection")
+#else
+@_section("__mysection")
+#endif
 let my_global1: Int = 42
 
 @_used
+#if canImport(Darwin)
 @_section("__TEXT,__mysection")
+#else
+@_section("__mysection")
+#endif
 let my_global2: Int = 46
 
+#if canImport(Darwin)
 @_silgen_name(raw: "section$start$__TEXT$__mysection")
+#else
+@_silgen_name(raw: "__start___mysection")
+#endif
 var mysection_start: Int
 
+#if canImport(Darwin)
 @_silgen_name(raw: "section$end$__TEXT$__mysection")
+#else
+@_silgen_name(raw: "__stop___mysection")
+#endif
 var mysection_end: Int
 
 @main

--- a/test/IRGen/linker_set_low_level_exec.swift
+++ b/test/IRGen/linker_set_low_level_exec.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature SymbolLinkageMarkers) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+
+@_used
+@_section("__TEXT,__mysection")
+let my_global1: Int = 42
+
+@_used
+@_section("__TEXT,__mysection")
+let my_global2: Int = 46
+
+@_silgen_name(raw: "section$start$__TEXT$__mysection")
+var mysection_start: Int
+
+@_silgen_name(raw: "section$end$__TEXT$__mysection")
+var mysection_end: Int
+
+@main
+struct Main {
+	static func main() {
+		let start = UnsafeRawPointer(&mysection_start)
+		let end = UnsafeRawPointer(&mysection_end)
+		let size = end - start
+		let count = size / (Int.bitWidth / 8)
+		print("count: \(count)")
+		let linker_set = UnsafeBufferPointer(start: start.bindMemory(to: Int.self, capacity: count), count: count)
+		for i in 0 ..< linker_set.count {
+			print("mysection[\(i)]: \(linker_set[i])")
+		}
+	}
+}
+
+// CHECK: count: 2
+// CHECK: mysection[0]: 42
+// CHECK: mysection[1]: 46

--- a/test/IRGen/silgen_name_non_const.swift
+++ b/test/IRGen/silgen_name_non_const.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -parse-as-library -emit-sil %s -o /dev/null -verify
+
+// REQUIRES: swift_in_compiler
+
+@_silgen_name("g0") var g0: Int = 1
+@_silgen_name("g1") var g1: (Int, Int) = (1, 2)
+@_silgen_name("g2") var g2: [Int] = [1, 2, 3] // expected-error {{global variable must be a compile-time constant to use @_silgen_name attribute}}
+@_silgen_name("g3") var g3: [Int:Int] = [:] // expected-error {{global variable must be a compile-time constant to use @_silgen_name attribute}}
+@_silgen_name("g4") var g4: UInt = 42
+@_silgen_name("g5") var g5: String = "hello" // expected-error {{global variable must be a compile-time constant to use @_silgen_name attribute}}
+@_silgen_name("g6") var g6: Any = 1 // expected-error {{global variable must be a compile-time constant to use @_silgen_name attribute}}
+@_silgen_name("g7") var g7: UInt8 = 42
+@_silgen_name("g8") var g8: Int = 5 * 5
+
+@_silgen_name("fwd1") var fwd1: Int

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -182,7 +182,7 @@ TYPE_ATTR_KINDS = [
 # docs/ReferenceGuides/UnderscoredAttributes.md.
 DECL_ATTR_KINDS = [
     DeclAttribute('_silgen_name', 'SILGenName',
-                  OnAbstractFunction,
+                  OnAbstractFunction, OnVar,
                   LongAttribute, UserInaccessible, ABIStableToAdd, ABIStableToRemove,
                   APIStableToAdd, APIStableToRemove,
                   code=0),


### PR DESCRIPTION
Attribute @_silgen_name is today only allowed to be used on functions, this PR allows usage on globals as well. The motivation for that is to be able to "forward declare" globals just like it's today possible to do with functions (for the cases where it's not practical or convenient to use a bridging header).

Separately, this PR also adds a `@_silgen_name(raw: ...)` syntax, which simply avoids mangling the name (by using the `\01` name prefix that LLVM uses). The motivation for that is to be able to reference the "magic Darwin linker symbols" that can be used to look up section bounds (in the current dylib/module) -- those symbols don't use the underscore prefix in their mangled names. The attached testcases showcase this as a low-level "linker set" implementation.