### PR TITLE
[5.9][move-only] Ban resilient noncopyable types.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7224,6 +7224,11 @@ ERROR(noimplicitcopy_attr_invalid_in_generic_context,
       none, "'@_noImplicitCopy' attribute cannot be applied to entities in generic contexts", ())
 ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
       "'@_noImplicitCopy' has no effect when applied to a noncopyable type", ())
+ERROR(noncopyable_types_cannot_be_resilient, none,
+      "noncopyable %0 %1 must be @frozen in library evolution mode; "
+      "non-@frozen public and @usableFromInline noncopyable types are not "
+      "supported",
+      (DescriptiveDeclKind, Identifier))
 
 //------------------------------------------------------------------------------
 // MARK: Runtime discoverable attributes (@runtimeMetadata)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -129,6 +129,7 @@ EXPERIMENTAL_FEATURE(NoImplicitCopy, true)
 EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
 EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
+EXPERIMENTAL_FEATURE(MoveOnlyResilientTypes, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3294,6 +3294,12 @@ static bool usesFeatureMoveOnlyEnumDeinits(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureMoveOnlyResilientTypes(Decl *decl) {
+  if (auto *nomDecl = dyn_cast<NominalTypeDecl>(decl))
+    return nomDecl->isResilient() && usesFeatureMoveOnly(decl);
+  return false;
+}
+
 static bool usesFeatureOneWayClosureParameters(Decl *decl) {
   return false;
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2672,7 +2672,7 @@ public:
 
     // If our enum is marked as move only, it cannot be indirect or have any
     // indirect cases.
-    if (ED->getAttrs().hasAttribute<MoveOnlyAttr>()) {
+    if (ED->isMoveOnly()) {
       if (ED->isIndirect())
         ED->diagnose(diag::noncopyable_enums_do_not_support_indirect,
                      ED->getBaseIdentifier());
@@ -2681,6 +2681,13 @@ public:
           elt->diagnose(diag::noncopyable_enums_do_not_support_indirect,
                         ED->getBaseIdentifier());
         }
+      }
+
+      if (!ED->getASTContext().LangOpts.hasFeature(
+              Feature::MoveOnlyResilientTypes) &&
+          ED->isResilient()) {
+        ED->diagnose(diag::noncopyable_types_cannot_be_resilient,
+                     ED->getDescriptiveKind(), ED->getBaseIdentifier());
       }
     }
   }
@@ -2722,6 +2729,13 @@ public:
     diagnoseCopyableTypeContainingMoveOnlyType(SD);
 
     diagnoseIncompatibleProtocolsForMoveOnlyType(SD);
+
+    if (!SD->getASTContext().LangOpts.hasFeature(
+            Feature::MoveOnlyResilientTypes) &&
+        SD->isResilient() && SD->isMoveOnly()) {
+      SD->diagnose(diag::noncopyable_types_cannot_be_resilient,
+                   SD->getDescriptiveKind(), SD->getBaseIdentifier());
+    }
   }
 
   /// Check whether the given properties can be @NSManaged in this class.

--- a/test/IRGen/moveonly_split_module_source_deinit_library_evolution.swift
+++ b/test/IRGen/moveonly_split_module_source_deinit_library_evolution.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(MoveOnlySplit)) -enable-library-evolution %S/Inputs/moveonly_split_module_source_input.swift -emit-module -emit-module-path %t/MoveOnlySplit.swiftmodule -module-name MoveOnlySplit -DTEST_LIBRARY_EVOLUTION
+// RUN: %target-build-swift-dylib(%t/%target-library-name(MoveOnlySplit)) -enable-library-evolution %S/Inputs/moveonly_split_module_source_input.swift -emit-module -emit-module-path %t/MoveOnlySplit.swiftmodule -module-name MoveOnlySplit -DTEST_LIBRARY_EVOLUTION -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %target-codesign %t/%target-library-name(MoveOnlySplit)
 
-// RUN: %target-build-swift %s -lMoveOnlySplit -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-build-swift %s -lMoveOnlySplit -I %t -L %t -o %t/main %target-rpath(%t) -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(MoveOnlySplit) | %FileCheck -check-prefix=CHECK-LIBRARY-EVOLUTION %s
 

--- a/test/ModuleInterface/discard_interface.swift
+++ b/test/ModuleInterface/discard_interface.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -verify
-// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -verify -enable-experimental-feature MoveOnlyResilientTypes
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // This test makes sure that discard and _forget are emitted correctly in the

--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -1,6 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
-// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t
+7// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature MoveOnlyResilientTypes
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // this test makes sure that decls containing a move-only type are guarded by the $MoveOnly feature flag

--- a/test/ModuleInterface/moveonly_user.swift
+++ b/test/ModuleInterface/moveonly_user.swift
@@ -5,8 +5,8 @@
 // RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
 
 // >> now again with library evolution; we expect the same result.
-// RUN: %target-swift-frontend -DSYNTHESIZE_ACCESSORS -enable-library-evolution -emit-module -o %t/Hello.swiftmodule %S/Inputs/moveonly_api.swift
-// RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
+// RUN: %target-swift-frontend -DSYNTHESIZE_ACCESSORS -enable-library-evolution -enable-experimental-feature MoveOnlyResilientTypes -emit-module -o %t/Hello.swiftmodule %S/Inputs/moveonly_api.swift
+// RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyResilientTypes -emit-sil -sil-verify-all -I %t %s > /dev/null
 
 // FIXME: ideally this would also try executing the program rather than just generating SIL
 

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution %s
 
 ////////////////////////
 // MARK: Declarations //
@@ -47,4 +48,61 @@ public struct DeinitTest : ~Copyable {
 // CHECK: } // end sil function '$s26moveonly_library_evolution29callerArgumentSpillingTestArgyyAA13CopyableKlassCF'
 public func callerArgumentSpillingTestArg(_ x: CopyableKlass) {
     borrowVal(x.letStruct.e)
+}
+
+/////////////////////////////////////
+// MARK: UsableFromInline in Class //
+/////////////////////////////////////
+
+public class CopyableKlass2 {
+    public init() {}
+}
+
+@frozen
+public struct E : ~Copyable {
+    var x = CopyableKlass2()
+}
+
+public class UsableFromInlineTestKlass {
+    // Read accessor
+    //
+    // CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution25UsableFromInlineTestKlassC1eAA1EVvr : $@yield_once @convention(method) (@guaranteed UsableFromInlineTestKlass) -> @yields @guaranteed E {
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed
+    // CHECK:   [[FIELD:%.*]] = ref_element_addr [[ARG]]
+    // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD]]
+    // CHECK:   [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[ACCESS]]
+    // CHECK:   [[LOAD:%.*]] = load [copy] [[MARK]]
+    // CHECK:   yield [[LOAD]]
+    // CHECK: } // end sil function '$s26moveonly_library_evolution25UsableFromInlineTestKlassC1eAA1EVvr'
+
+    // Setter
+    // CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution25UsableFromInlineTestKlassC1eAA1EVvs : $@convention(method) (@owned E, @guaranteed UsableFromInlineTestKlass) -> () {
+    // CHECK: bb0([[NEW_VALUE:%.*]] : @owned $E, [[SELF:%.*]] : @guaranteed
+    // CHECK:  [[VALUE:%.*]] = alloc_box ${ let E }
+    // CHECK:  [[PROJECT:%.*]] = project_box [[VALUE]]
+    // CHECK:  store [[NEW_VALUE]] to [init] [[PROJECT]]
+    // CHECK:  [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
+    // CHECK:  [[LOAD:%.*]] = load [copy] [[MARK]]
+    // CHECK:  [[REF:%.*]] = ref_element_addr [[SELF]]
+    // CHECK:  [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF]]
+    // CHECK:  [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+    // CHECK:  assign [[LOAD]] to [[MARK]]
+    // CHECK: } // end sil function '$s26moveonly_library_evolution25UsableFromInlineTestKlassC1eAA1EVvs'
+
+    // Modify
+    // CHECK-LABEL: sil [ossa] @$s26moveonly_library_evolution25UsableFromInlineTestKlassC1eAA1EVvM : $@yield_once @convention(method) (@guaranteed UsableFromInlineTestKlass) -> @yields @inout E {
+    // CHECK: bb0([[ARG:%.*]] : @guaranteed
+    // CHECK:   [[FIELD:%.*]] = ref_element_addr [[ARG]]
+    // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[FIELD]]
+    // CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+    // CHECK:   yield [[MARK]]
+    // CHECK: } // end sil function '$s26moveonly_library_evolution25UsableFromInlineTestKlassC1eAA1EVvM'
+    @usableFromInline
+    var e = E()
+}
+
+
+func useUsableFromInlineTestKlass() {
+    let k = UsableFromInlineTestKlass()
+    k.e = E()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution -enable-experimental-feature MoveOnlyResilientTypes %s
 
 // This test is used to validate that we properly handle library evolution code
 // until we can get all of the normal moveonly_addresschecker_diagnostics test

--- a/test/Sema/discard_module.swift
+++ b/test/Sema/discard_module.swift
@@ -5,7 +5,7 @@
 // RUN: %target-typecheck-verify-swift -I %t
 
 // >> now again with library evolution; we expect the same result.
-// RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t/SorryModule.swiftmodule %S/Inputs/discard_module_defining.swift %S/Inputs/discard_module_adjacent.swift
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t/SorryModule.swiftmodule %S/Inputs/discard_module_defining.swift %S/Inputs/discard_module_adjacent.swift -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %target-typecheck-verify-swift -I %t
 
 // "Sorry" is meaningless

--- a/test/Sema/moveonly_resilient_type.swift
+++ b/test/Sema/moveonly_resilient_type.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -typecheck %s -enable-library-evolution -verify
+
+public struct ResilientStruct : ~Copyable { // expected-error {{noncopyable struct 'ResilientStruct' must be @frozen in library evolution mode; non-@frozen public and @usableFromInline noncopyable types are not supported}}
+}
+
+@frozen
+public struct FrozenStruct : ~Copyable {
+    public init() {}
+}
+
+@usableFromInline
+struct UsableFromInlineStruct : ~Copyable { // expected-error {{noncopyable struct 'UsableFromInlineStruct' must be @frozen in library evolution mode; non-@frozen public and @usableFromInline noncopyable types are not supported}}
+}
+
+public enum ResilientEnum : ~Copyable { // expected-error {{noncopyable enum 'ResilientEnum' must be @frozen in library evolution mode; non-@frozen public and @usableFromInline noncopyable types are not supported}}
+}
+
+@frozen
+public enum FrozenEnum : ~Copyable {
+}
+
+@usableFromInline
+enum UsableFromInlineEnum : ~Copyable { // expected-error {{noncopyable enum 'UsableFromInlineEnum' must be @frozen in library evolution mode; non-@frozen public and @usableFromInline noncopyable types are not supported}}
+}
+
+public class C {
+    @usableFromInline
+    var x: FrozenStruct
+
+    public init() {}
+
+    @inlinable
+    convenience public init(delegating: ()) {
+        self.init()
+        x = FrozenStruct()
+    }
+}


### PR DESCRIPTION
• Description: [move-only] Ban resilient noncopyable types
• Risk: This is very low risk since it just changes the type checker to ban resilient types from being marked as noncopyable. It just restricts the set of valid programs.
• Original PR: https://github.com/apple/swift/pull/66835
• Reviewed By: @jckarter
• Testing: Added regression tests
• Resolves: rdar://111125845

----

One can still in resilient frameworks have noncopyable frozen types.

This means that one cannot make a noncopyable:

1. Full resilient public type.
2. @usable from inline type.

NOTE: One can still use a frozen noncopyable type as a usableFromInline class field. I validated in the attached tests that we get the correct code generation.

I also eliminated a small bug in TypeCheckDeclPrimary where we weren't using a requestified attr check and instead were checking directly.

rdar://111125845
(cherry picked from commit 4a063d2e65efedd7d9826e5c49580d210e2dfebf)

Conflicts:
	test/SILGen/moveonly_library_evolution.swift
	test/SILOptimizer/moveonly_deinit_devirtualization_library_evolution.sil
