### PR TITLE
Clarify doc of `Dictionary.init(grouping:by:)`

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -534,9 +534,9 @@ public struct Dictionary<Key: Hashable, Value> {
     self.init(_native: native)
   }
 
-  /// Creates a new dictionary whose keys are the groupings returned by the
-  /// given closure and whose values are arrays of the elements that returned
-  /// each key.
+  /// Creates a new dictionary that groups up elements of `values`,
+  /// whose values are Arrays of grouped elements,
+  /// each keyed by the group key returned by the given closure.
   ///
   /// The arrays in the "values" position of the new dictionary each contain at
   /// least one element, with the elements in the same order as the source


### PR DESCRIPTION
This phrase is incorrect:

> whose keys are the groupings

The groupings are _not_ the keys, the _values_ are. The keys are the results of the closure.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
