### PR TITLE
[5.9] [CS] A couple of ExprPattern conjunction fixes

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2949,10 +2949,6 @@ namespace {
         PreWalkAction walkToDeclPre(Decl *D) override {
           return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
         }
-
-        PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-          return Action::SkipChildren(P);
-        }
       } collectVarRefs(CS);
 
       // Walk the capture list if this closure has one,  because it could

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2625,8 +2625,10 @@ void ConjunctionElement::findReferencedVariables(
   }
 
   if (element.is<Decl *>() || element.is<StmtConditionElement *>() ||
-      element.is<Expr *>() || element.isStmt(StmtKind::Return))
+      element.is<Expr *>() || element.isPattern(PatternKind::Expr) ||
+      element.isStmt(StmtKind::Return)) {
     element.walk(refFinder);
+  }
 }
 
 Type constraints::isPlaceholderVar(PatternBindingDecl *PB) {

--- a/test/Constraints/issue-66561.swift
+++ b/test/Constraints/issue-66561.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/66561
+
+@propertyWrapper
+struct WrapperValue<Value> {
+  var value: Value
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  var projectedValue: Self {
+    return self
+  }
+
+  var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+}
+
+func test() {
+  let _ = {
+    @WrapperValue var value: Bool = false
+    switch value {
+    case $value.wrappedValue:
+      break
+    default:
+      break
+    }
+  }
+}

--- a/test/Constraints/rdar110617471.swift
+++ b/test/Constraints/rdar110617471.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://110617471: Make sure we can type-check this.
+class C {
+  var prop = 0
+}
+
+func foo(_ fn: () -> Void) {}
+
+class D {
+  let c = C()
+
+  func bar() {
+    foo { [c] in
+      foo {
+        switch 0 {
+        case c.prop:
+          break
+        default:
+          break
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
*5.9 cherry-pick of #66565*

- Explanation: Fixes a couple of issues where ExprPatterns could fail to resolve references to variables in the local scope.
- Scope: Affects ExprPattern type-checking.
- Radars: rdar://110617471, rdar://110649179
- Risk: Low, extends existing conjunction solving logic to cover more cases.
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich