### PR TITLE
Super-level sendable checking for function parameters in overrides and conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5176,8 +5176,8 @@ WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %4 %2 %3|"
         "exiting %4 context in call to non-isolated %2 %3|"
         "passed in implicitly asynchronous call to %4 %2 %3|"
-        "in parameter of %4 %2 %3 satisfying protocol requirement|"
-        "in parameter of %4 overriding %2 %3|"
+        "in parameter of the protocol requirement satisfied by %4 %2 %3|"
+        "in parameter of superclass method overridden by %4 %2 %3|"
         "in parameter of %4 '@objc' %2 %3}1 cannot cross actor boundary",
         (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
 WARNING(non_sendable_call_param_type,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1003,8 +1003,9 @@ bool swift::diagnoseNonSendableTypes(
 }
 
 bool swift::diagnoseNonSendableTypesInReference(
-    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
-    SendableCheckReason reason, Optional<ActorIsolation> knownIsolation) {
+    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc refLoc,
+    SendableCheckReason refKind, Optional<ActorIsolation> knownIsolation,
+    FunctionCheckKind funcCheckKind, SourceLoc diagnoseLoc) {
 
   // Retrieve the actor isolation to use in diagnostics.
   auto getActorIsolation = [&] {
@@ -1017,23 +1018,31 @@ bool swift::diagnoseNonSendableTypesInReference(
   // For functions, check the parameter and result types.
   SubstitutionMap subs = declRef.getSubstitutions();
   if (auto function = dyn_cast<AbstractFunctionDecl>(declRef.getDecl())) {
-    for (auto param : *function->getParameters()) {
-      Type paramType = param->getInterfaceType().subst(subs);
-      if (diagnoseNonSendableTypes(
-              paramType, fromDC, loc, diag::non_sendable_param_type,
-              (unsigned)reason, function->getDescriptiveKind(),
-              function->getName(), getActorIsolation()))
-        return true;
+    if (funcCheckKind != FunctionCheckKind::Results) {
+      // only check params if funcCheckKind specifies so
+      for (auto param : *function->getParameters()) {
+        Type paramType = param->getInterfaceType().subst(subs);
+        if (diagnoseNonSendableTypes(
+            paramType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
+                diag::non_sendable_param_type,
+            (unsigned)refKind, function->getDescriptiveKind(),
+            function->getName(), getActorIsolation()))
+          return true;
+      }
     }
 
     // Check the result type of a function.
     if (auto func = dyn_cast<FuncDecl>(function)) {
-      Type resultType = func->getResultInterfaceType().subst(subs);
-      if (diagnoseNonSendableTypes(
-              resultType, fromDC, loc, diag::non_sendable_result_type,
-              (unsigned)reason, func->getDescriptiveKind(), func->getName(),
-              getActorIsolation()))
-        return true;
+      if (funcCheckKind != FunctionCheckKind::Params) {
+        // only check results if funcCheckKind specifies so
+        Type resultType = func->getResultInterfaceType().subst(subs);
+        if (diagnoseNonSendableTypes(
+            resultType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
+                diag::non_sendable_result_type,
+            (unsigned)refKind, func->getDescriptiveKind(), func->getName(),
+            getActorIsolation()))
+          return true;
+      }
     }
 
     return false;
@@ -1044,32 +1053,39 @@ bool swift::diagnoseNonSendableTypesInReference(
         ? var->getType()
         : var->getValueInterfaceType().subst(subs);
     if (diagnoseNonSendableTypes(
-            propertyType, fromDC, loc,
+            propertyType, fromDC, refLoc,
             diag::non_sendable_property_type,
             var->getDescriptiveKind(), var->getName(),
             var->isLocalCapture(),
-            (unsigned)reason,
+            (unsigned)refKind,
             getActorIsolation()))
       return true;
   }
 
   if (auto subscript = dyn_cast<SubscriptDecl>(declRef.getDecl())) {
     for (auto param : *subscript->getIndices()) {
-      Type paramType = param->getInterfaceType().subst(subs);
-      if (diagnoseNonSendableTypes(
-              paramType, fromDC, loc, diag::non_sendable_param_type,
-              (unsigned)reason, subscript->getDescriptiveKind(),
-              subscript->getName(), getActorIsolation()))
-        return true;
+      if (funcCheckKind != FunctionCheckKind::Results) {
+        // Check params of this subscript override for sendability
+        Type paramType = param->getInterfaceType().subst(subs);
+        if (diagnoseNonSendableTypes(
+                paramType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
+                diag::non_sendable_param_type,
+                (unsigned)refKind, subscript->getDescriptiveKind(),
+                subscript->getName(), getActorIsolation()))
+          return true;
+      }
     }
 
-    // Check the element type of a subscript.
-    Type resultType = subscript->getElementInterfaceType().subst(subs);
-    if (diagnoseNonSendableTypes(
-            resultType, fromDC, loc, diag::non_sendable_result_type,
-            (unsigned)reason, subscript->getDescriptiveKind(),
-            subscript->getName(), getActorIsolation()))
-      return true;
+    if (funcCheckKind != FunctionCheckKind::Results) {
+      // Check the element type of a subscript.
+      Type resultType = subscript->getElementInterfaceType().subst(subs);
+      if (diagnoseNonSendableTypes(
+          resultType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
+              diag::non_sendable_result_type,
+          (unsigned)refKind, subscript->getDescriptiveKind(),
+          subscript->getName(), getActorIsolation()))
+        return true;
+    }
 
     return false;
   }
@@ -3892,7 +3908,7 @@ static ActorIsolation getOverriddenIsolationFor(ValueDecl *value) {
   return isolation.subst(subs);
 }
 
-static ConcreteDeclRef getDeclRefInContext(ValueDecl *value) {
+ConcreteDeclRef swift::getDeclRefInContext(ValueDecl *value) {
   auto declContext = value->getInnermostDeclContext();
   if (auto genericEnv = declContext->getGenericEnvironmentOfContext()) {
     return ConcreteDeclRef(
@@ -4368,9 +4384,18 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
     return;
 
   case OverrideIsolationResult::Sendable:
+    // Check that the results of the overriding method are sendable
     diagnoseNonSendableTypesInReference(
         getDeclRefInContext(value), value->getInnermostDeclContext(),
-        value->getLoc(), SendableCheckReason::Override);
+        value->getLoc(), SendableCheckReason::Override,
+        getActorIsolation(value), FunctionCheckKind::Results);
+
+    // Check that the parameters of the overridden method are sendable
+    diagnoseNonSendableTypesInReference(
+        getDeclRefInContext(overridden), overridden->getInnermostDeclContext(),
+        overridden->getLoc(), SendableCheckReason::Override,
+        getActorIsolation(value), FunctionCheckKind::Params,
+        value->getLoc());
     return;
 
   case OverrideIsolationResult::Disallowed:

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -246,6 +246,17 @@ public:
   operator Kind() const { return kind; }
 };
 
+/// Specifies whether checks applied to function types should
+/// apply to their params, results, or both
+enum class FunctionCheckKind {
+  /// Check params and results
+  ParamsResults,
+  /// Check params only
+  Params,
+  /// Check results only
+  Results,
+};
+
 /// Diagnose the presence of any non-sendable types when referencing a
 /// given declaration from a particular declaration context.
 ///
@@ -260,17 +271,26 @@ public:
 ///
 /// \param fromDC The context from which the reference occurs.
 ///
-/// \param loc The location at which the reference occurs, which will be
+/// \param refLoc The location at which the reference occurs, which will be
 /// used when emitting diagnostics.
 ///
 /// \param refKind Describes what kind of reference is being made, which is
 /// used to tailor the diagnostic.
 ///
+/// \param funcCheckKind Describes whether function types in this reference
+/// should be checked for sendability of their results, params, or both
+///
+/// \param diagnoseLoc Provides an alternative source location to `refLoc`
+/// to be used for reporting the top level diagnostic while auxiliary
+/// warnings and diagnostics are reported at `refLoc`.
+///
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonSendableTypesInReference(
-    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
+    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc refLoc,
     SendableCheckReason refKind,
-    Optional<ActorIsolation> knownIsolation = None);
+    Optional<ActorIsolation> knownIsolation = None,
+    FunctionCheckKind funcCheckKind = FunctionCheckKind::ParamsResults,
+    SourceLoc diagnoseLoc = SourceLoc());
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(
@@ -282,6 +302,9 @@ void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
 
 /// Warn about deprecated `Executor.enqueue` implementations.
 void tryDiagnoseExecutorConformance(ASTContext &C, const NominalTypeDecl *nominal, ProtocolDecl *proto);
+
+// Get a concrete reference to a declaration
+ConcreteDeclRef getDeclRefInContext(ValueDecl *value);
 
 /// How the Sendable check should be performed.
 enum class SendableCheck {
@@ -362,6 +385,37 @@ namespace detail {
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
 ///
+/// \param typeLoc is the source location of the type being diagnosed
+///
+/// \param diagnoseLoc is the source location at which the main diagnostic should
+/// be reported, which can differ from typeLoc
+///
+/// \returns \c true if any errors were produced, \c false if no diagnostics or
+/// only warnings and notes were produced.
+template<typename ...DiagArgs>
+bool diagnoseNonSendableTypes(
+    Type type, SendableCheckContext fromContext,
+    SourceLoc typeLoc, SourceLoc diagnoseLoc,
+    Diag<Type, DiagArgs...> diag,
+    typename detail::Identity<DiagArgs>::type ...diagArgs) {
+
+    ASTContext &ctx = fromContext.fromDC->getASTContext();
+    return diagnoseNonSendableTypes(
+        type, fromContext, typeLoc, [&](Type specificType,
+                                        DiagnosticBehavior behavior) {
+
+          if (behavior != DiagnosticBehavior::Ignore) {
+            ctx.Diags.diagnose(diagnoseLoc, diag, type, diagArgs...)
+                .limitBehavior(behavior);
+          }
+
+          return false;
+        });
+}
+
+/// Diagnose any non-Sendable types that occur within the given type, using
+/// the given diagnostic.
+///
 /// \returns \c true if any errors were produced, \c false if no diagnostics or
 /// only warnings and notes were produced.
 template<typename ...DiagArgs>
@@ -369,17 +423,9 @@ bool diagnoseNonSendableTypes(
     Type type, SendableCheckContext fromContext, SourceLoc loc,
     Diag<Type, DiagArgs...> diag,
     typename detail::Identity<DiagArgs>::type ...diagArgs) {
-  ASTContext &ctx = fromContext.fromDC->getASTContext();
-  return diagnoseNonSendableTypes(
-      type, fromContext, loc, [&](Type specificType,
-      DiagnosticBehavior behavior) {
-    if (behavior != DiagnosticBehavior::Ignore) {
-      ctx.Diags.diagnose(loc, diag, type, diagArgs...)
-        .limitBehavior(behavior);
-    }
 
-    return false;
-  });
+    return diagnoseNonSendableTypes(type, fromContext, loc, loc, diag,
+                             std::forward<decltype(diagArgs)>(diagArgs)...);
 }
 
 /// Diagnose this sendability error with behavior based on the import of

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3006,16 +3006,6 @@ static bool hasExplicitGlobalActorAttr(ValueDecl *decl) {
 
 Optional<ActorIsolation> ConformanceChecker::checkActorIsolation(
     ValueDecl *requirement, ValueDecl *witness) {
-  /// Retrieve a concrete witness for Sendable checking.
-  auto getConcreteWitness = [&] {
-    if (auto genericEnv = witness->getInnermostDeclContext()
-            ->getGenericEnvironmentOfContext()) {
-      return ConcreteDeclRef(
-          witness, genericEnv->getForwardingSubstitutionMap());
-    }
-
-    return ConcreteDeclRef(witness);
-  };
 
   // Determine the isolation of the requirement itself.
   auto requirementIsolation = getActorIsolation(requirement);
@@ -3031,7 +3021,7 @@ Optional<ActorIsolation> ConformanceChecker::checkActorIsolation(
     loc = Conformance->getLoc();
 
   auto refResult = ActorReferenceResult::forReference(
-      getConcreteWitness(), witness->getLoc(), DC, None, None,
+      getDeclRefInContext(witness), witness->getLoc(), DC, None, None,
       None, requirementIsolation);
   bool sameConcurrencyDomain = false;
   switch (refResult) {
@@ -3048,7 +3038,7 @@ Optional<ActorIsolation> ConformanceChecker::checkActorIsolation(
 
   case ActorReferenceResult::ExitsActorToNonisolated:
     diagnoseNonSendableTypesInReference(
-        getConcreteWitness(), DC, loc, SendableCheckReason::Conformance);
+        getDeclRefInContext(witness), DC, loc, SendableCheckReason::Conformance);
     return None;
 
   case ActorReferenceResult::EntersActor:
@@ -3130,8 +3120,19 @@ Optional<ActorIsolation> ConformanceChecker::checkActorIsolation(
         witness->getAttrs().hasAttribute<NonisolatedAttr>())
       return None;
 
+    // Check that the results of the witnessing method are sendable
     diagnoseNonSendableTypesInReference(
-        getConcreteWitness(), DC, loc, SendableCheckReason::Conformance);
+        getDeclRefInContext(witness), DC, loc, SendableCheckReason::Conformance,
+        getActorIsolation(witness), FunctionCheckKind::Results);
+
+    // If this requirement is a function, check that its parameters are Sendable as well
+    if (isa<AbstractFunctionDecl>(requirement)) {
+      diagnoseNonSendableTypesInReference(
+          getDeclRefInContext(requirement),
+          requirement->getInnermostDeclContext(), requirement->getLoc(),
+          SendableCheckReason::Conformance, getActorIsolation(witness),
+          FunctionCheckKind::Params, loc);
+    }
 
     // If the witness is accessible across actors, we don't need to consider it
     // isolated.

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -223,7 +223,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of actor-isolated instance method 'asyncMethod' satisfying protocol requirement cannot cross actor boundary}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of the protocol requirement satisfied by actor-isolated instance method 'asyncMethod' cannot cross actor boundary}}
 }
 
 protocol MainActorProto {
@@ -232,7 +232,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' satisfying protocol requirement cannot cross actor boundary}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of the protocol requirement satisfied by global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' cannot cross actor boundary}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -113,3 +113,106 @@ class SendableSubclass: NSClass, @unchecked Sendable { }
 func testSubclassing(obj: SendableSubclass) async {
   acceptCV(obj) // okay!
 }
+
+
+@available(SwiftStdlib 5.1, *)
+protocol P {
+  func foo (x : @Sendable () -> ()) async -> ()
+
+  func bar(x : () -> ()) async -> ()
+  // expected-note@-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+  func foo2<T : Sendable>(x : T) async -> ()
+
+  func bar2<T>(x : T) async -> ()
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+}
+
+// Make sure conformance to protocols checks sendability of
+// requirement parameters not witness parameters
+@available(SwiftStdlib 5.1, *)
+        actor A : P {
+  func foo(x : () -> ()) -> () {}
+
+  func bar(x : () -> ()) -> () {}
+  // expected-warning@-1 {{non-sendable type '() -> ()' in parameter of the protocol requirement satisfied by actor-isolated instance method 'bar(x:)' cannot cross actor boundary}}
+
+  func foo2<T>(x : T) -> () {}
+
+  func bar2<T>(x : T) -> () {}
+  // expected-warning@-1 {{non-sendable type 'T' in parameter of the protocol requirement satisfied by actor-isolated instance method 'bar2(x:)' cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+class Super {
+  @MainActor
+  func foo (x : @Sendable () -> ()) async {}
+
+  @MainActor
+  func bar (x : () -> ()) async {}
+  // expected-note@-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+  @MainActor
+  func foo2<T : Sendable>(x: T) async {}
+
+  @MainActor
+  func bar2<T>(x: T) async {}
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+}
+
+// Make sure isolation crossing overrides check sendability
+// of superclass parameters not subclass parameters
+@available(SwiftStdlib 5.1, *)
+class Sub : Super {
+  override nonisolated func foo(x : () -> ()) async {}
+
+  override nonisolated func bar(x : () -> ()) async {}
+  // expected-warning@-1 {{non-sendable type '() -> ()' in parameter of superclass method overridden by nonisolated instance method 'bar(x:)' cannot cross actor boundary}}
+
+  override nonisolated func foo2<T>(x: T) async {}
+
+  override nonisolated func bar2<T>(x: T) async {}
+  // expected-warning@-1 {{non-sendable type 'T' in parameter of superclass method overridden by nonisolated instance method 'bar2(x:)' cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+class SuperWSafeSubscript {
+  @MainActor
+  subscript<T : Sendable>(x : T) -> Int {
+    get async {
+      return 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+class SubWSafeSubscript : SuperWSafeSubscript {
+  override nonisolated subscript<T>(x : T) -> Int {
+    get async {
+      return 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+class SuperWUnsafeSubscript {
+  @MainActor
+  subscript<T>(x : T) -> Int {
+    // expected-note@-1 2{{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+    get async {
+      return 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+class SubWUnsafeSubscript : SuperWUnsafeSubscript {
+  override nonisolated subscript<T>(x : T) -> Int {
+    get async {
+      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated subscript 'subscript(_:)' cannot cross actor boundary}}
+      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated getter '_' cannot cross actor boundary}}
+      // there really shouldn't be two warnings produced here, see rdar://110846040 (Sendable diagnostics reported twice for subscript getters)
+      return 0
+    }
+  }
+}

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -19,10 +19,10 @@ class Super {
 @available(SwiftStdlib 5.1, *)
 class Sub: Super {
   @MainActor override func f(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of main actor-isolated overriding instance method 'f' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of superclass method overridden by main actor-isolated instance method 'f' cannot cross actor boundary}}
 
   nonisolated override func g1(_: NotSendable) { } // okay, synchronous
 
   nonisolated override func g2(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of nonisolated overriding instance method 'g2' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of superclass method overridden by nonisolated instance method 'g2' cannot cross actor boundary}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Sendable checking for overrides and protocol conformances ensures that if the override crosses an isolation domain the parameters and results of the overriding method are sendable. This is technically too strict, as only the parameters of the overridden method need be sendable. This PR fixes this for override and conformance checks by splitting the sendable checking to check Sensibility of parameters of the overridden method, and results of the overriding method. 

The test `sendable_checking.swift` ensures that new code now typechecks such as:

```
class Super {
    @MainActor
    func g<T : Sendable>(x: T) async {}
}

class Sub : Super {
    override nonisolated func g<T>(x: T) async {}
}
```

for overrides, and

```
protocol P {
  func foo(x : @Sendable () -> ()) async -> ()
}

actor A : P {
  func foo(x : () -> ()) -> () {}
}
```

for conformances.

note: this PR supplants https://github.com/apple/swift/pull/66605.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
