### PR TITLE
[Installer] Do not follow an existing symbolic link when overwriting

### DIFF
--- a/utils/darwin-installer-scripts/postinstall
+++ b/utils/darwin-installer-scripts/postinstall
@@ -13,4 +13,4 @@
 
 INSTALLED_TOOLCHAIN=$2
 
-ln -fs "${INSTALLED_TOOLCHAIN}" "${INSTALLED_TOOLCHAIN%/*}/swift-latest.xctoolchain"
+ln -fhs "${INSTALLED_TOOLCHAIN}" "${INSTALLED_TOOLCHAIN%/*}/swift-latest.xctoolchain"


### PR DESCRIPTION
In BSD, `ln` command follows the symbolic link given in its arguments if `-h` is not given.
This behavior causes odd situation when user tries to install .pkg toolchain with another toolchain installed. 

```
$ ln -fs swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain swift-latest.xctoolchain
$ tree
|-- swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain
|-- swift-latest.xctoolchain -> swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain
$ ln -fs swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain swift-latest.xctoolchain
$ tree
|-- swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain
|   |-- swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain -> swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain
|-- swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain
|-- swift-latest.xctoolchain -> swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain
```

The second `ln -fs` is interpreted as `ln -fs swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain` because of the symbolic link resolution, so it makes a new symbolic link under `swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain`

But we expect having like below:

```
$ tree
|-- swift-DEVELOPMENT-SNAPSHOT-XX.xctoolchain
|-- swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain
|-- swift-latest.xctoolchain -> swift-DEVELOPMENT-SNAPSHOT-YY.xctoolchain
```

So we should not follow the existing symbolic link even if it already exists.