### PR TITLE
[Concurrency] Fix calling convention mismatch in AsyncStream

### DIFF
--- a/stdlib/public/BackDeployConcurrency/AsyncStream.cpp
+++ b/stdlib/public/BackDeployConcurrency/AsyncStream.cpp
@@ -12,10 +12,12 @@
 
 #include <new>
 
+#include "swift/Runtime/Config.h"
 #include "swift/Threading/Mutex.h"
 
 namespace swift {
 // return the size in words for the given mutex primitive
+SWIFT_CC(swift)
 extern "C"
 size_t _swift_async_stream_lock_size() {
   size_t words = sizeof(Mutex) / sizeof(void *);
@@ -23,11 +25,14 @@ size_t _swift_async_stream_lock_size() {
   return words;
 }
 
+SWIFT_CC(swift)
 extern "C" void _swift_async_stream_lock_init(Mutex &lock) {
   new (&lock) Mutex();
 }
 
+SWIFT_CC(swift)
 extern "C" void _swift_async_stream_lock_lock(Mutex &lock) { lock.lock(); }
 
+SWIFT_CC(swift)
 extern "C" void _swift_async_stream_lock_unlock(Mutex &lock) { lock.unlock(); }
 }

--- a/stdlib/public/Concurrency/AsyncStream.cpp
+++ b/stdlib/public/Concurrency/AsyncStream.cpp
@@ -12,10 +12,12 @@
 
 #include <new>
 
+#include "swift/Runtime/Config.h"
 #include "swift/Threading/Mutex.h"
 
 namespace swift {
 // return the size in words for the given mutex primitive
+SWIFT_CC(swift)
 extern "C"
 size_t _swift_async_stream_lock_size() {
   size_t words = sizeof(Mutex) / sizeof(void *);
@@ -23,11 +25,14 @@ size_t _swift_async_stream_lock_size() {
   return words;
 }
 
+SWIFT_CC(swift)
 extern "C" void _swift_async_stream_lock_init(Mutex &lock) {
   new (&lock) Mutex();
 }
 
+SWIFT_CC(swift)
 extern "C" void _swift_async_stream_lock_lock(Mutex &lock) { lock.lock(); }
 
+SWIFT_CC(swift)
 extern "C" void _swift_async_stream_lock_unlock(Mutex &lock) { lock.unlock(); }
 }


### PR DESCRIPTION
Functions defined in AsyncStream.cpp are called from Swift with swiftcc but are defined with the C calling convention.
Here are the caller site decls:
https://github.com/apple/swift/blob/4e2f3b1c8c3c32c33c6c34d35595360d84a49294/stdlib/public/Concurrency/AsyncStreamBuffer.swift#L42-L52
