### PR TITLE
[5.9][Build] Read all shell output as UTF-8

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -228,8 +228,10 @@ def run(*args, **kwargs):
     my_pipe = subprocess.Popen(
         *args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         universal_newlines=True,
+        encoding='utf-8',
         **kwargs)
     (output, _) = my_pipe.communicate()
+    output = output.encode(encoding='ascii', errors='replace')
     ret = my_pipe.wait()
 
     if lock:


### PR DESCRIPTION
* Explanation: Windows CI has been failing as there seems to be non-ASCII output from running update-checkout sometimes. Read all output as UTF-8 and then encode it back into ASCII (replacing errors) as we've had issues with UTF-8 then being output to terminal in the past.
* Scope: Builds
* Risk: Low. This impacts build infrastructure, if everything builds then there shouldn't be any issues.
* Original PR: https://github.com/apple/swift/pull/66440 
