### PR TITLE
🍒[cxx-interop] Make libstdc++ header and modulemap arch-independent

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -105,7 +105,7 @@ static Optional<Path> getLibStdCxxModuleMapPath(
     SearchPathOptions &opts, const llvm::Triple &triple,
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs) {
   return getActualModuleMapPath("libstdcxx.modulemap", opts, triple,
-                                /*isArchSpecific*/ true, vfs);
+                                /*isArchSpecific*/ false, vfs);
 }
 
 Optional<SmallString<128>>

--- a/stdlib/public/Cxx/libstdcxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/libstdcxx/CMakeLists.txt
@@ -4,120 +4,115 @@ foreach(sdk ${SWIFT_SDKS})
     continue()
   endif()
 
-  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-    set(arch_suffix "${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
-    set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
+  set(module_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+  set(module_dir_static "${SWIFTSTATICLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
 
-    set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
-    set(module_dir_static "${SWIFTSTATICLIB_DIR}/${arch_subdir}")
+  set(libstdcxx_header "libstdcxx.h")
+  set(libstdcxx_header_out "${module_dir}/libstdcxx.h")
+  set(libstdcxx_header_out_static "${module_dir_static}/libstdcxx.h")
+  set(libstdcxx_modulemap "libstdcxx.modulemap")
+  set(libstdcxx_modulemap_out "${module_dir}/libstdcxx.modulemap")
+  set(libstdcxx_modulemap_out_static "${module_dir_static}/libstdcxx.modulemap")
 
-    set(libstdcxx_header "libstdcxx.h")
-    set(libstdcxx_header_out "${module_dir}/libstdcxx.h")
-    set(libstdcxx_header_out_static "${module_dir_static}/libstdcxx.h")
-    set(libstdcxx_modulemap "libstdcxx.modulemap")
-    set(libstdcxx_modulemap_out "${module_dir}/libstdcxx.modulemap")
-    set(libstdcxx_modulemap_out_static "${module_dir_static}/libstdcxx.modulemap")
+  add_custom_command_target(
+      copy_libstdcxx_modulemap
+      COMMAND
+      "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir}
+      COMMAND
+      "${CMAKE_COMMAND}" "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_modulemap}" "${libstdcxx_modulemap_out}"
+      OUTPUT ${libstdcxx_modulemap_out}
+      DEPENDS ${libstdcxx_modulemap}
+      COMMENT "Copying libstdcxx modulemap to resources")
+  list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_modulemap})
+  add_dependencies(swift-stdlib-${SWIFT_SDK_${sdk}_LIB_SUBDIR} ${copy_libstdcxx_modulemap})
+
+  add_custom_command_target(
+      copy_libstdcxx_header
+      COMMAND
+      "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir}
+      COMMAND
+      "${CMAKE_COMMAND}" "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_header}" "${libstdcxx_header_out}"
+      OUTPUT ${libstdcxx_header_out}
+      DEPENDS ${libstdcxx_header}
+      COMMENT "Copying libstdcxx header to resources")
+  list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_header})
+  add_dependencies(swift-stdlib-${SWIFT_SDK_${sdk}_LIB_SUBDIR} ${copy_libstdcxx_header})
+
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    add_custom_command_target(
+        copy_libstdcxx_modulemap_static
+        COMMAND
+        "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir_static}
+        COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+        "${libstdcxx_modulemap_out}" "${libstdcxx_modulemap_out_static}"
+        OUTPUT ${libstdcxx_modulemap_out_static}
+        DEPENDS ${copy_libstdcxx_modulemap}
+        COMMENT "Copying libstdcxx modulemap to static resources")
+    list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_modulemap_static})
+    add_dependencies(swift-stdlib-${SWIFT_SDK_${sdk}_LIB_SUBDIR} ${copy_libstdcxx_modulemap_static})
 
     add_custom_command_target(
-        copy_libstdcxx_modulemap
+        copy_libstdcxx_header_static
         COMMAND
-        "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir}
+        "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir_static}
         COMMAND
-        "${CMAKE_COMMAND}" "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_modulemap}" "${libstdcxx_modulemap_out}"
-        OUTPUT ${libstdcxx_modulemap_out}
-        DEPENDS ${libstdcxx_modulemap}
-        COMMENT "Copying libstdcxx modulemap to resources")
-    list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_modulemap})
-    add_dependencies(swift-stdlib-${arch_suffix} ${copy_libstdcxx_modulemap})
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+        "${libstdcxx_header_out}" "${libstdcxx_header_out_static}"
+        OUTPUT ${libstdcxx_header_out_static}
+        DEPENDS ${copy_libstdcxx_header}
+        COMMENT "Copying libstdcxx header to static resources")
+    list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_header_static})
+    add_dependencies(swift-stdlib-${SWIFT_SDK_${sdk}_LIB_SUBDIR} ${copy_libstdcxx_header_static})
+  endif()
 
-    add_custom_command_target(
-        copy_libstdcxx_header
-        COMMAND
-        "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir}
-        COMMAND
-        "${CMAKE_COMMAND}" "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_header}" "${libstdcxx_header_out}"
-        OUTPUT ${libstdcxx_header_out}
-        DEPENDS ${libstdcxx_header}
-        COMMENT "Copying libstdcxx header to resources")
-    list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_header})
-    add_dependencies(swift-stdlib-${arch_suffix} ${copy_libstdcxx_header})
+  swift_install_in_component(FILES "${libstdcxx_modulemap_out}"
+      DESTINATION "lib/swift/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+      COMPONENT sdk-overlay)
+  swift_install_in_component(FILES "${libstdcxx_header_out}"
+      DESTINATION "lib/swift/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+      COMPONENT sdk-overlay)
 
-    if(SWIFT_BUILD_STATIC_STDLIB)
-      add_custom_command_target(
-          copy_libstdcxx_modulemap_static
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    swift_install_in_component(FILES "${libstdcxx_modulemap_out_static}"
+        DESTINATION "lib/swift_static/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+        COMPONENT sdk-overlay)
+    swift_install_in_component(FILES "${libstdcxx_header_out_static}"
+        DESTINATION "lib/swift_static/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
+        COMPONENT sdk-overlay)
+  endif()
+
+  if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
+    foreach(bootstrapping "0" "1")
+      get_bootstrapping_path(bootstrapping_dir ${module_dir} ${bootstrapping})
+      set(libstdcxx_modulemap_out_bootstrapping "${bootstrapping_dir}/libstdcxx.modulemap")
+      set(libstdcxx_header_out_bootstrapping "${bootstrapping_dir}/libstdcxx.h")
+
+      add_custom_command_target(unused_var
           COMMAND
-          "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir_static}
+          "${CMAKE_COMMAND}" "-E" "make_directory" "${bootstrapping_dir}"
           COMMAND
           "${CMAKE_COMMAND}" "-E" "copy_if_different"
-          "${libstdcxx_modulemap_out}" "${libstdcxx_modulemap_out_static}"
-          OUTPUT ${libstdcxx_modulemap_out_static}
-          DEPENDS ${copy_libstdcxx_modulemap}
-          COMMENT "Copying libstdcxx modulemap to static resources")
-      list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_modulemap_static})
-      add_dependencies(swift-stdlib-${arch_suffix} ${copy_libstdcxx_modulemap_static})
+          "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_modulemap}" "${libstdcxx_modulemap_out_bootstrapping}"
 
-      add_custom_command_target(
-          copy_libstdcxx_header_static
+          CUSTOM_TARGET_NAME "copy-libstdcxx-modulemap-bootstrapping${bootstrapping}"
+          OUTPUT "${libstdcxx_modulemap_out_bootstrapping}"
+          DEPENDS ${libstdcxx_modulemap}
+          COMMENT "Copying libstdcxx modulemap to resources for bootstrapping${bootstrapping}")
+
+      add_custom_command_target(unused_var
           COMMAND
-          "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir_static}
+          "${CMAKE_COMMAND}" "-E" "make_directory" "${bootstrapping_dir}"
           COMMAND
           "${CMAKE_COMMAND}" "-E" "copy_if_different"
-          "${libstdcxx_header_out}" "${libstdcxx_header_out_static}"
-          OUTPUT ${libstdcxx_header_out_static}
-          DEPENDS ${copy_libstdcxx_header}
-          COMMENT "Copying libstdcxx header to static resources")
-      list(APPEND libstdcxx_modulemap_target_list ${copy_libstdcxx_header_static})
-      add_dependencies(swift-stdlib-${arch_suffix} ${copy_libstdcxx_header_static})
-    endif()
+          "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_header}" "${libstdcxx_header_out_bootstrapping}"
 
-    swift_install_in_component(FILES "${libstdcxx_modulemap_out}"
-        DESTINATION "lib/swift/${arch_subdir}"
-        COMPONENT sdk-overlay)
-    swift_install_in_component(FILES "${libstdcxx_header_out}"
-        DESTINATION "lib/swift/${arch_subdir}"
-        COMPONENT sdk-overlay)
-
-    if(SWIFT_BUILD_STATIC_STDLIB)
-      swift_install_in_component(FILES "${libstdcxx_modulemap_out_static}"
-          DESTINATION "lib/swift_static/${arch_subdir}"
-          COMPONENT sdk-overlay)
-      swift_install_in_component(FILES "${libstdcxx_header_out_static}"
-          DESTINATION "lib/swift_static/${arch_subdir}"
-          COMPONENT sdk-overlay)
-    endif()
-
-    if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
-      foreach(bootstrapping "0" "1")
-        get_bootstrapping_path(bootstrapping_dir ${module_dir} ${bootstrapping})
-        set(libstdcxx_modulemap_out_bootstrapping "${bootstrapping_dir}/libstdcxx.modulemap")
-        set(libstdcxx_header_out_bootstrapping "${bootstrapping_dir}/libstdcxx.h")
-
-        add_custom_command_target(unused_var
-            COMMAND
-            "${CMAKE_COMMAND}" "-E" "make_directory" "${bootstrapping_dir}"
-            COMMAND
-            "${CMAKE_COMMAND}" "-E" "copy_if_different"
-            "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_modulemap}" "${libstdcxx_modulemap_out_bootstrapping}"
-
-            CUSTOM_TARGET_NAME "copy-libstdcxx-modulemap-bootstrapping${bootstrapping}"
-            OUTPUT "${libstdcxx_modulemap_out_bootstrapping}"
-            DEPENDS ${libstdcxx_modulemap}
-            COMMENT "Copying libstdcxx modulemap to resources for bootstrapping${bootstrapping}")
-
-        add_custom_command_target(unused_var
-            COMMAND
-            "${CMAKE_COMMAND}" "-E" "make_directory" "${bootstrapping_dir}"
-            COMMAND
-            "${CMAKE_COMMAND}" "-E" "copy_if_different"
-            "${CMAKE_CURRENT_SOURCE_DIR}/${libstdcxx_header}" "${libstdcxx_header_out_bootstrapping}"
-
-            CUSTOM_TARGET_NAME "copy-libstdcxx-header-bootstrapping${bootstrapping}"
-            OUTPUT "${libstdcxx_header_out_bootstrapping}"
-            DEPENDS ${libstdcxx_header}
-            COMMENT "Copying libstdcxx header to resources for bootstrapping${bootstrapping}")
-      endforeach()
-    endif()
-  endforeach()
+          CUSTOM_TARGET_NAME "copy-libstdcxx-header-bootstrapping${bootstrapping}"
+          OUTPUT "${libstdcxx_header_out_bootstrapping}"
+          DEPENDS ${libstdcxx_header}
+          COMMENT "Copying libstdcxx header to resources for bootstrapping${bootstrapping}")
+    endforeach()
+  endif()
 endforeach()
 add_custom_target(libstdcxx-modulemap DEPENDS ${libstdcxx_modulemap_target_list})
 set_property(TARGET libstdcxx-modulemap PROPERTY FOLDER "Miscellaneous")

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -155,8 +155,7 @@ struct LibStdCxxInjectionVFS {
 
   // Add a libstdc++ modulemap that's part of Swift's distribution.
   LibStdCxxInjectionVFS &libstdCxxModulemap(StringRef contents = "") {
-    newFile("/usr/lib/swift/" + osString + "/" + archString +
-                "/libstdcxx.modulemap",
+    newFile("/usr/lib/swift/" + osString + "/libstdcxx.modulemap",
             contents.empty() ? getLibstdcxxModulemapContents() : contents);
     return *this;
   }
@@ -208,11 +207,11 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
-              "/usr/lib/swift/linux/x86_64/libstdcxx.h");
+              "/usr/lib/swift/linux/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[1].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
     EXPECT_EQ(paths.redirectedFiles[1].second,
-              "/usr/lib/swift/linux/x86_64/libstdcxx.modulemap");
+              "/usr/lib/swift/linux/libstdcxx.modulemap");
   }
 
   {
@@ -224,7 +223,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
-              "/usr/lib/swift/linux/x86_64/libstdcxx.h");
+              "/usr/lib/swift/linux/libstdcxx.h");
     EXPECT_EQ(paths.overridenFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
     EXPECT_NE(paths.overridenFiles[0].second.find(
@@ -250,7 +249,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
     EXPECT_EQ(paths.redirectedFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/libstdcxx.h");
     EXPECT_EQ(paths.redirectedFiles[0].second,
-              "/usr/lib/swift/linux/x86_64/libstdcxx.h");
+              "/usr/lib/swift/linux/libstdcxx.h");
     EXPECT_EQ(paths.overridenFiles[0].first,
               "/opt/rh/devtoolset-9/root/usr/include/c++/9/module.modulemap");
     EXPECT_NE(


### PR DESCRIPTION
**Explanation**: This moves `libstdcxx.modulemap` and `libstdcxx.h` from `*.xctoolchain/usr/lib/swift/linux/x86_64` to `*.xctoolchain/usr/lib/swift/linux` to simplify distribution.
**Scope**: This simplifies the CMake build scripts to ignore the architecture for these headers, and adjusts the compiler logic used to discover the headers.
**Risk**: Medium, this alters the distribution of the toolchain headers on Linux.

Original PR: https://github.com/apple/swift/pull/66855
This is a follow-up to https://github.com/apple/swift/pull/66807

rdar://110788977
(cherry picked from commit 3e28a7c525a9801259b4f14d8ef9e35969f2c4cb)