### PR TITLE
Conditional conformances for variadic generic types [5.9]

### DIFF
--- a/include/swift/ABI/GenericContext.h
+++ b/include/swift/ABI/GenericContext.h
@@ -183,10 +183,11 @@ public:
     return offsetof(typename std::remove_reference<decltype(*this)>::type, Param);
   }
 
-  /// Retrieve the right-hand type for a SameType or BaseClass requirement.
+  /// Retrieve the right-hand type for a SameType, BaseClass or SameShape requirement.
   llvm::StringRef getMangledTypeName() const {
     assert(getKind() == GenericRequirementKind::SameType ||
-           getKind() == GenericRequirementKind::BaseClass);
+           getKind() == GenericRequirementKind::BaseClass ||
+           getKind() == GenericRequirementKind::SameShape);
     return swift::Demangle::makeSymbolicMangledNameStringRef(Type.get());
   }
 

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2596,6 +2596,7 @@ struct TargetProtocolConformanceDescriptor final
              TargetProtocolConformanceDescriptor<Runtime>,
              TargetRelativeContextPointer<Runtime>,
              TargetGenericRequirementDescriptor<Runtime>,
+             GenericPackShapeDescriptor,
              TargetResilientWitnessesHeader<Runtime>,
              TargetResilientWitness<Runtime>,
              TargetGenericWitnessTable<Runtime>> {
@@ -2604,6 +2605,7 @@ struct TargetProtocolConformanceDescriptor final
                              TargetProtocolConformanceDescriptor<Runtime>,
                              TargetRelativeContextPointer<Runtime>,
                              TargetGenericRequirementDescriptor<Runtime>,
+                             GenericPackShapeDescriptor,
                              TargetResilientWitnessesHeader<Runtime>,
                              TargetResilientWitness<Runtime>,
                              TargetGenericWitnessTable<Runtime>>;
@@ -2695,10 +2697,17 @@ public:
 
   /// Retrieve the conditional requirements that must also be
   /// satisfied
-  llvm::ArrayRef<GenericRequirementDescriptor>
+  llvm::ArrayRef<TargetGenericRequirementDescriptor<Runtime>>
   getConditionalRequirements() const {
-    return {this->template getTrailingObjects<GenericRequirementDescriptor>(),
+    return {this->template getTrailingObjects<TargetGenericRequirementDescriptor<Runtime>>(),
             Flags.getNumConditionalRequirements()};
+  }
+
+  /// Retrieve the pack shape descriptors for the conditional pack requirements.
+  llvm::ArrayRef<GenericPackShapeDescriptor>
+  getConditionalPackShapeDescriptors() const {
+    return {this->template getTrailingObjects<GenericPackShapeDescriptor>(),
+            Flags.getNumConditionalPackShapeDescriptors()};
   }
 
   /// Get the directly-referenced witness table pattern, which may also
@@ -2757,6 +2766,10 @@ private:
 
   size_t numTrailingObjects(OverloadToken<GenericRequirementDescriptor>) const {
     return Flags.getNumConditionalRequirements();
+  }
+
+  size_t numTrailingObjects(OverloadToken<GenericPackShapeDescriptor>) const {
+    return Flags.getNumConditionalPackShapeDescriptors();
   }
 
   size_t numTrailingObjects(OverloadToken<ResilientWitnessesHeader>) const {

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -662,17 +662,20 @@ private:
   enum : int_type {
     UnusedLowBits = 0x07,      // historical conformance kind
 
-    TypeMetadataKindMask = 0x7 << 3, // 8 type reference kinds
+    TypeMetadataKindMask = 0x7u << 3, // 8 type reference kinds
     TypeMetadataKindShift = 3,
 
-    IsRetroactiveMask = 0x01 << 6,
-    IsSynthesizedNonUniqueMask = 0x01 << 7,
+    IsRetroactiveMask = 0x01u << 6,
+    IsSynthesizedNonUniqueMask = 0x01u << 7,
 
-    NumConditionalRequirementsMask = 0xFF << 8,
+    NumConditionalRequirementsMask = 0xFFu << 8,
     NumConditionalRequirementsShift = 8,
 
-    HasResilientWitnessesMask = 0x01 << 16,
-    HasGenericWitnessTableMask = 0x01 << 17,
+    HasResilientWitnessesMask = 0x01u << 16,
+    HasGenericWitnessTableMask = 0x01u << 17,
+
+    NumConditionalPackDescriptorsMask = 0xFFu << 24,
+    NumConditionalPackDescriptorsShift = 24
   };
 
   int_type Value;
@@ -700,6 +703,11 @@ public:
   ConformanceFlags withNumConditionalRequirements(unsigned n) const {
     return ConformanceFlags((Value & ~NumConditionalRequirementsMask)
                             | (n << NumConditionalRequirementsShift));
+  }
+
+  ConformanceFlags withNumConditionalPackDescriptors(unsigned n) const {
+    return ConformanceFlags((Value & ~NumConditionalPackDescriptorsMask)
+                            | (n << NumConditionalPackDescriptorsShift));
   }
 
   ConformanceFlags withHasResilientWitnesses(bool hasResilientWitnesses) const {
@@ -745,6 +753,12 @@ public:
   unsigned getNumConditionalRequirements() const {
     return (Value & NumConditionalRequirementsMask)
               >> NumConditionalRequirementsShift;
+  }
+
+  /// Retrieve the # of conditional pack shape descriptors.
+  unsigned getNumConditionalPackShapeDescriptors() const {
+    return (Value & NumConditionalPackDescriptorsMask)
+              >> NumConditionalPackDescriptorsShift;
   }
 
   /// Whether this conformance has any resilient witnesses.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -566,21 +566,7 @@ namespace {
       B.addInt(IGM.Int16Ty, shapes.size());
 
       // Emit each GenericPackShapeDescriptor collected previously.
-      for (const auto &packArg : packArgs) {
-        // Kind
-        B.addInt(IGM.Int16Ty, uint16_t(packArg.Kind));
-
-        // Index
-        B.addInt(IGM.Int16Ty, packArg.Index);
-
-        // ShapeClass
-        auto found = std::find(shapes.begin(), shapes.end(), packArg.ReducedShape);
-        assert(found != shapes.end());
-        B.addInt(IGM.Int16Ty, found - shapes.begin());
-
-        // Unused
-        B.addInt(IGM.Int16Ty, 0);
-      }
+      irgen::addGenericPackShapeDescriptors(IGM, B, shapes, packArgs);
     }
 
     uint8_t getVersion() {
@@ -6556,6 +6542,27 @@ GenericArgumentMetadata irgen::addGenericRequirements(
   }
 
   return metadata;
+}
+
+void irgen::addGenericPackShapeDescriptors(IRGenModule &IGM,
+                                           ConstantStructBuilder &B,
+                                           ArrayRef<CanType> shapes,
+                                           ArrayRef<GenericPackArgument> packArgs) {
+  for (const auto &packArg : packArgs) {
+    // Kind
+    B.addInt(IGM.Int16Ty, uint16_t(packArg.Kind));
+
+    // Index
+    B.addInt(IGM.Int16Ty, packArg.Index);
+
+    // ShapeClass
+    auto found = std::find(shapes.begin(), shapes.end(), packArg.ReducedShape);
+    assert(found != shapes.end());
+    B.addInt(IGM.Int16Ty, found - shapes.begin());
+
+    // Unused
+    B.addInt(IGM.Int16Ty, 0);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -239,6 +239,15 @@ namespace irgen {
                                           GenericSignature sig,
                                           ArrayRef<Requirement> requirements);
 
+  /// Add generic pack shape descriptors to the given constant struct builder.
+  ///
+  /// These appear in generic type metadata, and conformance descriptors with
+  /// conditional pack requirements.
+  void addGenericPackShapeDescriptors(IRGenModule &IGM,
+                                      ConstantStructBuilder &B,
+                                      ArrayRef<CanType> shapes,
+                                      ArrayRef<GenericPackArgument> packArgs);
+
   llvm::GlobalValue *emitAsyncFunctionPointer(IRGenModule &IGM,
                                               llvm::Function *function,
                                               LinkEntity entity,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5678,6 +5678,7 @@ instantiateWitnessTable(const Metadata *Type,
                         void **fullTable) {
   auto protocol = conformance->getProtocol();
   auto genericTable = conformance->getGenericWitnessTable();
+  auto *genericArgs = Type->getGenericArgs();
 
   // The number of witnesses provided by the table pattern.
   size_t numPatternWitnesses = genericTable->WitnessTableSizeInWords;
@@ -5719,20 +5720,38 @@ instantiateWitnessTable(const Metadata *Type,
   // requirements into the private area.
   {
     unsigned currentInstantiationArg = 0;
-    auto copyNextInstantiationArg = [&] {
-      assert(currentInstantiationArg < privateSizeInWords);
-      table[-1 - (int)currentInstantiationArg] =
-        const_cast<void *>(instantiationArgs[currentInstantiationArg]);
-      ++currentInstantiationArg;
-    };
+
+    llvm::ArrayRef<GenericPackShapeDescriptor> packShapeDescriptors =
+        conformance->getConditionalPackShapeDescriptors();
+    unsigned packIdx = 0;
 
     for (const auto &conditionalRequirement
           : conformance->getConditionalRequirements()) {
-      if (conditionalRequirement.Flags.hasKeyArgument())
-        copyNextInstantiationArg();
+      if (!conditionalRequirement.Flags.hasKeyArgument())
+        continue;
 
-      assert(!conditionalRequirement.Flags.isPackRequirement() &&
-             "Packs not supported here yet");
+      assert(currentInstantiationArg < privateSizeInWords);
+
+      auto *instantiationArg = instantiationArgs[currentInstantiationArg];
+
+      // Heap-allocate witness tables for conditional pack conformance requirements.
+      if (conditionalRequirement.Flags.isPackRequirement()) {
+        auto packShapeDescriptor = packShapeDescriptors[packIdx];
+        assert(packShapeDescriptor.Kind == GenericPackKind::WitnessTable);
+        assert(packShapeDescriptor.Index == currentInstantiationArg);
+        size_t count = reinterpret_cast<const size_t>(
+            genericArgs[packShapeDescriptor.ShapeClass]);
+
+        auto *wtable = reinterpret_cast<const WitnessTable * const*>(instantiationArg);
+        wtable = swift_allocateWitnessTablePack(wtable, count);
+
+        instantiationArg = wtable;
+        ++packIdx;
+      }
+
+      table[-1 - (int)currentInstantiationArg] = const_cast<void *>(instantiationArg);
+
+      ++currentInstantiationArg;
     }
   }
 
@@ -6047,6 +6066,9 @@ instantiateRelativeWitnessTable(const Metadata *Type,
           : conformance->getConditionalRequirements()) {
       if (conditionalRequirement.Flags.hasKeyArgument())
         copyNextInstantiationArg();
+
+      assert(!conditionalRequirement.Flags.isPackRequirement() &&
+             "Not supported yet");
     }
   }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2850,16 +2850,20 @@ void SubstGenericParametersFromMetadata::setup() const {
     assert(baseContext);
     DemanglerForRuntimeTypeResolution<StackAllocatedDemangler<2048>> demangler;
     numKeyGenericParameters = buildDescriptorPath(baseContext, demangler);
+    if (auto *genericCtx = baseContext->getGenericContext())
+      numShapeClasses = genericCtx->getGenericPackShapeHeader().NumShapeClasses;
     return;
   }
   case SourceKind::Environment: {
     assert(environment);
     numKeyGenericParameters = buildEnvironmentPath(environment);
+    // FIXME: Variadic generics
     return;
   }
   case SourceKind::Shape: {
     assert(shape);
     numKeyGenericParameters = buildShapePath(shape);
+    // FIXME: Variadic generics
     return;
   }
   }
@@ -2883,7 +2887,7 @@ SubstGenericParametersFromMetadata::getMetadata(
     return MetadataOrPack();
 
   // Compute the flat index.
-  unsigned flatIndex = pathElement.numKeyGenericParamsInParent;
+  unsigned flatIndex = pathElement.numKeyGenericParamsInParent + numShapeClasses;
   if (pathElement.hasNonKeyGenericParams > 0) {
     // We have non-key generic parameters at this level, so the index needs to
     // be checked more carefully.
@@ -2912,7 +2916,8 @@ SubstGenericParametersFromMetadata::getWitnessTable(const Metadata *type,
   // On first access, compute the descriptor path.
   setup();
 
-  return (const WitnessTable *)genericArgs[index + numKeyGenericParameters];
+  return (const WitnessTable *)genericArgs[
+      index + numKeyGenericParameters + numShapeClasses];
 }
 
 MetadataOrPack SubstGenericParametersFromWrittenArgs::getMetadata(

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -395,6 +395,9 @@ public:
     /// The number of key generic parameters.
     mutable unsigned numKeyGenericParameters = 0;
 
+    /// The number of pack shape classes.
+    mutable unsigned numShapeClasses = 0;
+
     /// Builds the descriptor path.
     ///
     /// \returns a pair containing the number of key generic parameters in

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1539,7 +1539,7 @@ checkGenericPackRequirement(const GenericRequirementDescriptor &req,
 
   case GenericRequirementKind::SameShape: {
     auto result = swift::getTypePackByMangledName(
-        req.getParam(), extraArguments.data(),
+        req.getMangledTypeName(), extraArguments.data(),
         substGenericParam, substWitnessTable);
     if (result.getError())
       return *result.getError();

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -332,8 +332,7 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
     auto error = _checkGenericRequirements(
         getConditionalRequirements(), conditionalArgs,
         [&substitutions](unsigned depth, unsigned index) {
-          // FIXME: Variadic generics
-          return substitutions.getMetadata(depth, index).getMetadataOrNull();
+          return substitutions.getMetadata(depth, index).Ptr;
         },
         [&substitutions](const Metadata *type, unsigned index) {
           return substitutions.getWitnessTable(type, index);

--- a/test/IRGen/variadic_generic_conditional_conformances.swift
+++ b/test/IRGen/variadic_generic_conditional_conformances.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking | %FileCheck %s
+
+protocol P {
+  static func foobar()
+}
+
+struct G<each T> {}
+
+extension G: P where repeat each T: P {
+  static func foobar() {}
+}
+
+// CHECK-LABEL: define internal swiftcc void @"$s41variadic_generic_conditional_conformances1GVyxxQp_QPGAA1PA2aEP6foobaryyFZTW"(%swift.type* swiftself %0, %swift.type* %Self, i8** %SelfWitnessTable)
+

--- a/test/Interpreter/variadic_generic_conditional_conformances.swift
+++ b/test/Interpreter/variadic_generic_conditional_conformances.swift
@@ -1,0 +1,48 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+var conformances = TestSuite("VariadicGenericConformances")
+
+protocol P {
+  static func foobar() -> [String]
+}
+
+struct G<each T> {}
+
+extension G: P where repeat each T: P {
+  static func foobar() -> [String] {
+    var result: [String] = []
+    repeat result += (each T).foobar()
+    return result
+  }
+}
+
+extension Int: P {
+  static func foobar() -> [String] {
+    return ["Int"]
+  }
+}
+
+extension String: P {
+  static func foobar() -> [String] {
+    return ["String"]
+  }
+}
+
+func callFoobar<T: P>(_: T) -> [String] {
+  return T.foobar()
+}
+
+conformances.test("conditional") {
+  expectEqual([], callFoobar(G< >()))
+  expectEqual(["Int"], callFoobar(G<Int>()))
+  expectEqual(["Int", "String"], callFoobar(G<Int, String>()))
+}
+
+runAllTests()

--- a/test/Interpreter/variadic_generic_conditional_conformances.swift
+++ b/test/Interpreter/variadic_generic_conditional_conformances.swift
@@ -59,4 +59,23 @@ conformances.test("cast") {
   expectEqual(false, cast(G<Bool, Int>(), to: (any P).self))
 }
 
+struct Outer<each U> {
+  struct Inner<each V> {}
+}
+
+extension Outer.Inner: P where repeat (repeat (each U, each V)): Any {
+  static func foobar() -> [String] {
+    return ["hello"]
+  }
+}
+
+conformances.test("shape") {
+  expectEqual(true, cast(Outer< >.Inner< >(), to: (any P).self))
+  expectEqual(true, cast(Outer<Int>.Inner<Bool>(), to: (any P).self))
+  expectEqual(true, cast(Outer<Int, String>.Inner<Bool, Float>(), to: (any P).self))
+
+  expectEqual(false, cast(Outer<Bool>.Inner< >(), to: (any P).self))
+  expectEqual(false, cast(Outer<Int, Bool>.Inner<String, Float, Character>(), to: (any P).self))
+}
+
 runAllTests()

--- a/test/Interpreter/variadic_generic_conditional_conformances.swift
+++ b/test/Interpreter/variadic_generic_conditional_conformances.swift
@@ -45,4 +45,18 @@ conformances.test("conditional") {
   expectEqual(["Int", "String"], callFoobar(G<Int, String>()))
 }
 
+func cast<T, U>(_ value: T, to: U.Type) -> Bool {
+  return value is U
+}
+
+conformances.test("cast") {
+  expectEqual(true, cast(G< >(), to: (any P).self))
+  expectEqual(true, cast(G<Int>(), to: (any P).self))
+  expectEqual(true, cast(G<Int, String>(), to: (any P).self))
+
+  expectEqual(false, cast(G<Bool>(), to: (any P).self))
+  expectEqual(false, cast(G<Int, Bool>(), to: (any P).self))
+  expectEqual(false, cast(G<Bool, Int>(), to: (any P).self))
+}
+
 runAllTests()

--- a/test/Interpreter/variadic_generic_conformances.swift
+++ b/test/Interpreter/variadic_generic_conformances.swift
@@ -7,7 +7,7 @@
 
 import StdlibUnittest
 
-var tuples = TestSuite("VariadicGenericConformances")
+var conformances = TestSuite("VariadicGenericConformances")
 
 protocol TypeMaker {
   func makeType() -> Any.Type
@@ -29,7 +29,7 @@ struct ElementTupleMaker<each T: Sequence> : TypeMaker {
   }
 }
 
-tuples.test("makeTuple1") {
+conformances.test("makeTuple1") {
   expectEqual("()", _typeName(makeTypeIndirectly(TupleMaker< >())))
 
   // FIXME: This should unwrap the one-element tuple!
@@ -38,7 +38,7 @@ tuples.test("makeTuple1") {
   expectEqual("(Swift.Int, Swift.Bool)", _typeName(makeTypeIndirectly(TupleMaker<Int, Bool>())))
 }
 
-tuples.test("makeTuple2") {
+conformances.test("makeTuple2") {
   expectEqual("()", _typeName(makeTypeIndirectly(ElementTupleMaker< >())))
 
   // FIXME: This should unwrap the one-element tuple!
@@ -88,7 +88,7 @@ func testPackRequirements2<T: HasPackRequirements, each U: Q>(_ t: T, _ u: repea
   return t.doStuff2(repeat each u)
 }
 
-tuples.test("packRequirements") {
+conformances.test("packRequirements") {
   expectEqual(([1], ["hi"], [false]), testPackRequirements1(ConformsPackRequirements(), 1, "hi", false))
   expectEqual(([1], ["hi"], [false]), testPackRequirements2(ConformsPackRequirements(), 1, "hi", false))
 }


### PR DESCRIPTION
* Description: The witness table for a conditional conformance stores witness tables for the conditional conformance requirements, if there are any. If the subject type of the conditional conformance requirement is a pack, we need to store a witness table pack. Plumb this through, which requires IRGen emitting where the packs are in the private area, and the runtime heap-allocating the witness table packs. Also fix a bug with dynamic checking of same-shape requirements, which would previously always succeed.

* Risk: Low, only changes variadic-related code.

* Reviewed by: @hborla