### PR TITLE
[5.9] [Macros] Add default plugin paths for Darwin SDKs and platforms.

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -143,6 +143,11 @@ protected:
                                      const llvm::opt::ArgList &inputArgs,
                                      llvm::opt::ArgStringList &arguments) const;
 
+  virtual void addPlatformSpecificPluginFrontendArgs(
+      const OutputInfo &OI,
+      const CommandOutput &output,
+      const llvm::opt::ArgList &inputArgs,
+      llvm::opt::ArgStringList &arguments) const;
   virtual InvocationInfo constructInvocation(const CompileJobAction &job,
                                              const JobContext &context) const;
   virtual InvocationInfo constructInvocation(const InterpretJobAction &job,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -375,6 +375,9 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   // Specify default plugin search path options after explicitly specified
   // options.
   inputArgs.AddAllArgs(arguments, options::OPT_plugin_search_Group);
+  addPlatformSpecificPluginFrontendArgs(OI, output, inputArgs, arguments);
+  
+  // Toolchain-relative plugin paths
   {
     SmallString<64> pluginPath;
     auto programPath = getDriver().getSwiftProgramPath();
@@ -401,6 +404,14 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);
+}
+
+void ToolChain::addPlatformSpecificPluginFrontendArgs(
+    const OutputInfo &OI,
+    const CommandOutput &output,
+    const llvm::opt::ArgList &inputArgs,
+    llvm::opt::ArgStringList &arguments) const {
+  // Overridden where necessary.
 }
 
 static void addRuntimeLibraryFlags(const OutputInfo &OI,

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -53,6 +53,12 @@ protected:
       const llvm::opt::ArgList &inputArgs,
       llvm::opt::ArgStringList &arguments) const override;
 
+  void addPlatformSpecificPluginFrontendArgs(
+      const OutputInfo &OI,
+      const CommandOutput &output,
+      const llvm::opt::ArgList &inputArgs,
+      llvm::opt::ArgStringList &arguments) const override;
+
   InvocationInfo constructInvocation(const InterpretJobAction &job,
                                      const JobContext &context) const override;
   InvocationInfo constructInvocation(const DynamicLinkJobAction &job,

--- a/test/Driver/compiler_plugin_path_macosx.swift
+++ b/test/Driver/compiler_plugin_path_macosx.swift
@@ -1,0 +1,24 @@
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK: -external-plugin-path
+// CHECK-SAME: .sdk/usr/lib/swift/host/plugins#
+// CHECK-SAME: .sdk/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -external-plugin-path
+// CHECK-SAME: .sdk/usr/local/lib/swift/host/plugins#
+// CHECK-SAME: .sdk/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -external-plugin-path
+// CHECK-SAME: MacOSX.platform/Developer/usr/lib/swift/host/plugins#
+// CHECK-SAME: MacOSX.platform/Developer/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -external-plugin-path
+// CHECK-SAME: MacOSX.platform/Developer/usr/local/lib/swift/host/plugins#
+// CHECK-SAME: MacOSX.platform/Developer/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -plugin-path
+// CHECK-SAME: {{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
+
+// CHECK-SAME: -plugin-path
+// CHECK-SAME: {{(/|\\\\)}}local{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -75,7 +75,7 @@
 // COMPLEX: bin{{/|\\\\}}swift
 // COMPLEX: -c
 // COMPLEX: Driver{{/|\\\\}}driver-compile.swift
-// COMPLEX-DAG: -sdk {{.*}}/Inputs/clang-importer-sdk
+// COMPLEX-DAG: -sdk
 // COMPLEX-DAG: -foo -bar
 // COMPLEX-DAG: -Xllvm -baz
 // COMPLEX-DAG: -Xcc -garply

--- a/test/Driver/merge-module.swift
+++ b/test/Driver/merge-module.swift
@@ -36,15 +36,16 @@
 // SIMPLE: -o main.swiftmodule
 
 
-// COMPLEX: {{bin(/|\\\\)swift(-frontend|c)?(\.exe)?"?}} -frontend
+// COMPLEX: -frontend
 // COMPLEX: -emit-module
 // COMPLEX-DAG: -emit-module-doc-path {{[^ ]*[/\\]}}merge-module-{{[^ ]*}}.swiftdoc
-// COMPLEX-DAG: -sdk {{.*}}/Inputs/clang-importer-sdk
+// COMPLEX-DAG: -sdk
+// COMPLEX-DAG /Inputs/clang-importer-sdk
 // COMPLEX-DAG: -foo -bar
 // COMPLEX-DAG: -F /path/to/frameworks -F /path/to/more/frameworks
 // COMPLEX-DAG: -I /path/to/headers -I path/to/more/headers
 // COMPLEX-DAG: -module-cache-path /tmp/modules
-// COMPLEX: {{bin(/|\\\\)swift(-frontend|c)?(\.exe)?"?}} -frontend
+// COMPLEX-DAG: -frontend
 // COMPLEX: -emit-module
 // COMPLEX-DAG: -F /path/to/frameworks -F /path/to/more/frameworks
 // COMPLEX-DAG: -I /path/to/headers -I path/to/more/headers

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -12,7 +12,7 @@
 // OSX: bin{{/|\\\\}}swift
 // OSX: Driver{{/|\\\\}}sdk.swift
 // OSX: -sdk {{.*}}/Inputs/clang-importer-sdk
-// OSX-NEXT: bin{{/|\\\\}}swift
+// OSX: bin{{/|\\\\}}swift
 // OSX: -sdk {{.*}}/Inputs/clang-importer-sdk
 // OSX: {{.*}}.o{{[ "]}}
 // OSX: {{-syslibroot|--sysroot}} {{[^ ]*}}/Inputs/clang-importer-sdk


### PR DESCRIPTION
* **Explanation**: Corresponding to https://github.com/apple/swift-driver/pull/1377, this adds some default plugin paths for Darwin SDKs and platforms so that macro implementations provided their can be used by the compiler through the plugin server.
* **Scope**: Narrow; applies to all macros that currently ship within the toolchain.
* **Risk**: Low: only affects macros in the toolchain, sending them through the out-of-process path instead of loading them directly into the compiler.
* **Reviewed by**: @bnbarham 
* **Issue**:  rdar://110819604
* **Original pull request**: https://github.com/apple/swift/pull/66711
