### PR TITLE
[Runtime+IRGen] Instantiate layout strings for generic multi payload …

### DIFF
--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -111,6 +111,12 @@ void swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
                                         unsigned numPayloads,
                                         const TypeLayout * const *payloadTypes);
 
+SWIFT_RUNTIME_EXPORT
+void swift_initEnumMetadataMultiPayloadWithLayoutString(EnumMetadata *enumType,
+                                                        EnumLayoutFlags flags,
+                                                        unsigned numPayloads,
+                                          const Metadata * const *payloadTypes);
+
 /// Return an integer value representing which case of a multi-payload
 ///        enum is inhabited.
 ///

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1276,7 +1276,8 @@ FUNCTION(InitStructMetadata,
 // void swift_initStructMetadataWithLayoutString(Metadata *structType,
 //                                               StructLayoutFlags flags,
 //                                               size_t numFields,
-//                                               Metadata * const *fieldTypes,
+//                                               uint8_t * const *fieldTypes,
+//                                               const uint8_t *fieldTags
 //                                               uint32_t *fieldOffsets);
 FUNCTION(InitStructMetadataWithLayoutString,
          swift_initStructMetadataWithLayoutString, C_CC, AlwaysAvailable,
@@ -1312,6 +1313,7 @@ FUNCTION(InitEnumMetadataSinglePayload,
          EFFECT(MetaData))
 
 // void swift_initEnumMetadataMultiPayload(Metadata *enumType,
+//                                         EnumLayoutFlags layoutFlags,
 //                                         size_t numPayloads,
 //                                         TypeLayout * const *payloadTypes);
 FUNCTION(InitEnumMetadataMultiPayload,
@@ -1319,6 +1321,19 @@ FUNCTION(InitEnumMetadataMultiPayload,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy, Int8PtrPtrTy->getPointerTo(0)),
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData))
+
+// void
+// swift_initEnumMetadataMultiPayloadWithLayoutString(Metadata *enumType,
+//                                                  EnumLayoutFlags layoutFlags,
+//                                                    size_t numPayloads,
+//                                              Metadata * const *payloadTypes);
+FUNCTION(InitEnumMetadataMultiPayloadWithLayoutString,
+         swift_initEnumMetadataMultiPayloadWithLayoutString,
+         C_CC, AlwaysAvailable,
+         RETURNS(VoidTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, SizeTy, TypeMetadataPtrPtrTy),
          ATTRS(NoUnwind, WillReturn),
          EFFECT(MetaData))
 

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -663,6 +663,15 @@ namespace {
                                       metadata);
     }
 
+    void initializeMetadataWithLayoutString(IRGenFunction &IGF,
+                            llvm::Value *metadata,
+                            bool isVWTMutable,
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
+      // Not yet supported on this type, so forward to regular method
+      initializeMetadata(IGF, metadata, isVWTMutable, T, collector);
+    }
+
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
       // FIXME: Hold off on registering extra inhabitants for dynamic enums
       // until initializeMetadata handles them.
@@ -956,6 +965,15 @@ namespace {
     }
 
     void initializeMetadata(IRGenFunction &IGF,
+                            llvm::Value *metadata,
+                            bool isVWTMutable,
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
+      // No-payload enums are always fixed-size so never need dynamic value
+      // witness table initialization.
+    }
+
+    void initializeMetadataWithLayoutString(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
                             SILType T,
@@ -3189,6 +3207,15 @@ namespace {
           {metadata, flags, payloadLayout, emptyCasesVal});
     }
 
+    void initializeMetadataWithLayoutString(IRGenFunction &IGF,
+                            llvm::Value *metadata,
+                            bool isVWTMutable,
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
+      // Not yet supported on this type, so forward to regular method
+      initializeMetadata(IGF, metadata, isVWTMutable, T, collector);
+    }
+
     /// \group Extra inhabitants
 
     // Extra inhabitants from the payload that we didn't use for our empty cases
@@ -5259,6 +5286,36 @@ namespace {
       return firstAddr;
     }
 
+    llvm::Value *emitPayloadMetadataArray(IRGenFunction &IGF, SILType T,
+                                 MetadataDependencyCollector *collector) const {
+      auto numPayloads = ElementsWithPayload.size();
+      auto metadataBufferTy = llvm::ArrayType::get(IGM.TypeMetadataPtrTy,
+                                                   numPayloads);
+      auto metadataBuffer = IGF.createAlloca(metadataBufferTy,
+                                             IGM.getPointerAlignment(),
+                                             "payload_types");
+      llvm::Value *firstAddr = nullptr;
+      for (unsigned i = 0; i < numPayloads; ++i) {
+        auto &elt = ElementsWithPayload[i];
+        Address eltAddr = IGF.Builder.CreateStructGEP(metadataBuffer, i,
+                                                  IGM.getPointerSize() * i);
+        if (i == 0) firstAddr = eltAddr.getAddress();
+
+        auto payloadTy =
+            T.getEnumElementType(elt.decl, IGF.getSILModule(),
+                                 IGF.IGM.getMaximalTypeExpansionContext());
+
+        auto request = DynamicMetadataRequest::getNonBlocking(
+          MetadataState::LayoutComplete, collector);
+        auto metadata = IGF.emitTypeMetadataRefForLayout(payloadTy, request);
+
+        IGF.Builder.CreateStore(metadata, eltAddr);
+      }
+      assert(firstAddr && "Expected firstAddr to be assigned to");
+
+      return firstAddr;
+    }
+
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
@@ -5275,6 +5332,25 @@ namespace {
       auto flags = emitEnumLayoutFlags(IGM, isVWTMutable);
       IGF.Builder.CreateCall(
           IGM.getInitEnumMetadataMultiPayloadFunctionPointer(),
+          {metadata, flags, numPayloadsVal, payloadLayoutArray});
+    }
+
+    void initializeMetadataWithLayoutString(IRGenFunction &IGF,
+                            llvm::Value *metadata,
+                            bool isVWTMutable,
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
+      // Fixed-size enums don't need dynamic metadata initialization.
+      if (TIK >= Fixed) return;
+
+      // Ask the runtime to set up the metadata record for a dynamic enum.
+      auto payloadLayoutArray = emitPayloadMetadataArray(IGF, T, collector);
+      auto numPayloadsVal = llvm::ConstantInt::get(IGM.SizeTy,
+                                                   ElementsWithPayload.size());
+
+      auto flags = emitEnumLayoutFlags(IGM, isVWTMutable);
+      IGF.Builder.CreateCall(
+          IGM.getInitEnumMetadataMultiPayloadWithLayoutStringFunctionPointer(),
           {metadata, flags, numPayloadsVal, payloadLayoutArray});
     }
 
@@ -5952,6 +6028,14 @@ namespace {
     }
 
     void initializeMetadata(IRGenFunction &IGF,
+                            llvm::Value *metadata,
+                            bool isVWTMutable,
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
+      llvm_unreachable("resilient enums cannot be defined");
+    }
+
+    void initializeMetadataWithLayoutString(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
                             SILType T,

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -384,6 +384,12 @@ public:
                                   SILType T,
                               MetadataDependencyCollector *collector) const = 0;
 
+  virtual void initializeMetadataWithLayoutString(IRGenFunction &IGF,
+                                                  llvm::Value *metadata,
+                                                  bool isVWTMutable,
+                                                  SILType T,
+                              MetadataDependencyCollector *collector) const = 0;
+
   virtual bool mayHaveExtraInhabitants(IRGenModule &IGM) const = 0;
 
   // Only ever called for fixed types.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3003,16 +3003,17 @@ static void emitInitializeValueMetadata(IRGenFunction &IGF,
                                         MetadataDependencyCollector *collector) {
   auto &IGM = IGF.IGM;
   auto loweredTy = IGM.getLoweredType(nominalDecl->getDeclaredTypeInContext());
+  bool useLayoutStrings = IGM.Context.LangOpts.hasFeature(Feature::LayoutStringValueWitnesses) &&
+        IGM.Context.LangOpts.hasFeature(
+            Feature::LayoutStringValueWitnessesInstantiation) &&
+        IGM.getOptions().EnableLayoutStringValueWitnesses &&
+        IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation;
 
   if (isa<StructDecl>(nominalDecl)) {
     auto &fixedTI = IGM.getTypeInfo(loweredTy);
     if (isa<FixedTypeInfo>(fixedTI)) return;
 
-    if (IGM.Context.LangOpts.hasFeature(Feature::LayoutStringValueWitnesses) &&
-        IGM.Context.LangOpts.hasFeature(
-            Feature::LayoutStringValueWitnessesInstantiation) &&
-        IGM.getOptions().EnableLayoutStringValueWitnesses &&
-        IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation) {
+    if (useLayoutStrings) {
       emitInitializeFieldOffsetVectorWithLayoutString(IGF, loweredTy, metadata,
                                                       isVWTMutable, collector);
     } else {
@@ -3021,9 +3022,16 @@ static void emitInitializeValueMetadata(IRGenFunction &IGF,
     }
   } else {
     assert(isa<EnumDecl>(nominalDecl));
+
     auto &strategy = getEnumImplStrategy(IGM, loweredTy);
-    strategy.initializeMetadata(IGF, metadata, isVWTMutable, loweredTy,
-                                collector);
+
+    if (useLayoutStrings) {
+      strategy.initializeMetadataWithLayoutString(IGF, metadata, isVWTMutable,
+                                                  loweredTy, collector);
+    } else {
+      strategy.initializeMetadata(IGF, metadata, isVWTMutable, loweredTy,
+                                  collector);
+    }
   }
 }
 
@@ -5721,10 +5729,28 @@ namespace {
       return {global, offset, structSize};
     }
 
+    bool hasLayoutString() {
+      if (!IGM.Context.LangOpts.hasFeature(
+              Feature::LayoutStringValueWitnesses) ||
+          !IGM.getOptions().EnableLayoutStringValueWitnesses) {
+        return false;
+      }
+
+      auto &strategy = getEnumImplStrategy(IGM, getLoweredType());
+
+      return !!getLayoutString() ||
+             (IGM.Context.LangOpts.hasFeature(
+                 Feature::LayoutStringValueWitnessesInstantiation) &&
+              IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation &&
+                    (HasDependentVWT || HasDependentMetadata) &&
+                      !isa<FixedTypeInfo>(IGM.getTypeInfo(getLoweredType())) &&
+                      strategy.getElementsWithPayload().size() > 1);
+    }
+
     llvm::Constant *emitNominalTypeDescriptor() {
       return EnumContextDescriptorBuilder(
                  IGM, Target, RequireMetadata,
-                 /*hasLayoutString*/ !!getLayoutString())
+                 /*hasLayoutString*/ hasLayoutString())
           .emit();
     }
 
@@ -5746,7 +5772,7 @@ namespace {
 
     bool hasCompletionFunction() {
       return !isa<FixedTypeInfo>(IGM.getTypeInfo(getLoweredType())) ||
-             !!getLayoutString();
+             hasLayoutString();
     }
   };
 

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -891,6 +891,9 @@ bool isRuntimeInstatiatedLayoutString(IRGenModule &IGM,
       IGM.Context.LangOpts.hasFeature(
           Feature::LayoutStringValueWitnessesInstantiation) &&
       IGM.getOptions().EnableLayoutStringValueWitnessesInstantiation) {
+    if (auto *enumEntry = typeLayoutEntry->getAsEnum()) {
+      return enumEntry->isMultiPayloadEnum();
+    }
     return (typeLayoutEntry->isAlignedGroup() &&
             !typeLayoutEntry->isFixedSize(IGM));
   }

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -83,6 +83,7 @@ public:
     MultiPayloadEnumFN = 0x13,
     // reserved
     // MultiPayloadEnumFNResolved = 0x14,
+    // MultiPayloadEnumGeneric = 0x15,
 
     Skip = 0x80,
     // We may use the MSB as flag that a count follows,

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -49,6 +49,7 @@ enum class RefCountingKind : uint8_t {
 
   MultiPayloadEnumFN = 0x13,
   MultiPayloadEnumFNResolved = 0x14,
+  MultiPayloadEnumGeneric = 0x15,
 
   Skip = 0x80,
   // We may use the MSB as flag that a count follows,

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -306,7 +306,7 @@ enum TestEnum {
 
 func testGenericWithEnumNonEmpty() {
     let ptr = allocateInternalGenericPtr(of: TestEnum.self)
-    
+
     do {
         let x = TestClass()
         testGenericInit(ptr, to: TestEnum.nonEmpty(x))
@@ -336,7 +336,7 @@ public struct ResilientWrapper {
 
 func testResilient() {
     let ptr = UnsafeMutablePointer<ResilientWrapper>.allocate(capacity: 1)
-    
+
     do {
         let x = TestClass()
         testInit(ptr, to: ResilientWrapper(x: SimpleResilient(x: 23, y: x), y: 5))
@@ -369,7 +369,7 @@ public struct GenericResilientWrapper<T> {
 
 func testGenericResilient() {
     let ptr = UnsafeMutablePointer<GenericResilientWrapper<TestClass>>.allocate(capacity: 1)
-    
+
     do {
         let x = TestClass()
         testInit(ptr, to: GenericResilientWrapper(x: GenericResilient(x: x, y: 32), y: 32))


### PR DESCRIPTION
…enum

Instantiating layout strings for generic types reduces code size and is expected to improve performance of generic value witnesses.