### PR TITLE
MoveOnlyChecker: Look through `convert_function` of nonescaping closures.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -910,7 +910,11 @@ static bool findNonEscapingPartialApplyUses(PartialApplyInst *pai,
         //
         // We have this separately from the other look through sections so that
         // we can make it clearer what we are doing here.
-        isa<PartialApplyInst>(user)) {
+        isa<PartialApplyInst>(user) ||
+        // Likewise with convert_function. Any valid function conversion that
+        // doesn't prevent stack promotion of the closure must retain the
+        // invariants on its transitive uses.
+        isa<ConvertFunctionInst>(user)) {
       for (auto *use : cast<SingleValueInstruction>(user)->getUses())
         worklist.push_back(use);
       continue;

--- a/test/SILOptimizer/moveonly_nonescaping_closures_function_conversion.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures_function_conversion.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// rdar://111060678
+
+protocol P {
+    func doStuff() throws
+}
+
+struct A: ~Copyable {
+    let b = B()
+
+    consuming func f(_ p: some P) throws -> B {
+        // Passing the closure here undergoes a SIL-level function conversion
+        // from the concrete type `() -> Void` to `<T> () throws -> T`.
+        try b.takeClosure {
+            try b.takeP(p)
+        }
+        return B()
+    }
+}
+
+struct B {
+    func takeClosure<T>(_ f: () throws -> T) throws -> T { try f() }
+    func takeP(_: some P) throws {}
+}


### PR DESCRIPTION
Like a nested partial_apply reabstraction, but without the thunk, these change the representation of the function but can't escape it without breaking the nonescaping closure promotion. rdar://111060678