### PR TITLE
[SwiftSyntax] Remove spacing between `Any` and `.`

### DIFF
--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -136,7 +136,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // EXPAND_MACRO_DECL-NEXT:     "hello"
 // EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-EMPTY:
-// EXPAND_MACRO_DECL-NEXT:   func getSelf() -> Any .Type {
+// EXPAND_MACRO_DECL-NEXT:   func getSelf() -> Any.Type {
 // EXPAND_MACRO_DECL-NEXT:      return Self.self
 // EXPAND_MACRO_DECL-NEXT:   }
 // EXPAND_MACRO_DECL-NEXT: }


### PR DESCRIPTION
Companion to https://github.com/apple/swift-syntax/pull/1820