### PR TITLE
Fix @objcImpl crash with async/sync overloads

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2943,7 +2943,7 @@ private:
     if (auto func = dyn_cast<AbstractFunctionDecl>(req)) {
       auto asyncFunc = func->getAsyncAlternative();
 
-      if (auto asyncAccessor = dyn_cast<AccessorDecl>(asyncFunc))
+      if (auto asyncAccessor = dyn_cast_or_null<AccessorDecl>(asyncFunc))
         return asyncAccessor->getStorage();
 
       return asyncFunc;

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -103,6 +103,9 @@
 - (void)doSomethingAsynchronousWithCompletionHandler:(void (^ _Nonnull)(id _Nullable result, NSError * _Nullable error))completionHandler;
 - (void)doSomethingElseAsynchronousWithCompletionHandler:(void (^ _Nullable)(id _Nonnull result))completionHandler;
 - (void)doSomethingFunAndAsynchronousWithCompletionHandler:(void (^ _Nonnull)(id _Nullable result, NSError * _Nullable error))completionHandler;
+
+- (void)doSomethingOverloadedWithCompletionHandler:(void (^ _Nonnull)())completionHandler;
+- (void)doSomethingOverloaded __attribute__((__swift_attr__("@_unavailableFromAsync(message: \"Use async doSomethingOverloaded instead.\")")));
 @end
 
 @protocol PartiallyOptionalProtocol

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -327,6 +327,14 @@ protocol EmptySwiftProto {}
 
   public func doSomethingFunAndAsynchronous(completionHandler: @escaping (Any?, Error?) -> Void) {
   }
+
+  @available(SwiftStdlib 5.1, *)
+  @objc(doSomethingOverloadedWithCompletionHandler:)
+  public func doSomethingOverloaded() async {}
+
+  @available(*, noasync)
+  @objc(doSomethingOverloaded)
+  public func doSomethingOverloaded() {}
 }
 
 @_objcImplementation(Conformance) extension ObjCClass {


### PR DESCRIPTION
The @objcImpl checker would accidentally dereference a null pointer when it tried to check if an async requirement could be satisfied by a non-async method. Fix that mistake.

Fixes rdar://111064481.