### PR TITLE
[5.9] A few SILGen fixes for variadic generics

### DIFF
--- a/include/swift/SIL/AbstractionPatternGenerators.h
+++ b/include/swift/SIL/AbstractionPatternGenerators.h
@@ -291,6 +291,22 @@ public:
     }
   }
 
+  /// Like `getSubstTypes`, but uses a different and possibly
+  /// non-canonical tuple type.
+  TupleEltTypeArrayRef getSubstTypes(Type ncSubstType) const {
+    assert(!isFinished());
+    if (!origTupleVanishes) {
+      return ncSubstType->castTo<TupleType>()
+               ->getElementTypes().slice(substEltIndex,
+                                         numSubstEltsForOrigElt);
+    } else if (numSubstEltsForOrigElt == 0) {
+      return TupleEltTypeArrayRef();
+    } else {
+      scratchSubstElt = TupleTypeElt(ncSubstType);
+      return TupleEltTypeArrayRef(scratchSubstElt);
+    }
+  }
+
   /// Call this to finalize the traversal and assert that it was done
   /// properly.
   void finish() {

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -2064,6 +2064,9 @@ public:
     if (auto gp = handleTypeParameter(pattern, t, level))
       return gp;
 
+    if (pattern.isTuple())
+      return visitTuplePattern(t, pattern);
+
     return CanTypeVisitor::visit(t, pattern);
   }
 
@@ -2312,11 +2315,15 @@ public:
         TC.Context, ppt->getBaseType(), substArgs));
   }
 
-  CanType visitTupleType(CanTupleType tuple, AbstractionPattern pattern) {
+  /// Visit a tuple pattern.  Note that, because of vanishing tuples,
+  /// we can't handle this case by matching a tuple type in the
+  /// substituted type; we have to check for a tuple pattern in the
+  /// top-level visit routine.
+  CanType visitTuplePattern(CanType substType, AbstractionPattern pattern) {
     assert(pattern.isTuple());
 
     SmallVector<TupleTypeElt, 4> tupleElts;
-    pattern.forEachTupleElement(tuple, [&](TupleElementGenerator &elt) {
+    pattern.forEachTupleElement(substType, [&](TupleElementGenerator &elt) {
       auto substEltTypes = elt.getSubstTypes();
       CanType eltTy;
       if (!elt.isOrigPackExpansion()) {

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -851,6 +851,16 @@ bool SILType::isLoweringOf(TypeExpansionContext context, SILModule &Mod,
     }
   }
 
+  // The pattern of a pack expansion is lowered.
+  if (auto formalExpansion = dyn_cast<PackExpansionType>(formalType)) {
+    if (auto loweredExpansion = loweredType.getAs<PackExpansionType>()) {
+      return loweredExpansion.getCountType() == formalExpansion.getCountType()
+         && SILType::getPrimitiveAddressType(loweredExpansion.getPatternType())
+               .isLoweringOf(context, Mod, formalExpansion.getPatternType());
+    }
+    return false;
+  }
+
   // Dynamic self has the same lowering as its contained type.
   if (auto dynamicSelf = dyn_cast<DynamicSelfType>(formalType))
     formalType = dynamicSelf.getSelfType();

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -94,12 +94,8 @@ public:
 
   void visitType(CanType formalType, ManagedValue v) {
     // If we have a loadable type that has not been loaded, actually load it.
-    if (!v.getType().isObject() && v.getType().isLoadable(SGF.F)) {
-      if (v.isPlusOne(SGF)) {
-        v = SGF.B.createLoadTake(loc, v);
-      } else {
-        v = SGF.B.createLoadBorrow(loc, v);
-      }
+    if (!v.getType().isObject()) {
+      v = SGF.B.createLoadIfLoadable(loc, v);
     }
 
     values.push_back(v);

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -437,6 +437,23 @@ ManagedValue SILGenBuilder::createUncheckedTakeEnumDataAddr(
   return cloner.clone(result);
 }
 
+ManagedValue
+SILGenBuilder::createLoadIfLoadable(SILLocation loc, ManagedValue addr) {
+  assert(addr.getType().isAddress());
+  if (!addr.getType().isLoadable(SGF.F))
+    return addr;
+  return createLoadWithSameOwnership(loc, addr);
+}
+
+ManagedValue
+SILGenBuilder::createLoadWithSameOwnership(SILLocation loc,
+                                           ManagedValue addr) {
+  if (addr.isPlusOne(SGF))
+    return createLoadTake(loc, addr);
+  else
+    return createLoadBorrow(loc, addr);
+}
+
 ManagedValue SILGenBuilder::createLoadTake(SILLocation loc, ManagedValue v) {
   auto &lowering = SGF.getTypeLowering(v.getType());
   return createLoadTake(loc, v, lowering);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -236,6 +236,15 @@ public:
   ManagedValue createUncheckedTakeEnumDataAddr(SILLocation loc, ManagedValue operand,
                                                EnumElementDecl *element, SILType ty);
 
+  /// Given the address of a value, load a scalar value from it if the type
+  /// is loadable.  Most general routines in SILGen expect to work with
+  /// values with the canonical scalar-ness for their type.
+  ManagedValue createLoadIfLoadable(SILLocation loc, ManagedValue addr);
+
+  /// Given the address of a loadable value, load the value but don't
+  /// change the ownership.
+  ManagedValue createLoadWithSameOwnership(SILLocation loc, ManagedValue addr);
+
   ManagedValue createLoadTake(SILLocation loc, ManagedValue addr);
   ManagedValue createLoadTake(SILLocation loc, ManagedValue addr,
                               const TypeLowering &lowering);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -263,10 +263,7 @@ public:
     bool argIsLoadable = argType.isLoadable(SGF.F);
     if (argIsLoadable) {
       if (argType.isAddress()) {
-        if (mv.isPlusOne(SGF))
-          mv = SGF.B.createLoadTake(loc, mv);
-        else
-          mv = SGF.B.createLoadBorrow(loc, mv);
+        mv = SGF.B.createLoadWithSameOwnership(loc, mv);
         argType = argType.getObjectType();
       }
     }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1566,54 +1566,91 @@ SILValue SILGenFunction::emitGetCurrentExecutor(SILLocation loc) {
   return ExpectedExecutor;
 }
 
+static void emitIndirectPackParameter(SILGenFunction &SGF,
+                                      PackType *resultType,
+                                      CanTupleEltTypeArrayRef
+                                        resultTypesInContext,
+                                      AbstractionPattern origExpansionType,
+                                      DeclContext *DC) {
+  auto &ctx = SGF.getASTContext();
+
+  bool indirect =
+    origExpansionType.arePackElementsPassedIndirectly(SGF.SGM.Types);
+  SmallVector<CanType, 4> packElts;
+  for (auto substEltType : resultTypesInContext) {
+    auto origComponentType
+      = origExpansionType.getPackExpansionComponentType(substEltType);
+    CanType loweredEltTy =
+      SGF.getLoweredRValueType(origComponentType, substEltType);
+    packElts.push_back(loweredEltTy);
+  }
+
+  SILPackType::ExtInfo extInfo(indirect);
+  auto packType = SILPackType::get(ctx, extInfo, packElts);
+  auto resultSILType = SILType::getPrimitiveAddressType(packType);
+
+  auto var = new (ctx) ParamDecl(SourceLoc(), SourceLoc(),
+                                 ctx.getIdentifier("$return_value"), SourceLoc(),
+                                 ctx.getIdentifier("$return_value"),
+                                 DC);
+  var->setSpecifier(ParamSpecifier::InOut);
+  var->setInterfaceType(resultType);
+  auto *arg = SGF.F.begin()->createFunctionArgument(resultSILType, var);
+  (void)arg;
+}
+
 static void emitIndirectResultParameters(SILGenFunction &SGF,
                                          Type resultType,
                                          AbstractionPattern origResultType,
                                          DeclContext *DC) {
-  // Expand tuples.
+  CanType resultTypeInContext =
+    DC->mapTypeIntoContext(resultType)->getCanonicalType();
+
+  // Tuples in the original result type are expanded.
   if (origResultType.isTuple()) {
-    auto tupleType = resultType->castTo<TupleType>();
-    for (unsigned i = 0, e = origResultType.getNumTupleElements(); i < e; ++i) {
-      emitIndirectResultParameters(SGF, tupleType->getElementType(i),
-                                   origResultType.getTupleElementType(i),
-                                   DC);
-    }
+    origResultType.forEachTupleElement(resultTypeInContext,
+                                       [&](TupleElementGenerator &elt) {
+      auto origEltType = elt.getOrigType();
+      auto substEltTypes = elt.getSubstTypes(resultType);
+
+      // If the original element isn't a pack expansion, pull out the
+      // corresponding substituted tuple element and recurse.
+      if (!elt.isOrigPackExpansion()) {
+        emitIndirectResultParameters(SGF, substEltTypes[0], origEltType, DC);
+        return;
+      }
+
+      // Otherwise, bind a pack parameter.
+      PackType *resultPackType = [&] {
+        SmallVector<Type, 4> packElts(substEltTypes.begin(),
+                                      substEltTypes.end());
+        return PackType::get(SGF.getASTContext(), packElts);
+      }();
+      emitIndirectPackParameter(SGF, resultPackType, elt.getSubstTypes(),
+                                origEltType, DC);
+    });
     return;
   }
 
+  assert(!resultType->is<PackExpansionType>());
+
   // If the return type is address-only, emit the indirect return argument.
   auto &resultTI =
-    SGF.SGM.Types.getTypeLowering(origResultType,
-                                  DC->mapTypeIntoContext(resultType),
+    SGF.SGM.Types.getTypeLowering(origResultType, resultTypeInContext,
                                   SGF.getTypeExpansionContext());
   
   // The calling convention always uses minimal resilience expansion.
   auto &resultTIConv = SGF.SGM.Types.getTypeLowering(
-      DC->mapTypeIntoContext(resultType), TypeExpansionContext::minimal());
+      resultTypeInContext, TypeExpansionContext::minimal());
   auto resultConvType = resultTIConv.getLoweredType();
 
   auto &ctx = SGF.getASTContext();
 
   SILType resultSILType = resultTI.getLoweredType().getAddressType();
 
-  // FIXME: respect susbtitution properly and collect the appropriate
-  // tuple components from resultType that correspond to the
-  // pack expansion in origType.
-  bool isPackExpansion = resultType->is<PackExpansionType>();
-  if (isPackExpansion) {
-    resultType = PackType::get(ctx, {resultType});
-
-    bool indirect =
-      origResultType.arePackElementsPassedIndirectly(SGF.SGM.Types);
-    SILPackType::ExtInfo extInfo(indirect);
-    resultSILType = SILType::getPrimitiveAddressType(
-      SILPackType::get(ctx, extInfo, {resultSILType.getASTType()}));
-  }
-
   // And the abstraction pattern may force an indirect return even if the
   // concrete type wouldn't normally be returned indirectly.
-  if (!isPackExpansion &&
-      !SILModuleConventions::isReturnedIndirectlyInSIL(resultConvType,
+  if (!SILModuleConventions::isReturnedIndirectlyInSIL(resultConvType,
                                                        SGF.SGM.M)) {
     if (!SILModuleConventions(SGF.SGM.M).useLoweredAddresses()
         || origResultType.getResultConvention(SGF.SGM.Types) != AbstractionPattern::Indirect)

--- a/test/SILGen/variadic-generic-closures.swift
+++ b/test/SILGen/variadic-generic-closures.swift
@@ -12,3 +12,12 @@ public struct UsesG<each Input> {
   public init<E>(builder: (repeat G<each Input>) -> E) {}
 }
 UsesG<Int, String, Bool> { a, b, c in 0 }
+
+// rdar://107367324
+func returnVariadicClosure<each T, R>(f: @escaping (repeat each T) -> R) -> (repeat each T) -> R {
+    { (t: repeat each T) -> R in
+        let tuple = (repeat each t)
+        print(tuple)
+        return f(repeat each t)
+    }
+}

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -331,3 +331,24 @@ func testFancyTuple_pack<each T>(values: repeat each T) {
 
 // rdar://107664237
 func f<each T>() -> (repeat Array<each T>) {}
+
+// rdar://109911655
+struct GenericButLoadable<X, Y> { }
+struct StructOfLoadableTuple<each S> {
+  let elements: (repeat GenericButLoadable<each S, each S>)
+}
+// Force the emission of the memberwise initializer.
+func testStructOfLoadableTuple() -> StructOfLoadableTuple<Int> {
+  StructOfLoadableTuple(elements: (GenericButLoadable<Int, Int>()))
+}
+
+//   The memberwise initializer.
+// CHECK-LABEL: sil {{.*}}@$s4main21StructOfLoadableTupleV8elementsACyxxQp_QPGAA010GenericButD0VyxxGxQp_t_tcfC :
+// CHECK:       bb0(%0 : $*StructOfLoadableTuple<repeat each S>, %1 : $*Pack{repeat GenericButLoadable<each S, each S>}, %2 : $@thin StructOfLoadableTuple<repeat each S>.Type):
+// CHECK-NEXT:    [[TUPLE:%.*]] = alloc_stack $(repeat GenericButLoadable<each S, each S>)
+// CHECK:         [[INDEX:%.*]] = dynamic_pack_index {{.*}} of $Pack{repeat GenericButLoadable<each S, each S>}
+// CHECK-NEXT:    open_pack_element [[INDEX]] of <each S> at <Pack{repeat each S}>, shape $each S, uuid [[UUID:".*"]]
+// CHECK-NEXT:    [[TUPLE_ELT_ADDR:%.*]] = tuple_pack_element_addr [[INDEX]] of [[TUPLE]] : $*(repeat GenericButLoadable<each S, each S>) as $*GenericButLoadable<@pack_element([[UUID]]) each S, @pack_element([[UUID]]) each S>
+// CHECK-NEXT:    [[PACK_ELT_ADDR:%.*]] = pack_element_get [[INDEX]] of %1 : $*Pack{repeat GenericButLoadable<each S, each S>} as $*GenericButLoadable<@pack_element([[UUID]]) each S, @pack_element([[UUID]]) each S>
+// CHECK-NEXT:    [[PACK_ELT:%.*]] = load [trivial] [[PACK_ELT_ADDR]] :
+// CHECK-NEXT:    store [[PACK_ELT]] to [trivial] [[TUPLE_ELT_ADDR]] :

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -352,3 +352,18 @@ func testStructOfLoadableTuple() -> StructOfLoadableTuple<Int> {
 // CHECK-NEXT:    [[PACK_ELT_ADDR:%.*]] = pack_element_get [[INDEX]] of %1 : $*Pack{repeat GenericButLoadable<each S, each S>} as $*GenericButLoadable<@pack_element([[UUID]]) each S, @pack_element([[UUID]]) each S>
 // CHECK-NEXT:    [[PACK_ELT:%.*]] = load [trivial] [[PACK_ELT_ADDR]] :
 // CHECK-NEXT:    store [[PACK_ELT]] to [trivial] [[TUPLE_ELT_ADDR]] :
+
+// rdar://107290521
+//   The verifier had some home-grown type-lowering logic that didn't
+//   know about pack expansions.
+// CHECK-LABEL: sil {{.*}}@$s4main22testExistentialErasureyyxxQpRvzlF1gL_yyqd__qd__QpRvzRvd__r__lF :
+// CHECK:         [[T0:%.*]] = init_existential_addr {{.*}} : $*Any, $(repeat each T.Type)
+// CHECK:         tuple_pack_element_addr {{.*}} of [[T0]] : $*(repeat @thick each T.Type) as $*@thick (@pack_element("{{.*}}") each T).Type
+func testExistentialErasure<each T>(_: repeat each T) {
+  func g<each U>(_: repeat each U) {
+    print((repeat (each T).self))
+    print((repeat (each U).self))
+  }
+
+  g(1, "hi", false)
+}


### PR DESCRIPTION
Explanation: Fixes a handful of bugs relating to code (SIL) emission for variadic generics, mostly relating to tuple types.  Bugs are described in the individual commits.
Scope: changes are mostly isolated to paths specific to variadic generics; there are some exceptions, but they just make the code follow well-established code patterns
Risk: Low
Reviewed by: Holly Borla, Joe Groff

Fixes rdar://107290521, rdar://109843932, rdar://109911655, and https://github.com/apple/swift/issues/66594.

5.9 version of #66658 and #66683.