### PR TITLE
[Diagnostics] Suppress printing explicit pack types in the ASTPrinter instead of stripping `PackType` out of diagnostic arguments.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -553,6 +553,12 @@ struct PrintOptions {
   /// Whether to always desugar optional types from `base_type?` to `Optional<base_type>`
   bool AlwaysDesugarOptionalTypes = false;
 
+  /// Whether to always print explicit `Pack{...}` around pack
+  /// types.
+  ///
+  /// This is set to \c false for diagnostic arguments.
+  bool PrintExplicitPackTypes = true;
+
   /// \see ShouldQualifyNestedDeclarations
   enum class QualifyNestedDeclarations {
     Never,
@@ -606,6 +612,7 @@ struct PrintOptions {
   /// The print options used for formatting diagnostic arguments.
   static PrintOptions forDiagnosticArguments() {
     PrintOptions result;
+    result.PrintExplicitPackTypes = false;
     return result;
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6051,7 +6051,8 @@ public:
   }
 
   void visitPackType(PackType *T) {
-    Printer << "Pack{";
+    if (Options.PrintExplicitPackTypes)
+      Printer << "Pack{";
 
     auto Fields = T->getElementTypes();
     for (unsigned i = 0, e = Fields.size(); i != e; ++i) {
@@ -6060,7 +6061,9 @@ public:
       Type EltType = Fields[i];
       visit(EltType);
     }
-    Printer << "}";
+
+    if (Options.PrintExplicitPackTypes)
+      Printer << "}";
   }
 
   void visitSILPackType(SILPackType *T) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -120,14 +120,6 @@ Type FailureDiagnostic::resolveType(Type rawType, bool reconstituteSugar,
       return env->mapElementTypeIntoPackContext(type);
     }
 
-    if (auto *packType = type->getAs<PackType>()) {
-      if (packType->getNumElements() == 1) {
-        auto eltType = resolveType(packType->getElementType(0));
-        if (auto expansion = eltType->getAs<PackExpansionType>())
-          return expansion->getPatternType();
-      }
-    }
-
     return type->isPlaceholder() ? Type(type->getASTContext().TheUnresolvedType)
                                  : type;
   });

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -839,6 +839,7 @@ static std::string gatherGenericParamBindingsText(
 
   SmallString<128> result;
   llvm::raw_svector_ostream OS(result);
+  auto options = PrintOptions::forDiagnosticArguments();
 
   for (auto gp : genericParams) {
     auto canonGP = gp->getCanonicalType()->castTo<GenericTypeParamType>();
@@ -860,19 +861,7 @@ static std::string gatherGenericParamBindingsText(
     if (!type)
       return "";
 
-    if (auto *packType = type->getAs<PackType>()) {
-      bool first = true;
-      for (auto eltType : packType->getElementTypes()) {
-        if (first)
-          first = false;
-        else
-          OS << ", ";
-
-        OS << eltType;
-      }
-    } else {
-      OS << type.getString();
-    }
+    type->print(OS, options);
   }
 
   OS << "]";

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -138,7 +138,7 @@ func tupleExpansion<each T, each U>(
   _ = zip(repeat each tuple1, with: repeat each tuple1.element) // legacy syntax
 
   _ = zip(repeat each tuple1, with: repeat each tuple2)
-  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each T' and 'each U' have the same shape}}
+  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'repeat each T' and 'repeat each U' have the same shape}}
 
   _ = forward(repeat each tuple3)
 }

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -240,9 +240,9 @@ func patternInstantiationConcreteValid() {
 
 func patternInstantiationConcreteInvalid() {
   let _: Set<Int> = patternInstantiationTupleTest1()
-  // expected-error@-1 {{cannot convert value of type '(repeat Array<Pack{_}>)' to specified type 'Set<Int>'}}
+  // expected-error@-1 {{cannot convert value of type '(repeat Array<_>)' to specified type 'Set<Int>'}}
 
-  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Pack{Int, _}>)' is not convertible to '(Array<Int>, Set<String>)', tuples have a different number of elements}}
+  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Int, _>)' is not convertible to '(Array<Int>, Set<String>)', tuples have a different number of elements}}
 }
 
 func patternInstantiationGenericValid<each T, each U>(t: repeat each T, u: repeat each U)
@@ -272,7 +272,7 @@ func patternInstantiationGenericInvalid<each T: Hashable>(t: repeat each T) {
   let _: (repeat Set<each T>) = patternInstantiationTupleTest1() // expected-error {{cannot convert value of type '(repeat Array<each T>)' to specified type '(repeat Set<each T>)}}
   // expected-error@-1 {{generic parameter 'each T' could not be inferred}}
 
-  let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<Pack{repeat each T, _}>)' is not convertible to '(repeat Array<each T>, Set<String>)', tuples have a different number of elements}}
+  let _: (repeat Array<each T>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{'(repeat Array<repeat each T, _>)' is not convertible to '(repeat Array<each T>, Set<String>)', tuples have a different number of elements}}
 }
 
 // rdar://107996926 - Vanishing metatype of tuple not supported

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -65,7 +65,7 @@ let _ = zip(t: 1, u: "hi")  // ok
 let _ = zip(t: 1, 2, u: "hi", "hello")  // ok
 let _ = zip(t: 1, 2, 3, u: "hi", "hello", "greetings")  // ok
 let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{extra arguments at positions #3, #4 in call}}
-// expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'Pack{Int}' and 'Pack{String, String, String}' have the same shape}}
+// expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'Int' and 'String, String, String' have the same shape}}
 
 func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any {
   _ = zip(t: repeat each t, u: repeat each u)
@@ -73,5 +73,5 @@ func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (re
 
 func badCallToZip<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = zip(t: repeat each t, u: repeat each u)
-  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each T' and 'each U' have the same shape}}
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'repeat each T' and 'repeat each U' have the same shape}}
 }

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -22,3 +22,10 @@ func g<each T>(_: repeat each T) {
   // expected-error@-1 {{pack expansion 'Int' must contain at least one pack reference}}
   // expected-error@-2 {{'each' cannot be applied to non-pack type 'Int'}}{{15-19=}}
 }
+
+struct MissingMemberError<each T> {
+  init() {
+    self.doesNotExist = 1
+    // expected-error@-1 {{value of type 'MissingMemberError<repeat each T>' has no member 'doesNotExist'}}
+  }
+}

--- a/test/Generics/variadic_generic_requirements.swift
+++ b/test/Generics/variadic_generic_requirements.swift
@@ -30,8 +30,8 @@ struct Outer<each T: Sequence> {
 }
 
 _ = Outer<Array<Int>, Array<String>>.Inner<Set<Int>, Set<String>>.self  // ok
-_ = Outer<Array<Int>, Array<String>>.Inner<Set<String>, Set<Int>>.self  // expected-error {{'Outer<Array<Int>, Array<String>>.Inner' requires the types 'Pack{Int, String}' and 'Pack{String, Int}' be equivalent}}
-_ = Outer<Array<Int>>.Inner<Set<Int>, Set<String>>.self  // expected-error {{'Outer<Array<Int>>.Inner' requires the types 'Pack{Int}' and 'Pack{Int, String}' be equivalent}}
+_ = Outer<Array<Int>, Array<String>>.Inner<Set<String>, Set<Int>>.self  // expected-error {{'Outer<Array<Int>, Array<String>>.Inner' requires the types 'Int, String' and 'String, Int' be equivalent}}
+_ = Outer<Array<Int>>.Inner<Set<Int>, Set<String>>.self  // expected-error {{'Outer<Array<Int>>.Inner' requires the types 'Int' and 'Int, String' be equivalent}}
 
 _ = Outer<Array<Int>, Array<String>>.InnerShape<Set<String>, Set<Int>>.self  // ok
-_ = Outer<Array<Int>>.InnerShape<Set<Int>, Set<String>>.self  // expected-error {{'Outer<Array<Int>>.InnerShape' requires the type packs 'Pack{Array<Int>}' and 'Pack{Set<Int>, Set<String>}' have the same shape}}
+_ = Outer<Array<Int>>.InnerShape<Set<Int>, Set<String>>.self  // expected-error {{'Outer<Array<Int>>.InnerShape' requires the type packs 'Array<Int>' and 'Set<Int>, Set<String>' have the same shape}}


### PR DESCRIPTION
There are places in the type printing code that assume the substitution for a type parameter pack is always a pack, and violating that invariant will crash the compiler. We also never want to print `Pack{...}` in diagnostics anyway, so the print option is a better approach and fixes a few existing tests that still contained `Pack{...}` in error messages.

Resolves https://github.com/apple/swift/issues/66395, rdar://110180564