### PR TITLE
Handle pack expansion types when verifying lowered types in SIL

### DIFF
--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -851,6 +851,16 @@ bool SILType::isLoweringOf(TypeExpansionContext context, SILModule &Mod,
     }
   }
 
+  // The pattern of a pack expansion is lowered.
+  if (auto formalExpansion = dyn_cast<PackExpansionType>(formalType)) {
+    if (auto loweredExpansion = loweredType.getAs<PackExpansionType>()) {
+      return loweredExpansion.getCountType() == formalExpansion.getCountType()
+         && SILType::getPrimitiveAddressType(loweredExpansion.getPatternType())
+               .isLoweringOf(context, Mod, formalExpansion.getPatternType());
+    }
+    return false;
+  }
+
   // Dynamic self has the same lowering as its contained type.
   if (auto dynamicSelf = dyn_cast<DynamicSelfType>(formalType))
     formalType = dynamicSelf.getSelfType();

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -352,3 +352,18 @@ func testStructOfLoadableTuple() -> StructOfLoadableTuple<Int> {
 // CHECK-NEXT:    [[PACK_ELT_ADDR:%.*]] = pack_element_get [[INDEX]] of %1 : $*Pack{repeat GenericButLoadable<each S, each S>} as $*GenericButLoadable<@pack_element([[UUID]]) each S, @pack_element([[UUID]]) each S>
 // CHECK-NEXT:    [[PACK_ELT:%.*]] = load [trivial] [[PACK_ELT_ADDR]] :
 // CHECK-NEXT:    store [[PACK_ELT]] to [trivial] [[TUPLE_ELT_ADDR]] :
+
+// rdar://107290521
+//   The verifier had some home-grown type-lowering logic that didn't
+//   know about pack expansions.
+// CHECK-LABEL: sil {{.*}}@$s4main22testExistentialErasureyyxxQpRvzlF1gL_yyqd__qd__QpRvzRvd__r__lF :
+// CHECK:         [[T0:%.*]] = init_existential_addr {{.*}} : $*Any, $(repeat each T.Type)
+// CHECK:         tuple_pack_element_addr {{.*}} of [[T0]] : $*(repeat @thick each T.Type) as $*@thick (@pack_element("{{.*}}") each T).Type
+func testExistentialErasure<each T>(_: repeat each T) {
+  func g<each U>(_: repeat each U) {
+    print((repeat (each T).self))
+    print((repeat (each U).self))
+  }
+
+  g(1, "hi", false)
+}


### PR DESCRIPTION
I don't like that this method exists, and I'd like to rip it out in favor of expecting an opaque lowering, but I'm worried about doing that this late in 5.9.

Fixes rdar://107290521