### PR TITLE
[🍒][cxx-interop] Correctly import fields with type `NS_OPTIONS`.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3584,11 +3584,30 @@ namespace {
           return nullptr;
       }
 
-      auto importedType =
-          Impl.importType(decl->getType(), ImportTypeKind::RecordField,
-                          ImportDiagnosticAdder(Impl, decl, decl->getLocation()),
-                          isInSystemModule(dc), Bridgeability::None,
-                          getImportTypeAttrs(decl));
+      ImportedType importedType;
+      auto fieldType = decl->getType();
+      if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
+        fieldType = elaborated->desugar();
+      if (auto typedefType = dyn_cast<clang::TypedefType>(fieldType)) {
+        if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
+          if (auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
+            // If this fails, it means that we need a stronger predicate for
+            // determining the relationship between an enum and typedef.
+            assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
+                   typedefType->getCanonicalTypeInternal());
+            if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
+              importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
+            }
+          }
+        }
+      }
+
+      if (!importedType)
+        importedType =
+            Impl.importType(decl->getType(), ImportTypeKind::RecordField,
+                            ImportDiagnosticAdder(Impl, decl, decl->getLocation()),
+                            isInSystemModule(dc), Bridgeability::None,
+                            getImportTypeAttrs(decl));
       if (!importedType) {
         Impl.addImportDiagnostic(
             decl, Diagnostic(diag::record_field_not_imported, decl),
@@ -5817,6 +5836,13 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
                                           const clang::EnumDecl *decl) {
   ASTContext &ctx = Impl.SwiftContext;
 
+  auto Loc = Impl.importSourceLoc(decl->getLocation());
+
+  // Create a struct with the underlying type as a field.
+  auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
+      decl, AccessLevel::Public, Loc, name, Loc, None, nullptr, dc);
+  Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = structDecl;
+
   // Compute the underlying type.
   auto underlyingType = Impl.importTypeIgnoreIUO(
       decl->getIntegerType(), ImportTypeKind::Enum,
@@ -5824,12 +5850,6 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
       isInSystemModule(dc), Bridgeability::None, ImportTypeAttrs());
   if (!underlyingType)
     return nullptr;
-
-  auto Loc = Impl.importSourceLoc(decl->getLocation());
-
-  // Create a struct with the underlying type as a field.
-  auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
-      decl, AccessLevel::Public, Loc, name, Loc, None, nullptr, dc);
 
   synthesizer.makeStructRawValued(structDecl, underlyingType,
                                   {KnownProtocolKind::OptionSet});

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -81,6 +81,10 @@ typedef NS_OPTIONS(NSUInteger, Bar) {
 
 typedef NS_OPTIONS(NSUInteger, Baz) { Baz1, Baz2 };
 
+struct HasNSOptionField {
+  Bar bar;
+};
+
 Baz CFunctionReturningNSOption();
 void CFunctionTakingNSOption(Baz);
 

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -20,3 +20,8 @@ import CenumsNSOptions
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "insertionIndex")
 // CHECK-NEXT:   static var InsertionIndex: NSBinarySearchingOptions { get }
 // CHECK-NEXT: }
+
+// CHECK: struct Bar : OptionSet, @unchecked Sendable
+// CHECK: struct HasNSOptionField {
+// CHECK:   var bar: Bar
+// CHECK: }

--- a/test/Interop/Cxx/enum/ns-option-as-field.swift
+++ b/test/Interop/Cxx/enum/ns-option-as-field.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import CenumsNSOptions
+import StdlibUnittest
+
+var FieldTestSuite = TestSuite("NS_Option as field")
+
+struct HasNSOptionMember {
+  var member: Bar
+}
+
+FieldTestSuite.test("NSOption as field") {
+  var parent = HasNSOptionMember(member: [.SwiftOptionOneApiNotes, .SwiftOptionTwoApiNotes])
+  expectEqual(parent.member, [.SwiftOptionOneApiNotes, .SwiftOptionTwoApiNotes])
+  
+  parent.member = [.SwiftOptionOneApiNotes]
+  expectNotEqual(parent.member, [.SwiftOptionOneApiNotes, .SwiftOptionTwoApiNotes])
+}
+
+runAllTests()


### PR DESCRIPTION
**Explanation:** NS_OPTIONS has a different definition in ObjC/C and C++. The C++ definition makes it hard for us to match up the enum with the typedef (type). We have had to add some ugly special cases that lookup the associated enum using an attribute: `findAnonymousEnumForTypedef`. We've updated most places that import types to check for this special case, but every now and again we find another edge case. Hopefully this is the last one. This patch adds this special case/lookup when we are importing the type of fields. This bug has been hitting a lot of people, see https://github.com/apple/swift/issues/65885 and rdar://109830715

**Scope:** C++ interoperability
**Risk:** Low, changes a narrow class of API imports; uses same pattern as elsewhere to find NS_OPTIONS. 
**Testing:** Swift unit tests.
**PR:** https://github.com/apple/swift/pull/66452