### PR TITLE
don't use Clang modules in the "only re-export public symbols" check

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -718,7 +718,10 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
 
     // Symbols from exported-imported modules should only be included if they
     // were originally public.
-    if (Walker.isFromExportedImportedModule(D) &&
+    // We force compiler-equality here to ensure that the presence of an underlying
+    // Clang module does not prevent internal Swift symbols from being emitted when
+    // MinimumAccessLevel is set to `internal` or below.
+    if (Walker.isFromExportedImportedModule(D, /*countUnderlyingClangModule*/false) &&
         VD->getFormalAccess() < AccessLevel::Public) {
       return true;
     }

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -103,13 +103,19 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   virtual bool isConsideredExportedImported(const Decl *D) const;
   
   /// Returns whether the given declaration comes from an `@_exported import` module.
-  virtual bool isFromExportedImportedModule(const Decl *D) const;
+  ///
+  /// If `countUnderlyingClangModule` is `false`, decls from Clang modules will not be considered
+  /// re-exported unless the Clang module was itself directly re-exported.
+  virtual bool isFromExportedImportedModule(const Decl *D, bool countUnderlyingClangModule = true) const;
 
   /// Returns whether the given declaration was imported via an `@_exported import <type>` declaration.
   virtual bool isQualifiedExportedImport(const Decl *D) const;
 
   /// Returns whether the given module is an `@_exported import` module.
-  virtual bool isExportedImportedModule(const ModuleDecl *M) const;
+  ///
+  /// If `countUnderlyingClangModule` is `false`, Clang modules will not be considered re-exported
+  /// unless the Clang module itself was directly re-exported.
+  virtual bool isExportedImportedModule(const ModuleDecl *M, bool countUnderlyingClangModule = true) const;
 
   /// Returns whether the given module is the main module, or is an `@_exported import` module.
   virtual bool isOurModule(const ModuleDecl *M) const;

--- a/test/SymbolGraph/ClangImporter/MinimumAccessLevel.swift
+++ b/test/SymbolGraph/ClangImporter/MinimumAccessLevel.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s %S/Inputs/EmitWhileBuilding/Extra.swift -emit-symbol-graph -emit-symbol-graph-dir %t -symbol-graph-minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %{python} -c 'import os.path; import sys; sys.exit(1 if os.path.exists(sys.argv[1]) else 0)' %t/EmitWhileBuilding@EmitWhileBuilding.symbols.json
+
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name EmitWhileBuilding -F %t -output-dir %t -pretty-print -v -minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %{python} -c 'import os.path; import sys; sys.exit(1 if os.path.exists(sys.argv[1]) else 0)' %t/EmitWhileBuilding@EmitWhileBuilding.symbols.json
+
+// REQUIRES: objc_interop
+
+// Ensure that having an underlying Clang module does not override the
+// `-symbol-graph-minimum-access-level` flag (rdar://110399757)
+
+// CHECK: "s:17EmitWhileBuilding9innerFuncSSyF"
+
+internal func innerFunc() -> String { "sup" }
+
+public func someFunc() -> String { innerFunc() }


### PR DESCRIPTION
Cherry-pick of #66610

- **Explanation**: When an underlying Clang module is present, the `[-symbol-graph]-minimum-access-level` flags for SymbolGraphGen are overridden by the "export-import only public symbols" check. This PR changes the latter check to require that symbols and export-imported modules come from the same compiler for the symbol to be considered re-exported.
- **Scope**: Affects users who want to view internal symbols in a symbol graph but also have Clang code in their project.
- **Issue**: rdar://110399757
- **Risk**: Low. The change in behavior should only affect underlying Clang modules; other behavior around export-imports should be unaffected, as is normal compilation.
- **Testing**: A test has been added to ensure that `[-symbol-graph]-minimum-access-level` continues to work as expected in the presence of an underlying Clang module. Existing tests continue to pass.
- **Reviewer**: @daniel-grumberg 