### PR TITLE
[cxx-interop] Allow inserting elements into `std::set` from Swift

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -114,6 +114,7 @@ PROTOCOL(CxxPair)
 PROTOCOL(CxxSet)
 PROTOCOL(CxxRandomAccessCollection)
 PROTOCOL(CxxSequence)
+PROTOCOL(CxxUniqueSet)
 PROTOCOL(UnsafeCxxInputIterator)
 PROTOCOL(UnsafeCxxRandomAccessIterator)
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1138,6 +1138,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSet:
   case KnownProtocolKind::CxxSequence:
+  case KnownProtocolKind::CxxUniqueSet:
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
     M = getLoadedModule(Id_Cxx);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6308,6 +6308,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSet:
   case KnownProtocolKind::CxxSequence:
+  case KnownProtocolKind::CxxUniqueSet:
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
   case KnownProtocolKind::Executor:

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -61,4 +61,32 @@ StdSetTestSuite.test("UnorderedSetOfCInt.init()") {
     expectTrue(s.contains(3))
 }
 
+StdSetTestSuite.test("SetOfCInt.insert") {
+    var s = SetOfCInt()
+    expectFalse(s.contains(123))
+
+    let res1 = s.insert(123)
+    expectTrue(res1.inserted)
+    expectTrue(s.contains(123))
+
+    let res2 = s.insert(123)
+    expectFalse(res2.inserted)
+    expectTrue(s.contains(123))
+}
+
+#if !os(Linux) // FIXME: https://github.com/apple/swift/issues/66767 / rdar://105220600
+StdSetTestSuite.test("UnorderedSetOfCInt.insert") {
+    var s = UnorderedSetOfCInt()
+    expectFalse(s.contains(123))
+
+    let res1 = s.insert(123)
+    expectTrue(res1.inserted)
+    expectTrue(s.contains(123))
+
+    let res2 = s.insert(123)
+    expectFalse(res2.inserted)
+    expectTrue(s.contains(123))
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
`std::set::insert` isn't exposed into Swift, because it returns an instance of an unsafe type.

This change adds a Swift overload of `insert` for `std::set` and `std::unordered_set` that has the return type identical to `Swift.Set.insert`: a tuple of `(inserted: Bool, memberAfterInsert: Element)`.

rdar://111036912