### PR TITLE
Sema: Diagnose `@backDeployed` on functions with opaque result types

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -564,6 +564,15 @@ namespace swift {
     /// until the next major language version.
     InFlightDiagnostic &warnUntilSwiftVersion(unsigned majorVersion);
 
+    /// Limit the diagnostic behavior to warning if the context is a
+    /// swiftinterface.
+    ///
+    /// This is useful for diagnostics for restrictions that may be lifted by a
+    /// future version of the compiler. In such cases, it may be helpful to
+    /// avoid failing to build a module from its interface if the interface was
+    /// emitted using a compiler that no longer has the restriction.
+    InFlightDiagnostic &warnInSwiftInterface(const DeclContext *context);
+
     /// Conditionally limit the diagnostic behavior to warning until
     /// the specified version.  If the condition is false, no limit is
     /// imposed, meaning (presumably) it is treated as an error.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7053,6 +7053,10 @@ ERROR(attr_incompatible_with_back_deploy,none,
       "'%0' cannot be applied to a back deployed %1",
       (DeclAttribute, DescriptiveDeclKind))
 
+ERROR(backdeployed_opaque_result_not_supported,none,
+      "'%0' is unsupported on a %1 with a 'some' return type",
+      (DeclAttribute, DescriptiveDeclKind))
+
 //------------------------------------------------------------------------------
 // MARK: Implicit opening of existential types
 //------------------------------------------------------------------------------

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -335,6 +335,16 @@ InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
 }
 
 InFlightDiagnostic &
+InFlightDiagnostic::warnInSwiftInterface(const DeclContext *context) {
+  auto sourceFile = context->getParentSourceFile();
+  if (sourceFile && sourceFile->Kind == SourceFileKind::Interface) {
+    return limitBehavior(DiagnosticBehavior::Warning);
+  }
+
+  return *this;
+}
+
+InFlightDiagnostic &
 InFlightDiagnostic::wrapIn(const Diagnostic &wrapper) {
   // Save current active diagnostic into WrappedDiagnostics, ignoring state
   // so we don't get a None return or influence future diagnostics.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4349,6 +4349,14 @@ void AttributeChecker::checkBackDeployedAttrs(
       }
     }
 
+    if (VD->getOpaqueResultTypeDecl()) {
+      diagnoseAndRemoveAttr(Attr,
+                            diag::backdeployed_opaque_result_not_supported,
+                            Attr, D->getDescriptiveKind())
+          .warnInSwiftInterface(D->getDeclContext());
+      continue;
+    }
+
     auto AtLoc = Attr->AtLoc;
     auto Platform = Attr->Platform;
 

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -261,6 +261,21 @@ protocol CannotBackDeployProtocol {}
 @backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' attribute cannot be applied to this declaration}}
 public actor CannotBackDeployActor {}
 
+public struct ConformsToTopLevelProtocol: TopLevelProtocol {
+  public init() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+@backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' is unsupported on a var with a 'some' return type}}
+public var cannotBackDeployVarWithOpaqueResultType: some TopLevelProtocol {
+  return ConformsToTopLevelProtocol()
+}
+
+@available(SwiftStdlib 5.1, *)
+@backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' is unsupported on a global function with a 'some' return type}}
+public func cannotBackDeployFuncWithOpaqueResultType() -> some TopLevelProtocol {
+  return ConformsToTopLevelProtocol()
+}
 
 // MARK: - Function body diagnostics
 


### PR DESCRIPTION
The compiler does not yet implement support for back deploying opaque result types.

Resolves rdar://110806234
