### PR TITLE
[AutoDiff] Supporting differentiable functions with multiple semantic results

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -32,6 +32,7 @@
 
 namespace swift {
 
+class AbstractFunctionDecl;
 class AnyFunctionType;
 class SourceFile;
 class SILFunctionType;
@@ -398,9 +399,6 @@ public:
   enum class Kind {
     /// Original function type has no semantic results.
     NoSemanticResults,
-    /// Original function type has multiple semantic results.
-    // TODO(TF-1250): Support function types with multiple semantic results.
-    MultipleSemanticResults,
     /// Differentiability parmeter indices are empty.
     NoDifferentiabilityParameters,
     /// A differentiability parameter does not conform to `Differentiable`.
@@ -429,7 +427,6 @@ public:
   explicit DerivativeFunctionTypeError(AnyFunctionType *functionType, Kind kind)
       : functionType(functionType), kind(kind), value(Value()) {
     assert(kind == Kind::NoSemanticResults ||
-           kind == Kind::MultipleSemanticResults ||
            kind == Kind::NoDifferentiabilityParameters);
   };
 
@@ -578,6 +575,10 @@ void getFunctionSemanticResultTypes(
     AnyFunctionType *functionType,
     SmallVectorImpl<AutoDiffSemanticFunctionResultType> &result,
     GenericEnvironment *genericEnv = nullptr);
+
+/// Returns the indices of all semantic results for a given function.
+IndexSubset *getAllFunctionSemanticResultIndices(
+    const AbstractFunctionDecl *AFD);
 
 /// Returns the lowered SIL parameter indices for the given AST parameter
 /// indices and `AnyfunctionType`.

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -248,7 +248,12 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
 /// an `inout` parameter type. Used in derivative function type calculation.
 struct AutoDiffSemanticFunctionResultType {
   Type type;
-  bool isInout;
+  unsigned index : 30;
+  bool isInout : 1;
+  bool isWrtParam : 1;
+
+  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, bool inout, bool wrt)
+    : type(t), index(idx), isInout(inout), isWrtParam(wrt) { }
 };
 
 /// Key for caching SIL derivative function types.
@@ -569,19 +574,22 @@ namespace autodiff {
 /// `inout` parameter types.
 ///
 /// The function type may have at most two parameter lists.
-///
-/// Remaps the original semantic result using `genericEnv`, if specified.
-void getFunctionSemanticResultTypes(
-    AnyFunctionType *functionType,
-    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &result,
-    GenericEnvironment *genericEnv = nullptr);
+void getFunctionSemanticResults(
+    const AnyFunctionType *functionType,
+    const IndexSubset *parameterIndices,
+    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &resultTypes);
 
-/// Returns the indices of all semantic results for a given function.
-IndexSubset *getAllFunctionSemanticResultIndices(
-    const AbstractFunctionDecl *AFD);
+/// Returns the indices of semantic results for a given function.
+IndexSubset *getFunctionSemanticResultIndices(
+    const AnyFunctionType *functionType,
+    const IndexSubset *parameterIndices);
+
+IndexSubset *getFunctionSemanticResultIndices(
+    const AbstractFunctionDecl *AFD,
+    const IndexSubset *parameterIndices);
 
 /// Returns the lowered SIL parameter indices for the given AST parameter
-/// indices and `AnyfunctionType`.
+/// indices and `AnyFunctionType`.
 ///
 /// Notable lowering-related changes:
 /// - AST tuple parameter types are exploded when lowered to SIL.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3950,9 +3950,6 @@ NOTE(autodiff_attr_original_decl_not_same_type_context,none,
      (DescriptiveDeclKind))
 ERROR(autodiff_attr_original_void_result,none,
       "cannot differentiate void function %0", (DeclName))
-ERROR(autodiff_attr_original_multiple_semantic_results,none,
-      "cannot differentiate functions with both an 'inout' parameter and a "
-      "result", ())
 ERROR(autodiff_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -176,57 +176,89 @@ void AnyFunctionType::getSubsetParameters(
   }
 }
 
-void autodiff::getFunctionSemanticResultTypes(
-    AnyFunctionType *functionType,
-    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &result,
-    GenericEnvironment *genericEnv) {
+void autodiff::getFunctionSemanticResults(
+    const AnyFunctionType *functionType,
+    const IndexSubset *parameterIndices,
+    SmallVectorImpl<AutoDiffSemanticFunctionResultType> &resultTypes) {
   auto &ctx = functionType->getASTContext();
-
-  // Remap type in `genericEnv`, if specified.
-  auto remap = [&](Type type) {
-    if (!genericEnv)
-      return type;
-    return genericEnv->mapTypeIntoContext(type);
-  };
 
   // Collect formal result type as a semantic result, unless it is
   // `Void`.
   auto formalResultType = functionType->getResult();
   if (auto *resultFunctionType =
-          functionType->getResult()->getAs<AnyFunctionType>()) {
+      functionType->getResult()->getAs<AnyFunctionType>())
     formalResultType = resultFunctionType->getResult();
-  }
+
+  unsigned resultIdx = 0;
   if (!formalResultType->isEqual(ctx.TheEmptyTupleType)) {
     // Separate tuple elements into individual results.
     if (formalResultType->is<TupleType>()) {
       for (auto elt : formalResultType->castTo<TupleType>()->getElements()) {
-        result.push_back({remap(elt.getType()), /*isInout*/ false});
+        resultTypes.emplace_back(elt.getType(), resultIdx++,
+                                 /*isInout*/ false, /*isWrt*/ false);
       }
     } else {
-      result.push_back({remap(formalResultType), /*isInout*/ false});
+      resultTypes.emplace_back(formalResultType, resultIdx++,
+                               /*isInout*/ false, /*isWrt*/ false);
     }
   }
 
-  // Collect `inout` parameters as semantic results.
-  for (auto param : functionType->getParams())
-    if (param.isInOut())
-      result.push_back({remap(param.getPlainType()), /*isInout*/ true});
-  if (auto *resultFunctionType =
-          functionType->getResult()->getAs<AnyFunctionType>()) {
-    for (auto param : resultFunctionType->getParams())
-      if (param.isInOut())
-        result.push_back({remap(param.getPlainType()), /*isInout*/ true});
-  }
+  bool addNonWrts = resultTypes.empty();
+
+  // Collect wrt `inout` parameters as semantic results
+  // As an extention, collect all (including non-wrt) inouts as results for
+  // functions returning void.
+  auto collectSemanticResults = [&](const AnyFunctionType *functionType,
+                                    unsigned curryOffset = 0) {
+    for (auto paramAndIndex : enumerate(functionType->getParams())) {
+      if (!paramAndIndex.value().isInOut())
+        continue;
+
+      unsigned idx = paramAndIndex.index() + curryOffset;
+      assert(idx < parameterIndices->getCapacity() &&
+             "invalid parameter index");
+      bool isWrt = parameterIndices->contains(idx);
+      if (addNonWrts || isWrt)
+        resultTypes.emplace_back(paramAndIndex.value().getPlainType(),
+                                 resultIdx, /*isInout*/ true, isWrt);
+      resultIdx += 1;
+    }
+  };
+
+  if (auto *resultFnType =
+      functionType->getResult()->getAs<AnyFunctionType>()) {
+    // Here we assume that the input is a function type with curried `Self`
+    assert(functionType->getNumParams() == 1 && "unexpected function type");
+
+    collectSemanticResults(resultFnType);
+    collectSemanticResults(functionType, resultFnType->getNumParams());
+  } else
+    collectSemanticResults(functionType);
 }
 
 IndexSubset *
-autodiff::getAllFunctionSemanticResultIndices(const AbstractFunctionDecl *AFD) {
-  auto originalFn = AFD->getInterfaceType()->castTo<AnyFunctionType>();
+autodiff::getFunctionSemanticResultIndices(const AnyFunctionType *functionType,
+                                           const IndexSubset *parameterIndices) {
+  auto &ctx = functionType->getASTContext();
+
   SmallVector<AutoDiffSemanticFunctionResultType, 1> semanticResults;
-  autodiff::getFunctionSemanticResultTypes(originalFn, semanticResults);
-  auto numResults = semanticResults.size();
-  return IndexSubset::getDefault(
-    AFD->getASTContext(), numResults, /*includeAll*/ true);
+  autodiff::getFunctionSemanticResults(functionType, parameterIndices,
+                                       semanticResults);
+  SmallVector<unsigned> resultIndices;
+  unsigned cap = 0;
+  for (const auto& result : semanticResults) {
+    resultIndices.push_back(result.index);
+    cap = std::max(cap, result.index + 1U);
+  }
+
+  return IndexSubset::get(ctx, cap, resultIndices);
+}
+
+IndexSubset *
+autodiff::getFunctionSemanticResultIndices(const AbstractFunctionDecl *AFD,
+                                           const IndexSubset *parameterIndices) {
+  return getFunctionSemanticResultIndices(AFD->getInterfaceType()->castTo<AnyFunctionType>(),
+                                          parameterIndices);
 }
 
 // TODO(TF-874): Simplify this helper. See TF-874 for WIP.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5548,31 +5548,86 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
   getSubsetParameters(parameterIndices, diffParams,
                       /*reverseCurryLevels*/ !makeSelfParamFirst);
 
-  // Get the original semantic result type.
+  // Get the original non-inout semantic result types.
   SmallVector<AutoDiffSemanticFunctionResultType, 1> originalResults;
   autodiff::getFunctionSemanticResultTypes(this, originalResults);
   // Error if no original semantic results.
   if (originalResults.empty())
     return llvm::make_error<DerivativeFunctionTypeError>(
         this, DerivativeFunctionTypeError::Kind::NoSemanticResults);
-  // Error if multiple original semantic results.
-  // TODO(TF-1250): Support functions with multiple semantic results.
-  if (originalResults.size() > 1)
-    return llvm::make_error<DerivativeFunctionTypeError>(
-        this, DerivativeFunctionTypeError::Kind::MultipleSemanticResults);
-  auto originalResult = originalResults.front();
-  auto originalResultType = originalResult.type;
+  // Accumulate non-inout result tangent spaces.
+  SmallVector<Type, 1> resultTanTypes;
+  bool hasInoutResult = false;
+  for (auto i : range(originalResults.size())) {
+    auto originalResult = originalResults[i];
+    auto originalResultType = originalResult.type;
+    // Voids currently have a defined tangent vector, so ignore them.
+    if (originalResultType->isVoid())
+      continue;
+    if (originalResult.isInout) {
+      hasInoutResult = true;
+      continue;
+    }
+    // Get the original semantic result type's `TangentVector` associated type.
+    auto resultTan =
+        originalResultType->getAutoDiffTangentSpace(lookupConformance);
+    if (!resultTan)
+      continue;
+    auto resultTanType = resultTan->getType();
+    resultTanTypes.push_back(resultTanType);
+  }
+  // Append non-wrt inout result tangent spaces.
+  // This uses the logic from getSubsetParameters(), only operating over all
+  // parameter indices and looking for non-wrt indices.
+  SmallVector<AnyFunctionType *, 2> curryLevels;
+  // An inlined version of unwrapCurryLevels().
+  AnyFunctionType *fnTy = this;
+  while (fnTy != nullptr) {
+    curryLevels.push_back(fnTy);
+    fnTy = fnTy->getResult()->getAs<AnyFunctionType>();
+  }
 
-  // Get the original semantic result type's `TangentVector` associated type.
-  auto resultTan =
-      originalResultType->getAutoDiffTangentSpace(lookupConformance);
-  // Error if original semantic result has no tangent space.
-  if (!resultTan) {
+  SmallVector<unsigned, 2> curryLevelParameterIndexOffsets(curryLevels.size());
+  unsigned currentOffset = 0;
+  for (unsigned curryLevelIndex : llvm::reverse(indices(curryLevels))) {
+    curryLevelParameterIndexOffsets[curryLevelIndex] = currentOffset;
+    currentOffset += curryLevels[curryLevelIndex]->getNumParams();
+  }
+
+  if (!makeSelfParamFirst) {
+    std::reverse(curryLevels.begin(), curryLevels.end());
+    std::reverse(curryLevelParameterIndexOffsets.begin(),
+                 curryLevelParameterIndexOffsets.end());
+  }
+
+  for (unsigned curryLevelIndex : indices(curryLevels)) {
+    auto *curryLevel = curryLevels[curryLevelIndex];
+    unsigned parameterIndexOffset =
+        curryLevelParameterIndexOffsets[curryLevelIndex];
+    for (unsigned paramIndex : range(curryLevel->getNumParams())) {
+      if (parameterIndices->contains(parameterIndexOffset + paramIndex))
+        continue;
+
+      auto param = curryLevel->getParams()[paramIndex];
+      if (param.isInOut()) {
+        auto resultType = param.getPlainType();
+        if (resultType->isVoid())
+          continue;
+        auto resultTan = resultType->getAutoDiffTangentSpace(lookupConformance);
+        if (!resultTan)
+          continue;
+        auto resultTanType = resultTan->getType();
+        resultTanTypes.push_back(resultTanType);
+      }
+    }
+  }
+
+  // Error if no semantic result has a tangent space.
+  if (resultTanTypes.empty() && !hasInoutResult) {
     return llvm::make_error<DerivativeFunctionTypeError>(
         this, DerivativeFunctionTypeError::Kind::NonDifferentiableResult,
-        std::make_pair(originalResultType, /*index*/ 0));
+        std::make_pair(originalResults.front().type, /*index*/ 0));
   }
-  auto resultTanType = resultTan->getType();
 
   // Compute the result linear map function type.
   FunctionType *linearMapType;
@@ -5592,7 +5647,6 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // - Original:     `(T0, inout T1, ...) -> Void`
     // - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
     SmallVector<AnyFunctionType::Param, 4> differentialParams;
-    bool hasInoutDiffParameter = false;
     for (auto i : range(diffParams.size())) {
       auto diffParam = diffParams[i];
       auto paramType = diffParam.getPlainType();
@@ -5607,11 +5661,22 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
       }
       differentialParams.push_back(AnyFunctionType::Param(
           paramTan->getType(), Identifier(), diffParam.getParameterFlags()));
-      if (diffParam.isInOut())
-        hasInoutDiffParameter = true;
     }
-    auto differentialResult =
-        hasInoutDiffParameter ? Type(ctx.TheEmptyTupleType) : resultTanType;
+    Type differentialResult;
+    if (resultTanTypes.empty()) {
+      differentialResult = ctx.TheEmptyTupleType;
+    } else if (resultTanTypes.size() == 1) {
+      differentialResult = resultTanTypes.front();
+    } else {
+      SmallVector<TupleTypeElt, 2> differentialResults;
+      for (auto i : range(resultTanTypes.size())) {
+        auto resultTanType = resultTanTypes[i];
+        differentialResults.push_back(
+            TupleTypeElt(resultTanType, Identifier()));
+      }
+      differentialResult = TupleType::get(differentialResults, ctx);
+    }
+
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     FunctionType::ExtInfo info;
     linearMapType =
@@ -5629,11 +5694,11 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // - Original: `(T0, inout T1, ...) -> Void`
     // - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
     //
-    // Case 3: original function has a wrt `inout` parameter.
-    // - Original: `(T0, inout T1, ...) -> Void`
-    // - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
+    // Case 3: original function has wrt `inout` parameters.
+    // - Original: `(T0, inout T1, ...) -> R`
+    // - Pullback: `(R.Tan, inout T1.Tan) -> (T0.Tan, ...)`
     SmallVector<TupleTypeElt, 4> pullbackResults;
-    bool hasInoutDiffParameter = false;
+    SmallVector<AnyFunctionType::Param, 2> inoutParams;
     for (auto i : range(diffParams.size())) {
       auto diffParam = diffParams[i];
       auto paramType = diffParam.getPlainType();
@@ -5647,7 +5712,9 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
             std::make_pair(paramType, i));
       }
       if (diffParam.isInOut()) {
-        hasInoutDiffParameter = true;
+        if (paramType->isVoid())
+          continue;
+        inoutParams.push_back(diffParam);
         continue;
       }
       pullbackResults.emplace_back(paramTan->getType());
@@ -5660,12 +5727,27 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     } else {
       pullbackResult = TupleType::get(pullbackResults, ctx);
     }
-    auto flags = ParameterTypeFlags().withInOut(hasInoutDiffParameter);
-    auto pullbackParam =
-        AnyFunctionType::Param(resultTanType, Identifier(), flags);
+    // First accumulate non-inout results as pullback parameters.
+    SmallVector<FunctionType::Param, 2> pullbackParams;
+    for (auto i : range(resultTanTypes.size())) {
+      auto resultTanType = resultTanTypes[i];
+      auto flags = ParameterTypeFlags().withInOut(false);
+      pullbackParams.push_back(AnyFunctionType::Param(
+          resultTanType, Identifier(), flags));
+    }
+    // Then append inout parameters.
+    for (auto i : range(inoutParams.size())) {
+      auto inoutParam = inoutParams[i];
+      auto inoutParamType = inoutParam.getPlainType();
+      auto inoutParamTan =
+          inoutParamType->getAutoDiffTangentSpace(lookupConformance);
+      auto flags = ParameterTypeFlags().withInOut(true);
+      pullbackParams.push_back(AnyFunctionType::Param(
+          inoutParamTan->getType(), Identifier(), flags));
+    }
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     FunctionType::ExtInfo info;
-    linearMapType = FunctionType::get({pullbackParam}, pullbackResult, info);
+    linearMapType = FunctionType::get(pullbackParams, pullbackResult, info);
     break;
   }
   }

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -57,9 +57,11 @@ public:
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
+    auto *resultIndices =
+        autodiff::getAllFunctionSemanticResultIndices(func);
     AutoDiffConfig config(
         derivativeId->getParameterIndices(),
-        IndexSubset::get(func->getASTContext(), 1, {0}),
+        resultIndices,
         derivativeId->getDerivativeGenericSignature());
     appendAutoDiffFunctionParts("TJ", kind, config);
     appendOperator("Tj");
@@ -86,9 +88,11 @@ public:
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
+    auto *resultIndices =
+        autodiff::getAllFunctionSemanticResultIndices(func);
     AutoDiffConfig config(
         derivativeId->getParameterIndices(),
-        IndexSubset::get(func->getASTContext(), 1, {0}),
+        resultIndices,
         derivativeId->getDerivativeGenericSignature());
     appendAutoDiffFunctionParts("TJ", kind, config);
     appendOperator("Tq");

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -58,7 +58,8 @@ public:
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
-        autodiff::getAllFunctionSemanticResultIndices(func);
+      autodiff::getFunctionSemanticResultIndices(func,
+                                                 derivativeId->getParameterIndices());
     AutoDiffConfig config(
         derivativeId->getParameterIndices(),
         resultIndices,
@@ -89,7 +90,8 @@ public:
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
-        autodiff::getAllFunctionSemanticResultIndices(func);
+      autodiff::getFunctionSemanticResultIndices(func,
+                                                 derivativeId->getParameterIndices());
     AutoDiffConfig config(
         derivativeId->getParameterIndices(),
         resultIndices,

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1067,8 +1067,10 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     auto *silParameterIndices = autodiff::getLoweredParameterIndices(
         derivativeFunctionIdentifier->getParameterIndices(),
         getDecl()->getInterfaceType()->castTo<AnyFunctionType>());
-    auto *resultIndices = autodiff::getAllFunctionSemanticResultIndices(
-        asAutoDiffOriginalFunction().getAbstractFunctionDecl());
+    // FIXME: is this correct in the presence of curried types?
+    auto *resultIndices = autodiff::getFunctionSemanticResultIndices(
+      asAutoDiffOriginalFunction().getAbstractFunctionDecl(),
+      derivativeFunctionIdentifier->getParameterIndices());
     AutoDiffConfig silConfig(
         silParameterIndices, resultIndices,
         derivativeFunctionIdentifier->getDerivativeGenericSignature());

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1067,7 +1067,8 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     auto *silParameterIndices = autodiff::getLoweredParameterIndices(
         derivativeFunctionIdentifier->getParameterIndices(),
         getDecl()->getInterfaceType()->castTo<AnyFunctionType>());
-    auto *resultIndices = IndexSubset::get(getDecl()->getASTContext(), 1, {0});
+    auto *resultIndices = autodiff::getAllFunctionSemanticResultIndices(
+        asAutoDiffOriginalFunction().getAbstractFunctionDecl());
     AutoDiffConfig silConfig(
         silParameterIndices, resultIndices,
         derivativeFunctionIdentifier->getDerivativeGenericSignature());

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -238,8 +238,6 @@ IndexSubset *SILFunctionType::getDifferentiabilityResultIndices() {
       resultIndices.push_back(resultAndIndex.index());
   // Check `inout` parameters.
   for (auto inoutParamAndIndex : enumerate(getIndirectMutatingParameters()))
-    // FIXME(TF-1305): The `getResults().empty()` condition is a hack.
-    //
     // Currently, an `inout` parameter can either be:
     // 1. Both a differentiability parameter and a differentiability result.
     // 2. `@noDerivative`: neither a differentiability parameter nor a
@@ -251,13 +249,8 @@ IndexSubset *SILFunctionType::getDifferentiabilityResultIndices() {
     //    cases, so supporting it is a non-goal.
     //
     // See TF-1305 for solution ideas. For now, `@noDerivative` `inout`
-    // parameters are not treated as differentiability results, unless the
-    // original function has no formal results, in which case all `inout`
     // parameters are treated as differentiability results.
-    if (getResults().empty() ||
-        inoutParamAndIndex.value().getDifferentiability() !=
-            SILParameterDifferentiability::NotDifferentiable)
-      resultIndices.push_back(getNumResults() + inoutParamAndIndex.index());
+    resultIndices.push_back(getNumResults() + inoutParamAndIndex.index());
   auto numSemanticResults =
       getNumResults() + getNumIndirectMutatingParameters();
   return IndexSubset::get(getASTContext(), numSemanticResults, resultIndices);
@@ -603,7 +596,7 @@ static CanSILFunctionType getAutoDiffDifferentialType(
       differentialResults.push_back({resultTanType, resultConv});
       continue;
     }
-    // Handle original `inout` parameter.
+    // Handle original `inout` parameters.
     auto inoutParamIndex = resultIndex - originalFnTy->getNumResults();
     auto inoutParamIt = std::next(
         originalFnTy->getIndirectMutatingParameters().begin(), inoutParamIndex);
@@ -745,7 +738,7 @@ static CanSILFunctionType getAutoDiffPullbackType(
       pullbackParams.push_back({resultTanType, paramConv});
       continue;
     }
-    // Handle original `inout` parameter.
+    // Handle `inout` parameters.
     auto inoutParamIndex = resultIndex - originalFnTy->getNumResults();
     auto inoutParamIt = std::next(
         originalFnTy->getIndirectMutatingParameters().begin(), inoutParamIndex);

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -465,17 +465,22 @@ public:
 
     // Add derivative function symbols.
     for (const auto *differentiableAttr :
-         AFD->getAttrs().getAttributes<DifferentiableAttr>())
+           AFD->getAttrs().getAttributes<DifferentiableAttr>()) {
+      auto *resultIndices = autodiff::getFunctionSemanticResultIndices(
+        AFD,
+        differentiableAttr->getParameterIndices());
       addDerivativeConfiguration(
           differentiableAttr->getDifferentiabilityKind(), AFD,
           AutoDiffConfig(differentiableAttr->getParameterIndices(),
-                         autodiff::getAllFunctionSemanticResultIndices(AFD),
+                         resultIndices,
                          differentiableAttr->getDerivativeGenericSignature()));
+    }
 
     for (const auto *derivativeAttr :
          AFD->getAttrs().getAttributes<DerivativeAttr>()) {
-      auto *resultIndices = autodiff::getAllFunctionSemanticResultIndices(
-        derivativeAttr->getOriginalFunction(AFD->getASTContext()));
+      auto *resultIndices = autodiff::getFunctionSemanticResultIndices(
+        derivativeAttr->getOriginalFunction(AFD->getASTContext()),
+        derivativeAttr->getParameterIndices());
       addDerivativeConfiguration(
           DifferentiabilityKind::Reverse,
           derivativeAttr->getOriginalFunction(AFD->getASTContext()),
@@ -533,7 +538,8 @@ public:
           differentiableAttr->getDifferentiabilityKind(),
           accessorDecl,
           AutoDiffConfig(differentiableAttr->getParameterIndices(),
-                         autodiff::getAllFunctionSemanticResultIndices(accessorDecl),
+                         autodiff::getFunctionSemanticResultIndices(accessorDecl,
+                                                                    differentiableAttr->getParameterIndices()),
                          differentiableAttr->getDerivativeGenericSignature()));
     }
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1255,11 +1255,12 @@ void SILGenModule::emitDifferentiabilityWitnessesForFunction(
   auto *AFD = constant.getAbstractFunctionDecl();
   auto emitWitnesses = [&](DeclAttributes &Attrs) {
     for (auto *diffAttr : Attrs.getAttributes<DifferentiableAttr>()) {
-      auto *resultIndices = IndexSubset::get(getASTContext(), 1, {0});
       assert((!F->getLoweredFunctionType()->getSubstGenericSignature() ||
               diffAttr->getDerivativeGenericSignature()) &&
              "Type-checking should resolve derivative generic signatures for "
              "all original SIL functions with generic signatures");
+      auto *resultIndices =
+          autodiff::getAllFunctionSemanticResultIndices(AFD);
       auto witnessGenSig =
           autodiff::getDifferentiabilityWitnessGenericSignature(
               AFD->getGenericSignature(),
@@ -1288,7 +1289,8 @@ void SILGenModule::emitDifferentiabilityWitnessesForFunction(
       auto witnessGenSig =
           autodiff::getDifferentiabilityWitnessGenericSignature(
               origAFD->getGenericSignature(), AFD->getGenericSignature());
-      auto *resultIndices = IndexSubset::get(getASTContext(), 1, {0});
+      auto *resultIndices =
+          autodiff::getAllFunctionSemanticResultIndices(origAFD);
       AutoDiffConfig config(derivAttr->getParameterIndices(), resultIndices,
                             witnessGenSig);
       emitDifferentiabilityWitness(origAFD, origFn,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1260,7 +1260,8 @@ void SILGenModule::emitDifferentiabilityWitnessesForFunction(
              "Type-checking should resolve derivative generic signatures for "
              "all original SIL functions with generic signatures");
       auto *resultIndices =
-          autodiff::getAllFunctionSemanticResultIndices(AFD);
+        autodiff::getFunctionSemanticResultIndices(AFD,
+                                                   diffAttr->getParameterIndices());
       auto witnessGenSig =
           autodiff::getDifferentiabilityWitnessGenericSignature(
               AFD->getGenericSignature(),
@@ -1290,7 +1291,8 @@ void SILGenModule::emitDifferentiabilityWitnessesForFunction(
           autodiff::getDifferentiabilityWitnessGenericSignature(
               origAFD->getGenericSignature(), AFD->getGenericSignature());
       auto *resultIndices =
-          autodiff::getAllFunctionSemanticResultIndices(origAFD);
+        autodiff::getFunctionSemanticResultIndices(origAFD,
+                                                   derivAttr->getParameterIndices());
       AutoDiffConfig config(derivAttr->getParameterIndices(), resultIndices,
                             witnessGenSig);
       emitDifferentiabilityWitness(origAFD, origFn,
@@ -1313,6 +1315,7 @@ void SILGenModule::emitDifferentiabilityWitness(
   auto origSilFnType = originalFunction->getLoweredFunctionType();
   auto *silParamIndices =
       autodiff::getLoweredParameterIndices(config.parameterIndices, origFnType);
+
   // NOTE(TF-893): Extending capacity is necessary when `origSilFnType` has
   // parameters corresponding to captured variables. These parameters do not
   // appear in the type of `origFnType`.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4885,10 +4885,12 @@ getWitnessFunctionRef(SILGenFunction &SGF,
       auto *loweredParamIndices = autodiff::getLoweredParameterIndices(
           derivativeId->getParameterIndices(),
           witness.getDecl()->getInterfaceType()->castTo<AnyFunctionType>());
-      auto *loweredResultIndices = IndexSubset::get(
-          SGF.getASTContext(), 1, {0}); // FIXME, set to all results
+      // FIXME: is this correct in the presence of curried types?
+      auto *resultIndices = autodiff::getFunctionSemanticResultIndices(
+        witness.getDecl()->getInterfaceType()->castTo<AnyFunctionType>(),
+        derivativeId->getParameterIndices());
       auto diffFn = SGF.B.createDifferentiableFunction(
-          loc, loweredParamIndices, loweredResultIndices, originalFn);
+          loc, loweredParamIndices, resultIndices, originalFn);
       return SGF.B.createDifferentiableFunctionExtract(
           loc,
           NormalDifferentiableFunctionTypeComponent(derivativeId->getKind()),

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -549,8 +549,9 @@ SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(
   SILGenFunctionBuilder builder(*this);
   auto originalFnDeclRef = derivativeFnDeclRef.asAutoDiffOriginalFunction();
   Mangle::ASTMangler mangler;
-  auto *resultIndices = autodiff::getAllFunctionSemanticResultIndices(
-      originalFnDeclRef.getAbstractFunctionDecl());
+  auto *resultIndices = autodiff::getFunctionSemanticResultIndices(
+    originalFnDeclRef.getAbstractFunctionDecl(),
+    derivativeId->getParameterIndices());
   auto name = mangler.mangleAutoDiffDerivativeFunction(
       originalFnDeclRef.getAbstractFunctionDecl(),
       derivativeId->getKind(),
@@ -575,8 +576,12 @@ SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(
   auto *loweredParamIndices = autodiff::getLoweredParameterIndices(
       derivativeId->getParameterIndices(),
       derivativeFnDecl->getInterfaceType()->castTo<AnyFunctionType>());
-  auto *loweredResultIndices = autodiff::getAllFunctionSemanticResultIndices(
-      originalFnDeclRef.getAbstractFunctionDecl());
+  // FIXME: Do we need to lower the result indices? Likely yes.
+  auto *loweredResultIndices =
+    autodiff::getFunctionSemanticResultIndices(
+      originalFnDeclRef.getAbstractFunctionDecl(),
+      derivativeId->getParameterIndices()
+    );
   auto diffFn = SGF.B.createDifferentiableFunction(
       loc, loweredParamIndices, loweredResultIndices, originalFn);
   auto derivativeFn = SGF.B.createDifferentiableFunctionExtract(

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -549,11 +549,13 @@ SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(
   SILGenFunctionBuilder builder(*this);
   auto originalFnDeclRef = derivativeFnDeclRef.asAutoDiffOriginalFunction();
   Mangle::ASTMangler mangler;
+  auto *resultIndices = autodiff::getAllFunctionSemanticResultIndices(
+      originalFnDeclRef.getAbstractFunctionDecl());
   auto name = mangler.mangleAutoDiffDerivativeFunction(
       originalFnDeclRef.getAbstractFunctionDecl(),
       derivativeId->getKind(),
       AutoDiffConfig(derivativeId->getParameterIndices(),
-                     IndexSubset::get(getASTContext(), 1, {0}),
+                     resultIndices,
                      derivativeId->getDerivativeGenericSignature()),
       /*isVTableThunk*/ true);
   auto *thunk = builder.getOrCreateFunction(
@@ -573,7 +575,8 @@ SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(
   auto *loweredParamIndices = autodiff::getLoweredParameterIndices(
       derivativeId->getParameterIndices(),
       derivativeFnDecl->getInterfaceType()->castTo<AnyFunctionType>());
-  auto *loweredResultIndices = IndexSubset::get(getASTContext(), 1, {0});
+  auto *loweredResultIndices = autodiff::getAllFunctionSemanticResultIndices(
+      originalFnDeclRef.getAbstractFunctionDecl());
   auto diffFn = SGF.B.createDifferentiableFunction(
       loc, loweredParamIndices, loweredResultIndices, originalFn);
   auto derivativeFn = SGF.B.createDifferentiableFunctionExtract(

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -492,10 +492,6 @@ findMinimalDerivativeConfiguration(AbstractFunctionDecl *original,
 SILDifferentiabilityWitness *getOrCreateMinimalASTDifferentiabilityWitness(
     SILModule &module, SILFunction *original, DifferentiabilityKind kind,
     IndexSubset *parameterIndices, IndexSubset *resultIndices) {
-  // AST differentiability witnesses always have a single result.
-  if (resultIndices->getCapacity() != 1 || !resultIndices->contains(0))
-    return nullptr;
-
   // Explicit differentiability witnesses only exist on SIL functions that come
   // from AST functions.
   auto *originalAFD = findAbstractFunctionDecl(original);

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -232,7 +232,7 @@ void collectMinimalIndicesForFunctionCall(
     auto &param = paramAndIdx.value();
     if (!param.isIndirectMutating())
       continue;
-    unsigned idx = paramAndIdx.index();
+    unsigned idx = paramAndIdx.index() + calleeFnTy->getNumIndirectFormalResults();
     auto inoutArg = ai->getArgument(idx);
     results.push_back(inoutArg);
     resultIndices.push_back(inoutParamResultIndex++);

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -772,8 +772,8 @@ getOrCreateSubsetParametersThunkForDerivativeFunction(
         /*withoutActuallyEscaping*/ false);
   }
   assert(origFnType->getNumResults() +
-             origFnType->getNumIndirectMutatingParameters() ==
-         1);
+             origFnType->getNumIndirectMutatingParameters() >
+         0);
   if (origFnType->getNumResults() > 0 &&
       origFnType->getResults().front().isFormalDirect()) {
     auto result =

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -752,7 +752,7 @@ static SILFunction *createEmptyVJP(ADContext &context,
   auto original = witness->getOriginalFunction();
   LLVM_DEBUG({
     auto &s = getADDebugStream();
-    s << "Creating VJP:\n\t";
+    s << "Creating VJP for " << original->getName() << ":\n\t";
     s << "Original type: " << original->getLoweredFunctionType() << "\n\t";
   });
 
@@ -796,7 +796,7 @@ static SILFunction *createEmptyJVP(ADContext &context,
   auto original = witness->getOriginalFunction();
   LLVM_DEBUG({
     auto &s = getADDebugStream();
-    s << "Creating JVP:\n\t";
+    s << "Creating JVP for " << original->getName() << ":\n\t";
     s << "Original type: " << original->getLoweredFunctionType() << "\n\t";
   });
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -750,15 +750,16 @@ static SILFunction *createEmptyVJP(ADContext &context,
                                    SILDifferentiabilityWitness *witness,
                                    IsSerialized_t isSerialized) {
   auto original = witness->getOriginalFunction();
+  auto config = witness->getConfig();
   LLVM_DEBUG({
     auto &s = getADDebugStream();
     s << "Creating VJP for " << original->getName() << ":\n\t";
     s << "Original type: " << original->getLoweredFunctionType() << "\n\t";
+    s << "Config: " << config << "\n\t";
   });
 
   auto &module = context.getModule();
   auto originalTy = original->getLoweredFunctionType();
-  auto config = witness->getConfig();
 
   // === Create an empty VJP. ===
   Mangle::DifferentiationMangler mangler;
@@ -794,15 +795,16 @@ static SILFunction *createEmptyJVP(ADContext &context,
                                    SILDifferentiabilityWitness *witness,
                                    IsSerialized_t isSerialized) {
   auto original = witness->getOriginalFunction();
+  auto config = witness->getConfig();
   LLVM_DEBUG({
     auto &s = getADDebugStream();
     s << "Creating JVP for " << original->getName() << ":\n\t";
     s << "Original type: " << original->getLoweredFunctionType() << "\n\t";
+    s << "Config: " << config << "\n\t";
   });
 
   auto &module = context.getModule();
   auto originalTy = original->getLoweredFunctionType();
-  auto config = witness->getConfig();
 
   Mangle::DifferentiationMangler mangler;
   auto jvpName = mangler.mangleDerivativeFunction(

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5669,10 +5669,10 @@ typecheckDifferentiableAttrforDecl(AbstractFunctionDecl *original,
         derivativeGenEnv->mapTypeIntoContext(originalFnRemappedTy)
             ->castTo<AnyFunctionType>();
   
-  autodiff::getFunctionSemanticResultTypes(originalFnRemappedTy, semanticResults);
-  auto numResults = semanticResults.size();
-  auto *resultIndices = IndexSubset::getDefault(
-      ctx, numResults, /*includeAll*/ true);
+  auto *resultIndices =
+    autodiff::getFunctionSemanticResultIndices(originalFnRemappedTy,
+                                               resolvedDiffParamIndices);
+
   original->addDerivativeFunctionConfiguration(
       {resolvedDiffParamIndices, resultIndices, derivativeGenSig});
   return resolvedDiffParamIndices;
@@ -6220,7 +6220,8 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
 
   // Register derivative function configuration.
   auto *resultIndices =
-    autodiff::getAllFunctionSemanticResultIndices(originalAFD);
+    autodiff::getFunctionSemanticResultIndices(originalAFD,
+                                               resolvedDiffParamIndices);
   originalAFD->addDerivativeFunctionConfiguration(
       {resolvedDiffParamIndices, resultIndices,
        derivative->getGenericSignature()});

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5509,12 +5509,6 @@ bool resolveDifferentiableAttrDifferentiabilityParameters(
                     original->getName())
           .highlight(original->getSourceRange());
       return;
-    case DerivativeFunctionTypeError::Kind::MultipleSemanticResults:
-      diags
-          .diagnose(attr->getLocation(),
-                    diag::autodiff_attr_original_multiple_semantic_results)
-          .highlight(original->getSourceRange());
-      return;
     case DerivativeFunctionTypeError::Kind::NoDifferentiabilityParameters:
       diags.diagnose(attr->getLocation(),
                      diag::diff_params_clause_no_inferred_parameters);
@@ -5666,7 +5660,19 @@ typecheckDifferentiableAttrforDecl(AbstractFunctionDecl *original,
   }
 
   // Register derivative function configuration.
-  auto *resultIndices = IndexSubset::get(ctx, 1, {0});
+  SmallVector<AutoDiffSemanticFunctionResultType, 1> semanticResults;
+
+  // Compute the derivative function type.
+  auto originalFnRemappedTy = original->getInterfaceType()->castTo<AnyFunctionType>();
+  if (auto *derivativeGenEnv = derivativeGenSig.getGenericEnvironment())
+    originalFnRemappedTy =
+        derivativeGenEnv->mapTypeIntoContext(originalFnRemappedTy)
+            ->castTo<AnyFunctionType>();
+  
+  autodiff::getFunctionSemanticResultTypes(originalFnRemappedTy, semanticResults);
+  auto numResults = semanticResults.size();
+  auto *resultIndices = IndexSubset::getDefault(
+      ctx, numResults, /*includeAll*/ true);
   original->addDerivativeFunctionConfiguration(
       {resolvedDiffParamIndices, resultIndices, derivativeGenSig});
   return resolvedDiffParamIndices;
@@ -6124,12 +6130,6 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
                     originalAFD->getName())
           .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
       return;
-    case DerivativeFunctionTypeError::Kind::MultipleSemanticResults:
-      diags
-          .diagnose(attr->getLocation(),
-                    diag::autodiff_attr_original_multiple_semantic_results)
-          .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
-      return;
     case DerivativeFunctionTypeError::Kind::NoDifferentiabilityParameters:
       diags.diagnose(attr->getLocation(),
                      diag::diff_params_clause_no_inferred_parameters);
@@ -6219,7 +6219,8 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
   }
 
   // Register derivative function configuration.
-  auto *resultIndices = IndexSubset::get(Ctx, 1, {0});
+  auto *resultIndices =
+    autodiff::getAllFunctionSemanticResultIndices(originalAFD);
   originalAFD->addDerivativeFunctionConfiguration(
       {resolvedDiffParamIndices, resultIndices,
        derivative->getGenericSignature()});

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -493,7 +493,8 @@ matchWitnessDifferentiableAttr(DeclContext *dc, ValueDecl *req,
           success = true;
           // Register derivative function configuration.
           auto *resultIndices =
-              autodiff::getAllFunctionSemanticResultIndices(witnessAFD);
+            autodiff::getFunctionSemanticResultIndices(witnessAFD,
+                                                       newAttr->getParameterIndices());
           witnessAFD->addDerivativeFunctionConfiguration(
               {newAttr->getParameterIndices(), resultIndices,
                newAttr->getDerivativeGenericSignature()});

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -492,7 +492,8 @@ matchWitnessDifferentiableAttr(DeclContext *dc, ValueDecl *req,
           witness->getAttrs().add(newAttr);
           success = true;
           // Register derivative function configuration.
-          auto *resultIndices = IndexSubset::get(ctx, 1, {0});
+          auto *resultIndices =
+              autodiff::getAllFunctionSemanticResultIndices(witnessAFD);
           witnessAFD->addDerivativeFunctionConfiguration(
               {newAttr->getParameterIndices(), resultIndices,
                newAttr->getDerivativeGenericSignature()});

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -722,9 +722,9 @@ void ModuleFile::loadDerivativeFunctionConfigurations(
     }
     auto derivativeGenSig = derivativeGenSigOrError.get();
     // NOTE(TF-1038): Result indices are currently unsupported in derivative
-    // registration attributes. In the meantime, always use `{0}` (wrt the
-    // first and only result).
-    auto resultIndices = IndexSubset::get(ctx, 1, {0});
+    // registration attributes. In the meantime, always use all results.
+    auto *resultIndices =
+        autodiff::getAllFunctionSemanticResultIndices(originalAFD);
     results.insert({parameterIndices, resultIndices, derivativeGenSig});
   }
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -724,7 +724,8 @@ void ModuleFile::loadDerivativeFunctionConfigurations(
     // NOTE(TF-1038): Result indices are currently unsupported in derivative
     // registration attributes. In the meantime, always use all results.
     auto *resultIndices =
-        autodiff::getAllFunctionSemanticResultIndices(originalAFD);
+      autodiff::getFunctionSemanticResultIndices(originalAFD,
+                                                 parameterIndices);
     results.insert({parameterIndices, resultIndices, derivativeGenSig});
   }
 }

--- a/test/AutoDiff/SILGen/inout_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/inout_differentiability_witness.swift
@@ -1,0 +1,60 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+import _Differentiation
+
+public struct NonDiffableStruct {}
+
+public struct DiffableStruct : Differentiable {}
+
+@differentiable(reverse)
+func test1(x: Int, y: inout NonDiffableStruct, z: Float) -> Float { return 42.0 }
+
+@differentiable(reverse)
+func test2(x: Int, y: inout DiffableStruct, z: Float) {  }
+
+@differentiable(reverse)
+func test3(x: Int, y: inout DiffableStruct, z: Float) -> (Float, Float) { return (42.0, 42.0) }
+
+@differentiable(reverse, wrt: y)
+func test4(x: Int, y: inout DiffableStruct, z: Float) -> Void { }
+
+@differentiable(reverse, wrt: z)
+func test5(x: Int, y: inout DiffableStruct, z: Float) -> Void { }
+
+@differentiable(reverse, wrt: (y, z))
+func test6(x: Int, y: inout DiffableStruct, z: Float) -> (Float, Float) { return (42.0, 42.0) }
+
+// CHECK-LABEL: differentiability witness for test1(x:y:z:)
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 2] [results 0] @$s31inout_differentiability_witness5test11x1y1zSfSi_AA17NonDiffableStructVzSftF : $@convention(thin) (Int, @inout NonDiffableStruct, Float) -> Float {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test11x1y1zSfSi_AA17NonDiffableStructVzSftFTJfUUSpSr : $@convention(thin) (Int, @inout NonDiffableStruct, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK:   vjp: @$s31inout_differentiability_witness5test11x1y1zSfSi_AA17NonDiffableStructVzSftFTJrUUSpSr : $@convention(thin) (Int, @inout NonDiffableStruct, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK: }
+
+// CHECK-LABEL: differentiability witness for test2(x:y:z:)
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 1 2] [results 0] @$s31inout_differentiability_witness5test21x1y1zySi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> () {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test21x1y1zySi_AA14DiffableStructVzSftFTJfUSSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@inout DiffableStruct.TangentVector, Float) -> ()
+// CHECK:   vjp: @$s31inout_differentiability_witness5test21x1y1zySi_AA14DiffableStructVzSftFTJrUSSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@inout DiffableStruct.TangentVector) -> Float
+// CHECK: }
+
+// CHECK-LABEL: differentiability witness for test3(x:y:z:)
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 1 2] [results 0 1 2] @$s31inout_differentiability_witness5test31x1y1zSf_SftSi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> (Float, Float) {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test31x1y1zSf_SftSi_AA14DiffableStructVzSftFTJfUSSpSSSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> (Float, Float, @owned @callee_guaranteed (@inout DiffableStruct.TangentVector, Float) -> (Float, Float))
+// CHECK:   vjp: @$s31inout_differentiability_witness5test31x1y1zSf_SftSi_AA14DiffableStructVzSftFTJrUSSpSSSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> (Float, Float, @owned @callee_guaranteed (Float, Float, @inout DiffableStruct.TangentVector) -> Float)
+// CHECK: }
+
+// CHECK-LABEL: differentiability witness for test4(x:y:z:)
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 1] [results 0] @$s31inout_differentiability_witness5test41x1y1zySi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> () {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test41x1y1zySi_AA14DiffableStructVzSftFTJfUSUpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@inout DiffableStruct.TangentVector) -> ()
+// CHECK:   vjp: @$s31inout_differentiability_witness5test41x1y1zySi_AA14DiffableStructVzSftFTJrUSUpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@inout DiffableStruct.TangentVector) -> ()
+// CHECK: }
+
+// CHECK-LABEL: differentiability witness for test5(x:y:z:)
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 2] [results 0] @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> () {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftFTJfUUSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (Float) -> @out DiffableStruct.TangentVector
+// CHECK:   vjp: @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftFTJrUUSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@in_guaranteed DiffableStruct.TangentVector) -> Float
+// CHECK: }
+
+// CHECK-LABEL: differentiability witness for test6(x:y:z:)
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 1 2] [results 0 1 2] @$s31inout_differentiability_witness5test61x1y1zSf_SftSi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> (Float, Float) {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test61x1y1zSf_SftSi_AA14DiffableStructVzSftFTJfUSSpSSSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> (Float, Float, @owned @callee_guaranteed (@inout DiffableStruct.TangentVector, Float) -> (Float, Float))
+// CHECK:   vjp: @$s31inout_differentiability_witness5test61x1y1zSf_SftSi_AA14DiffableStructVzSftFTJrUSSpSSSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> (Float, Float, @owned @callee_guaranteed (Float, Float, @inout DiffableStruct.TangentVector) -> Float)
+// CHECK: }

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/a.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/a.swift
@@ -1,3 +1,25 @@
+import _Differentiation
+
 public struct Struct {
   public func method(_ x: Float) -> Float { x }
+}
+
+// Test cross-module recognition of functions with multiple semantic results.
+@differentiable(reverse)
+public func swap(_ x: inout Float, _ y: inout Float) {
+  let tmp = x; x = y; y = tmp
+}
+
+@differentiable(reverse)
+public func swapCustom(_ x: inout Float, _ y: inout Float) {
+  let tmp = x; x = y; y = tmp
+}
+@derivative(of: swapCustom)
+public func vjpSwapCustom(_ x: inout Float, _ y: inout Float) -> (
+  value: Void, pullback: (inout Float, inout Float) -> Void
+) {
+  swapCustom(&x, &y)
+  return ((), {v1, v2 in
+    let tmp = v1; v1 = v2; v2 = tmp
+  })
 }

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/b.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/b.swift
@@ -11,3 +11,18 @@ extension Struct: Differentiable {
     (x, { $0 })
   }
 }
+
+// Test cross-module recognition of functions with multiple semantic results.
+@differentiable(reverse)
+func multiply_swap(_ x: Float, _ y: Float) -> Float {
+  var tuple = (x, y)
+  swap(&tuple.0, &tuple.1)
+  return tuple.0 * tuple.1
+}
+
+@differentiable(reverse)
+func multiply_swapCustom(_ x: Float, _ y: Float) -> Float {
+  var tuple = (x, y)
+  swapCustom(&tuple.0, &tuple.1)
+  return tuple.0 * tuple.1
+}

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -749,13 +749,18 @@ extension ProtocolRequirementDerivative {
 func multipleSemanticResults(_ x: inout Float) -> Float {
   return x
 }
-// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @derivative(of: multipleSemanticResults)
 func vjpMultipleSemanticResults(x: inout Float) -> (
-  value: Float, pullback: (Float) -> Float
-) {
-  return (multipleSemanticResults(&x), { $0 })
+  value: Float, pullback: (Float, inout Float) -> Void
+) { fatalError() }
+
+func inoutNonDifferentiableResult(_ x: inout Float) -> Int {
+  return 5
 }
+@derivative(of: inoutNonDifferentiableResult)
+func vjpInoutNonDifferentiableResult(x: inout Float) -> (
+  value: Int, pullback: (inout Float) -> Void
+) { fatalError() }
 
 struct InoutParameters: Differentiable {
   typealias TangentVector = DummyTangentVector
@@ -888,17 +893,31 @@ func vjpNoSemanticResults(_ x: Float) -> (value: Void, pullback: Void) {}
 
 extension InoutParameters {
   func multipleSemanticResults(_ x: inout Float) -> Float { x }
-  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
-  @derivative(of: multipleSemanticResults)
+  @derivative(of: multipleSemanticResults, wrt: x)
   func vjpMultipleSemanticResults(_ x: inout Float) -> (
-    value: Float, pullback: (inout Float) -> Void
+    value: Float, pullback: (Float, inout Float) -> Void
   ) { fatalError() }
 
   func inoutVoid(_ x: Float, _ void: inout Void) -> Float {}
-  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
-  @derivative(of: inoutVoid)
+  @derivative(of: inoutVoid, wrt: (x, void))
   func vjpInoutVoidParameter(_ x: Float, _ void: inout Void) -> (
-    value: Float, pullback: (inout Float) -> Void
+    value: Float, pullback: (Float) -> Float
+  ) { fatalError() }
+}
+
+// Test tuple results.
+
+extension InoutParameters {
+  func tupleResults(_ x: Float) -> (Float, Float) { (x, x) }
+  @derivative(of: tupleResults, wrt: x)
+  func vjpTupleResults(_ x: Float) -> (
+    value: (Float, Float), pullback: (Float, Float) -> Float
+  ) { fatalError() }
+
+  func tupleResultsInt(_ x: Float) -> (Int, Float) { (1, x) }
+  @derivative(of: tupleResultsInt, wrt: x)
+  func vjpTupleResults(_ x: Float) -> (
+    value: (Int, Float), pullback: (Float) -> Float
   ) { fatalError() }
 }
 

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -757,6 +757,7 @@ func vjpMultipleSemanticResults(x: inout Float) -> (
 func inoutNonDifferentiableResult(_ x: inout Float) -> Int {
   return 5
 }
+// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
 @derivative(of: inoutNonDifferentiableResult)
 func vjpInoutNonDifferentiableResult(x: inout Float) -> (
   value: Int, pullback: (inout Float) -> Void
@@ -915,6 +916,7 @@ extension InoutParameters {
   ) { fatalError() }
 
   func tupleResultsInt(_ x: Float) -> (Int, Float) { (1, x) }
+  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
   @derivative(of: tupleResultsInt, wrt: x)
   func vjpTupleResults(_ x: Float) -> (
     value: (Int, Float), pullback: (Float) -> Float

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -680,6 +680,19 @@ struct InoutParameters: Differentiable {
   mutating func move(by _: TangentVector) {}
 }
 
+extension NonDiffableStruct {
+  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'NonDiffableStruct' does not conform to 'Differentiable'}}
+  @differentiable(reverse)
+  static func nondiffResult(x: Int, y: inout NonDiffableStruct, z: Float) {}
+
+  @differentiable(reverse)
+  static func diffResult(x: Int, y: inout NonDiffableStruct, z: Float) -> Float {}
+
+  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'NonDiffableStruct' does not conform to 'Differentiable'}}
+  @differentiable(reverse, wrt: (y, z))
+  static func diffResult2(x: Int, y: inout NonDiffableStruct, z: Float) -> Float {}
+}
+
 extension InoutParameters {
   @differentiable(reverse)
   static func staticMethod(_ lhs: inout Self, rhs: Self) {}
@@ -702,11 +715,20 @@ extension InoutParameters {
   @differentiable(reverse)
   static func tupleResults(_ x: Self) -> (Self, Self) {}
 
+  // Int does not conform to Differentiable
+  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
   @differentiable(reverse)
   static func tupleResultsInt(_ x: Self) -> (Int, Self) {}
 
+  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Int' does not conform to 'Differentiable'}}
   @differentiable(reverse)
   static func tupleResultsInt2(_ x: Self) -> (Self, Int) {}
+
+  @differentiable(reverse)
+  static func tupleResultsFloat(_ x: Self) -> (Float, Self) {}
+
+  @differentiable(reverse)
+  static func tupleResultsFloat2(_ x: Self) -> (Self, Float) {}
 }
 
 // Test accessors: `set`, `_read`, `_modify`.

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -528,7 +528,6 @@ func two9(x: Float, y: Float) -> Float {
 func inout1(x: Float, y: inout Float) -> Void {
   let _ = x + y
 }
-// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(reverse, wrt: y)
 func inout2(x: Float, y: inout Float) -> Float {
   let _ = x + y
@@ -670,11 +669,9 @@ final class FinalClass: Differentiable {
 @differentiable(reverse, wrt: y)
 func inoutVoid(x: Float, y: inout Float) {}
 
-// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(reverse)
 func multipleSemanticResults(_ x: inout Float) -> Float { x }
 
-// expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
 @differentiable(reverse, wrt: y)
 func swap(x: inout Float, y: inout Float) {}
 
@@ -687,7 +684,6 @@ extension InoutParameters {
   @differentiable(reverse)
   static func staticMethod(_ lhs: inout Self, rhs: Self) {}
 
-  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
   @differentiable(reverse)
   static func multipleSemanticResults(_ lhs: inout Self, rhs: Self) -> Self {}
 }
@@ -696,9 +692,21 @@ extension InoutParameters {
   @differentiable(reverse)
   mutating func mutatingMethod(_ other: Self) {}
 
-  // expected-error @+1 {{cannot differentiate functions with both an 'inout' parameter and a result}}
   @differentiable(reverse)
   mutating func mutatingMethod(_ other: Self) -> Self {}
+}
+
+// Test tuple results.
+
+extension InoutParameters {
+  @differentiable(reverse)
+  static func tupleResults(_ x: Self) -> (Self, Self) {}
+
+  @differentiable(reverse)
+  static func tupleResultsInt(_ x: Self) -> (Int, Self) {}
+
+  @differentiable(reverse)
+  static func tupleResultsInt2(_ x: Self) -> (Self, Int) {}
 }
 
 // Test accessors: `set`, `_read`, `_modify`.

--- a/test/AutoDiff/Serialization/derivative_attr.swift
+++ b/test/AutoDiff/Serialization/derivative_attr.swift
@@ -37,6 +37,26 @@ func derivativeTop2<T: Differentiable, U: Differentiable>(
   (y, { (dx, dy) in dy })
 }
 
+// Test top-level inout functions.
+
+func topInout1(_ x: inout S) {}
+
+// CHECK: @derivative(of: topInout1, wrt: x)
+@derivative(of: topInout1)
+func derivativeTopInout1(_ x: inout S) -> (value: Void, pullback: (inout S) -> Void) {
+  fatalError()
+}
+
+func topInout2(_ x: inout S) -> S {
+  x
+}
+
+// CHECK: @derivative(of: topInout2, wrt: x)
+@derivative(of: topInout2)
+func derivativeTopInout2(_ x: inout S) -> (value: S, pullback: (S, inout S) -> Void) {
+  fatalError()
+}
+
 // Test instance methods.
 
 extension S {

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -43,6 +43,29 @@ func testWrtClause(x: Float, y: Float) -> Float {
   return x
 }
 
+// CHECK: @differentiable(reverse, wrt: x)
+// CHECK-NEXT: func testInout(x: inout Float)
+@differentiable(reverse)
+func testInout(x: inout Float) {
+  x = x * 2.0
+}
+
+// CHECK: @differentiable(reverse, wrt: x)
+// CHECK-NEXT: func testInoutResult(x: inout Float) -> Float
+@differentiable(reverse)
+func testInoutResult(x: inout Float) -> Float {
+  x = x * 2.0
+  return x
+}
+
+// CHECK: @differentiable(reverse, wrt: (x, y))
+// CHECK-NEXT: func testMultipleInout(x: inout Float, y: inout Float)
+@differentiable(reverse)
+func testMultipleInout(x: inout Float, y: inout Float) {
+  x = x * y
+  y = x
+}
+
 struct InstanceMethod : Differentiable {
   // CHECK: @differentiable(reverse, wrt: (self, y))
   // CHECK-NEXT: func testWrtClause(x: Float, y: Float) -> Float

--- a/test/AutoDiff/Serialization/differentiable_function.swift
+++ b/test/AutoDiff/Serialization/differentiable_function.swift
@@ -15,3 +15,15 @@ func b(_ f: @differentiable(_linear) (Float) -> Float) {}
 
 func c(_ f: @differentiable(reverse) (Float, @noDerivative Float) -> Float) {}
 // CHECK: func c(_ f: @differentiable(reverse) (Float, @noDerivative Float) -> Float)
+
+func d(_ f: @differentiable(reverse) (inout Float) -> ()) {}
+// CHECK: func d(_ f: @differentiable(reverse) (inout Float) -> ())
+
+func e(_ f: @differentiable(reverse) (inout Float, inout Float) -> ()) {}
+// CHECK: func e(_ f: @differentiable(reverse) (inout Float, inout Float) -> ())
+
+func f(_ f: @differentiable(reverse) (inout Float) -> Float) {}
+// CHECK: func f(_ f: @differentiable(reverse) (inout Float) -> Float)
+
+func g(_ f: @differentiable(reverse) (inout Float, Float) -> Float) {}
+// CHECK: func g(_ f: @differentiable(reverse) (inout Float, Float) -> Float)


### PR DESCRIPTION
PR https://github.com/apple/swift/pull/32629 added reverse-mode differentiation support for apply instructions with multiple active semantic results. This completes user-facing support for differentiable functions with multiple semantic results.

Previously, it was not possible to state that a function with multiple semantic results was `@differentiable`. This included:

  * functions with an inout parameter which returned a result
  * functions with multiple inout parameters
  * mutating functions which returned a result
  * functions that return a tuple of results

It is now possible to mark these functions as `@differentiable` and to supply custom pullbacks for them.

This is essentially https://github.com/apple/swift/pull/38781 rebased on `main` with additional bugfixes and some changes here and there

Co-authored-by: @BradLarson