### PR TITLE
Simplify forwarding instruction definitions in SIL

### DIFF
--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -296,7 +296,7 @@ bool OwnershipUseVisitor<Impl>::visitInnerBorrowScopeEnd(Operand *borrowEnd) {
     // TODO: When we have ForwardingInstruction abstraction, walk the use-def
     // chain to ensure we have a partial_apply [on_stack] def.
     assert(pai && pai->isOnStack() ||
-           OwnershipForwardingMixin::get(
+           ForwardingInstruction::get(
                cast<SingleValueInstruction>(borrowEnd->get())));
     return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
   }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -219,7 +219,7 @@ public:
   }
 
   bool preservesOwnership() const {
-    auto &mixin = *OwnershipForwardingMixin::get(use->getUser());
+    auto &mixin = *ForwardingInstruction::get(use->getUser());
     return mixin.preservesOwnership();
   }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1693,7 +1693,7 @@ visitRefToBridgeObjectInst(RefToBridgeObjectInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createRefToBridgeObject(
-                getOpLocation(Inst->getLoc()), getOpValue(Inst->getConverted()),
+                getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand(0)),
                 getOpValue(Inst->getBitsOperand()),
                 getBuilder().hasOwnership()
                     ? Inst->getForwardingOwnershipKind()
@@ -1707,7 +1707,7 @@ visitBridgeObjectToRefInst(BridgeObjectToRefInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createBridgeObjectToRef(
-                getOpLocation(Inst->getLoc()), getOpValue(Inst->getConverted()),
+                getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
                 getOpType(Inst->getType()),
                 getBuilder().hasOwnership()
                     ? Inst->getForwardingOwnershipKind()
@@ -1721,7 +1721,7 @@ visitBridgeObjectToWordInst(BridgeObjectToWordInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createBridgeObjectToWord(
                                     getOpLocation(Inst->getLoc()),
-                                    getOpValue(Inst->getConverted()),
+                                    getOpValue(Inst->getOperand()),
                                     getOpType(Inst->getType())));
 }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8285,8 +8285,7 @@ public:
 /// checking by the checkers that rely upon this instruction.
 class MarkMustCheckInst
     : public UnaryInstructionBase<SILInstructionKind::MarkMustCheckInst,
-                                  SingleValueInstruction>,
-      public ForwardingInstruction {
+                                  OwnershipForwardingSingleValueInstruction> {
   friend class SILBuilder;
 
 public:
@@ -8325,9 +8324,8 @@ private:
 
   MarkMustCheckInst(SILDebugLocation DebugLoc, SILValue operand,
                     CheckKind checkKind)
-      : UnaryInstructionBase(DebugLoc, operand, operand->getType()),
-        ForwardingInstruction(SILInstructionKind::MarkMustCheckInst,
-                              operand->getOwnershipKind()),
+      : UnaryInstructionBase(DebugLoc, operand, operand->getType(),
+                             operand->getOwnershipKind()),
         kind(checkKind) {
     assert(operand->getType().isMoveOnly() &&
            "mark_must_check can only take a move only typed value");
@@ -8356,8 +8354,7 @@ public:
 class MarkUnresolvedReferenceBindingInst
     : public UnaryInstructionBase<
           SILInstructionKind::MarkUnresolvedReferenceBindingInst,
-          SingleValueInstruction>,
-      public ForwardingInstruction {
+          OwnershipForwardingSingleValueInstruction> {
   friend class SILBuilder;
 
 public:
@@ -8372,10 +8369,8 @@ private:
 
   MarkUnresolvedReferenceBindingInst(SILDebugLocation debugLoc,
                                      SILValue operand, Kind kind)
-      : UnaryInstructionBase(debugLoc, operand, operand->getType()),
-        ForwardingInstruction(
-            SILInstructionKind::MarkUnresolvedReferenceBindingInst,
-            operand->getOwnershipKind()),
+      : UnaryInstructionBase(debugLoc, operand, operand->getType(),
+                             operand->getOwnershipKind()),
         kind(kind) {}
 
 public:
@@ -10819,9 +10814,7 @@ inline bool ForwardingInstruction::isa(SILInstructionKind kind) {
          OwnershipForwardingTermInst::classof(kind) ||
          OwnershipForwardingConversionInst::classof(kind) ||
          OwnershipForwardingSelectEnumInstBase::classof(kind) ||
-         OwnershipForwardingMultipleValueInstruction::classof(kind) ||
-         kind == SILInstructionKind::MarkMustCheckInst ||
-         kind == SILInstructionKind::MarkUnresolvedReferenceBindingInst;
+         OwnershipForwardingMultipleValueInstruction::classof(kind);
 }
 
 inline ForwardingInstruction *ForwardingInstruction::get(SILInstruction *inst) {
@@ -10839,10 +10832,6 @@ inline ForwardingInstruction *ForwardingInstruction::get(SILInstruction *inst) {
     return result;
   if (auto *result =
           dyn_cast<OwnershipForwardingMultipleValueInstruction>(inst))
-    return result;
-  if (auto *result = dyn_cast<MarkMustCheckInst>(inst))
-    return result;
-  if (auto *result = dyn_cast<MarkUnresolvedReferenceBindingInst>(inst))
     return result;
   if (auto *result = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(inst))
     return result;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1270,14 +1270,13 @@ public:
 ///
 /// TODO: This name is extremely misleading because it may apply to an
 /// operation that has no operand at all, like `enum .None`.
-class FirstArgOwnershipForwardingSingleValueInst
-    : public SingleValueInstruction,
-      public ForwardingInstruction {
+class OwnershipForwardingSingleValueInstruction : public SingleValueInstruction,
+                                                  public ForwardingInstruction {
 protected:
-  FirstArgOwnershipForwardingSingleValueInst(SILInstructionKind kind,
-                                             SILDebugLocation debugLoc,
-                                             SILType ty,
-                                             ValueOwnershipKind ownershipKind)
+  OwnershipForwardingSingleValueInstruction(SILInstructionKind kind,
+                                            SILDebugLocation debugLoc,
+                                            SILType ty,
+                                            ValueOwnershipKind ownershipKind)
       : SingleValueInstruction(kind, debugLoc, ty),
         ForwardingInstruction(kind, ownershipKind) {
     assert(classof(kind) && "classof missing new subclass?!");
@@ -1297,97 +1296,8 @@ public:
   }
 };
 
-/// An ownership forwarding single value that has a preferred operand of owned
-/// but if its inputs are all none can have OwnershipKind::None as a result. We
-/// assume that we always forward from operand 0.
-class OwnedFirstArgForwardingSingleValueInst
-    : public FirstArgOwnershipForwardingSingleValueInst {
-protected:
-  OwnedFirstArgForwardingSingleValueInst(SILInstructionKind kind,
-                                         SILDebugLocation debugLoc, SILType ty,
-                                         ValueOwnershipKind resultOwnershipKind)
-      : FirstArgOwnershipForwardingSingleValueInst(kind, debugLoc, ty,
-                                                   resultOwnershipKind) {
-    assert(resultOwnershipKind.isCompatibleWith(OwnershipKind::Owned));
-    assert(classof(kind) && "classof missing new subclass?!");
-  }
-
-public:
-  ValueOwnershipKind getPreferredOwnership() const {
-    return OwnershipKind::Owned;
-  }
-
-  static bool classof(SILNodePointer node) {
-    if (auto *i = dyn_cast<SILInstruction>(node.get()))
-      return classof(i);
-    return false;
-  }
-
-  static bool classof(SILInstructionKind kind) {
-    switch (kind) {
-    case SILInstructionKind::MarkUninitializedInst:
-      return true;
-    default:
-      return false;
-    }
-  }
-
-  static bool classof(const SILInstruction *inst) {
-    return classof(inst->getKind());
-  }
-};
-
-/// An instruction that forwards guaranteed or none ownership. Assumed to always
-/// forward from Operand(0) -> Result(0).
-class GuaranteedFirstArgForwardingSingleValueInst
-    : public FirstArgOwnershipForwardingSingleValueInst {
-protected:
-  GuaranteedFirstArgForwardingSingleValueInst(
-      SILInstructionKind kind, SILDebugLocation debugLoc, SILType ty,
-      ValueOwnershipKind resultOwnershipKind)
-      : FirstArgOwnershipForwardingSingleValueInst(kind, debugLoc, ty,
-                                                   resultOwnershipKind) {
-    assert(resultOwnershipKind.isCompatibleWith(OwnershipKind::Guaranteed));
-    assert(classof(kind) && "classof missing new subclass?!");
-  }
-
-public:
-  ValueOwnershipKind getPreferredOwnership() const {
-    return OwnershipKind::Guaranteed;
-  }
-
-  static bool classof(SILNodePointer node) {
-    if (auto *i = dyn_cast<SILInstruction>(node.get()))
-      return classof(i);
-    return false;
-  }
-
-  static bool classof(SILInstructionKind kind) {
-    switch (kind) {
-    case SILInstructionKind::TupleExtractInst:
-    case SILInstructionKind::StructExtractInst:
-    case SILInstructionKind::DifferentiableFunctionExtractInst:
-    case SILInstructionKind::LinearFunctionExtractInst:
-    case SILInstructionKind::OpenExistentialValueInst:
-    case SILInstructionKind::OpenExistentialBoxValueInst:
-      return true;
-    default:
-      return false;
-    }
-  }
-
-  static bool classof(const SILInstruction *inst) {
-    return classof(inst->getKind());
-  }
-};
-
 inline bool
-FirstArgOwnershipForwardingSingleValueInst::classof(SILInstructionKind kind) {
-  if (OwnedFirstArgForwardingSingleValueInst::classof(kind))
-    return true;
-  if (GuaranteedFirstArgForwardingSingleValueInst::classof(kind))
-    return true;
-
+OwnershipForwardingSingleValueInstruction::classof(SILInstructionKind kind) {
   switch (kind) {
   case SILInstructionKind::ObjectInst:
   case SILInstructionKind::EnumInst:
@@ -1403,42 +1313,6 @@ FirstArgOwnershipForwardingSingleValueInst::classof(SILInstructionKind kind) {
     return false;
   }
 }
-
-class AllArgOwnershipForwardingSingleValueInst : public SingleValueInstruction,
-                                                 public ForwardingInstruction {
-protected:
-  AllArgOwnershipForwardingSingleValueInst(SILInstructionKind kind,
-                                           SILDebugLocation debugLoc,
-                                           SILType ty,
-                                           ValueOwnershipKind ownershipKind)
-      : SingleValueInstruction(kind, debugLoc, ty),
-        ForwardingInstruction(kind, ownershipKind) {
-    assert(classof(kind) && "classof missing new subclass?!");
-  }
-
-public:
-  static bool classof(SILNodePointer node) {
-    if (auto *i = dyn_cast<SILInstruction>(node.get()))
-      return classof(i);
-    return false;
-  }
-
-  static bool classof(SILInstructionKind kind) {
-    switch (kind) {
-    case SILInstructionKind::StructInst:
-    case SILInstructionKind::TupleInst:
-    case SILInstructionKind::LinearFunctionInst:
-    case SILInstructionKind::DifferentiableFunctionInst:
-      return true;
-    default:
-      return false;
-    }
-  }
-
-  static bool classof(const SILInstruction *inst) {
-    return classof(inst->getKind());
-  }
-};
 
 /// A value base result of a multiple value instruction.
 ///
@@ -5010,7 +4884,7 @@ public:
 /// this instruction. This is only valid in Raw SIL.
 class MarkUninitializedInst
     : public UnaryInstructionBase<SILInstructionKind::MarkUninitializedInst,
-                                  OwnedFirstArgForwardingSingleValueInst> {
+                                  OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
 public:
@@ -6077,7 +5951,7 @@ public:
 /// StructInst - Represents a constructed loadable struct.
 class StructInst final : public InstructionBaseWithTrailingOperands<
                              SILInstructionKind::StructInst, StructInst,
-                             AllArgOwnershipForwardingSingleValueInst> {
+                             OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   /// Because of the storage requirements of StructInst, object
@@ -6331,7 +6205,7 @@ class SetDeallocatingInst
 /// static initializer list.
 class ObjectInst final : public InstructionBaseWithTrailingOperands<
                              SILInstructionKind::ObjectInst, ObjectInst,
-                             FirstArgOwnershipForwardingSingleValueInst> {
+                             OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   unsigned numBaseElements;
@@ -6378,7 +6252,7 @@ public:
 /// TupleInst - Represents a constructed loadable tuple.
 class TupleInst final : public InstructionBaseWithTrailingOperands<
                             SILInstructionKind::TupleInst, TupleInst,
-                            AllArgOwnershipForwardingSingleValueInst> {
+                            OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   /// Because of the storage requirements of TupleInst, object
@@ -6453,7 +6327,7 @@ public:
 /// elements.
 class EnumInst
     : public InstructionBase<SILInstructionKind::EnumInst,
-                             FirstArgOwnershipForwardingSingleValueInst> {
+                             OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
   enum : unsigned { InvalidCaseIndex = ~unsigned(0) };
 
@@ -6507,7 +6381,7 @@ public:
 /// the tag.
 class UncheckedEnumDataInst
     : public UnaryInstructionBase<SILInstructionKind::UncheckedEnumDataInst,
-                                  FirstArgOwnershipForwardingSingleValueInst> {
+                                  OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
   enum : unsigned { InvalidCaseIndex = ~unsigned(0) };
 
@@ -6921,7 +6795,7 @@ class ExistentialMetatypeInst
 /// Extract a numbered element out of a value of tuple type.
 class TupleExtractInst
     : public UnaryInstructionBase<SILInstructionKind::TupleExtractInst,
-                                  GuaranteedFirstArgForwardingSingleValueInst> {
+                                  OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
   USE_SHARED_UINT32;
 
@@ -7053,7 +6927,7 @@ public:
 class StructExtractInst
     : public UnaryInstructionBase<
           SILInstructionKind::StructExtractInst,
-          FieldIndexCacheBase<GuaranteedFirstArgForwardingSingleValueInst>> {
+          FieldIndexCacheBase<OwnershipForwardingSingleValueInstruction>> {
   friend SILBuilder;
 
   StructExtractInst(SILDebugLocation DebugLoc, SILValue Operand, VarDecl *Field,
@@ -7321,7 +7195,7 @@ public:
 /// captures the (dynamic) conformances.
 class OpenExistentialValueInst
     : public UnaryInstructionBase<SILInstructionKind::OpenExistentialValueInst,
-                                  GuaranteedFirstArgForwardingSingleValueInst> {
+                                  OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   OpenExistentialValueInst(SILDebugLocation debugLoc, SILValue operand,
@@ -7342,7 +7216,7 @@ public:
 /// captures the (dynamic) conformances.
 class OpenExistentialRefInst
     : public UnaryInstructionBase<SILInstructionKind::OpenExistentialRefInst,
-                                  FirstArgOwnershipForwardingSingleValueInst> {
+                                  OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   OpenExistentialRefInst(SILDebugLocation DebugLoc, SILValue Operand,
@@ -7406,7 +7280,7 @@ public:
 class OpenExistentialBoxValueInst
     : public UnaryInstructionBase<
           SILInstructionKind::OpenExistentialBoxValueInst,
-          GuaranteedFirstArgForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   OpenExistentialBoxValueInst(SILDebugLocation DebugLoc, SILValue operand,
@@ -7505,7 +7379,7 @@ public:
 class InitExistentialRefInst final
     : public UnaryInstructionWithTypeDependentOperandsBase<
           SILInstructionKind::InitExistentialRefInst, InitExistentialRefInst,
-          FirstArgOwnershipForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   CanType ConcreteType;
@@ -8190,7 +8064,7 @@ public:
 /// "value"'.
 class MarkDependenceInst
     : public InstructionBase<SILInstructionKind::MarkDependenceInst,
-                             FirstArgOwnershipForwardingSingleValueInst> {
+                             OwnershipForwardingSingleValueInstruction> {
   friend SILBuilder;
 
   FixedOperandList<2> Operands;
@@ -8530,7 +8404,7 @@ public:
 class CopyableToMoveOnlyWrapperValueInst
     : public UnaryInstructionBase<
           SILInstructionKind::CopyableToMoveOnlyWrapperValueInst,
-          FirstArgOwnershipForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
 public:
   enum InitialKind {
     Guaranteed,
@@ -8592,7 +8466,7 @@ public:
 class MoveOnlyWrapperToCopyableValueInst
     : public UnaryInstructionBase<
           SILInstructionKind::MoveOnlyWrapperToCopyableValueInst,
-          FirstArgOwnershipForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
 public:
   enum InitialKind {
     Guaranteed,
@@ -10436,7 +10310,7 @@ class DifferentiableFunctionInst final
     : public InstructionBaseWithTrailingOperands<
           SILInstructionKind::DifferentiableFunctionInst,
           DifferentiableFunctionInst,
-          AllArgOwnershipForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
 private:
   friend SILBuilder;
   /// Differentiability parameter indices.
@@ -10550,7 +10424,7 @@ public:
 class LinearFunctionInst final
     : public InstructionBaseWithTrailingOperands<
           SILInstructionKind::LinearFunctionInst, LinearFunctionInst,
-          AllArgOwnershipForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
 private:
   friend SILBuilder;
   /// Parameters to differentiate with respect to.
@@ -10615,7 +10489,7 @@ public:
 class DifferentiableFunctionExtractInst
     : public UnaryInstructionBase<
           SILInstructionKind::DifferentiableFunctionExtractInst,
-          GuaranteedFirstArgForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
 private:
   /// The extractee.
   NormalDifferentiableFunctionTypeComponent Extractee;
@@ -10658,7 +10532,7 @@ public:
 /// extract the specified function.
 class LinearFunctionExtractInst
     : public UnaryInstructionBase<SILInstructionKind::LinearFunctionExtractInst,
-                                  GuaranteedFirstArgForwardingSingleValueInst> {
+                                  OwnershipForwardingSingleValueInstruction> {
 private:
   /// The extractee.
   LinearDifferentiableFunctionTypeComponent extractee;
@@ -10941,8 +10815,7 @@ inline bool Operand::isTypeDependent() const {
 }
 
 inline bool ForwardingInstruction::isa(SILInstructionKind kind) {
-  return FirstArgOwnershipForwardingSingleValueInst::classof(kind) ||
-         AllArgOwnershipForwardingSingleValueInst::classof(kind) ||
+  return OwnershipForwardingSingleValueInstruction::classof(kind) ||
          OwnershipForwardingTermInst::classof(kind) ||
          OwnershipForwardingConversionInst::classof(kind) ||
          OwnershipForwardingSelectEnumInstBase::classof(kind) ||
@@ -10956,9 +10829,7 @@ inline ForwardingInstruction *ForwardingInstruction::get(SILInstruction *inst) {
   // casting to ForwardingInstruction to ensure that we offset to the
   // appropriate offset inside of inst instead of converting inst's current
   // location to an ForwardingInstruction which would be incorrect.
-  if (auto *result = dyn_cast<FirstArgOwnershipForwardingSingleValueInst>(inst))
-    return result;
-  if (auto *result = dyn_cast<AllArgOwnershipForwardingSingleValueInst>(inst))
+  if (auto *result = dyn_cast<OwnershipForwardingSingleValueInstruction>(inst))
     return result;
   if (auto *result = dyn_cast<OwnershipForwardingTermInst>(inst))
     return result;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8504,7 +8504,7 @@ public:
 class MoveOnlyWrapperToCopyableBoxInst
     : public UnaryInstructionBase<
           SILInstructionKind::MoveOnlyWrapperToCopyableBoxInst,
-          FirstArgOwnershipForwardingSingleValueInst> {
+          OwnershipForwardingSingleValueInstruction> {
   friend class SILBuilder;
 
   MoveOnlyWrapperToCopyableBoxInst(SILDebugLocation DebugLoc, SILValue operand,
@@ -10832,8 +10832,6 @@ inline ForwardingInstruction *ForwardingInstruction::get(SILInstruction *inst) {
     return result;
   if (auto *result =
           dyn_cast<OwnershipForwardingMultipleValueInstruction>(inst))
-    return result;
-  if (auto *result = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(inst))
     return result;
   if (auto *result = dyn_cast<CopyableToMoveOnlyWrapperValueInst>(inst))
     return result;

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -370,53 +370,52 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
     SINGLE_VALUE_INST_RANGE(MethodInst, ClassMethodInst, WitnessMethodInst)
 
   // Conversions
-  ABSTRACT_SINGLE_VALUE_INST(ConversionInst, SingleValueInstruction)
     SINGLE_VALUE_INST(UpcastInst, upcast,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(AddressToPointerInst, address_to_pointer,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(PointerToAddressInst, pointer_to_address,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(UncheckedRefCastInst, unchecked_ref_cast,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(UncheckedAddrCastInst, unchecked_addr_cast,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(UncheckedTrivialBitCastInst, unchecked_trivial_bit_cast,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(UncheckedBitwiseCastInst, unchecked_bitwise_cast,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(UncheckedValueCastInst, unchecked_value_cast,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(RefToRawPointerInst, ref_to_raw_pointer,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(RawPointerToRefInst, raw_pointer_to_ref,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
 #define LOADABLE_REF_STORAGE(Name, name, ...) \
     SINGLE_VALUE_INST(RefTo##Name##Inst, ref_to_##name, \
-                      ConversionInst, None, DoesNotRelease) \
+                      SingleValueInstruction, None, DoesNotRelease) \
     SINGLE_VALUE_INST(Name##ToRefInst, name##_to_ref, \
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
 #include "swift/AST/ReferenceStorage.def"
     SINGLE_VALUE_INST(ConvertFunctionInst, convert_function,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(ConvertEscapeToNoEscapeInst, convert_escape_to_noescape,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(RefToBridgeObjectInst, ref_to_bridge_object,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(BridgeObjectToRefInst, bridge_object_to_ref,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(BridgeObjectToWordInst, bridge_object_to_word,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(ThinToThickFunctionInst, thin_to_thick_function,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(ThickToObjCMetatypeInst, thick_to_objc_metatype,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(ObjCToThickMetatypeInst, objc_to_thick_metatype,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(ObjCMetatypeToObjectInst, objc_metatype_to_object,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     SINGLE_VALUE_INST(ObjCExistentialMetatypeToObjectInst, objc_existential_metatype_to_object,
-                      ConversionInst, None, DoesNotRelease)
+                      SingleValueInstruction, None, DoesNotRelease)
     // unconditional_checked_cast_inst is only MayRead to prevent a subsequent
     // release of the cast's source from being hoisted above the cast:
     // retain X
@@ -429,8 +428,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
     // scalar cast that doesn't affect the value's representation, its
     // side effect can then be modeled as None.
     DYNAMICCAST_SINGLE_VALUE_INST(UnconditionalCheckedCastInst, unconditional_checked_cast,
-                      ConversionInst, MayRead, DoesNotRelease)
-    SINGLE_VALUE_INST_RANGE(ConversionInst, UpcastInst, UnconditionalCheckedCastInst)
+                      SingleValueInstruction, MayRead, DoesNotRelease)
 
   SINGLE_VALUE_INST(ClassifyBridgeObjectInst, classify_bridge_object,
                     SingleValueInstruction, None, DoesNotRelease)

--- a/include/swift/SILOptimizer/Utils/CastOptimizer.h
+++ b/include/swift/SILOptimizer/Utils/CastOptimizer.h
@@ -135,7 +135,7 @@ public:
   void deleteInstructionsAfterUnreachable(SILInstruction *UnreachableInst,
                                           SILInstruction *TrapInst);
 
-  SILValue optimizeMetatypeConversion(ConversionInst *mci,
+  SILValue optimizeMetatypeConversion(ConversionOperation mci,
                                       MetatypeRepresentation representation);
 };
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6601,7 +6601,7 @@ void IRGenSILFunction::visitObjCProtocolInst(ObjCProtocolInst *i) {
 
 void IRGenSILFunction::visitRefToBridgeObjectInst(
                                               swift::RefToBridgeObjectInst *i) {
-  Explosion refEx = getLoweredExplosion(i->getConverted());
+  Explosion refEx = getLoweredExplosion(i->getOperand(0));
   llvm::Value *ref = refEx.claimNext();
   
   Explosion bitsEx = getLoweredExplosion(i->getBitsOperand());
@@ -6659,7 +6659,7 @@ void IRGenSILFunction::visitValueToBridgeObjectInst(
 
 void IRGenSILFunction::visitBridgeObjectToRefInst(
                                               swift::BridgeObjectToRefInst *i) {
-  Explosion boEx = getLoweredExplosion(i->getConverted());
+  Explosion boEx = getLoweredExplosion(i->getOperand());
   llvm::Value *bo = boEx.claimNext();
   Explosion resultEx;
   
@@ -6730,7 +6730,7 @@ void IRGenSILFunction::visitBridgeObjectToRefInst(
 
 void IRGenSILFunction::visitBridgeObjectToWordInst(
                                              swift::BridgeObjectToWordInst *i) {
-  Explosion boEx = getLoweredExplosion(i->getConverted());
+  Explosion boEx = getLoweredExplosion(i->getOperand());
   llvm::Value *val = boEx.claimNext();
   val = Builder.CreatePtrToInt(val, IGM.SizeTy);
   Explosion wordEx;

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3066,7 +3066,7 @@ void LoadableByAddress::run() {
             }
           }
         } else if (auto *Cvt = dyn_cast<ConvertEscapeToNoEscapeInst>(&I)) {
-          SILValue val = Cvt->getConverted();
+          SILValue val = Cvt->getOperand();
           SILType currType = val->getType();
           auto fType = currType.getAs<SILFunctionType>();
           assert(fType && "Expected SILFunctionType");
@@ -3074,7 +3074,7 @@ void LoadableByAddress::run() {
             conversionInstrs.insert(Cvt);
           }
         } else if (auto *CFI = dyn_cast<ConvertFunctionInst>(&I)) {
-          SILValue val = CFI->getConverted();
+          SILValue val = CFI->getOperand();
           SILType currType = val->getType();
           auto fType = currType.getAs<SILFunctionType>();
           assert(fType && "Expected SILFunctionType");

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -15,16 +15,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/SILInstruction.h"
-#include "swift/Basic/type_traits.h"
+#include "swift/Basic/AssertImplements.h"
 #include "swift/Basic/Unicode.h"
+#include "swift/Basic/type_traits.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILDebugScope.h"
-#include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/DynamicCasts.h"
-#include "swift/Basic/AssertImplements.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILVisitor.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -1767,8 +1768,8 @@ DestroyValueInst::getNonescapingClosureAllocation() const {
       // Stop at a conversion from escaping closure, since there's no stack
       // allocation in that case.
       return nullptr;
-    } else if (auto conv = dyn_cast<ConversionInst>(operand)) {
-      operand = conv->getConverted();
+    } else if (auto convert = ConversionOperation(operand)) {
+      operand = convert.getConverted();
       continue;
     } else if (auto pa = dyn_cast<PartialApplyInst>(operand)) {
       // If we found the `[on_stack]` partial apply, we're done.

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -3229,13 +3229,15 @@ bool ForwardingInstruction::hasSameRepresentation(SILInstruction *inst) {
 }
 
 bool ForwardingInstruction::isAddressOnly(SILInstruction *inst) {
-  if (auto *aggregate =
-          dyn_cast<AllArgOwnershipForwardingSingleValueInst>(inst)) {
+  if (canForwardAllOperands(inst)) {
+    // All ForwardingInstructions that forward all operands are currently a
+    // single value instruction.
+    auto *aggregate = cast<OwnershipForwardingSingleValueInstruction>(inst);
     // If any of the operands are address-only, then the aggregate must be.
     return aggregate->getType().isAddressOnly(*inst->getFunction());
   }
   // All other forwarding instructions must forward their first operand.
-  assert(ForwardingInstruction::isa(inst));
+  assert(canForwardFirstOperandOnly(inst));
   return inst->getOperand(0)->getType().isAddressOnly(*inst->getFunction());
 }
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -3200,7 +3200,7 @@ ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,
          "result info?!");
 }
 
-bool OwnershipForwardingMixin::hasSameRepresentation(SILInstruction *inst) {
+bool ForwardingInstruction::hasSameRepresentation(SILInstruction *inst) {
   switch (inst->getKind()) {
   // Explicitly list instructions which definitely involve a representation
   // change.
@@ -3208,7 +3208,7 @@ bool OwnershipForwardingMixin::hasSameRepresentation(SILInstruction *inst) {
   default:
     // Conservatively assume that a conversion changes representation.
     // Operations can be added as needed to participate in SIL opaque values.
-    assert(OwnershipForwardingMixin::isa(inst));
+    assert(ForwardingInstruction::isa(inst));
     return false;
 
   case SILInstructionKind::ConvertFunctionInst:
@@ -3228,14 +3228,14 @@ bool OwnershipForwardingMixin::hasSameRepresentation(SILInstruction *inst) {
   }
 }
 
-bool OwnershipForwardingMixin::isAddressOnly(SILInstruction *inst) {
+bool ForwardingInstruction::isAddressOnly(SILInstruction *inst) {
   if (auto *aggregate =
-      dyn_cast<AllArgOwnershipForwardingSingleValueInst>(inst)) {
+          dyn_cast<AllArgOwnershipForwardingSingleValueInst>(inst)) {
     // If any of the operands are address-only, then the aggregate must be.
     return aggregate->getType().isAddressOnly(*inst->getFunction());
   }
   // All other forwarding instructions must forward their first operand.
-  assert(OwnershipForwardingMixin::isa(inst));
+  assert(ForwardingInstruction::isa(inst));
   return inst->getOperand(0)->getType().isAddressOnly(*inst->getFunction());
 }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1725,8 +1725,7 @@ public:
     }
   }
 
-  void printForwardingOwnershipKind(OwnershipForwardingMixin *inst,
-                                    SILValue op) {
+  void printForwardingOwnershipKind(ForwardingInstruction *inst, SILValue op) {
     if (!op)
       return;
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -28,6 +28,7 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/CFG.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILCoverageMap.h"
 #include "swift/SIL/SILDebugScope.h"
@@ -1931,9 +1932,9 @@ public:
       *this << " !false_count(" << CI->getFalseBBCount().getValue() << ")";
   }
 
-  void printUncheckedConversionInst(ConversionInst *CI, SILValue operand) {
+  void printUncheckedConversionInst(ConversionOperation CI, SILValue operand) {
     *this << getIDAndType(operand) << " to " << CI->getType();
-    if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(CI)) {
+    if (auto *ofci = dyn_cast<OwnershipForwardingSingleValueInstruction>(*CI)) {
       printForwardingOwnershipKind(ofci, ofci->getOperand(0));
     }
   }
@@ -1957,11 +1958,11 @@ public:
           << getIDAndType(CI->getOperand()) << " to " << CI->getType();
   }
   void visitUpcastInst(UpcastInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitAddressToPointerInst(AddressToPointerInst *CI) {
     *this << (CI->needsStackProtection() ? "[stack_protection] " : "");
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitPointerToAddressInst(PointerToAddressInst *CI) {
     *this << getIDAndType(CI->getOperand()) << " to ";
@@ -1974,7 +1975,7 @@ public:
     *this << CI->getType();
   }
   void visitUncheckedRefCastInst(UncheckedRefCastInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitUncheckedRefCastAddrInst(UncheckedRefCastAddrInst *CI) {
     *this << ' ' << CI->getSourceFormalType() << " in " << getIDAndType(CI->getSrc())
@@ -1982,64 +1983,64 @@ public:
           << getIDAndType(CI->getDest());
   }
   void visitUncheckedAddrCastInst(UncheckedAddrCastInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitUncheckedTrivialBitCastInst(UncheckedTrivialBitCastInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitUncheckedValueCastInst(UncheckedValueCastInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitRefToRawPointerInst(RefToRawPointerInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitRawPointerToRefInst(RawPointerToRefInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
 
-#define LOADABLE_REF_STORAGE(Name, ...) \
-  void visitRefTo##Name##Inst(RefTo##Name##Inst *CI) { \
-    printUncheckedConversionInst(CI, CI->getOperand()); \
-  } \
-  void visit##Name##ToRefInst(Name##ToRefInst *CI) { \
-    printUncheckedConversionInst(CI, CI->getOperand()); \
+#define LOADABLE_REF_STORAGE(Name, ...)                                        \
+  void visitRefTo##Name##Inst(RefTo##Name##Inst *CI) {                         \
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());   \
+  }                                                                            \
+  void visit##Name##ToRefInst(Name##ToRefInst *CI) {                           \
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());   \
   }
 #include "swift/AST/ReferenceStorage.def"
   void visitThinToThickFunctionInst(ThinToThickFunctionInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitThickToObjCMetatypeInst(ThickToObjCMetatypeInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitObjCToThickMetatypeInst(ObjCToThickMetatypeInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitObjCMetatypeToObjectInst(ObjCMetatypeToObjectInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitObjCExistentialMetatypeToObjectInst(
                                       ObjCExistentialMetatypeToObjectInst *CI) {
-    printUncheckedConversionInst(CI, CI->getOperand());
+    printUncheckedConversionInst(ConversionOperation(CI), CI->getOperand());
   }
   void visitObjCProtocolInst(ObjCProtocolInst *CI) {
     *this << "#" << CI->getProtocol()->getName() << " : " << CI->getType();
   }
   
   void visitRefToBridgeObjectInst(RefToBridgeObjectInst *I) {
-    *this << getIDAndType(I->getConverted()) << ", "
+    *this << getIDAndType(I->getOperand(0)) << ", "
           << getIDAndType(I->getBitsOperand());
-    printForwardingOwnershipKind(I, I->getConverted());
+    printForwardingOwnershipKind(I, I->getOperand(0));
   }
-  
+
   void visitBridgeObjectToRefInst(BridgeObjectToRefInst *I) {
-    printUncheckedConversionInst(I, I->getOperand());
+    printUncheckedConversionInst(ConversionOperation(I), I->getOperand());
     printForwardingOwnershipKind(I, I->getOperand());
   }
   void visitBridgeObjectToWordInst(BridgeObjectToWordInst *I) {
-    printUncheckedConversionInst(I, I->getOperand());
+    printUncheckedConversionInst(ConversionOperation(I), I->getOperand());
   }
 
   void visitCopyValueInst(CopyValueInst *I) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -4273,7 +4273,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       return true;
 
     ValueOwnershipKind forwardingOwnership = Val->getOwnershipKind();
-    if (OwnershipForwardingMixin::isa(Opcode)) {
+    if (ForwardingInstruction::isa(Opcode)) {
       if (parseForwardingOwnershipKind(forwardingOwnership))
         return true;
     }

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -268,8 +268,8 @@ SILValue swift::stripBorrow(SILValue V) {
 // This is guaranteed to handle all function-type conversions: ThinToThick,
 // ConvertFunction, and ConvertEscapeToNoEscapeInst.
 SingleValueInstruction *swift::getSingleValueCopyOrCast(SILInstruction *I) {
-  if (auto *convert = dyn_cast<ConversionInst>(I))
-    return convert;
+  if (auto convert = ConversionOperation(I))
+    return *convert;
 
   switch (I->getKind()) {
   default:

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -899,10 +899,10 @@ SILValue swift::findOwnershipReferenceAggregate(SILValue ref) {
     if (!root)
       return root;
 
-    if (isa<FirstArgOwnershipForwardingSingleValueInst>(root)
-        || isa<OwnershipForwardingConversionInst>(root)
-        || isa<OwnershipForwardingSelectEnumInstBase>(root)
-        || isa<OwnershipForwardingMultipleValueInstruction>(root)) {
+    if (isa<FirstArgOwnershipForwardingSingleValueInst>(root) ||
+        isa<OwnershipForwardingConversionInst>(root) ||
+        isa<OwnershipForwardingSelectEnumInstBase>(root) ||
+        isa<OwnershipForwardingMultipleValueInstruction>(root)) {
       SILInstruction *inst = root->getDefiningInstruction();
 
       // The `enum` instruction can have no operand.

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -899,18 +899,15 @@ SILValue swift::findOwnershipReferenceAggregate(SILValue ref) {
     if (!root)
       return root;
 
-    if (isa<FirstArgOwnershipForwardingSingleValueInst>(root) ||
-        isa<OwnershipForwardingConversionInst>(root) ||
-        isa<OwnershipForwardingSelectEnumInstBase>(root) ||
-        isa<OwnershipForwardingMultipleValueInstruction>(root)) {
-      SILInstruction *inst = root->getDefiningInstruction();
+    if (auto *inst = root->getDefiningInstruction()) {
+      if (ForwardingInstruction::canForwardFirstOperandOnly(inst)) {
+        // The `enum` instruction can have no operand.
+        if (inst->getNumOperands() == 0)
+          return root;
 
-      // The `enum` instruction can have no operand.
-      if (inst->getNumOperands() == 0)
-        return root;
-
-      root = inst->getOperand(0);
-      continue;
+        root = inst->getOperand(0);
+        continue;
+      }
     }
     if (auto *termResult = SILArgument::isTerminatorResult(root)) {
       if (auto *oper = termResult->forwardedTerminatorResultOperand()) {

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -112,10 +112,10 @@ bool swift::canOpcodeForwardInnerGuaranteedValues(SILValue value) {
   if (auto *arg = dyn_cast<SILArgument>(value))
     if (auto *ti = arg->getSingleTerminator())
       if (ti->mayHaveTerminatorResult())
-        return OwnershipForwardingMixin::get(ti)->preservesOwnership();
+        return ForwardingInstruction::get(ti)->preservesOwnership();
 
   if (auto *inst = value->getDefiningInstruction())
-    if (auto *mixin = OwnershipForwardingMixin::get(inst))
+    if (auto *mixin = ForwardingInstruction::get(inst))
       return mixin->preservesOwnership() &&
              !isa<OwnedFirstArgForwardingSingleValueInst>(inst);
 
@@ -123,7 +123,7 @@ bool swift::canOpcodeForwardInnerGuaranteedValues(SILValue value) {
 }
 
 bool swift::canOpcodeForwardInnerGuaranteedValues(Operand *use) {
-  if (auto *mixin = OwnershipForwardingMixin::get(use->getUser()))
+  if (auto *mixin = ForwardingInstruction::get(use->getUser()))
     return mixin->preservesOwnership() &&
            !isa<OwnedFirstArgForwardingSingleValueInst>(use->getUser());
   return false;
@@ -131,7 +131,7 @@ bool swift::canOpcodeForwardInnerGuaranteedValues(Operand *use) {
 
 bool swift::canOpcodeForwardOwnedValues(SILValue value) {
   if (auto *inst = value->getDefiningInstructionOrTerminator()) {
-    if (auto *mixin = OwnershipForwardingMixin::get(inst)) {
+    if (auto *mixin = ForwardingInstruction::get(inst)) {
       return mixin->preservesOwnership() &&
              !isa<GuaranteedFirstArgForwardingSingleValueInst>(inst);
     }
@@ -141,7 +141,7 @@ bool swift::canOpcodeForwardOwnedValues(SILValue value) {
 
 bool swift::canOpcodeForwardOwnedValues(Operand *use) {
   auto *user = use->getUser();
-  if (auto *mixin = OwnershipForwardingMixin::get(user))
+  if (auto *mixin = ForwardingInstruction::get(user))
     return mixin->preservesOwnership() &&
            !isa<GuaranteedFirstArgForwardingSingleValueInst>(user);
   return false;
@@ -1733,12 +1733,12 @@ bool swift::visitForwardedGuaranteedOperands(
   if (inst->getNumRealOperands() == 0) {
     return false;
   }
-  if (isa<FirstArgOwnershipForwardingSingleValueInst>(inst)
-      || isa<OwnershipForwardingConversionInst>(inst)
-      || isa<OwnershipForwardingSelectEnumInstBase>(inst)
-      || isa<OwnershipForwardingMultipleValueInstruction>(inst)
-      || isa<MoveOnlyWrapperToCopyableValueInst>(inst)
-      || isa<CopyableToMoveOnlyWrapperValueInst>(inst)) {
+  if (isa<FirstArgOwnershipForwardingSingleValueInst>(inst) ||
+      isa<OwnershipForwardingConversionInst>(inst) ||
+      isa<OwnershipForwardingSelectEnumInstBase>(inst) ||
+      isa<OwnershipForwardingMultipleValueInstruction>(inst) ||
+      isa<MoveOnlyWrapperToCopyableValueInst>(inst) ||
+      isa<CopyableToMoveOnlyWrapperValueInst>(inst)) {
     assert(!isa<SingleValueInstruction>(inst)
            || !BorrowedValue(cast<SingleValueInstruction>(inst))
                   && "forwarded operand cannot begin a borrow scope");

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1366,10 +1366,7 @@ ValueOwnershipKind ForwardingOperand::getForwardingOwnershipKind() const {
   // NOTE: This if chain is meant to be a covered switch, so make sure to return
   // in each if itself since we have an unreachable at the bottom to ensure if a
   // new subclass of OwnershipForwardingInst is added
-  if (auto *ofsvi = dyn_cast<AllArgOwnershipForwardingSingleValueInst>(user))
-    return ofsvi->getForwardingOwnershipKind();
-
-  if (auto *ofsvi = dyn_cast<FirstArgOwnershipForwardingSingleValueInst>(user))
+  if (auto *ofsvi = dyn_cast<OwnershipForwardingSingleValueInstruction>(user))
     return ofsvi->getForwardingOwnershipKind();
 
   if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(user))
@@ -1405,9 +1402,7 @@ void ForwardingOperand::setForwardingOwnershipKind(
   // NOTE: This if chain is meant to be a covered switch, so make sure to return
   // in each if itself since we have an unreachable at the bottom to ensure if a
   // new subclass of OwnershipForwardingInst is added
-  if (auto *ofsvi = dyn_cast<AllArgOwnershipForwardingSingleValueInst>(user))
-    return ofsvi->setForwardingOwnershipKind(newKind);
-  if (auto *ofsvi = dyn_cast<FirstArgOwnershipForwardingSingleValueInst>(user))
+  if (auto *ofsvi = dyn_cast<OwnershipForwardingSingleValueInstruction>(user))
     return ofsvi->setForwardingOwnershipKind(newKind);
   if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(user))
     return ofci->setForwardingOwnershipKind(newKind);
@@ -1471,11 +1466,7 @@ void ForwardingOperand::replaceOwnershipKind(ValueOwnershipKind oldKind,
                                              ValueOwnershipKind newKind) const {
   auto *user = use->getUser();
 
-  if (auto *fInst = dyn_cast<AllArgOwnershipForwardingSingleValueInst>(user))
-    if (fInst->getForwardingOwnershipKind() == oldKind)
-      return fInst->setForwardingOwnershipKind(newKind);
-
-  if (auto *fInst = dyn_cast<FirstArgOwnershipForwardingSingleValueInst>(user))
+  if (auto *fInst = dyn_cast<OwnershipForwardingSingleValueInstruction>(user))
     if (fInst->getForwardingOwnershipKind() == oldKind)
       return fInst->setForwardingOwnershipKind(newKind);
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1386,13 +1386,6 @@ ValueOwnershipKind ForwardingOperand::getForwardingOwnershipKind() const {
     return ofti->getForwardingOwnershipKind();
   }
 
-  if (auto *move = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
-    return move->getForwardingOwnershipKind();
-  }
-
-  if (auto *move = dyn_cast<MoveOnlyWrapperToCopyableBoxInst>(user))
-    return move->getForwardingOwnershipKind();
-
   llvm_unreachable("Unhandled forwarding inst?!");
 }
 
@@ -1727,9 +1720,7 @@ bool swift::visitForwardedGuaranteedOperands(
   if (isa<FirstArgOwnershipForwardingSingleValueInst>(inst) ||
       isa<OwnershipForwardingConversionInst>(inst) ||
       isa<OwnershipForwardingSelectEnumInstBase>(inst) ||
-      isa<OwnershipForwardingMultipleValueInstruction>(inst) ||
-      isa<MoveOnlyWrapperToCopyableValueInst>(inst) ||
-      isa<CopyableToMoveOnlyWrapperValueInst>(inst)) {
+      isa<OwnershipForwardingMultipleValueInstruction>(inst)) {
     assert(!isa<SingleValueInstruction>(inst)
            || !BorrowedValue(cast<SingleValueInstruction>(inst))
                   && "forwarded operand cannot begin a borrow scope");

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1372,9 +1372,6 @@ ValueOwnershipKind ForwardingOperand::getForwardingOwnershipKind() const {
   if (auto *ofsvi = dyn_cast<OwnershipForwardingSingleValueInstruction>(user))
     return ofsvi->getForwardingOwnershipKind();
 
-  if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(user))
-    return ofci->getForwardingOwnershipKind();
-
   if (auto *ofseib = dyn_cast<OwnershipForwardingSelectEnumInstBase>(user))
     return ofseib->getForwardingOwnershipKind();
 
@@ -1400,8 +1397,6 @@ void ForwardingOperand::setForwardingOwnershipKind(
   // new subclass of OwnershipForwardingInst is added
   if (auto *ofsvi = dyn_cast<OwnershipForwardingSingleValueInstruction>(user))
     return ofsvi->setForwardingOwnershipKind(newKind);
-  if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(user))
-    return ofci->setForwardingOwnershipKind(newKind);
   if (auto *ofseib = dyn_cast<OwnershipForwardingSelectEnumInstBase>(user))
     return ofseib->setForwardingOwnershipKind(newKind);
   if (auto *ofmvi = dyn_cast<OwnershipForwardingMultipleValueInstruction>(user)) {
@@ -1465,10 +1460,6 @@ void ForwardingOperand::replaceOwnershipKind(ValueOwnershipKind oldKind,
   if (auto *fInst = dyn_cast<OwnershipForwardingSingleValueInstruction>(user))
     if (fInst->getForwardingOwnershipKind() == oldKind)
       return fInst->setForwardingOwnershipKind(newKind);
-
-  if (auto *ofci = dyn_cast<OwnershipForwardingConversionInst>(user))
-    if (ofci->getForwardingOwnershipKind() == oldKind)
-      return ofci->setForwardingOwnershipKind(newKind);
 
   if (auto *ofseib = dyn_cast<OwnershipForwardingSelectEnumInstBase>(user))
     if (ofseib->getForwardingOwnershipKind() == oldKind)

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4697,10 +4697,9 @@ public:
   }
   
   void checkRefToBridgeObjectInst(RefToBridgeObjectInst *RI) {
-    require(RI->getConverted()->getType().isObject(),
+    require(RI->getOperand(0)->getType().isObject(),
             "ref_to_bridge_object must convert from a value");
-    require(RI->getConverted()->getType().getASTType()
-              ->isBridgeableObjectType(),
+    require(RI->getOperand(0)->getType().getASTType()->isBridgeableObjectType(),
             "ref_to_bridge_object must convert from a heap object ref");
     requireSameType(
         RI->getBitsOperand()->getType(),
@@ -4713,7 +4712,7 @@ public:
   
   void checkBridgeObjectToRefInst(BridgeObjectToRefInst *RI) {
     verifyLocalArchetype(RI, RI->getType().getASTType());
-    requireSameType(RI->getConverted()->getType(),
+    requireSameType(RI->getOperand()->getType(),
                     SILType::getBridgeObjectType(F.getASTContext()),
                     "bridge_object_to_ref must take a BridgeObject");
     require(RI->getType().isObject(),
@@ -4722,7 +4721,7 @@ public:
             "bridge_object_to_ref must produce a heap object reference");
   }
   void checkBridgeObjectToWordInst(BridgeObjectToWordInst *RI) {
-    requireSameType(RI->getConverted()->getType(),
+    requireSameType(RI->getOperand()->getType(),
                     SILType::getBridgeObjectType(F.getASTContext()),
                     "bridge_object_to_word must take a BridgeObject");
     require(RI->getType().isObject(),

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1355,14 +1355,14 @@ public:
     ValueOwnershipKind ownership =
         ForwardingInstruction::get(i)->getForwardingOwnershipKind();
 
-    if (auto *o = dyn_cast<OwnedFirstArgForwardingSingleValueInst>(i)) {
+    if (ForwardingInstruction::canForwardOwnedCompatibleValuesOnly(i)) {
       ValueOwnershipKind kind = OwnershipKind::Owned;
       require(kind.isCompatibleWith(ownership),
               "OwnedFirstArgForwardingSingleValueInst's ownership kind must be "
               "compatible with owned");
     }
 
-    if (auto *o = dyn_cast<GuaranteedFirstArgForwardingSingleValueInst>(i)) {
+    if (ForwardingInstruction::canForwardGuaranteedCompatibleValuesOnly(i)) {
       ValueOwnershipKind kind = OwnershipKind::Guaranteed;
       require(kind.isCompatibleWith(ownership),
               "GuaranteedFirstArgForwardingSingleValueInst's ownership kind "

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1306,7 +1306,7 @@ public:
       }
     }
 
-    if (I->getFunction()->hasOwnership() && OwnershipForwardingMixin::isa(I)) {
+    if (I->getFunction()->hasOwnership() && ForwardingInstruction::isa(I)) {
       checkOwnershipForwardingInst(I);
     }
   }
@@ -1353,7 +1353,7 @@ public:
   /// of its results, check forwarding invariants.
   void checkOwnershipForwardingInst(SILInstruction *i) {
     ValueOwnershipKind ownership =
-        OwnershipForwardingMixin::get(i)->getForwardingOwnershipKind();
+        ForwardingInstruction::get(i)->getForwardingOwnershipKind();
 
     if (auto *o = dyn_cast<OwnedFirstArgForwardingSingleValueInst>(i)) {
       ValueOwnershipKind kind = OwnershipKind::Owned;
@@ -1378,9 +1378,9 @@ public:
     // representation. Non-destructive projection is allowed. Aggregation and
     // destructive disaggregation is not allowed. See SIL.rst, Forwarding
     // Addres-Only Values.
-    if (ownership == OwnershipKind::Guaranteed
-        && OwnershipForwardingMixin::isAddressOnly(i)) {
-      require(OwnershipForwardingMixin::hasSameRepresentation(i),
+    if (ownership == OwnershipKind::Guaranteed &&
+        ForwardingInstruction::isAddressOnly(i)) {
+      require(ForwardingInstruction::hasSameRepresentation(i),
               "Forwarding a guaranteed address-only value requires the same "
               "representation since no move or copy is allowed.");
     }

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -477,10 +477,10 @@ SILValue InstSimplifier::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
   // SILCombine.
   //
   // (convert_function Y->X (convert_function x X->Y)) -> x
-  SILValue convertedValue = lookThroughOwnershipInsts(cfi->getConverted());
+  SILValue convertedValue = lookThroughOwnershipInsts(cfi->getOperand());
   if (auto *subCFI = dyn_cast<ConvertFunctionInst>(convertedValue))
-    if (subCFI->getConverted()->getType() == cfi->getType())
-      return lookThroughOwnershipInsts(subCFI->getConverted());
+    if (subCFI->getOperand()->getType() == cfi->getType())
+      return lookThroughOwnershipInsts(subCFI->getOperand());
 
   return SILValue();
 }

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1300,9 +1300,9 @@ void ElementUseCollector::collectClassSelfUses(SILValue ClassPointer) {
         // interrupted before the initializer was called.
         SILValue src = SI->getSrc();
         // Look through conversions.
-        while (auto conversion = dyn_cast<ConversionInst>(src))
-          src = conversion->getConverted();
-        
+        while (auto conversion = ConversionOperation(src))
+          src = conversion.getConverted();
+
         if (auto *LI = dyn_cast<LoadInst>(src))
           if (LI->getOperand() == TheMemory.getUninitializedValue())
             continue;
@@ -1844,9 +1844,9 @@ void ClassInitElementUseCollector::collectClassInitSelfUses() {
         // interrupted before the initializer was called.
         SILValue src = SI->getSrc();
         // Look through conversions.
-        while (auto conversion = dyn_cast<ConversionInst>(src))
-          src = conversion->getConverted();
-        
+        while (auto conversion = ConversionOperation(src))
+          src = conversion.getConverted();
+
         if (auto *LI = dyn_cast<LoadInst>(src))
           if (LI->getOperand() == uninitMemory)
             continue;
@@ -1994,8 +1994,8 @@ void ClassInitElementUseCollector::collectClassInitSelfLoadUses(
         SILValue src = SI->getSrc();
 
         // Look through conversions.
-        while (auto *conversion = dyn_cast<ConversionInst>(src)) {
-          src = conversion->getConverted();
+        while (auto conversion = ConversionOperation(src)) {
+          src = conversion.getConverted();
         }
 
         if (auto *li = dyn_cast<LoadInst>(src)) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -530,11 +530,11 @@ static void checkApply(ASTContext &Context, FullApplySite site) {
     auto arg = pair.first;
     bool capture = pair.second;
 
-    if (auto *CI = dyn_cast<ConversionInst>(arg)) {
-      arglistInsert(CI->getConverted(), /*capture=*/false);
+    if (auto CI = ConversionOperation(arg)) {
+      arglistInsert(CI.getConverted(), /*capture=*/false);
       continue;
     }
-    
+
     if (auto *Copy = dyn_cast<CopyValueInst>(arg)) {
       arglistInsert(Copy->getOperand(), capture);
     }

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -122,7 +122,7 @@ struct OwnershipModelEliminatorVisitor
   bool visitSILInstruction(SILInstruction *inst) {
     // Make sure this wasn't a forwarding instruction in case someone adds a new
     // forwarding instruction but does not update this code.
-    if (OwnershipForwardingMixin::isa(inst)) {
+    if (ForwardingInstruction::isa(inst)) {
       llvm::errs() << "Found unhandled forwarding inst: " << *inst;
       llvm_unreachable("standard error handler");
     }
@@ -190,7 +190,7 @@ struct OwnershipModelEliminatorVisitor
 
 #define HANDLE_FORWARDING_INST(Cls)                                            \
   bool visit##Cls##Inst(Cls##Inst *i) {                                        \
-    OwnershipForwardingMixin::get(i)->setForwardingOwnershipKind(              \
+    ForwardingInstruction::get(i)->setForwardingOwnershipKind(                 \
         OwnershipKind::None);                                                  \
     return true;                                                               \
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -440,8 +440,7 @@ bool SILCombiner::doOneIteration(SILFunction &F, unsigned Iteration) {
       // owned parameters since chains of these values will be in the same
       // block.
       if (auto *svi = dyn_cast<SingleValueInstruction>(I)) {
-        if ((isa<FirstArgOwnershipForwardingSingleValueInst>(svi) ||
-             isa<OwnershipForwardingConversionInst>(svi)) &&
+        if (ForwardingInstruction::canForwardFirstOperandOnly(svi) &&
             SILValue(svi)->getOwnershipKind() == OwnershipKind::Owned) {
           // Try to sink the value. If we sank the value and deleted it,
           // continue. If we didn't optimize or sank but we are still able to

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -791,7 +791,7 @@ bool SemanticARCOptVisitor::tryPerformOwnedCopyValueOptimization(
   SmallVector<Operand *, 8> parentLifetimeEndingUses;
   for (auto *origValueUse : originalValue->getUses())
     if (origValueUse->isLifetimeEnding() &&
-        !OwnershipForwardingMixin::isa(origValueUse->getUser()))
+        !ForwardingInstruction::isa(origValueUse->getUser()))
       parentLifetimeEndingUses.push_back(origValueUse);
 
   // Ok, we have an owned value. If we do not have any non-destroying consuming

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -83,14 +83,14 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
       continue;
     }
 
-    // If we have a subclass of OwnershipForwardingMixin that doesnt directly
+    // If we have a subclass of ForwardingInstruction that doesnt directly
     // forward its operand to the result, treat the use as an unknown consuming
     // use.
     //
     // If we do not directly forward and we have an owned value (which we do
     // here), we could get back a different value. Thus we can not transform
     // such a thing from owned to guaranteed.
-    if (auto *i = OwnershipForwardingMixin::get(op->getUser())) {
+    if (auto *i = ForwardingInstruction::get(op->getUser())) {
       if (!i->preservesOwnership()) {
         tmpUnknownConsumingUses.push_back(op);
         continue;

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -124,7 +124,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
 
   bool visitSILInstruction(SILInstruction *i) {
     assert((isa<OwnershipForwardingTermInst>(i) ||
-            !OwnershipForwardingMixin::isa(i)) &&
+            !ForwardingInstruction::isa(i)) &&
            "Should have forwarding visitor for all ownership forwarding "
            "non-term instructions");
     return false;
@@ -134,7 +134,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool visitValueBase(ValueBase *v) {
     auto *inst = v->getDefiningInstruction();
     (void)inst;
-    assert((!inst || !OwnershipForwardingMixin::isa(inst)) &&
+    assert((!inst || !ForwardingInstruction::isa(inst)) &&
            "Should have forwarding visitor for all ownership forwarding "
            "instructions");
     return false;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2361,15 +2361,15 @@ simplifyCheckedCastAddrBranchBlock(CheckedCastAddrBranchInst *CCABI) {
 static SILValue getActualCallee(SILValue Callee) {
   while (!isa<FunctionRefInst>(Callee)) {
     if (auto *CFI = dyn_cast<ConvertFunctionInst>(Callee)) {
-      Callee = CFI->getConverted();
+      Callee = CFI->getOperand();
       continue;
     }
     if (auto *Cvt = dyn_cast<ConvertEscapeToNoEscapeInst>(Callee)) {
-      Callee = Cvt->getConverted();
+      Callee = Cvt->getOperand();
       continue;
     }
     if (auto *TTI = dyn_cast<ThinToThickFunctionInst>(Callee)) {
-      Callee = TTI->getConverted();
+      Callee = TTI->getOperand();
       continue;
     }
     break;
@@ -2391,7 +2391,7 @@ static bool isTryApplyOfConvertFunction(TryApplyInst *TAI,
   // Look through a @noescape conversion.
   auto *Cvt = dyn_cast<ConvertEscapeToNoEscapeInst>(CalleeOperand);
   if (Cvt)
-    CalleeOperand = Cvt->getConverted();
+    CalleeOperand = Cvt->getOperand();
 
   auto *CFI = dyn_cast<ConvertFunctionInst>(CalleeOperand);
   if (!CFI)
@@ -2400,7 +2400,7 @@ static bool isTryApplyOfConvertFunction(TryApplyInst *TAI,
   // Check if it is a conversion of a non-throwing function into
   // a throwing function. If this is the case, replace by a
   // simple apply.
-  auto OrigFnTy = CFI->getConverted()->getType().getAs<SILFunctionType>();
+  auto OrigFnTy = CFI->getOperand()->getType().getAs<SILFunctionType>();
   if (!OrigFnTy || OrigFnTy->hasErrorResult())
     return false;
   
@@ -2409,7 +2409,7 @@ static bool isTryApplyOfConvertFunction(TryApplyInst *TAI,
     return false;
 
   // Look through the conversions and find the real callee.
-  Callee = getActualCallee(CFI->getConverted());
+  Callee = getActualCallee(CFI->getOperand());
   CalleeType = Callee->getType();
   
   // If it a call of a throwing callee, bail.

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -96,10 +96,10 @@ bool CanonicalizeBorrowScope::isRewritableOSSAForward(SILInstruction *inst) {
   if (inst->getNumOperands() != 1)
     return false;
 
-  if (isa<OwnershipForwardingConversionInst>(inst)
-      || isa<OwnershipForwardingMultipleValueInstruction>(inst)
-      || isa<AllArgOwnershipForwardingSingleValueInst>(inst)
-      || isa<FirstArgOwnershipForwardingSingleValueInst>(inst)) {
+  if (isa<OwnershipForwardingConversionInst>(inst) ||
+      isa<OwnershipForwardingMultipleValueInstruction>(inst) ||
+      isa<AllArgOwnershipForwardingSingleValueInst>(inst) ||
+      isa<FirstArgOwnershipForwardingSingleValueInst>(inst)) {
     Operand *forwardedOper = &inst->getOperandRef(0);
     // Trivial conversions do not need to be hoisted out of a borrow scope.
     auto operOwnership = forwardedOper->getOperandOwnership();

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -95,7 +95,6 @@ bool CanonicalizeBorrowScope::isRewritableOSSAForward(SILInstruction *inst) {
     return false;
 
   if (isa<OwnershipForwardingSingleValueInstruction>(inst) ||
-      isa<OwnershipForwardingConversionInst>(inst) ||
       isa<OwnershipForwardingMultipleValueInstruction>(inst)) {
     Operand *forwardedOper = &inst->getOperandRef(0);
     // Trivial conversions do not need to be hoisted out of a borrow scope.

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -78,8 +78,6 @@ static void deleteCopyAndMoveChain(SILValue v, InstructionDeleter &deleter) {
 ///   OwnershipForwardingConversionInst (all kinds of ref casts)
 ///   OwnershipForwardingMultipleValueInstruction
 ///     (DestructureStruct, DestructureTuple)
-///   AllArgOwnershipForwardingSingleValueInst
-///     (Struct, Tuple)
 ///   FirstArgOwnershipForwardingSingleValueInst
 ///     (Object, Enum, UncheckedEnumData, Open/InitExistentialRef,
 ///      MarkDependence)
@@ -96,7 +94,7 @@ bool CanonicalizeBorrowScope::isRewritableOSSAForward(SILInstruction *inst) {
   if (inst->getNumOperands() != 1)
     return false;
 
-  if (isa<OwnershipForwardingSingleValueInstruction>(inst)
+  if (isa<OwnershipForwardingSingleValueInstruction>(inst) ||
       isa<OwnershipForwardingConversionInst>(inst) ||
       isa<OwnershipForwardingMultipleValueInstruction>(inst)) {
     Operand *forwardedOper = &inst->getOperandRef(0);

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -96,10 +96,9 @@ bool CanonicalizeBorrowScope::isRewritableOSSAForward(SILInstruction *inst) {
   if (inst->getNumOperands() != 1)
     return false;
 
-  if (isa<OwnershipForwardingConversionInst>(inst) ||
-      isa<OwnershipForwardingMultipleValueInstruction>(inst) ||
-      isa<AllArgOwnershipForwardingSingleValueInst>(inst) ||
-      isa<FirstArgOwnershipForwardingSingleValueInst>(inst)) {
+  if (isa<OwnershipForwardingSingleValueInstruction>(inst)
+      isa<OwnershipForwardingConversionInst>(inst) ||
+      isa<OwnershipForwardingMultipleValueInstruction>(inst)) {
     Operand *forwardedOper = &inst->getOperandRef(0);
     // Trivial conversions do not need to be hoisted out of a borrow scope.
     auto operOwnership = forwardedOper->getOperandOwnership();

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -526,7 +526,7 @@ eliminateUnneededForwardingUnarySingleValueInst(SingleValueInstruction *inst,
 static Optional<SILBasicBlock::iterator>
 tryEliminateUnneededForwardingInst(SILInstruction *i,
                                    CanonicalizeInstruction &pass) {
-  assert(OwnershipForwardingMixin::isa(i) &&
+  assert(ForwardingInstruction::isa(i) &&
          "Must be an ownership forwarding inst");
   if (auto *svi = dyn_cast<SingleValueInstruction>(i))
     if (svi->getNumOperands() == 1)
@@ -565,7 +565,7 @@ CanonicalizeInstruction::canonicalize(SILInstruction *inst) {
   auto *fn = inst->getFunction();
   if (!preserveDebugInfo && fn->hasOwnership()
       && fn->getModule().getStage() != SILStage::Raw) {
-    if (OwnershipForwardingMixin::isa(inst))
+    if (ForwardingInstruction::isa(inst))
       if (auto newNext = tryEliminateUnneededForwardingInst(inst, *this))
         return *newNext;
   }

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1631,7 +1631,7 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
 
 /// Simplify conversions between thick and objc metatypes.
 SILValue CastOptimizer::optimizeMetatypeConversion(
-    ConversionInst *mci, MetatypeRepresentation representation) {
+    ConversionOperation mci, MetatypeRepresentation representation) {
   SILValue op = mci->getOperand(0);
   // Instruction has a proper target type already.
   SILType ty = mci->getType();
@@ -1646,14 +1646,14 @@ SILValue CastOptimizer::optimizeMetatypeConversion(
   auto replaceCast = [&](SILValue newValue) -> SILValue {
     assert(ty.getAs<AnyMetatypeType>()->getRepresentation() ==
            newValue->getType().getAs<AnyMetatypeType>()->getRepresentation());
-    replaceValueUsesAction(mci, newValue);
-    eraseInstAction(mci);
+    replaceValueUsesAction(*mci, newValue);
+    eraseInstAction(*mci);
     return newValue;
   };
 
   if (auto *mi = dyn_cast<MetatypeInst>(op)) {
     return replaceCast(
-        SILBuilderWithScope(mci, builderContext).createMetatype(loc, ty));
+        SILBuilderWithScope(*mci, builderContext).createMetatype(loc, ty));
   }
 
   // For metatype instructions that require an operand, generate the new

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1803,8 +1803,10 @@ SILValue swift::makeValueAvailable(SILValue value, SILBasicBlock *inBlock) {
 
 bool swift::tryEliminateOnlyOwnershipUsedForwardingInst(
     SingleValueInstruction *forwardingInst, InstModCallbacks &callbacks) {
-  if (!ForwardingInstruction::isa(forwardingInst) ||
-      isa<AllArgOwnershipForwardingSingleValueInst>(forwardingInst))
+  if (!ForwardingInstruction::isa(forwardingInst))
+    return false;
+
+  if (ForwardingInstruction::canForwardAllOperands(forwardingInst))
     return false;
 
   SmallVector<Operand *, 32> worklist(getNonDebugUses(forwardingInst));

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1803,7 +1803,7 @@ SILValue swift::makeValueAvailable(SILValue value, SILBasicBlock *inBlock) {
 
 bool swift::tryEliminateOnlyOwnershipUsedForwardingInst(
     SingleValueInstruction *forwardingInst, InstModCallbacks &callbacks) {
-  if (!OwnershipForwardingMixin::isa(forwardingInst) ||
+  if (!ForwardingInstruction::isa(forwardingInst) ||
       isa<AllArgOwnershipForwardingSingleValueInst>(forwardingInst))
     return false;
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1931,15 +1931,15 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::RefToBridgeObjectInst: {
     auto RI = cast<RefToBridgeObjectInst>(&SI);
-    SILTwoOperandsLayout::emitRecord(Out, ScratchRecord,
-           SILAbbrCodes[SILTwoOperandsLayout::Code], (unsigned)SI.getKind(),
-           /*attr*/ 0,
-           S.addTypeRef(RI->getConverted()->getType().getRawASTType()),
-           (unsigned)RI->getConverted()->getType().getCategory(),
-           addValueRef(RI->getConverted()),
-           S.addTypeRef(RI->getBitsOperand()->getType().getRawASTType()),
-           (unsigned)RI->getBitsOperand()->getType().getCategory(),
-           addValueRef(RI->getBitsOperand()));
+    auto op = RI->getOperand(0);
+    SILTwoOperandsLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILTwoOperandsLayout::Code],
+        (unsigned)SI.getKind(),
+        /*attr*/ 0, S.addTypeRef(op->getType().getRawASTType()),
+        (unsigned)op->getType().getCategory(), addValueRef(op),
+        S.addTypeRef(RI->getBitsOperand()->getType().getRawASTType()),
+        (unsigned)RI->getBitsOperand()->getType().getCategory(),
+        addValueRef(RI->getBitsOperand()));
     break;
   }
   // Checked Conversion instructions.


### PR DESCRIPTION
We had several types to represent forwarding instructions : 

`FirstArgOwnershipForwardingSingleValueInst`, `GuaranteedFirstArgForwardingSingleValueInst`, `OwnedFirstArgForwardingSingleValueInst`, `AllArgForwardingSingleValueInst`, `OwnershipConversionInstruction`

They are unnecessary and the additional functionality they are providing can just be an API on a common type. They also became hard to maintain, and new forwarding instructions did not inherit from any of these types. They were also hard to use. eg: to check if a forwarding instruction forwarded its first first operand, clients were checking if some forwarding instruction is `FirstArgOwnershipForwardingSingleValueInst ||   OwnershipConversionInstruction || OwnershipForwardingTermInst`, making the purpose non obvious to the reader.

This PR gets rid of all mixin types. With this change we will have a common type `ForwardingInstruction` and 3 additional types `OwnershipForwardingSingleValueInstruction`,  `OwnershipForwardingMultipleValueInstruction`, `OwnershipForwardingTermInstruction`. New apis are added on `ForwardingInstruction` to classify forwarding instructions.

PR to remove `OwnershipForwardingSelectEnumInstBase` will follow this. 

