### PR TITLE
Gardening: Silenced Optional::hasValue warning.

### DIFF
--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -518,7 +518,7 @@ public:
     assert(!discoveredBlocks || discoveredBlocks->empty());
   }
 
-  bool isInitialized() const { return numBitsToTrack.hasValue(); }
+  bool isInitialized() const { return numBitsToTrack.has_value(); }
 
   unsigned getNumBitsToTrack() const { return *numBitsToTrack; }
 


### PR DESCRIPTION
```
../include/swift/SIL/FieldSensitivePrunedLiveness.h:531:54: warning: 'hasValue' is deprecated: Use has_value instead. [-Wdeprecated-declarations]
  bool isInitialized() const { return numBitsToTrack.hasValue(); }
                                                     ^~~~~~~~
                                                     has_value
```
