### PR TITLE
[Concurrency] Fix signature mismatch of _startTaskOnMainActor

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -933,7 +933,7 @@ extension UnsafeCurrentTask: Equatable {
 func _getCurrentAsyncTask() -> Builtin.NativeObject?
 
 @_silgen_name("swift_task_startOnMainActor")
-fileprivate func _startTaskOnMainActor(_ task: Builtin.NativeObject) -> Builtin.NativeObject?
+fileprivate func _startTaskOnMainActor(_ task: Builtin.NativeObject)
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getJobFlags")


### PR DESCRIPTION
The function is defined in Task.cpp with a void return type, but referenced in Task.swift with an pointer return type.
Here is the definition site:
https://github.com/apple/swift/blob/4e2f3b1c8c3c32c33c6c34d35595360d84a49294/stdlib/public/Concurrency/Task.cpp#L1618