### PR TITLE
Allow using structs with trivial initializers in globals that require static initialization (e.g. @_section attribute)

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -12,7 +12,8 @@
 
 import SIL
 
-/// Performs mandatory optimizations for performance-annotated functions.
+/// Performs mandatory optimizations for performance-annotated functions, and global
+/// variable initializers that are required to be statically initialized.
 ///
 /// Optimizations include:
 /// * de-virtualization
@@ -22,7 +23,7 @@ import SIL
 /// * dead alloc elimination
 /// * instruction simplification
 ///
-/// The pass starts with performance-annotated functions and transitively handles
+/// The pass starts with performance-annotated functions / globals and transitively handles
 /// called functions.
 ///
 let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-optimizations") {
@@ -30,6 +31,7 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
 
   var worklist = FunctionWorklist()
   worklist.addAllPerformanceAnnotatedFunctions(of: moduleContext)
+  worklist.addAllAnnotatedGlobalInitOnceFunctions(of: moduleContext)
 
   optimizeFunctionsTopDown(using: &worklist, moduleContext)
 }
@@ -48,33 +50,37 @@ private func optimizeFunctionsTopDown(using worklist: inout FunctionWorklist,
 }
 
 private func optimize(function: Function, _ context: FunctionPassContext) {
-  runSimplification(on: function, context, preserveDebugInfo: true) { instruction, simplifyCtxt in
-    if let i = instruction as? OnoneSimplifyable {
-      i.simplify(simplifyCtxt)
-      if instruction.isDeleted {
-        return
+  var alreadyInlinedFunctions: [SmallProjectionPath:Set<Function>] = [:]
+  
+  var changed = true
+  while changed {
+    changed = runSimplification(on: function, context, preserveDebugInfo: true) { instruction, simplifyCtxt in
+      if let i = instruction as? OnoneSimplifyable {
+        i.simplify(simplifyCtxt)
+        if instruction.isDeleted {
+          return
+        }
+      }
+      switch instruction {
+      case let apply as FullApplySite:
+        inlineAndDevirtualize(apply: apply, alreadyInlinedFunctions: &alreadyInlinedFunctions, context, simplifyCtxt)
+      default:
+        break
       }
     }
-    switch instruction {
-    case let apply as FullApplySite:
-      inlineAndDevirtualize(apply: apply, context, simplifyCtxt)
-    default:
-      break
-    }
-  }
 
-  _ = context.specializeApplies(in: function, isMandatory: true)
+    _ = context.specializeApplies(in: function, isMandatory: true)
 
-  removeUnusedMetatypeInstructions(in: function, context)
+    removeUnusedMetatypeInstructions(in: function, context)
 
-  // If this is a just specialized function, try to optimize copy_addr, etc.
-  if context.optimizeMemoryAccesses(in: function) {
+    // If this is a just specialized function, try to optimize copy_addr, etc.
+    changed = context.optimizeMemoryAccesses(in: function) || changed
     _ = context.eliminateDeadAllocations(in: function)
   }
 }
 
-private func inlineAndDevirtualize(apply: FullApplySite, _ context: FunctionPassContext, _ simplifyCtxt: SimplifyContext) {
-
+private func inlineAndDevirtualize(apply: FullApplySite, alreadyInlinedFunctions: inout [SmallProjectionPath:Set<Function>],
+                                   _ context: FunctionPassContext, _ simplifyCtxt: SimplifyContext) {
   if simplifyCtxt.tryDevirtualize(apply: apply, isMandatory: true) != nil {
     return
   }
@@ -88,7 +94,7 @@ private func inlineAndDevirtualize(apply: FullApplySite, _ context: FunctionPass
     return
   }
 
-  if shouldInline(apply: apply, callee: callee) {
+  if shouldInline(apply: apply, callee: callee, alreadyInlinedFunctions: &alreadyInlinedFunctions) {
     simplifyCtxt.inlineFunction(apply: apply, mandatoryInline: true)
 
     // In OSSA `partial_apply [on_stack]`s are represented as owned values rather than stack locations.
@@ -110,7 +116,7 @@ private func removeUnusedMetatypeInstructions(in function: Function, _ context: 
   }
 }
 
-private func shouldInline(apply: FullApplySite, callee: Function) -> Bool {
+private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlinedFunctions: inout [SmallProjectionPath:Set<Function>]) -> Bool {
   if callee.isTransparent {
     return true
   }
@@ -123,7 +129,102 @@ private func shouldInline(apply: FullApplySite, callee: Function) -> Bool {
     // Force inlining them in global initializers so that it's possible to statically initialize the global.
     return true
   }
+  if apply.parentFunction.isGlobalInitOnceFunction,
+      let global = apply.parentFunction.getInitializedGlobal(),
+      global.mustBeInitializedStatically,
+      let applyInst = apply as? ApplyInst,
+      let projectionPath = applyInst.isStored(to: global),
+      !alreadyInlinedFunctions[projectionPath, default: Set()].contains(callee) {
+    alreadyInlinedFunctions[projectionPath, default: Set()].insert(callee)
+    return true
+  }
   return false
+}
+
+private extension Value {
+  /// Analyzes the def-use chain of an apply instruction, and looks for a single chain that leads to a store instruction
+  /// that initializes a part of a global variable or the entire variable:
+  ///
+  /// Example:
+  ///   %g = global_addr @global
+  ///   ...
+  ///   %f = function_ref @func
+  ///   %apply = apply %f(...)
+  ///   store %apply to %g   <--- is a store to the global trivially (the apply result is immediately going into a store)
+  ///
+  /// Example:
+  ///   %apply = apply %f(...)
+  ///   %apply2 = apply %f2(%apply)
+  ///   store %apply2 to %g   <--- is a store to the global (the apply result has a single chain into the store)
+  ///
+  /// Example:
+  ///   %a = apply %f(...)
+  ///   %s = struct $MyStruct (%a, %b)
+  ///   store %s to %g   <--- is a partial store to the global (returned SmallProjectionPath is MyStruct.s0)
+  ///
+  /// Example:
+  ///   %a = apply %f(...)
+  ///   %as = struct $AStruct (%other, %a)
+  ///   %bs = struct $BStruct (%as, %bother)
+  ///   store %bs to %g   <--- is a partial store to the global (returned SmallProjectionPath is MyStruct.s0.s1)
+  ///
+  /// Returns nil if we cannot find a singular def-use use chain (e.g. because a value has more than one user)
+  /// leading to a store to the specified global variable.
+  func isStored(to global: GlobalVariable) -> SmallProjectionPath? {
+    var singleUseValue: any Value = self
+    var path = SmallProjectionPath()
+    while true {
+      guard let use = singleUseValue.uses.singleUse else {
+        return nil
+      }
+      
+      switch use.instruction {
+      case is StructInst:
+        path = path.push(.structField, index: use.index)
+        break
+      case is TupleInst:
+        path = path.push(.tupleField, index: use.index)
+        break
+      case is EnumInst:
+        path = path.push(.enumCase, index: use.index)
+        break
+      case let si as StoreInst:
+        guard let storeDestination = si.destination as? GlobalAddrInst else {
+          return nil
+        }
+
+        guard storeDestination.global == global else {
+          return nil
+        }
+        
+        return path
+      default:
+        break
+      }
+
+      guard let nextInstruction = use.instruction as? SingleValueInstruction else {
+        return nil
+      }
+
+      singleUseValue = nextInstruction
+    }
+  }
+}
+
+private extension Function {
+  /// Analyzes the global initializer function and returns global it initializes (from `alloc_global` instruction).
+  func getInitializedGlobal() -> GlobalVariable? {
+    for inst in self.entryBlock.instructions {
+      switch inst {
+      case let agi as AllocGlobalInst:
+        return agi.global
+      default:
+        break
+      }
+    }
+
+    return nil
+  }
 }
 
 fileprivate struct FunctionWorklist {
@@ -143,6 +244,15 @@ fileprivate struct FunctionWorklist {
   mutating func addAllPerformanceAnnotatedFunctions(of moduleContext: ModulePassContext) {
     for f in moduleContext.functions where f.performanceConstraints != .none {
       pushIfNotVisited(f)
+    }
+  }
+
+  mutating func addAllAnnotatedGlobalInitOnceFunctions(of moduleContext: ModulePassContext) {
+    for f in moduleContext.functions where f.isGlobalInitOnceFunction {
+      if let global = f.getInitializedGlobal(),
+         global.mustBeInitializedStatically {
+        pushIfNotVisited(f)
+      }
     }
   }
 

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -53,6 +53,10 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
     return bridged.canBeInitializedStatically()
   }
 
+  public var mustBeInitializedStatically: Bool {
+    return bridged.mustBeInitializedStatically()
+  }
+
   public static func ==(lhs: GlobalVariable, rhs: GlobalVariable) -> Bool {
     lhs === rhs
   }

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -342,6 +342,8 @@ ERROR(performance_callee_unavailable,none,
       "called function is not available in this module and can have unpredictable performance", ())
 ERROR(bad_attr_on_non_const_global,none,
       "global variable must be a compile-time constant to use %0 attribute", (StringRef))
+ERROR(global_must_be_compile_time_const,none,
+      "global variable must be a compile-time constant", ())
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -369,6 +369,8 @@ struct BridgedGlobalVar {
   inline OptionalBridgedInstruction getStaticInitializerValue() const;
 
   bool canBeInitializedStatically() const;
+  
+  bool mustBeInitializedStatically() const;
 };
 
 struct OptionalBridgedGlobalVar {

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -173,6 +173,8 @@ public:
   /// static initializer.
   SILInstruction *getStaticInitializerValue();
 
+  bool mustBeInitializedStatically() const;
+
   /// Returns true if the global is a statically initialized heap object.
   bool isInitializedObject() {
     return dyn_cast_or_null<ObjectInst>(getStaticInitializerValue()) != nullptr;

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -81,6 +81,17 @@ SILInstruction *SILGlobalVariable::getStaticInitializerValue() {
   return &StaticInitializerBlock.back();
 }
 
+bool SILGlobalVariable::mustBeInitializedStatically() const {
+  if (getSectionAttr())
+    return true;
+
+  auto *decl = getDecl();
+  if (decl && isDefinition() && decl->getAttrs().hasAttribute<SILGenNameAttr>())
+    return true;
+
+  return false;
+}
+
 /// Return whether this variable corresponds to a Clang node.
 bool SILGlobalVariable::hasClangNode() const {
   return (VDecl ? VDecl->hasClangNode() : false);

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -208,6 +208,11 @@ bool BridgedGlobalVar::canBeInitializedStatically() const {
   return tl.isLoadable();
 }
 
+bool BridgedGlobalVar::mustBeInitializedStatically() const {
+  SILGlobalVariable *global = getGlobal();
+  return global->mustBeInitializedStatically();
+}
+
 //===----------------------------------------------------------------------===//
 //                            SILVTable
 //===----------------------------------------------------------------------===//

--- a/test/IRGen/section_non_const.swift
+++ b/test/IRGen/section_non_const.swift
@@ -11,3 +11,67 @@
 @_section("__TEXT,__mysection") var g6: Any = 1 // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
 @_section("__TEXT,__mysection") var g7: UInt8 = 42
 @_section("__TEXT,__mysection") var g8: Int = 5 * 5
+
+@_section("__TEXT,__mysection") var s: StaticString = "hello"
+
+struct MyStruct1 {
+    var a: [Int]
+}
+@_section("__TEXT,__mysection") var g_MyStruct1: MyStruct1 = MyStruct1(a: [1, 2, 3]) // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
+
+struct MyStruct2 {
+    struct SubStruct { var x: Int }
+    var a: Int
+    var b: SubStruct
+    init(a: Int) {
+        self.a = a
+        self.b = SubStruct(x: self.a)
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct2: MyStruct2 = MyStruct2(a: 42)
+
+struct MyStruct3 {
+    struct SubStruct { var x: Int }
+    var a: Int
+    var b: SubStruct
+    init(a: Int, b: SubStruct) {
+        self.a = a
+        self.b = b
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct3: MyStruct3 = MyStruct3(a: 42, b: MyStruct3.SubStruct(x: 77))
+
+// Check that we don't end up infinitely inlining
+struct MyStruct4 {
+    var a: Int
+    init(a: Int) {
+        if a > 0 { _ = MyStruct4(a: a + 1) }
+        self.a = a
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct4: MyStruct4 = MyStruct4(a: 42) // expected-error {{global variable must be a compile-time constant to use @_section attribute}}
+
+struct MyStruct5 {
+    struct SubStruct { var x: Int }
+    var a: (SubStruct, SubStruct)
+    init(a: Int) {
+        self.a = (SubStruct(x: a), SubStruct(x: a))
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct5: MyStruct5 = MyStruct5(a: 42)
+
+// Check that we don't end up infinitely inlining
+struct MyStruct6 {
+    struct SubStruct {
+        var x: Int
+        init(x: Int) {
+            if x > 0 { _ = SubStruct(x: x + 1) }
+            self.x = x
+        }
+    }
+    var a: (SubStruct, SubStruct)
+    init(a: Int) {
+        self.a = (SubStruct(x: a), SubStruct(x: a))
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct6: MyStruct6 = MyStruct6(a: 42) // expected-error {{global variable must be a compile-time constant to use @_section attribute}}

--- a/test/IRGen/section_structs.swift
+++ b/test/IRGen/section_structs.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -parse-as-library -emit-ir %s -o - | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+struct MyStruct1 {
+    var a, b: Int
+}
+@_section("__TEXT,__mysection") var g_MyStruct1: MyStruct1 = MyStruct1(a: 42, b: 66)
+
+struct MyStruct2 {
+    var a: Int
+    var b: (Int, Int)
+}
+@_section("__TEXT,__mysection") var g_MyStruct2: MyStruct2 = MyStruct2(a: 42, b: (66, 67))
+
+struct MyStruct3 {
+    var a, b: Int
+    public init(a: Int, b: Int) {
+        self.a = a
+        self.b = b
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct3: MyStruct3 = MyStruct3(a: 42, b: 77)
+
+struct MyStruct4 {
+    var a: Int
+    var s: MyStruct1
+}
+@_section("__TEXT,__mysection") var g_MyStruct4: MyStruct4 = MyStruct4(a: 42, s: MyStruct1(a: 43, b: 44))
+
+struct MyStruct5 {
+    var q: MyStruct4
+    var r: MyStruct4
+    public init(q: MyStruct4, r: MyStruct4) {
+        self.q = q
+        self.r = r
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct5: MyStruct5 = MyStruct5(q: MyStruct4(a: 42, s: MyStruct1(a: 43, b: 44)), r: MyStruct4(a: 42, s: MyStruct1(a: 43, b: 44)))
+
+// CHECK: @"{{.*}}g_MyStruct1{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, %TSi <{ {{(i32|i64)}} 66 }> }>
+// CHECK: @"{{.*}}g_MyStruct2{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, <{ %TSi, %TSi }> <{ %TSi <{ {{(i32|i64)}} 66 }>, %TSi <{ {{(i32|i64)}} 67 }> }> }>
+// CHECK: @"{{.*}}g_MyStruct3{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, %TSi <{ {{(i32|i64)}} 77 }> }>
+// CHECK: @"{{.*}}g_MyStruct4{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }>
+// CHECK: @"{{.*}}g_MyStruct5{{.*}}Vvp" = hidden global {{.*}} <{ {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }> }>

--- a/test/IRGen/section_structs_generic.swift
+++ b/test/IRGen/section_structs_generic.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -parse-as-library -emit-ir %s -o - | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+struct MyStruct1<T> {
+    var a, b: T
+}
+@_section("__TEXT,__mysection") var g_MyStruct1 = MyStruct1<Int>(a: 42, b: 66)
+
+struct MyStruct2<T> {
+    var a: T
+    var b: (T, T)
+}
+@_section("__TEXT,__mysection") var g_MyStruct2 = MyStruct2<Int>(a: 42, b: (66, 67))
+
+struct MyStruct3<T> {
+    var a, b: T
+    public init(a: T, b: T) {
+        self.a = a
+        self.b = b
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct3 = MyStruct3<Int>(a: 42, b: 77)
+
+struct MyStruct4<T> {
+    var a: T
+    var s: MyStruct1<T>
+}
+@_section("__TEXT,__mysection") var g_MyStruct4 = MyStruct4<Int>(a: 42, s: MyStruct1<Int>(a: 43, b: 44))
+
+struct MyStruct5<T> {
+    var q: MyStruct4<T>
+    var r: MyStruct4<T>
+    public init(q: MyStruct4<T>, r: MyStruct4<T>) {
+        self.q = q
+        self.r = r
+    }
+}
+@_section("__TEXT,__mysection") var g_MyStruct5 = MyStruct5<Int>(q: MyStruct4<Int>(a: 42, s: MyStruct1<Int>(a: 43, b: 44)), r: MyStruct4<Int>(a: 42, s: MyStruct1<Int>(a: 43, b: 44)))
+
+// CHECK: @"{{.*}}g_MyStruct1{{.*}}Gvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, %TSi <{ {{(i32|i64)}} 66 }> }>
+// CHECK: @"{{.*}}g_MyStruct2{{.*}}Gvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, <{ %TSi, %TSi }> <{ %TSi <{ {{(i32|i64)}} 66 }>, %TSi <{ {{(i32|i64)}} 67 }> }> }>
+// CHECK: @"{{.*}}g_MyStruct3{{.*}}Gvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, %TSi <{ {{(i32|i64)}} 77 }> }>
+// CHECK: @"{{.*}}g_MyStruct4{{.*}}Gvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }>
+// CHECK: @"{{.*}}g_MyStruct5{{.*}}Gvp" = hidden global {{.*}} <{ {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }> }>


### PR DESCRIPTION
Currently, if a global variable is required to be statically initialized (e.g. due to @_section attribute), we don't allow its type to be a structs, only a scalar type works. Let's improve on that by teaching MandatoryPerformanceOptimizations pass to inline struct initializer calls into initializer of globals, as long as they are simple enough so that we can be sure that we don't trigger recursive/infinite inlining.