### PR TITLE
[FieldSensitivePL] NFC: Removed unused API.

### DIFF
--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -581,11 +581,6 @@ public:
     return getBlockLiveness(block, bitNo);
   }
 
-  /// Update this range of liveness results for a single use.
-  void updateForUse(SILInstruction *user, unsigned startBitNo,
-                    unsigned endBitNo,
-                    SmallVectorImpl<IsLive> &resultingLiveness);
-
   IsLive getBlockLiveness(SILBasicBlock *bb, unsigned bitNo) const {
     assert(isInitialized());
     auto liveBlockIter = liveBlocks.find(bb);
@@ -853,9 +848,6 @@ public:
   ///
   /// Also for flexibility, \p affectedAddress must be a derived projection from
   /// the base that \p user is affecting.
-  void updateForUse(SILInstruction *user, TypeTreeLeafTypeRange span,
-                    bool lifetimeEnding);
-
   void updateForUse(SILInstruction *user, SmallBitVector const &bits,
                     bool lifetimeEnding);
 
@@ -946,11 +938,6 @@ protected:
   ///
   /// This call is not considered the end of %val's lifetime. The @owned
   /// argument must be copied.
-  void addInterestingUser(SILInstruction *user, TypeTreeLeafTypeRange range,
-                          bool lifetimeEnding) {
-    getOrCreateInterestingUser(user).addUses(range, lifetimeEnding);
-  }
-
   void addInterestingUser(SILInstruction *user, SmallBitVector const &bits,
                           bool lifetimeEnding) {
     getOrCreateInterestingUser(user).addUses(bits, lifetimeEnding);

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -801,35 +801,9 @@ void FieldSensitivePrunedLiveRange<LivenessWithDefs>::computeBoundary(
 template <typename LivenessWithDefs>
 void FieldSensitivePrunedLiveRange<LivenessWithDefs>::updateForUse(
     SILInstruction *user, TypeTreeLeafTypeRange range, bool lifetimeEnding) {
-  PRUNED_LIVENESS_LOG(
-      llvm::dbgs()
-      << "Begin FieldSensitivePrunedLiveRange<LivenessWithDefs>::updateForUse "
-         "for: "
-      << *user);
-  PRUNED_LIVENESS_LOG(
-      llvm::dbgs() << "Looking for def instruction earlier in the block!\n");
-
-  auto *parentBlock = user->getParent();
-  for (auto ii = std::next(user->getReverseIterator()),
-            ie = parentBlock->rend();
-       ii != ie; ++ii) {
-    // If we find the def, just mark this instruction as being an interesting
-    // instruction.
-    if (asImpl().isDef(&*ii, range)) {
-      PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Found def: " << *ii);
-      PRUNED_LIVENESS_LOG(llvm::dbgs()
-                 << "    Marking inst as interesting user and returning!\n");
-      addInterestingUser(user, range, lifetimeEnding);
-      return;
-    }
-  }
-
-  // Otherwise, just delegate to our parent class's update for use. This will
-  // update liveness for our predecessor blocks and add this instruction as an
-  // interesting user.
-  PRUNED_LIVENESS_LOG(llvm::dbgs() << "No defs found! Delegating to "
-                             "FieldSensitivePrunedLiveness::updateForUse.\n");
-  FieldSensitivePrunedLiveness::updateForUse(user, range, lifetimeEnding);
+  SmallBitVector bits(getNumSubElements());
+  range.setBits(bits);
+  updateForUse(user, bits, lifetimeEnding);
 }
 
 template <typename LivenessWithDefs>


### PR DESCRIPTION
An overload using `SmallBitVector`s that duplicated the implementation of the original function which used `TypeTreeLeafTypeRange`s was added earlier.  Here, the original function is (1) made to delegate to the new overload and then (2) removed altogether because it's no longer used.
