### PR TITLE
[5.9] SILCombine: correctly set the `[stack]` flag when replacing `alloc_ref_dynamic` with `alloc_ref`

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -2145,8 +2145,13 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
   Builder.setCurrentDebugScope(ARDI->getDebugScope());
 
   SILValue MDVal = ARDI->getMetatypeOperand();
-  while (auto *UCI = dyn_cast<UpcastInst>(MDVal))
+  while (auto *UCI = dyn_cast<UpcastInst>(MDVal)) {
+    // For simplicity ignore a cast of an `alloc_ref [stack]`. It would need more
+    // work to keep its `dealloc_stack_ref` correct.
+    if (ARDI->canAllocOnStack())
+      return nullptr;
     MDVal = UCI->getOperand();
+  }
 
   SingleValueInstruction *NewInst = nullptr;
   if (auto *MI = dyn_cast<MetatypeInst>(MDVal)) {
@@ -2159,7 +2164,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
       return nullptr;
 
     NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
-                                     ARDI->isObjC(), false,
+                                     ARDI->isObjC(), ARDI->canAllocOnStack(),
                                      ARDI->getTailAllocatedTypes(),
                                      getCounts(ARDI));
 
@@ -2184,11 +2189,14 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
       if (!SILInstanceTy.getClassOrBoundGenericClass())
         return nullptr;
       NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
-                                       ARDI->isObjC(), false,
+                                       ARDI->isObjC(), ARDI->canAllocOnStack(),
                                        ARDI->getTailAllocatedTypes(),
                                        getCounts(ARDI));
     }
   } else if (auto *AI = dyn_cast<ApplyInst>(MDVal)) {
+    if (ARDI->canAllocOnStack())
+      return nullptr;
+
     SILFunction *SF = AI->getReferencedFunctionOrNull();
     if (!SF)
       return nullptr;
@@ -2217,6 +2225,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
   if (NewInst && NewInst->getType() != ARDI->getType()) {
     // In case the argument was an upcast of the metatype, we have to upcast the
     // resulting reference.
+    assert(!ARDI->canAllocOnStack() && "upcasting alloc_ref [stack] not supported");
     NewInst = Builder.createUpcast(ARDI->getLoc(), NewInst, ARDI->getType());
   }
   return NewInst;

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -3149,6 +3149,61 @@ bb3 (%10: $Builtin.Int32):
   return %10 : $Builtin.Int32
 }
 
+// CHECK-LABEL: sil [ossa] @alloc_ref_dynamic_stack_with_metatype :
+// CHECK:       bb0:
+// CHECK-NOT:     alloc_ref_dynamic
+// CHECK-NEXT:    alloc_ref [stack] $B
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    dealloc_stack_ref
+// CHECK: return
+// CHECK: } // end sil function 'alloc_ref_dynamic_stack_with_metatype'
+sil [ossa] @alloc_ref_dynamic_stack_with_metatype : $() -> () {
+  %1 = metatype $@thick B.Type
+  %2 = alloc_ref_dynamic [stack] %1 : $@thick B.Type, $B
+  destroy_value %2 : $B
+  dealloc_stack_ref %2 : $B
+  %4 = tuple()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @alloc_ref_dynamic_stack_with_upcast_metatype :
+// CHECK:         alloc_ref_dynamic [stack]
+// CHECK:       } // end sil function 'alloc_ref_dynamic_stack_with_upcast_metatype'
+sil [ossa] @alloc_ref_dynamic_stack_with_upcast_metatype : $() -> () {
+  %1 = metatype $@thick E.Type
+  %2 = upcast %1 : $@thick E.Type to $@thick B.Type
+  %3 = alloc_ref_dynamic [stack] %2 : $@thick B.Type, $B
+  destroy_value %3 : $B
+  dealloc_stack_ref %3 : $B
+  %4 = tuple()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @alloc_ref_dynamic_stack_after_successful_checked_cast_br :
+// CHECK:         checked_cast_br
+// CHECK:       bb1
+// CHECK-NOT:     alloc_ref_dynamic
+// CHECK:         alloc_ref [stack] $B
+// CHECK:       } // end sil function 'alloc_ref_dynamic_stack_after_successful_checked_cast_br'
+sil [ossa] @alloc_ref_dynamic_stack_after_successful_checked_cast_br : $(@thick B.Type) -> Builtin.Int32 {
+bb0(%1 : $@thick B.Type):
+  checked_cast_br [exact] %1 : $@thick B.Type to B.Type, bb1, bb2
+
+bb1(%2 : $@thick B.Type):
+  %3 = alloc_ref_dynamic [stack] %2 : $@thick B.Type, $B
+  destroy_value %3 : $B
+  dealloc_stack_ref %3 : $B
+  %4 = integer_literal $Builtin.Int32, 1
+  br bb3 (%4 : $Builtin.Int32)
+
+bb2(%2a : $@thick B.Type):
+  %5 = integer_literal $Builtin.Int32, 2
+  br bb3 (%5 : $Builtin.Int32)
+
+bb3 (%10: $Builtin.Int32):
+  return %10 : $Builtin.Int32
+}
+
 // CHECK-LABEL: sil [ossa] @delete_dead_alloc_stack
 // XHECK: bb0
 // XHECK-NEXT: tuple


### PR DESCRIPTION
* **Explanation**: This is a fix for a SIL verifier crash. When optimizing `alloc_ref_dynamic` instructions in SILCombine, the `[stack]` attribute was not set correctly. Beside a verifier crash, this also results in a memory leak in the compiled code (if the verifier is disabled, like in no-assert compiler builds). Interestingly, this bug is in the compiler since 7 years. It's surprising that it didn't show up earlier.

* **Scope**: Although the `alloc_ref_dynamic` instruction is used in the stdlib's array and dictionary code, it is obviously very rare that this optimizer bug really shows up.

* **Issue**: https://github.com/apple/swift/issues/66312

* **Risk**: Low. The change is small. Some variants of the peephole optimization are disabled now in case of an `alloc_ref_dynamic [stack]`. In the remaining cases, the `[stack]` attribute is set correctly. These are the cases where the verifier would have crashed before.

* **Testing**: With a regression test

* **Reviewer**: @nate-chandler 

* **Main branch PR**: https://github.com/apple/swift/pull/66800