### PR TITLE
[5.9][cxx-interop] add a testcase to verify that 'borrowing' works with co…

### DIFF
--- a/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
+++ b/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
@@ -1,0 +1,79 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-build-swift %t/test.swift -I %t -o %t/out -Xfrontend -enable-experimental-cxx-interop -O
+// RUN: %target-codesign %t/out
+// RUN: %target-run %t/out
+
+// Verify that a non-const ref value parameter can't implicitly receive
+// aborrowed value.
+// RUN: %target-swift-frontend -DBORROW_PASS_TO_VALUE_PARAM -emit-ir -o /dev/null -I %t %t/test.swift -enable-experimental-cxx-interop -verify
+
+//--- Inputs/module.modulemap
+module CxxTest {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+
+inline int &getCopyCounter() {
+    static int value = 0;
+    return value;
+}
+
+class BorrowMe {
+public:
+  BorrowMe(): x_(11) {}
+  BorrowMe(const BorrowMe &) {
+    ++getCopyCounter();
+  }
+
+  const int &x() const { return x_; }
+  int &x() { return x_; }
+private:
+  int x_;
+};
+
+inline int takeBorrowConstRef(const BorrowMe &value) {
+    return value.x();
+}
+
+inline int takeBorrowByVal(BorrowMe value) {
+    return value.x();
+}
+
+//--- test.swift
+
+import CxxTest
+
+extension BorrowMe {
+    borrowing func getX() -> CInt {
+        __xUnsafe().pointee
+    }
+
+    var x: CInt {
+        getX()
+    }
+}
+
+func testBorrowingParam(_ value: borrowing BorrowMe) {
+    let x = takeBorrowConstRef(value)
+    assert(x == 11)
+#if BORROW_PASS_TO_VALUE_PARAM
+    takeBorrowByVal(value) // expected-error@-4 {{'value' is borrowed and cannot be consumed}} expected-note {{consumed here}}
+    takeBorrowByVal(copy value) // ok
+#endif
+}
+
+public func testBorrowingSafeReferenceUse() {
+    let x: CInt
+    do {
+        let p = BorrowMe()
+        x = p.x
+        testBorrowingParam(p)
+    }
+    if x != 11 { fatalError("wrong value") }
+    assert(getCopyCounter().pointee == 0)
+}
+
+testBorrowingSafeReferenceUse()


### PR DESCRIPTION
…pyable C++ types

This lets us verify that our suggested pattern for calling unsafe functions is working as intended in Swift

This also lets us verify that we can still pass borrowed C++ types to C++ functions that take in a const ref parameter

Tests now fixed https://github.com/apple/swift/issues/61454

(cherry picked from commit da8c52c2460ca3a2c0b5c3162ae6d93e6f790905)

- Explanation:
Swift now allows `borrowing` of copyable types. We should that `borrowing` works with C++ records as well, to ensure that the pattern we suggest in the docs for calling unsafe member functions works .
- Risk: Low, only add a new test.
- Testing: Swift unit tests.
- PR: https://github.com/apple/swift/pull/66687