### PR TITLE
[5.9] [SILGen] Emit block after unreachable when emitting if/switch expressions

### DIFF
--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -500,3 +500,11 @@ struct TestLValues {
     opt![keyPath: kp] = if .random() { 1 } else { throw Err() }
   }
 }
+
+func testNever1() -> Never {
+  if case let x = fatalError() { x } else { fatalError() }
+}
+
+func testNever2() -> Never {
+  if .random() { fatalError() } else { fatalError() }
+}

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -616,3 +616,90 @@ func exprPatternInClosure() {
     }
   }
 }
+
+func testNeverSwitch1() {
+  let x = switch fatalError() {}
+  return x
+}
+
+func testNeverSwitch2() -> Never {
+  let x = switch fatalError() {
+            case let x: x
+          }
+  return x
+}
+
+func testNeverSwitch3() -> Int {
+  let x = switch fatalError() {
+            case fatalError(): 0
+            case _ where .random(): 1
+            default: 2
+          }
+  return x
+}
+
+func testNeverSwitch4() {
+  let x: Void
+  x = switch fatalError() {}
+  return x
+}
+
+func testNeverSwitch5() -> Never {
+  let x: Never
+  x = switch fatalError() {
+        case let x: x
+      }
+  return x
+}
+
+func testNeverSwitch6() -> Int {
+  let x: Int
+  x = switch fatalError() {
+        case fatalError(): 0
+        case _ where .random(): 1
+        default: 2
+      }
+  return x
+}
+
+func testNeverSwitch7() {
+  let _ = switch fatalError() {}
+  let _ = switch fatalError() { case let x: x }
+  let _ = switch fatalError() { default: "" }
+}
+
+func testNeverSwitch8() {
+  let _ = switch fatalError() { default: C() }
+}
+
+func testNeverSwitch9() {
+  let i = switch Bool.random() {
+  case true:
+    switch fatalError() {}
+  case false:
+    switch fatalError() {}
+  }
+  return i
+}
+
+func testNeverSwitch10() -> Never {
+  switch fatalError() {}
+}
+
+func testNeverSwitch11() {
+  return switch fatalError() {}
+}
+
+func testNeverSwitch12() -> Never {
+  return switch fatalError() { case let x: x }
+}
+
+func testNeverSwitch13() {
+  return switch fatalError() { case let x: x }
+}
+
+extension Never {
+  init(value: Self) {
+    self = switch value { case let v: v }
+  }
+}


### PR DESCRIPTION
*5.9 cherry-pick of #66551*

- Explanation: Fixes an issue where a switch expression over an uninhabited subject would crash the compiler.
- Scope: Affects switch expressions with uninhabited subjects (i.e Never)
- Radar: rdar://110636210
- Risk: Low, only affects switch expressions over uninhabited subjects
- Testing: Added tests to test suite
- Reviewer: @eeckstein