### PR TITLE
[Runtime] Properly handle tuple types in layout string instantiation

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -666,9 +666,6 @@ void swift_initStructMetadataWithLayoutString(StructMetadata *self,
                                               const uint8_t *fieldTags,
                                               uint32_t *fieldOffsets);
 
-SWIFT_RUNTIME_STDLIB_INTERNAL
-size_t _swift_refCountBytesForMetatype(const Metadata *type);
-
 enum LayoutStringFlags : uint64_t {
   Empty = 0,
   // TODO: Track other useful information tha can be used to optimize layout
@@ -687,6 +684,9 @@ inline LayoutStringFlags operator|(LayoutStringFlags a, LayoutStringFlags b) {
 inline LayoutStringFlags &operator|=(LayoutStringFlags &a, LayoutStringFlags b) {
   return a = (a | b);
 }
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+size_t _swift_refCountBytesForMetatype(const Metadata *type);
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 void _swift_addRefCountStringForMetatype(uint8_t *layoutStr,

--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -37,26 +37,6 @@
 
 using namespace swift;
 
-static const size_t layoutStringHeaderSize = sizeof(uint64_t) + sizeof(size_t);
-
-/// Given a pointer and an offset, read the requested data and increment the
-/// offset
-template <typename T>
-static T readBytes(const uint8_t *typeLayout, size_t &i) {
-  T returnVal;
-  memcpy(&returnVal, typeLayout + i, sizeof(T));
-  i += sizeof(T);
-  return returnVal;
-}
-
-/// Given a pointer, a value, and an offset, write the value at the given
-/// offset and increment offset by the size of T
-template <typename T>
-static void writeBytes(uint8_t *typeLayout, size_t &i, T value) {
-  memcpy(typeLayout + i, &value, sizeof(T));
-  i += sizeof(T);
-}
-
 static Metadata *getExistentialTypeMetadata(OpaqueValue *object) {
   return reinterpret_cast<Metadata**>(object)[NumWords_ValueBuffer];
 }

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -73,6 +73,23 @@ void swift_resolve_resilientAccessors(uint8_t *layoutStr,
                                       size_t layoutStrOffset,
                                       const uint8_t *fieldLayoutStr,
                                       const Metadata *fieldType);
+
+template <typename T>
+inline T readBytes(const uint8_t *layoutStr, size_t &i) {
+  T returnVal;
+  memcpy(&returnVal, layoutStr + i, sizeof(T));
+  i += sizeof(T);
+  return returnVal;
+}
+
+template <typename T>
+inline void writeBytes(uint8_t *layoutStr, size_t &i, T value) {
+  memcpy(layoutStr + i, &value, sizeof(T));
+  i += sizeof(T);
+}
+
+constexpr size_t layoutStringHeaderSize = sizeof(uint64_t) + sizeof(size_t);
+
 } // namespace swift
 
 #endif // SWIFT_BYTECODE_LAYOUTS_H


### PR DESCRIPTION
Tuple types contain metadata entries for each element, so we can handle them individually to avoid unnecessary indirection.
