### PR TITLE
[5.9][GenericEnvironment] Don't apply outer context substitutions before `type.subst` in `mapTypeIntoContext`.

### DIFF
--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -635,7 +635,6 @@ Type GenericEnvironment::mapTypeIntoContext(
   assert((!type->hasArchetype() || type->hasLocalArchetype()) &&
          "already have a contextual type");
 
-  type = maybeApplyOuterContextSubstitutions(type);
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
                            lookupConformance,
                            SubstFlags::AllowLoweredTypes |

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -552,3 +552,11 @@ do {
     _ = (repeat overloaded(1, each a))
   }
 }
+
+func configure<T, each Element>(
+  _ item: T,
+  with configuration: repeat (ReferenceWritableKeyPath<T, each Element>, each Element)
+) -> T {
+  repeat item[keyPath: (each configuration).0] = (each configuration).1
+  return item
+}


### PR DESCRIPTION
* **Explanation**: The outer context substitutions are already applied when invoking `QueryInterfaceTypeSubstitutions`. Applying the context substitutions before `subst` also causes problems because `QueryInterfaceTypeSubstitutions` will return a null type if given an archetype, which manifested with opened pack element environments. This eliminates a common source of cryptic ambiguity errors with parameter packs.
* **Issue**: https://github.com/apple/swift/issues/66502, https://github.com/apple/swift/issues/66125
* **Risk**: Very low. This change just removes a redundant substitution operation in generic environments.
* **Testing**: Added new tests.
* **Reviewer**: @xedin @slavapestov 
* **Main branch PR**: https://github.com/apple/swift/pull/66589