### PR TITLE
[Runtime] Add function to get parent type

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1037,6 +1037,12 @@ SWIFT_RUNTIME_STDLIB_SPI
 void _swift_registerConcurrencyStandardTypeDescriptors(
     const ConcurrencyStandardTypeDescriptors *descriptors);
 
+/// Walk the parent descriptor chain to find the nominal type parent of the
+/// provided type.
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_SPI
+const Metadata *_swift_getParentType(const Metadata *type);
+
 #pragma clang diagnostic pop
 
 } // end namespace swift

--- a/test/Runtime/getParentType.swift
+++ b/test/Runtime/getParentType.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let suite = TestSuite("GetParentType")
+
+@_silgen_name("_swift_getParentType")
+func getParent(of: Any.Type) -> Any.Type?
+
+struct A {
+  struct B {}
+}
+
+extension Int {
+  struct C {}
+}
+
+struct D {
+  func e() {
+    struct F {}
+
+    expectTrue(D.self == getParent(of: F.self))
+  }
+}
+
+class G {
+  enum H {}
+}
+
+suite.test("basic") {
+  expectTrue(A.self == getParent(of: A.B.self))
+  expectTrue(Int.self == getParent(of: Int.C.self))
+  D().e()
+  expectTrue(G.self == getParent(of: G.H.self))
+}
+
+runAllTests()


### PR DESCRIPTION
Given a nominal type metadata, walk the parent chain to get the nominal type parent of the type. This doesn't handle generics for the time being as they make this trivial operation unnecessarily complicated.

Resolves: rdar://111049291