### PR TITLE
sourcekitd: adjust the definition of `SOURCEKIT_PUBLIC`

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -49,6 +49,8 @@ else()
     HAS_SWIFT_MODULES
   )
 endif()
+set_target_properties(sourcekitdInProc PROPERTIES
+  DEFINE_SYMBOL sourcekitd_EXPORTS)
 target_link_libraries(sourcekitdInProc PRIVATE
   SourceKitSwiftLang
   sourcekitdAPI

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -13,10 +13,6 @@
 #ifndef LLVM_SOURCEKITD_INTERNAL_H
 #define LLVM_SOURCEKITD_INTERNAL_H
 
-#if defined (_MSC_VER)
-# define SOURCEKITD_PUBLIC __declspec(dllexport)
-#endif
-
 #include "SourceKit/Support/CancellationToken.h"
 #include "sourcekitd/sourcekitd.h"
 #include "llvm/ADT/Optional.h"

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
@@ -52,12 +52,14 @@
 # define SOURCEKITD_END_DECLS
 #endif
 
-#ifndef SOURCEKITD_PUBLIC
-# if defined (_MSC_VER)
-#  define SOURCEKITD_PUBLIC __declspec(dllimport)
+#if defined(_WIN32)
+# if defined(sourcekitd_EXPORTS)
+#   define SOURCEKITD_PUBLIC __declspec(dllexport)
 # else
-#  define SOURCEKITD_PUBLIC
+#   define SOURCEKITD_PUBLIC __declspec(dllimport)
 # endif
+#else
+# define SOURCEKITD_PUBLIC
 #endif
 
 #ifndef __has_feature

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -14,6 +14,8 @@ add_sourcekit_library(sourcekitdAPI
   VariableTypeArray.cpp
   UIDHandling.cpp)
 
+target_compile_definitions(sourcekitdAPI PRIVATE
+  sourcekitd_EXPORTS)
 target_link_libraries(sourcekitdAPI PRIVATE
   swiftBasic
   SourceKitSupport)

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/CMakeLists.txt
@@ -2,6 +2,8 @@
 add_sourcekit_library(sourcekitdService
   Requests.cpp
 )
+target_compile_definitions(sourcekitdService PRIVATE
+  sourcekitd_EXPORTS)
 target_link_libraries(sourcekitdService PRIVATE
   sourcekitdAPI
   swiftBasic


### PR DESCRIPTION
The API surface for sourcekitd is exported through libAPI and libService.  Use the `sourcekitd_EXPORTS` macro (reflecting the CMake default behaviour of `_EXPORTS` macros) to provide a proper definition of the macro on Windows.  This is not related to MSVC but to PE/COFF which uses this to define the ABI boundary for the symbol.

This is helpful in partially repairing the ARM64 build of sourcekitd.