### PR TITLE
fix an assert-nonassert mismatch in SILModule

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -395,9 +395,7 @@ private:
   /// Action to be executed for serializing the SILModule.
   ActionCallback SerializeSILAction;
 
-#ifndef NDEBUG
   BasicBlockNameMapType basicBlockNames;
-#endif
 
   SILModule(llvm::PointerUnion<FileUnit *, ModuleDecl *> context,
             Lowering::TypeConverter &TC, const SILOptions &Options,


### PR DESCRIPTION
Data structures must be layout compatible when built with and without asserts.

Fixes a  compiler crash when C++ sources are built without asserts because SwiftCompilerSources are built with asserts.

rdar://110363377
