### PR TITLE
GettingStarted.md: add missing link for Ubuntu 18.04 dependencies

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -157,12 +157,13 @@ toolchain as a one-off, there are a couple of differences:
 ### Linux
 
 1. The latest Linux dependencies are listed in the respective Dockerfiles:
+   * [Ubuntu 18.04](https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/18.04/Dockerfile)
    * [Ubuntu 20.04](https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/20.04/Dockerfile)
    * [Ubuntu 22.04](https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile)
    * [CentOS 7](https://github.com/apple/swift-docker/blob/main/swift-ci/master/centos/7/Dockerfile)
    * [Amazon Linux 2](https://github.com/apple/swift-docker/blob/main/swift-ci/master/amazon-linux/2/Dockerfile)
 
-2. To install [Sccache][] (optional):
+3. To install [Sccache][] (optional):
    * If you're not building within a Docker container:
      ```sh
      sudo snap install sccache --candidate --classic

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -163,7 +163,7 @@ toolchain as a one-off, there are a couple of differences:
    * [CentOS 7](https://github.com/apple/swift-docker/blob/main/swift-ci/master/centos/7/Dockerfile)
    * [Amazon Linux 2](https://github.com/apple/swift-docker/blob/main/swift-ci/master/amazon-linux/2/Dockerfile)
 
-3. To install [Sccache][] (optional):
+2. To install [Sccache][] (optional):
    * If you're not building within a Docker container:
      ```sh
      sudo snap install sccache --candidate --classic


### PR DESCRIPTION
For some reason only Ubuntu 20.04 and 22.04 were listed.