### PR TITLE
PerformanceDiagnostics: fix two small issues which result in false alarms

### DIFF
--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -901,7 +901,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
       if (pa->isOnStack()) {
         for (SILValue arg : pa->getArguments()) {
           if (!arg->getType().isTrivial(*pa->getFunction()))
-            rt |= RuntimeEffect::RefCounting;
+            rt |= ifNonTrivial(arg->getType(), RuntimeEffect::RefCounting);
         }
       } else {
         rt |= RuntimeEffect::Allocating | RuntimeEffect::Releasing;

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -217,6 +217,8 @@ bool PerformanceDiagnostics::checkClosureValue(SILValue closure,
       closure = tfi->getOperand();
     } else if (auto *cp = dyn_cast<CopyValueInst>(closure)) {
       closure = cp->getOperand();
+    } else if (auto *bb = dyn_cast<BeginBorrowInst>(closure)) {
+      closure = bb->getOperand();
     } else if (auto *cv = dyn_cast<ConvertFunctionInst>(closure)) {
       closure = cv->getOperand();
     } else if (acceptFunctionArgs && isa<SILFunctionArgument>(closure)) {

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -302,3 +302,31 @@ public func testCollectionSort(a: X) -> Int {
     return 0
 }
 
+public struct Y {
+  var a, b, c: Int
+}
+
+extension Y {
+  func with2(_ body: () -> ()) {
+    body()
+  }
+  
+  func with1(_ body: (Int) -> (Int)) -> Int {
+    with2 {
+      _ = body(48)
+    }
+    return 777
+  }
+  
+  func Xsort() -> Int {
+    with1 { i in
+      i
+    }
+  }
+}
+
+@_noLocks
+public func testClosurePassing(a: inout Y) -> Int {
+    return a.Xsort()
+}
+


### PR DESCRIPTION
* Look through `begin_borrow` when analyzing closure values
* Treat non-escaping closures as trivial values when passed to a `partial_apply`

rdar://111046264
