### PR TITLE
Re-land `static-executable-args.lnk` changes

### DIFF
--- a/stdlib/public/Resources/wasi/static-executable-args.lnk
+++ b/stdlib/public/Resources/wasi/static-executable-args.lnk
@@ -1,0 +1,11 @@
+-static
+-lswiftSwiftOnoneSupport
+-ldl
+-lstdc++
+-lm
+-lwasi-emulated-mman
+-lwasi-emulated-signal
+-lwasi-emulated-process-clocks
+-Xlinker --error-limit=0
+-Xlinker --no-gc-sections
+-Xlinker --threads=1

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -102,30 +102,38 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
-set(sdk "${SWIFT_HOST_VARIANT_SDK}")
-if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
+if(SWIFT_BUILD_STATIC_STDLIB)
   set(static_binary_lnk_file_list)
-  string(TOLOWER "${sdk}" lowercase_sdk)
-  set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lowercase_sdk}/static-executable-args.lnk")
 
-  # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-  set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
-  add_custom_command_target(swift_static_binary_${sdk}_args
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy
-      "${static_binary_lnk_src}"
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    OUTPUT
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DEPENDS
-      "${static_binary_lnk_src}")
+  foreach(sdk ${SWIFT_SDKS})
+    if(NOT "${sdk}" STREQUAL "LINUX")
+      continue()
+    endif()
 
-  list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
-  swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                             DESTINATION "lib/swift_static/${lowercase_sdk}"
-                             COMPONENT stdlib)
-  add_dependencies(stdlib ${static_binary_lnk_file_list})
-  add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+    string(TOLOWER "${sdk}" lowercase_sdk)
+    set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lowercase_sdk}/static-executable-args.lnk")
+
+    # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
+    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    add_custom_command_target(swift_static_binary_${sdk}_args
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${static_binary_lnk_src}"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DEPENDS
+        "${static_binary_lnk_src}")
+
+    list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
+    swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+                               DESTINATION "lib/swift_static/${lowercase_sdk}"
+                               COMPONENT stdlib)
+  endforeach()
+  if(static_binary_lnk_file_list)
+    add_dependencies(stdlib ${static_binary_lnk_file_list})
+    add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+  endif()
 endif()
 
 add_swift_target_library(swiftRuntime OBJECT_LIBRARY

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -106,7 +106,7 @@ if(SWIFT_BUILD_STATIC_STDLIB)
   set(static_binary_lnk_file_list)
 
   foreach(sdk ${SWIFT_SDKS})
-    if(NOT "${sdk}" STREQUAL "LINUX")
+    if(NOT "${sdk}" STREQUAL "LINUX" AND NOT "${sdk}" STREQUAL "WASI")
       continue()
     endif()
 


### PR DESCRIPTION
The original change didn't care about the case where `SWIFT_BUILD_STATIC_STDLIB=YES` but no `static-executable-args.lnk` is necessary (like on Darwin). It broke freestanding build https://ci.swift.org/job/oss-swift-test-stdlib-with-toolchain-minimal/4880/ with the following error, so the change was reverted by https://github.com/apple/swift/pull/66811

```
CMake Error at stdlib/public/runtime/CMakeLists.txt:133 (add_dependencies):
  add_dependencies called with incorrect number of arguments
```

This is the take 2 to re-land the change with a fix for the case.