### PR TITLE
[5.9] MoveOnlyChecker: Look through `convert_function` of nonescaping closures.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -909,7 +909,11 @@ static bool findNonEscapingPartialApplyUses(PartialApplyInst *pai,
         //
         // We have this separately from the other look through sections so that
         // we can make it clearer what we are doing here.
-        isa<PartialApplyInst>(user)) {
+        isa<PartialApplyInst>(user) ||
+        // Likewise with convert_function. Any valid function conversion that
+        // doesn't prevent stack promotion of the closure must retain the
+        // invariants on its transitive uses.
+        isa<ConvertFunctionInst>(user)) {
       for (auto *use : cast<SingleValueInstruction>(user)->getUses())
         worklist.push_back(use);
       continue;

--- a/test/SILOptimizer/moveonly_nonescaping_closures_function_conversion.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures_function_conversion.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// rdar://111060678
+
+protocol P {
+    func doStuff() throws
+}
+
+struct A: ~Copyable {
+    let b = B()
+
+    consuming func f(_ p: some P) throws -> B {
+        // Passing the closure here undergoes a SIL-level function conversion
+        // from the concrete type `() -> Void` to `<T> () throws -> T`.
+        try b.takeClosure {
+            try b.takeP(p)
+        }
+        return B()
+    }
+}
+
+struct B {
+    func takeClosure<T>(_ f: () throws -> T) throws -> T { try f() }
+    func takeP(_: some P) throws {}
+}


### PR DESCRIPTION
Issue: rdar://111060678
• Explanation: Certain uses of nonescaping closures that capture noncopyable values as arguments to a generic function call would cause the compiler to incorrectly raise an error about unknown use of the noncopyable value.
• Scope of Issue: Reject-valid bug.
• Origination: Noncopyable types feature work.
• Risk: Low -- Change only affects new code adopting noncopyable types. The fix is a one-liner filling in an unhandled SIL instruction in the move-only checker.
• Reviewed By: @gottesmm 
• Automated Testing: Swift CI
• Dependencies: None
• Builder Impact: Not applicable
• Directions for QE: None