### PR TITLE
[5.9] Add Primary AssocTypes to Opaque GenericSignature

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -589,6 +589,12 @@ Type TypeBase::typeEraseOpenedArchetypesWithRoot(
             Type interfaceType = opaque->getInterfaceType();
             auto genericSig =
                 opaque->getDecl()->getOpaqueInterfaceGenericSignature();
+
+            SmallVector<GenericTypeParamType *, 2> params;
+            SmallVector<Requirement, 2> newRequirements;
+
+            newRequirements.append(sig.getRequirements().begin(), sig.getRequirements().end());
+            genericSig = buildGenericSignature(getASTContext(), genericSig, params, newRequirements);
             return genericSig->getNonDependentUpperBounds(interfaceType);
           }
         }

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -369,3 +369,48 @@ func testPrimaryAssocReturn(p: any P4<Int>) {
 func testPrimaryAssocCollection(p: any P4<Float>) {
   let _: any Collection<Float> = p.returnAssocTypeCollection()
 }
+
+protocol P5<X> {
+  associatedtype X = Void
+}
+
+struct K<T>: P5 {
+  typealias X = T
+}
+
+extension P5 {
+  func foo() -> some P5<X>{
+    K<X>()
+  }
+  func bar(_ handler: @escaping (X) -> Void) -> some P5<X> {
+    K<X>()
+  }
+}
+
+func test(_ p: any P5<String>) -> any P5<String> {
+  p.bar { _ in }
+}
+
+func testFoo<T,U>(_ p: any P5<Result<U, Error>>) -> any P5<T> {
+  p.foo() //expected-error {{cannot convert return expression of type 'T' to return type 'Result<U, any Error>'}} {{10-10= as! Result<U, any Error>}}
+}
+
+func testBar<U>(_ p: any P5<Result<U, Error>>) -> any P5 {
+  p.bar { _ in }
+}
+
+enum Node<T> {
+  case e(any P5)
+  case f(any P5<Result<T, Error>>)
+}
+
+struct S<T, U> {
+  func foo(_ elt: Node<U>) -> Node<T>? {
+    switch elt {
+    case let .e(p):
+      return .e(p)
+    case let .f(p):
+      return .e(p.bar { _ in })
+    }
+  }
+}


### PR DESCRIPTION
* **Explanation**: Now that Primary Associated Types are preserved during type erasure, they also need to be preserved for opaque types. This prevents a crash in cases where we coerce an existential type to an opaque type.. 
* **Scope**: Narrow; effects existential parameterized protocol type coercion to opaque types
* **Risk**: Low, this adds support for parameterized protocol type to generic signature
* **Reviewers**: 
* **Issue**: rdar://110262754
* **Original pull request**: https://github.com/apple/swift/pull/66829