### PR TITLE
require `consume x` for noncopyable pattern bindings since they're consuming

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4672,7 +4672,7 @@ ERROR(unknown_case_multiple_patterns,none,
 ERROR(unknown_case_must_be_last,none,
       "'@unknown' can only be applied to the last case in a switch", ())
 
-WARNING(move_only_pattern_match_not_consumed,none,
+ERROR(move_only_pattern_match_not_consumed,none,
         "noncopyable binding being pattern-matched must have the 'consume' operator applied", ())
 
 WARNING(where_on_one_item, none,

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -131,7 +131,7 @@ public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
 public func useNonTrivialEnum(_ s: borrowing NonTrivialEnum) {
     borrowVal(s)
     let s2 = s
-    switch s {
+    switch consume s {
     case _:
         break
     }
@@ -149,7 +149,7 @@ public func useNonTrivialEnum(_ s: borrowing NonTrivialEnum) {
 public func useNonTrivialOwnedEnum(_ s: __owned NonTrivialEnum) {
     borrowVal(s)
     let s2 = s
-    switch s {
+    switch consume s {
     case _:
         break
     }
@@ -705,7 +705,13 @@ var booleanGuard2: Bool { false }
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF : $@convention(thin) (@guaranteed EnumSwitchTests.E) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[COPY_ARG]]
+// CHECK:   [[ARG_MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[COPY_ARG]]
+//             -- code corresponding to the consume x --
+// CHECK:   [[BORROW_ARG_MARKED_VALUE:%.*]] = begin_borrow [[ARG_MARKED_VALUE]]
+// CHECK:   [[COPY_COPY_ARG:%.*]] = copy_value [[BORROW_ARG_MARKED_VALUE]]
+// CHECK:   [[MOVE_COPY_COPY_ARG:%.*]] = move_value [allows_diagnostics] [[COPY_COPY_ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [consumable_and_assignable] [[MOVE_COPY_COPY_ARG]]
+//           -- now switching on the `consume x` --
 // CHECK:   [[BORROWED_VALUE:%.*]] = begin_borrow [[MARKED_VALUE]]
 // CHECK:   switch_enum [[BORROWED_VALUE]] : $EnumSwitchTests.E, case #EnumSwitchTests.E.first!enumelt: [[BB_E_1:bb[0-9]+]], case #EnumSwitchTests.E.second!enumelt: [[BB_E_2:bb[0-9]+]], case #EnumSwitchTests.E.third!enumelt: [[BB_E_3:bb[0-9]+]], case #EnumSwitchTests.E.fourth!enumelt: [[BB_E_4:bb[0-9]+]]
 //
@@ -758,10 +764,10 @@ var booleanGuard2: Bool { false }
 // CHECK:   br [[BB_CONT]]
 //
 // CHECK: [[BB_CONT]]:
-// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK:   destroy_value [[ARG_MARKED_VALUE]]
 // CHECK: } // end sil function '$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF'
 func enumSwitchTest1(_ e: borrowing EnumSwitchTests.E) {
-    switch e {
+    switch consume e {
     case .first:
         break
     case .second(let x):

--- a/test/Sema/moveonly_enum.swift
+++ b/test/Sema/moveonly_enum.swift
@@ -22,7 +22,7 @@ enum Foo3 {
 }
 
 func test_switch(x: consuming Foo3) {
-    switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
+    switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
     default:
         break
     }
@@ -32,7 +32,7 @@ func test_switch(x: consuming Foo3) {
         break
     }
 
-    switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
+    switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
     default:
         break
     }
@@ -43,7 +43,7 @@ func test_switch(x: consuming Foo3) {
     }
 
     let _: () -> () = {
-        switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
+        switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
         default:
             break
         }
@@ -57,7 +57,7 @@ func test_switch(x: consuming Foo3) {
     }
 
     let _: () -> () = {
-        switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
+        switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
         default:
             break
         }
@@ -72,9 +72,9 @@ func test_switch(x: consuming Foo3) {
 }
 
 func test_if_case(x: consuming Foo3) {
-    if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
+    if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
 
-    guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
+    guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
     _ = y
 
     if case .bar(let z) = consume x { _ = z }
@@ -82,9 +82,9 @@ func test_if_case(x: consuming Foo3) {
     guard case .bar(let z) = consume x else { return }
     _ = z
 
-    if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
+    if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
 
-    guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
     _ = a
 
     if case .bar(let b) = (consume x) { _ = b }
@@ -93,11 +93,11 @@ func test_if_case(x: consuming Foo3) {
     _ = b
 
     let _: () -> () = {
-        if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+        if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
     }
 
     let _: () -> () = {
-        guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
+        guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
         _ = y
     }
 
@@ -111,11 +111,11 @@ func test_if_case(x: consuming Foo3) {
     }
 
     let _: () -> () = {
-        if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
+        if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
     }
 
     let _: () -> () = {
-        guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
+        guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
         _ = a
     }
 
@@ -130,7 +130,7 @@ func test_if_case(x: consuming Foo3) {
 }
 
 func test_switch_b(x: __owned Foo3) {
-    switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
+    switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{12-12=consume }}
     default:
         break
     }
@@ -140,7 +140,7 @@ func test_switch_b(x: __owned Foo3) {
         break
     }
 
-    switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
+    switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{13-13=consume }}
     default:
         break
     }
@@ -151,7 +151,7 @@ func test_switch_b(x: __owned Foo3) {
     }
 
     let _: () -> () = {
-        switch x { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
+        switch x { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{16-16=consume }}
         default:
             break
         }
@@ -165,7 +165,7 @@ func test_switch_b(x: __owned Foo3) {
     }
 
     let _: () -> () = {
-        switch (x) { // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
+        switch (x) { // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{17-17=consume }}
         default:
             break
         }
@@ -180,9 +180,9 @@ func test_switch_b(x: __owned Foo3) {
 }
 
 func test_if_case_b(x: __owned Foo3) {
-    if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
+    if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{27-27=consume }}
 
-    guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
+    guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{30-30=consume }}
     _ = y
 
     if case .bar(let z) = consume x { _ = z }
@@ -190,9 +190,9 @@ func test_if_case_b(x: __owned Foo3) {
     guard case .bar(let z) = consume x else { return }
     _ = z
 
-    if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
+    if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{28-28=consume }}
 
-    guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+    guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
     _ = a
 
     if case .bar(let b) = (consume x) { _ = b }
@@ -201,11 +201,11 @@ func test_if_case_b(x: __owned Foo3) {
     _ = b
 
     let _: () -> () = {
-        if case .bar(let y) = x { _ = y } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
+        if case .bar(let y) = x { _ = y } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{31-31=consume }}
     }
 
     let _: () -> () = {
-        guard case .bar(let y) = x else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
+        guard case .bar(let y) = x else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{34-34=consume }}
         _ = y
     }
 
@@ -219,11 +219,11 @@ func test_if_case_b(x: __owned Foo3) {
     }
 
     let _: () -> () = {
-        if case .bar(let a) = (x) { _ = a } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
+        if case .bar(let a) = (x) { _ = a } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{32-32=consume }}
     }
 
     let _: () -> () = {
-        guard case .bar(let a) = (x) else { return } // expected-warning{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
+        guard case .bar(let a) = (x) else { return } // expected-error{{noncopyable binding being pattern-matched must have the 'consume' operator applied}} {{35-35=consume }}
         _ = a
     }
 


### PR DESCRIPTION
this was staged in as a warning initially but it was intended to be an error if the consume is not written, so that we can move to a world where these pattern matches are done as a borrowing operation by default when nothing is written there.

rdar://110908714