### PR TITLE
[TypeResolution] Ban local variable packs

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -457,6 +457,13 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
       return &pbe;
     }
 
+    // Local variable packs are not allowed.
+    if (binding->getDeclContext()->isLocalContext() &&
+        binding->getInit(entryNumber)->getType()->is<PackExpansionType>()) {
+      binding->diagnose(diag::expansion_not_allowed,
+                        binding->getInit(entryNumber)->getType());
+    }
+
     // A pattern binding at top level is not allowed to pick up another decl's
     // opaque result type as its type by type inference.
     if (!binding->getDeclContext()->isLocalContext() &&

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4617,7 +4617,7 @@ NeverNullType TypeResolver::resolvePackExpansionType(PackExpansionTypeRepr *repr
   }
 
   // We might not allow variadic expansions here at all.
-  if (!options.isPackExpansionSupported(getDeclContext())) {
+  if (!options.isPackExpansionSupported()) {
     diagnose(repr->getLoc(), diag::expansion_not_allowed, result);
     return ErrorType::get(ctx);
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -335,7 +335,7 @@ public:
   }
 
   /// Whether pack expansion types are supported in this context.
-  bool isPackExpansionSupported(DeclContext *dc) const {
+  bool isPackExpansionSupported() const {
     switch (context) {
     case Context::FunctionInput:
     case Context::VariadicFunctionInput:
@@ -343,12 +343,7 @@ public:
     case Context::TupleElement:
     case Context::GenericArgument:
       return true;
-
-    // Local variable packs are supported, but property packs
-    // are not.
     case Context::PatternBindingDecl:
-      return !dc->isTypeContext();
-
     case Context::None:
     case Context::ProtocolGenericArgument:
     case Context::Inherited:

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -36,6 +36,7 @@ func coerceExpansion<each T>(_ value: repeat each T) {
 
 func localValuePack<each T>(_ t: repeat each T) -> (repeat each T, repeat each T) {
   let local = repeat each t
+  // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
   let localAnnotated: repeat each T = repeat each t
   // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -37,7 +37,7 @@ func coerceExpansion<each T>(_ value: repeat each T) {
 func localValuePack<each T>(_ t: repeat each T) -> (repeat each T, repeat each T) {
   let local = repeat each t
   let localAnnotated: repeat each T = repeat each t
-  // expected-error@-1{{value pack expansion can only appear inside a function argument list or tuple element}}
+  // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
 
   return (repeat each local, repeat each localAnnotated)
 }


### PR DESCRIPTION
This change bans local variable packs as they are not supported. 
* Undo #61755.
* Add a check for the case where this type is inferred.
