### PR TITLE
[5.9][CSSimplify] Add special handling if specialized type comes from `TypeExpr`

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1271,6 +1271,15 @@ public:
     return ConstraintLocatorBuilder(this, newElt, newFlags);
   }
 
+  /// Determine whether this locator builder points directly to a
+  /// given expression.
+  template <typename E>
+  bool directlyAt() const {
+    if (auto *expr = getAnchor().dyn_cast<Expr *>())
+      return isa<E>(expr) && hasEmptyPath();
+    return false;
+  }
+
   /// Determine whether this builder has an empty path.
   bool hasEmptyPath() const {
     return !element;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13547,6 +13547,38 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
       auto *genericParam = typeVar->getImpl().getGenericParameter();
       openedTypes.push_back({genericParam, typeVar});
     }
+  } else if (locator.directlyAt<TypeExpr>()) {
+    auto *BGT = type1->getAs<BoundGenericType>();
+    if (!BGT)
+      return SolutionKind::Error;
+
+    decl = BGT->getDecl();
+
+    auto genericParams = BGT->getDecl()->getInnermostGenericParamTypes();
+    if (genericParams.size() != BGT->getGenericArgs().size())
+      return SolutionKind::Error;
+
+    for (unsigned i = 0, n = genericParams.size(); i != n; ++i) {
+      auto argType = BGT->getGenericArgs()[i];
+      if (auto *typeVar = argType->getAs<TypeVariableType>()) {
+        openedTypes.push_back({genericParams[i], typeVar});
+      } else {
+        // If we have a concrete substitution then we need to create
+        // a new type variable to be able to add it to the list as-if
+        // it is opened generic parameter type.
+        auto *GP = genericParams[i];
+
+        unsigned options = TVO_CanBindToNoEscape;
+        if (GP->isParameterPack())
+          options |= TVO_CanBindToPack;
+
+        auto *argVar = createTypeVariable(
+            getConstraintLocator(locator, LocatorPathElt::GenericArgument(i)),
+            options);
+        addConstraint(ConstraintKind::Bind, argVar, argType, locator);
+        openedTypes.push_back({GP, argVar});
+      }
+    }
   } else {
     // If the overload hasn't been resolved, we can't simplify this constraint.
     auto overloadLocator = getCalleeLocator(getConstraintLocator(locator));

--- a/test/decl/ext/specialize.swift
+++ b/test/decl/ext/specialize.swift
@@ -74,3 +74,15 @@ func testNestedExtensions() {
 
   Tree<Int>.Branch<String>.Nest<Void>.Egg.twite()
 }
+
+// rdar://111059036 - failed to produce a diagnostic in specialized extension
+struct Test {
+  struct Key<Value> {}
+}
+
+class State {
+}
+
+extension Test.Key<State> {
+  static let state = Self<State>()
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66796

---

- Explanation:

Add a special case for `TypeExpr` due to i.e. context specialization,
in such cases there is nothing for the solver to "open" so we need to
form opened type map manually.

- Scope: Attempts to specialize type references (including in specialized extensions).

- Main Branch PR: https://github.com/apple/swift/pull/66796

- Risk: Low

- Resolves: rdar://111059036

- Reviewed By: @DougGregor 

- Testing: Added regression test-cases to the suite.

Resolves: rdar://111059036

(cherry picked from commit e1e933cecac10094b90a7e69394a0c2aac67395b)
(cherry picked from commit 5e30445495ac7b7db15404bd88d0b2e98c579972)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
