### PR TITLE
Enable expansion of classes in DebuggerSupport's print

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -150,21 +150,8 @@ public enum _DebuggerSupport {
   
     print(String(repeating: " ", count: indent), terminator: "", to: &target)
 
-    // do not expand classes with no custom Mirror
-    // yes, a type can lie and say it's a class when it's not since we only
-    // check the displayStyle - but then the type would have a custom Mirror
-    // anyway, so there's that...
-    let isNonClass = mirror.displayStyle != .`class`
-    let isCustomReflectable: Bool
-    if let value = value {
-      isCustomReflectable = value is CustomReflectable
-    } else {
-      isCustomReflectable = true
-    }
-    let willExpand = isNonClass || isCustomReflectable
-
     let count = mirror.children.count
-    let bullet = isRoot && (count == 0 || !willExpand) ? ""
+    let bullet = isRoot && count == 0 ? ""
       : count == 0    ? "- "
       : maxDepth <= 0 ? "▹ " : "▿ "
     print(bullet, terminator: "", to: &target)
@@ -179,7 +166,7 @@ public enum _DebuggerSupport {
       print(str, terminator: "", to: &target)
     }
   
-    if (maxDepth <= 0) || !willExpand {
+    if (maxDepth <= 0) {
       print("", to: &target)
       return
     }

--- a/test/stdlib/BridgedObjectDebuggerSupport.swift
+++ b/test/stdlib/BridgedObjectDebuggerSupport.swift
@@ -42,7 +42,7 @@ StringForPrintObjectTests.test("Basic") {
   let a_printed = printObj(a)
   let a_debug = debugVal(&a)
   expectEqual("Hello World", String(reflecting: a))
-  expectEqual("Hello World\n", a_printed)
+  expectEqual("Hello World\n  - super : NSMutableString\n    - super : NSString\n      - super : NSObject\n", a_printed)
   expectEqual(a_printed, a_debug)
 }
 
@@ -51,7 +51,7 @@ StringForPrintObjectTests.test("NSStringFromStringLiteral") {
   let a_printed = printObj(a)
   let a_debug = debugVal(&a)
   expectEqual("Hello World", String(reflecting: a))
-  expectEqual("Hello World\n", a_printed)
+  expectEqual("Hello World\n  - super : NSMutableString\n    - super : NSString\n      - super : NSObject\n", a_printed)
   expectEqual(a_printed, a_debug)
 }
 
@@ -63,7 +63,7 @@ StringForPrintObjectTests.test("NSStringFromUnsafeBuffer") {
   let a_printed = printObj(a)
   let a_debug = debugVal(&a)
   expectEqual("A", String(reflecting: a))
-  expectEqual("A\n", a_printed)
+  expectEqual("A\n  - super : NSString\n    - super : NSObject\n", a_printed)
   expectEqual(a_printed, a_debug)
   buf.deallocate()
 }
@@ -86,7 +86,7 @@ StringForPrintObjectTests.test("ArrayOfStrings") {
   let a_printed = printObj(a)
   let a_debug = debugVal(&a)
   expectEqual("[Hello World]", String(reflecting: a))
-  expectEqual("▿ 1 element\n  - 0 : Hello World\n", a_printed)
+  expectEqual("▿ 1 element\n  - 0 : Hello World\n    - super : NSMutableString\n      - super : NSString\n        - super : NSObject\n", a_printed)
   expectEqual(a_printed, a_debug)
 }
 
@@ -99,7 +99,7 @@ StringForPrintObjectTests.test("StructWithOneMember") {
   let a_printed = printObj(StructWithOneMember())
   let a_debug = debugVal(&a)
   expectEqual("main.StructWithOneMember(a: Hello World)", String(reflecting: a))
-  expectEqual("▿ StructWithOneMember\n  - a : Hello World\n", a_printed)
+  expectEqual("▿ StructWithOneMember\n  - a : Hello World\n    - super : NSMutableString\n      - super : NSString\n        - super : NSObject\n", a_printed)
   expectEqual(a_printed, a_debug)
 }
 
@@ -113,7 +113,7 @@ StringForPrintObjectTests.test("StructWithTwoMembers") {
   let a_printed = printObj(StructWithTwoMembers())
   let a_debug = debugVal(&a)
   expectEqual("main.StructWithTwoMembers(a: 1, b: Hello World)", String(reflecting: a))
-  expectEqual("▿ StructWithTwoMembers\n  - a : 1\n  - b : Hello World\n", a_printed)
+  expectEqual("▿ StructWithTwoMembers\n  - a : 1\n  - b : Hello World\n    - super : NSMutableString\n      - super : NSString\n        - super : NSObject\n", a_printed)
   expectEqual(a_printed, a_debug)
 }
 

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -21,6 +21,15 @@ class ClassWithMirror: CustomReflectable {
   }
 }
 
+class RecursiveClass {
+  var a = 1
+  var b = "Hello World"
+  var c: RecursiveClass?
+  init() {
+    self.c = self
+  }
+}
+
 #if _runtime(_ObjC)
 struct DontBridgeThisStruct {
   var message = "Hello World"
@@ -61,12 +70,21 @@ StringForPrintObjectTests.test("StructWithMembers") {
   expectEqual(printed, "▿ StructWithMembers\n  - a : 1\n  - b : \"Hello World\"\n")
 }
 
+
 #if _runtime(_ObjC)
 StringForPrintObjectTests.test("ClassWithMembers") {
   let printed = _stringForPrintObject(ClassWithMembers())
-  expectTrue(printed.hasPrefix("<ClassWithMembers: 0x"))
+  expectTrue(printed.hasPrefix("▿ <ClassWithMembers: 0x"))
+  expectTrue(printed.hasSuffix(">\n  - a : 1\n  - b : \"Hello World\"\n"))
 }
 #endif
+
+StringForPrintObjectTests.test("RecursiveClass") {
+  let printed = _stringForPrintObject(RecursiveClass())
+  expectTrue(printed.hasPrefix("▿ <RecursiveClass: 0x"))
+  expectTrue(printed.contains(">\n  - a : 1\n  - b : \"Hello World\"\n  ▿ c : Optional<RecursiveClass>\n    ▿ some : <RecursiveClass: 0x"))
+  expectTrue(printed.hasSuffix("> { ... }\n"))
+}
 
 StringForPrintObjectTests.test("ClassWithMirror") {
   let printed = _stringForPrintObject(ClassWithMirror())


### PR DESCRIPTION
Currently DebuggerSupport prints classes as just an address (when the type doesn't implement one of the description protocols), even though DebuggerSupport could already handle expanding them (including checks for recursive class types. Enable expansion of classes, so DebuggerSupport produces a similar output to structs in the default case.
