### PR TITLE
[5.9] Fix MoveOnlyAddressChecker to handle value deinits

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -70,8 +70,13 @@ TypeSubElementCount::TypeSubElementCount(SILType type, SILModule &mod,
           type.getFieldType(fieldDecl, mod, context), mod, context);
     number = numElements;
 
+    if (type.isValueTypeWithDeinit()) {
+      // 'self' has its own liveness represented as an additional field at the
+      // end of the structure.
+      ++number;
+    }
     // If we do not have any elements, just set our size to 1.
-    if (numElements == 0)
+    if (number == 0)
       number = 1;
 
     return;
@@ -349,6 +354,10 @@ void TypeTreeLeafTypeRange::constructFilteredProjections(
           builder.createStructElementAddr(insertPt->getLoc(), value, varDecl);
       callback(newValue, TypeTreeLeafTypeRange(start, next));
       start = next;
+    }
+    if (type.isValueTypeWithDeinit()) {
+      // 'self' has its own liveness
+      ++start;
     }
     assert(start == endEltOffset);
     return;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -437,6 +437,7 @@ static bool memInstMustConsume(Operand *memOper) {
 
   SILInstruction *memInst = memOper->getUser();
 
+  // FIXME: drop_deinit must be handled here!
   switch (memInst->getKind()) {
   default:
     return false;

--- a/test/Interpreter/moveonly_discard.swift
+++ b/test/Interpreter/moveonly_discard.swift
@@ -90,7 +90,34 @@ struct SillyEmptyGeneric<T>: ~Copyable {
   deinit { fatalError("ran unexpectedly!") }
 }
 
+struct SingleMutableField: ~Copyable {
+  var value = 0
+
+  consuming func justDiscard() {
+    discard self
+  }
+
+  deinit {
+    print("SingleMutableField.deinit")
+  }
+}
+
+// rdar://110232973 ([move-only] Checker should distinguish in between
+// field of single field struct vs parent field itself (was: mutation
+// of field in noncopyable struct should not trigger deinit))
+//
+// This test must not be in a closure.
+@inline(never)
+func testSingleMutableFieldNoMemberReinit() {
+  var x = SingleMutableField()
+  x.value = 20 // should not trigger deinit.
+  // CHECK-NOT: SingleMutableField.deinit
+  x.justDiscard()
+}
+
 func main() {
+  testSingleMutableFieldNoMemberReinit()
+
   let _ = {
     let x = FileDescriptor() // 0
     x.close()

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -3,6 +3,7 @@
 sil_stage raw
 
 import Swift
+import Builtin
 
 public class CopyableKlass {}
 
@@ -51,6 +52,17 @@ sil @useNonTrivialStruct2 : $@convention(thin) (@guaranteed NonTrivialStruct2) -
 final class ClassContainingMoveOnly {
   var value = NonTrivialStruct()
 }
+
+struct SingleTrivialFieldAndDeinit: ~Copyable {
+    var value: Builtin.IntLiteral
+
+    consuming func finalize()
+
+    deinit
+}
+
+sil @getSingleTrivialFieldAndDeinit : $@convention(thin) () -> @owned SingleTrivialFieldAndDeinit
+sil @finalizeSingleTrivialFieldAndDeinit : $@convention(thin) (@owned SingleTrivialFieldAndDeinit) -> ()
 
 @_hasStorage @_hasInitialValue var varGlobal: NonTrivialStruct { get set }
 @_hasStorage @_hasInitialValue let letGlobal: NonTrivialStruct { get }
@@ -631,4 +643,37 @@ bb0:
   dealloc_stack %0 : $*M2
   %22 = tuple ()
   return %22 : $()
+}
+
+// rdar://110232973 ([move-only] Checker should distinguish in between field of single field struct
+// vs parent field itself (was: mutation of field in noncopyable struct should not trigger deinit))
+//
+// Test that the SingleTrivialFieldAndDeinit aggregate is not
+// deinitialized when it's only field is consumed.
+//
+// CHECK-LABEL: sil hidden [ossa] @testNoFieldReinit : $@convention(thin) () -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack [lexical] $SingleTrivialFieldAndDeinit
+// CHECK-NOT: destroy_addr [[ALLOC]]
+// CHECK-LABEL: } // end sil function 'testNoFieldReinit'
+sil hidden [ossa] @testNoFieldReinit : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $SingleTrivialFieldAndDeinit, var
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*SingleTrivialFieldAndDeinit
+  %3 = function_ref @getSingleTrivialFieldAndDeinit : $@convention(thin) () -> @owned SingleTrivialFieldAndDeinit
+  %4 = apply %3() : $@convention(thin) () -> @owned SingleTrivialFieldAndDeinit
+  store %4 to [init] %1 : $*SingleTrivialFieldAndDeinit
+  %6 = integer_literal $Builtin.IntLiteral, 20
+  %10 = begin_access [modify] [static] %1 : $*SingleTrivialFieldAndDeinit
+  %11 = struct_element_addr %10 : $*SingleTrivialFieldAndDeinit, #SingleTrivialFieldAndDeinit.value
+  store %6 to [trivial] %11 : $*Builtin.IntLiteral
+  end_access %10 : $*SingleTrivialFieldAndDeinit
+  %14 = begin_access [deinit] [static] %1 : $*SingleTrivialFieldAndDeinit
+  %15 = load [take] %14 : $*SingleTrivialFieldAndDeinit
+  %16 = function_ref @finalizeSingleTrivialFieldAndDeinit : $@convention(thin) (@owned SingleTrivialFieldAndDeinit) -> ()
+  %17 = apply %16(%15) : $@convention(thin) (@owned SingleTrivialFieldAndDeinit) -> ()
+  end_access %14 : $*SingleTrivialFieldAndDeinit
+  destroy_addr %1 : $*SingleTrivialFieldAndDeinit
+  dealloc_stack %0 : $*SingleTrivialFieldAndDeinit
+  %21 = tuple ()
+  return %21 : $()
 }


### PR DESCRIPTION
Fixes rdar://110232973 ([move-only] Checker should distinguish in between field of single field struct vs parent field itself (was: mutation of field in noncopyable struct should not trigger deinit))

(cherry picked from commit a8c45c55c4839ba58344073b201507ba6a59dc35)

--- CCC ---

- Explanation: Track liveness of self so we don't accidentally think that such types can be memberwise reinitialized.

- Scope of Issue: Miscompilation occurs for a NonCopyable struct with a deinit. The deinitializer incorrectly runs when the programmer reassigns the struct fields.

- Risk: This change only affects the MoveOnlyAddressChecker, which was already miscompiling cases that weren't explicitly tested.

- PR to main: https://github.com/apple/swift/pull/66691

- Reviewed By: Michael Gottesman

- Resolves: rdar://110232973 ([move-only] Checker should distinguish in between field of single field struct vs parent field itself (was: mutation of field in noncopyable struct should not trigger deinit))
