### PR TITLE
[cxx-interop] Avoid linker errors when calling a defaulted constructor

### DIFF
--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -10,6 +10,11 @@ struct ImplicitDefaultConstructor {
   int x = 42;
 };
 
+struct DefaultedDefaultConstructor {
+  int x = 42;
+  DefaultedDefaultConstructor() = default;
+};
+
 struct MemberOfClassType {
   ImplicitDefaultConstructor member;
 };

--- a/test/Interop/Cxx/class/constructors-executable.swift
+++ b/test/Interop/Cxx/class/constructors-executable.swift
@@ -19,6 +19,12 @@ CxxConstructorTestSuite.test("ImplicitDefaultConstructor") {
   expectEqual(42, instance.x)
 }
 
+CxxConstructorTestSuite.test("DefaultedDefaultConstructor") {
+  let instance = DefaultedDefaultConstructor()
+
+  expectEqual(42, instance.x)
+}
+
 CxxConstructorTestSuite.test("MemberOfClassType") {
   let instance = MemberOfClassType()
 

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -9,6 +9,11 @@
 // CHECK-NEXT:   init(x: Int32)
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
+// CHECK-NEXT: struct DefaultedDefaultConstructor {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32)
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT: }
 // CHECK-NEXT: struct MemberOfClassType {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(member: ImplicitDefaultConstructor)

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -11,13 +11,11 @@ import Cxx
 
 var StdMapTestSuite = TestSuite("StdMap")
 
-#if !os(Linux) // https://github.com/apple/swift/issues/61412
 StdMapTestSuite.test("init") {
   let m = Map()
   expectEqual(m.size(), 0)
   expectTrue(m.empty())
 }
-#endif
 
 StdMapTestSuite.test("Map.subscript") {
   // This relies on the `std::map` conformance to `CxxDictionary` protocol.


### PR DESCRIPTION
When a default constructor is declared, but does not have a body because it is defaulted (`= default;`), Swift did not emit the IR for it. This was causing linker error for types such as `std::map` in libstdc++ when someone tried to initialize such types from Swift.

rdar://110638499 / resolves https://github.com/apple/swift/issues/61412