### PR TITLE
AST: Fix logic error in TypeMatcher::visitParameterizedProtocolType()

### DIFF
--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -438,10 +438,12 @@ class TypeMatcher {
 
         if (firstArgs.size() == secondArgs.size()) {
           for (unsigned i : indices(firstArgs)) {
-            return this->visit(CanType(firstArgs[i]),
-                               secondArgs[i],
-                               sugaredFirstType->castTo<ParameterizedProtocolType>()
-                                   ->getArgs()[i]);
+            if (!this->visit(CanType(firstArgs[i]),
+                             secondArgs[i],
+                             sugaredFirstType->castTo<ParameterizedProtocolType>()
+                                 ->getArgs()[i])) {
+              return false;
+            }
           }
 
           return true;

--- a/test/Generics/issue-63410.swift
+++ b/test/Generics/issue-63410.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Derived<A, B> where C == any Derived<Never, B> {
+  associatedtype A
+  associatedtype B
+
+  associatedtype C
+}


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/63410.