### PR TITLE
[Docs][Android] Fix minimal Android API level

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -62,7 +62,7 @@ $ utils/build-script \
     --android \                                # Build for Android.
     --android-ndk $NDK_PATH \                  # Path to an Android NDK.
     --android-arch aarch64 \                   # Optionally specify Android architecture, alternately armv7 or x86_64
-    --android-api-level 21 \                   # The Android API level to target. Swift only supports 21 or greater.
+    --android-api-level 23 \                   # The Android API level to target. Swift only supports 21 or greater.
     --stdlib-deployment-targets=android-aarch64 \ # Only cross-compile the stdlib for Android, ie don't build the native stdlib for Linux
     --native-swift-tools-path=$SWIFT_PATH \    # Path to your prebuilt Swift compiler
     --native-clang-tools-path=$SWIFT_PATH \    # Path to a prebuilt clang compiler, one comes with the Swift toolchain

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -62,7 +62,7 @@ $ utils/build-script \
     --android \                                # Build for Android.
     --android-ndk $NDK_PATH \                  # Path to an Android NDK.
     --android-arch aarch64 \                   # Optionally specify Android architecture, alternately armv7 or x86_64
-    --android-api-level 23 \                   # The Android API level to target. Swift only supports 21 or greater.
+    --android-api-level 23 \                   # The Android API level to target. Swift only supports 23 or greater.
     --stdlib-deployment-targets=android-aarch64 \ # Only cross-compile the stdlib for Android, ie don't build the native stdlib for Linux
     --native-swift-tools-path=$SWIFT_PATH \    # Path to your prebuilt Swift compiler
     --native-clang-tools-path=$SWIFT_PATH \    # Path to a prebuilt clang compiler, one comes with the Swift toolchain
@@ -88,7 +88,7 @@ $ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
 $ $SWIFT_PATH/swiftc \                                               # The prebuilt Swift compiler you downloaded
                                                                      # The location of the tools used to build Android binaries
     -tools-directory ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/ \
-    -target aarch64-unknown-linux-android21 \                        # Targeting Android aarch64 at API 21
+    -target aarch64-unknown-linux-android23 \                        # Targeting Android aarch64 at API 23
     -sdk ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot \ # The SDK is the Android unified sysroot and the resource-dir is where you just built the Swift stdlib.
     -resource-dir build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift
     hello.swift
@@ -178,7 +178,7 @@ $ utils/build-script \
   --android \                        # Build for Android.
   --android-ndk ~/android-ndk-r25b \  # Path to an Android NDK.
   --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7
-  --android-api-level 21
+  --android-api-level 23
 ```
 
 This will build the Swift compiler and other host tools first, so expect a much

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -978,7 +978,7 @@ build-ninja
 
 android
 android-ndk=%(ndk_path)s
-android-api-level=21
+android-api-level=23
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra


### PR DESCRIPTION
<!-- What's in this pull request? -->
When compile swift using NDK, I meet this problem.
```
/home/eki/Project/swift-project/swift/stdlib/public/runtime/CrashHandlerLinux.cpp:665:12: error: use of undeclared identifier 'process_vm_readv'
    return process_vm_readv(memserver_pid, &local, 1, &remote, 1, 0);
           ^
1 error generated.
```

I found that this function should use android api level greater than 23
```
#if __ANDROID_API__ >= 23
ssize_t process_vm_readv(pid_t __pid, const struct iovec* __local_iov, unsigned long __local_iov_count, const struct iovec* __remote_iov, unsigned long __remote_iov_count, unsigned long __flags) __INTRODUCED_IN(23);
```

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
