### PR TITLE
[5.9] Try using withContiguousStorageIfAvailable in RangeReplaceableCollection.append(contentsOf:) before falling back to a slow element-by-element loop

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -459,8 +459,6 @@ extension RangeReplaceableCollection {
     }
       
     if done == nil {
-      let approximateCapacity = self.count + newElements.underestimatedCount
-      self.reserveCapacity(approximateCapacity)
       for element in newElements {
         append(element)
       }

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -455,7 +455,6 @@ extension RangeReplaceableCollection {
     where S.Element == Element {
     
     let done:Void? = newElements.withContiguousStorageIfAvailable {
-      _onFastPath()
       replaceSubrange(endIndex..<endIndex, with: $0)
     }
       

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -453,11 +453,18 @@ extension RangeReplaceableCollection {
   @inlinable
   public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
-
-    let approximateCapacity = self.count + newElements.underestimatedCount
-    self.reserveCapacity(approximateCapacity)
-    for element in newElements {
-      append(element)
+    
+    let done:Void? = newElements.withContiguousStorageIfAvailable {
+      _onFastPath()
+      replaceSubrange(endIndex..<endIndex, with: $0)
+    }
+      
+    if done == nil {
+      let approximateCapacity = self.count + newElements.underestimatedCount
+      self.reserveCapacity(approximateCapacity)
+      for element in newElements {
+        append(element)
+      }
     }
   }
 


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/65778 and https://github.com/apple/swift/pull/65927

Explanation: The default implementation of append(contentsOf:) on RangeReplaceableCollection has several serious performance issues, which this fixes
Radars: rdar://111121942, rdar://111121976
Scope: Important performance improvement
Risk: Relatively low risk. The change is simple and well understood, and our core types override this code path anyway.
Testing: This has been on main since mid-May, and has dedicated test coverage in the stdlib test suite
Reviewed By: Karoy Lorentey 