### PR TITLE
🍒[cxx-interop] Add `std::set` initializer that takes a Swift Sequence

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -20,6 +20,8 @@ namespace swift {
 
 bool isIterator(const clang::CXXRecordDecl *clangDecl);
 
+bool isUnsafeStdMethod(const clang::CXXMethodDecl *methodDecl);
+
 /// If the decl is a C++ input iterator, synthesize a conformance to the
 /// UnsafeCxxInputIterator protocol, which is defined in the Cxx module.
 void conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6747,6 +6747,11 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
         method->getReturnType()->isReferenceType())
       return false;
 
+    // Check if it's one of the known unsafe methods we currently
+    // mark as safe by default.
+    if (isUnsafeStdMethod(method))
+      return false;
+
     // Try to figure out the semantics of the return type. If it's a
     // pointer/iterator, it's unsafe.
     if (auto returnType = dyn_cast<clang::RecordType>(

--- a/stdlib/public/Cxx/CxxSet.swift
+++ b/stdlib/public/Cxx/CxxSet.swift
@@ -13,11 +13,31 @@
 public protocol CxxSet<Element> {
   associatedtype Element
   associatedtype Size: BinaryInteger
+  associatedtype InsertionResult // std::pair<iterator, bool>
+
+  init()
+
+  @discardableResult
+  mutating func __insertUnsafe(_ element: Element) -> InsertionResult
 
   func count(_ element: Element) -> Size
 }
 
 extension CxxSet {
+  /// Creates a C++ set containing the elements of a Swift Sequence.
+  ///
+  /// This initializes the set by copying every element of the sequence.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of elements in the Swift
+  ///   sequence
+  @inlinable
+  public init<S: Sequence>(_ sequence: S) where S.Element == Element {
+    self.init()
+    for item in sequence {
+      self.__insertUnsafe(item)
+    }
+  }
+
   @inlinable
   public func contains(_ element: Element) -> Bool {
     return count(element) > 0

--- a/stdlib/public/Cxx/CxxSet.swift
+++ b/stdlib/public/Cxx/CxxSet.swift
@@ -31,7 +31,7 @@ extension CxxSet {
   /// - Complexity: O(*n*), where *n* is the number of elements in the Swift
   ///   sequence
   @inlinable
-  public init<S: Sequence>(_ sequence: S) where S.Element == Element {
+  public init<S: Sequence>(_ sequence: __shared S) where S.Element == Element {
     self.init()
     for item in sequence {
       self.__insertUnsafe(item)

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -47,4 +47,18 @@ StdSetTestSuite.test("MultisetOfCInt.contains") {
     expectFalse(s.contains(3))
 }
 
+StdSetTestSuite.test("SetOfCInt.init()") {
+    let s = SetOfCInt([1, 3, 5])
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+}
+
+StdSetTestSuite.test("UnorderedSetOfCInt.init()") {
+    let s = UnorderedSetOfCInt([1, 3, 5])
+    expectTrue(s.contains(1))
+    expectFalse(s.contains(2))
+    expectTrue(s.contains(3))
+}
+
 runAllTests()


### PR DESCRIPTION
**Explanation**: It was previously not possible to easily initialize an `std::set` from a Swift Sequence. This change adds an extra initializer to `std::set` that takes a Swift Sequence as a parameter.
**Scope**: This adds a requirement to the `CxxSet` protocol, adjusts the auto-conformance logic to check the new requirement, and adds an extra initializer to `CxxSet`.
**Risk**: Low, this only has an effect when C++ interop is enabled.

rdar://107909624
(cherry picked from commit dd7e1775fc20cea2d9a6ba71172538c4100dff0f)