### PR TITLE
[Test] Use SyntaxRewriter.rewrite not visit

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -164,7 +164,7 @@ public enum AddBlocker: ExpressionMacro {
     in context: some MacroExpansionContext
   ) -> ExprSyntax {
     let visitor = AddVisitor()
-    let result = visitor.visit(Syntax(node))
+    let result = visitor.rewrite(Syntax(node))
 
     for diag in visitor.diagnostics {
       context.diagnose(diag)


### PR DESCRIPTION
SyntaxRewriters should use `rewrite` to create a new node, not `visit`.