### PR TITLE
[DebugInfo] Emit distinct DILocation for different inline instances

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -414,7 +414,7 @@ public:
     // Pretend transparent functions don't exist.
     if (!Scope)
       return createInlinedAt(CS);
-    auto InlinedAt = llvm::DILocation::get(
+    auto InlinedAt = llvm::DILocation::getDistinct(
         IGM.getLLVMContext(), L.line, L.column, Scope, createInlinedAt(CS));
     InlinedAtCache.insert({CS, llvm::TrackingMDNodeRef(InlinedAt)});
     return InlinedAt;

--- a/test/DebugInfo/inlinedAt.swift
+++ b/test/DebugInfo/inlinedAt.swift
@@ -40,11 +40,11 @@ public func f(_ i : Int) -> Int { // 301
 // CHECK: ![[F:.*]] = distinct !DISubprogram(name: "f",
 // CHECK: ![[G:.*]] = distinct !DISubprogram(name: "g",
 
-// CHECK: ![[L3:.*]] = !DILocation(line: 302, column: 10,
-// CHECK-SAME:                     scope: ![[F:.*]])
+// CHECK: ![[L3:.*]] = distinct !DILocation(line: 302, column: 10,
+// CHECK-SAME:                              scope: ![[F:.*]])
 // CHECK: ![[H:.*]] = distinct !DISubprogram(name: "h",
 // CHECK: ![[L1]] = !DILocation(line: 101, column: 8, scope: ![[H]],
 // CHECK-SAME:                  inlinedAt: ![[L2:.*]])
-// CHECK: ![[L2]] = !DILocation(line: 203, column: 10, scope: ![[G]],
-// CHECK-SAME:                  inlinedAt: ![[L3]])
+// CHECK: ![[L2]] = distinct !DILocation(line: 203, column: 10, scope: ![[G]],
+// CHECK-SAME:                           inlinedAt: ![[L3]])
 

--- a/test/DebugInfo/inlinescopes.swift
+++ b/test/DebugInfo/inlinescopes.swift
@@ -26,7 +26,7 @@ func transparent(_ x: Int64) -> Int64 { return noinline(x) }
 func inlined(_ x: Int64) -> Int64 {
   let result = transparent(x)
 // CHECK-DAG: ![[CALL]] = !DILocation(line: [[@LINE-1]], column: {{.*}}, scope: ![[INLINED1:.*]], inlinedAt: ![[INLINEDAT:.*]])
-// CHECK-DAG: ![[INLINEDAT]] = !DILocation({{.*}}scope: ![[INLINEDAT1:[0-9]+]]
+// CHECK-DAG: ![[INLINEDAT]] = distinct !DILocation({{.*}}scope: ![[INLINEDAT1:[0-9]+]]
 // CHECK-DAG: ![[INLINED1]] = distinct !DILexicalBlock(scope: ![[INLINED:[0-9]+]]
 // Check if the inlined and removed function still has the correct linkage name.
 // CHECK-DAG: ![[INLINED]] = distinct !DISubprogram(name: "inlined", linkageName: "$s4main7inlinedys5Int64VADF"

--- a/test/IRGen/debug_scope_distinct.swift
+++ b/test/IRGen/debug_scope_distinct.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -DM -emit-module -emit-module-path %t/M.swiftmodule %s -module-name M
 // RUN: %target-swiftc_driver -O -g -I %t -c %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swiftc_driver -O -g -I %t -c %s -o /dev/null
 
 // CHECK: define {{.*}} void @"$s4main1TV4move2byyAC13TangentVectorV_tF"
 // CHECK-SAME: ptr {{.*}} %[[ARG_PTR:.*]],
@@ -13,16 +14,19 @@
 //
 // CHECK: %[[ARG2_GEP:.*]] = getelementptr inbounds %T4main1TV13TangentVectorV, ptr %[[ARG_PTR]], i64 0, i32 2
 // CHECK: %[[ARG2:.*]] = load {{.*}} %[[ARG2_GEP]]
-// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG2]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg ![[LOC1]]
+// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG2]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg ![[LOC2:[0-9]+]]
 // CHECK: %[[ARG3_GEP:.*]] = getelementptr inbounds %T4main1TV13TangentVectorV, ptr %[[ARG_PTR]], i64 0, i32 2, i32 0, i32 1
 // CHECK: %[[ARG3:.*]] = load {{.*}} %[[ARG3_GEP]]
-// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG3]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 8)), !dbg ![[LOC1]]
+// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG3]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 8)), !dbg ![[LOC2]]
 
 // CHECK-DAG: ![[VAR1]] = !DILocalVariable(name: "offset", arg: 1, scope: ![[SCOPE:[0-9]+]]
 
 // CHECK-DAG: ![[LOC1]] = !DILocation(line: 0, scope: ![[SCOPE]], inlinedAt: ![[LOCINL1:[0-9]+]])
-// CHECK-DAG: ![[LOCINL1]] = !DILocation(line: 0, scope: ![[SUBPROG:[0-9]+]])
+// CHECK-DAG: ![[LOCINL1]] = distinct !DILocation(line: 0, scope: ![[SUBPROG:[0-9]+]])
 // CHECK-DAG: ![[SUBPROG]] = distinct !DISubprogram(name: "move", linkageName: "$s4main1TV4move2byyAC13TangentVectorV_tF"
+
+// CHECK-DAG: ![[LOC2]] = !DILocation(line: 0, scope: ![[SCOPE]], inlinedAt: ![[LOCINL2:[0-9]+]])
+// CHECK-DAG: ![[LOCINL2]] = distinct !DILocation(line: 0, scope: ![[SUBPROG]])
 
 #if M
 import _Differentiation

--- a/test/IRGen/debug_scope_distinct.swift
+++ b/test/IRGen/debug_scope_distinct.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -DM -emit-module -emit-module-path %t/M.swiftmodule %s -module-name M
+// RUN: %target-swiftc_driver -O -g -I %t -c %s -emit-ir -o - | %FileCheck %s
+
+// CHECK: define {{.*}} void @"$s4main1TV4move2byyAC13TangentVectorV_tF"
+// CHECK-SAME: ptr {{.*}} %[[ARG_PTR:.*]],
+//
+// CHECK: %[[ARG0:.*]] = load {{.*}} %[[ARG_PTR]]
+// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG0]], metadata ![[VAR1:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg ![[LOC1:[0-9]+]]
+// CHECK: %[[ARG1_GEP:.*]] = getelementptr inbounds i8, ptr %[[ARG_PTR]], i64 8
+// CHECK: %[[ARG1:.*]] = load {{.*}} %[[ARG1_GEP]]
+// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG1]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 8)), !dbg ![[LOC1]]
+//
+// CHECK: %[[ARG2_GEP:.*]] = getelementptr inbounds %T4main1TV13TangentVectorV, ptr %[[ARG_PTR]], i64 0, i32 2
+// CHECK: %[[ARG2:.*]] = load {{.*}} %[[ARG2_GEP]]
+// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG2]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg ![[LOC1]]
+// CHECK: %[[ARG3_GEP:.*]] = getelementptr inbounds %T4main1TV13TangentVectorV, ptr %[[ARG_PTR]], i64 0, i32 2, i32 0, i32 1
+// CHECK: %[[ARG3:.*]] = load {{.*}} %[[ARG3_GEP]]
+// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG3]], metadata ![[VAR1]], metadata !DIExpression(DW_OP_LLVM_fragment, 64, 8)), !dbg ![[LOC1]]
+
+// CHECK-DAG: ![[VAR1]] = !DILocalVariable(name: "offset", arg: 1, scope: ![[SCOPE:[0-9]+]]
+
+// CHECK-DAG: ![[LOC1]] = !DILocation(line: 0, scope: ![[SCOPE]], inlinedAt: ![[LOCINL1:[0-9]+]])
+// CHECK-DAG: ![[LOCINL1]] = !DILocation(line: 0, scope: ![[SUBPROG:[0-9]+]])
+// CHECK-DAG: ![[SUBPROG]] = distinct !DISubprogram(name: "move", linkageName: "$s4main1TV4move2byyAC13TangentVectorV_tF"
+
+#if M
+import _Differentiation
+
+public struct S<T> {
+  class C {}
+  let c: C
+  internal var b: Int8
+  init(_ initb: Int8) {
+    b = initb;
+    c = C();
+  }
+}
+
+extension S: AdditiveArithmetic {
+  public static var zero: S { let ret = S(0); return ret; }
+  public static func == (_ lhs: S, _ rhs: S) -> Bool { return lhs.b == rhs.b; }
+  public static func + (_ lhs: S, _ rhs: S) -> S { var ret = lhs; ret.b += rhs.b; return ret; }
+  public static func - (_ lhs: S, _ rhs: S) -> S { var ret = lhs; ret.b -= rhs.b; return ret; }
+}
+
+extension S: Differentiable {
+  public typealias TangentVector = S
+}
+
+#else
+import _Differentiation
+import M
+
+struct T: Differentiable {
+  var u1: U
+  var u2: U
+}
+
+struct U: Differentiable {
+  var s: S<Float>
+  var v: V
+}
+
+struct V: Differentiable {
+  var s: S<Float>
+}
+#endif

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -140,9 +140,9 @@ func testFileID(a: Int, b: Int) {
   // CHECK-AST: macro_expansion_expr type='String'{{.*}}name=line
   print("Builtin result is \(#fileID)")
   print(
-    /// CHECK-IR-DAG: ![[L1:[0-9]+]] = !DILocation(line: [[@LINE+1]], column: 5
+    /// CHECK-IR-DAG: ![[L1:[0-9]+]] = distinct !DILocation(line: [[@LINE+1]], column: 5
     #addBlocker(
-      /// CHECK-IR-DAG: ![[L2:[0-9]+]] = !DILocation({{.*}}inlinedAt: ![[L1]])
+      /// CHECK-IR-DAG: ![[L2:[0-9]+]] = distinct !DILocation({{.*}}inlinedAt: ![[L1]])
       /// CHECK-IR-DAG: ![[L3:[0-9]+]] = !DILocation({{.*}}inlinedAt: ![[L2]])
       #stringify(a - b)
       )


### PR DESCRIPTION
LLVM seems to determine a variable instance as a combination of DILocalVariable
and DILocation. Therefore if multiple llvm.dbg.declare have the same
variable/location parameters, they are considered to be referencing the same
instance of variable.

Swift IRGen emits a set of llvm.dbg.declare calls for every variable
instance (with unique SILDebugScope), so it is important that these calls have
distinct variable/location parameters. Otherwise their DIExpression may be
incorrect when treated as referencing the same variable. For example, if they
have a DIExpression with fragments, we will see this as multiple declarations of
the same fragment. LLVM detects this and crashes with assertion failure:

DwarfExpression.cpp:679: void llvm::DwarfExpression::addFragmentOffset(const
llvm::DIExpression *): Assertion `FragmentOffset >= OffsetInBits &&
"overlapping or duplicate fragments"' failed.

The patch resolves #55703. The LIT test (debug_scope_distinct.swift) is the
reproducer from that issue.
