### PR TITLE
Add a `BasicBlockWorkqueue` as a common utility.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -283,12 +283,8 @@ void DiagnosticEmitter::emitMissingConsumeInDiscardingContext(
     //          / \        / \
     //         d   d      .   .
     //
-    BasicBlockSet visited(destroyPoint->getFunction());
-    std::deque<SILBasicBlock *> bfsWorklist = {destroyPoint->getParent()};
-    while (auto *bb = bfsWorklist.front()) {
-      visited.insert(bb);
-      bfsWorklist.pop_front();
-
+    BasicBlockWorkqueue bfsWorklist = {destroyPoint->getParent()};
+    while (auto *bb = bfsWorklist.pop()) {
       TermInst *term = bb->getTerminator();
 
       // Looking for a block that exits the function or terminates the program.
@@ -308,8 +304,7 @@ void DiagnosticEmitter::emitMissingConsumeInDiscardingContext(
       }
 
       for (auto *nextBB : term->getSuccessorBlocks())
-        if (!visited.contains(nextBB))
-          bfsWorklist.push_back(nextBB);
+        bfsWorklist.pushIfNotVisited(nextBB);
     }
   }
 


### PR DESCRIPTION
The pattern of using a breadth-first traversal over a control-flow graph shows up in a few places within the SIL optimizer, so this data-structure unifies those manually-implemented traversals into a common utility.