### PR TITLE
Revert "Disable several Backtracing tests on Linux AArch64."

### DIFF
--- a/test/Backtracing/Crash.swift
+++ b/test/Backtracing/Crash.swift
@@ -20,9 +20,6 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-// rdar://110743884
-// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-
 func level1() {
   level2()
 }

--- a/test/Backtracing/CrashAsync.swift
+++ b/test/Backtracing/CrashAsync.swift
@@ -15,9 +15,6 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-// rdar://110743884
-// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-
 @available(SwiftStdlib 5.1, *)
 func crash() {
   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!

--- a/test/Backtracing/CrashWithThunk.swift
+++ b/test/Backtracing/CrashWithThunk.swift
@@ -11,9 +11,6 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-// rdar://110743884
-// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-
 struct Foo<T> {
   var value: T
 }

--- a/test/Backtracing/Overflow.swift
+++ b/test/Backtracing/Overflow.swift
@@ -9,10 +9,6 @@
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
-
-// rdar://110743884
-// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-
 var x: UInt = 0
 
 func level1() {

--- a/test/Backtracing/StackOverflow.swift
+++ b/test/Backtracing/StackOverflow.swift
@@ -12,9 +12,6 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-// rdar://110743884
-// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-
 func recurse(_ level: Int) {
   if level % 100000 == 0 {
     print(level)


### PR DESCRIPTION
This reverts commit 0ceff1ba2d840c3b10c921f01ca90036b7b7ae71.
