### PR TITLE
[static-stdlib] Add static executable support for WASI target

### DIFF
--- a/stdlib/public/Resources/wasi/static-executable-args.lnk
+++ b/stdlib/public/Resources/wasi/static-executable-args.lnk
@@ -1,0 +1,11 @@
+-static
+-lswiftSwiftOnoneSupport
+-ldl
+-lstdc++
+-lm
+-lwasi-emulated-mman
+-lwasi-emulated-signal
+-lwasi-emulated-process-clocks
+-Xlinker --error-limit=0
+-Xlinker --no-gc-sections
+-Xlinker --threads=1

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -106,7 +106,7 @@ if(SWIFT_BUILD_STATIC_STDLIB)
   set(static_binary_lnk_file_list)
 
   foreach(sdk ${SWIFT_SDKS})
-    if(NOT "${sdk}" STREQUAL "LINUX")
+    if(NOT "${sdk}" STREQUAL "LINUX" AND NOT "${sdk}" STREQUAL "WASI")
       continue()
     endif()
 


### PR DESCRIPTION
This patch adds static-executble-args.lnk file for WASI target