### PR TITLE
[Driver] Remove unused runtime library path on non-Darwin platforms

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1512,7 +1512,8 @@ void ToolChain::getRuntimeLibraryPaths(SmallVectorImpl<std::string> &runtimeLibP
   if (!scratchPath.empty())
     runtimeLibPaths.push_back(std::string(scratchPath.str()));
 
-  if (!SDKPath.empty()) {
+  // Only Darwin places libraries directly in /sdk/usr/lib/swift/.
+  if (Triple.isOSDarwin() && !SDKPath.empty()) {
     if (!scratchPath.empty()) {
       // If we added the secondary resource dir, we also need the iOSSupport
       // directory.

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -58,6 +58,9 @@
 // CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
 // CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift($| )}}
 
+// RUN: %swift_driver_plain -sdk /sdk -### -target aarch64-unknown-linux-gnu %s | %FileCheck -check-prefix=CHECK-RUNTIME-LIBRARY-PATH %s
+// CHECK-RUNTIME-LIBRARY-PATH-NOT: # LD_LIBRARY_PATH=/sdk/usr/lib/swift/linux:/sdk/usr/lib/swift
+
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}
 // CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux($|:)}}


### PR DESCRIPTION
Translation of apple/swift-driver#1374 to the legacy C++ Driver, with the addition of a test.

Fixes #63416