### PR TITLE
[cxx-interop] Simplify a `std::string` test

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -3,11 +3,6 @@ module StdVector {
   requires cplusplus
 }
 
-module StdString {
-  header "std-string.h"
-  requires cplusplus
-}
-
 module StdMap {
   header "std-map.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-string.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-string.h
@@ -1,8 +1,0 @@
-#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_STRING_H
-#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_STRING_H
-
-#include <string>
-
-using CxxString = std::string;
-
-#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_STRING_H

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -3,19 +3,18 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-import StdString
 import CxxStdlib
 
 var StdStringTestSuite = TestSuite("StdString")
 
 StdStringTestSuite.test("init") {
-    let s = CxxString()
+    let s = std.string()
     expectEqual(s.size(), 0)
     expectTrue(s.empty())
 }
 
 StdStringTestSuite.test("push back") {
-    var s = CxxString()
+    var s = std.string()
     s.push_back(42)
     expectEqual(s.size(), 1)
     expectFalse(s.empty())


### PR DESCRIPTION
`std::string` can be accessed directly from Swift, there is no need to go through a using-decl.