### PR TITLE
Sink address projections in ArrayPropertyOpt and enable verification to ensure we have no address phis

### DIFF
--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -136,6 +136,8 @@ bool canCloneTerminator(TermInst *termInst);
 class SinkAddressProjections {
   // Projections ordered from last to first in the chain.
   SmallVector<SingleValueInstruction *, 4> oldProjections;
+  // Cloned projections to avoid address phis.
+  SmallVectorImpl<SingleValueInstruction *> *newProjections;
   SmallSetVector<SILValue, 4> inBlockDefs;
 
   // Transient per-projection data for use during cloning.
@@ -143,6 +145,10 @@ class SinkAddressProjections {
   llvm::SmallDenseMap<SILBasicBlock *, Operand *, 4> firstBlockUse;
 
 public:
+  SinkAddressProjections(
+      SmallVectorImpl<SingleValueInstruction *> *newProjections = nullptr)
+      : newProjections(newProjections) {}
+
   /// Check for an address projection chain ending at \p inst. Return true if
   /// the given instruction is successfully analyzed.
   ///
@@ -163,6 +169,7 @@ public:
   ArrayRef<SILValue> getInBlockDefs() const {
     return inBlockDefs.getArrayRef();
   }
+
   /// Clone the chain of projections at their use sites.
   ///
   /// Return true if anything was done.

--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -135,7 +135,7 @@ bool canCloneTerminator(TermInst *termInst);
 /// BasicBlockCloner handles this internally.
 class SinkAddressProjections {
   // Projections ordered from last to first in the chain.
-  SmallVector<SingleValueInstruction *, 4> projections;
+  SmallVector<SingleValueInstruction *, 4> oldProjections;
   SmallSetVector<SILValue, 4> inBlockDefs;
 
   // Transient per-projection data for use during cloning.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1065,24 +1065,6 @@ public:
     return InstNumbers[a] < InstNumbers[b];
   }
 
-  // FIXME: For sanity, address-type phis should be prohibited at all SIL
-  // stages. However, the optimizer currently breaks the invariant in three
-  // places:
-  // 1. Normal Simplify CFG during conditional branch simplification
-  //    (sneaky jump threading).
-  // 2. Simplify CFG via Jump Threading.
-  // 3. Loop Rotation.
-  //
-  // BasicBlockCloner::canCloneInstruction and sinkAddressProjections is
-  // designed to avoid this issue, we just need to make sure all passes use it
-  // correctly.
-  //
-  // Minimally, we must prevent address-type phis as long as access markers are
-  // preserved. A goal is to preserve access markers in OSSA.
-  bool prohibitAddressPhis() {
-    return F.hasOwnership();
-  }
-
   void visitSILPhiArgument(SILPhiArgument *arg) {
     // Verify that the `isPhiArgument` property is sound:
     // - Phi arguments come from branches.
@@ -1106,7 +1088,7 @@ public:
                 "All phi argument inputs must be from branches.");
       }
     }
-    if (arg->isPhi() && prohibitAddressPhis()) {
+    if (arg->isPhi()) {
       // As a property of well-formed SIL, we disallow address-type
       // phis. Supporting them would prevent reliably reasoning about the
       // underlying storage of memory access. This reasoning is important for

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -297,9 +297,12 @@ bool SinkAddressProjections::cloneProjections() {
       auto *useBB = use->getUser()->getParent();
       auto *firstUse = firstBlockUse.lookup(useBB);
       SingleValueInstruction *newProj;
-      if (use == firstUse)
+      if (use == firstUse) {
         newProj = cast<SingleValueInstruction>(oldProj->clone(use->getUser()));
-      else {
+        if (newProjections) {
+          newProjections->push_back(newProj);
+        }
+      } else {
         newProj = cast<SingleValueInstruction>(firstUse->get());
         assert(newProj->getParent() == useBB);
         newProj->moveFront(useBB);

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -223,7 +223,7 @@ void BasicBlockCloner::sinkAddressProjections() {
 //
 // Return true on success, even if projections is empty.
 bool SinkAddressProjections::analyzeAddressProjections(SILInstruction *inst) {
-  projections.clear();
+  oldProjections.clear();
   inBlockDefs.clear();
 
   SILBasicBlock *bb = inst->getParent();
@@ -237,7 +237,7 @@ bool SinkAddressProjections::analyzeAddressProjections(SILInstruction *inst) {
     }
     if (auto *addressProj = dyn_cast<SingleValueInstruction>(def)) {
       if (addressProj->isPure()) {
-        projections.push_back(addressProj);
+        oldProjections.push_back(addressProj);
         return true;
       }
     }
@@ -252,12 +252,12 @@ bool SinkAddressProjections::analyzeAddressProjections(SILInstruction *inst) {
       return false;
   }
   // Recurse upward through address projections.
-  for (unsigned idx = 0; idx < projections.size(); ++idx) {
+  for (unsigned idx = 0; idx < oldProjections.size(); ++idx) {
     // Only one address result/operand can be handled per instruction.
-    if (projections.size() != idx + 1)
+    if (oldProjections.size() != idx + 1)
       return false;
 
-    for (SILValue operandVal : projections[idx]->getOperandValues())
+    for (SILValue operandVal : oldProjections[idx]->getOperandValues())
       if (!pushOperandVal(operandVal))
         return false;
   }
@@ -267,13 +267,13 @@ bool SinkAddressProjections::analyzeAddressProjections(SILInstruction *inst) {
 // Clone the projections gathered by 'analyzeAddressProjections' at
 // their use site outside this block.
 bool SinkAddressProjections::cloneProjections() {
-  if (projections.empty())
+  if (oldProjections.empty())
     return false;
 
-  SILBasicBlock *bb = projections.front()->getParent();
+  SILBasicBlock *bb = oldProjections.front()->getParent();
   // Clone projections in last-to-first order.
-  for (unsigned idx = 0; idx < projections.size(); ++idx) {
-    auto *oldProj = projections[idx];
+  for (unsigned idx = 0; idx < oldProjections.size(); ++idx) {
+    auto *oldProj = oldProjections[idx];
     assert(oldProj->getParent() == bb);
     // Reset transient per-projection sets.
     usesToReplace.clear();

--- a/test/SILOptimizer/array_property_opt.sil
+++ b/test/SILOptimizer/array_property_opt.sil
@@ -1,5 +1,9 @@
 // RUN: %target-sil-opt -parse-serialized-sil -enable-sil-verify-all %s -array-property-opt | %FileCheck %s
 
+// Linux doesn't have the same symbol name for _ArrayBuffer, which is part of
+// the ObjC runtime interop.  Use `_ContiguousArrayBuffer instead.
+// REQUIRES: objc_interop
+
 sil_stage canonical
 
 import Builtin
@@ -257,4 +261,133 @@ bb10: // Exit dominated by bb3
 
 bb11: // Non-exit dominated by bb1
   return %4 : $Builtin.Int1
+}
+
+class Klass {
+  var val: Optional<Int>
+}
+
+struct WrapperStruct {
+  var val: Klass
+}
+
+sil @use_klass : $@convention(thin) (@in_guaranteed Klass) -> ()
+
+sil @test_sink_address_proj : $@convention(thin) (@inout MyArray<MyClass>, @in_guaranteed WrapperStruct) -> () {
+bb0(%0 : $*MyArray<MyClass>, %1 : $*WrapperStruct):
+  %3 = load %0 : $*MyArray<MyClass>
+  br bb1
+
+bb1:
+  %2 = function_ref @arrayPropertyIsNative : $@convention(method) (@owned MyArray<MyClass>) -> Bool
+  retain_value %3 : $MyArray<MyClass>
+  %5 = apply %2(%3) : $@convention(method) (@owned MyArray<MyClass>) -> Bool
+  %ele = struct_element_addr %1 : $*WrapperStruct, #WrapperStruct.val
+  cond_br undef, bb5, bb2
+
+bb2:
+ %6 = integer_literal $Builtin.Int1, -1
+ cond_br %6, bb3, bb4
+
+bb3:
+  br bb1
+
+bb4:
+ br bb6
+
+bb5:
+ %f = function_ref @use_klass : $@convention(thin) (@in_guaranteed Klass) -> ()
+ %a = apply %f(%ele) : $@convention(thin) (@in_guaranteed Klass) -> ()
+ br bb6
+
+bb6:
+ %t = tuple ()
+ return %t : $()
+}
+
+sil [_semantics "array.props.isNativeTypeChecked"] @hoistableIsNativeTypeChecked : $@convention(method) (@guaranteed Array<Klass>) -> Bool
+sil [_semantics "array.get_element"] @getElement : $@convention(method) (Int, Bool, _DependenceToken, @guaranteed Array<Klass>) -> @owned Klass
+sil [_semantics "array.get_count"] @getCount : $@convention(method) (@guaranteed Array<Klass>) -> Int
+
+sil hidden @test_array_prop_opt : $@convention(thin) (@guaranteed Optional<Array<Klass>>) -> Int {
+bb0(%0 : $Optional<Array<Klass>>):
+  %4 = integer_literal $Builtin.Int64, 0
+  switch_enum %0 : $Optional<Array<Klass>>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+
+bb1:
+  br bb12(%4 : $Builtin.Int64)
+
+bb2(%12 : $Array<Klass>):
+  %14 = function_ref @getCount : $@convention(method) (@guaranteed Array<Klass>) -> Int
+  retain_value %0 : $Optional<Array<Klass>>
+  retain_value %0 : $Optional<Array<Klass>>
+  %17 = apply %14(%12) : $@convention(method) (@guaranteed Array<Klass>) -> Int
+  %18 = struct_extract %17 : $Int, #Int._value
+  %19 = builtin "cmp_eq_Int64"(%18 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %19, bb3, bb4
+
+bb3:
+  release_value %0 : $Optional<Array<Klass>>
+  %22 = unchecked_enum_data %0 : $Optional<Array<Klass>>, #Optional.some!enumelt
+  %23 = struct_extract %22 : $Array<Klass>, #Array._buffer
+  %24 = struct_extract %23 : $_ArrayBuffer<Klass>, #_ArrayBuffer._storage
+  %25 = struct_extract %24 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
+  strong_release %25 : $Builtin.BridgeObject
+  br bb12(%4 : $Builtin.Int64)
+
+bb4:
+  %28 = function_ref @hoistableIsNativeTypeChecked : $@convention(method) (@guaranteed Array<Klass>) -> Bool
+  %29 = function_ref @getElement : $@convention(method) (Int, Bool, _DependenceToken, @guaranteed Array<Klass>) -> @owned Klass
+  %30 = integer_literal $Builtin.Int64, 1
+  %31 = integer_literal $Builtin.Int1, -1
+  %32 = struct $_DependenceToken ()
+  br bb5(%4 : $Builtin.Int64)
+
+bb5(%34 : $Builtin.Int64):
+  %35 = struct $Int (%34 : $Builtin.Int64)
+  %36 = apply %28(%12) : $@convention(method) (@guaranteed Array<Klass>) -> Bool
+  %37 = apply %29(%35, %36, %32, %12) : $@convention(method) (Int, Bool, _DependenceToken, @guaranteed Array<Klass>) -> @owned Klass
+  %38 = builtin "sadd_with_overflow_Int64"(%34 : $Builtin.Int64, %30 : $Builtin.Int64, %31 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %39 = tuple_extract %38 : $(Builtin.Int64, Builtin.Int1), 0
+  %40 = tuple_extract %38 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %40 : $Builtin.Int1, "arithmetic overflow"
+  %43 = ref_element_addr %37 : $Klass, #Klass.val
+  %44 = begin_access [read] [dynamic] [no_nested_conflict] %43 : $*Optional<Int>
+  %45 = load %44 : $*Optional<Int>
+  end_access %44 : $*Optional<Int>
+  switch_enum %45 : $Optional<Int>, case #Optional.some!enumelt: bb9, case #Optional.none!enumelt: bb6
+
+bb6:
+  strong_release %37 : $Klass
+  %49 = builtin "cmp_eq_Int64"(%39 : $Builtin.Int64, %18 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %49, bb7, bb8
+
+bb7:
+  release_value %0 : $Optional<Array<Klass>>
+  release_value %0 : $Optional<Array<Klass>>
+  br bb12(%4 : $Builtin.Int64)
+
+bb8:
+  br bb5(%39 : $Builtin.Int64)
+
+bb9:
+  release_value %0 : $Optional<Array<Klass>>
+  %57 = begin_access [read] [dynamic] [no_nested_conflict] %43 : $*Optional<Int>
+  %58 = load %57 : $*Optional<Int>
+  end_access %57 : $*Optional<Int>
+  switch_enum %58 : $Optional<Int>, case #Optional.some!enumelt: bb11, case #Optional.none!enumelt: bb10
+
+bb10:
+  cond_fail %31 : $Builtin.Int1, "Unexpectedly found nil while unwrapping an Optional value"
+  unreachable
+
+bb11(%63 : $Int):
+  release_value %0 : $Optional<Array<Klass>>
+  strong_release %37 : $Klass
+  %66 = struct_extract %63 : $Int, #Int._value
+  br bb12(%66 : $Builtin.Int64)
+
+bb12(%69 : $Builtin.Int64):
+  %70 = struct $Int (%69 : $Builtin.Int64)
+  return %70 : $Int
 }


### PR DESCRIPTION
ArrayPropertyOpt is the last pass left that generates address phis. Sink address projections by cloning to avoid address phis. Turn on verification to ensure there are no address phis in non-OSSA SIL as well.