### PR TITLE
[cxx-interop] Itanium ABI C++ records should have address-only layout when they can't be passed in registers

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2712,6 +2712,17 @@ namespace {
       if (!result)
         return nullptr;
 
+      if (decl->hasAttr<clang::TrivialABIAttr>()) {
+        // We cannot yet represent trivial_abi C++ records in Swift.
+        // Clang tells us such type can be passed in registers, so
+        // we avoid using AddressOnly type-layout for such type, which means
+        // that it then does not use C++'s copy and destroy semantics from
+        // Swift.
+        Impl.markUnavailable(cast<ValueDecl>(result),
+                             "C++ classes with `trivial_abi` Clang attribute "
+                             "are not yet available in Swift");
+      }
+
       if (auto classDecl = dyn_cast<ClassDecl>(result)) {
         validateForeignReferenceType(decl, classDecl);
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2447,15 +2447,9 @@ namespace {
       }
 
       if (cxxRecordDecl) {
-        auto isNonTrivialForPurposeOfCalls =
-            [](const clang::CXXRecordDecl *decl) -> bool {
-          return decl->hasNonTrivialCopyConstructor() ||
-                 decl->hasNonTrivialMoveConstructor() ||
-                 !decl->hasTrivialDestructor();
-        };
         if (auto structResult = dyn_cast<StructDecl>(result))
           structResult->setIsCxxNonTrivial(
-              isNonTrivialForPurposeOfCalls(cxxRecordDecl));
+              !cxxRecordDecl->canPassInRegisters());
 
         for (auto &getterAndSetter : Impl.GetterSetterMap[result]) {
           auto getter = getterAndSetter.second.first;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2447,9 +2447,39 @@ namespace {
       }
 
       if (cxxRecordDecl) {
+        // FIXME: Swift right now uses AddressOnly type layout
+        // in a way that conflates C++ types
+        // that need to be destroyed or copied explicitly with C++
+        // types that have to be passed indirectly, because
+        // only AddressOnly types can be copied or destroyed using C++
+        // semantics. However, in actuality these two concepts are
+        // separate and don't map to one notion of AddressOnly type
+        // layout cleanly. We should reserve the use of AddressOnly
+        // type layout when types have to use C++ copy/move/destroy
+        // operations, but allow AddressOnly types to be passed
+        // directly as well. This will help unify the MSVC and
+        // Itanium difference here, and will allow us to support
+        // trivial_abi C++ types as well.
+        auto isNonTrivialForPurposeOfCalls =
+            [](const clang::CXXRecordDecl *decl) -> bool {
+          return decl->hasNonTrivialCopyConstructor() ||
+                 decl->hasNonTrivialMoveConstructor() ||
+                 !decl->hasTrivialDestructor();
+        };
+        auto isAddressOnlySwiftStruct =
+            [&](const clang::CXXRecordDecl *decl) -> bool {
+          // MSVC ABI allows non-trivially destroyed C++ types
+          // to be passed in register. This is not supported, as such
+          // type wouldn't be destroyed in Swift correctly. Therefore,
+          // force AddressOnly type layout using the old heuristic.
+          // FIXME: Support can pass in registers for MSVC correctly.
+          if (Impl.SwiftContext.LangOpts.Target.isWindowsMSVCEnvironment())
+            return isNonTrivialForPurposeOfCalls(decl);
+          return !decl->canPassInRegisters();
+        };
         if (auto structResult = dyn_cast<StructDecl>(result))
           structResult->setIsCxxNonTrivial(
-              !cxxRecordDecl->canPassInRegisters());
+              isAddressOnlySwiftStruct(cxxRecordDecl));
 
         for (auto &getterAndSetter : Impl.GetterSetterMap[result]) {
           auto getter = getterAndSetter.second.first;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3212,6 +3212,12 @@ getIndirectCParameterConvention(const clang::ParmVarDecl *param) {
 ///
 /// Generally, whether the parameter is +1 is handled before this.
 static ParameterConvention getDirectCParameterConvention(clang::QualType type) {
+  if (auto *cxxRecord = type->getAsCXXRecordDecl()) {
+    // Directly passed non-trivially destroyed C++ record is consumed by the
+    // callee.
+    if (!cxxRecord->hasTrivialDestructor())
+      return ParameterConvention::Direct_Owned;
+  }
   return ParameterConvention::Direct_Unowned;
 }
 

--- a/test/Interop/Cxx/class/clang-trivial-abi.swift
+++ b/test/Interop/Cxx/class/clang-trivial-abi.swift
@@ -1,0 +1,33 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop -verify
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+
+class TrivialABIRecord {
+    int x = 0;
+public:
+    TrivialABIRecord() {}
+    ~TrivialABIRecord() {
+    }
+}
+__attribute__((trivial_abi));
+
+// CHECK: @available(*, unavailable, message: "C++ classes with `trivial_abi` Clang attribute are not yet available in Swift")
+// CHECK-NEXT: struct TrivialABIRecord {
+
+//--- test.swift
+
+import Test
+
+func test() {
+    let _ = TrivialABIRecord() // expected-error{{'TrivialABIRecord' is unavailable: C++ classes with `trivial_abi` Clang attribute are not yet available in Swift}}
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-class-with-arc-fields-ctor.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-class-with-arc-fields-ctor.h
@@ -5,6 +5,10 @@ struct S {
   NSString *_Nullable B;
   NSString *_Nullable C;
 
+#ifdef S_NONTRIVIAL_DESTRUCTOR
+  ~S() {}
+#endif
+
   void dump() const {
     printf("%s\n", [A UTF8String]);
     printf("%s\n", [B UTF8String]);
@@ -12,3 +16,30 @@ struct S {
   }
 };
 
+inline void takeSFunc(S s) {
+  s.dump();
+}
+
+struct NonTrivialLogDestructor {
+    int x = 0;
+
+    ~NonTrivialLogDestructor() {
+        printf("~NonTrivialLogDestructor %d\n", x);
+    }
+};
+
+@interface ClassWithNonTrivialDestructorIvar: NSObject
+
+- (ClassWithNonTrivialDestructorIvar * _Nonnull)init;
+
+- (void)takesS:(S)s;
+
+@end
+
+struct ReferenceStructToClassWithNonTrivialLogDestructorIvar {
+    ClassWithNonTrivialDestructorIvar *_Nonnull x;
+
+#ifdef S_NONTRIVIAL_DESTRUCTOR
+    ~ReferenceStructToClassWithNonTrivialLogDestructorIvar() {}
+#endif
+};

--- a/test/Interop/Cxx/objc-correctness/Inputs/objc-class-with-non-trivial-cxx-record.mm
+++ b/test/Interop/Cxx/objc-correctness/Inputs/objc-class-with-non-trivial-cxx-record.mm
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import "cxx-class-with-arc-fields-ctor.h"
+
+@implementation ClassWithNonTrivialDestructorIvar {
+    NonTrivialLogDestructor value;
+};
+
+- (ClassWithNonTrivialDestructorIvar *)init {
+    self->value.x = 21;
+    return self;
+}
+
+- (void)takesS:(S)s {
+    printf("takesS!\n");
+    s.dump();
+}
+
+@end

--- a/test/Interop/Cxx/objc-correctness/objcxx-arc-field-in-struct-type-layout-execution.swift
+++ b/test/Interop/Cxx/objc-correctness/objcxx-arc-field-in-struct-type-layout-execution.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t2)
+
+// RUN: %target-interop-build-clangxx -c %S/Inputs/objc-class-with-non-trivial-cxx-record.mm -o %t2/objc-class-impl.o -fobjc-arc
+
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -Xlinker %t2/objc-class-impl.o) | %FileCheck %s
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -O -Xlinker %t2/objc-class-impl.o) | %FileCheck %s
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -Xcc -DS_NONTRIVIAL_DESTRUCTOR -Xlinker %t2/objc-class-impl.o) | %FileCheck %s
+//
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import CxxClassWithNSStringInit
+
+func testS() {
+    let copy: S
+    do {
+        let foo: NSString? = "super long string actually allocated"
+        let bar: NSString? = "bar"
+        let baz: NSString? = "baz"
+        var s = S(A: foo, B: bar, C: baz)
+        s.dump()
+        copy = s
+    }
+    print("after scope")
+    copy.dump()
+    print("takeSFunc")
+    takeSFunc(copy)
+}
+
+@inline(never)
+func blackHole<T>(_ x: T) {
+
+}
+
+func testReferenceStructToClassWithNonTrivialLogDestructorIvar() {
+    print("testReferenceStructToClassWithNonTrivialLogDestructorIvar")
+    let m = ReferenceStructToClassWithNonTrivialLogDestructorIvar(x: ClassWithNonTrivialDestructorIvar())
+    m.x.takesS(S(A: "hello world two", B: "bar", C: "baz"))
+    blackHole(m)
+}
+
+testS()
+testReferenceStructToClassWithNonTrivialLogDestructorIvar()
+
+// CHECK: super long string actually allocated
+// CHECK-NEXT: bar
+// CHECK-NEXT: baz
+// CHECK-NEXT: after scope
+// CHECK-NEXT: super long string actually allocated
+// CHECK-NEXT: bar
+// CHECK-NEXT: baz
+// CHECK-NEXT: takeSFunc
+// CHECK-NEXT: super long string actually allocated
+// CHECK-NEXT: bar
+// CHECK-NEXT: baz
+// CHECK-NEXT: testReferenceStructToClassWithNonTrivialLogDestructorIvar
+// CHECK-NEXT: takesS!
+// CHECK-NEXT: hello world two
+// CHECK-NEXT: bar
+// CHECK-NEXT: baz
+// CHECK-NEXT: ~NonTrivialLogDestructor 21

--- a/test/Interop/Cxx/objc-correctness/objcxx-arc-field-in-struct-type-layout-execution.swift
+++ b/test/Interop/Cxx/objc-correctness/objcxx-arc-field-in-struct-type-layout-execution.swift
@@ -4,7 +4,9 @@
 
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -Xlinker %t2/objc-class-impl.o) | %FileCheck %s
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -O -Xlinker %t2/objc-class-impl.o) | %FileCheck %s
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -Xcc -DS_NONTRIVIAL_DESTRUCTOR -Xlinker %t2/objc-class-impl.o) | %FileCheck %s
+
+// RUN: %target-interop-build-clangxx -c %S/Inputs/objc-class-with-non-trivial-cxx-record.mm -o %t2/objc-class-impl-non-trivial.o -fobjc-arc -DS_NONTRIVIAL_DESTRUCTOR
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions -Xcc -DS_NONTRIVIAL_DESTRUCTOR -Xlinker %t2/objc-class-impl-non-trivial.o) | %FileCheck %s
 //
 // REQUIRES: executable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
This ensures that a C++ record with only ObjC ARC pointers with trivial other members is passed by value in SIL.
Fixes https://github.com/apple/swift/issues/61929

Additionally, mark C++ classes with trivial_abi attribute as unavailable in Swift.

- Explanation:
Non-trivial C++ records become AddressOnly Swift structures, as that's the only way to guarantee the invocation of their copy and/or destroy operations from Swift. AddressOnly implies indirect parameter passing as well. However, under Itanium ABI, some C++ records that have only ARC pointers can be passed directly even though they're non-trivial types. This causes a runtime crash as we think such C++ records are passed indirectly instead from Swift.

This change modifies the way we decide which records become AddressOnly Swift structs on Itanium ABI, by using Clang's own mechanism that determines if the record can be passed in registers or not. This largely aligns the semantics of C++'s indirect + non-trivial copy/destroy with Swift's AddressOnly semantics, except for C++ records annotated with `trivial_abi`. Such types are now marked as unavailable in Swift instead, as they can't be supported yet in the current implementation.

On Windows for the MSVC target the situation is more complicated, and this patch leaves the current behavior instead. The problem is that the MSVC ABI allows non-trivially destroyed but trivially copyable C++ records to be passed in registers. This can't be supported without AddressOnly in Swift, as we wouldn't be able to destroy such C++ record correctly. Thus, for now, preserve the existing behavior. A follow-up future fix will need to teach Swift's code generator how to pass AddressOnly C++ records **directly** to fix both the MSVC ABI and to support `trivial_abi` for Itanium as well.

- Risk: Medium, as it changes which C++ records are considered to be AddressOnly in Swift. This should only affect types like ObjC++ records with ARC types or `trivial_abi` records though. We are not aware of any adopters using `trivial_abi` records yet, so that shouldn't be a concern at the moment.
- Testing: Swift unit tests.
- PR: https://github.com/apple/swift/pull/65813