### PR TITLE
🍒[cxx-interop] Make `std::string::append` usable from Swift and avoid crashing for substitution failures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2056,6 +2056,9 @@ ERROR(unable_to_convert_generic_swift_types,none,
       "the following Swift type(s) provided to '%0' could not be "
       "converted: %1",
       (StringRef, StringRef))
+ERROR(unable_to_substitute_cxx_function_template,none,
+      "could not substitute parameters for C++ function template '%0': %1",
+      (StringRef, StringRef))
 
 // Type aliases
 ERROR(type_alias_underlying_type_access,none,

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -77,7 +77,12 @@ extension std.string: Equatable {
   }
 
   public static func +=(lhs: inout std.string, rhs: std.string) {
-    lhs.__appendUnsafe(rhs) // ignore the returned pointer
+    lhs.append(rhs)
+  }
+
+  @inlinable
+  public mutating func append(_ other: std.string) {
+    __appendUnsafe(other) // ignore the returned pointer
   }
 
   public static func +(lhs: std.string, rhs: std.string) -> std.string {
@@ -93,7 +98,12 @@ extension std.u16string: Equatable {
   }
 
   public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
-    lhs.__appendUnsafe(rhs) // ignore the returned pointer
+    lhs.append(rhs)
+  }
+
+  @inlinable
+  public mutating func append(_ other: std.u16string) {
+    __appendUnsafe(other) // ignore the returned pointer
   }
 
   public static func +(lhs: std.u16string, rhs: std.u16string) -> std.u16string {

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -85,6 +85,20 @@ StdStringOverlayTestSuite.test("std::u16string operators") {
   expectTrue(s1 == "something123literal")
 }
 
+StdStringOverlayTestSuite.test("std::string::append") {
+  var s1 = std.string("0123")
+  let s2 = std.string("abc")
+  s1.append(s2)
+  expectEqual(s1, std.string("0123abc"))
+}
+
+StdStringOverlayTestSuite.test("std::u16string::append") {
+  var s1 = std.u16string("0123")
+  let s2 = std.u16string("abc")
+  s1.append(s2)
+  expectEqual(s1, std.u16string("0123abc"))
+}
+
 StdStringOverlayTestSuite.test("std::string as Hashable") {
   let s0 = std.string()
   let h0 = s0.hashValue

--- a/test/Interop/Cxx/templates/Inputs/enable-if.h
+++ b/test/Interop/Cxx/templates/Inputs/enable-if.h
@@ -1,0 +1,29 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H
+
+template <bool B, class T = void>
+struct enable_if {};
+
+template <class T>
+struct enable_if<true, T> {
+  typedef T type;
+};
+
+template <class T>
+struct is_bool {
+  static const bool value = false;
+};
+
+template <>
+struct is_bool<bool> {
+  static const bool value = true;
+};
+
+struct HasMethodWithEnableIf {
+  template <typename T>
+  typename enable_if<is_bool<T>::value, bool>::type onlyEnabledForBool(T t) const {
+    return !t;
+  }
+};
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -133,6 +133,11 @@ module TemplateTypeParameterNotInSignature {
   requires cplusplus
 }
 
+module EnableIf {
+  header "enable-if.h"
+  requires cplusplus
+}
+
 module DefineReferencedInline {
   header "define-referenced-inline.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/enable-if-typechecker.swift
+++ b/test/Interop/Cxx/templates/enable-if-typechecker.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop 2>&1 | %FileCheck %s
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import EnableIf
+
+let x = HasMethodWithEnableIf()
+x.onlyEnabledForBool("a")
+// CHECK: error: could not substitute parameters for C++ function template 'HasMethodWithEnableIf::onlyEnabledForBool': NSString *


### PR DESCRIPTION
**Explanation**: This makes `std::string::append` callable from Swift. Previously this was causing a compiler crash, since it tried to substitute `std::string` as a templated parameter to an `append` overload that takes `std::string_view` as a parameter. This PR also prevents a compiler crash in this kind of cases.
**Scope**: This adds a Swift function `append` into the CxxStdlib overlay, and fixes the compiler crash.
**Risk**: Low, this only has an effect when C++ interop is enabled.

Original PR: https://github.com/apple/swift/pull/66749

rdar://107018724
(cherry picked from commit 4a1afa9bd3cf30886d26c393b157b5d604814d4d)
(cherry picked from commit 6cd4b7c28f82af0dafcd295e172e6ee63f19c880)