### PR TITLE
[static-stdlib] NFC: Generalize the static-executable-args.lnk file generation

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -102,28 +102,34 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
-set(sdk "${SWIFT_HOST_VARIANT_SDK}")
-if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
+if(SWIFT_BUILD_STATIC_STDLIB)
   set(static_binary_lnk_file_list)
-  string(TOLOWER "${sdk}" lowercase_sdk)
-  set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lowercase_sdk}/static-executable-args.lnk")
 
-  # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-  set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
-  add_custom_command_target(swift_static_binary_${sdk}_args
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy
-      "${static_binary_lnk_src}"
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    OUTPUT
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DEPENDS
-      "${static_binary_lnk_src}")
+  foreach(sdk ${SWIFT_SDKS})
+    if(NOT "${sdk}" STREQUAL "LINUX")
+      continue()
+    endif()
 
-  list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
-  swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                             DESTINATION "lib/swift_static/${lowercase_sdk}"
-                             COMPONENT stdlib)
+    string(TOLOWER "${sdk}" lowercase_sdk)
+    set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lowercase_sdk}/static-executable-args.lnk")
+
+    # Generate the static-executable-args.lnk file used for ELF systems (e.g. Linux, FreeBSD etc) and Wasm systems
+    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    add_custom_command_target(swift_static_binary_${sdk}_args
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${static_binary_lnk_src}"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DEPENDS
+        "${static_binary_lnk_src}")
+
+    list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
+    swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+                               DESTINATION "lib/swift_static/${lowercase_sdk}"
+                               COMPONENT stdlib)
+  endforeach()
   add_dependencies(stdlib ${static_binary_lnk_file_list})
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
 endif()


### PR DESCRIPTION
This patch makes the build system to copy the lnk files for each stdlib targets if needed instead of only for the Linux target. This makes it easier to add other platform support.
