### PR TITLE
[ConstraintSystem] Allow generic parameters to bind to holes only in …

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1866,10 +1866,13 @@ TypeVariableType *ConstraintSystem::openGenericParameter(
   auto *paramLocator = getConstraintLocator(
       locator.withPathElement(LocatorPathElt::GenericParameter(parameter)));
 
-  unsigned options = (TVO_PrefersSubtypeBinding |
-                      TVO_CanBindToHole);
+  unsigned options = TVO_PrefersSubtypeBinding;
+
   if (parameter->isParameterPack())
     options |= TVO_CanBindToPack;
+
+  if (shouldAttemptFixes())
+    options |= TVO_CanBindToHole;
 
   auto typeVar = createTypeVariable(paramLocator, options);
   auto result = replacements.insert(std::make_pair(


### PR DESCRIPTION
…diagnostic mode

If generic parameter gets opened during regular solving it cannot be bound to a hole, 
that can only happen in diagnostic mode, so let's not even try. Doing so also makes 
sure that there are no inference side-effects related to holes because bindings are 
ranked based on their attributes.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
