### PR TITLE
emit error when a noncopyable enum has a raw type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3246,6 +3246,9 @@ ERROR(enum_raw_type_nonconforming_and_nonsynthable,none,
       "and conformance could not be synthesized", (Type, Type))
 NOTE(enum_declares_rawrep_with_raw_type,none,
       "%0 declares raw type %1, which implies RawRepresentable", (Type, Type))
+ERROR(enum_raw_type_nonconforming_and_noncopyable,none,
+      "%0 declares raw type %1, but cannot yet conform to RawRepresentable "
+      "because it is noncopyable", (Type, Type))
 ERROR(enum_raw_type_access,none,
       "enum %select{must be declared %select{"
       "%select{private|fileprivate|internal|package|%error|%error}1|private or fileprivate}3"

--- a/test/Sema/moveonly_objc_enum.swift
+++ b/test/Sema/moveonly_objc_enum.swift
@@ -6,12 +6,14 @@
 
 @_moveOnly
 @objc enum Foo : Int { // expected-error {{noncopyable enums cannot be marked '@objc'}}
+                       // expected-error@-1 {{'Foo' declares raw type 'Int', but cannot yet conform to RawRepresentable because it is noncopyable}}
   case X, Y, Z
   deinit {} // expected-error {{deinitializers cannot be declared on an @objc enum type}}
 }
 
 @_moveOnly
 @objc enum Foo2 : Int { // expected-error {{noncopyable enums cannot be marked '@objc'}}
+                        // expected-error@-1 {{'Foo2' declares raw type 'Int', but cannot yet conform to RawRepresentable because it is noncopyable}}
   case X, Y, Z
 }
 

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -216,8 +216,8 @@ enum Color {
     }
 }
 
-@_moveOnly
-enum StrengthLevel: Int { // ensure move-only raw enums do not conform to RawRepresentable
+// expected-error@+1:21 {{'StrengthLevel' declares raw type 'Int', but cannot yet conform to RawRepresentable because it is noncopyable}}
+enum StrengthLevel: Int, ~Copyable {
     case none = 0
     case low
     case high


### PR DESCRIPTION
previously I was allowing these because I thought there was some representational difference if the enum is raw. it turns out that a raw enum is only useful if you synthesize conformance to RawRepresentable. since I disabled that synthesis it's kind of silly to still allow the raw type to be written at all.

rdar://110539937