### PR TITLE
[5.9][Test] Use SyntaxRewriter.rewrite not visit

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -164,7 +164,7 @@ public enum AddBlocker: ExpressionMacro {
     in context: some MacroExpansionContext
   ) -> ExprSyntax {
     let visitor = AddVisitor()
-    let result = visitor.visit(Syntax(node))
+    let result = visitor.rewrite(Syntax(node))
 
     for diag in visitor.diagnostics {
       context.diagnose(diag)


### PR DESCRIPTION
* Explanation: Updates macro tests to use `SyntaxRewriter.rewrite` rather than `visit`, which is the intended API for rewriting (visit is more of an internal detail).
* Scope: Tests
* Risk: None, just updates a test.
* Original PR: https://github.com/apple/swift/pull/66569