### PR TITLE
[DebugInfo][NFC] Update test to not check width of alloca integer arguments

### DIFF
--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -51,7 +51,7 @@ public class C<R> {
     // SIL: function_ref {{.*}}yes{{.*}} scope [[F1G1]]
     // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H]]
     // IR: dbg.value(metadata ptr %[[ARG_S]], metadata ![[MD_1_0:[0-9]+]]
-    // IR: %[[RS_PAIR:.*]] = alloca i8, i64 %
+    // IR: %[[RS_PAIR:.*]] = alloca i8, i{{.*}} %
     // IR: dbg.declare(metadata ptr %[[RS_PAIR]], metadata ![[GRS_T:[0-9]+]],
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[S:[0-9]+]]
     // IR: dbg.value(metadata ptr %[[ARG_0]], metadata ![[GS_T:[0-9]+]]


### PR DESCRIPTION
    For the size argument of an alloca, some targets use a i32 bit integer, some use
    a 64 bit integer; the updated test was hard-coding i64, which caused it to fail
    in other targets. This is irrelevant for what the test is doing, so we remove
    that.