### PR TITLE
[IRGen] Fix symbol generation for getEnumTag function for layout strings

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -501,7 +501,7 @@ llvm::Function *createFixedEnumLoadTag(IRGenModule &IGM,
 
   IRGenMangler mangler;
   auto symbol = mangler.mangleSymbolNameForMangledGetEnumTagForLayoutString(
-      entry.ty.getASTType());
+      entry.ty.getASTType()->mapTypeOutOfContext()->getCanonicalType());
 
   auto helperFn = IGM.getOrCreateHelperFunction(
       symbol, IGM.Int32Ty /*retTy*/, IGM.Int8PtrTy /*argTys*/,


### PR DESCRIPTION
The type needs to be cleaned up to prevent issues with mangling when it contains archetypes