### PR TITLE
GenericSpecializer: drop metatype arguments in specialized functions

### DIFF
--- a/include/swift/SIL/GenericSpecializationMangler.h
+++ b/include/swift/SIL/GenericSpecializationMangler.h
@@ -88,7 +88,8 @@ public:
       : SpecializationMangler(SpecializationPass::GenericSpecializer,
                               Serialized, F) {}
 
-  std::string mangleNotReabstracted(SubstitutionMap subs);
+  std::string mangleNotReabstracted(SubstitutionMap subs,
+                                    bool metatyeParamsRemoved);
 
   /// Mangle a generic specialization with re-abstracted parameters.
   ///

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -157,10 +157,6 @@ class ReabstractionInfo {
     LoadableAndTrivial
   };
   
-  unsigned param2ArgIndex(unsigned ParamIdx) const  {
-    return ParamIdx + NumFormalIndirectResults;
-  }
-
   // Create a new substituted type with the updated signature.
   CanSILFunctionType createSubstitutedType(SILFunction *OrigF,
                                            SubstitutionMap SubstMap,
@@ -199,8 +195,8 @@ public:
                     ApplySite Apply, SILFunction *Callee,
                     SubstitutionMap ParamSubs,
                     IsSerialized_t Serialized,
-                    bool ConvertIndirectToDirect = true,
-                    bool dropMetatypeArgs = false,
+                    bool ConvertIndirectToDirect,
+                    bool dropMetatypeArgs,
                     OptRemark::Emitter *ORE = nullptr);
 
   /// Constructs the ReabstractionInfo for generic function \p Callee with
@@ -214,7 +210,11 @@ public:
   IsSerialized_t isSerialized() const {
     return Serialized;
   }
-  
+
+  unsigned param2ArgIndex(unsigned ParamIdx) const  {
+    return ParamIdx + NumFormalIndirectResults;
+  }
+
   /// Returns true if the specialized function needs an alternative mangling.
   /// See hasConvertedResilientParams.
   bool needAlternativeMangling() const {
@@ -313,6 +313,8 @@ public:
   /// SubstFTy by applying the re-abstractions.
   CanSILFunctionType createSpecializedType(CanSILFunctionType SubstFTy,
                                            SILModule &M) const;
+
+  CanSILFunctionType createThunkType(PartialApplyInst *forPAI) const;
 
   SILFunction *getNonSpecializedFunction() const { return Callee; }
 

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -100,10 +100,15 @@ manglePrespecialized(GenericSignature sig, SubstitutionMap subs) {
 }
                                   
 std::string GenericSpecializationMangler::
-mangleNotReabstracted(SubstitutionMap subs) {
+mangleNotReabstracted(SubstitutionMap subs,
+                      bool metatyeParamsRemoved) {
   beginMangling();
   appendSubstitutions(getGenericSignature(), subs);
-  appendSpecializationOperator("TG");
+  if (metatyeParamsRemoved) {
+    appendSpecializationOperator("TGm");
+  } else {
+    appendSpecializationOperator("TG");
+  }
   return finalize();
 }
                                   

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -492,7 +492,7 @@ static SILFunction *getSpecializedWithDeadParams(
         FuncBuilder.getModule().getSwiftModule(),
         FuncBuilder.getModule().isWholeModule(), ApplySite(), Specialized,
         PAI->getSubstitutionMap(), Specialized->isSerialized(),
-        /* ConvertIndirectToDirect */ false);
+        /* ConvertIndirectToDirect */ false, /*dropMetatypeArgs=*/ false);
     GenericFuncSpecializer FuncSpecializer(FuncBuilder,
                                            Specialized,
                                            ReInfo.getClonerParamSubstitutionMap(),

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -91,7 +91,9 @@ bool UsePrespecialized::replaceByPrespecialized(SILFunction &F) {
       continue;
 
     ReabstractionInfo ReInfo(M.getSwiftModule(), M.isWholeModule(), AI,
-                             ReferencedF, Subs, IsNotSerialized);
+                             ReferencedF, Subs, IsNotSerialized,
+                             /*ConvertIndirectToDirect=*/ true,
+                             /*dropMetatypeArgs=*/ false);
 
     if (!ReInfo.canBeSpecialized())
       continue;

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -217,6 +217,8 @@ bool PerformanceDiagnostics::checkClosureValue(SILValue closure,
       closure = tfi->getOperand();
     } else if (auto *cp = dyn_cast<CopyValueInst>(closure)) {
       closure = cp->getOperand();
+    } else if (auto *cv = dyn_cast<ConvertFunctionInst>(closure)) {
+      closure = cv->getOperand();
     } else if (acceptFunctionArgs && isa<SILFunctionArgument>(closure)) {
       // We can assume that a function closure argument is already checked at
       // the call site.

--- a/test/SIL/Serialization/specializer_can_deserialize.swift
+++ b/test/SIL/Serialization/specializer_can_deserialize.swift
@@ -8,10 +8,10 @@ import Swift
 
 // CHECK-LABEL: sil {{.*}}@main
 // CHECK: bb0({{.*}}):
-// CHECK: function_ref @$ss9ContainerVAByxGycfCBi32__Tg5{{.*}}
+// CHECK: function_ref @$ss9ContainerVAByxGycfCBi32__Tgm5{{.*}}
 // CHECK: function_ref @$ss9ContainerV11doSomethingyyFBi32__Tg5{{.*}} 
 
-// CHECK-LABEL: sil shared [noinline] @$ss9ContainerVAByxGycfCBi32__Tg5Tf4d_n
+// CHECK-LABEL: sil shared [noinline] @$ss9ContainerVAByxGycfCBi32__Tgm5
 
 // CHECK-LABEL: sil shared [noinline] @$ss9ContainerV11doSomethingyyFBi32__Tg5Tf4d_n
 

--- a/test/SILOptimizer/existential_metatype.swift
+++ b/test/SILOptimizer/existential_metatype.swift
@@ -3,12 +3,12 @@ protocol SomeP {}
 
 public enum SpecialEnum : SomeP {}
 
-// CHECK-LABEL: sil shared [noinline] @$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tg5Tf4d_n : $@convention(thin) () -> Bool {
+// CHECK-LABEL: sil shared [noinline] @$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tgm5 : $@convention(thin) () -> Bool {
 // CHECK:       bb0:
 // CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
 // CHECK-NEXT:   %1 = struct $Bool (%0 : $Builtin.Int1)
 // CHECK-NEXT:   return %1 : $Bool
-// CHECK-LABEL: } // end sil function '$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tg5Tf4d_n'
+// CHECK-LABEL: } // end sil function '$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tgm5'
 @inline(never)
 func checkProtocolType<P : SomeP>(existentialType: P.Type) -> Bool {
   return existentialType == SpecialEnum.self

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -272,3 +272,33 @@ func testGlobalsWithConversion() -> UInt32 {
     return globalB
 }
 
+public struct X: Collection {
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+    public subscript(position: Int) -> Int {
+        get {
+            return 0
+        }
+    }
+    public var startIndex: Int = 0
+    public var endIndex: Int = 1
+    public typealias Index = Int
+}
+
+extension Collection where Element: Comparable {
+    public func testSorted() -> Int {
+        return testSorted(by: <)
+    }
+    public func testSorted(by areInIncreasingOrder: (Element, Element) -> Bool) -> Int {
+        let x = 0
+        _ = areInIncreasingOrder(self.first!, self.first!)
+        return x
+    }
+}
+@_noLocks
+public func testCollectionSort(a: X) -> Int {
+    _ = a.testSorted()
+    return 0
+}
+

--- a/test/SILOptimizer/set.swift
+++ b/test/SILOptimizer/set.swift
@@ -23,7 +23,7 @@ public func createEmptySetWithInitializer() -> Set<Int> {
 
 // CHECK-LABEL: sil {{.*}}@$s4test17createNonEmptySetShySiGyF
 // CHECK:         global_value
-// CHECK:         [[F:%[0-9]+]] = function_ref @$sSh21_nonEmptyArrayLiteralShyxGSayxG_tcfCSi_Tg5
+// CHECK:         [[F:%[0-9]+]] = function_ref @$sSh21_nonEmptyArrayLiteralShyxGSayxG_tcfCSi_Tgm5
 // CHECK:         apply [[F]]
 // CHECK:       } // end sil function '$s4test17createNonEmptySetShySiGyF'
 public func createNonEmptySet() -> Set<Int> {

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -9,7 +9,7 @@ import Swift
 // CHECK-LABEL: sil @exp1 : $@convention(thin) () -> () {
 // CHECK-NOT: apply
 // Call of specialized initializer: <Int32>
-// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tg5
+// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tgm5
 // CHECK: apply [[CTOR]]
 // CHECK: [[ACCEPTS_INT:%[0-9]+]] = function_ref @acceptsInt
 // Call of specialized XXX_foo: <Int32>
@@ -35,7 +35,7 @@ import Swift
 // YAML:            Line:            73
 // YAML:            Column:          17
 // YAML-NEXT:   - String:          ' with type '
-// YAML-NEXT:   - FuncType:        '(Int32, @thin XXX<Int32>.Type) -> XXX<Int32>'
+// YAML-NEXT:   - FuncType:        '(Int32) -> XXX<Int32>'
 // YAML-NEXT: ...
 // YAML-NEXT: --- !Passed
 // YAML-NEXT: Pass:            sil-generic-specializer
@@ -556,7 +556,7 @@ bb0:
 
 // test_bind<A> (Builtin.RawPointer, A.Type) -> ()
 // Check that this is specialized as T=Int.
-// CHECK-LABEL: sil shared @$s9test_bindSi_Tg5 : $@convention(thin) (Builtin.RawPointer, @thick Int.Type) -> ()
+// CHECK-LABEL: sil shared @$s9test_bindSi_Tgm5 : $@convention(thin) (Builtin.RawPointer) -> ()
 // CHECK: bind_memory %0 : $Builtin.RawPointer, {{%.*}} : $Builtin.Word to $*Int
 // CHECK: return
 sil hidden @test_bind : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> () {
@@ -701,7 +701,7 @@ bb0(%0 : $*T, %1 :$*T):
 }
 
 // This should not assert.
-// CHECK-LABEL: sil shared @$s26specialize_no_return_applys5NeverO_Tg5
+// CHECK-LABEL: sil shared @$s26specialize_no_return_applys5NeverO_Tgm5
 // CHECK:      apply
 // CHECK-NEXT: unreachable
 

--- a/test/SILOptimizer/specialize_chain.swift
+++ b/test/SILOptimizer/specialize_chain.swift
@@ -45,6 +45,6 @@ func exp1() {
 //CHECK: sil shared [noinline] @$s16specialize_chain3YYYV4AAA2{{[_0-9a-zA-Z]*}}FSi_Tg5
 //CHECK: sil shared [noinline] @$s16specialize_chain3YYYV4AAA1{{[_0-9a-zA-Z]*}}FSi_Tg5
 //CHECK: exp1
-//CHECK: function_ref @$s16specialize_chain3YYYV{{[_0-9a-zA-Z]*}}fCSi_Tg5
+//CHECK: function_ref @$s16specialize_chain3YYYV{{[_0-9a-zA-Z]*}}fCSi_Tgm5
 //CHECK: function_ref @$s16specialize_chain3YYYV4AAA9{{[_0-9a-zA-Z]*}}FSi_Tg5
 //CHECK: return

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -6,6 +6,7 @@ import Builtin
 import Swift
 
 class Klass {}
+class GenericKlass<T> {}
 
 sil [ossa] [transparent] @ossaTransparentCallee : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
@@ -43,7 +44,7 @@ bb0(%0 : $Builtin.NativeObject):
 // CHECK-LABEL: sil [ossa] @exp1 : $@convention(thin) () -> () {
 // CHECK-NOT: apply
 // Call of specialized initializer: <Int32>
-// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tg5
+// CHECK: [[CTOR:%[0-9]+]] = function_ref @$s8XXX_inits5Int32V_Tgm5
 // CHECK: apply [[CTOR]]
 // CHECK: [[ACCEPTS_INT:%[0-9]+]] = function_ref @acceptsInt
 // Call of specialized XXX_foo: <Int32>
@@ -634,7 +635,7 @@ bb0:
 
 // test_bind<A> (Builtin.RawPointer, A.Type) -> ()
 // Check that this is specialized as T=Int.
-// CHECK-LABEL: sil shared [ossa] @$s9test_bindSi_Tg5 : $@convention(thin) (Builtin.RawPointer, @thick Int.Type) -> ()
+// CHECK-LABEL: sil shared [ossa] @$s9test_bindSi_Tgm5 : $@convention(thin) (Builtin.RawPointer) -> () {
 // CHECK: bind_memory %0 : $Builtin.RawPointer, {{%.*}} : $Builtin.Word to $*Int
 // CHECK: return
 sil hidden [ossa] @test_bind : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> () {
@@ -893,7 +894,7 @@ bb0(%0 : $*T, %1 :$*T):
 }
 
 // This should not assert.
-// CHECK-LABEL: sil shared [ossa] @$s26specialize_no_return_applys5NeverO_Tg5
+// CHECK-LABEL: sil shared [ossa] @$s26specialize_no_return_applys5NeverO_Tgm5 : $@convention(thin) () -> () {
 // CHECK:      apply
 // CHECK-NEXT: unreachable
 
@@ -1305,7 +1306,7 @@ sil @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed AnyObject) -> @out
 // The generic cloner needs to be able to compute liveness to fixup a
 // store borrow scope when the only use is in unreachable code.
 // specialized testNoReturnSpecialization
-// CHECK-LABEL: sil shared [ossa] @$s26testNoReturnSpecializations5NeverO_Tg5 : $@convention(thin) (@guaranteed AnyObject, @thick Never.Type) -> () {
+// CHECK-LABEL: sil shared [ossa] @$s26testNoReturnSpecializations5NeverO_Tgm5 : $@convention(thin) (@guaranteed AnyObject) -> () {
 // CHECK:   [[SB:%.*]] = store_borrow %0 to %{{.*}} : $*AnyObject
 // CHECK:   [[LB:%.*]] = load_borrow [[SB]] : $*AnyObject
 // CHECK:   apply %{{.*}}<Never>(%{{.*}}, [[LB]]) : $@convention(thin) <τ_0_0> (@guaranteed AnyObject) -> @out τ_0_0
@@ -1314,7 +1315,7 @@ sil @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed AnyObject) -> @out
 // CHECK: bb1:
 // CHECK:   end_borrow [[LB]] : $AnyObject
 // CHECK:   end_borrow [[SB]] : $*AnyObject
-// CHECK-LABEL: } // end sil function '$s26testNoReturnSpecializations5NeverO_Tg5'
+// CHECK-LABEL: } // end sil function '$s26testNoReturnSpecializations5NeverO_Tgm5'
 sil [ossa] @testNoReturnSpecialization : $@convention(thin) <T> (@in_guaranteed AnyObject, @thick T.Type) -> () {
 bb0(%0 : $*AnyObject, %1 : $@thick T.Type):
   %2 = load_borrow %0 : $*AnyObject
@@ -1336,3 +1337,132 @@ bb0(%0 : $*AnyObject):
   %t = tuple ()
   return %t : $()
 }
+
+sil [ossa] @metatypeUsed : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> () {
+bb0(%0 : $@thick GenericKlass<T>.Type):
+  %1 = alloc_ref_dynamic %0 : $@thick GenericKlass<T>.Type, $GenericKlass<T>
+  destroy_value %1 : $GenericKlass<T>
+   %3 = tuple ()
+  return %3 : $()
+}
+
+sil [ossa] @metatypeUnused : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> () {
+bb0(%0 : $@thick GenericKlass<T>.Type):
+  debug_value %0 : $@thick GenericKlass<T>.Type, let, name "mt", argno 0
+   %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @callUsedMetatypeWithConcreteMetatype :
+// CHECK:         = function_ref @$s12metatypeUsedSi_Tgm5 : $@convention(thin) () -> ()
+// CHECK-LABEL: } // end sil function 'callUsedMetatypeWithConcreteMetatype'
+sil [ossa] @callUsedMetatypeWithConcreteMetatype : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick GenericKlass<Int>.Type
+  %1 = function_ref @metatypeUsed : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> ()
+  %2 = apply %1<Int>(%0) : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @callUsedMetatypeWithUnknownMetatype :
+// CHECK:         = function_ref @$s12metatypeUsedSi_Tg5 : $@convention(thin) (@thick GenericKlass<Int>.Type) -> ()
+// CHECK-LABEL: } // end sil function 'callUsedMetatypeWithUnknownMetatype'
+sil [ossa] @callUsedMetatypeWithUnknownMetatype : $@convention(thin) (@thick GenericKlass<Int>.Type) -> () {
+bb0(%0 : $@thick GenericKlass<Int>.Type):
+  %1 = function_ref @metatypeUsed : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> ()
+  %2 = apply %1<Int>(%0) : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @callUnusedMetatypeWithUnknownMetatype :
+// CHECK:         = function_ref @$s14metatypeUnusedSi_Tgm5 : $@convention(thin) () -> ()
+// CHECK-LABEL: } // end sil function 'callUnusedMetatypeWithUnknownMetatype'
+sil [ossa] @callUnusedMetatypeWithUnknownMetatype : $@convention(thin) (@thick GenericKlass<Int>.Type) -> () {
+bb0(%0 : $@thick GenericKlass<Int>.Type):
+  %1 = function_ref @metatypeUnused : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> ()
+  %2 = apply %1<Int>(%0) : $@convention(thin) <T> (@thick GenericKlass<T>.Type) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil [ossa] @closure_with_metatype : $@convention(thin) <T> (@in_guaranteed T, @thick GenericKlass<T>.Type) -> () {
+bb0(%0 : $*T, %1 : $@thick GenericKlass<T>.Type):
+   %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @returnClosureWithAppliedMetatype :
+// CHECK:         = function_ref @$s21closure_with_metatypeSi_TGm5 : $@convention(thin) (@in_guaranteed Int) -> ()
+// CHECK-LABEL: } // end sil function 'returnClosureWithAppliedMetatype'
+sil [ossa] @returnClosureWithAppliedMetatype : $@convention(thin) () -> @owned @callee_owned (@in_guaranteed Int) -> () {
+bb0:
+  %0 = metatype $@thick GenericKlass<Int>.Type
+  %1 = function_ref @closure_with_metatype : $@convention(thin) <T> (@in_guaranteed T, @thick GenericKlass<T>.Type) -> ()
+  %2 = partial_apply %1<Int>(%0) : $@convention(thin) <T> (@in_guaranteed T, @thick GenericKlass<T>.Type) -> ()
+  return %2 : $@callee_owned (@in_guaranteed Int) -> ()
+}
+
+// CHECK-LABEL: sil [ossa] @returnClosureWithNotAppliedMetatype :
+// CHECK:         = function_ref @$s21closure_with_metatypeSi_TG5 : $@convention(thin) (@in_guaranteed Int, @thick GenericKlass<Int>.Type) -> ()
+// CHECK-LABEL: } // end sil function 'returnClosureWithNotAppliedMetatype'
+sil [ossa] @returnClosureWithNotAppliedMetatype : $@convention(thin) () -> @owned @callee_owned (@in_guaranteed Int, @thick GenericKlass<Int>.Type) -> () {
+bb0:
+  %1 = function_ref @closure_with_metatype : $@convention(thin) <T> (@in_guaranteed T, @thick GenericKlass<T>.Type) -> ()
+  %2 = partial_apply %1<Int>() : $@convention(thin) <T> (@in_guaranteed T, @thick GenericKlass<T>.Type) -> ()
+  return %2 : $@callee_owned (@in_guaranteed Int, @thick GenericKlass<Int>.Type) -> ()
+}
+
+sil [ossa] @method_with_dynamic_self : $@convention(method) <T> (@thick GenericKlass<T>.Type) -> () {
+bb0(%0 : $@thick GenericKlass<T>.Type):
+  %1 = metatype $@thick @dynamic_self GenericKlass<T>.Type
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @callMethodWithDynamicSelf :
+// CHECK:         = function_ref @$s24method_with_dynamic_selfSi_Tg5 : $@convention(method) (@thick GenericKlass<Int>.Type) -> ()
+// CHECK-LABEL: } // end sil function 'callMethodWithDynamicSelf'
+sil [ossa] @callMethodWithDynamicSelf : $@convention(thin) () -> () {
+bb0:
+  %0 = metatype $@thick GenericKlass<Int>.Type
+  %1 = function_ref @method_with_dynamic_self : $@convention(method) <T> (@thick GenericKlass<T>.Type) -> ()
+  %2 = apply %1<Int>(%0) : $@convention(method) <T> (@thick GenericKlass<T>.Type) -> ()
+  return %2 : $()
+}
+
+sil @complex_closure : $@convention(thin) <T> (@thick T.Type, @in_guaranteed T, Bool) -> @out T {
+bb0(%0 : $*T, %2 : $@thick T.Type, %3 : $*T, %4 : $Bool):
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @returnComplexClosure :
+// CHECK:         = function_ref @$s15complex_closureSi_TGm5 : $@convention(thin) (@in_guaranteed Int, Bool) -> @out Int
+// CHECK-LABEL: } // end sil function 'returnComplexClosure'
+sil [ossa] @returnComplexClosure : $@convention(thin) (@in Int, Bool) -> @owned @callee_owned () -> @out Int {
+bb0(%0: $*Int, %1 : $Bool):
+  %2 = metatype $@thick Int.Type
+  %3 = function_ref @complex_closure : $@convention(thin) <T> (@thick T.Type, @in_guaranteed T, Bool) -> @out T
+  %4 = partial_apply %3<Int>(%2, %0, %1) : $@convention(thin) <T> (@thick T.Type, @in_guaranteed T, Bool) -> @out T
+  return %4 : $@callee_owned () -> @out Int
+}
+
+sil [ossa] @closure_with_thin_metatype : $@convention(thin) <T> (@in_guaranteed T, @thin GenericKlass<T>.Type) -> @out T {
+bb0(%0 : $*T, %1 : $*T, %2 : $@thin GenericKlass<T>.Type):
+  copy_addr %1 to [init] %0: $*T
+   %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @returnClosureWithNotAppliedThinMetatype :
+// CHECK:         = function_ref @$s26closure_with_thin_metatypeSi_TG5 : $@convention(thin) (@in_guaranteed Int, @thin GenericKlass<Int>.Type) -> @out Int
+// CHECK-LABEL: } // end sil function 'returnClosureWithNotAppliedThinMetatype'
+sil [ossa] @returnClosureWithNotAppliedThinMetatype : $@convention(thin) () -> @owned @callee_owned (@in_guaranteed Int, @thin GenericKlass<Int>.Type) -> @out Int {
+bb0:
+  %1 = function_ref @closure_with_thin_metatype : $@convention(thin) <T> (@in_guaranteed T, @thin GenericKlass<T>.Type) -> @out T
+  %2 = partial_apply %1<Int>() : $@convention(thin) <T> (@in_guaranteed T, @thin GenericKlass<T>.Type) -> @out T
+  return %2 : $@callee_owned (@in_guaranteed Int, @thin GenericKlass<Int>.Type) -> @out Int
+}
+

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -374,8 +374,8 @@ ExistentialToArchetype(o: o, t: o)
 // value cast. We could do the promotion, but the optimizer would need
 // to insert the Optional unwrapping logic before the cast.
 //
-// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast15genericDownCastyq_x_q_mtr0_lFAA1CCSg_AA1DCTg5 : $@convention(thin) (@guaranteed Optional<C>, @thick D.Type) -> @owned D {
-// CHECK: bb0(%0 : $Optional<C>, %1 : $@thick D.Type):
+// CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast15genericDownCastyq_x_q_mtr0_lFAA1CCSg_AA1DCTgm5 : $@convention(thin) (@guaranteed Optional<C>) -> @owned D {
+// CHECK: bb0(%0 : $Optional<C>):
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $Optional<C>
 // CHECK-DAG: store [[ARG]] to [[STACK_C]]

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -40,7 +40,7 @@ public func f() {
 
 // Generic specialization, from the foo call in f
 // CHECK-LABEL: // specialized Foo.foo<A>(_:)
-// CHECK-NEXT: sil private [noinline] @$s14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Tg5Tf4dd_n : $@convention(thin) () -> ()
+// CHECK-NEXT: sil private [noinline] @$s14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Tgm5Tf4d_n : $@convention(thin) () -> ()
 
 // Function signature specialization, from the bar call in Bar.init
 // CHECK-LABEL: // specialized Bar.bar()


### PR DESCRIPTION
And replace them with explicit `metatype` instruction in the entry block.
This allows such metatype instructions to be deleted if they are dead.

This was already done for performance-annotated functions. But now do this for all functions.

It is essential that performance-annotated functions are specialized in the same way as other functions.
Because otherwise it can happen that the same specialization has different performance characteristics in different modules.
And it's up to the linker to select one of those ODR functions when linking.

Also, dropping metatype arguments is good for performance and code size in general.

This change also contains a few bug fixes for dropping metatype arguments and improvements for performance annotations.

rdar://110509780