### PR TITLE
[CanonicalizeOSSALifetime] Bail early in lifetime extension backwards walk.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -558,7 +558,8 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
 
     // Walk backwards from consuming blocks.
     while (auto *block = worklist.pop()) {
-      originalLiveBlocks.insert(block);
+      if (!originalLiveBlocks.insert(block))
+        continue;
       for (auto *predecessor : block->getPredecessorBlocks()) {
         // If the block was discovered by liveness, we already added it to the
         // set.


### PR DESCRIPTION
While collecting originalLiveBlocks, walking backward from consuming blocks, if a visited block is already in originalLiveBlocks, don't visit its predecessors.

Continuing the backwards walk is wasteful.

rdar://110854874
