### PR TITLE
[5.9][Macros] Update plugin search options serialization

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -44,7 +44,7 @@ namespace swift {
     StringRef ModuleLinkName;
     StringRef ModuleInterface;
     std::vector<std::string> ExtraClangOptions;
-    std::vector<swift::PluginSearchOption::Value> PluginSearchOptions;
+    std::vector<swift::PluginSearchOption> PluginSearchOptions;
 
     /// Path prefixes that should be rewritten in debug info.
     PathRemapper DebuggingOptionsPrefixMap;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SERIALIZATION_SERIALIZATIONOPTIONS_H
 #define SWIFT_SERIALIZATION_SERIALIZATIONOPTIONS_H
 
+#include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/PathRemapper.h"
 #include "llvm/Support/VersionTuple.h"
@@ -43,10 +44,7 @@ namespace swift {
     StringRef ModuleLinkName;
     StringRef ModuleInterface;
     std::vector<std::string> ExtraClangOptions;
-    std::vector<std::string> PluginSearchPaths;
-    std::vector<std::string> ExternalPluginSearchPaths;
-    std::vector<std::string> CompilerPluginLibraryPaths;
-    std::vector<std::string> CompilerPluginExecutablePaths;
+    std::vector<swift::PluginSearchOption::Value> PluginSearchOptions;
 
     /// Path prefixes that should be rewritten in debug info.
     PathRemapper DebuggingOptionsPrefixMap;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -111,10 +111,7 @@ struct ValidationInfo {
 class ExtendedValidationInfo {
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
 
-  SmallVector<StringRef, 1> PluginSearchPaths;
-  SmallVector<StringRef, 1> ExternalPluginSearchPaths;
-  SmallVector<StringRef, 1> CompilerPluginLibraryPaths;
-  SmallVector<StringRef, 1> CompilerPluginExecutablePaths;
+  SmallVector<std::pair<StringRef, StringRef>, 2> PluginSearchOptions;
 
   std::string SDKPath;
   StringRef ModuleABIName;
@@ -149,32 +146,11 @@ public:
     ExtraClangImporterOpts.push_back(option);
   }
 
-  ArrayRef<StringRef> getPluginSearchPaths() const {
-    return PluginSearchPaths;
+  ArrayRef<std::pair<StringRef, StringRef>> getPluginSearchOptions() const {
+    return PluginSearchOptions;
   }
-  void addPluginSearchPath(StringRef path) {
-    PluginSearchPaths.push_back(path);
-  }
-
-  ArrayRef<StringRef> getExternalPluginSearchPaths() const {
-    return ExternalPluginSearchPaths;
-  }
-  void addExternalPluginSearchPath(StringRef path) {
-    ExternalPluginSearchPaths.push_back(path);
-  }
-
-  ArrayRef<StringRef> getCompilerPluginLibraryPaths() const {
-    return CompilerPluginLibraryPaths;
-  }
-  void addCompilerPluginLibraryPath(StringRef path) {
-    CompilerPluginLibraryPaths.push_back(path);
-  }
-
-  ArrayRef<StringRef> getCompilerPluginExecutablePaths() const {
-    return CompilerPluginExecutablePaths;
-  }
-  void addCompilerPluginExecutablePath(StringRef path) {
-    CompilerPluginExecutablePaths.push_back(path);
+  void addPluginSearchOption(const std::pair<StringRef, StringRef> &opt) {
+    PluginSearchOptions.push_back(opt);
   }
 
   bool isSIB() const { return Bits.IsSIB; }

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -111,7 +111,8 @@ struct ValidationInfo {
 class ExtendedValidationInfo {
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
 
-  SmallVector<std::pair<StringRef, StringRef>, 2> PluginSearchOptions;
+  SmallVector<std::pair<PluginSearchOption::Kind, StringRef>, 2>
+      PluginSearchOptions;
 
   std::string SDKPath;
   StringRef ModuleABIName;
@@ -146,10 +147,12 @@ public:
     ExtraClangImporterOpts.push_back(option);
   }
 
-  ArrayRef<std::pair<StringRef, StringRef>> getPluginSearchOptions() const {
+  ArrayRef<std::pair<PluginSearchOption::Kind, StringRef>>
+  getPluginSearchOptions() const {
     return PluginSearchOptions;
   }
-  void addPluginSearchOption(const std::pair<StringRef, StringRef> &opt) {
+  void addPluginSearchOption(
+      const std::pair<PluginSearchOption::Kind, StringRef> &opt) {
     PluginSearchOptions.push_back(opt);
   }
 

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -15,22 +15,10 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Parse/Lexer.h"
 #include "llvm/Config/config.h"
 
 using namespace swift;
-
-void PluginLoader::createModuleToExecutablePluginMap() {
-  for (auto &elem : Ctx.SearchPathOpts.PluginSearchOpts) {
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
-      // Create a moduleName -> pluginPath mapping.
-      assert(!arg->ExecutablePath.empty() && "empty plugin path");
-      StringRef pathStr = Ctx.AllocateCopy(arg->ExecutablePath);
-      for (auto moduleName : arg->ModuleNames) {
-        ExecutablePluginPaths[Ctx.getIdentifier(moduleName)] = pathStr;
-      }
-    }
-  }
-}
 
 void PluginLoader::setRegistry(PluginRegistry *newValue) {
   assert(Registry == nullptr && "Too late to set a new plugin registry");
@@ -48,65 +36,121 @@ PluginRegistry *PluginLoader::getRegistry() {
   return Registry;
 }
 
-std::pair<std::string, std::string>
-PluginLoader::lookupPluginByModuleName(Identifier moduleName) {
-  auto fs = Ctx.SourceMgr.getFileSystem();
-
-  // Look for 'lib${module name}(.dylib|.so)'.
+/// Get plugin module name from \p path if the path looks like a shared library
+/// path. Otherwise, returns an empty string.
+static StringRef pluginModuleNameStringFromPath(StringRef path) {
+  // Plugin library must be named 'lib${module name}(.dylib|.so|.dll)'.
   // FIXME: Shared library prefix might be different between platforms.
-  SmallString<64> pluginLibBasename;
-  pluginLibBasename.append("lib");
-  pluginLibBasename.append(moduleName.str());
-  pluginLibBasename.append(LTDL_SHLIB_EXT);
+  constexpr StringRef libPrefix = "lib";
+  constexpr StringRef libSuffix = LTDL_SHLIB_EXT;
 
-  // FIXME: Should we create a lookup table keyed by module name?
-  for (auto &entry : Ctx.SearchPathOpts.PluginSearchOpts) {
-    switch (entry.getKind()) {
-    // Try '-load-plugin-library'.
-    case PluginSearchOption::Kind::LoadPluginLibrary: {
-      auto &val = entry.get<PluginSearchOption::LoadPluginLibrary>();
-      if (llvm::sys::path::filename(val.LibraryPath) == pluginLibBasename) {
-        return {val.LibraryPath, ""};
-      }
-      continue;
-    }
+  StringRef filename = llvm::sys::path::filename(path);
+  if (filename.starts_with(libPrefix) && filename.ends_with(libSuffix)) {
+    // We don't check if the result it a valid identifier. Even if we put
+    // invalid name in the lookup table, clients wound not be able to lookup
+    // that name, thus harmless.
+    return filename.drop_front(libPrefix.size()).drop_back(libSuffix.size());
+  }
+  return "";
+}
 
-    // Try '-load-plugin-executable'.
-    case PluginSearchOption::Kind::LoadPluginExecutable: {
-      auto &val = entry.get<PluginSearchOption::LoadPluginExecutable>();
-      auto found = ExecutablePluginPaths.find(moduleName);
-      if (found != ExecutablePluginPaths.end() &&
-          found->second == val.ExecutablePath) {
-        return {"", val.ExecutablePath};
-      }
-      continue;
-    }
-
-    // Try '-plugin-path'.
-    case PluginSearchOption::Kind::PluginPath: {
-      auto &val = entry.get<PluginSearchOption::PluginPath>();
-      SmallString<128> fullPath(val.SearchPath);
-      llvm::sys::path::append(fullPath, pluginLibBasename);
-      if (fs->exists(fullPath)) {
-        return {std::string(fullPath), ""};
-      }
-      continue;
-    }
-
-    // Try '-external-plugin-path'.
-    case PluginSearchOption::Kind::ExternalPluginPath: {
-      auto &val = entry.get<PluginSearchOption::ExternalPluginPath>();
-      SmallString<128> fullPath(val.SearchPath);
-      llvm::sys::path::append(fullPath, pluginLibBasename);
-      if (fs->exists(fullPath)) {
-        return {std::string(fullPath), val.ServerPath};
-      }
-      continue;
-    }
-    }
+llvm::DenseMap<Identifier, PluginLoader::PluginEntry> &
+PluginLoader::getPluginMap() {
+  if (PluginMap.has_value()) {
+    return PluginMap.value();
   }
 
-  return {};
+  // Create and populate the map.
+  PluginMap.emplace();
+  auto &map = PluginMap.value();
+
+  // Helper function to try inserting an entry if there's no existing entry
+  // associated with the module name.
+  auto try_emplace = [&](StringRef moduleName, StringRef libPath,
+                         StringRef execPath) {
+    auto moduleNameIdentifier = Ctx.getIdentifier(moduleName);
+    if (map.find(moduleNameIdentifier) != map.end()) {
+      // Specified module name is already in the map.
+      return;
+    }
+
+    libPath = libPath.empty() ? "" : Ctx.AllocateCopy(libPath);
+    execPath = execPath.empty() ? "" : Ctx.AllocateCopy(execPath);
+    auto result = map.insert({moduleNameIdentifier, {libPath, execPath}});
+    assert(result.second);
+    (void)result;
+  };
+
+  auto fs = Ctx.SourceMgr.getFileSystem();
+  std::error_code ec;
+
+  for (auto &entry : Ctx.SearchPathOpts.PluginSearchOpts) {
+    switch (entry.getKind()) {
+
+    // '-load-plugin-library <library path>'.
+    case PluginSearchOption::Kind::LoadPluginLibrary: {
+      auto &val = entry.get<PluginSearchOption::LoadPluginLibrary>();
+      auto moduleName = pluginModuleNameStringFromPath(val.LibraryPath);
+      if (!moduleName.empty()) {
+        try_emplace(moduleName, val.LibraryPath, /*executablePath=*/"");
+      }
+      continue;
+    }
+
+    // '-load-plugin-executable <executable path>#<module name>, ...'.
+    case PluginSearchOption::Kind::LoadPluginExecutable: {
+      auto &val = entry.get<PluginSearchOption::LoadPluginExecutable>();
+      assert(!val.ExecutablePath.empty() && "empty plugin path");
+      for (auto &moduleName : val.ModuleNames) {
+        try_emplace(moduleName, /*libraryPath=*/"", val.ExecutablePath);
+      }
+      continue;
+    }
+
+    // '-plugin-path <library search path>'.
+    case PluginSearchOption::Kind::PluginPath: {
+      auto &val = entry.get<PluginSearchOption::PluginPath>();
+      for (auto i = fs->dir_begin(val.SearchPath, ec);
+           i != llvm::vfs::directory_iterator(); i = i.increment(ec)) {
+        auto libPath = i->path();
+        auto moduleName = pluginModuleNameStringFromPath(libPath);
+        if (!moduleName.empty()) {
+          try_emplace(moduleName, libPath, /*executablePath=*/"");
+        }
+      }
+      continue;
+    }
+
+    // '-external-plugin-path <library search path>#<server path>'.
+    case PluginSearchOption::Kind::ExternalPluginPath: {
+      auto &val = entry.get<PluginSearchOption::ExternalPluginPath>();
+      for (auto i = fs->dir_begin(val.SearchPath, ec);
+           i != llvm::vfs::directory_iterator(); i = i.increment(ec)) {
+        auto libPath = i->path();
+        auto moduleName = pluginModuleNameStringFromPath(libPath);
+        if (!moduleName.empty()) {
+          try_emplace(moduleName, libPath, val.ServerPath);
+        }
+      }
+      continue;
+    }
+    }
+    llvm_unreachable("unhandled PluginSearchOption::Kind");
+  }
+
+  return map;
+}
+
+const PluginLoader::PluginEntry &
+PluginLoader::lookupPluginByModuleName(Identifier moduleName) {
+  auto &map = getPluginMap();
+  auto found = map.find(moduleName);
+  if (found != map.end()) {
+    return found->second;
+  } else {
+    static PluginEntry notFound{"", ""};
+    return notFound;
+  }
 }
 
 LoadedLibraryPlugin *PluginLoader::loadLibraryPlugin(StringRef path) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -202,36 +202,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   }
 
-  // FIXME: Preserve the order of these options.
-  for (auto &elem : getSearchPathOptions().PluginSearchOpts) {
-    // '-plugin-path' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::PluginPath>()) {
-      serializationOpts.PluginSearchPaths.push_back(arg->SearchPath);
-      continue;
-    }
-
-    // '-external-plugin-path' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::ExternalPluginPath>()) {
-      serializationOpts.ExternalPluginSearchPaths.push_back(
-          arg->SearchPath + "#" + arg->ServerPath);
-      continue;
-    }
-
-    // '-load-plugin-library' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::LoadPluginLibrary>()) {
-      serializationOpts.CompilerPluginLibraryPaths.push_back(arg->LibraryPath);
-      continue;
-    }
-
-    // '-load-plugin-executable' options.
-    if (auto *arg = elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
-      std::string optStr = arg->ExecutablePath + "#";
-      llvm::interleave(
-          arg->ModuleNames, [&](auto &name) { optStr += name; },
-          [&]() { optStr += ","; });
-      serializationOpts.CompilerPluginExecutablePaths.push_back(optStr);
-    }
-  }
+  serializationOpts.PluginSearchOptions =
+      getSearchPathOptions().PluginSearchOpts;
 
   serializationOpts.DisableCrossModuleIncrementalInfo =
       opts.DisableCrossModuleIncrementalBuild;

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -342,21 +342,17 @@ LoadedCompilerPlugin
 CompilerPluginLoadRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
                                     Identifier moduleName) const {
   PluginLoader &loader = ctx->getPluginLoader();
+  const auto &entry = loader.lookupPluginByModuleName(moduleName);
 
-  std::string libraryPath;
-  std::string executablePath;
-  std::tie(libraryPath, executablePath) =
-      loader.lookupPluginByModuleName(moduleName);
-
-  if (!executablePath.empty()) {
+  if (!entry.executablePath.empty()) {
     if (LoadedExecutablePlugin *executablePlugin =
-            loader.loadExecutablePlugin(executablePath)) {
-      return initializeExecutablePlugin(*ctx, executablePlugin, libraryPath,
-                                        moduleName);
+            loader.loadExecutablePlugin(entry.executablePath)) {
+      return initializeExecutablePlugin(*ctx, executablePlugin,
+                                        entry.libraryPath, moduleName);
     }
-  } else if (!libraryPath.empty()) {
+  } else if (!entry.libraryPath.empty()) {
     if (LoadedLibraryPlugin *libraryPlugin =
-            loader.loadLibraryPlugin(libraryPath)) {
+            loader.loadLibraryPlugin(entry.libraryPath)) {
       return libraryPlugin;
     }
   }

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -127,24 +127,24 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
       extendedInfo.addExtraClangImporterOption(blobData);
       break;
     case options_block::PLUGIN_SEARCH_OPTION: {
-      unsigned optKind;
-      StringRef optStr;
-      options_block::ResilienceStrategyLayout::readRecord(scratch, optKind);
-      switch (PluginSearchOptionKind(optKind)) {
+      unsigned kind;
+      options_block::ResilienceStrategyLayout::readRecord(scratch, kind);
+      PluginSearchOption::Kind optKind;
+      switch (PluginSearchOptionKind(kind)) {
       case PluginSearchOptionKind::PluginPath:
-        optStr = "-plugin-path";
+        optKind = PluginSearchOption::Kind::PluginPath;
         break;
       case PluginSearchOptionKind::ExternalPluginPath:
-        optStr = "-external-plugin-path";
+        optKind = PluginSearchOption::Kind::ExternalPluginPath;
         break;
       case PluginSearchOptionKind::LoadPluginLibrary:
-        optStr = "-load-plugin-library";
+        optKind = PluginSearchOption::Kind::LoadPluginLibrary;
         break;
       case PluginSearchOptionKind::LoadPluginExecutable:
-        optStr = "-load-plugin-executable";
+        optKind = PluginSearchOption::Kind::LoadPluginExecutable;
         break;
       }
-      extendedInfo.addPluginSearchOption({optStr, blobData});
+      extendedInfo.addPluginSearchOption({optKind, blobData});
       break;
     }
     case options_block::IS_SIB:

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -126,18 +126,27 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::XCC:
       extendedInfo.addExtraClangImporterOption(blobData);
       break;
-    case options_block::PLUGIN_SEARCH_PATH:
-      extendedInfo.addPluginSearchPath(blobData);
+    case options_block::PLUGIN_SEARCH_OPTION: {
+      unsigned optKind;
+      StringRef optStr;
+      options_block::ResilienceStrategyLayout::readRecord(scratch, optKind);
+      switch (PluginSearchOptionKind(optKind)) {
+      case PluginSearchOptionKind::PluginPath:
+        optStr = "-plugin-path";
+        break;
+      case PluginSearchOptionKind::ExternalPluginPath:
+        optStr = "-external-plugin-path";
+        break;
+      case PluginSearchOptionKind::LoadPluginLibrary:
+        optStr = "-load-plugin-library";
+        break;
+      case PluginSearchOptionKind::LoadPluginExecutable:
+        optStr = "-load-plugin-executable";
+        break;
+      }
+      extendedInfo.addPluginSearchOption({optStr, blobData});
       break;
-    case options_block::EXTERNAL_SEARCH_PLUGIN_PATH:
-      extendedInfo.addExternalPluginSearchPath(blobData);
-      break;
-    case options_block::COMPILER_PLUGIN_LIBRARY_PATH:
-      extendedInfo.addCompilerPluginLibraryPath(blobData);
-      break;
-    case options_block::COMPILER_PLUGIN_EXECUTABLE_PATH:
-      extendedInfo.addCompilerPluginExecutablePath(blobData);
-      break;
+    }
     case options_block::IS_SIB:
       bool IsSIB;
       options_block::IsSIBLayout::readRecord(scratch, IsSIB);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 787; // HasCxxInteroperability
+const uint16_t SWIFTMODULE_VERSION_MINOR = 788; // PluginSearchOption
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -651,6 +651,16 @@ enum class MacroIntroducedDeclNameKind : uint8_t {
 };
 using MacroIntroducedDeclNameKindField = BCFixed<4>;
 
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
+enum class PluginSearchOptionKind : uint8_t {
+  PluginPath,
+  ExternalPluginPath,
+  LoadPluginLibrary,
+  LoadPluginExecutable,
+};
+using PluginSearchOptionKindField = BCFixed<3>;
+
 // Encodes a VersionTuple:
 //
 //  Major
@@ -884,10 +894,7 @@ namespace options_block {
     IS_CONCURRENCY_CHECKED,
     MODULE_PACKAGE_NAME,
     MODULE_EXPORT_AS_NAME,
-    PLUGIN_SEARCH_PATH,
-    EXTERNAL_SEARCH_PLUGIN_PATH,
-    COMPILER_PLUGIN_LIBRARY_PATH,
-    COMPILER_PLUGIN_EXECUTABLE_PATH,
+    PLUGIN_SEARCH_OPTION,
     HAS_CXX_INTEROPERABILITY_ENABLED,
   };
 
@@ -901,24 +908,10 @@ namespace options_block {
     BCBlob // -Xcc flag, as string
   >;
 
-  using PluginSearchPathLayout = BCRecordLayout<
-    PLUGIN_SEARCH_PATH,
-    BCBlob // -plugin-path value
-  >;
-
-  using ExternalPluginSearchPathLayout = BCRecordLayout<
-    EXTERNAL_SEARCH_PLUGIN_PATH,
-    BCBlob // -external-plugin-path value
-  >;
-
-  using CompilerPluginLibraryPathLayout = BCRecordLayout<
-    COMPILER_PLUGIN_LIBRARY_PATH,
-    BCBlob // -load-plugin-library value
-  >;
-
-  using CompilerPluginExecutablePathLayout = BCRecordLayout<
-    COMPILER_PLUGIN_EXECUTABLE_PATH,
-    BCBlob // -load-plugin-executable value
+  using PluginSearchOptionLayout = BCRecordLayout<
+    PLUGIN_SEARCH_OPTION,
+    PluginSearchOptionKindField, // kind
+    BCBlob                       // option value string
   >;
 
   using IsSIBLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1137,38 +1137,41 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         // Macro plugins
         options_block::PluginSearchOptionLayout PluginSearchOpt(Out);
         for (auto &elem : options.PluginSearchOptions) {
-          if (auto *opt = elem.dyn_cast<PluginSearchOption::PluginPath>()) {
+          switch (elem.getKind()) {
+          case PluginSearchOption::Kind::PluginPath: {
+            auto &opt = elem.get<PluginSearchOption::PluginPath>();
             PluginSearchOpt.emit(ScratchRecord,
                                  uint8_t(PluginSearchOptionKind::PluginPath),
-                                 opt->SearchPath);
+                                 opt.SearchPath);
             continue;
           }
-          if (auto *opt =
-                  elem.dyn_cast<PluginSearchOption::ExternalPluginPath>()) {
+          case PluginSearchOption::Kind::ExternalPluginPath: {
+            auto &opt = elem.get<PluginSearchOption::ExternalPluginPath>();
             PluginSearchOpt.emit(
                 ScratchRecord,
                 uint8_t(PluginSearchOptionKind::ExternalPluginPath),
-                opt->SearchPath + "#" + opt->ServerPath);
+                opt.SearchPath + "#" + opt.ServerPath);
             continue;
           }
-          if (auto *opt =
-                  elem.dyn_cast<PluginSearchOption::LoadPluginLibrary>()) {
+          case PluginSearchOption::Kind::LoadPluginLibrary: {
+            auto &opt = elem.get<PluginSearchOption::LoadPluginLibrary>();
             PluginSearchOpt.emit(
                 ScratchRecord,
                 uint8_t(PluginSearchOptionKind::LoadPluginLibrary),
-                opt->LibraryPath);
+                opt.LibraryPath);
             continue;
           }
-          if (auto *opt =
-                  elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
-            std::string optStr = opt->ExecutablePath + "#";
+          case PluginSearchOption::Kind::LoadPluginExecutable: {
+            auto &opt = elem.get<PluginSearchOption::LoadPluginExecutable>();
+            std::string optStr = opt.ExecutablePath + "#";
             llvm::interleave(
-                opt->ModuleNames, [&](auto &name) { optStr += name; },
+                opt.ModuleNames, [&](auto &name) { optStr += name; },
                 [&]() { optStr += ","; });
             PluginSearchOpt.emit(
                 ScratchRecord,
                 uint8_t(PluginSearchOptionKind::LoadPluginExecutable), optStr);
             continue;
+          }
           }
         }
       }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -846,10 +846,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, HAS_CXX_INTEROPERABILITY_ENABLED);
   BLOCK_RECORD(options_block, MODULE_PACKAGE_NAME);
   BLOCK_RECORD(options_block, MODULE_EXPORT_AS_NAME);
-  BLOCK_RECORD(options_block, PLUGIN_SEARCH_PATH);
-  BLOCK_RECORD(options_block, EXTERNAL_SEARCH_PLUGIN_PATH);
-  BLOCK_RECORD(options_block, COMPILER_PLUGIN_LIBRARY_PATH);
-  BLOCK_RECORD(options_block, COMPILER_PLUGIN_EXECUTABLE_PATH);
+  BLOCK_RECORD(options_block, PLUGIN_SEARCH_OPTION);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1138,27 +1135,41 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         }
 
         // Macro plugins
-        options_block::PluginSearchPathLayout PluginSearchPath(Out);
-        for (auto Arg : options.PluginSearchPaths) {
-          PluginSearchPath.emit(ScratchRecord, Arg);
-        }
-
-        options_block::ExternalPluginSearchPathLayout
-          ExternalPluginSearchPath(Out);
-        for (auto Arg : options.ExternalPluginSearchPaths) {
-          ExternalPluginSearchPath.emit(ScratchRecord, Arg);
-        }
-
-        options_block::CompilerPluginLibraryPathLayout
-          CompilerPluginLibraryPath(Out);
-        for (auto Arg : options.CompilerPluginLibraryPaths) {
-          CompilerPluginLibraryPath.emit(ScratchRecord, Arg);
-        }
-
-        options_block::CompilerPluginExecutablePathLayout
-          CompilerPluginExecutablePath(Out);
-        for (auto Arg : options.CompilerPluginExecutablePaths) {
-          CompilerPluginExecutablePath.emit(ScratchRecord, Arg);
+        options_block::PluginSearchOptionLayout PluginSearchOpt(Out);
+        for (auto &elem : options.PluginSearchOptions) {
+          if (auto *opt = elem.dyn_cast<PluginSearchOption::PluginPath>()) {
+            PluginSearchOpt.emit(ScratchRecord,
+                                 uint8_t(PluginSearchOptionKind::PluginPath),
+                                 opt->SearchPath);
+            continue;
+          }
+          if (auto *opt =
+                  elem.dyn_cast<PluginSearchOption::ExternalPluginPath>()) {
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::ExternalPluginPath),
+                opt->SearchPath + "#" + opt->ServerPath);
+            continue;
+          }
+          if (auto *opt =
+                  elem.dyn_cast<PluginSearchOption::LoadPluginLibrary>()) {
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::LoadPluginLibrary),
+                opt->LibraryPath);
+            continue;
+          }
+          if (auto *opt =
+                  elem.dyn_cast<PluginSearchOption::LoadPluginExecutable>()) {
+            std::string optStr = opt->ExecutablePath + "#";
+            llvm::interleave(
+                opt->ModuleNames, [&](auto &name) { optStr += name; },
+                [&]() { optStr += ","; });
+            PluginSearchOpt.emit(
+                ScratchRecord,
+                uint8_t(PluginSearchOptionKind::LoadPluginExecutable), optStr);
+            continue;
+          }
         }
       }
     }

--- a/test/Macros/serialize_plugin_search_paths.swift
+++ b/test/Macros/serialize_plugin_search_paths.swift
@@ -11,10 +11,10 @@
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin
 
 // RUN: %lldb-moduleimport-test -verbose -dump-module %t/a.out | %FileCheck %s
-// CHECK: - Macro Search Paths:
-// CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -plugin-path: {{.*}}plugins
-// CHECK:     -external-plugin-path: {{.*}}plugins#{{.*}}swift-plugin-server
-// CHECK:     -load-plugin-library: {{.*}}MacroDefinition.{{dylib|so|dll}}
-// CHECK:     -load-plugin-executable: {{.*}}mock-plugin#TestPlugin
+// CHECK: - Plugin Search Options:
+// CHECK:     -plugin-path {{.*}}plugins
+// CHECK:     -external-plugin-path {{.*}}plugins#{{.*}}swift-plugin-server
+// CHECK:     -load-plugin-library {{.*}}MacroDefinition.{{dylib|so|dll}}
+// CHECK:     -load-plugin-executable {{.*}}mock-plugin#TestPlugin
+// CHECK:     -plugin-path {{.*}}plugins
+// CHECK:     -plugin-path {{.*}}plugins

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -89,15 +89,10 @@ static bool validateModule(
       llvm::outs() << ", system=" << (searchPath.IsSystem ? "true" : "false")
                    << "\n";
     }
-    llvm::outs() << "- Macro Search Paths:\n";
-    for (auto path : extendedInfo.getPluginSearchPaths())
-      llvm::outs() << "    -plugin-path: " << path << "\n";
-    for (auto path : extendedInfo.getExternalPluginSearchPaths())
-      llvm::outs() << "    -external-plugin-path: " << path << "\n";
-    for (auto path : extendedInfo.getCompilerPluginLibraryPaths())
-      llvm::outs() << "    -load-plugin-library: " << path << "\n";
-    for (auto path : extendedInfo.getCompilerPluginExecutablePaths())
-      llvm::outs() << "    -load-plugin-executable: " << path << "\n";
+    llvm::outs() << "- Plugin Search Options:\n";
+    for (auto opt : extendedInfo.getPluginSearchOptions()) {
+      llvm::outs() << "    " << opt.first << " " << opt.second << "\n";
+    }
   }
 
   return true;

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -91,7 +91,22 @@ static bool validateModule(
     }
     llvm::outs() << "- Plugin Search Options:\n";
     for (auto opt : extendedInfo.getPluginSearchOptions()) {
-      llvm::outs() << "    " << opt.first << " " << opt.second << "\n";
+      StringRef optStr;
+      switch (opt.first) {
+      case swift::PluginSearchOption::Kind::PluginPath:
+        optStr = "-plugin-path";
+        break;
+      case swift::PluginSearchOption::Kind::ExternalPluginPath:
+        optStr = "-external-plugin-path";
+        break;
+      case swift::PluginSearchOption::Kind::LoadPluginLibrary:
+        optStr = "-load-plugin-library";
+        break;
+      case swift::PluginSearchOption::Kind::LoadPluginExecutable:
+        optStr = "-load-plugin-executable";
+        break;
+      }
+      llvm::outs() << "    " << optStr << " " << opt.second << "\n";
     }
   }
 


### PR DESCRIPTION
Cherry-pick #66689 and #66722 into release/5.9

* **Explanation**: Since https://github.com/apple/swift/pull/66678, plugin search compiler options (e.g. `-plugin-path`, `-load-plugin-library`) are processed by the order specified in the argument list. But they were still serialized/deserialized in the module grouped by each option kind. That may have caused incorrect plugins loading. This change fix that by updating the serialization. Also, this PR includes plugin search table change which which may improve plugin search performance.
* **Scope**: Macro plugin loading.
* **Risk**: Low. Plugin search option serialization and lldb support is a new feature for 5.9.
* **Testing**: Passed existing test suite
* **Issue**: rdar://110903149
* **Reviewer**: Ben Barham (@bnbarham), Alexis Laferrière (@xymus)
