### PR TITLE
Correct variance for sendable checking of cross-isolation overrides

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -277,6 +277,9 @@ enum class FunctionCheckType {
 /// \param refKind Describes what kind of reference is being made, which is
 /// used to tailor the diagnostic.
 ///
+/// \param funcCheckType Describes whether function types in this reference
+/// should be checked for sendability of their results, params, or both
+///
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonSendableTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -246,6 +246,17 @@ public:
   operator Kind() const { return kind; }
 };
 
+/// Specifies whether checks applied to function types should
+/// apply to their params, results, or both
+enum class FunctionCheckType {
+  /// Check params and results
+  ParamsResults,
+  /// Check params only
+  Params,
+  /// Check results only
+  Results,
+};
+
 /// Diagnose the presence of any non-sendable types when referencing a
 /// given declaration from a particular declaration context.
 ///
@@ -270,7 +281,8 @@ public:
 bool diagnoseNonSendableTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
     SendableCheckReason refKind,
-    Optional<ActorIsolation> knownIsolation = None);
+    Optional<ActorIsolation> knownIsolation = None,
+    FunctionCheckType funcCheckType = FunctionCheckType::ParamsResults);
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(


### PR DESCRIPTION
<!-- What's in this pull request? -->

The following code is safe for strict concurrency checking, but not allowed:

```
class Super {
    @MainActor
    func g<T : Sendable>(x: T) async {}
}

class Sub : Super {
    override nonisolated func g<T>(x: T) async {} // warning: non-sendable type 'T' in parameter of nonisolated overriding instance method 'g(x:)' cannot cross actor boundary
}
```

This is because `checkOverrideActorIsolation` checks the params and results of overriding methods for sensibility, when instead it should check the params of the overridden method and the results of the overriding method. This PR implements that fix.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
