### PR TITLE
[wasm][stdlib] Stop including stdint.h in wasi-libc for SwiftShims

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;


### PR DESCRIPTION
To avoid `error: 'stddef.h' file not found'` issue described in SwiftStdint.h

