### PR TITLE
[Macros] Plugin search options group

### DIFF
--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -52,30 +52,19 @@ public:
   void setRegistry(PluginRegistry *newValue);
   PluginRegistry *getRegistry();
 
-  /// Lookup a library plugin that can handle \p moduleName and return the path
-  /// to it from `-load-plugin-library`.
-  /// The path returned can be loaded by 'loadLibraryPlugin' method.
-  llvm::Optional<std::string>
-  lookupExplicitLibraryPluginByModuleName(Identifier moduleName);
-
-  /// Lookup a library plugin that can handle \p moduleName and return the path
-  /// to it from `-plugin-path`.
-  /// The path returned can be loaded by 'loadLibraryPlugin' method.
-  llvm::Optional<std::string>
-  lookupLibraryPluginInSearchPathByModuleName(Identifier moduleName);
-
-  /// Lookup an executable plugin that is declared to handle \p moduleName
-  /// module by '-load-plugin-executable'.
-  /// The path returned can be loaded by 'loadExecutablePlugin' method.
-  llvm::Optional<StringRef>
-  lookupExecutablePluginByModuleName(Identifier moduleName);
-
-  /// Look for dynamic libraries in paths from `-external-plugin-path` and
-  /// return a pair of `(library path, plugin server executable)` if found.
-  /// These paths are valid within the VFS, use `FS.getRealPath()` for their
-  /// underlying path.
-  llvm::Optional<std::pair<std::string, std::string>>
-  lookupExternalLibraryPluginByModuleName(Identifier moduleName);
+  /// Lookup a plugin that can handle \p moduleName and return the path(s) to
+  /// it. The path returned can be loaded by 'load(Library|Executable)Plugin()'.
+  /// The return value is a pair of a "library path" and a "executable path".
+  ///
+  ///  * (libPath: empty, execPath: empty) - plugin not found.
+  ///  * (libPath: some,  execPath: empty) - load the library path by
+  ///    'loadLibraryPlugin()'.
+  ///  * (libPath: empty, execPath: some) - load the executable path by
+  ///    'loadExecutablePlugin()'.
+  ///  * (libPath: some,  execPath: some) - load the executable path by
+  ///    'loadExecutablePlugin()' and let the plugin load the libPath via IPC.
+  std::pair<std::string, std::string>
+  lookupPluginByModuleName(Identifier moduleName);
 
   /// Load the specified dylib plugin path resolving the path with the
   /// current VFS. If it fails to load the plugin, a diagnostic is emitted, and

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -198,14 +198,6 @@ public:
     SearchPathOpts.VFSOverlayFiles = Overlays;
   }
 
-  void setCompilerPluginLibraryPaths(const std::vector<std::string> &Paths) {
-    SearchPathOpts.setCompilerPluginLibraryPaths(Paths);
-  }
-
-  ArrayRef<std::string> getCompilerPluginLibraryPaths() {
-    return SearchPathOpts.getCompilerPluginLibraryPaths();
-  }
-
   void setExtraClangArgs(const std::vector<std::string> &Args) {
     ClangImporterOpts.ExtraArgs = Args;
   }

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -304,15 +304,6 @@ def I : JoinedOrSeparate<["-"], "I">,
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<I>;
 
-def plugin_path : Separate<["-"], "plugin-path">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
-  HelpText<"Add directory to the plugin search path">;
-
-def external_plugin_path : Separate<["-"], "external-plugin-path">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
-  HelpText<"Add directory to the plugin search path with a plugin server executable">,
-  MetaVarName<"<path>#<plugin-server-path>">;
-
 def import_underlying_module : Flag<["-"], "import-underlying-module">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Implicitly imports the Objective-C half of a module">;
@@ -1852,15 +1843,27 @@ def clang_include_tree_root: Separate<["-"], "clang-include-tree-root">,
   Flags<[FrontendOption, NoDriverOption]>,
   HelpText<"Clang Include Tree CASID">, MetaVarName<"<cas-id>">;
 
+
+def plugin_search_Group : OptionGroup<"<plugin search options>">;
+
+def plugin_path : Separate<["-"], "plugin-path">, Group<plugin_search_Group>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"Add directory to the plugin search path">;
+
+def external_plugin_path : Separate<["-"], "external-plugin-path">, Group<plugin_search_Group>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"Add directory to the plugin search path with a plugin server executable">,
+  MetaVarName<"<path>#<plugin-server-path>">;
+
 def load_plugin_library:
-  Separate<["-"], "load-plugin-library">,
+  Separate<["-"], "load-plugin-library">, Group<plugin_search_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Path to a dynamic library containing compiler plugins such as "
            "macros">,
   MetaVarName<"<path>">;
 
 def load_plugin_executable:
-  Separate<["-"], "load-plugin-executable">,
+  Separate<["-"], "load-plugin-executable">, Group<plugin_search_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Path to an executable compiler plugins and providing module names "
            "such as macros">,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -103,11 +103,10 @@ llvm::StringRef swift::getProtocolName(KnownProtocolKind kind) {
 }
 
 namespace {
-  enum class SearchPathKind : uint8_t {
-    Import = 1 << 0,
-    Framework = 1 << 1,
-    CompilerPlugin = 1 << 2
-  };
+enum class SearchPathKind : uint8_t {
+  Import = 1 << 0,
+  Framework = 1 << 1,
+};
 } // end anonymous namespace
 
 using AssociativityCacheType =
@@ -694,8 +693,6 @@ ASTContext::ASTContext(
     getImpl().SearchPathsSet[path] |= SearchPathKind::Import;
   for (const auto &framepath : SearchPathOpts.getFrameworkSearchPaths())
     getImpl().SearchPathsSet[framepath.Path] |= SearchPathKind::Framework;
-  for (StringRef path : SearchPathOpts.getCompilerPluginLibraryPaths())
-    getImpl().SearchPathsSet[path] |= SearchPathKind::CompilerPlugin;
 
   // Register any request-evaluator functions available at the AST layer.
   registerAccessRequestFunctions(evaluator);

--- a/lib/AST/SearchPathOptions.cpp
+++ b/lib/AST/SearchPathOptions.cpp
@@ -73,12 +73,6 @@ void ModuleSearchPathLookup::rebuildLookupTable(const SearchPathOptions *Opts,
                                 /*isSystem=*/true, Entry.index());
   }
 
-  for (auto Entry : llvm::enumerate(Opts->getCompilerPluginLibraryPaths())) {
-    addFilesInPathToLookupTable(FS, Entry.value(),
-                                ModuleSearchPathKind::CompilerPlugin,
-                                /*isSystem=*/false, Entry.index());
-  }
-
   State.FileSystem = FS;
   State.IsOSDarwin = IsOSDarwin;
   State.Opts = Opts;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -236,8 +236,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddAllArgs(arguments, options::OPT_I);
   inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
   inputArgs.AddAllArgs(arguments, options::OPT_vfsoverlay);
-  inputArgs.AddAllArgs(arguments, options::OPT_plugin_path);
-  inputArgs.AddAllArgs(arguments, options::OPT_external_plugin_path);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);
@@ -325,8 +323,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_bare_slash_regex);
   inputArgs.AddLastArg(arguments, options::OPT_enable_experimental_cxx_interop);
   inputArgs.AddLastArg(arguments, options::OPT_cxx_interoperability_mode);
-  inputArgs.AddLastArg(arguments, options::OPT_load_plugin_library);
-  inputArgs.AddLastArg(arguments, options::OPT_load_plugin_executable);
   inputArgs.AddLastArg(arguments, options::OPT_enable_builtin_module);
 
   // Pass on any build config options
@@ -376,9 +372,9 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     inputArgs.AddAllArgs(arguments, options::OPT_file_compilation_dir);
   }
 
-  // Add plugin path options.
-  inputArgs.AddAllArgs(arguments, options::OPT_plugin_path);
-
+  // Specify default plugin search path options after explicitly specified
+  // options.
+  inputArgs.AddAllArgs(arguments, options::OPT_plugin_search_Group);
   {
     SmallString<64> pluginPath;
     auto programPath = getDriver().getSwiftProgramPath();

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -345,25 +345,8 @@ CompilerPluginLoadRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
 
   std::string libraryPath;
   std::string executablePath;
-
-  // '-load-plugin-libarary'.
-  if (auto found = loader.lookupExplicitLibraryPluginByModuleName(moduleName)) {
-    libraryPath = found.value();
-  }
-  // '-load-plugin-executable'.
-  else if (auto found = loader.lookupExecutablePluginByModuleName(moduleName)) {
-    executablePath = found->str();
-  }
-  // '-plugin-path'.
-  else if (auto found =
-               loader.lookupLibraryPluginInSearchPathByModuleName(moduleName)) {
-    libraryPath = found.value();
-  }
-  // '-external-plugin-path'.
-  else if (auto found =
-               loader.lookupExternalLibraryPluginByModuleName(moduleName)) {
-    std::tie(libraryPath, executablePath) = found.value();
-  }
+  std::tie(libraryPath, executablePath) =
+      loader.lookupPluginByModuleName(moduleName);
 
   if (!executablePath.empty()) {
     if (LoadedExecutablePlugin *executablePlugin =

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -205,8 +205,7 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
       });
       return None;
     }
-    case ModuleSearchPathKind::RuntimeLibrary:
-    case ModuleSearchPathKind::CompilerPlugin: {
+    case ModuleSearchPathKind::RuntimeLibrary: {
       // Look for:
       // (Darwin OS) $PATH/{name}.swiftmodule/{arch}.{extension}
       // (Other OS)  $PATH/{name}.{extension}
@@ -678,8 +677,7 @@ bool SerializedModuleLoaderBase::findModule(
 
     switch (searchPath->getKind()) {
     case ModuleSearchPathKind::Import:
-    case ModuleSearchPathKind::RuntimeLibrary:
-    case ModuleSearchPathKind::CompilerPlugin: {
+    case ModuleSearchPathKind::RuntimeLibrary: {
       isFramework = false;
 
       // On Apple platforms, we can assume that the runtime libraries use

--- a/test/Macros/macro_mixedpluginpath.swift
+++ b/test/Macros/macro_mixedpluginpath.swift
@@ -25,14 +25,14 @@
 
 //#-- Check '-load-plugin-library' takes precedence over '-plugin-path'.
 // RUN: %target-swift-frontend -typecheck -verify -swift-version 5 \
-// RUN:   -plugin-path %t/plugins \
 // RUN:   -load-plugin-library %t/plugins_local/%target-library-name(MacroDefinition) \
+// RUN:   -plugin-path %t/plugins \
 // RUN:   %t/src/test.swift
 
-//#-- Same, but with different argument order.
-// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 \
-// RUN:   -load-plugin-library %t/plugins_local/%target-library-name(MacroDefinition) \
+//#-- Different argument order changes the search order, hence fail.
+// RUN: not %target-swift-frontend -typecheck -verify -swift-version 5 \
 // RUN:   -plugin-path %t/plugins \
+// RUN:   -load-plugin-library %t/plugins_local/%target-library-name(MacroDefinition) \
 // RUN:   %t/src/test.swift
 
 //--- test.swift
@@ -40,7 +40,7 @@
 
 func foo() {
   let _: Int = #constInt
-  // If 'MacroDefinition.float.swift' is loaded, type checking this fails because it expands to '4.2' which is a float literal.
+  // If 'MacroDefinition.float.swift' (in '-pluing-path') is loaded, type checking this fails because it expands to '4.2' which is a float literal.
 }
 
 //--- MacroDefinition.float.swift

--- a/test/Macros/macro_plugin_searchorder.swift
+++ b/test/Macros/macro_plugin_searchorder.swift
@@ -50,39 +50,42 @@
 
 //#-- Expect -load-plugin-library
 // RUN: %target-build-swift %t/src/test.swift \
-// RUN:   -o %t/main1 \
 // RUN:   -module-name test \
+// RUN:   -load-plugin-library %t/lib/tmp/%target-library-name(MacroDefinition) \
 // RUN:   -plugin-path %t/lib/plugins \
 // RUN:   -external-plugin-path %t/external#%swift-plugin-server \
-// RUN:   -load-plugin-library %t/lib/tmp/%target-library-name(MacroDefinition) \
-// RUN:   -load-plugin-executable  %t/libexec/MacroDefinitionPlugin#MacroDefinition
+// RUN:   -load-plugin-executable  %t/libexec/MacroDefinitionPlugin#MacroDefinition \
+// RUN:   -o %t/main1
 // RUN: %target-codesign %t/main1
 // RUN: %target-run %t/main1 | %FileCheck --check-prefix=CHECK_LOAD_PLUGIN_LIBRARY %s
 
 //#-- Expect -load-plugin-executable
 // RUN: %target-build-swift %t/src/test.swift \
-// RUN:   -o %t/main2 \
 // RUN:   -module-name test \
+// RUN:   -load-plugin-executable  %t/libexec/MacroDefinitionPlugin#MacroDefinition \
 // RUN:   -plugin-path %t/lib/plugins \
 // RUN:   -external-plugin-path %t/external#%swift-plugin-server \
-// RUN:   -load-plugin-executable  %t/libexec/MacroDefinitionPlugin#MacroDefinition
+// RUN:   -o %t/main2
 // RUN: %target-codesign %t/main2
 // RUN: %target-run %t/main2 | %FileCheck --check-prefix=CHECK_LOAD_PLUGIN_EXECUTABLE %s
 
 //#-- Expect -plugin-path
 // RUN: %target-build-swift %t/src/test.swift \
-// RUN:   -o %t/main3 \
 // RUN:   -module-name test \
 // RUN:   -plugin-path %t/lib/plugins \
-// RUN:   -external-plugin-path %t/external#%swift-plugin-server
+// RUN:   -load-plugin-library %t/lib/tmp/%target-library-name(MacroDefinition) \
+// RUN:   -external-plugin-path %t/external#%swift-plugin-server \
+// RUN:   -o %t/main3
 // RUN: %target-codesign %t/main3
 // RUN: %target-run %t/main3 | %FileCheck --check-prefix=CHECK_PLUGIN_PATH %s
 
 //#-- Expect -external-plugin-path
 // RUN: %target-build-swift %t/src/test.swift \
-// RUN:   -o %t/main4 \
 // RUN:   -module-name test \
-// RUN:   -external-plugin-path %t/external#%swift-plugin-server
+// RUN:   -external-plugin-path %t/external#%swift-plugin-server \
+// RUN:   -plugin-path %t/lib/plugins \
+// RUN:   -load-plugin-executable  %t/libexec/MacroDefinitionPlugin#MacroDefinition \
+// RUN:   -o %t/main4
 // RUN: %target-codesign %t/main4
 // RUN: %target-run %t/main4 | %FileCheck --check-prefix=CHECK_EXTERNAL_PLUGIN_PATH %s
 

--- a/test/Macros/serialize_plugin_search_paths.swift
+++ b/test/Macros/serialize_plugin_search_paths.swift
@@ -15,7 +15,6 @@
 // CHECK:     -plugin-path: {{.*}}plugins
 // CHECK:     -plugin-path: {{.*}}plugins
 // CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -plugin-path: {{.*}}plugins
 // CHECK:     -external-plugin-path: {{.*}}plugins#{{.*}}swift-plugin-server
 // CHECK:     -load-plugin-library: {{.*}}MacroDefinition.{{dylib|so|dll}}
 // CHECK:     -load-plugin-executable: {{.*}}mock-plugin#TestPlugin

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4513,15 +4513,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  for (auto path : options::PluginPath) {
-    InitInvok.getSearchPathOptions().PluginSearchPaths.push_back(path);
-  }
   if (!options::LoadPluginLibrary.empty()) {
     std::vector<std::string> paths;
     for (auto path: options::LoadPluginLibrary) {
-      paths.push_back(path);
+      InitInvok.getSearchPathOptions().PluginSearchOpts.emplace_back(
+          PluginSearchOption::LoadPluginLibrary{path});
     }
-    InitInvok.getSearchPathOptions().setCompilerPluginLibraryPaths(paths);
   }
   if (!options::LoadPluginExecutable.empty()) {
     std::vector<PluginExecutablePathAndModuleNames> pairs;
@@ -4533,10 +4530,14 @@ int main(int argc, char *argv[]) {
       for (auto name : llvm::split(modulesStr, ',')) {
         moduleNames.emplace_back(name);
       }
-      pairs.push_back({std::string(path), std::move(moduleNames)});
+      InitInvok.getSearchPathOptions().PluginSearchOpts.emplace_back(
+          PluginSearchOption::LoadPluginExecutable{std::string(path),
+                                                   std::move(moduleNames)});
     }
-
-    InitInvok.getSearchPathOptions().setCompilerPluginExecutablePaths(std::move(pairs));
+  }
+  for (auto path : options::PluginPath) {
+    InitInvok.getSearchPathOptions().PluginSearchOpts.emplace_back(
+        PluginSearchOption::PluginPath{path});
   }
 
   // Process the clang arguments last and allow them to override previously


### PR DESCRIPTION
`load-plugin-library`, `load-plugin-executable`, `-plugin-path` and `-external-plugin-path` should be searched in the order they are specified in the arguments.

Previously, for example `-plugin-path` used to precede `-external-plugin-path` regardless of the position in the arguments.
