### PR TITLE
Use swift::once instead of swift_once to clean up the code a little, and make sure we unconditionally set the state from CF to make sure it's set even if we failed a lazy load earlier

### DIFF
--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -123,6 +123,7 @@ SWIFT_RUNTIME_EXPORT void swift_initializeCoreFoundationState(CFBridgingState co
   //It's fine if this runs more than once, it's a noop if it's been done before
   //and we want to make sure it still happens if CF loads late after it failed initially
   bridgingState = state;
+  std::atomic_thread_fence(std::memory_order_seq_cst); //This is probably unnecessary, but thinking through why it's unnecessary has given multiple people headaches now, and since this only runs once it's not a big deal to just have the barrier.
   _reparentClasses();
 }
 


### PR DESCRIPTION
Additional fix for rdar://111104451