### PR TITLE
[AST] ASTDumper: Print overload choices of non-operator `OverloadedDe…

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2128,6 +2128,17 @@ public:
     PrintWithColorRAII(OS, ExprModifierColor)
       << " number_of_decls=" << E->getDecls().size()
       << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());
+    if (!E->isForOperator()) {
+      PrintWithColorRAII(OS, ExprModifierColor) << " decls=[\n";
+      interleave(
+          E->getDecls(),
+          [&](ValueDecl *D) {
+            OS.indent(Indent + 2);
+            D->dumpRef(PrintWithColorRAII(OS, DeclModifierColor).getOS());
+          },
+          [&] { PrintWithColorRAII(OS, DeclModifierColor) << ",\n"; });
+      PrintWithColorRAII(OS, ExprModifierColor) << "]";
+    }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitUnresolvedDeclRefExpr(UnresolvedDeclRefExpr *E) {


### PR DESCRIPTION
…clRefExpr`s

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
