### PR TITLE
Fix sign of fractional units in Duration initializers from Double.

### DIFF
--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -122,7 +122,7 @@ extension Duration {
     // handle them slightly differently to ensure that integer values are
     // never rounded if `scale` is representable as Double.
     let integralPart = duration.rounded(.towardZero)
-    let fractionalPart = integralPart - duration
+    let fractionalPart = duration - integralPart
     self.init(_attoseconds:
       // This term may trap due to overflow, but it cannot round, so if the
       // input `seconds` is an exact integer, we get an exact integer result.

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -14,8 +14,8 @@ if #available(SwiftStdlib 5.7, *) {
       expectEqual(sec, Int64(integerValue))
       expectEqual(attosec, 0)
     }
-    let halfSecond = Duration.seconds(0.25)
-    expectEqual(halfSecond.components, (0, 250_000_000_000_000_000))
+    let quarterSecond = Duration.seconds(0.25)
+    expectEqual(quarterSecond.components, (0, 250_000_000_000_000_000))
     // Value that overflows conversion from Double -> Int64, but should be
     // representable as a number of seconds:
     let huge: Double = 1.7e20

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -14,6 +14,8 @@ if #available(SwiftStdlib 5.7, *) {
       expectEqual(sec, Int64(integerValue))
       expectEqual(attosec, 0)
     }
+    let halfSecond = Duration.seconds(0.25)
+    expectEqual(halfSecond.components, (0, 250_000_000_000_000_000))
     // Value that overflows conversion from Double -> Int64, but should be
     // representable as a number of seconds:
     let huge: Double = 1.7e20


### PR DESCRIPTION
When separating a double duration into integral and fractional parts, we got the sign wrong. This fixes that bug.