### PR TITLE
Corrects wrong insertion point for 'await' at uncovered 'async' site.

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2867,8 +2867,13 @@ private:
         awaitInsertLoc = tryExpr->getSubExpr()->getStartLoc();
     }
 
-    Ctx.Diags.diagnose(anchor->getStartLoc(), diag::async_expr_without_await)
-      .fixItInsert(awaitInsertLoc, "await ")
+    auto anchorDecl = dyn_cast<DeclRefExpr>(anchor);
+    auto anchorVar = dyn_cast<VarDecl>(anchorDecl->getDecl());
+    auto anchorIdentifier = anchorVar->getName().str().str();
+    auto awaitInsertString = anchorIdentifier + " = await ";
+    
+    Ctx.Diags.diagnose(awaitInsertLoc, diag::async_expr_without_await)
+      .fixItInsert(awaitInsertLoc, StringRef(awaitInsertString))
       .highlight(anchor->getSourceRange());
 
     for (const DiagnosticInfo &diag: errors) {


### PR DESCRIPTION
Fixes Issue #65913
