### PR TITLE
[DO NOT MERGE] [Observation] Potential future of Observation with CoW based registrars and async sequences

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -232,9 +232,9 @@ extension FunctionDeclSyntax {
   var signatureStandin: SignatureStandin {
     var parameters = [String]()
     for parameter in signature.input.parameterList {
-      parameters.append(parameter.firstName.text + ":" + (parameter.type.genericSubstitution(genericParameterClause?.genericParameterList) ?? "" ))
+      parameters.append(parameter.firstName.text + ":" + (parameter.type.genericSubstitution(genericParameterClause?.parameters) ?? "" ))
     }
-    let returnType = signature.output?.returnType.genericSubstitution(genericParameterClause?.genericParameterList) ?? "Void"
+    let returnType = signature.output?.returnType.genericSubstitution(genericParameterClause?.parameters) ?? "Void"
     return SignatureStandin(isInstance: isInstance, identifier: identifier.text, parameters: parameters, returnType: returnType)
   }
   
@@ -249,12 +249,12 @@ enum SyntaxVisibility {
   case `private`
   case `fileprivate`
   
-  var description: TokenSyntax {
+  var description: String {
     switch self {
-    case .public: "public"
-    case .internal: "internal"
-    case .private: "private"
-    case .fileprivate: "fileprivate"
+    case .public: return "public"
+    case .internal: return "internal"
+    case .private: return "private"
+    case .fileprivate: return "fileprivate"
     }
   }
 }

--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -83,6 +83,20 @@ extension VariableDeclSyntax {
     }
   }
   
+  var isOverride: Bool {
+    if let modifiers {
+      for modifier in modifiers {
+        if modifier.name.trimmed.tokenKind == .keyword(.override) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  var hasSetter: Bool {
+    return accessorsMatching({ $0 == .keyword(.set) }).count > 0
+  }
   
   var isImmutable: Bool {
     return bindingKeyword.tokenKind == .keyword(.let)
@@ -97,6 +111,26 @@ extension VariableDeclSyntax {
   
   var initializer: InitializerClauseSyntax? {
     bindings.first?.initializer
+  }
+
+  var visibility: SyntaxVisibility? {
+    if let modifiers {
+      for modifier in modifiers {
+        switch modifier.name.tokenKind {
+        case .keyword(.public):
+          return .public
+        case .keyword(.internal):
+          return .internal
+        case .keyword(.private):
+          return .private
+        case .keyword(.fileprivate):
+          return .fileprivate
+        default:
+          break
+        }
+      }
+    }
+    return nil
   }
   
   func hasMacroApplication(_ name: String) -> Bool {
@@ -209,6 +243,22 @@ extension FunctionDeclSyntax {
   }
 }
 
+enum SyntaxVisibility {
+  case `public`
+  case `internal`
+  case `private`
+  case `fileprivate`
+  
+  var description: TokenSyntax {
+    switch self {
+    case .public: "public"
+    case .internal: "internal"
+    case .private: "private"
+    case .fileprivate: "fileprivate"
+    }
+  }
+}
+
 extension DeclGroupSyntax {
   var memberFunctionStandins: [FunctionDeclSyntax.SignatureStandin] {
     var standins = [FunctionDeclSyntax.SignatureStandin]()
@@ -250,6 +300,39 @@ extension DeclGroupSyntax {
       return nil
     }
   }
+
+  func hasMemberType<I: IdentifiedDeclSyntax>(equivalentTo other: I) -> Bool {
+    for member in memberBlock.members {
+      guard let member = member.as(MemberDeclListItemSyntax.self) else {
+        continue
+      }
+      if let ty = member.decl.as(EnumDeclSyntax.self) {
+        if other.identifier.text == ty.identifier.text {
+          return true
+        }
+      } else if let ty = member.decl.as(StructDeclSyntax.self) {
+        if other.identifier.text == ty.identifier.text {
+          return true
+        }
+      } else if let ty = member.decl.as(ClassDeclSyntax.self) {
+        if other.identifier.text == ty.identifier.text {
+          return true
+        }
+      } else if let ty = member.decl.as(ActorDeclSyntax.self) {
+        if other.identifier.text == ty.identifier.text {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  
+  
+  func addIfNeeded(_ decls: [DeclSyntax], to declarations: inout [DeclSyntax]) {
+    for declaration in decls {
+      addIfNeeded(declaration, to: &declarations)
+    }
+  }
   
   func addIfNeeded(_ decl: DeclSyntax?, to declarations: inout [DeclSyntax]) {
     guard let decl else { return }
@@ -259,6 +342,22 @@ extension DeclGroupSyntax {
       }
     } else if let property = decl.as(VariableDeclSyntax.self) {
       if !hasMemberProperty(equivalentTo: property) {
+        declarations.append(decl)
+      }
+    } else if let ty = decl.as(EnumDeclSyntax.self) {
+      if !hasMemberType(equivalentTo: ty) {
+        declarations.append(decl)
+      }
+    } else if let ty = decl.as(StructDeclSyntax.self) {
+      if !hasMemberType(equivalentTo: ty) {
+        declarations.append(decl)
+      }
+    } else if let ty = decl.as(ClassDeclSyntax.self) {
+      if !hasMemberType(equivalentTo: ty) {
+        declarations.append(decl)
+      }
+    } else if let ty = decl.as(ActorDeclSyntax.self) {
+      if !hasMemberType(equivalentTo: ty) {
         declarations.append(decl)
       }
     }
@@ -274,5 +373,40 @@ extension DeclGroupSyntax {
   
   var isEnum: Bool {
     return self.is(EnumDeclSyntax.self)
+  }
+
+  var isStruct: Bool {
+    return self.is(StructDeclSyntax.self)
+  }
+  
+  var isPublic: Bool {
+    if let modifiers {
+      for modifier in modifiers {
+        if modifier.name.tokenKind == .keyword(.public) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  
+  var visibility: SyntaxVisibility? {
+    if let modifiers {
+      for modifier in modifiers {
+        switch modifier.name.tokenKind {
+        case .keyword(.public):
+          return .public
+        case .keyword(.internal):
+          return .internal
+        case .keyword(.private):
+          return .private
+        case .keyword(.fileprivate):
+          return .fileprivate
+        default:
+          break
+        }
+      }
+    }
+    return nil
   }
 }

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -35,6 +35,12 @@ public struct ObservableMacro {
   
   static let trackedMacroName = "ObservationTracked"
   static let ignoredMacroName = "ObservationIgnored"
+  static let valuesMacroName = "ObservableValues"
+
+  static let valuesName = "ObservedValues"
+  static var qualifiedValuesTypeName: String {
+    return "\(moduleName).\(valuesName)"
+  }
 
   static let registrarVariableName = "_$observationRegistrar"
   
@@ -46,7 +52,7 @@ public struct ObservableMacro {
   }
   
   static func accessFunction(_ observableType: TokenSyntax) -> DeclSyntax {
-    return 
+    return
       """
       internal nonisolated func access<Member>(
           keyPath: KeyPath<\(observableType), Member>
@@ -56,23 +62,32 @@ public struct ObservableMacro {
       """
   }
   
-  static func withMutationFunction(_ observableType: TokenSyntax) -> DeclSyntax {
-    return 
+  static func withMutationFunction(_ observableType: TokenSyntax, structural: Bool) -> DeclSyntax {
+    return
       """
-      internal nonisolated func withMutation<Member, T>(
+      internal \(raw: structural ? "mutating " : "")nonisolated func withMutation<Member, T>(
         keyPath: KeyPath<\(observableType), Member>,
         _ mutation: () throws -> T
       ) rethrows -> T {
-        try \(raw: registrarVariableName).withMutation(of: self, keyPath: keyPath, mutation)
+        try \(raw: registrarVariableName).\(raw: structural ? "withUniqueMutation" : "withMutation")(of: self, keyPath: keyPath, mutation)
       }
       """
   }
-
+  
   static var ignoredAttribute: AttributeSyntax {
     AttributeSyntax(
       leadingTrivia: .space,
       atSignToken: .atSignToken(),
       attributeName: SimpleTypeIdentifierSyntax(name: .identifier(ignoredMacroName)),
+      trailingTrivia: .space
+    )
+  }
+  
+  static var valuesAttribute: AttributeSyntax {
+    AttributeSyntax(
+      leadingTrivia: .space,
+      atSignToken: .atSignToken(),
+      attributeName: SimpleTypeIdentifierSyntax(name: .identifier(valuesMacroName)),
       trailingTrivia: .space
     )
   }
@@ -173,10 +188,26 @@ extension PatternBindingListSyntax {
 }
 
 extension VariableDeclSyntax {
-    func privatePrefixed(_ prefix: String, addingAttribute attribute: AttributeSyntax) -> VariableDeclSyntax {
-    VariableDeclSyntax(
+  func privatePrefixed(_ prefix: String, addingAttribute attribute: AttributeSyntax, removingAttribute toRemove: AttributeSyntax? = nil) -> VariableDeclSyntax {
+    let filtered = attributes?.filter {
+      switch $0 {
+      case .attribute(let attr):
+        if attr.trimmed.attributeName.identifier == attribute.trimmed.attributeName.identifier {
+          return false
+        } else if let toRemove, attr.trimmed.attributeName.identifier == toRemove.trimmed.attributeName.identifier {
+          return false
+        } else {
+          return true
+        }
+      default:
+        return true
+      }
+    } ?? []
+    
+    
+    return VariableDeclSyntax(
       leadingTrivia: leadingTrivia,
-      attributes: attributes?.appending(.attribute(attribute)) ?? [.attribute(attribute)],
+      attributes: AttributeListSyntax(filtered + [.attribute(attribute)]),
       modifiers: modifiers?.privatePrefixed(prefix) ?? ModifierListSyntax(keyword: .private),
       bindingKeyword: TokenSyntax(bindingKeyword.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
       bindings: bindings.privatePrefixed(prefix),
@@ -186,6 +217,10 @@ extension VariableDeclSyntax {
   
   var isValidForObservation: Bool {
     !isComputed && isInstance && !isImmutable && identifier != nil
+  }
+  
+  var isValidForValueObservation: Bool {
+    isInstance && !isImmutable && identifier != nil
   }
 }
 
@@ -217,17 +252,8 @@ extension ObservableMacro: MemberMacro {
 
     declaration.addIfNeeded(ObservableMacro.registrarVariable(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
-    declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
-
-#if !OBSERVATION_SUPPORTS_PEER_MACROS
-    let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
-    for property in storedInstanceVariables {
-       if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
-       let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
-       declaration.addIfNeeded(storage, to: &declarations)
-    }
-#endif
-
+    declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType, structural: declaration.isStruct), to: &declarations)
+    
     return declarations
   }
 }
@@ -249,8 +275,7 @@ extension ObservableMacro: MemberAttributeMacro {
     }
 
     // dont apply to ignored properties or properties that are already flaged as tracked
-    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) ||
-       property.hasMacroApplication(ObservableMacro.trackedMacroName) {
+    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) {
       return []
     }
     
@@ -288,7 +313,9 @@ extension ObservableMacro: ConformanceMacro {
   }
 }
 
-public struct ObservationTrackedMacro: AccessorMacro {
+public struct ObservationTrackedMacro {}
+
+extension ObservationTrackedMacro: AccessorMacro {
   public static func expansion<
     Context: MacroExpansionContext,
     Declaration: DeclSyntaxProtocol
@@ -336,21 +363,19 @@ public struct ObservationTrackedMacro: AccessorMacro {
 }
 
 extension ObservationTrackedMacro: PeerMacro {
-  public static func expansion<
-    Context: MacroExpansionContext,
-    Declaration: DeclSyntaxProtocol
-  >(
+  public static func expansion(
     of node: SwiftSyntax.AttributeSyntax,
-    providingPeersOf declaration: Declaration,
-    in context: Context
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     guard let property = declaration.as(VariableDeclSyntax.self),
           property.isValidForObservation else {
       return []
     }
-    
+
     if property.hasMacroApplication(ObservableMacro.ignoredMacroName) ||
-       property.hasMacroApplication(ObservableMacro.trackedMacroName) {
+       property.hasMacroApplication(ObservableMacro.trackedMacroName) || 
+       property.hasMacroApplication(ObservableMacro.valuesMacroName) {
       return []
     }
     
@@ -369,5 +394,54 @@ public struct ObservationIgnoredMacro: AccessorMacro {
     in context: Context
   ) throws -> [AccessorDeclSyntax] {
     return []
+  }
+}
+
+public struct ObservableValuesMacro { }
+
+extension ObservableValuesMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let property = declaration.as(VariableDeclSyntax.self),
+          property.isValidForValueObservation else {
+      return []
+    }
+
+    if property.hasMacroApplication(ObservableMacro.ignoredMacroName) {
+      return []
+    }
+    
+    guard let identifier = property.identifier else {
+      return []
+    }
+    
+    guard let type = property.type else {
+      throw DiagnosticsError(syntax: node, message: "@ObservableValues may only be applied to properties with specified types", id: .invalidApplication)
+    }
+    var modifiers = "\((property.visibility?.description ?? "")) "
+    if property.isOverride {
+      modifiers += "override "
+    }
+    if property.isComputed {
+      let values: DeclSyntax =
+        """
+        \(raw: modifiers)var \(identifier)Values: \(raw: qualifiedValuesTypeName)<\(type)> {
+          \(raw: qualifiedValuesTypeName)(of: self, computed: \\.\(identifier))
+        }
+        """
+      return [values]
+    } else {
+      let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute, removingAttribute: ObservableMacro.valuesAttribute))
+      let values: DeclSyntax =
+        """
+        \(raw: modifiers)var \(identifier)Values: \(raw: qualifiedValuesTypeName)<\(type)> {
+          \(raw: qualifiedValuesTypeName)(of: self, stored: \\.\(identifier), registrar: \(raw: ObservableMacro.registrarVariableName))
+        }
+        """
+      return [storage, values]
+    }
   }
 }

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -428,8 +428,8 @@ extension ObservableValuesMacro: PeerMacro {
     if property.isComputed {
       let values: DeclSyntax =
         """
-        \(raw: modifiers)var \(identifier)Values: \(raw: qualifiedValuesTypeName)<\(type)> {
-          \(raw: qualifiedValuesTypeName)(of: self, computed: \\.\(identifier))
+        \(raw: modifiers)var \(identifier)Values: \(raw: ObservableMacro.qualifiedValuesTypeName)<\(type)> {
+          \(raw: ObservableMacro.qualifiedValuesTypeName)(of: self, computed: \\.\(identifier))
         }
         """
       return [values]
@@ -437,8 +437,8 @@ extension ObservableValuesMacro: PeerMacro {
       let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute, removingAttribute: ObservableMacro.valuesAttribute))
       let values: DeclSyntax =
         """
-        \(raw: modifiers)var \(identifier)Values: \(raw: qualifiedValuesTypeName)<\(type)> {
-          \(raw: qualifiedValuesTypeName)(of: self, stored: \\.\(identifier), registrar: \(raw: ObservableMacro.registrarVariableName))
+        \(raw: modifiers)var \(identifier)Values: \(raw: ObservableMacro.qualifiedValuesTypeName)<\(type)> {
+          \(raw: ObservableMacro.qualifiedValuesTypeName)(of: self, stored: \\.\(identifier), registrar: \(raw: ObservableMacro.registrarVariableName))
         }
         """
       return [storage, values]

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -18,6 +18,7 @@ add_swift_target_library(swift_Observation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   Observable.swift
   ObservationRegistrar.swift
   ObservationTracking.swift
+  ObservedValues.swift
   ThreadLocal.cpp
   ThreadLocal.swift
 

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -72,4 +72,10 @@ public macro ObservationTracked() =
 public macro ObservationIgnored() =
   #externalMacro(module: "ObservationMacros", type: "ObservationIgnoredMacro")
 
+@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@attached(peer, names: prefixed(_), suffixed(Values))
+public macro ObservableValues() =
+  #externalMacro(module: "ObservationMacros", type: "ObservableValuesMacro")
+
+
 #endif

--- a/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
@@ -13,25 +13,24 @@
 @_spi(SwiftUI)
 public struct ObservationTracking {
   struct Entry: @unchecked Sendable {
-    let registerTracking: @Sendable (Set<AnyKeyPath>, @Sendable @escaping () -> Void) -> Int
-    let cancel: @Sendable (Int) -> Void
+    let context: ObservationRegistrar.Context
+    
     var properties = Set<AnyKeyPath>()
     
     init(_ context: ObservationRegistrar.Context) {
-      registerTracking = { properties, observer in
-        context.registerTracking(for: properties, observer: observer)
-      }
-      cancel = { id in
-        context.cancel(id)
-      }
+      self.context = context
     }
     
     func addObserver(_ changed: @Sendable @escaping () -> Void) -> Int {
-      return registerTracking(properties, changed)
+      return context.registerTracking(for: properties, observer: changed)
+    }
+    
+    func addObserver(_ changed: @Sendable @escaping (Any) -> Void) -> Int {
+      return context.registerTracking(for: properties, observer: changed)
     }
     
     func removeObserver(_ token: Int) {
-      cancel(token)
+      context.cancel(token)
     }
     
     mutating func insert(_ keyPath: AnyKeyPath) {

--- a/stdlib/public/Observation/Sources/Observation/ObservedValues.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservedValues.swift
@@ -13,7 +13,7 @@ import _Concurrency
 
 @available(SwiftStdlib 5.9, *)
 public struct ObservedValues<Element> {
-  private class Storage: ObservationRegistrar.ValueObservationStorage {
+  internal class Storage: ObservationRegistrar.ValueObservationStorage {
     func next() async -> Element? {
       return nil
     }
@@ -88,7 +88,7 @@ public struct ObservedValues<Element> {
   
   private final class ComputedPropertyStorage<Subject: Observable>: Storage {
     private struct State {
-      private var observers = [ObjectIdentifier: Int]()
+      internal var observers = [ObjectIdentifier: Int]()
       private var terminal = false
       private var buffer = [Element]()
       private var continuations = [UnsafeContinuation<Element?, Never>]()
@@ -203,7 +203,7 @@ public struct ObservedValues<Element> {
 @available(SwiftStdlib 5.9, *)
 extension ObservedValues: AsyncSequence {
   public struct Iterator: AsyncIteratorProtocol {
-    let storage: Storage
+    internal let storage: Storage
     
     init(storage: Storage) {
       self.storage = storage

--- a/stdlib/public/Observation/Sources/Observation/ObservedValues.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservedValues.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
+
 @available(SwiftStdlib 5.9, *)
 public struct ObservedValues<Element> {
   private class Storage: ObservationRegistrar.ValueObservationStorage {

--- a/stdlib/public/Observation/Sources/Observation/ObservedValues.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservedValues.swift
@@ -1,0 +1,224 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 5.9, *)
+public struct ObservedValues<Element> {
+  private class Storage: ObservationRegistrar.ValueObservationStorage {
+    func next() async -> Element? {
+      return nil
+    }
+  }
+  
+  private final class StoredPropertyStorage: Storage {
+    private struct State {
+      private var terminal = false
+      private var buffer = [Element]()
+      private var continuations = [UnsafeContinuation<Element?, Never>]()
+      
+      @discardableResult
+      private mutating func drain() -> Bool {
+        if !continuations.isEmpty && !buffer.isEmpty {
+          let continuation = continuations.removeFirst()
+          let element = buffer.removeFirst()
+          continuation.resume(returning: element)
+        }
+        if terminal && buffer.isEmpty && !continuations.isEmpty {
+          let continuations = self.continuations
+          self.continuations.removeAll(keepingCapacity: false)
+          for continuation in continuations {
+            continuation.resume(returning: nil)
+          }
+          return true
+        }
+        return false
+      }
+      
+      internal mutating func emit(_ value: Element) -> Bool {
+        if terminal && buffer.isEmpty {
+          drain()
+          return true
+        }
+        buffer.append(value)
+        return drain()
+      }
+      
+      internal mutating func next(_ continuation: UnsafeContinuation<Element?, Never>) {
+        continuations.append(continuation)
+        drain()
+      }
+      
+      internal mutating func cancel() {
+        terminal = true
+        drain()
+      }
+    }
+    
+    private var id: Int = 0
+    private let state = _ManagedCriticalState(State())
+    
+    internal init<Subject: Observable>(context: ObservationRegistrar.Context, subject: Subject, keyPath: KeyPath<Subject, Element>) {
+      super.init()
+      self.id = context.registerValues(for: [keyPath], storage: self)
+    }
+    
+    internal override func next() async -> Element? {
+      await withUnsafeContinuation { continuation in
+        state.withCriticalRegion { $0.next(continuation) }
+      }
+    }
+    
+    internal override func emit<E>(_ element: E) -> Bool {
+      state.withCriticalRegion { $0.emit(element as! Element) }
+    }
+
+    internal override func cancel() {
+      state.withCriticalRegion { $0.cancel() }
+    }
+  }
+  
+  private final class ComputedPropertyStorage<Subject: Observable>: Storage {
+    private struct State {
+      private var observers = [ObjectIdentifier: Int]()
+      private var terminal = false
+      private var buffer = [Element]()
+      private var continuations = [UnsafeContinuation<Element?, Never>]()
+      
+      private mutating func drain() {
+        if !continuations.isEmpty && !buffer.isEmpty {
+          let continuation = continuations.removeFirst()
+          let element = buffer.removeFirst()
+          continuation.resume(returning: element)
+        }
+        if terminal && buffer.isEmpty && !continuations.isEmpty {
+          let continuations = self.continuations
+          self.continuations.removeAll(keepingCapacity: false)
+          for continuation in continuations {
+            continuation.resume(returning: nil)
+          }
+        }
+      }
+      
+      internal mutating func emit(_ value: Element) {
+        if terminal && buffer.isEmpty {
+          drain()
+          return
+        }
+        buffer.append(value)
+        drain()
+      }
+      
+      internal mutating func next(_ continuation: UnsafeContinuation<Element?, Never>) {
+        continuations.append(continuation)
+        drain()
+      }
+      
+      internal mutating func cancel() {
+        terminal = true
+        drain()
+      }
+    }
+
+    private let keyPath: KeyPath<Subject, Element>
+    private let state = _ManagedCriticalState(State())
+    
+    internal init(subject: Subject, keyPath: KeyPath<Subject, Element>) {
+      self.keyPath = keyPath
+      super.init()
+      emitAccess(subject)
+      
+    }
+    
+    internal override func emit<E>(_ element: E) -> Bool {
+      return true
+    }
+    
+    private func emitAccess(_ subject: Subject) {
+      let value = access(subject)
+      state.withCriticalRegion { $0.emit(value) }
+    }
+    
+    internal override func next() async -> Element? {
+      await withUnsafeContinuation { continuation in
+        state.withCriticalRegion { $0.next(continuation) }
+      }
+    }
+    
+    internal override func cancel() {
+      state.withCriticalRegion { $0.cancel() }
+    }
+    
+    private func access(_ subject: Subject) -> Element {
+      var accessList: ObservationTracking._AccessList?
+      let result = withUnsafeMutablePointer(to: &accessList) { ptr in
+        let previous = _ThreadLocal.value
+        _ThreadLocal.value = UnsafeMutableRawPointer(ptr)
+        defer {
+          if let scoped = ptr.pointee, let previous {
+            if var prevList = previous.assumingMemoryBound(to: ObservationTracking._AccessList?.self).pointee {
+              prevList.merge(scoped)
+              previous.assumingMemoryBound(to: ObservationTracking._AccessList?.self).pointee = prevList
+            } else {
+              previous.assumingMemoryBound(to: ObservationTracking._AccessList?.self).pointee = scoped
+            }
+          }
+          _ThreadLocal.value = previous
+        }
+        return subject[keyPath: keyPath]
+      }
+      if let list = accessList {
+        let values = list.entries.mapValues { $0.addObserver { [state] subject in
+          let values = state.withCriticalRegion { $0.observers }
+          for (id, token) in values {
+            list.entries[id]?.removeObserver(token)
+          }
+          self.emitAccess(subject as! Subject)
+        }}
+        state.withCriticalRegion { $0.observers = values }
+      }
+      return result
+    }
+  }
+  
+  private let storage: Storage
+  
+  public init<Subject: Observable>(of subject: Subject, computed keyPath: KeyPath<Subject, Element>) {
+    storage = ComputedPropertyStorage(subject: subject, keyPath: keyPath)
+  }
+  
+  public init<Subject: Observable>(of subject: Subject, stored keyPath: KeyPath<Subject, Element>, registrar: ObservationRegistrar) {
+    storage = StoredPropertyStorage(context: registrar.context, subject: subject, keyPath: keyPath)
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+extension ObservedValues: AsyncSequence {
+  public struct Iterator: AsyncIteratorProtocol {
+    let storage: Storage
+    
+    init(storage: Storage) {
+      self.storage = storage
+    }
+    
+    public mutating func next() async -> Element? {
+      await storage.next()
+    }
+  }
+  
+  public func makeAsyncIterator() -> Iterator {
+    Iterator(storage: storage)
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+extension ObservedValues: @unchecked Sendable where Element: Sendable { }
+
+@available(*, unavailable)
+extension ObservedValues.Iterator: Sendable { }


### PR DESCRIPTION
This adds in AsyncSequence attributes for fields that synthesizes peer members to restore the capability of emitting values over time. Additionally it includes an implementation of the CoW storage for the `ObservationRegistrar` to more adequately handle structural type observation.

```swift
@Observable
class Person {
  // The `@ObservableValues` macro can be applied to stored properties to provide a peer property with the `Values` suffix.
  // This allows observing the values as an AsyncSequence.
  @ObservableValues
  var firstName: String

  var lastName: String
  
  // Computed properties can also have this application and use the observation tracking mechanism to determine underlying values that compose computed properties without needing to state the dependencies!
  @ObservableValues
  var fullName: String {
    "\(firstName) \(lastName)"
  }
  
  init(firstName: String, lastName: String) {
    self.firstName = firstName
    self.lastName = lastName
  }
}
```

Note: the names here are completely provisional and just there to provide something to hang the hat of value observation on.