### PR TITLE
The test IRGen/protocol_metadata.swift does not support arm64e

### DIFF
--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 // REQUIRES: PTRSIZE=64
+// UNSUPPORTED: CPU=arm64e
 
 protocol A { func a() }
 protocol B { func b() }


### PR DESCRIPTION
rdar://111080147
