### PR TITLE
[Backtracing] Fix crash in CrashAsync test on Ubuntu 18.04.

### DIFF
--- a/stdlib/public/Backtracing/FramePointerUnwinder.swift
+++ b/stdlib/public/Backtracing/FramePointerUnwinder.swift
@@ -161,7 +161,7 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
           return nil
         }
 
-        if next <= fp {
+        if next <= fp || pc == 0 {
           return nil
         }
 


### PR DESCRIPTION
This seems to be happening because we're hitting an invalid frame on the stack where the program counter value is read back as zero.

If we find one of those, treat it as the end of our stack walk.

rdar://110846253
