### PR TITLE
🍒[cxx-interop] Avoid linker errors when calling a defaulted constructor

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2634,30 +2634,38 @@ namespace {
         }
         clang::CXXConstructorDecl *copyCtor = nullptr;
         clang::CXXConstructorDecl *moveCtor = nullptr;
+        clang::CXXConstructorDecl *defaultCtor = nullptr;
         if (decl->needsImplicitCopyConstructor()) {
           copyCtor = clangSema.DeclareImplicitCopyConstructor(
               const_cast<clang::CXXRecordDecl *>(decl));
-        } else if (decl->needsImplicitMoveConstructor()) {
+        }
+        if (decl->needsImplicitMoveConstructor()) {
           moveCtor = clangSema.DeclareImplicitMoveConstructor(
               const_cast<clang::CXXRecordDecl *>(decl));
-        } else {
-          // We may have a defaulted copy constructor that needs to be defined.
-          // Try to find it.
-          for (auto methods : decl->methods()) {
-            if (auto declCtor = dyn_cast<clang::CXXConstructorDecl>(methods)) {
-              if (declCtor->isDefaulted() &&
-                  declCtor->getAccess() == clang::AS_public &&
-                  !declCtor->isDeleted() &&
-                  // Note: we use "doesThisDeclarationHaveABody" here because
-                  // that's what "DefineImplicitCopyConstructor" checks.
-                  !declCtor->doesThisDeclarationHaveABody()) {
-                if (declCtor->isCopyConstructor()) {
+        }
+        if (decl->needsImplicitDefaultConstructor()) {
+          defaultCtor = clangSema.DeclareImplicitDefaultConstructor(
+              const_cast<clang::CXXRecordDecl *>(decl));
+        }
+        // We may have a defaulted copy/move/default constructor that needs to
+        // be defined. Try to find it.
+        for (auto methods : decl->methods()) {
+          if (auto declCtor = dyn_cast<clang::CXXConstructorDecl>(methods)) {
+            if (declCtor->isDefaulted() &&
+                declCtor->getAccess() == clang::AS_public &&
+                !declCtor->isDeleted() &&
+                // Note: we use "doesThisDeclarationHaveABody" here because
+                // that's what "DefineImplicitCopyConstructor" checks.
+                !declCtor->doesThisDeclarationHaveABody()) {
+              if (declCtor->isCopyConstructor()) {
+                if (!copyCtor)
                   copyCtor = declCtor;
-                  break;
-                } else if (declCtor->isMoveConstructor()) {
+              } else if (declCtor->isMoveConstructor()) {
+                if (!moveCtor)
                   moveCtor = declCtor;
-                  break;
-                }
+              } else if (declCtor->isDefaultConstructor()) {
+                if (!defaultCtor)
+                  defaultCtor = declCtor;
               }
             }
           }
@@ -2669,6 +2677,10 @@ namespace {
         if (moveCtor) {
           clangSema.DefineImplicitMoveConstructor(clang::SourceLocation(),
                                                   moveCtor);
+        }
+        if (defaultCtor) {
+          clangSema.DefineImplicitDefaultConstructor(clang::SourceLocation(),
+                                                     defaultCtor);
         }
 
         if (decl->needsImplicitDestructor()) {

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -10,6 +10,11 @@ struct ImplicitDefaultConstructor {
   int x = 42;
 };
 
+struct DefaultedDefaultConstructor {
+  int x = 42;
+  DefaultedDefaultConstructor() = default;
+};
+
 struct MemberOfClassType {
   ImplicitDefaultConstructor member;
 };

--- a/test/Interop/Cxx/class/constructors-executable.swift
+++ b/test/Interop/Cxx/class/constructors-executable.swift
@@ -19,6 +19,12 @@ CxxConstructorTestSuite.test("ImplicitDefaultConstructor") {
   expectEqual(42, instance.x)
 }
 
+CxxConstructorTestSuite.test("DefaultedDefaultConstructor") {
+  let instance = DefaultedDefaultConstructor()
+
+  expectEqual(42, instance.x)
+}
+
 CxxConstructorTestSuite.test("MemberOfClassType") {
   let instance = MemberOfClassType()
 

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -9,6 +9,11 @@
 // CHECK-NEXT:   init(x: Int32)
 // CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
+// CHECK-NEXT: struct DefaultedDefaultConstructor {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32)
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT: }
 // CHECK-NEXT: struct MemberOfClassType {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(member: ImplicitDefaultConstructor)

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -11,13 +11,11 @@ import Cxx
 
 var StdMapTestSuite = TestSuite("StdMap")
 
-#if !os(Linux) // https://github.com/apple/swift/issues/61412
 StdMapTestSuite.test("init") {
   let m = Map()
   expectEqual(m.size(), 0)
   expectTrue(m.empty())
 }
-#endif
 
 StdMapTestSuite.test("Map.subscript") {
   // This relies on the `std::map` conformance to `CxxDictionary` protocol.


### PR DESCRIPTION
**Explanation**: When a default constructor is declared, but does not have a body because it is defaulted (`= default;`), Swift did not emit the IR for it. This was causing linker error for types such as `std::map` in libstdc++ when someone tried to initialize such types from Swift.
**Scope**: This adjusts the way default constructors are imported for C++ structs.
**Risk**: Low, this only has an effect when C++ interop is enabled.

rdar://110638499 / resolves https://github.com/apple/swift/issues/61412 (cherry picked from commit b459fb5fc20eee7081c107f71f8ffc50d9d5ba08)