### PR TITLE
swift_build_support cmake.py: allow bootstrapping CMake on FreeBSD

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -283,11 +283,11 @@ class CMake(object):
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')
 
-    # For Linux only, determine the version of the installed CMake compared to
-    # the source and build the source if necessary. Returns the path to the
-    # cmake binary.
+    # For Linux and FreeBSD only, determine the version of the installed
+    # CMake compared to the source and build the source if necessary.
+    # Returns the path to the cmake binary.
     def check_cmake_version(self, source_root, build_root):
-        if platform.system() != 'Linux':
+        if not platform.system() in ["Linux", "FreeBSD"]:
             return
 
         cmake_source_dir = os.path.join(source_root, 'cmake')


### PR DESCRIPTION
A given FreeBSD version may not always have latest CMake installed if any at all. Let's bootstrap it the same way we do it on Linux.
