### PR TITLE
[AST] Add Builtin.packLength

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -538,6 +538,11 @@ BUILTIN_SIL_OPERATION(WithUnsafeThrowingContinuation, "withUnsafeThrowingContinu
 /// Force the current task to be rescheduled on the specified actor.
 BUILTIN_SIL_OPERATION(HopToActor, "hopToActor", None)
 
+/// packLength: <each T>(_: repeat each T) -> Int
+///
+/// Returns the number of items in a pack.
+BUILTIN_SIL_OPERATION(PackLength, "packLength", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1708,6 +1708,19 @@ static ManagedValue emitBuiltinHopToActor(SILGenFunction &SGF, SILLocation loc,
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
+static ManagedValue emitBuiltinPackLength(SILGenFunction &SGF, SILLocation loc,
+                                          SubstitutionMap subs,
+                                          ArrayRef<ManagedValue> args,
+                                          SGFContext C) {
+  auto argTy = args[0].getType().getASTType();
+  auto tupleTy = CanTupleType(argTy->getMetatypeInstanceType()
+      ->castTo<TupleType>());
+  auto packTy = tupleTy.getInducedPackType();
+
+  return ManagedValue::forObjectRValueWithoutOwnership(
+    SGF.B.createPackLength(loc, packTy));
+}
+
 static ManagedValue emitBuiltinAutoDiffCreateLinearMapContextWithType(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     ArrayRef<ManagedValue> args, SGFContext C) {

--- a/test/IRGen/builtin_pack_length.swift
+++ b/test/IRGen/builtin_pack_length.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -module-name builtins -enable-builtin-module -Xllvm -sil-disable-pass=target-constant-folding -disable-access-control -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module -disable-availability-checking -O | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+
+// REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
+
+import Builtin
+
+// CHECK: define {{.*}} @"$s8builtins9packCountyBwxxQpRvzlF"(ptr {{.*}} %0, i64 {{.*}} [[PACK_COUNT:%.*]], ptr {{.*}} %"each T")
+// CHECK: ret i64 [[PACK_COUNT]]
+func packCount<each T>(_: repeat each T) -> Builtin.Word {
+  Builtin.packLength((repeat each T).self)
+}
+
+// CHECK: define {{.*}} @"$s8builtins12packCountUseBwyF"()
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret i64 4
+func packCountUse() -> Builtin.Word {
+  packCount(123, 321, 456, 654)
+}
+
+// CHECK: define {{.*}} @"$s8builtins18weirdPackCountUse0yBwxxQpRvzlF"(ptr {{.*}} %0, i64 [[PACK_COUNT:%.*]], ptr {{.*}} %"each T")
+// CHECK: [[ADD:%.*]] = add i64 [[PACK_COUNT]], 2
+// CHECK-NEXT: ret i64 [[ADD]]
+func weirdPackCountUse0<each T>(_ x: repeat each T) -> Builtin.Word {
+  Builtin.packLength((String, repeat each T, Int).self)
+}
+
+// CHECK: define {{.*}} @"$s8builtins18weirdPackCountUse1yBwxxQpRvzlF"(ptr {{.*}} %0, i64 %1, ptr {{.*}} %"each T")
+// CHECK: ret i64 3
+func weirdPackCountUse1<each T>(_ x: repeat each T) -> Builtin.Word {
+  Builtin.packLength((String, (repeat each T), Int).self)
+}
+
+struct Pack<each T> {
+// CHECK: define {{.*}} @"$s8builtins4PackV5countBwvgZ"(i64 returned [[PACK_COUNT:%.*]], ptr nocapture readnone %"each T")
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret i64 [[PACK_COUNT]]
+  static var count: Builtin.Word {
+    Builtin.packLength((repeat each T).self)
+  }
+}

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -876,3 +876,12 @@ func assumeTrue(_ x: Builtin.Int1) {
 func assumeAlignment(_ p: Builtin.RawPointer, _ x: Builtin.Word) {
   Builtin.assumeAlignment(p, x)
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s8builtins9packCountyBwxxQpRvzlF : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}) -> Builtin.Word {
+// CHECK: bb0(%0 : $*Pack{repeat each T}):
+// CHECK:   [[META:%.*]] = metatype $@thin (repeat each T).Type
+// CHECK:   [[PACK_LENGTH:%.*]] = pack_length $Pack{repeat each T}
+// CHECK:   return [[PACK_LENGTH]] : $Builtin.Word
+func packCount<each T>(_ x: repeat each T) -> Builtin.Word {
+  Builtin.packLength((repeat each T).self)
+}


### PR DESCRIPTION
Add a new builtin which takes a pack expansion and counts the number of items within it. This is built on top of https://github.com/apple/swift/pull/66638.