### PR TITLE
[test] Make KeyPath test pointer-size agnostic

### DIFF
--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1078,7 +1078,7 @@ if #available(SwiftStdlib 5.9, *) {
     let dogAgeKp = _createOffsetBasedKeyPath(
       root: Dog.self,
       value: Int.self,
-      offset: 16
+      offset: MemoryLayout<String>.size
     ) as? KeyPath<Dog, Int>
 
     expectNotNil(dogAgeKp)


### PR DESCRIPTION
The field offset of the `age` property is 16 bytes on 64-bit platforms but not on other pointer-sized platforms.


