### PR TITLE
[5.9] IRGen: alloc_global and global_addr instructions need to agree on the storage

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2939,10 +2939,9 @@ void IRGenSILFunction::visitAllocGlobalInst(AllocGlobalInst *i) {
 
 void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
   SILGlobalVariable *var = i->getReferencedGlobal();
-  SILType loweredTy = var->getLoweredTypeInContext(getExpansionContext());
-  assert(loweredTy == i->getType().getObjectType());
+  SILType loweredTy = var->getLoweredType();
   auto &ti = getTypeInfo(loweredTy);
-  
+
   auto expansion = IGM.getResilienceExpansionForLayout(var);
 
   // If the variable is empty in all resilience domains that can see it,
@@ -2965,7 +2964,15 @@ void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
   // Otherwise, the static storage for the global consists of a fixed-size
   // buffer; project it.
   addr = emitProjectValueInBuffer(*this, loweredTy, addr);
-  
+
+
+  // Get the address of the type in context.
+  SILType loweredTyInContext = var->getLoweredTypeInContext(getExpansionContext());
+  auto &tiInContext = getTypeInfo(loweredTyInContext);
+  auto ptr = Builder.CreateBitOrPointerCast(addr.getAddress(),
+                                            tiInContext.getStorageType()->getPointerTo());
+  addr = Address(ptr, tiInContext.getStorageType(),
+                 tiInContext.getBestKnownAlignment());
   setLoweredAddress(i, addr);
 }
 

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -disable-availability-checking -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 
@@ -53,3 +53,18 @@ extension A {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main(i32 %0, i8** %1) {{.*}} {
 // CHECK:      store  i64 {{.*}}, i64* getelementptr inbounds ([[INT]], [[INT]]* @"$s7globals2g0Sivp", i32 0, i32 0), align 8
 
+// CHECK:  [[BUF_PROJ:%.*]] = call {{.*}} @__swift_project_value_buffer({{.*}}s7globals1gQrvp
+// CHECK:  [[CAST:%.*]] = bitcast {{.*}} [[BUF_PROJ]]
+// CHECK:  [[CAST2:%.*]] = bitcast {{.*}} [[CAST]]
+// CHECK:  call void @llvm.memcpy{{.*}}({{.*}}[[CAST2]]
+
+
+public protocol Some {}
+
+public struct Implementer : Some {
+  var w = (0, 1, 2, 3, 4)
+
+  public init() { }
+}
+
+let g : some Some = Implementer()


### PR DESCRIPTION
The ABI used for `some` typed globals is similar to existential values. We reserve an "inline" 3 word buffer, query type metadata's size, and if the size is bigger allocate storage on the heap.

The `global_addr` instruction needs to follow this logic: If the storage is opaque we need to project to the underlying buffer.

Risk: Low. The change should only affect opaque types (`some` types).

Without the change any `some` typed globals bigger than 3 words might clobber storage in memory immediately after it.

e.g. the following code is broken

```
public protocol Some {}

 public struct Implementer : Some {
   var w = (0, 1, 2, 3, 4)

   public init() { }
 }

 let g : some Some = Implementer()
 ```

Original PR: https://github.com/apple/swift/pull/66507
rdar://109636344