### PR TITLE
cmake: correctly set NDEBUG for imported headers in SwiftCompilerSources

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -87,6 +87,10 @@ function(add_swift_compiler_modules_library name)
     list(APPEND swift_compile_options "-O" "-cross-module-optimization")
   endif()
 
+  if(NOT LLVM_ENABLE_ASSERTIONS)
+    list(APPEND swift_compile_options "-Xcc" "-DNDEBUG")
+  endif()
+
   if(NOT SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
     list(APPEND swift_compile_options "-Xfrontend" "-disable-legacy-type-info")
   endif()


### PR DESCRIPTION
So that it's consistent with C++ sources

rdar://110363377
