### PR TITLE
[5.9] DefiniteInitialization: Error when noncopyable types are conditionally initialized.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -193,6 +193,11 @@ ERROR(ivar_not_initialized_by_init_accessor,none,
       "property %0 not initialized by init accessor",
       (DeclName))
 
+ERROR(noncopyable_dynamic_lifetime_unsupported,none,
+      "conditional initialization or destruction of noncopyable types is not "
+      "supported; this variable must be consistently in an initialized or "
+      "uninitialized state through every code path", ())
+
 ERROR(self_use_before_fully_init,none,
       "'self' used in %select{method call|property access}1 %0 before "
       "%select{all stored properties are initialized|"

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1220,6 +1220,11 @@ void LifetimeChecker::doIt() {
     } else if (auto *ABI = dyn_cast<AllocBoxInst>(memAddr)) {
       ABI->setDynamicLifetime();
     }
+    // We don't support noncopyable types with dynamic lifetimes currently.
+    if (TheMemory.getType().isMoveOnly()) {
+      diagnose(Module, TheMemory.getUninitializedValue()->getLoc(),
+               diag::noncopyable_dynamic_lifetime_unsupported);
+    }
   }
   if (!ConditionalDestroys.empty())
     handleConditionalDestroys(ControlVariable);

--- a/test/SILOptimizer/definite_init_disallow_move_only_dynamic.swift
+++ b/test/SILOptimizer/definite_init_disallow_move_only_dynamic.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+enum E: Error { case err }
+
+struct NC: ~Copyable {
+  let x = 0
+
+  deinit { print("deinit") }
+}
+
+func chk(_ cond: Bool) throws {
+  let y: NC // expected-error{{not supported}} expected-warning{{never used}}
+  if cond {
+    y = NC()
+  }
+  throw E.err
+}
+
+try? chk(true)


### PR DESCRIPTION
Issue: rdar://109695770
• Explanation: Introduces an error when noncopyable values are initialized in some code paths but not others. We handle this for copyable types by introducing dynamic flags to track when the value is initialized in order to know when to destroy it. However, borrow checking relies on static analysis and is incompatible in its current form with this dynamic checking, so we will disallow it for now.
• Scope of Issue: Disables unsupported code patterns.
• Origination: New feature work.
• Risk: low -- introduces a diagnostic for the new noncopyable types feature disallowing unsupported code.
• Reviewed By: @xedin and @gottesmm
• Automated Testing: Swift CI
• Dependencies: None
• Builder Impact: Not applicable
• Directions for QE: None