### PR TITLE
[5.9][SourceKit] Fix a potential deadlock when a cursor info request is cancelled while another one is inside a cancellation callback

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2039,8 +2039,14 @@ void SwiftLangSupport::getCursorInfo(
                            fileSystem, Receiver, Offset, Actionables,
                            SymbolGraph](
                               const RequestResult<CursorInfoData> &Res) {
+    if (Res.isCancelled()) {
+      // If the AST-based result got cancelled, we don’t want to start
+      // solver-based cursor info anymore.
+      Receiver(Res);
+      return;
+    }
     // AST based completion *always* produces a result
-    bool NoResults = Res.isError() || Res.isCancelled();
+    bool NoResults = Res.isError();
     if (Res.isValue()) {
       NoResults = Res.value().Symbols.empty();
     }


### PR DESCRIPTION
* **Explanation**: Cancelling cursor info could result in a deadlock of SourceKit. This started happening more frequently since we ran solver-based cursor info after AST-based cursor info failed because we ran solver-based cursor info even if AST-based cursor info was cancelled. This widened up the window for a potential deadlock. This PR tightens the window for potential deadlocks as well as fixing the underlying deadlock issue.
* **Scope**: Cancellation notifications in SourceKit
* **Risk**: Low, moving `requestCancellation` callback to a serial background queue should be safe as should be not executing solver-based cursor info if the request has been cancelled. 
* **Testing**: None
* **Issue**: rdar://110357502
* **Reviewer**:  @bnbarham on https://github.com/apple/swift/pull/66866