### PR TITLE
Requestify the computation of the list of memberwise initialized properties

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3995,6 +3995,10 @@ public:
   /// this type.
   ArrayRef<VarDecl *> getInitAccessorProperties() const;
 
+  /// Return a collection of all properties that will be part of the memberwise
+  ///  initializer.
+  ArrayRef<VarDecl *> getMemberwiseInitProperties() const;
+  
   /// Establish a mapping between properties that could be iniitalized
   /// via other properties by means of init accessors. This mapping is
   /// one-to-many because we allow intersecting `initializes(...)`.

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -850,8 +850,22 @@ public:
     HasNestedClassDeclarations = 1;
   }
 
-  /// Retrieve the set of members in this context.
+  /// Retrieve the current set of members in this context.
+  ///
+  /// NOTE: This operation is an alias of \c getCurrentMembers() that is considered
+  /// deprecated. Most clients should not use this or \c getCurrentMembers(), but
+  /// instead should use one of the projections of members that provides a semantic
+  /// view, e.g., \c getParsedMembers(), \c getABIMembers(), \c getAllMembers(), and so
+  /// on.
   DeclRange getMembers() const;
+
+  /// Retrieve the current set of members in this context, without triggering the
+  /// creation of new members via code synthesis, macro expansion, etc.
+  ///
+  /// This operation should only be used in narrow places where any side-effect
+  /// producing operations have been done earlier. For the most part, this means that
+  /// it should only be used in the implementation of
+  DeclRange getCurrentMembers() const;
 
   /// Get the members that were syntactically present in the source code,
   /// and will not contain any members that are implicitly synthesized by

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1693,6 +1693,28 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Request to obtain a list of properties that will be reflected in the parameters of a
+/// memberwise initializer.
+class MemberwiseInitPropertiesRequest :
+    public SimpleRequest<MemberwiseInitPropertiesRequest,
+                         ArrayRef<VarDecl *>(NominalTypeDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ArrayRef<VarDecl *>
+  evaluate(Evaluator &evaluator, NominalTypeDecl *decl) const;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, AbstractStorageDecl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 class HasStorageRequest :
     public SimpleRequest<HasStorageRequest,
                          bool(AbstractStorageDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -312,6 +312,9 @@ SWIFT_REQUEST(TypeChecker, StoredPropertiesRequest,
 SWIFT_REQUEST(TypeChecker, InitAccessorPropertiesRequest,
               ArrayRef<VarDecl *>(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, MemberwiseInitPropertiesRequest,
+              ArrayRef<VarDecl *>(NominalTypeDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, StructuralTypeRequest, Type(TypeAliasDecl *), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SuperclassTypeRequest,

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -61,10 +61,7 @@ public:
 
   /// A convenience method to visit all the members.
   void visitMembers(NominalTypeDecl *D) {
-    for (Decl *member : D->getMembers()) {
-      member->visitAuxiliaryDecls([&](Decl *decl) {
-        asImpl().visit(decl);
-      });
+    for (Decl *member : D->getAllMembers()) {
       asImpl().visit(member);
     }
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7187,8 +7187,10 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   // If this is a computed property with `init` accessor, it's
   // memberwise initializable when it could be used to initialize
   // other stored properties.
-  if (auto *init = getAccessor(AccessorKind::Init))
-    return init->getAttrs().hasAttribute<InitializesAttr>();
+  if (hasInitAccessor()) {
+    if (auto *init = getAccessor(AccessorKind::Init))
+      return init->getAttrs().hasAttribute<InitializesAttr>();
+  }
 
   // If this is a computed property, it's not memberwise initialized unless
   // the caller has asked for the declared properties and it is either a

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4920,6 +4920,16 @@ NominalTypeDecl::getInitAccessorProperties() const {
       {});
 }
 
+ArrayRef<VarDecl *>
+NominalTypeDecl::getMemberwiseInitProperties() const {
+  auto &ctx = getASTContext();
+  auto mutableThis = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(
+      ctx.evaluator,
+      MemberwiseInitPropertiesRequest{mutableThis},
+      {});
+}
+
 void NominalTypeDecl::collectPropertiesInitializableByInitAccessors(
     std::multimap<VarDecl *, VarDecl *> &result) const {
   for (auto *property : getInitAccessorProperties()) {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -920,6 +920,10 @@ DeclRange IterableDeclContext::getCurrentMembersWithoutLoading() const {
 }
 
 DeclRange IterableDeclContext::getMembers() const {
+  return getCurrentMembers();
+}
+
+DeclRange IterableDeclContext::getCurrentMembers() const {
   loadAllMembers();
 
   return getCurrentMembersWithoutLoading();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -706,14 +706,7 @@ private:
       return;
 
     unsigned CurLabel = 0;
-    for (auto Member : TypeContext->getMembers()) {
-      auto Prop = dyn_cast<VarDecl>(Member);
-      if (!Prop)
-        continue;
-
-      if (!Prop->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
-        continue;
-
+    for (auto Prop : TypeContext->getMemberwiseInitProperties()) {
       if (CurLabel == Args.size())
         break;
 

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -3415,7 +3415,7 @@ collectMembersForInit(ResolvedCursorInfoPtr CursorInfo,
 
   SourceManager &SM = nominalDecl->getASTContext().SourceMgr;
 
-  for (auto member : nominalDecl->getMembers()) {
+  for (auto member : nominalDecl->getMemberwiseInitProperties()) {
     auto varDecl = dyn_cast<VarDecl>(member);
     if (!varDecl) {
       continue;

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -3428,10 +3428,6 @@ collectMembersForInit(ResolvedCursorInfoPtr CursorInfo,
       continue;
     }
 
-    if (!varDecl->isMemberwiseInitialized(/*preferDeclaredProperties=*/true)) {
-      continue;
-    }
-
     auto patternBinding = varDecl->getParentPatternBinding();
     if (!patternBinding)
       continue;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -406,7 +406,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
       storedProperties.insert(properties.begin(), properties.end());
     }
 
-    for (auto *member : decl->getMembers()) {
+    for (auto *member : decl->getAllMembers()) {
       auto *field = dyn_cast<VarDecl>(member);
       if (!field)
         continue;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -297,14 +297,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
     std::multimap<VarDecl *, VarDecl *> initializedViaAccessor;
     decl->collectPropertiesInitializableByInitAccessors(initializedViaAccessor);
 
-    for (auto member : decl->getMembers()) {
-      auto var = dyn_cast<VarDecl>(member);
-      if (!var)
-        continue;
-
-      if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
-        continue;
-
+    for (auto var : decl->getMemberwiseInitProperties()) {
       if (initializedViaAccessor.count(var))
         continue;
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -294,13 +294,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
   if (ICK == ImplicitConstructorKind::Memberwise) {
     assert(isa<StructDecl>(decl) && "Only struct have memberwise constructor");
 
-    std::multimap<VarDecl *, VarDecl *> initializedViaAccessor;
-    decl->collectPropertiesInitializableByInitAccessors(initializedViaAccessor);
-
     for (auto var : decl->getMemberwiseInitProperties()) {
-      if (initializedViaAccessor.count(var))
-        continue;
-
       accessLevel = std::min(accessLevel, var->getFormalAccess());
       params.push_back(createMemberwiseInitParameter(decl, Loc, var));
     }
@@ -1401,8 +1395,7 @@ ResolveEffectiveMemberwiseInitRequest::evaluate(Evaluator &evaluator,
   auto accessLevel = AccessLevel::Public;
   for (auto *member : decl->getMembers()) {
     auto *var = dyn_cast<VarDecl>(member);
-    if (!var ||
-        !var->isMemberwiseInitialized(/*preferDeclaredProperties*/ true))
+    if (!var || !var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
       continue;
     accessLevel = std::min(accessLevel, var->getFormalAccess());
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -333,22 +333,10 @@ bool HasInitAccessorRequest::evaluate(Evaluator &evaluator,
 ArrayRef<VarDecl *>
 InitAccessorPropertiesRequest::evaluate(Evaluator &evaluator,
                                         NominalTypeDecl *decl) const {
-  IterableDeclContext *implDecl = decl->getImplementationContext();
-
-  if (!hasStoredProperties(decl, implDecl))
-    return ArrayRef<VarDecl *>();
-
-  // Make sure we expand what we need to to get all of the properties.
-  computeLoweredProperties(decl, implDecl, LoweredPropertiesReason::Memberwise);
-
   SmallVector<VarDecl *, 4> results;
-  for (auto *member : decl->getMembers()) {
-    auto *var = dyn_cast<VarDecl>(member);
-    if (!var || var->isStatic() || !var->hasInitAccessor()) {
-      continue;
-    }
-
-    results.push_back(var);
+  for (auto var : decl->getMemberwiseInitProperties()) {
+    if (var->hasInitAccessor())
+      results.push_back(var);
   }
 
   return decl->getASTContext().AllocateCopy(results);

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -221,8 +221,7 @@ macro AddPeerStoredProperty() =
 
 struct SomeStructWithPeerProperties {
   @AddPeerStoredProperty
-
-  func foo() {}
+  var foo: String = "hello"
 }
 
 func testStructWithPeers() {


### PR DESCRIPTION
Fixes rdar://110776763, a case where initialized stored properties introduced by peer macros weren't working alongside declared stored properties.
