### PR TITLE
[ConstraintSystem] Fix keyPath diagnostic error for value convert to contextual types

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12202,7 +12202,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
              (definitelyKeyPathType && capability == ReadOnly)) {
     auto resolvedKPTy =
       BoundGenericType::get(kpDecl, nullptr, {rootTy, valueTy});
-    return matchTypes(keyPathTy, resolvedKPTy, ConstraintKind::Bind, subflags,
+    return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
                       loc);
   } else {
     addUnsolvedConstraint(Constraint::create(*this, ConstraintKind::KeyPath,

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -206,3 +206,19 @@ func rdar85458997() {
   _ = S(\.name)
   // expected-error@-1 {{cannot infer key path type from context; consider explicitly specifying a root type}} {{10-10=<#Root#>}}
 }
+
+// https://github.com/apple/swift/issues/65965 - failed to produce correct types for key path capability mismatch
+func issue_65965() {
+  struct S {
+	  var s: String
+	  let v: String
+  }
+	
+  let refKP: ReferenceWritableKeyPath<S, String>
+  refKP = \.s
+  // expected-error@-1 {{key path value type 'WritableKeyPath<S, String>' cannot be converted to contextual type 'ReferenceWritableKeyPath<S, String>'}}
+	
+  let writeKP: WritableKeyPath<S, String>
+  writeKP = \.v
+  // expected-error@-1 {{key path value type 'KeyPath<S, String>' cannot be converted to contextual type 'WritableKeyPath<S, String>'}}
+}


### PR DESCRIPTION
This fixes flipped types for diagnostic errors for when keyPath capabilities do not match contextual type capabilities. The fixed diagnostic will now read as:

```
struct S {
  var s: String
}

let kp: ReferenceWritableKeyPath<S, String>
kp = \.s   // error: key path value type 'WritableKeyPath<S, String>' cannot be converted to contextual type 'ReferenceWritableKeyPath<S, String>'
``` 


Resolves #65965.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
