### PR TITLE
🍒 Fix @objcImpl crash with async/sync overloads

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2950,7 +2950,7 @@ private:
     if (auto func = dyn_cast<AbstractFunctionDecl>(req)) {
       auto asyncFunc = func->getAsyncAlternative();
 
-      if (auto asyncAccessor = dyn_cast<AccessorDecl>(asyncFunc))
+      if (auto asyncAccessor = dyn_cast_or_null<AccessorDecl>(asyncFunc))
         return asyncAccessor->getStorage();
 
       return asyncFunc;

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -94,6 +94,9 @@
 - (void)doSomethingAsynchronousWithCompletionHandler:(void (^ _Nonnull)(id _Nullable result, NSError * _Nullable error))completionHandler;
 - (void)doSomethingElseAsynchronousWithCompletionHandler:(void (^ _Nullable)(id _Nonnull result))completionHandler;
 - (void)doSomethingFunAndAsynchronousWithCompletionHandler:(void (^ _Nonnull)(id _Nullable result, NSError * _Nullable error))completionHandler;
+
+- (void)doSomethingOverloadedWithCompletionHandler:(void (^ _Nonnull)())completionHandler;
+- (void)doSomethingOverloaded __attribute__((__swift_attr__("@_unavailableFromAsync(message: \"Use async doSomethingOverloaded instead.\")")));
 @end
 
 @protocol PartiallyOptionalProtocol

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -312,6 +312,14 @@ protocol EmptySwiftProto {}
 
   public func doSomethingFunAndAsynchronous(completionHandler: @escaping (Any?, Error?) -> Void) {
   }
+
+  @available(SwiftStdlib 5.1, *)
+  @objc(doSomethingOverloadedWithCompletionHandler:)
+  public func doSomethingOverloaded() async {}
+
+  @available(*, noasync)
+  @objc(doSomethingOverloaded)
+  public func doSomethingOverloaded() {}
 }
 
 @_objcImplementation(Conformance) extension ObjCClass {


### PR DESCRIPTION
* Explanation: The `@_objcImplementation` checker sometimes dereferenced a null pointer when it tried to check an `async` method in the header against a non-`async` method in the extension. Modify the code to tolerate this situation.
* Radar (and possibly SR Issue): rdar://111064481
* Scope: Early adopters of `@_objcImplementation` who are using it to implement methods with completion handlers.
* Risk: Very low. The change simply makes the compiler handle `nullptr` correctly.
* Testing: Includes unit tests.
* Reviewed By: @tshortli and @xedin in #66858.