### PR TITLE
Add RISCV as llvm target to build

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1261,7 +1261,7 @@ def create_argument_parser():
            help='enable building llvm using modules')
 
     option('--llvm-targets-to-build', store,
-           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips',
+           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV',
            help='LLVM target generators to build')
 
     option('--llvm-ninja-targets', append,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -218,7 +218,7 @@ EXPECTED_DEFAULTS = {
     'llvm_ninja_targets_for_cross_compile_hosts': [],
     'llvm_max_parallel_lto_link_jobs':
         defaults.LLVM_MAX_PARALLEL_LTO_LINK_JOBS,
-    'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips',
+    'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV',
     'tsan_libdispatch_test': False,
     'long_test': False,
     'lto_type': None,


### PR DESCRIPTION
<!-- What's in this pull request? -->
Test Environment
OS = Ubuntu
Release = 22.04 / Jammy

When trying to build swift on a riscv64 linux system the following error occurs -
```bash
error: unable to create target: 'No available targets are compatible with triple "riscv64-unknown-linux-gnu"
```
<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/swift-riscv/swift-riscv64/issues/2

Updates and fixes the issues with https://github.com/apple/swift/pull/61891

@gottesmm , on #61891 you requested testing of how much extra build time adding RISCV will add to a clean build.
I have run several test builds at https://ci.swiftlang.xyz/job/swift-main-ubuntu-jammy/
There does not seem to be any noticeable increase build time. All build times are between 1h 4min and 1h 12min.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
