### PR TITLE
[5.9] Add support for an externally defined block list configuration file

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -30,6 +30,7 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/Malloc.h"
+#include "swift/Basic/BlockList.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/DeclTemplate.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -360,6 +361,8 @@ public:
   /// The Swift module currently being compiled.
   ModuleDecl *MainModule = nullptr;
 
+  /// The block list where we can find special actions based on module name;
+  BlockListStore blockListConfig;
 private:
   /// The current generation number, which reflects the number of
   /// times that external modules have been loaded.

--- a/include/swift/Basic/BlockList.h
+++ b/include/swift/Basic/BlockList.h
@@ -25,8 +25,8 @@ namespace swift {
 
 enum class BlockListAction: uint8_t {
   Undefined = 0,
-  ShouldUseBinaryModule,
-  ShouldUseTextualModule,
+#define BLOCKLIST_ACTION(NAME) NAME,
+#include "BlockListAction.def"
 };
 
 enum class BlockListKeyKind: uint8_t {

--- a/include/swift/Basic/BlockList.h
+++ b/include/swift/Basic/BlockList.h
@@ -24,11 +24,13 @@
 namespace swift {
 
 enum class BlockListAction: uint8_t {
-  ShouldUseBinaryModule = 0,
+  Undefined = 0,
+  ShouldUseBinaryModule,
   ShouldUseTextualModule,
 };
 
 enum class BlockListKeyKind: uint8_t {
+  Undefined = 0,
   ModuleName,
   ProjectName
 };
@@ -36,13 +38,12 @@ enum class BlockListKeyKind: uint8_t {
 class BlockListStore {
 public:
   struct Implementation;
+  void addConfigureFilePath(StringRef path);
   bool hasBlockListAction(StringRef key, BlockListKeyKind keyKind,
                           BlockListAction action);
   BlockListStore();
   ~BlockListStore();
 private:
-  friend class ASTContext;
-  void addConfigureFilePath(StringRef path);
   Implementation &Impl;
 };
 

--- a/include/swift/Basic/BlockList.h
+++ b/include/swift/Basic/BlockList.h
@@ -23,7 +23,7 @@
 
 namespace swift {
 
-enum class BlockListAction : uint8_t {
+enum class BlockListAction: uint8_t {
   ShouldUseBinaryModule = 0,
   ShouldUseTextualModule,
 };
@@ -38,10 +38,11 @@ public:
   struct Implementation;
   bool hasBlockListAction(StringRef key, BlockListKeyKind keyKind,
                           BlockListAction action);
-  void addConfigureFilePath(StringRef path);
   BlockListStore();
   ~BlockListStore();
 private:
+  friend class ASTContext;
+  void addConfigureFilePath(StringRef path);
   Implementation &Impl;
 };
 

--- a/include/swift/Basic/BlockList.h
+++ b/include/swift/Basic/BlockList.h
@@ -1,0 +1,50 @@
+//===--- BlockList.h ---------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines some miscellaneous overloads of hash_value() and
+// simple_display().
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_BLOCKLIST_H
+#define SWIFT_BASIC_BLOCKLIST_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+
+enum class BlockListAction : uint8_t {
+  ShouldUseBinaryModule = 0,
+  ShouldUseTextualModule,
+};
+
+enum class BlockListKeyKind: uint8_t {
+  ModuleName,
+  ProjectName
+};
+
+class BlockListStore {
+public:
+  struct Implementation;
+  bool hasBlockListAction(StringRef key, BlockListKeyKind keyKind,
+                          BlockListAction action);
+  void addConfigureFilePath(StringRef path);
+  BlockListStore();
+  ~BlockListStore();
+private:
+  Implementation &Impl;
+};
+
+} // namespace swift
+
+#endif // SWIFT_BASIC_BLOCKLIST_H

--- a/include/swift/Basic/BlockListAction.def
+++ b/include/swift/Basic/BlockListAction.def
@@ -21,5 +21,6 @@
 
 BLOCKLIST_ACTION(ShouldUseBinaryModule)
 BLOCKLIST_ACTION(ShouldUseTextualModule)
+BLOCKLIST_ACTION(DowngradeInterfaceVerificationFailure)
 
 #undef BLOCKLIST_ACTION

--- a/include/swift/Basic/BlockListAction.def
+++ b/include/swift/Basic/BlockListAction.def
@@ -1,0 +1,25 @@
+//===--- BlockListAction.def - Define all blocklist actions -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes all block list actions for meta-programming
+//  purposes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BLOCKLIST_ACTION
+#define BLOCKLIST_ACTION(NAME)
+#endif
+
+BLOCKLIST_ACTION(ShouldUseBinaryModule)
+BLOCKLIST_ACTION(ShouldUseTextualModule)
+
+#undef BLOCKLIST_ACTION

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -567,7 +567,7 @@ namespace swift {
     ConcurrencyModel ActiveConcurrencyModel = ConcurrencyModel::Standard;
 
     /// All block list configuration files to be honored in this compilation.
-    std::vector<std::string> BlocklistConfigFilePath;
+    std::vector<std::string> BlocklistConfigFilePaths;
 
     bool isConcurrencyModelTaskToThread() const {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -566,6 +566,9 @@ namespace swift {
     /// The model of concurrency to be used.
     ConcurrencyModel ActiveConcurrencyModel = ConcurrencyModel::Standard;
 
+    /// All block list configuration files to be honored in this compilation.
+    std::vector<std::string> BlocklistConfigFilePath;
+
     bool isConcurrencyModelTaskToThread() const {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;
     }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -232,6 +232,9 @@ public:
   ///       options have been parsed.
   void setDefaultPrebuiltCacheIfNecessary();
 
+  /// If we haven't explicitly passed -blocklist-paths, set it to the default value.
+  void setDefaultBlocklistsIfNecessary();
+
   /// Computes the runtime resource path relative to the given Swift
   /// executable.
   static void computeRuntimeResourcePathFromExecutablePath(

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -512,6 +512,8 @@ public:
   /// textual imports
   bool EmitClangHeaderWithNonModularIncludes = false;
 
+  /// All block list configuration files to be honored in this compilation.
+  std::vector<std::string> BlocklistConfigFilePaths;
 private:
   static bool canActionEmitDependencies(ActionType);
   static bool canActionEmitReferenceDependencies(ActionType);

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -240,6 +240,9 @@ def Raccess_note : Separate<["-"], "Raccess-note">,
 def Raccess_note_EQ : Joined<["-"], "Raccess-note=">,
     Alias<Raccess_note>;
 
+def block_list_file
+  : Separate<["-"], "blocklist-file">, MetaVarName<"<path>">,
+    HelpText<"The path to a blocklist configuration file">;
 } // end let Flags = [FrontendOption, NoDriverOption]
 
 def debug_crash_Group : OptionGroup<"<automatic crashing options>">;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -694,6 +694,10 @@ ASTContext::ASTContext(
   // Register any request-evaluator functions available at the AST layer.
   registerAccessRequestFunctions(evaluator);
   registerNameLookupRequestFunctions(evaluator);
+  // Insert all block list config paths.
+  for (auto path: langOpts.BlocklistConfigFilePath) {
+    blockListConfig.addConfigureFilePath(path);
+  }
 }
 
 ASTContext::~ASTContext() {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -695,7 +695,7 @@ ASTContext::ASTContext(
   registerAccessRequestFunctions(evaluator);
   registerNameLookupRequestFunctions(evaluator);
   // Insert all block list config paths.
-  for (auto path: langOpts.BlocklistConfigFilePath) {
+  for (auto path: langOpts.BlocklistConfigFilePaths) {
     blockListConfig.addConfigureFilePath(path);
   }
 }

--- a/lib/Basic/BlockList.cpp
+++ b/lib/Basic/BlockList.cpp
@@ -115,10 +115,8 @@ void swift::BlockListStore::Implementation::addConfigureFilePath(StringRef path)
     for (auto &pair: *dyn_cast<yaml::MappingNode>(N)) {
       std::string key = getScalaString(pair.getKey());
       auto action = llvm::StringSwitch<BlockListAction>(key)
-#define CASE(X) .Case(#X, BlockListAction::X)
-        CASE(ShouldUseBinaryModule)
-        CASE(ShouldUseTextualModule)
-#undef CASE
+#define BLOCKLIST_ACTION(X) .Case(#X, BlockListAction::X)
+#include "swift/Basic/BlockListAction.def"
         .Default(BlockListAction::Undefined);
       if (action == BlockListAction::Undefined)
         continue;

--- a/lib/Basic/BlockList.cpp
+++ b/lib/Basic/BlockList.cpp
@@ -1,0 +1,41 @@
+//===--- BlockList.cpp - BlockList utilities ------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/BlockList.h"
+
+struct swift::BlockListStore::Implementation {
+  void addConfigureFilePath(StringRef path);
+  bool hasBlockListAction(StringRef key, BlockListKeyKind keyKind,
+                          BlockListAction action);
+};
+
+swift::BlockListStore::BlockListStore(): Impl(*new Implementation()) {}
+
+swift::BlockListStore::~BlockListStore() { delete &Impl; }
+
+bool swift::BlockListStore::hasBlockListAction(StringRef key,
+    BlockListKeyKind keyKind, BlockListAction action) {
+  return Impl.hasBlockListAction(key, keyKind, action);
+}
+
+void swift::BlockListStore::addConfigureFilePath(StringRef path) {
+  Impl.addConfigureFilePath(path);
+}
+
+bool swift::BlockListStore::Implementation::hasBlockListAction(StringRef key,
+    BlockListKeyKind keyKind, BlockListAction action) {
+  return false;
+}
+
+void swift::BlockListStore::Implementation::addConfigureFilePath(StringRef path) {
+
+}

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -78,6 +78,7 @@ add_swift_host_library(swiftBasic STATIC
   Unicode.cpp
   UUID.cpp
   Version.cpp
+  BlockList.cpp
 
   ${llvm_revision_inc}
   ${clang_revision_inc}

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -350,6 +350,9 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.serializedPathObfuscator.addMapping(SplitMap.first, SplitMap.second);
   }
   Opts.emptyABIDescriptor = Args.hasArg(OPT_empty_abi_descriptor);
+  for (auto A : Args.getAllArgValues(options::OPT_block_list_file)) {
+    Opts.BlocklistConfigFilePaths.push_back(A);
+  }
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -159,6 +159,31 @@ void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
     (llvm::Twine(pair.first) + "preferred-interfaces" + pair.second).str();
 }
 
+void CompilerInvocation::setDefaultBlocklistsIfNecessary() {
+  if (!LangOpts.BlocklistConfigFilePaths.empty())
+    return;
+  if (SearchPathOpts.RuntimeResourcePath.empty())
+    return;
+  // XcodeDefault.xctoolchain/usr/lib/swift
+  SmallString<64> blocklistDir{SearchPathOpts.RuntimeResourcePath};
+  // XcodeDefault.xctoolchain/usr/lib
+  llvm::sys::path::remove_filename(blocklistDir);
+  // XcodeDefault.xctoolchain/usr
+  llvm::sys::path::remove_filename(blocklistDir);
+  // XcodeDefault.xctoolchain/usr/local/lib/swift/blocklists
+  llvm::sys::path::append(blocklistDir, "local", "lib", "swift", "blocklists");
+  std::error_code EC;
+  if (llvm::sys::fs::is_directory(blocklistDir)) {
+    for (llvm::sys::fs::directory_iterator F(blocklistDir, EC), FE;
+         F != FE; F.increment(EC)) {
+      StringRef ext = llvm::sys::path::extension(F->path());
+      if (ext == "yml" || ext == "yaml") {
+        LangOpts.BlocklistConfigFilePaths.push_back(F->path());
+      }
+    }
+  }
+}
+
 static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
                                       llvm::Triple &Triple) {
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
@@ -2934,6 +2959,7 @@ bool CompilerInvocation::parseArgs(
 
   updateRuntimeLibraryPaths(SearchPathOpts, LangOpts.Target);
   setDefaultPrebuiltCacheIfNecessary();
+  setDefaultBlocklistsIfNecessary();
 
   // Now that we've parsed everything, setup some inter-option-dependent state.
   setIRGenOutputOptsFromFrontendOptions(IRGenOpts, FrontendOpts);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1236,7 +1236,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 
-  Opts.BlocklistConfigFilePaths = FrontendOpts.BlocklistConfigFilePaths;
+  for (auto &block: FrontendOpts.BlocklistConfigFilePaths)
+    Opts.BlocklistConfigFilePaths.push_back(block);
   if (const Arg *A = Args.getLastArg(options::OPT_concurrency_model)) {
     Opts.ActiveConcurrencyModel =
         llvm::StringSwitch<ConcurrencyModel>(A->getValue())

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1211,9 +1211,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 
-  for (auto A : Args.getAllArgValues(options::OPT_block_list_file)) {
-    Opts.BlocklistConfigFilePath.push_back(A);
-  }
+  Opts.BlocklistConfigFilePaths = FrontendOpts.BlocklistConfigFilePaths;
   if (const Arg *A = Args.getLastArg(options::OPT_concurrency_model)) {
     Opts.ActiveConcurrencyModel =
         llvm::StringSwitch<ConcurrencyModel>(A->getValue())

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1211,6 +1211,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 
+  for (auto A : Args.getAllArgValues(options::OPT_block_list_file)) {
+    Opts.BlocklistConfigFilePath.push_back(A);
+  }
   if (const Arg *A = Args.getLastArg(options::OPT_concurrency_model)) {
     Opts.ActiveConcurrencyModel =
         llvm::StringSwitch<ConcurrencyModel>(A->getValue())

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -180,6 +180,14 @@ bool ExplicitModuleInterfaceBuilder::collectDepsForSerialization(
   return false;
 }
 
+static bool shouldDowngradeInterfaceVerificationError(const FrontendOptions &opts,
+                                                      ASTContext &ctx) {
+  return opts.DowngradeInterfaceVerificationError ||
+    ctx.blockListConfig.hasBlockListAction(opts.ModuleName,
+                                           BlockListKeyKind::ModuleName,
+                        BlockListAction::DowngradeInterfaceVerificationFailure);
+}
+
 std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
     StringRef InterfacePath, StringRef OutputPath, bool ShouldSerializeDeps,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
@@ -206,7 +214,8 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
                           << " to " << OutputPath << "\n");
 
   LLVM_DEBUG(llvm::dbgs() << "Performing sema\n");
-  if (isTypeChecking && FEOpts.DowngradeInterfaceVerificationError) {
+  if (isTypeChecking &&
+      shouldDowngradeInterfaceVerificationError(FEOpts, Instance.getASTContext())) {
     ErrorDowngradeConsumerRAII R(Instance.getDiags());
     Instance.performSema();
     return std::error_code();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1723,6 +1723,13 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // module cache path at this point.
   if (buildModuleCacheDirIfAbsent && !moduleCachePath.empty())
     (void)llvm::sys::fs::create_directories(moduleCachePath);
+
+  // Inherit all block list configuration files
+  frontendOpts.BlocklistConfigFilePaths = langOpts.BlocklistConfigFilePaths;
+  for (auto &blocklist: langOpts.BlocklistConfigFilePaths) {
+    GenericArgs.push_back("-blocklist-file");
+    GenericArgs.push_back(blocklist);
+  }
 }
 
 /// Calculate an output filename in \p genericSubInvocation's cache path that

--- a/test/ModuleInterface/blocklist_action.swift
+++ b/test/ModuleInterface/blocklist_action.swift
@@ -1,0 +1,21 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test  %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
+
+// RUN: echo "<<<<<>>>>>>>>" >> %t/Test.swiftinterface
+// RUN: not %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
+
+// RUN: echo "---" > %t/blocklist.yml
+// RUN: echo "DowngradeInterfaceVerificationFailure:" >> %t/blocklist.yml
+// RUN: echo "  ModuleName:" >> %t/blocklist.yml
+// RUN: echo "    - FooBar" >> %t/blocklist.yml
+
+// RUN: not %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml
+
+// RUN: echo "    - Test" >> %t/blocklist.yml
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -downgrade-typecheck-interface-error
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml
+
+public func foo() {}

--- a/test/ScanDependencies/blocklist-path-pass-down.swift
+++ b/test/ScanDependencies/blocklist-path-pass-down.swift
@@ -1,0 +1,23 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/Frameworks
+// RUN: mkdir -p %t/Frameworks/E.framework/
+// RUN: mkdir -p %t/Frameworks/E.framework/Modules
+// RUN: mkdir -p %t/Frameworks/E.framework/Modules/E.swiftmodule
+
+// RUN: echo "---" > %t/blocklist.yml
+// RUN: echo "action:" >> %t/blocklist.yml
+
+// Copy over the interface
+// RUN: cp %S/Inputs/Swift/E.swiftinterface %t/Frameworks/E.framework/Modules/E.swiftmodule/%module-target-triple.swiftinterface
+
+
+// Run the scan
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -F %t/Frameworks/ -sdk %t -blocklist-file %t/blocklist.yml
+// RUN: %FileCheck %s < %t/deps.json
+
+import E
+
+// CHECK: "-blocklist-file"
+// CHECK-NEXT: {{.*}}blocklist.yml"

--- a/unittests/Basic/BlocklistTest.cpp
+++ b/unittests/Basic/BlocklistTest.cpp
@@ -1,0 +1,117 @@
+//===------- BlocklistTest.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+#include "swift/AST/SearchPathOptions.h"
+#include "swift/Basic/Defer.h"
+#include "swift/Basic/BlockList.h"
+
+using namespace swift;
+
+static std::string createFilename(StringRef base, StringRef name) {
+  SmallString<256> path = base;
+  llvm::sys::path::append(path, name);
+  return llvm::Twine(path).str();
+}
+
+static bool emitFileWithContents(StringRef path, StringRef contents,
+                                 std::string *pathOut = nullptr) {
+  int FD;
+  if (llvm::sys::fs::openFileForWrite(path, FD))
+    return true;
+  if (pathOut)
+    *pathOut = path.str();
+  llvm::raw_fd_ostream file(FD, /*shouldClose=*/true);
+  file << contents;
+  return false;
+}
+
+static bool emitFileWithContents(StringRef base, StringRef name,
+                                 StringRef contents,
+                                 std::string *pathOut = nullptr) {
+  return emitFileWithContents(createFilename(base, name), contents, pathOut);
+}
+
+TEST(BlocklistTest, testYamlParsing) {
+  SmallString<256> temp;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "BlocklistTest.testYamlParsing", temp));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(temp); };
+  BlockListStore store;
+  std::string path1, path2;
+  ASSERT_FALSE(emitFileWithContents(temp, "block1.yaml",
+                                    "---\n"
+                                    "ShouldUseBinaryModule:\n"
+                                      "  ModuleName:\n"
+                                        "    - M1 #rdar12345\n"
+                                        "    - M2 #rdar12345\n"
+                                        "    - M3\n"
+                                        "    - M4\n"
+                                      "  ProjectName:\n"
+                                        "    - P1\n"
+                                        "    - P2\n"
+                                        "    - P3 #rdar12344\n"
+                                        "    - P4\n"
+                                    "---\n"
+                                    "ShouldUseTextualModule:\n"
+                                      "  ModuleName:\n"
+                                        "    - M1_2 #rdar12345\n"
+                                        "    - M2_2 #rdar12345\n"
+                                        "    - M3_2\n"
+                                        "    - M4_2\n"
+                                      "  ProjectName:\n"
+                                        "    - P1_2\n"
+                                        "    - P2_2\n"
+                                        "    - P3_2 #rdar12344\n"
+                                        "    - P4_2\n",
+                                    &path1));
+  ASSERT_FALSE(emitFileWithContents(temp, "block2.yml",
+                                    "---\n"
+                                    "ShouldUseBinaryModule:\n"
+                                    "  ModuleName:\n"
+                                    "    - M1_block2 #rdar12345\n"
+                                    "  ProjectName:\n"
+                                    "    - P1_block2\n"
+                                    "---\n"
+                                    "ShouldUseTextualModule:\n"
+                                    "  ModuleName:\n"
+                                    "    - M1_2_block2 #rdar12345\n"
+                                    "  ProjectName:\n"
+                                    "    - P1_2_block2\n",
+                                    &path2));
+  store.addConfigureFilePath(path1);
+  store.addConfigureFilePath(path2);
+  ASSERT_TRUE(store.hasBlockListAction("M1", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_TRUE(store.hasBlockListAction("M2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_TRUE(store.hasBlockListAction("P1", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_TRUE(store.hasBlockListAction("P2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseBinaryModule));
+
+  ASSERT_TRUE(store.hasBlockListAction("M1_2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseTextualModule));
+  ASSERT_TRUE(store.hasBlockListAction("M2_2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseTextualModule));
+  ASSERT_TRUE(store.hasBlockListAction("P1_2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseTextualModule));
+  ASSERT_TRUE(store.hasBlockListAction("P2_2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseTextualModule));
+
+  ASSERT_FALSE(store.hasBlockListAction("P1", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_FALSE(store.hasBlockListAction("P2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_FALSE(store.hasBlockListAction("M1", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_FALSE(store.hasBlockListAction("M2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseBinaryModule));
+
+  ASSERT_TRUE(store.hasBlockListAction("M1_block2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_TRUE(store.hasBlockListAction("P1_block2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_TRUE(store.hasBlockListAction("M1_2_block2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseTextualModule));
+  ASSERT_TRUE(store.hasBlockListAction("P1_2_block2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseTextualModule));
+
+  ASSERT_FALSE(store.hasBlockListAction("M1_block2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_FALSE(store.hasBlockListAction("P1_block2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseBinaryModule));
+  ASSERT_FALSE(store.hasBlockListAction("M1_2_block2", BlockListKeyKind::ProjectName, BlockListAction::ShouldUseTextualModule));
+  ASSERT_FALSE(store.hasBlockListAction("P1_2_block2", BlockListKeyKind::ModuleName, BlockListAction::ShouldUseTextualModule));
+}

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -7,6 +7,7 @@ handle_gyb_sources(
 
 add_swift_unittest(SwiftBasicTests
   BlotMapVectorTest.cpp
+  BlocklistTest.cpp
   CacheTest.cpp
   ClangImporterOptionsTest.cpp
   ClusteredBitVectorTest.cpp


### PR DESCRIPTION
- cherry-picks:
-- https://github.com/apple/swift/pull/64943
-- https://github.com/apple/swift/pull/65009
-- https://github.com/apple/swift/pull/65024
-- https://github.com/apple/swift/pull/65031
-- https://github.com/apple/swift/pull/65033
-- https://github.com/apple/swift/pull/65072

- Explanation: These PRs add support for an externally defined block list to feed into the compiler. To avoid hard-coding module-specific behaviors in the compiler, we could skip rebuilding the compiler when the block list updates.
- Scope: Module loading
- Risk: Low
- Reviewed by: @xymus 