### PR TITLE
[CSSimplify] Add special handling if specialized type comes from `TypeExpr`

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1271,6 +1271,15 @@ public:
     return ConstraintLocatorBuilder(this, newElt, newFlags);
   }
 
+  /// Determine whether this locator builder points directly to a
+  /// given expression.
+  template <typename E>
+  bool directlyAt() const {
+    if (auto *expr = getAnchor().dyn_cast<Expr *>())
+      return isa<E>(expr) && hasEmptyPath();
+    return false;
+  }
+
   /// Determine whether this builder has an empty path.
   bool hasEmptyPath() const {
     return !element;

--- a/test/decl/ext/specialize.swift
+++ b/test/decl/ext/specialize.swift
@@ -74,3 +74,15 @@ func testNestedExtensions() {
 
   Tree<Int>.Branch<String>.Nest<Void>.Egg.twite()
 }
+
+// rdar://111059036 - failed to produce a diagnostic in specialized extension
+struct Test {
+  struct Key<Value> {}
+}
+
+class State {
+}
+
+extension Test.Key<State> {
+  static let state = Self<State>()
+}


### PR DESCRIPTION
Add a special case for `TypeExpr` due to i.e. context specialization,
in such cases there is nothing for the solver to "open" so we need
to form opened type map manually.

Resolves: rdar://111059036

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
