### PR TITLE
[5.9 🍒][Compile Time Constant Extraction] Add extraction of all conformancesand type aliases of applicable nominal types

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -71,13 +71,21 @@ std::string toFullyQualifiedTypeNameString(const swift::Type &Type) {
   Options.AlwaysDesugarArraySliceTypes = true;
   Options.AlwaysDesugarDictionaryTypes = true;
   Options.AlwaysDesugarOptionalTypes = true;
+  Options.OpaqueReturnTypePrinting =
+    PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword;
   Type.print(OutputStream, Options);
   OutputStream.flush();
   return TypeNameOutput;
 }
 
+std::string toFullyQualifiedProtocolNameString(const swift::ProtocolDecl &Protocol) {
+  // Protocols cannot be nested in other declarations, so the only fully-qualified
+  // context is the declaring module name.
+  return Protocol.getParentModule()->getNameStr().str() + "." + Protocol.getNameStr().str();
+}
+
 std::string toMangledTypeNameString(const swift::Type &Type) {
-  return Mangle::ASTMangler().mangleTypeWithoutPrefix(Type);
+  return Mangle::ASTMangler().mangleTypeWithoutPrefix(Type->getCanonicalType());
 }
 
 } // namespace
@@ -803,46 +811,178 @@ void writeAttrInformation(llvm::json::OStream &JSON,
   });
 }
 
+void writeParameterizedProtocolSameTypeRequirements(
+    llvm::json::OStream &JSON,
+    const ParameterizedProtocolType &ParameterizedProtoTy) {
+  auto Protocol = ParameterizedProtoTy.getProtocol();
+  auto ProtocolTy = ParameterizedProtoTy.getBaseType();
+  auto Requirements = Protocol->getProtocolRequirements();
+  auto ParameterTypeNames = Protocol->getPrimaryAssociatedTypeNames();
+  auto ProtocolArguments = ParameterizedProtoTy.getArgs();
+  llvm::dbgs() << Requirements.size() << "\n";
+  assert(ProtocolArguments.size() >= ParameterTypeNames.size());
+
+  for (size_t i = 0; i < ProtocolArguments.size(); ++i) {
+    auto ProtocolArgumentTy = ProtocolArguments[i];
+    std::string ArgumentName = ParameterTypeNames.size() > i
+                                   ? ParameterTypeNames[i].first.str().str()
+                                   : "unknown";
+
+    JSON.object([&] {
+      auto QualifiedTypeAliasName = toFullyQualifiedProtocolNameString(
+                                        *ParameterizedProtoTy.getProtocol()) +
+                                    "." + ArgumentName;
+      JSON.attribute("typeAliasName", QualifiedTypeAliasName);
+      JSON.attribute("substitutedTypeName",
+                     toFullyQualifiedTypeNameString(ProtocolArgumentTy));
+      JSON.attribute("substitutedMangledTypeName",
+                     toMangledTypeNameString(ProtocolArgumentTy));
+    });
+  }
+}
+
+void writeOpaqueTypeProtocolCompositionSameTypeRequirements(
+    llvm::json::OStream &JSON,
+    const ProtocolCompositionType &ProtocolCompositionTy) {
+  for (auto CompositionMemberProto : ProtocolCompositionTy.getMembers()) {
+    if (auto ParameterizedProtoTy =
+            CompositionMemberProto->getAs<ParameterizedProtocolType>()) {
+      writeParameterizedProtocolSameTypeRequirements(JSON,
+                                                     *ParameterizedProtoTy);
+    }
+  }
+}
+
+void writeSubstitutedOpaqueTypeAliasDetails(
+    llvm::json::OStream &JSON, const OpaqueTypeArchetypeType &OpaqueTy) {
+  JSON.attributeArray("opaqueTypeProtocolRequirements", [&] {
+    auto ConformsToProtocols = OpaqueTy.getConformsTo();
+    for (auto Proto : ConformsToProtocols) {
+      JSON.value(toFullyQualifiedProtocolNameString(*Proto));
+    }
+  });
+  JSON.attributeArray("opaqueTypeSameTypeRequirements", [&] {
+    auto GenericSig = OpaqueTy.getDecl()
+                          ->getNamingDecl()
+                          ->getInnermostDeclContext()
+                          ->getGenericSignatureOfContext();
+    auto ConstraintTy = OpaqueTy.getExistentialType();
+    if (auto existential = ConstraintTy->getAs<ExistentialType>())
+      ConstraintTy = existential->getConstraintType();
+
+    // Opaque archetype substitutions are always canonical, so
+    // re-sugar the constraint type using the owning
+    // declaration's generic parameter names.
+    if (GenericSig)
+      ConstraintTy = GenericSig->getSugaredType(ConstraintTy);
+
+    if (auto ParameterizedProtoTy =
+            ConstraintTy->getAs<ParameterizedProtocolType>()) {
+      writeParameterizedProtocolSameTypeRequirements(JSON,
+                                                     *ParameterizedProtoTy);
+    } else if (auto ProtocolCompositionTy =
+                   ConstraintTy->getAs<ProtocolCompositionType>()) {
+      writeOpaqueTypeProtocolCompositionSameTypeRequirements(
+          JSON, *ProtocolCompositionTy);
+    }
+  });
+}
+
+void writeAssociatedTypeAliases(llvm::json::OStream &JSON,
+                                const NominalTypeDecl &NomTypeDecl) {
+  JSON.attributeArray("associatedTypeAliases", [&] {
+    for (auto &Conformance : NomTypeDecl.getAllConformances()) {
+      Conformance->forEachTypeWitness(
+          [&](AssociatedTypeDecl *assoc, Type type, TypeDecl *typeDecl) {
+            JSON.object([&] {
+              JSON.attribute("typeAliasName", assoc->getName().str().str());
+              JSON.attribute("substitutedTypeName",
+                             toFullyQualifiedTypeNameString(type));
+              JSON.attribute("substitutedMangledTypeName",
+                             toMangledTypeNameString(type));
+              if (auto OpaqueTy = dyn_cast<OpaqueTypeArchetypeType>(type)) {
+                writeSubstitutedOpaqueTypeAliasDetails(JSON, *OpaqueTy);
+              }
+            });
+            return false;
+          });
+    }
+  });
+}
+
+void writeProperties(llvm::json::OStream &JSON,
+                     const ConstValueTypeInfo &TypeInfo,
+                     const NominalTypeDecl &NomTypeDecl) {
+  JSON.attributeArray("properties", [&] {
+    for (const auto &PropertyInfo : TypeInfo.Properties) {
+      JSON.object([&] {
+        const auto *decl = PropertyInfo.VarDecl;
+        JSON.attribute("label", decl->getName().str().str());
+        JSON.attribute("type", toFullyQualifiedTypeNameString(decl->getType()));
+        JSON.attribute("mangledTypeName", toMangledTypeNameString(decl->getType()));
+        JSON.attribute("isStatic", decl->isStatic() ? "true" : "false");
+        JSON.attribute("isComputed", !decl->hasStorage() ? "true" : "false");
+        writeLocationInformation(JSON, decl->getLoc(),
+                                 decl->getDeclContext()->getASTContext());
+        writeValue(JSON, PropertyInfo.Value);
+        writePropertyWrapperAttributes(JSON, PropertyInfo.PropertyWrappers,
+                                       decl->getASTContext());
+        writeRuntimeMetadataAttributes(JSON,
+                                       PropertyInfo.RuntimeMetadataAttributes,
+                                       decl->getASTContext());
+        writeResultBuilderInformation(JSON, &NomTypeDecl, decl);
+        writeAttrInformation(JSON, decl->getAttrs());
+      });
+    }
+  });
+}
+
+void writeConformances(llvm::json::OStream &JSON,
+                       const NominalTypeDecl &NomTypeDecl) {
+  JSON.attributeArray("conformances", [&] {
+    for (auto &Protocol : NomTypeDecl.getAllProtocols()) {
+      JSON.value(toFullyQualifiedProtocolNameString(*Protocol));
+    }
+  });
+}
+
+void writeTypeName(llvm::json::OStream &JSON, const TypeDecl &TypeDecl) {
+  JSON.attribute("typeName",
+                 toFullyQualifiedTypeNameString(
+                                 TypeDecl.getDeclaredInterfaceType()));
+  JSON.attribute("mangledTypeName",
+                 toMangledTypeNameString(TypeDecl.getDeclaredInterfaceType()));
+}
+
+void writeNominalTypeKind(llvm::json::OStream &JSON,
+                          const NominalTypeDecl &NomTypeDecl) {
+  JSON.attribute(
+      "kind",
+      NomTypeDecl.getDescriptiveKindName(NomTypeDecl.getDescriptiveKind())
+          .str());
+}
+
 bool writeAsJSONToFile(const std::vector<ConstValueTypeInfo> &ConstValueInfos,
                        llvm::raw_fd_ostream &OS) {
   llvm::json::OStream JSON(OS, 2);
   JSON.array([&] {
     for (const auto &TypeInfo : ConstValueInfos) {
+      assert(isa<NominalTypeDecl>(TypeInfo.TypeDecl) &&
+             "Expected Nominal Type Decl for a conformance");
+      const auto *NomTypeDecl = cast<NominalTypeDecl>(TypeInfo.TypeDecl);
+      const auto SourceLoc =
+          extractNearestSourceLoc(NomTypeDecl->getInnermostDeclContext());
+      const auto &Ctx = NomTypeDecl->getInnermostDeclContext()->getASTContext();
+
       JSON.object([&] {
-        const auto *TypeDecl = TypeInfo.TypeDecl;
-        JSON.attribute("typeName", toFullyQualifiedTypeNameString(
-                                       TypeDecl->getDeclaredInterfaceType()));
-        JSON.attribute(
-            "kind",
-            TypeDecl->getDescriptiveKindName(TypeDecl->getDescriptiveKind())
-                .str());
-        writeLocationInformation(
-            JSON, extractNearestSourceLoc(TypeDecl->getInnermostDeclContext()),
-            TypeDecl->getInnermostDeclContext()->getASTContext());
-        JSON.attributeArray("properties", [&] {
-          for (const auto &PropertyInfo : TypeInfo.Properties) {
-            JSON.object([&] {
-              const auto *decl = PropertyInfo.VarDecl;
-              JSON.attribute("label", decl->getName().str().str());
-              JSON.attribute("type",
-                             toFullyQualifiedTypeNameString(decl->getType()));
-              JSON.attribute("isStatic", decl->isStatic() ? "true" : "false");
-              JSON.attribute("isComputed",
-                             !decl->hasStorage() ? "true" : "false");
-              writeLocationInformation(JSON, decl->getLoc(),
-                                       decl->getDeclContext()->getASTContext());
-              writeValue(JSON, PropertyInfo.Value);
-              writePropertyWrapperAttributes(
-                  JSON, PropertyInfo.PropertyWrappers, decl->getASTContext());
-              writeRuntimeMetadataAttributes(
-                  JSON, PropertyInfo.RuntimeMetadataAttributes, decl->getASTContext());
-              writeResultBuilderInformation(JSON, TypeDecl, decl);
-              writeAttrInformation(JSON, decl->getAttrs());
-            });
-          }
-        });
+        writeTypeName(JSON, *NomTypeDecl);
+        writeNominalTypeKind(JSON, *NomTypeDecl);
+        writeLocationInformation(JSON, SourceLoc, Ctx);
+        writeConformances(JSON, *NomTypeDecl);
+        writeAssociatedTypeAliases(JSON, *NomTypeDecl);
+        writeProperties(JSON, TypeInfo, *NomTypeDecl);
         writeEnumCases(JSON, TypeInfo.EnumElements);
-        writeAttrInformation(JSON, TypeDecl->getAttrs());
+        writeAttrInformation(JSON, NomTypeDecl->getAttrs());
       });
     }
   });

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -32,6 +32,9 @@
     },
     {
       "name": "package-name-if-supported"
+    },
+    {
+      "name": "const-extract-complete-metadata"
     }
   ]
 }

--- a/test/ConstExtraction/ExtractAnnotations.swift
+++ b/test/ConstExtraction/ExtractAnnotations.swift
@@ -30,13 +30,19 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractAnnotations.Annotations",
+// CHECK-NEXT:    "mangledTypeName": "18ExtractAnnotations0B0V",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
 // CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractAnnotations.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "available1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -61,6 +67,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "deprecated1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -85,6 +92,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "renamed1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -104,6 +112,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "introduced1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -123,9 +132,14 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractAnnotations.DeprecatedAnnotations",
+// CHECK-NEXT:    "mangledTypeName": "18ExtractAnnotations010DeprecatedB0V",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
 // CHECK-NEXT:    "line": 28,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractAnnotations.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [],
 // CHECK-NEXT:    "availabilityAttributes": [
 // CHECK-NEXT:      {

--- a/test/ConstExtraction/ExtractCalls.swift
+++ b/test/ConstExtraction/ExtractCalls.swift
@@ -39,13 +39,19 @@ public struct Bat {
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractCalls.Foo",
+// CHECK-NEXT:    "mangledTypeName": "12ExtractCalls3FooV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
 // CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractCalls.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init1",
 // CHECK-NEXT:        "type": "ExtractCalls.Bar",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BarV",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -59,6 +65,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init2",
 // CHECK-NEXT:        "type": "ExtractCalls.Bat",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BatV",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -85,6 +92,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init3",
 // CHECK-NEXT:        "type": "ExtractCalls.Bat",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BatV",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -110,6 +118,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "func1",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -119,6 +128,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init4",
 // CHECK-NEXT:        "type": "Swift.Optional<ExtractCalls.Bar>",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BarVSg",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -132,6 +142,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "ext1",
 // CHECK-NEXT:        "type": "ExtractCalls.Foo.Boo",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3FooV3BooV",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",

--- a/test/ConstExtraction/ExtractEnums.swift
+++ b/test/ConstExtraction/ExtractEnums.swift
@@ -31,13 +31,21 @@ public struct Enums: MyProto {
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractEnums.SimpleEnum",
+// CHECK-NEXT:    "mangledTypeName": "12ExtractEnums10SimpleEnumO",
 // CHECK-NEXT:    "kind": "enum",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
 // CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "Swift.Equatable",
+// CHECK-NEXT:      "Swift.Hashable",
+// CHECK-NEXT:      "ExtractEnums.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "hashValue",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "valueKind": "Runtime"
@@ -54,13 +62,28 @@ public struct Enums: MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractEnums.StringEnum",
+// CHECK-NEXT:    "mangledTypeName": "12ExtractEnums10StringEnumO",
 // CHECK-NEXT:    "kind": "enum",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
 // CHECK-NEXT:    "line": 14,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "Swift.Equatable",
+// CHECK-NEXT:      "Swift.Hashable",
+// CHECK-NEXT:      "Swift.RawRepresentable",
+// CHECK-NEXT:      "ExtractEnums.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "typeAliasName": "RawValue",
+// CHECK-NEXT:        "substitutedTypeName": "Swift.String",
+// CHECK-NEXT:        "substitutedMangledTypeName": "SS"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],    
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "rawValue",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "valueKind": "Runtime"
@@ -83,9 +106,14 @@ public struct Enums: MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractEnums.AssociatedEnums",
+// CHECK-NEXT:    "mangledTypeName": "12ExtractEnums010AssociatedB0O",    
 // CHECK-NEXT:    "kind": "enum",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
 // CHECK-NEXT:    "line": 19,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractEnums.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],    
 // CHECK-NEXT:    "properties": [],
 // CHECK-NEXT:    "cases": [
 // CHECK-NEXT:      {
@@ -113,13 +141,19 @@ public struct Enums: MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractEnums.Enums",
+// CHECK-NEXT:    "mangledTypeName": "12ExtractEnums0B0V",    
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
 // CHECK-NEXT:    "line": 24,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractEnums.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],    
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum1",
 // CHECK-NEXT:        "type": "ExtractEnums.SimpleEnum",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums10SimpleEnumO",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
@@ -132,6 +166,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum3",
 // CHECK-NEXT:        "type": "ExtractEnums.AssociatedEnums",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums010AssociatedB0O",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
@@ -158,6 +193,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum2",
 // CHECK-NEXT:        "type": "ExtractEnums.StringEnum",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums10StringEnumO",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
@@ -170,6 +206,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum4",
 // CHECK-NEXT:        "type": "ExtractEnums.AssociatedEnums",
+// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums010AssociatedB0O",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -38,13 +38,19 @@ extension String: Foo {}
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractGroups.Arrays",
+// CHECK-NEXT:    "mangledTypeName": "13ExtractGroups6ArraysV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
 // CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractGroups.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array1",
 // CHECK-NEXT:        "type": "Swift.Array<Swift.Int>",
+// CHECK-NEXT:        "mangledTypeName": "SaySiG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -68,6 +74,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array2",
 // CHECK-NEXT:        "type": "Swift.Array<ExtractGroups.Foo>",
+// CHECK-NEXT:        "mangledTypeName": "Say13ExtractGroups3Foo_pG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -94,6 +101,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array3",
 // CHECK-NEXT:        "type": "Swift.Array<ExtractGroups.Bar>",
+// CHECK-NEXT:        "mangledTypeName": "Say13ExtractGroups3BarVG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -113,13 +121,19 @@ extension String: Foo {}
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractGroups.Dictionaries",
+// CHECK-NEXT:    "mangledTypeName": "13ExtractGroups12DictionariesV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
 // CHECK-NEXT:    "line": 15,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractGroups.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],    
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict1",
 // CHECK-NEXT:        "type": "Swift.Dictionary<Swift.String, Swift.Int>",
+// CHECK-NEXT:        "mangledTypeName": "SDySSSiG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -161,6 +175,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict2",
 // CHECK-NEXT:        "type": "Swift.Dictionary<Swift.Int, Swift.Array<Swift.String>>",
+// CHECK-NEXT:        "mangledTypeName": "SDySiSaySSGG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -210,6 +225,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict3",
 // CHECK-NEXT:        "type": "Swift.Dictionary<Swift.String, ExtractGroups.Foo>",
+// CHECK-NEXT:        "mangledTypeName": "SDySS13ExtractGroups3Foo_pG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -245,13 +261,19 @@ extension String: Foo {}
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractGroups.Tuples",
+// CHECK-NEXT:    "mangledTypeName": "13ExtractGroups6TuplesV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
 // CHECK-NEXT:    "line": 27,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractGroups.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple1",
 // CHECK-NEXT:        "type": "(Swift.String, ExtractGroups.Bar)",
+// CHECK-NEXT:        "mangledTypeName": "SS_13ExtractGroups3BarVt",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -276,6 +298,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple2",
 // CHECK-NEXT:        "type": "(lat: Swift.Float, lng: Swift.Float)",
+// CHECK-NEXT:        "mangledTypeName": "Sf3lat_Sf3lngt",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -299,6 +322,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple3",
 // CHECK-NEXT:        "type": "Swift.Void",
+// CHECK-NEXT:        "mangledTypeName": "yt",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -94,13 +94,19 @@ public struct PropertyWrappers : MyProto {
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractLiterals.Bools",
+// CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals5BoolsV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
 // CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "bool1",
 // CHECK-NEXT:        "type": "Swift.Bool",
+// CHECK-NEXT:        "mangledTypeName": "Sb",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -111,6 +117,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "bool2",
 // CHECK-NEXT:        "type": "Swift.Optional<Swift.Bool>",
+// CHECK-NEXT:        "mangledTypeName": "SbSg",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -122,13 +129,19 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractLiterals.Ints",
+// CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals4IntsV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
 // CHECK-NEXT:    "line": 14,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [], 
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "int1",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -139,6 +152,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "int2",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -149,6 +163,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "int3",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -160,13 +175,19 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractLiterals.Floats",
+// CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals6FloatsV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:    "line": 20,
+// CHECK-NEXT:    "line": 20, 
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "float1",
 // CHECK-NEXT:        "type": "Swift.Float",
+// CHECK-NEXT:        "mangledTypeName": "Sf",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -177,6 +198,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "float2",
 // CHECK-NEXT:        "type": "Swift.Float",
+// CHECK-NEXT:        "mangledTypeName": "Sf", 
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -187,6 +209,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "float3",
 // CHECK-NEXT:        "type": "Swift.Float",
+// CHECK-NEXT:        "mangledTypeName": "Sf", 
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -197,13 +220,19 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractLiterals.Strings",
+// CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals7StringsV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
 // CHECK-NEXT:    "line": 26,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [], 
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "string1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -214,6 +243,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "string2",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -224,6 +254,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "string3",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -235,13 +266,19 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractLiterals.PropertyWrappers",
+// CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals16PropertyWrappersV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
 // CHECK-NEXT:    "line": 37,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractLiterals.MyProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "_propertyWrapper1",
 // CHECK-NEXT:        "type": "ExtractLiterals.Buffered<Swift.String>",
+// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8BufferedVySSG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -262,6 +299,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "_propertyWrapper2",
 // CHECK-NEXT:        "type": "ExtractLiterals.Clamping<Swift.Int>",
+// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8ClampingVySiG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -294,6 +332,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "_propertyWrapper3",
 // CHECK-NEXT:        "type": "ExtractLiterals.Buffered<ExtractLiterals.Clamping<Swift.Int>>",
+// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8BufferedVyAA8ClampingVySiGG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -336,6 +375,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -364,6 +404,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "$propertyWrapper1",
 // CHECK-NEXT:        "type": "(Swift.String, Swift.Optional<Swift.String>)",
+// CHECK-NEXT:        "mangledTypeName": "SS_SSSgt",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -373,6 +414,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper2",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -426,6 +468,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper3",
 // CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "mangledTypeName": "Si",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -495,6 +538,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "$propertyWrapper3",
 // CHECK-NEXT:        "type": "(ExtractLiterals.Clamping<Swift.Int>, Swift.Optional<ExtractLiterals.Clamping<Swift.Int>>)",
+// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8ClampingVySiG_ADSgt",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",

--- a/test/ConstExtraction/ExtractOpaqueTypealias.swift
+++ b/test/ConstExtraction/ExtractOpaqueTypealias.swift
@@ -1,0 +1,73 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/includes)
+// RUN: echo "[myProto]" > %t/protocols.json
+
+// Build external Swift library/module to also check conformances to external protocols
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %S/../Reflection/Inputs/swiftmodules/testModB.swift -parse-as-library -emit-module -emit-library -module-name testModB -o %t/includes/testModB.o
+
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -typecheck -emit-const-values-path %t/ExtractOpaqueTypealias.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s -I %t/includes
+// RUN: cat %t/ExtractOpaqueTypealias.swiftconstvalues 2>&1 | %FileCheck %s
+
+import testModB
+
+public protocol myProto {
+    associatedtype PerformReturn
+    func perform() -> PerformReturn
+}
+public protocol protoA<T> {
+    associatedtype T
+}
+public protocol protoB<K> {
+    associatedtype K
+}
+
+public struct Bar<M, N> : protoA, protoB, testModBProtocol {
+    public typealias T = M
+    public typealias K = N
+}
+
+public struct Foo : myProto {
+    public func perform() -> some protoA<testModBStruct> & protoB<Float> & testModBProtocol { return baz() }
+}
+
+private func baz() -> some protoA<testModBStruct> & protoB<Float> & testModBProtocol { return Bar<testModBStruct, Float>() }
+
+
+// CHECK: [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractOpaqueTypealias.Foo",
+// CHECK-NEXT:    "mangledTypeName": "22ExtractOpaqueTypealias3FooV",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractOpaqueTypealias.swift",
+// CHECK-NEXT:    "line": 30,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractOpaqueTypealias.myProto"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "typeAliasName": "PerformReturn",
+// CHECK-NEXT:        "substitutedTypeName": "some ExtractOpaqueTypealias.protoA<testModB.testModBStruct> & ExtractOpaqueTypealias.protoB<Swift.Float> & testModB.testModBProtocol",
+// CHECK-NEXT:        "substitutedMangledTypeName": "22ExtractOpaqueTypealias3FooV7performQryFQOy_Qo_",
+// CHECK-NEXT:        "opaqueTypeProtocolRequirements": [
+// CHECK-NEXT:          "ExtractOpaqueTypealias.protoA",
+// CHECK-NEXT:          "ExtractOpaqueTypealias.protoB",
+// CHECK-NEXT:          "testModB.testModBProtocol"
+// CHECK-NEXT:        ],
+// CHECK-NEXT:        "opaqueTypeSameTypeRequirements": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "typeAliasName": "ExtractOpaqueTypealias.protoA.T",
+// CHECK-NEXT:            "substitutedTypeName": "testModB.testModBStruct",
+// CHECK-NEXT:            "substitutedMangledTypeName": "8testModB0aB7BStructV"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "typeAliasName": "ExtractOpaqueTypealias.protoB.K",
+// CHECK-NEXT:            "substitutedTypeName": "Swift.Float",
+// CHECK-NEXT:            "substitutedMangledTypeName": "Sf"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "properties": []
+// CHECK-NEXT:  }
+// CHECK-NEXT:]

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -49,13 +49,19 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK: [
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "typeName": "ExtractResultBuilders.MyFooProvider",
+// CHECK-NEXT:      "mangledTypeName": "21ExtractResultBuilders13MyFooProviderV",
 // CHECK-NEXT:      "kind": "struct",
 // CHECK-NEXT:      "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
 // CHECK-NEXT:      "line": 28,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:      "properties": [
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "label": "foos",
 // CHECK-NEXT:          "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:          "mangledTypeName": "Say21ExtractResultBuilders3FooVG",
 // CHECK-NEXT:          "isStatic": "true",
 // CHECK-NEXT:          "isComputed": "true",
 // CHECK-NEXT:          "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
@@ -68,6 +74,7 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "label": "fooTwo",
 // CHECK-NEXT:          "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:          "mangledTypeName": "Say21ExtractResultBuilders3FooVG",
 // CHECK-NEXT:          "isStatic": "true",
 // CHECK-NEXT:          "isComputed": "true",
 // CHECK-NEXT:          "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
@@ -81,13 +88,19 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "typeName": "ExtractResultBuilders.MyFooProviderInferred",
+// CHECK-NEXT:      "mangledTypeName": "21ExtractResultBuilders21MyFooProviderInferredV",
 // CHECK-NEXT:      "kind": "struct",
 // CHECK-NEXT:      "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
 // CHECK-NEXT:      "line": 42,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractResultBuilders.FooProvider"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:      "properties": [
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "label": "foos",
 // CHECK-NEXT:          "type": "Swift.Array<ExtractResultBuilders.Foo>",
+// CHECK-NEXT:          "mangledTypeName": "Say21ExtractResultBuilders3FooVG",
 // CHECK-NEXT:          "isStatic": "true",
 // CHECK-NEXT:          "isComputed": "true",
 // CHECK-NEXT:          "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",

--- a/test/ConstExtraction/ExtractRuntimeMetadataAttr.swift
+++ b/test/ConstExtraction/ExtractRuntimeMetadataAttr.swift
@@ -20,13 +20,20 @@ struct A : MyProto {
 }
 
 // CHECK:    "typeName": "ExtractRuntimeMetadataAttr.A",
+// CHECK-NEXT:    "mangledTypeName": "26ExtractRuntimeMetadataAttr1AV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractRuntimeMetadataAttr.swift",
 // CHECK-NEXT:    "line": 18,
+// CHECK-NEXT:    "conformances": [
+// CHECK-NEXT:      "ExtractRuntimeMetadataAttr.MyProto",
+// CHECK-NEXT:      "Swift.Sendable"
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "v1",
 // CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "mangledTypeName": "SS", 
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractRuntimeMetadataAttr.swift",

--- a/test/ConstExtraction/ExtractTypeValue.swift
+++ b/test/ConstExtraction/ExtractTypeValue.swift
@@ -17,6 +17,7 @@ struct TypeValuePropertyStruct : MyProto {
 
 // CHECK:             "label": "birdTypes",
 // CHECK-NEXT:        "type": "Swift.Array<ExtractTypeValue.Bird.Type>",
+// CHECK-NEXT:        "mangledTypeName": "Say16ExtractTypeValue4Bird_pXpG",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}ExtractTypeValue.swift",


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66639/commits
------------------------
**• Release:** 5.9
**• Explanation:**
This change adds to the extracted type metadata the following fields:
- Conformances: this is a list of all protocols that the given nominal type conforms to
- associated type aliases: this is a list of all associated types across all conformances that the given nominal type substitutes with concrete types. For a given associated type, we gather:
  - Associated type name
  - Substituted type's fully-qualified name
  - Substituted type's mangled name
  - If the substituted type is opaque:
    - List of conformance requirements of this opaque type
    - List of same-type requirements of this opaque type

**• Scope of Issue:** This change adds additional metadata gathered only for the conformances of protocols specified as inputs to compilation.
**• Risk:** Low. Does not affect compilation which does not request extraction of metadata conformances. For compilation that does request extraction of metadata conformances, the change is small in scope and uses established tools to query basic type information.

