### PR TITLE
[cxx-interop] Make `std::string::append` usable from Swift

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -77,7 +77,12 @@ extension std.string: Equatable {
   }
 
   public static func +=(lhs: inout std.string, rhs: std.string) {
-    lhs.__appendUnsafe(rhs) // ignore the returned pointer
+    lhs.append(rhs)
+  }
+
+  @inlinable
+  public mutating func append(_ other: std.string) {
+    __appendUnsafe(other) // ignore the returned pointer
   }
 
   public static func +(lhs: std.string, rhs: std.string) -> std.string {
@@ -93,7 +98,12 @@ extension std.u16string: Equatable {
   }
 
   public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
-    lhs.__appendUnsafe(rhs) // ignore the returned pointer
+    lhs.append(rhs)
+  }
+
+  @inlinable
+  public mutating func append(_ other: std.u16string) {
+    __appendUnsafe(other) // ignore the returned pointer
   }
 
   public static func +(lhs: std.u16string, rhs: std.u16string) -> std.u16string {

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -85,6 +85,20 @@ StdStringOverlayTestSuite.test("std::u16string operators") {
   expectTrue(s1 == "something123literal")
 }
 
+StdStringOverlayTestSuite.test("std::string::append") {
+  var s1 = std.string("0123")
+  let s2 = std.string("abc")
+  s1.append(s2)
+  expectEqual(s1, std.string("0123abc"))
+}
+
+StdStringOverlayTestSuite.test("std::u16string::append") {
+  var s1 = std.u16string("0123")
+  let s2 = std.u16string("abc")
+  s1.append(s2)
+  expectEqual(s1, std.u16string("0123abc"))
+}
+
 StdStringOverlayTestSuite.test("std::string as Hashable") {
   let s0 = std.string()
   let h0 = s0.hashValue


### PR DESCRIPTION
This adds a new Swift overload for `append` that takes another `std::string` as a parameter.

The original C++ overload for `append` is not exposed into Swift because it returns a mutable reference `string&`.

rdar://107018724