### PR TITLE
[Distributed] Don't diagnose declared dist member properties when importing module

### DIFF
--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -657,9 +657,13 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
 void swift::checkDistributedActorProperties(const NominalTypeDecl *decl) {
   auto &C = decl->getASTContext();
 
-  auto sourceFile = decl->getDeclContext()->getParentSourceFile();
-  if (sourceFile && sourceFile->Kind == SourceFileKind::Interface) {
-    // Don't diagnose properties in swiftinterfaces.
+  if (auto sourceFile = decl->getDeclContext()->getParentSourceFile()) {
+    if (sourceFile->Kind == SourceFileKind::Interface) {
+      // Don't diagnose properties in swiftinterfaces.
+      return;
+    }
+  } else {
+    // Don't diagnose when checking without source file (e.g. from module, importer etc).
     return;
   }
 


### PR DESCRIPTION
We previously fixed that this method should not diagnose when checking in `SourceFileKind::Interface` mode, but we also should skip when there is no source file at all. 

This fixes compilation of the distributed cluster in 5.9, since the behavior of typechecking seems to have changed slightly and we didn't enter this function in such situations previously.

Resolves: rdar://111080052
