### PR TITLE
[Test] Update expected macro error

### DIFF
--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -21,7 +21,7 @@ func test(a: Int, b: Int) {
 
 struct TestStruct {
   @myWrapper var x: Int
-  // expected-error@-1{{expansion of macro 'myWrapper' did not produce a non-observing accessor}}
+  // expected-error@-1{{expansion of macro 'myWrapper()' did not produce a non-observing accessor}}
 }
 
 @ArbitraryMembers


### PR DESCRIPTION
https://github.com/apple/swift/pull/66497 and
https://github.com/apple/swift/pull/66482 succeeded separately, then merged. But after 66497 the error now includes parentheses.

Resolves rdar://110655182.