### PR TITLE
[5.9] AST: Inherit access level of opaque type decls from naming decl

### DIFF
--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -67,6 +67,13 @@ AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
     }
   }
 
+  // Special case for opaque type decls, which inherit the access of their
+  // naming decls.
+  if (auto *opaqueType = dyn_cast<OpaqueTypeDecl>(D)) {
+    if (auto *namingDecl = opaqueType->getNamingDecl())
+      return namingDecl->getFormalAccess();
+  }
+
   DeclContext *DC = D->getDeclContext();
 
   // Special case for generic parameters; we just give them a dummy

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3737,6 +3737,15 @@ bool ValueDecl::isUsableFromInline() const {
       return true;
   }
 
+  if (auto *opaqueType = dyn_cast<OpaqueTypeDecl>(this)) {
+    if (auto *namingDecl = opaqueType->getNamingDecl()) {
+      if (namingDecl->getAttrs().hasAttribute<UsableFromInlineAttr>() ||
+          namingDecl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>() ||
+          namingDecl->getAttrs().hasAttribute<InlinableAttr>())
+        return true;
+    }
+  }
+
   if (auto *EED = dyn_cast<EnumElementDecl>(this))
     if (EED->getParentEnum()->getAttrs().hasAttribute<UsableFromInlineAttr>())
       return true;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -213,7 +213,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   auto opaqueDecl = OpaqueTypeDecl::get(
       originatingDecl, genericParams, parentDC, interfaceSignature,
       opaqueReprs);
-  opaqueDecl->copyFormalAccessFrom(originatingDecl);
   if (auto originatingSig = originatingDC->getGenericSignatureOfContext()) {
     opaqueDecl->setGenericSignature(originatingSig);
   } else {

--- a/test/IRGen/Inputs/AlwaysInlineIntoWithOpaque.swift
+++ b/test/IRGen/Inputs/AlwaysInlineIntoWithOpaque.swift
@@ -14,3 +14,16 @@ public func testInlineWithOpaque() -> some P {
   }
   return 2.0
 }
+
+@_alwaysEmitIntoClient
+public func testInlineWithOpaqueUsableFromInline() -> some P {
+  if #available(macOS 9.0, *) {
+    return usableFromInline()
+  }
+  return 4.0
+}
+
+@usableFromInline
+func usableFromInline() -> some P {
+  return 3
+}

--- a/test/IRGen/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift
+++ b/test/IRGen/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift
@@ -6,3 +6,8 @@ extension Int : P {
 
 extension Double : P {
 }
+
+@usableFromInline
+func usableFromInline() -> some P {
+  return 3
+}

--- a/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
+++ b/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaque.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque -enable-library-evolution %S/Inputs/AlwaysInlineIntoWithOpaque.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
 // RUN: %target-codesign %t/%target-library-name(AlwaysInlineIntoWithOpaque)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lAlwaysInlineIntoWithOpaque -module-name main -I %t -L %t %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque -enable-library-evolution %S/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
@@ -27,3 +27,11 @@ public func test() {
 
 test()
 // CHECK: 1
+
+public func testUsableFromInline() {
+  let p = testInlineWithOpaqueUsableFromInline()
+  print(p)
+}
+
+testUsableFromInline()
+// CHECK: 3

--- a/test/TBD/opaque_result_type.swift
+++ b/test/TBD/opaque_result_type.swift
@@ -77,6 +77,11 @@ public func dynReplacement(x: String) -> some P {
   return "replaced"
 }
 
+@usableFromInline
+func ufi() -> some O {
+  return 1
+}
+
 extension String: P {
   public func poo() -> some O {
     return 0


### PR DESCRIPTION
Take 2 of https://github.com/apple/swift/pull/66516.

* **Explanation**: When an `OpaqueTypeDecl` is constructed, the access level attributes of the decl that names the opaque type were copied on to it. However, the `@usableFromInline` attribute is not permitted on every decl, so it does not get copied. This in turn causes access level computations for opaque types to fail to take `@usableFromInline` into account and that results in the emitted symbol getting the wrong linkage during IRGen. The fix is to make access level computations take this quirk of opaque types into account directly (like they already to for several other kinds of decls), instead of relying on copying of attributes.
* **Scope**: The change is narrow in the sense that the only type of declaration it affects is opaque type decls. However, access level is queried in many parts of the compiler.
* **Issues**: rdar://110544170
* **Risk**: Medium. Decl access level is queried from many different locations in the compiler so it's difficult to predict whether this change might expose any other issues.
* **Testing**: Regression tests added.
* **Reviewers**: @slavapestov 
* **Main branch PR**: https://github.com/apple/swift/pull/66515.
