### PR TITLE
[5.9][ConstraintSystem] Use fallback type constraint to default pack expansion

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -186,14 +186,12 @@ enum class ConstraintKind : char {
   /// constraint.
   OneWayBindParam,
   /// If there is no contextual info e.g. `_ = { 42 }` default first type
-  /// to a second type (inferred closure type). This is effectively a
-  /// `Defaultable` constraint which a couple of differences:
+  /// to a second type. This is effectively a `Defaultable` constraint
+  /// which one significant difference:
   ///
-  /// - References inferred closure type and all of the outer parameters
-  ///   referenced by closure body.
   /// - Handled specially by binding inference, specifically contributes
   ///   to the bindings only if there are no contextual types available.
-  DefaultClosureType,
+  FallbackType,
   /// The first type represents a result of an unresolved member chain,
   /// and the second type is its base type. This constraint acts almost
   /// like `Equal` but also enforces following semantics:
@@ -701,7 +699,7 @@ public:
     case ConstraintKind::OptionalObject:
     case ConstraintKind::OneWayEqual:
     case ConstraintKind::OneWayBindParam:
-    case ConstraintKind::DefaultClosureType:
+    case ConstraintKind::FallbackType:
     case ConstraintKind::UnresolvedMemberChainBase:
     case ConstraintKind::PackElementOf:
     case ConstraintKind::SameShape:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4847,11 +4847,12 @@ private:
                                              TypeMatchOptions flags,
                                              ConstraintLocatorBuilder locator);
 
-  /// Attempt to simplify the given defaultable closure type constraint.
-  SolutionKind simplifyDefaultClosureTypeConstraint(
-      Type closureType, Type inferredType,
-      ArrayRef<TypeVariableType *> referencedOuterParameters,
-      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
+  /// Attempt to simplify the given fallback type constraint.
+  SolutionKind
+  simplifyFallbackTypeConstraint(Type defaultableType, Type fallbackType,
+                                 ArrayRef<TypeVariableType *> referencedVars,
+                                 TypeMatchOptions flags,
+                                 ConstraintLocatorBuilder locator);
 
   /// Attempt to simplify a property wrapper constraint.
   SolutionKind simplifyPropertyWrapperConstraint(Type wrapperType, Type wrappedValueType,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2921,9 +2921,9 @@ namespace {
       SmallVector<TypeVariableType *, 4> referencedVars{
           collectVarRefs.varRefs.begin(), collectVarRefs.varRefs.end()};
 
-      CS.addUnsolvedConstraint(Constraint::create(
-          CS, ConstraintKind::DefaultClosureType, closureType, inferredType,
-          locator, referencedVars));
+      CS.addUnsolvedConstraint(
+          Constraint::create(CS, ConstraintKind::FallbackType, closureType,
+                             inferredType, locator, referencedVars));
 
       CS.setClosureType(closure, inferredType);
       return closureType;

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -99,7 +99,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
     llvm_unreachable("Wrong constructor for member constraint");
 
   case ConstraintKind::Defaultable:
-  case ConstraintKind::DefaultClosureType:
+  case ConstraintKind::FallbackType:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -164,7 +164,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::Conjunction:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
-  case ConstraintKind::DefaultClosureType:
+  case ConstraintKind::FallbackType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::SyntacticElement:
@@ -314,7 +314,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::Defaultable:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
-  case ConstraintKind::DefaultClosureType:
+  case ConstraintKind::FallbackType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
@@ -470,8 +470,8 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
   case ConstraintKind::OpenedExistentialOf: Out << " opened archetype of "; break;
   case ConstraintKind::OneWayEqual: Out << " one-way bind to "; break;
   case ConstraintKind::OneWayBindParam: Out << " one-way bind param to "; break;
-  case ConstraintKind::DefaultClosureType:
-    Out << " closure can default to ";
+  case ConstraintKind::FallbackType:
+    Out << " can fallback to ";
     break;
   case ConstraintKind::UnresolvedMemberChainBase:
     Out << " unresolved member chain base ";
@@ -742,7 +742,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
-  case ConstraintKind::DefaultClosureType:
+  case ConstraintKind::FallbackType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1031,7 +1031,7 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
   // This constraint is important to make sure that pack expansion always
   // has a binding and connect pack expansion var to any type variables
   // that appear in pattern and shape types.
-  addUnsolvedConstraint(Constraint::create(*this, ConstraintKind::Defaultable,
+  addUnsolvedConstraint(Constraint::create(*this, ConstraintKind::FallbackType,
                                            expansionVar, openedPackExpansion,
                                            expansionLoc));
 
@@ -7391,7 +7391,7 @@ bool TypeVarBindingProducer::requiresOptionalAdjustment(
 PotentialBinding
 TypeVarBindingProducer::getDefaultBinding(Constraint *constraint) const {
   assert(constraint->getKind() == ConstraintKind::Defaultable ||
-         constraint->getKind() == ConstraintKind::DefaultClosureType);
+         constraint->getKind() == ConstraintKind::FallbackType);
 
   auto type = constraint->getSecondType();
   Binding binding{type, BindingKind::Exact, constraint};

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -560,3 +560,45 @@ func configure<T, each Element>(
   repeat item[keyPath: (each configuration).0] = (each configuration).1
   return item
 }
+
+// rdar://110819621 - generic parameter is bound before pack expansion type which result in inference failures
+func test_that_expansions_are_bound_early() {
+  struct Data {
+    let prop: Int?
+  }
+
+  struct Value<each T> {
+    init(_ body: (repeat each T) -> Bool) {}
+  }
+
+  func compute<Root, Value>(
+    root: Root,
+    keyPath: KeyPath<Root, Value>,
+    other: Value) -> Bool { true }
+
+  func test_keypath(v: Int) {
+    let _: Value<Data> = Value({
+        compute(
+          root: $0,
+          keyPath: \.prop,
+          other: v
+        )
+      }) // Ok
+
+    let _: Value = Value<Data>({
+        compute(
+          root: $0,
+          keyPath: \.prop,
+          other: v
+        )
+      }) // Ok
+  }
+
+  func equal<Value>(_: Value, _: Value) -> Bool {}
+
+  func test_equality(i: Int) {
+    let _: Value<Data> = Value({
+        equal($0.prop, i) // Ok
+      })
+  }
+}

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -111,7 +111,7 @@ TEST_F(SemaTest, TestClosureInferenceFromOptionalContext) {
   auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
 
   cs.addUnsolvedConstraint(Constraint::create(
-      cs, ConstraintKind::DefaultClosureType, closureTy, defaultTy,
+      cs, ConstraintKind::FallbackType, closureTy, defaultTy,
       cs.getConstraintLocator(closure), /*referencedVars=*/{}));
 
   auto contextualTy =


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66708

---

- Explanation:

Binding of pack expansion types is delayed until solving but use of `Defaultable`
was preventing it from being considered early because that constraint impacts 
binding set ranking, switching to `FallbackType` constraint give us better semantics
where pack expansion type variables are going to be bound as soon as they have
a contextual type.

- Scope: Expressions with value pack expansions used inside of closures.

- Main Branch PR: https://github.com/apple/swift/pull/66708

- Risk: Very Low

- Reviewed By: @hborla 

- Testing: Added regression test-cases to the suite.

Resolves: rdar://110819621

(cherry picked from commit c0d0908f25433a1f3c42daaff81b55b6c5773e24) (cherry picked from commit 4823bf29609d2fcbe80bf085d641ddbb8cf4fe11)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
