### PR TITLE
[cxx-interop] Add fix for corner case where NS_OPTIONS typedef has to be desugared

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6854,14 +6854,25 @@ const clang::TypedefType *ClangImporter::getTypeDefForCXXCFOptionsDefinition(
   if (!enumDecl->getDeclName().isEmpty())
     return nullptr;
 
-  if (auto typedefType = dyn_cast<clang::TypedefType>(
-          enumDecl->getIntegerType().getTypePtr())) {
-    if (auto enumExtensibilityAttr =
-            typedefType->getDecl()->getAttr<clang::EnumExtensibilityAttr>();
-        enumExtensibilityAttr &&
+  const clang::ElaboratedType *elaboratedType =
+      dyn_cast<clang::ElaboratedType>(enumDecl->getIntegerType().getTypePtr());
+  if (auto typedefType =
+          elaboratedType
+              ? dyn_cast<clang::TypedefType>(elaboratedType->desugar())
+              : dyn_cast<clang::TypedefType>(
+                    enumDecl->getIntegerType().getTypePtr())) {
+    auto enumExtensibilityAttr =
+        elaboratedType
+            ? enumDecl->getAttr<clang::EnumExtensibilityAttr>()
+            : typedefType->getDecl()->getAttr<clang::EnumExtensibilityAttr>();
+    const bool hasFlagEnumAttr =
+        elaboratedType ? enumDecl->hasAttr<clang::FlagEnumAttr>()
+                       : typedefType->getDecl()->hasAttr<clang::FlagEnumAttr>();
+
+    if (enumExtensibilityAttr &&
         enumExtensibilityAttr->getExtensibility() ==
             clang::EnumExtensibilityAttr::Open &&
-        typedefType->getDecl()->hasAttr<clang::FlagEnumAttr>()) {
+        hasFlagEnumAttr) {
       return Impl.isUnavailableInSwift(typedefType->getDecl()) ? typedefType
                                                                : nullptr;
     }

--- a/test/Interop/Cxx/objc-correctness/Inputs/NSOptionsMangling.apinotes
+++ b/test/Interop/Cxx/objc-correctness/Inputs/NSOptionsMangling.apinotes
@@ -1,0 +1,5 @@
+---
+Name: NSOptionsMangling
+Tags:
+- Name: UIControlState
+  SwiftName: UIControl.State

--- a/test/Interop/Cxx/objc-correctness/Inputs/NSOptionsMangling.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/NSOptionsMangling.h
@@ -1,0 +1,22 @@
+#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#if (__cplusplus)
+#define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
+#else
+#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
+#endif
+
+typedef CF_OPTIONS(unsigned, UIControlState) { UIControlStateNormal = 0 };
+
+#ifdef __cplusplus
+#define UIKIT_EXTERN extern "C" __attribute__((visibility ("default")))
+#else
+#define UIKIT_EXTERN extern __attribute__((visibility ("default")))
+#endif
+
+@interface UIView
+@end
+
+UIKIT_EXTERN
+@interface UIControl : UIView
+@end
+

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -9,3 +9,6 @@ module CxxClassWithNSStringInit [extern_c] {
   requires cplusplus
 }
 
+module NSOptionsMangling {
+  header "NSOptionsMangling.h"
+}

--- a/test/Interop/Cxx/objc-correctness/ns-options-mangling.swift
+++ b/test/Interop/Cxx/objc-correctness/ns-options-mangling.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -I %S/Inputs -c -cxx-interoperability-mode=swift-5.9 %s -S -o - | %FileCheck %s
+// RUN: %target-swift-frontend -I %S/Inputs -c %s -S -o - | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK: _$sSo14UIControlStateV4main7FooableACMc
+// The following check is to ensure the conformance is mangled properly:
+// protocol conformance descriptor for __C.UIControlState : main.Fooable in main
+import NSOptionsMangling
+protocol Fooable { }
+extension UIControl.State: Fooable {}


### PR DESCRIPTION
This patch is an add-on to https://github.com/apple/swift/pull/64043. Essentially when encountering NS_OPTIONS enums, in C++-Interop mode if they are not specially handled then they can mangle differently than they do without C++-Interop. This patch adds logic to handle when a typedef and enum have additional clang::ElaboratedType sugar, but otherwise it does the same as the existing 64043 patch.

The test case provided was encountered in a real app build. The problem came from when two modules are each compiled one with and one without C++-Interop. For the test case code provided the mangling of the protocol conformance is not consistent and the code in SILGenLazyConformance.cpp crashes on an invalid conformance with reason "Invalid conformance in type-checked AST".

(cherry picked from commit fe6ccd7a29b5cbd6f193e151b57640f05f24f42b)



## Release Branch Checklist:
* **Explanation:** This patch aims to ensure that names mangled for NS_OPTIONS when C++-Interop is enabled mangle the same way as they do when it is off. It builds on and handles a missing corner case for an existing patch. 
* **Scope:** C++-Interop mangling consistency
* **Issue:** https://github.com/apple/swift/issues/66602
* **Risk:** low, only intends to alter mangling for a very specific NF_OPTIONS case and checks for attribute associated with NS_OPTIONS
* **Testing:** lit test, checks that mangled name is as expected
* **Reviewer:** @hyp @zoecarver @NuriAmari  
