### PR TITLE
[SourceKit] Record module loading errors when generating interfaces

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1449,6 +1449,22 @@ namespace swift {
     }
   };
 
+  /// A RAII object that adds and removes a diagnostic consumer from an engine.
+  class DiagnosticConsumerRAII final {
+    DiagnosticEngine &Diags;
+    DiagnosticConsumer &Consumer;
+
+  public:
+    DiagnosticConsumerRAII(DiagnosticEngine &diags,
+                           DiagnosticConsumer &consumer)
+        : Diags(diags), Consumer(consumer) {
+      Diags.addConsumer(Consumer);
+    }
+    ~DiagnosticConsumerRAII() {
+      Diags.removeConsumer(Consumer);
+    }
+  };
+
   inline void
   DiagnosticEngine::diagnoseWithNotes(InFlightDiagnostic parentDiag,
                                       llvm::function_ref<void(void)> builder) {

--- a/test/SourceKit/InterfaceGen/error_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/error_clang_module.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t/Inputs)
+// RUN: %empty-directory(%t/Inputs/objcfail)
+// RUN: split-file %s %t/Inputs
+
+//--- objcfail/objcfail.h
+
+#ifdef FAIL
+#error some error from Clang module
+
+// We only record the first error emitted, so we ignore this one.
+#error another error from Clang module
+#endif
+
+void foo(void);
+
+//--- objcfail/module.modulemap
+
+module ObjCFail {
+  header "objcfail.h"
+  export *
+}
+
+//--- Library.swift
+
+import ObjCFail
+
+// First try printing the interface of the Clang module directly.
+
+// RUN: %sourcekitd-test -req=interface-gen -module ObjCFail -- -I %t/Inputs/objcfail -target %target-triple %s | %FileCheck --check-prefix DIRECT-SUCCESS %s
+// DIRECT-SUCCESS: public func foo()
+
+// RUN: not %sourcekitd-test -req=interface-gen -module ObjCFail -- -Xcc -DFAIL -I %t/Inputs/objcfail -target %target-triple %s 2>&1 | %FileCheck --check-prefix DIRECT-FAIL %s
+// DIRECT-FAIL: Could not load module: ObjCFail (could not build {{Objective-C|C}} module 'ObjCFail', some error from Clang module)
+
+// Now try doing it transitively
+
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Library.swift -I %t/Inputs/objcfail -module-name Library -o %t
+
+// RUN: %sourcekitd-test -req=interface-gen -module Library -- -I %t -target %target-triple %s | %FileCheck --check-prefix TRANSITIVE-SUCCESS %s
+// TRANSITIVE-SUCCESS: import ObjCFail
+
+// RUN: not %sourcekitd-test -req=interface-gen -module Library -- -Xcc -DFAIL -I %t -target %target-triple %s 2>&1 | %FileCheck --check-prefix TRANSITIVE-FAIL %s
+// TRANSITIVE-FAIL: Could not load module: Library (could not build {{Objective-C|C}} module 'ObjCFail', some error from Clang module)

--- a/test/SourceKit/InterfaceGen/error_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/error_swift_module.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t/Inputs)
+// RUN: split-file %s %t/Inputs
+
+//--- Transitive.swift
+
+public func foo() {}
+
+//--- Library.swift
+
+import Transitive
+
+//--- LibraryWrong.swift
+
+import WrongName
+
+//--- LibraryNonExistant.swift
+
+import NonExistant
+
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Transitive.swift -module-name Transitive -o %t/WrongName.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Transitive.swift -module-name Transitive -o %t/Transitive.swiftmodule
+
+// First try printing the interface of the Transitive module directly.
+
+// RUN: %sourcekitd-test -req=interface-gen -module Transitive -- -I %t -target %target-triple %s | %FileCheck --check-prefix DIRECT-SUCCESS %s
+// DIRECT-SUCCESS: public func foo()
+
+// RUN: not %sourcekitd-test -req=interface-gen -module WrongName -- -I %t -target %target-triple %s 2>&1 | %FileCheck --check-prefix DIRECT-FAIL %s
+// DIRECT-FAIL: Could not load module: WrongName (cannot load module 'Transitive' as 'WrongName')
+
+// Now try doing it transitively
+
+// First undo the WrongName module
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Transitive.swift -module-name WrongName -o %t/WrongName.swiftmodule
+
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Library.swift -I %t -module-name Library -o %t
+// RUN: %target-swift-frontend -emit-module %t/Inputs/LibraryWrong.swift -I %t -module-name LibraryWrong -o %t
+
+// Then redo the WrongName module
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Transitive.swift -module-name Transitive -o %t/WrongName.swiftmodule
+
+// RUN: %sourcekitd-test -req=interface-gen -module Library -- -I %t -target %target-triple %s | %FileCheck --check-prefix TRANSITIVE-SUCCESS %s
+// TRANSITIVE-SUCCESS: import Transitive
+
+// RUN: not %sourcekitd-test -req=interface-gen -module LibraryWrong -- -I %t -target %target-triple %s 2>&1 | %FileCheck --check-prefix TRANSITIVE-FAIL %s
+// TRANSITIVE-FAIL: Could not load module: LibraryWrong (cannot load module 'Transitive' as 'WrongName')
+
+// Try a non-existant module
+
+// RUN: not %sourcekitd-test -req=interface-gen -module NonExistant -- -I %t -target %target-triple %s 2>&1 | %FileCheck --check-prefix DIRECT-NONEXISTANT %s
+// DIRECT-NONEXISTANT: Could not load module: NonExistant
+
+// RUN: %target-swift-frontend -emit-module %t/Inputs/Transitive.swift -module-name NonExistant -o %t
+// RUN: %target-swift-frontend -emit-module %t/Inputs/LibraryNonExistant.swift -module-name LibraryNonExistant -I %t -o %t
+// RUN: rm -rf %t/NonExistant.swiftmodule
+
+// RUN: not %sourcekitd-test -req=interface-gen -module LibraryNonExistant -- -I %t -target %target-triple %s 2>&1 | %FileCheck --check-prefix TRANSITIVE-NONEXISTANT %s
+// TRANSITIVE-NONEXISTANT: Could not load module: LibraryNonExistant (missing required module 'NonExistant')


### PR DESCRIPTION
Record up to two errors emitted when we fail to load a module for interface generation, and include these errors in the message we pass back to the editor. This should help us better pin down the reason why interface generation failed.

rdar://109511099