### PR TITLE
[Macros] Update plugin search options serialization

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -44,7 +44,7 @@ namespace swift {
     StringRef ModuleLinkName;
     StringRef ModuleInterface;
     std::vector<std::string> ExtraClangOptions;
-    std::vector<swift::PluginSearchOption::Value> PluginSearchOptions;
+    std::vector<swift::PluginSearchOption> PluginSearchOptions;
 
     /// Path prefixes that should be rewritten in debug info.
     PathRemapper DebuggingOptionsPrefixMap;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SERIALIZATION_SERIALIZATIONOPTIONS_H
 #define SWIFT_SERIALIZATION_SERIALIZATIONOPTIONS_H
 
+#include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/PathRemapper.h"
 #include "llvm/Support/VersionTuple.h"
@@ -43,10 +44,7 @@ namespace swift {
     StringRef ModuleLinkName;
     StringRef ModuleInterface;
     std::vector<std::string> ExtraClangOptions;
-    std::vector<std::string> PluginSearchPaths;
-    std::vector<std::string> ExternalPluginSearchPaths;
-    std::vector<std::string> CompilerPluginLibraryPaths;
-    std::vector<std::string> CompilerPluginExecutablePaths;
+    std::vector<swift::PluginSearchOption::Value> PluginSearchOptions;
 
     /// Path prefixes that should be rewritten in debug info.
     PathRemapper DebuggingOptionsPrefixMap;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -111,10 +111,7 @@ struct ValidationInfo {
 class ExtendedValidationInfo {
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
 
-  SmallVector<StringRef, 1> PluginSearchPaths;
-  SmallVector<StringRef, 1> ExternalPluginSearchPaths;
-  SmallVector<StringRef, 1> CompilerPluginLibraryPaths;
-  SmallVector<StringRef, 1> CompilerPluginExecutablePaths;
+  SmallVector<std::pair<StringRef, StringRef>, 2> PluginSearchOptions;
 
   std::string SDKPath;
   StringRef ModuleABIName;
@@ -149,32 +146,11 @@ public:
     ExtraClangImporterOpts.push_back(option);
   }
 
-  ArrayRef<StringRef> getPluginSearchPaths() const {
-    return PluginSearchPaths;
+  ArrayRef<std::pair<StringRef, StringRef>> getPluginSearchOptions() const {
+    return PluginSearchOptions;
   }
-  void addPluginSearchPath(StringRef path) {
-    PluginSearchPaths.push_back(path);
-  }
-
-  ArrayRef<StringRef> getExternalPluginSearchPaths() const {
-    return ExternalPluginSearchPaths;
-  }
-  void addExternalPluginSearchPath(StringRef path) {
-    ExternalPluginSearchPaths.push_back(path);
-  }
-
-  ArrayRef<StringRef> getCompilerPluginLibraryPaths() const {
-    return CompilerPluginLibraryPaths;
-  }
-  void addCompilerPluginLibraryPath(StringRef path) {
-    CompilerPluginLibraryPaths.push_back(path);
-  }
-
-  ArrayRef<StringRef> getCompilerPluginExecutablePaths() const {
-    return CompilerPluginExecutablePaths;
-  }
-  void addCompilerPluginExecutablePath(StringRef path) {
-    CompilerPluginExecutablePaths.push_back(path);
+  void addPluginSearchOption(const std::pair<StringRef, StringRef> &opt) {
+    PluginSearchOptions.push_back(opt);
   }
 
   bool isSIB() const { return Bits.IsSIB; }

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -111,7 +111,8 @@ struct ValidationInfo {
 class ExtendedValidationInfo {
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
 
-  SmallVector<std::pair<StringRef, StringRef>, 2> PluginSearchOptions;
+  SmallVector<std::pair<PluginSearchOption::Kind, StringRef>, 2>
+      PluginSearchOptions;
 
   std::string SDKPath;
   StringRef ModuleABIName;
@@ -146,10 +147,12 @@ public:
     ExtraClangImporterOpts.push_back(option);
   }
 
-  ArrayRef<std::pair<StringRef, StringRef>> getPluginSearchOptions() const {
+  ArrayRef<std::pair<PluginSearchOption::Kind, StringRef>>
+  getPluginSearchOptions() const {
     return PluginSearchOptions;
   }
-  void addPluginSearchOption(const std::pair<StringRef, StringRef> &opt) {
+  void addPluginSearchOption(
+      const std::pair<PluginSearchOption::Kind, StringRef> &opt) {
     PluginSearchOptions.push_back(opt);
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -209,36 +209,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   }
 
-  // FIXME: Preserve the order of these options.
-  for (auto &elem : getSearchPathOptions().PluginSearchOpts) {
-    // '-plugin-path' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::PluginPath>()) {
-      serializationOpts.PluginSearchPaths.push_back(arg->SearchPath);
-      continue;
-    }
-
-    // '-external-plugin-path' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::ExternalPluginPath>()) {
-      serializationOpts.ExternalPluginSearchPaths.push_back(
-          arg->SearchPath + "#" + arg->ServerPath);
-      continue;
-    }
-
-    // '-load-plugin-library' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::LoadPluginLibrary>()) {
-      serializationOpts.CompilerPluginLibraryPaths.push_back(arg->LibraryPath);
-      continue;
-    }
-
-    // '-load-plugin-executable' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
-      std::string optStr = arg->ExecutablePath + "#";
-      llvm::interleave(
-          arg->ModuleNames, [&](auto &name) { optStr += name; },
-          [&]() { optStr += ","; });
-      serializationOpts.CompilerPluginExecutablePaths.push_back(optStr);
-    }
-  }
+  serializationOpts.PluginSearchOptions =
+      getSearchPathOptions().PluginSearchOpts;
 
   serializationOpts.DisableCrossModuleIncrementalInfo =
       opts.DisableCrossModuleIncrementalBuild;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -127,24 +127,24 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
       extendedInfo.addExtraClangImporterOption(blobData);
       break;
     case options_block::PLUGIN_SEARCH_OPTION: {
-      unsigned optKind;
-      StringRef optStr;
-      options_block::ResilienceStrategyLayout::readRecord(scratch, optKind);
-      switch (PluginSearchOptionKind(optKind)) {
+      unsigned kind;
+      options_block::ResilienceStrategyLayout::readRecord(scratch, kind);
+      PluginSearchOption::Kind optKind;
+      switch (PluginSearchOptionKind(kind)) {
       case PluginSearchOptionKind::PluginPath:
-        optStr = "-plugin-path";
+        optKind = PluginSearchOption::Kind::PluginPath;
         break;
       case PluginSearchOptionKind::ExternalPluginPath:
-        optStr = "-external-plugin-path";
+        optKind = PluginSearchOption::Kind::ExternalPluginPath;
         break;
       case PluginSearchOptionKind::LoadPluginLibrary:
-        optStr = "-load-plugin-library";
+        optKind = PluginSearchOption::Kind::LoadPluginLibrary;
         break;
       case PluginSearchOptionKind::LoadPluginExecutable:
-        optStr = "-load-plugin-executable";
+        optKind = PluginSearchOption::Kind::LoadPluginExecutable;
         break;
       }
-      extendedInfo.addPluginSearchOption({optStr, blobData});
+      extendedInfo.addPluginSearchOption({optKind, blobData});
       break;
     }
     case options_block::IS_SIB:

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -126,18 +126,27 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::XCC:
       extendedInfo.addExtraClangImporterOption(blobData);
       break;
-    case options_block::PLUGIN_SEARCH_PATH:
-      extendedInfo.addPluginSearchPath(blobData);
+    case options_block::PLUGIN_SEARCH_OPTION: {
+      unsigned optKind;
+      StringRef optStr;
+      options_block::ResilienceStrategyLayout::readRecord(scratch, optKind);
+      switch (PluginSearchOptionKind(optKind)) {
+      case PluginSearchOptionKind::PluginPath:
+        optStr = "-plugin-path";
+        break;
+      case PluginSearchOptionKind::ExternalPluginPath:
+        optStr = "-external-plugin-path";
+        break;
+      case PluginSearchOptionKind::LoadPluginLibrary:
+        optStr = "-load-plugin-library";
+        break;
+      case PluginSearchOptionKind::LoadPluginExecutable:
+        optStr = "-load-plugin-executable";
+        break;
+      }
+      extendedInfo.addPluginSearchOption({optStr, blobData});
       break;
-    case options_block::EXTERNAL_SEARCH_PLUGIN_PATH:
-      extendedInfo.addExternalPluginSearchPath(blobData);
-      break;
-    case options_block::COMPILER_PLUGIN_LIBRARY_PATH:
-      extendedInfo.addCompilerPluginLibraryPath(blobData);
-      break;
-    case options_block::COMPILER_PLUGIN_EXECUTABLE_PATH:
-      extendedInfo.addCompilerPluginExecutablePath(blobData);
-      break;
+    }
     case options_block::IS_SIB:
       bool IsSIB;
       options_block::IsSIBLayout::readRecord(scratch, IsSIB);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 792; // removed select_value
+const uint16_t SWIFTMODULE_VERSION_MINOR = 793; // PluginSearchOption
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -651,6 +651,16 @@ enum class MacroIntroducedDeclNameKind : uint8_t {
 };
 using MacroIntroducedDeclNameKindField = BCFixed<4>;
 
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
+enum class PluginSearchOptionKind : uint8_t {
+  PluginPath,
+  ExternalPluginPath,
+  LoadPluginLibrary,
+  LoadPluginExecutable,
+};
+using PluginSearchOptionKindField = BCFixed<3>;
+
 // Encodes a VersionTuple:
 //
 //  Major
@@ -884,10 +894,7 @@ namespace options_block {
     IS_CONCURRENCY_CHECKED,
     MODULE_PACKAGE_NAME,
     MODULE_EXPORT_AS_NAME,
-    PLUGIN_SEARCH_PATH,
-    EXTERNAL_SEARCH_PLUGIN_PATH,
-    COMPILER_PLUGIN_LIBRARY_PATH,
-    COMPILER_PLUGIN_EXECUTABLE_PATH,
+    PLUGIN_SEARCH_OPTION,
     HAS_CXX_INTEROPERABILITY_ENABLED,
   };
 
@@ -901,24 +908,10 @@ namespace options_block {
     BCBlob // -Xcc flag, as string
   >;
 
-  using PluginSearchPathLayout = BCRecordLayout<
-    PLUGIN_SEARCH_PATH,
-    BCBlob // -plugin-path value
-  >;
-
-  using ExternalPluginSearchPathLayout = BCRecordLayout<
-    EXTERNAL_SEARCH_PLUGIN_PATH,
-    BCBlob // -external-plugin-path value
-  >;
-
-  using CompilerPluginLibraryPathLayout = BCRecordLayout<
-    COMPILER_PLUGIN_LIBRARY_PATH,
-    BCBlob // -load-plugin-library value
-  >;
-
-  using CompilerPluginExecutablePathLayout = BCRecordLayout<
-    COMPILER_PLUGIN_EXECUTABLE_PATH,
-    BCBlob // -load-plugin-executable value
+  using PluginSearchOptionLayout = BCRecordLayout<
+    PLUGIN_SEARCH_OPTION,
+    PluginSearchOptionKindField, // kind
+    BCBlob                       // option value string
   >;
 
   using IsSIBLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1137,38 +1137,41 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         // Macro plugins
         options_block::PluginSearchOptionLayout PluginSearchOpt(Out);
         for (auto &elem : options.PluginSearchOptions) {
-          if (auto *opt = elem.dyn_cast<PluginSearchOption::PluginPath>()) {
+          switch (elem.getKind()) {
+          case PluginSearchOption::Kind::PluginPath: {
+            auto &opt = elem.get<PluginSearchOption::PluginPath>();
             PluginSearchOpt.emit(ScratchRecord,
                                  uint8_t(PluginSearchOptionKind::PluginPath),
-                                 opt->SearchPath);
+                                 opt.SearchPath);
             continue;
           }
-          if (auto *opt =
-                  elem.dyn_cast<PluginSearchOption::ExternalPluginPath>()) {
+          case PluginSearchOption::Kind::ExternalPluginPath: {
+            auto &opt = elem.get<PluginSearchOption::ExternalPluginPath>();
             PluginSearchOpt.emit(
                 ScratchRecord,
                 uint8_t(PluginSearchOptionKind::ExternalPluginPath),
-                opt->SearchPath + "#" + opt->ServerPath);
+                opt.SearchPath + "#" + opt.ServerPath);
             continue;
           }
-          if (auto *opt =
-                  elem.dyn_cast<PluginSearchOption::LoadPluginLibrary>()) {
+          case PluginSearchOption::Kind::LoadPluginLibrary: {
+            auto &opt = elem.get<PluginSearchOption::LoadPluginLibrary>();
             PluginSearchOpt.emit(
                 ScratchRecord,
                 uint8_t(PluginSearchOptionKind::LoadPluginLibrary),
-                opt->LibraryPath);
+                opt.LibraryPath);
             continue;
           }
-          if (auto *opt =
-                  elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
-            std::string optStr = opt->ExecutablePath + "#";
+          case PluginSearchOption::Kind::LoadPluginExecutable: {
+            auto &opt = elem.get<PluginSearchOption::LoadPluginExecutable>();
+            std::string optStr = opt.ExecutablePath + "#";
             llvm::interleave(
-                opt->ModuleNames, [&](auto &name) { optStr += name; },
+                opt.ModuleNames, [&](auto &name) { optStr += name; },
                 [&]() { optStr += ","; });
             PluginSearchOpt.emit(
                 ScratchRecord,
                 uint8_t(PluginSearchOptionKind::LoadPluginExecutable), optStr);
             continue;
+          }
           }
         }
       }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -846,10 +846,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, HAS_CXX_INTEROPERABILITY_ENABLED);
   BLOCK_RECORD(options_block, MODULE_PACKAGE_NAME);
   BLOCK_RECORD(options_block, MODULE_EXPORT_AS_NAME);
-  BLOCK_RECORD(options_block, PLUGIN_SEARCH_PATH);
-  BLOCK_RECORD(options_block, EXTERNAL_SEARCH_PLUGIN_PATH);
-  BLOCK_RECORD(options_block, COMPILER_PLUGIN_LIBRARY_PATH);
-  BLOCK_RECORD(options_block, COMPILER_PLUGIN_EXECUTABLE_PATH);
+  BLOCK_RECORD(options_block, PLUGIN_SEARCH_OPTION);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1138,27 +1135,41 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         }
 
         // Macro plugins
-        options_block::PluginSearchPathLayout PluginSearchPath(Out);
-        for (auto Arg : options.PluginSearchPaths) {
-          PluginSearchPath.emit(ScratchRecord, Arg);
-        }
-
-        options_block::ExternalPluginSearchPathLayout
-          ExternalPluginSearchPath(Out);
-        for (auto Arg : options.ExternalPluginSearchPaths) {
-          ExternalPluginSearchPath.emit(ScratchRecord, Arg);
-        }
-
-        options_block::CompilerPluginLibraryPathLayout
-          CompilerPluginLibraryPath(Out);
-        for (auto Arg : options.CompilerPluginLibraryPaths) {
-          CompilerPluginLibraryPath.emit(ScratchRecord, Arg);
-        }
-
-        options_block::CompilerPluginExecutablePathLayout
-          CompilerPluginExecutablePath(Out);
-        for (auto Arg : options.CompilerPluginExecutablePaths) {
-          CompilerPluginExecutablePath.emit(ScratchRecord, Arg);
+        options_block::PluginSearchOptionLayout PluginSearchOpt(Out);
+        for (auto &elem : options.PluginSearchOptions) {
+          if (auto *opt = elem.dyn_cast<PluginSearchOption::PluginPath>()) {
+            PluginSearchOpt.emit(ScratchRecord,
+                                 uint8_t(PluginSearchOptionKind::PluginPath),
+                                 opt->SearchPath);
+            continue;
+          }
+          if (auto *opt =
+                  elem.dyn_cast<PluginSearchOption::ExternalPluginPath>()) {
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::ExternalPluginPath),
+                opt->SearchPath + "#" + opt->ServerPath);
+            continue;
+          }
+          if (auto *opt =
+                  elem.dyn_cast<PluginSearchOption::LoadPluginLibrary>()) {
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::LoadPluginLibrary),
+                opt->LibraryPath);
+            continue;
+          }
+          if (auto *opt =
+                  elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
+            std::string optStr = opt->ExecutablePath + "#";
+            llvm::interleave(
+                opt->ModuleNames, [&](auto &name) { optStr += name; },
+                [&]() { optStr += ","; });
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::LoadPluginExecutable), optStr);
+            continue;
+          }
         }
       }
     }

--- a/test/Macros/serialize_plugin_search_paths.swift
+++ b/test/Macros/serialize_plugin_search_paths.swift
@@ -11,10 +11,10 @@
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin
 
 // RUN: %lldb-moduleimport-test -verbose -dump-module %t/a.out | %FileCheck %s
-// CHECK: - Macro Search Paths:
-// CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -external-plugin-path: {{.*}}plugins#{{.*}}swift-plugin-server
-// CHECK:     -load-plugin-library: {{.*}}MacroDefinition.{{dylib|so|dll}}
-// CHECK:     -load-plugin-executable: {{.*}}mock-plugin#TestPlugin
+// CHECK: - Plugin Search Options:
+// CHECK:     -plugin-path {{.*}}plugins
+// CHECK:     -external-plugin-path {{.*}}plugins#{{.*}}swift-plugin-server
+// CHECK:     -load-plugin-library {{.*}}MacroDefinition.{{dylib|so|dll}}
+// CHECK:     -load-plugin-executable {{.*}}mock-plugin#TestPlugin
+// CHECK:     -plugin-path {{.*}}plugins
+// CHECK:     -plugin-path {{.*}}plugins

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -89,15 +89,10 @@ static bool validateModule(
       llvm::outs() << ", system=" << (searchPath.IsSystem ? "true" : "false")
                    << "\n";
     }
-    llvm::outs() << "- Macro Search Paths:\n";
-    for (auto path : extendedInfo.getPluginSearchPaths())
-      llvm::outs() << "    -plugin-path: " << path << "\n";
-    for (auto path : extendedInfo.getExternalPluginSearchPaths())
-      llvm::outs() << "    -external-plugin-path: " << path << "\n";
-    for (auto path : extendedInfo.getCompilerPluginLibraryPaths())
-      llvm::outs() << "    -load-plugin-library: " << path << "\n";
-    for (auto path : extendedInfo.getCompilerPluginExecutablePaths())
-      llvm::outs() << "    -load-plugin-executable: " << path << "\n";
+    llvm::outs() << "- Plugin Search Options:\n";
+    for (auto opt : extendedInfo.getPluginSearchOptions()) {
+      llvm::outs() << "    " << opt.first << " " << opt.second << "\n";
+    }
   }
 
   return true;

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -91,7 +91,22 @@ static bool validateModule(
     }
     llvm::outs() << "- Plugin Search Options:\n";
     for (auto opt : extendedInfo.getPluginSearchOptions()) {
-      llvm::outs() << "    " << opt.first << " " << opt.second << "\n";
+      StringRef optStr;
+      switch (opt.first) {
+      case swift::PluginSearchOption::Kind::PluginPath:
+        optStr = "-plugin-path";
+        break;
+      case swift::PluginSearchOption::Kind::ExternalPluginPath:
+        optStr = "-external-plugin-path";
+        break;
+      case swift::PluginSearchOption::Kind::LoadPluginLibrary:
+        optStr = "-load-plugin-library";
+        break;
+      case swift::PluginSearchOption::Kind::LoadPluginExecutable:
+        optStr = "-load-plugin-executable";
+        break;
+      }
+      llvm::outs() << "    " << optStr << " " << opt.second << "\n";
     }
   }
 


### PR DESCRIPTION
Previously plugin search options were serialized for each option kind. Instead serialize them in the order specified.

rdar://110903149
