### PR TITLE
Optimizer: add simplifications for checked_cast_br and unchecked_ref_cast

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -19,6 +19,7 @@ swift_compiler_sources(Optimizer
   SimplifyInitEnumDataAddr.swift
   SimplifyLoad.swift
   SimplifyPartialApply.swift
+  SimplifyRefCasts.swift
   SimplifyRetainReleaseValue.swift
   SimplifyStrongRetainRelease.swift
   SimplifyStructExtract.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
@@ -1,0 +1,128 @@
+//===--- SimplifyRefCasts.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+// Note: this simplifications are not SILCombineSimplifyable, because SILCombine has
+// its own simplifications for those cast instructions which are not ported to Swift, yet.
+
+extension CheckedCastBranchInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+    // Has only an effect if the source is an (existential) reference.
+    simplifySourceOperandOfRefCast(context)
+  }
+}
+
+extension UncheckedRefCastInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+    simplifySourceOperandOfRefCast(context)
+  }
+}
+
+private extension UnaryInstruction {
+
+  /// Look through `upcast` and `init_existential_ref` instructions and replace the
+  /// operand of this cast instruction with the original value.
+  /// For example:
+  /// ```
+  ///   %2 = upcast %1 : $Derived to $Base
+  ///   %3 = init_existential_ref %2 : $Base : $Base, $AnyObject
+  ///   checked_cast_br %3 : $AnyObject to Derived, bb1, bb2
+  /// ```
+  ///
+  /// This makes it more likely that the cast can be constant folded because the source
+  /// operand's type is more accurate. In the example above, the cast reduces to
+  /// ```
+  ///   checked_cast_br %1 : $Derived to Derived, bb1, bb2
+  /// ```
+  /// which can be trivially folded to always-succeeds.
+  ///
+  func simplifySourceOperandOfRefCast(_ context: SimplifyContext) {
+    while true {
+      switch operand.value {
+      case let ier as InitExistentialRefInst:
+        if !tryReplaceSource(withOperandOf: ier, context) {
+          return
+        }
+      case let uc as UpcastInst:
+        if !tryReplaceSource(withOperandOf: uc, context) {
+          return
+        }
+      default:
+        return
+      }
+    }
+
+  }
+
+  func tryReplaceSource(withOperandOf inst: SingleValueInstruction, _ context: SimplifyContext) -> Bool {
+    let singleUse = context.preserveDebugInfo ? inst.uses.singleUse : inst.uses.singleNonDebugUse
+    let canEraseInst = singleUse?.instruction == self
+    let replacement = inst.operands[0].value
+
+    if parentFunction.hasOwnership {
+      if !canEraseInst && replacement.ownership == .owned {
+        // We cannot add more uses to `replacement` without inserting a copy.
+        return false
+      }
+
+      operand.set(to: replacement, context)
+
+      if let ccb = self as? CheckedCastBranchInst {
+        // In OSSA, the source value is passed as block argument to the failure block.
+        // We have to re-create the skipped source instruction in the failure block.
+        insertCompensatingInstructions(for: inst, in: ccb.failureBlock, context)
+      }
+    } else {
+      operand.set(to: replacement, context)
+    }
+
+    if canEraseInst {
+      context.erase(instructionIncludingDebugUses: inst)
+    }
+    return true
+  }
+}
+
+/// Compensate a removed source value instruction in the failure block.
+/// For example:
+/// ```
+///   %inst = upcast %sourceValue : $Derived to $Base
+///   checked_cast_br %inst : $Base to Derived, success_block, failure_block
+///   ...
+/// failure_block(%oldArg : $Base):
+/// ```
+/// is converted to:
+/// ```
+///   checked_cast_br %sourceValue : $Derived to Derived, success_block, failure_block
+///   ...
+/// failure_block(%newArg : $Derived):
+///   %3 = upcast %newArg : $Derived to $Base
+/// ```
+private func insertCompensatingInstructions(for inst: Instruction, in failureBlock: BasicBlock, _ context: SimplifyContext) {
+  assert(failureBlock.arguments.count == 1)
+  let sourceValue = inst.operands[0].value
+  let newArg = failureBlock.addBlockArgument(type: sourceValue.type, ownership: sourceValue.ownership, context)
+  let builder = Builder(atBeginOf: failureBlock, context)
+  let newInst: SingleValueInstruction
+  switch inst {
+  case let ier as InitExistentialRefInst:
+    newInst = builder.createInitExistentialRef(instance: newArg, existentialType: ier.type, useConformancesOf: ier)
+  case let uc as UpcastInst:
+    newInst = builder.createUpcast(from: newArg, to: uc.type)
+  default:
+    fatalError("unhandled instruction")
+  }
+  let oldArg = failureBlock.arguments[0]
+  oldArg.uses.replaceAll(with: newInst, context)
+  failureBlock.eraseArgument(at: 0, context)
+}

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -262,4 +262,13 @@ public struct Builder {
     let store = bridged.createStore(source.bridged, destination.bridged, ownership.rawValue)
     return notifyNew(store.getAs(StoreInst.self))
   }
+
+  public func createInitExistentialRef(instance: Value,
+                                       existentialType: Type,
+                                       useConformancesOf: InitExistentialRefInst) -> InitExistentialRefInst {
+    let initExistential = bridged.createInitExistentialRef(instance.bridged,
+                                                           existentialType.bridged,
+                                                           useConformancesOf.bridged)
+    return notifyNew(initExistential.getAs(InitExistentialRefInst.self))
+  }
 }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1004,6 +1004,9 @@ final public class AwaitAsyncContinuationInst : TermInst, UnaryInstruction {
 }
 
 final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
+  public var source: Value { operand.value }
+  public var successBlock: BasicBlock { bridged.CheckedCastBranch_getSuccessBlock().block }
+  public var failureBlock: BasicBlock { bridged.CheckedCastBranch_getFailureBlock().block }
 }
 
 final public class CheckedCastAddrBranchInst : TermInst, UnaryInstruction {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -787,6 +787,12 @@ struct BridgedInstruction {
   }
 
   SWIFT_IMPORT_UNSAFE
+  inline BridgedBasicBlock CheckedCastBranch_getSuccessBlock() const;
+
+  SWIFT_IMPORT_UNSAFE
+  inline BridgedBasicBlock CheckedCastBranch_getFailureBlock() const;
+
+  SWIFT_IMPORT_UNSAFE
   swift::SubstitutionMap ApplySite_getSubstitutionMap() const {
     auto as = swift::ApplySite(getInst());
     return as.getSubstitutionMap();
@@ -1258,6 +1264,17 @@ struct BridgedBuilder{
     return {builder().createStore(regularLoc(), src.getSILValue(), dst.getSILValue(),
                                   (swift::StoreOwnershipQualifier)ownership)};
   }
+
+  SWIFT_IMPORT_UNSAFE
+  BridgedInstruction createInitExistentialRef(BridgedValue instance,
+                                              swift::SILType type,
+                                              BridgedInstruction useConformancesOf) const {
+    auto *src = useConformancesOf.getAs<swift::InitExistentialRefInst>();
+    return {builder().createInitExistentialRef(regularLoc(), type,
+                                               src->getFormalConcreteType(),
+                                               instance.getSILValue(),
+                                               src->getConformances())};
+  }
 };
 
 // AST bridging
@@ -1350,6 +1367,14 @@ BridgedBasicBlock BridgedInstruction::BranchInst_getTargetBlock() const {
 
 void BridgedInstruction::TermInst_replaceBranchTarget(BridgedBasicBlock from, BridgedBasicBlock to) const {
   getAs<swift::TermInst>()->replaceBranchTarget(from.getBlock(), to.getBlock());
+}
+
+BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getSuccessBlock() const {
+  return {getAs<swift::CheckedCastBranchInst>()->getSuccessBB()};
+}
+
+inline BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getFailureBlock() const {
+  return {getAs<swift::CheckedCastBranchInst>()->getFailureBB()};
 }
 
 OptionalBridgedSuccessor BridgedBasicBlock::getFirstPred() const {

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -5,6 +5,7 @@
 // long enough in the same form to be worth rewriting CHECK lines.
 
 // REQUIRES: objc_interop
+// REQUIRES: swift_in_compiler
 
 import ObjectiveC
 
@@ -68,7 +69,7 @@ class Cat : FakeNSObject {
     // CHECK-NEXT: strong_release [[ARG2]]
     // CHECK-NEXT: [[RELOAD_ARG2:%.*]] = load [[SELF_BOX]]
     // CHECK-NEXT: [[SUPER:%.*]] = upcast [[RELOAD_ARG2]] : $Cat to $FakeNSObject
-    // CHECK-NEXT: [[SUB:%.*]] = unchecked_ref_cast [[SUPER]] : $FakeNSObject to $Cat
+    // CHECK-NEXT: [[SUB:%.*]] = unchecked_ref_cast [[RELOAD_ARG2]] : $Cat to $Cat
     // CHECK-NEXT: [[SUPER_FN:%.*]] = objc_super_method [[SUB]] : $Cat, #FakeNSObject.init!initializer.foreign : (FakeNSObject.Type) -> () -> FakeNSObject, $@convention(objc_method) (@owned FakeNSObject) -> @owned FakeNSObject
     // CHECK-NEXT: [[NEW_SUPER_SELF:%.*]] = apply [[SUPER_FN]]([[SUPER]]) : $@convention(objc_method) (@owned FakeNSObject) -> @owned FakeNSObject
     // CHECK-NEXT: [[NEW_SELF:%.*]] = unchecked_ref_cast [[NEW_SUPER_SELF]] : $FakeNSObject to $Cat

--- a/test/SILOptimizer/simplify_checked_cast_br.sil
+++ b/test/SILOptimizer/simplify_checked_cast_br.sil
@@ -1,0 +1,105 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=checked_cast_br | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ONONE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=checked_cast_br | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-O
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+protocol P : AnyObject {}
+class B : P {}
+class X : B {}
+
+// CHECK-LABEL: sil @test_non_ossa :
+// CHECK:         %0 = alloc_ref
+// CHECK:         checked_cast_br %0 : $X
+// CHECK:       } // end sil function 'test_non_ossa'
+sil @test_non_ossa : $@convention(thin) () -> AnyObject {
+bb0:
+  %0 = alloc_ref $X
+  %1 = upcast %0 : $X to $B
+  %2 = init_existential_ref %1 : $B : $B, $AnyObject
+  checked_cast_br %2 : $AnyObject to X, bb1, bb2
+
+bb1(%5 : $X):
+  strong_release %5 : $X
+  return %2 : $AnyObject
+
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @test_ossa :
+// CHECK:         %0 = alloc_ref
+// CHECK-O-NEXT:  checked_cast_br %0 : $X
+// CHECK-ONONE:   checked_cast_br %2 : $AnyObject
+// CHECK-O:     bb2([[A:%.*]] : @owned $X):
+// CHECK-O-NEXT:  [[U:%.*]] = upcast [[A]] : $X to $B
+// CHECK-O-NEXT:  [[E:%.*]] = init_existential_ref [[U]] : $B
+// CHECK-O-NEXT:  destroy_value [[E]]
+// CHECK-ONONE: bb2(%{{[0-9]+}} : @owned $AnyObject):
+// CHECK:       } // end sil function 'test_ossa'
+sil [ossa] @test_ossa : $@convention(thin) () -> @owned X {
+bb0:
+  %0 = alloc_ref $X
+  %1 = upcast %0 : $X to $B
+  %2 = init_existential_ref %1 : $B : $B, $AnyObject
+  debug_value %2 : $AnyObject, name "x"
+  checked_cast_br %2 : $AnyObject to X, bb1, bb2
+
+bb1(%5 : @owned $X):
+  return %5 : $X
+
+bb2(%7 : @owned $AnyObject):
+  destroy_value %7: $AnyObject
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @test_ossa_multiple_uses :
+// CHECK:         checked_cast_br %1 : $B
+// CHECK:       } // end sil function 'test_ossa_multiple_uses'
+sil [ossa] @test_ossa_multiple_uses : $@convention(thin) () -> @owned X {
+bb0:
+  %0 = alloc_ref $X
+  %1 = upcast %0 : $X to $B
+  fix_lifetime %1 : $B
+  checked_cast_br %1 : $B to X, bb1, bb2
+
+bb1(%5 : @owned $X):
+  return %5 : $X
+
+bb2(%7 : @owned $B):
+  destroy_value %7: $B
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @test_borrow :
+// CHECK:         %1 = begin_borrow
+// CHECK-NEXT:    checked_cast_br %1 : $X
+// CHECK:       bb2([[A:%.*]] : @guaranteed $X):
+// CHECK-NEXT:    [[U:%.*]] = upcast [[A]] : $X to $B
+// CHECK-NEXT:    [[E:%.*]] = init_existential_ref [[U]] : $B
+// CHECK-NEXT:    fix_lifetime [[E]]
+// CHECK:       } // end sil function 'test_borrow'
+sil [ossa] @test_borrow : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $X
+  %1 = begin_borrow %0 : $X
+  %2 = upcast %1 : $X to $B
+  %3 = init_existential_ref %2 : $B : $B, $P
+  checked_cast_br %3 : $P to X, bb1, bb2
+
+bb1(%5 : @guaranteed $X):
+  end_borrow %1 : $X
+  destroy_value %0: $X
+  %8 = tuple ()
+  return %8 : $()
+
+bb2(%10 : @guaranteed $P):
+  fix_lifetime %10 : $P
+  destroy_value %0: $X
+  unreachable
+}
+
+sil_vtable X {
+}

--- a/test/SILOptimizer/simplify_unchecked_ref_cast.sil
+++ b/test/SILOptimizer/simplify_unchecked_ref_cast.sil
@@ -1,0 +1,74 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=unchecked_ref_cast | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ONONE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=unchecked_ref_cast | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-O
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+protocol P : AnyObject {}
+class B : P {}
+class X : B {}
+
+// CHECK-LABEL: sil @test_non_ossa :
+// CHECK:         %0 = alloc_ref
+// CHECK:         unchecked_ref_cast %0 : $X
+// CHECK:       } // end sil function 'test_non_ossa'
+sil @test_non_ossa : $@convention(thin) () -> X {
+bb0:
+  %0 = alloc_ref $X
+  %1 = upcast %0 : $X to $B
+  %2 = init_existential_ref %1 : $B : $B, $AnyObject
+  %3 = unchecked_ref_cast %2 : $AnyObject to $X
+  return %3 : $X
+}
+
+// CHECK-LABEL: sil [ossa] @test_ossa :
+// CHECK:         %0 = alloc_ref
+// CHECK-O-NEXT:  unchecked_ref_cast %0 : $X
+// CHECK-ONONE:   unchecked_ref_cast %2 : $AnyObject
+// CHECK:       } // end sil function 'test_ossa'
+sil [ossa] @test_ossa : $@convention(thin) () -> @owned X {
+bb0:
+  %0 = alloc_ref $X
+  %1 = upcast %0 : $X to $B
+  %2 = init_existential_ref %1 : $B : $B, $AnyObject
+  debug_value %2 : $AnyObject, name "x"
+  %4 = unchecked_ref_cast %2 : $AnyObject to $X
+  return %4 : $X
+}
+
+// CHECK-LABEL: sil [ossa] @test_ossa_multiple_uses :
+// CHECK:         unchecked_ref_cast %1 : $B
+// CHECK:       } // end sil function 'test_ossa_multiple_uses'
+sil [ossa] @test_ossa_multiple_uses : $@convention(thin) () -> @owned X {
+bb0:
+  %0 = alloc_ref $X
+  %1 = upcast %0 : $X to $B
+  fix_lifetime %1 : $B
+  %3 = unchecked_ref_cast %1 : $B to $X
+  return %3 : $X
+}
+
+// CHECK-LABEL: sil [ossa] @test_borrow :
+// CHECK:         %1 = begin_borrow
+// CHECK-NEXT:    %2 = unchecked_ref_cast %1 : $X
+// CHECK-NEXT:    fix_lifetime %2
+// CHECK:       } // end sil function 'test_borrow'
+sil [ossa] @test_borrow : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $X
+  %1 = begin_borrow %0 : $X
+  %2 = upcast %1 : $X to $B
+  %3 = init_existential_ref %2 : $B : $B, $P
+  %4 = unchecked_ref_cast %3 : $P to $X
+  fix_lifetime %4 : $X
+  end_borrow %1 : $X
+  destroy_value %0: $X
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil_vtable X {
+}
+


### PR DESCRIPTION
Look through `upcast` and `init_existential_ref` instructions and replace the operand of this cast instruction with the original value. For example:
```
  %2 = upcast %1 : $Derived to $Base
  %3 = init_existential_ref %2 : $Base : $Base, $AnyObject
  checked_cast_br %3 : $AnyObject to Derived, bb1, bb2
```

This makes it more likely that the cast can be constant folded because the source operand's type is more accurate. In the example above, the cast reduces to
```
  checked_cast_br %1 : $Derived to Derived, bb1, bb2
```
which can be trivially folded to always-succeeds.

Found while looking at `_SwiftDeferredNSDictionary.bridgeValues()`
