### PR TITLE
[cxx-interop] Avoid crashing when template substitution fails

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2128,6 +2128,9 @@ ERROR(unable_to_convert_generic_swift_types,none,
       "the following Swift type(s) provided to '%0' could not be "
       "converted: %1",
       (StringRef, StringRef))
+ERROR(unable_to_substitute_cxx_function_template,none,
+      "could not substitute parameters for C++ function template '%0': %1",
+      (StringRef, StringRef))
 
 // Type aliases
 ERROR(type_alias_underlying_type_access,none,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5772,20 +5772,24 @@ clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
   std::unique_ptr<TemplateInstantiationError> error =
       ctx.getClangTemplateArguments(func->getTemplateParameters(),
                                     subst.getReplacementTypes(), templateSubst);
+
+  auto getFuncName = [&]() -> std::string {
+    std::string funcName;
+    llvm::raw_string_ostream funcNameStream(funcName);
+    func->printQualifiedName(funcNameStream);
+    return funcName;
+  };
+
   if (error) {
     std::string failedTypesStr;
     llvm::raw_string_ostream failedTypesStrStream(failedTypesStr);
     llvm::interleaveComma(error->failedTypes, failedTypesStrStream);
 
-    std::string funcName;
-    llvm::raw_string_ostream funcNameStream(funcName);
-    func->printQualifiedName(funcNameStream);
-
     // TODO: Use the location of the apply here.
     // TODO: This error message should not reference implementation details.
     // See: https://github.com/apple/swift/pull/33053#discussion_r477003350
     ctx.Diags.diagnose(SourceLoc(), diag::unable_to_convert_generic_swift_types,
-                       funcName, failedTypesStr);
+                       getFuncName(), failedTypesStr);
     return nullptr;
   }
 
@@ -5795,6 +5799,20 @@ clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
   auto &sema = getClangInstance().getSema();
   auto *spec = sema.InstantiateFunctionDeclaration(func, templateArgList,
                                                    clang::SourceLocation());
+  if (!spec) {
+    std::string templateParams;
+    llvm::raw_string_ostream templateParamsStream(templateParams);
+    llvm::interleaveComma(templateArgList->asArray(), templateParamsStream,
+                          [&](const clang::TemplateArgument &arg) {
+                            arg.print(func->getASTContext().getPrintingPolicy(),
+                                      templateParamsStream,
+                                      /*IncludeType*/ true);
+                          });
+    ctx.Diags.diagnose(SourceLoc(),
+                       diag::unable_to_substitute_cxx_function_template,
+                       getFuncName(), templateParams);
+    return nullptr;
+  }
   sema.InstantiateFunctionDefinition(clang::SourceLocation(), spec);
   return spec;
 }

--- a/test/Interop/Cxx/templates/Inputs/enable-if.h
+++ b/test/Interop/Cxx/templates/Inputs/enable-if.h
@@ -1,0 +1,29 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H
+
+template <bool B, class T = void>
+struct enable_if {};
+
+template <class T>
+struct enable_if<true, T> {
+  typedef T type;
+};
+
+template <class T>
+struct is_bool {
+  static const bool value = false;
+};
+
+template <>
+struct is_bool<bool> {
+  static const bool value = true;
+};
+
+struct HasMethodWithEnableIf {
+  template <typename T>
+  typename enable_if<is_bool<T>::value, bool>::type onlyEnabledForBool(T t) const {
+    return !t;
+  }
+};
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -133,6 +133,11 @@ module TemplateTypeParameterNotInSignature {
   requires cplusplus
 }
 
+module EnableIf {
+  header "enable-if.h"
+  requires cplusplus
+}
+
 module DefineReferencedInline {
   header "define-referenced-inline.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/enable-if-typechecker.swift
+++ b/test/Interop/Cxx/templates/enable-if-typechecker.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop 2>&1 | %FileCheck %s
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import EnableIf
+
+let x = HasMethodWithEnableIf()
+x.onlyEnabledForBool("a")
+// CHECK: error: could not substitute parameters for C++ function template 'HasMethodWithEnableIf::onlyEnabledForBool': NSString *


### PR DESCRIPTION
This code used to crash the compiler:

```swift
var s = std.string("hi")
s.append("foo")
```

`append` in this case resolves to a templated C++ method that accepts `std::string_view`, while we tried passing a Swift String to it as a parameter.

rdar://107018724