### PR TITLE
[SourceKit] Fix a potential deadlock when a cursor info request is cancelled while another one is inside a cancellation callback

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2041,8 +2041,14 @@ void SwiftLangSupport::getCursorInfo(
                            fileSystem, Receiver, Offset, Actionables,
                            SymbolGraph](
                               const RequestResult<CursorInfoData> &Res) {
+    if (Res.isCancelled()) {
+      // If the AST-based result got cancelled, we don’t want to start
+      // solver-based cursor info anymore.
+      Receiver(Res);
+      return;
+    }
     // AST based completion *always* produces a result
-    bool NoResults = Res.isError() || Res.isCancelled();
+    bool NoResults = Res.isError();
     if (Res.isValue()) {
       NoResults = Res.value().Symbols.empty();
     }


### PR DESCRIPTION
This started happening more frequently since we ran solver-based cursor info after AST-based cursor info failed because we ran solver-based cursor info even if AST-based cursor info was cancelled. This widened up the window for a potential deadlock. https://github.com/apple/swift/commit/35661f2ab6b88996780834295a3f8b737c6a6245 fixes this by not running solver-based cursor info in case AST-based cursor info was cancelled. This is a performance win on its own.

The underlying issue is fixed in https://github.com/apple/swift/commit/35661f2ab6b88996780834295a3f8b737c6a6245. This is a cherry-pick of https://github.com/apple/swift/pull/58978 to only the necessary change to fix this now-known deadlock. The intention is that this PR will be cherry-picked to release/5.9.

rdar://110357502