### PR TITLE
[IRGen+Runtime] Layout string getEnumTag for generic multi payload enums

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2315,6 +2315,16 @@ FUNCTION(GenericInitWithTake,
          ATTRS(NoUnwind),
          EFFECT(Refcounting))
 
+// unsigned swift_multiPayloadEnumGeneric_getEnumTag(opaque* address,
+//                                                   const Metadata *type);
+FUNCTION(MultiPayloadEnumGenericGetEnumTag,
+         swift_multiPayloadEnumGeneric_getEnumTag,
+         C_CC, AlwaysAvailable,
+         RETURNS(Int32Ty),
+         ARGS(Int8PtrTy, TypeMetadataPtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(NoEffect))
+
 // void swift_generic_instantiateLayoutString(const uint8_t* layoutStr, Metadata* type);
 FUNCTION(GenericInstantiateLayoutString,
          swift_generic_instantiateLayoutString,

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1113,7 +1113,29 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
     goto standard;
   }
 
-  case ValueWitness::GetEnumTag:
+  case ValueWitness::GetEnumTag: {
+    assert(concreteType.getEnumOrBoundGenericEnum());
+
+    if (IGM.Context.LangOpts.hasFeature(Feature::LayoutStringValueWitnesses) &&
+        IGM.getOptions().EnableLayoutStringValueWitnesses) {
+      auto ty = boundGenericCharacteristics
+                    ? boundGenericCharacteristics->concreteType
+                    : concreteType;
+      auto &typeInfo = boundGenericCharacteristics
+                           ? *boundGenericCharacteristics->TI
+                           : concreteTI;
+      if (auto *typeLayoutEntry = typeInfo.buildTypeLayoutEntry(
+              IGM, ty, /*useStructLayouts*/ true)) {
+        if (auto *enumLayoutEntry = typeLayoutEntry->getAsEnum()) {
+          if (enumLayoutEntry->isMultiPayloadEnum() &&
+              !typeLayoutEntry->isFixedSize(IGM)) {
+            return addFunction(IGM.getMultiPayloadEnumGenericGetEnumTagFn());
+          }
+        }
+      }
+    }
+    goto standard;
+  }
   case ValueWitness::DestructiveProjectEnumData:
   case ValueWitness::DestructiveInjectEnumTag:
     assert(concreteType.getEnumOrBoundGenericEnum());

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -94,17 +94,30 @@ struct LayoutStringWriter {
 };
 
 SWIFT_RUNTIME_EXPORT
-void swift_generic_destroy(swift::OpaqueValue *address, const Metadata *metadata);
+void swift_generic_destroy(swift::OpaqueValue *address,
+                           const Metadata *metadata);
 SWIFT_RUNTIME_EXPORT
-swift::OpaqueValue *swift_generic_assignWithCopy(swift::OpaqueValue *dest, swift::OpaqueValue *src, const Metadata *metadata);
+swift::OpaqueValue *swift_generic_assignWithCopy(swift::OpaqueValue *dest,
+                                                 swift::OpaqueValue *src,
+                                                 const Metadata *metadata);
 SWIFT_RUNTIME_EXPORT
-swift::OpaqueValue *swift_generic_assignWithTake(swift::OpaqueValue *dest, swift::OpaqueValue *src, const Metadata *metadata);
+swift::OpaqueValue *swift_generic_assignWithTake(swift::OpaqueValue *dest,
+                                                 swift::OpaqueValue *src,
+                                                 const Metadata *metadata);
 SWIFT_RUNTIME_EXPORT
-swift::OpaqueValue *swift_generic_initWithCopy(swift::OpaqueValue *dest, swift::OpaqueValue *src, const Metadata *metadata);
+swift::OpaqueValue *swift_generic_initWithCopy(swift::OpaqueValue *dest,
+                                               swift::OpaqueValue *src,
+                                               const Metadata *metadata);
 SWIFT_RUNTIME_EXPORT
-swift::OpaqueValue *swift_generic_initWithTake(swift::OpaqueValue *dest, swift::OpaqueValue *src, const Metadata *metadata);
+swift::OpaqueValue *swift_generic_initWithTake(swift::OpaqueValue *dest,
+                                               swift::OpaqueValue *src,
+                                               const Metadata *metadata);
 SWIFT_RUNTIME_EXPORT
-void swift_generic_instantiateLayoutString(const uint8_t *layoutStr, Metadata *type);
+unsigned swift_multiPayloadEnumGeneric_getEnumTag(swift::OpaqueValue *address,
+                                                  const Metadata *metadata);
+SWIFT_RUNTIME_EXPORT
+void swift_generic_instantiateLayoutString(const uint8_t *layoutStr,
+                                           Metadata *type);
 
 void swift_resolve_resilientAccessors(uint8_t *layoutStr,
                                       size_t layoutStrOffset,

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -18,3 +18,14 @@ public struct GenericResilient<C, T> {
         self.y = y
     }
 }
+
+public enum ResilientMultiPayloadEnum<T> {
+    case empty0
+    case empty1
+    case nonEmpty0(AnyObject)
+    case nonEmpty1(T)
+}
+
+public func getResilientMultiPayloadEnumEmpty0<T>(_ t: T.Type) -> ResilientMultiPayloadEnum<T> {
+    return .empty0
+}

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -516,6 +516,20 @@ func testGenericSinglePayloadEnumManyXI() {
 
 testGenericSinglePayloadEnumManyXI()
 
+func testResilientMultiPayloadEnumTag() {
+    let x = switch getResilientMultiPayloadEnumEmpty0(AnyObject.self) {
+    case .nonEmpty0: 0
+    case .nonEmpty1: 1
+    case .empty0: 2
+    case .empty1: 3
+    }
+
+    // CHECK: Enum case: 2
+    print("Enum case: \(x)")
+}
+
+testResilientMultiPayloadEnumTag()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
We already store all necessary information to extract the tag in the layout string, so we should utilize it for the getEnumTag witness