### PR TITLE
[Backtracing][Linux] Properly align the stacks.

### DIFF
--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -796,7 +796,7 @@ struct spawn_info {
   int memserver;
 };
 
-uint8_t spawn_stack[4096];
+uint8_t spawn_stack[4096] __attribute__((aligned(SWIFT_PAGE_SIZE)));
 
 int
 do_spawn(void *ptr) {

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -607,7 +607,7 @@ wait_paused(uint32_t expected, const struct timespec *timeout)
    We don't want to require CAP_SYS_PTRACE because we're potentially being
    used inside of a Docker container, which won't have that enabled. */
 
-char memserver_stack[4096];
+char memserver_stack[4096] __attribute__((aligned(SWIFT_PAGE_SIZE)));
 char memserver_buffer[4096];
 int memserver_fd;
 bool memserver_has_ptrace;


### PR DESCRIPTION
We have two stacks that we set up during crash handling, both of which were potentially misaligned.  This only tripped us up on Ubuntu 20.04 on aarch64 - my guess is that maybe `clone()` aligns the stack pointer on newer kernels which is why we didn't see it on 22.04.

rdar://110743884
