### PR TITLE
[5.9] SIL: hop_to_executor can release

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -798,7 +798,7 @@ NON_VALUE_INST(FixLifetimeInst, fix_lifetime,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 
 NON_VALUE_INST(HopToExecutorInst, hop_to_executor,
-               SILInstruction, MayHaveSideEffects, DoesNotRelease)
+               SILInstruction, MayHaveSideEffects, MayRelease)
 
 NON_VALUE_INST(DestroyValueInst, destroy_value,
                SILInstruction, MayHaveSideEffects, MayRelease)

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1138,6 +1138,7 @@ bool SILInstruction::mayRelease() const {
     return true;
 
   case SILInstructionKind::DestroyValueInst:
+  case SILInstructionKind::HopToExecutorInst:
     return true;
 
   case SILInstructionKind::UnconditionalCheckedCastAddrInst:

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -50,6 +50,13 @@ class C2  {
  init()
 }
 
+class Y {
+  @_hasStorage public var c: C2 { get }
+}
+
+actor Act {
+}
+
 struct S {
   var ptr : Builtin.NativeObject
 }
@@ -1077,4 +1084,25 @@ bb0:
   dealloc_stack %queue : $*Queue
   %12 = tuple ()
   return %12 : $()
+}
+
+// CHECK-LABEL: sil @test_hop_to_executor :
+// CHECK:         strong_retain
+// CHECK:         hop_to_executor
+// CHECK:         strong_release
+// CHECK:       } // end sil function 'test_hop_to_executor'
+sil @test_hop_to_executor : $@convention(thin) @async (@guaranteed Y, @guaranteed Act) -> A {
+bb0(%0 : $Y, %1 : $Act):
+  %2 = ref_element_addr %0 : $Y, #Y.c
+  %3 = load %2 : $*C2
+  strong_retain %3 : $C2
+
+  // This is a synchronization point and any kind of other code might run here,
+  // which potentially can release C2.
+  hop_to_executor %1 : $Act
+
+  %6 = ref_element_addr %3 : $C2, #C2.current
+  %7 = load %6 : $*A
+  strong_release %3 : $C2
+  return %7 : $A
 }


### PR DESCRIPTION
* **Explanation**: This is a fix for a miscompile in async functions. The ARC optimizations moved retains or releases over hop_to_executor instructions. The `hop_to_executor` instruction is a synchronization point and any kind of other code might run at this point, which potentially can release objects. This caused reference counted objects to be released too early. The fix is to define that the `hop_to_executor` instruction can release objects.

* **Scope**: Affects async functions

* **Issue**: rdar://110924258

* **Risk**: Very low. It's a minimal change which makes ARC optimizations more conservative.

* **Testing**: With a regression test

* **Reviewer**: @rjmccall

* **Main branch PR**: https://github.com/apple/swift/pull/66773