### PR TITLE
🍒[cxx-interop] Make CxxShim header and modulemap arch-independent

### DIFF
--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -1,55 +1,50 @@
 set(libcxxshim_modulemap_target_list)
 foreach(sdk ${SWIFT_SDKS})
-  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES} ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
-    set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
-    set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
+  set(module_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+  set(module_dir_static "${SWIFTSTATICLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
 
-    set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
-    set(module_dir_static "${SWIFTSTATICLIB_DIR}/${arch_subdir}")
+  add_custom_command(OUTPUT ${module_dir}
+                     COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${module_dir}")
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    add_custom_command(OUTPUT ${module_dir_static}
+                       COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${module_dir_static}")
+  endif()
 
-    add_custom_command(OUTPUT ${module_dir}
-                       COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${module_dir}")
+  set(outputs)
+  foreach(source libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h)
+    add_custom_command(OUTPUT ${module_dir}/${source}
+                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source}
+                       COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${module_dir}/${source}"
+                       COMMENT "Copying ${source} to ${module_dir}")
+    list(APPEND outputs "${module_dir}/${source}")
+
     if(SWIFT_BUILD_STATIC_STDLIB)
-      add_custom_command(OUTPUT ${module_dir_static}
-                         COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${module_dir_static}")
-    endif()
-
-    set(outputs)
-    foreach(source libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h)
-      add_custom_command(OUTPUT ${module_dir}/${source}
+      add_custom_command(OUTPUT ${module_dir_static}/${source}
                          DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source}
-                         COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${module_dir}/${source}"
-                         COMMENT "Copying ${source} to ${module_dir}")
-      list(APPEND outputs "${module_dir}/${source}")
-
-      if(SWIFT_BUILD_STATIC_STDLIB)
-        add_custom_command(OUTPUT ${module_dir_static}/${source}
-                           DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source}
-                           COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${module_dir_static}/${source}"
-                           COMMENT "Copying ${source} to ${module_dir_static}")
-        list(APPEND outputs "${module_dir_static}/${source}")
-      endif()
-    endforeach()
-    list(APPEND outputs ${module_dir})
-    if(SWIFT_BUILD_STATIC_STDLIB)
-      list(APPEND outputs ${module_dir_static})
-    endif()
-
-    add_custom_target(cxxshim-${sdk}-${arch} ALL
-                      DEPENDS ${outputs}
-                      COMMENT "Copying cxxshims to ${module_dir}")
-    list(APPEND libcxxshim_modulemap_target_list cxxshim-${sdk}-${arch})
-
-
-    swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
-                               DESTINATION "lib/swift/${arch_subdir}"
-                               COMPONENT compiler)
-    if(SWIFT_BUILD_STATIC_STDLIB)
-      swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
-                                 DESTINATION "lib/swift_static/${arch_subdir}"
-                                 COMPONENT compiler)
+                         COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${source}" "${module_dir_static}/${source}"
+                         COMMENT "Copying ${source} to ${module_dir_static}")
+      list(APPEND outputs "${module_dir_static}/${source}")
     endif()
   endforeach()
+  list(APPEND outputs ${module_dir})
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    list(APPEND outputs ${module_dir_static})
+  endif()
+
+  add_custom_target(cxxshim-${sdk} ALL
+                    DEPENDS ${outputs}
+                    COMMENT "Copying cxxshims to ${module_dir}")
+  list(APPEND libcxxshim_modulemap_target_list cxxshim-${sdk})
+
+
+  swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
+                             DESTINATION "lib/swift/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+                             COMPONENT compiler)
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
+                               DESTINATION "lib/swift_static/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+                               COMPONENT compiler)
+  endif()
 endforeach()
 
 add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})


### PR DESCRIPTION
**Explanation**: This moves `libcxxshim.modulemap`, `libcxxshim.h` and `libcxxstdlibshim.h` from `*.xctoolchain/usr/lib/swift/macosx/arm64e` to `*.xctoolchain/usr/lib/swift/macosx` to simplify distribution.
**Scope**: This simplifies the CMake build scripts to ignore the architecture for these headers, and adjusts the compiler logic used to discover the headers.
**Risk**: Medium, this alters the distribution of the toolchain headers.

rdar://110788977
(cherry picked from commit 4ce4527ef1474b2d6a181fcc57db4a2966361943)