### PR TITLE
[5.9] [Parse] Avoid creating binding patterns in a couple more positions

### DIFF
--- a/test/Constraints/rdar108738034.swift
+++ b/test/Constraints/rdar108738034.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://108738034: Make sure we can type-check this.
+enum E<T>: Error {
+  case e(T)
+}
+
+struct S {
+  func bar(_: (Error?) -> Void) {}
+}
+
+func foo(_ s: S) {
+  s.bar { error in
+      guard let error = error else {
+        return
+      }
+      if case let E<Int>.e(y) = error {
+        print(y)
+      }
+    }
+}

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -364,3 +364,51 @@ let (responseObject: Int?) = op1
 // expected-error @-1 {{expected ',' separator}} {{25-25=,}}
 // expected-error @-2 {{expected pattern}}
 // expected-error @-3 {{cannot convert value of type 'Int?' to specified type '(responseObject: _)'}}
+
+enum E<T> {
+  case e(T)
+}
+
+// rdar://108738034 - Make sure we don't treat 'E' as a binding, but can treat
+// 'y' as a binding
+func testNonBinding1(_ x: E<Int>) -> Int {
+  if case let E<Int>.e(y) = x { y } else { 0 }
+}
+
+func testNonBinding2(_ e: E<Int>) -> Int {
+  switch e {
+  case let E<Int>.e(y):
+    y
+  }
+}
+
+// In this case, 'y' should be an identifier, but 'z' is a binding.
+func testNonBinding3(_ x: (Int, Int), y: [Int]) -> Int {
+  if case let (y[0], z) = x { z } else { 0 }
+}
+
+func testNonBinding4(_ x: (Int, Int), y: [Int]) -> Int {
+  switch x {
+  case let (y[0], z):
+    z
+  default:
+    0
+  }
+}
+
+func testNonBinding5(_ x: Int, y: [Int]) {
+  // We treat 'z' here as a binding, which is invalid.
+  if case let y[z] = x {} // expected-error {{pattern variable binding cannot appear in an expression}}
+}
+
+func testNonBinding6(y: [Int], z: Int) -> Int {
+  switch 0 {
+  // We treat 'z' here as a binding, which is invalid.
+  case let y[z]: // expected-error {{pattern variable binding cannot appear in an expression}}
+    z
+  case y[z]: // This is fine
+    0
+  default:
+    0
+  }
+}


### PR DESCRIPTION
*5.9 cherry-pick of #66718*

- Explanation: Allows the parser to correctly parse the patterns `case let E<Int>.foo(x)` and `case let (y[0], x)`, where only `x` becomes a binding. Previously we would attempt to treat `E` and `y` as bindings.
- Scope: Affects parsing of patterns
- Issue: rdar://108738034
- Risk: Low, only affects code that was previously invalid
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen