### PR TITLE
Replace hardcoded special names with call into getUserfacingName()

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -569,14 +569,8 @@ private:
     if (FuncDecl *FD = L.getAsASTNode<FuncDecl>())
       return getName(*FD);
 
-    if (L.isASTNode<ConstructorDecl>())
-      return "init";
-
-    if (L.isASTNode<DestructorDecl>())
-      return "deinit";
-
     if (ValueDecl *D = L.getAsASTNode<ValueDecl>())
-      return D->getBaseIdentifier().str();
+      return D->getBaseName().userFacingName();
 
     if (auto *D = L.getAsASTNode<MacroExpansionDecl>())
       return D->getMacroName().getBaseIdentifier().str();

--- a/test/DebugInfo/subscript.swift
+++ b/test/DebugInfo/subscript.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -Onone -emit-ir -g -o - -parse-as-library -module-name a | %FileCheck %s
+public protocol P {}
+public class C : P {}
+public struct S {}
+public extension S {
+  subscript<T>(_ val: T, _ type : T.Type = T.self) -> T? { return nil }
+}
+
+public func f() {
+  S()[0]
+}
+// CHECK: !DISubprogram(name: "deinit"
+// CHECK: !DISubprogram(name: "init"
+// CHECK: !DISubprogram(name: "subscript


### PR DESCRIPTION
This fixes an assertion failure when encountering previously unhandled special names.

rdar://109173022 (cherry picked from commit 229ad8ba84cc10ab9d28fa76c8ab6259b01952e0)
