### PR TITLE
5.9: [Test] Remove 64-bit specific FileCheck line.

### DIFF
--- a/test/IRGen/pack_metadata_marker_inserter.sil
+++ b/test/IRGen/pack_metadata_marker_inserter.sil
@@ -108,7 +108,6 @@ sil @forward_type_pack : $<each T>() -> () {
 // CHECK-LLVM-SAME:        i8* [[LIFETIME_START_CAST]])
 // CHECK-LLVM:         [[LIFETIME_END_CAST:%[^,]+]] = bitcast [3 x %swift.type*]* [[PACK_ADDR]] to i8*
 // CHECK-LLVM:         call void @llvm.lifetime.end.p0i8(
-// CHECK-LLVM-SAME:        [[INT]] 24, 
 // CHECK-LLVM-SAME:        i8* [[LIFETIME_END_CAST]])
 // CHECK-LLVM:         ret void
 // CHECK-LLVM:       }


### PR DESCRIPTION
Removed one last 64-bit specific check-line that wasn't removed in https://github.com/apple/swift/pull/66434 .

rdar://110744959
