### PR TITLE
[cherry-pick][release/5.9] [Build] Introduce --lldb-configure-tests option

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1398,6 +1398,10 @@ mixin-preset=
 skip-test-lldb
 skip-test-playgroundsupport
 
+# Don't configure LLDB tests either since that
+# would require us to build libcxx (rdar://109774179)
+lldb-configure-tests=0
+
 [preset: buildbot_osx_package,use_os_runtime]
 mixin-preset=
     buildbot_osx_package

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -174,6 +174,7 @@ KNOWN_SETTINGS=(
     lldb-test-swift-compatibility                 ""                "specify additional Swift compilers to test lldb with"
     lldb-test-swift-only                          "0"               "when running lldb tests, only include Swift-specific tests"
     lldb-use-system-debugserver                   ""                "don't try to codesign debugserver, and use the system's debugserver instead"
+    lldb-configure-tests                          "1"               "if set, will make sure we configure LLDB's test target without running the tests"
 
     ## LLVM Options
     llvm-enable-lto                               ""                "Must be set to one of 'thin' or 'full'"
@@ -2187,7 +2188,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     DOTEST_ARGS="${DOTEST_ARGS};-E;${DOTEST_EXTRA}"
                 fi
 
-                if [[ "${SKIP_TEST_LLDB}" ]]; then
+                if [[ $(true_false "${LLDB_CONFIGURE_TESTS}") == "FALSE" ]]; then
                     should_configure_tests="FALSE"
                 else
                     should_configure_tests=$(false_true ${BUILD_TOOLCHAIN_ONLY})


### PR DESCRIPTION
We recently changed the build-script to stop configuring LLDB tests if `SKIP_TESTS_LLDB` is set  (see rdar://109774179 and https://github.com/apple/swift/pull/66171).

A common use-case is to build lldb without `-t` (to avoid running the tests) and then run the tests separately later. However, if we don't specify the `-t` flag to the build-script, `SKIP_TESTS_LLDB` is implicitly set. Meaning this multi-step way of running lldb tests regressed.

This patch addresses this by creating a new `--lldb-configure-tests` option which when set makes sure we set the CMake variable `LLDB_INCLUDE_TESTS` (which will be the default behaviour).

The preset for which we originally introduced the `SKIP_TESTS_LLDB` check now sets this new option to `0` to avoid configuring LLDB tests. The preset skips running the tests anyway, we're not losing test coverage.

(cherry picked from commit 511c3445777dbfe1e34b3f19eb0f141989826bb0)