### PR TITLE
[5.9][Completion] Add targetEnvironment(macCatalyst) platform condition

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1204,6 +1204,9 @@ static void addPlatformConditions(CodeCompletionResultSink &Sink) {
   addWithName("targetEnvironment", [](CodeCompletionResultBuilder &Builder) {
     Builder.addTextChunk("simulator");
   });
+  addWithName("targetEnvironment", [](CodeCompletionResultBuilder &Builder) {
+    Builder.addTextChunk("macCatalyst");
+  });
   addWithName("swift", [](CodeCompletionResultBuilder &Builder) {
     Builder.addTextChunk(">=");
     Builder.addSimpleNamedParameter("version");

--- a/test/IDE/complete_pound_directive.swift
+++ b/test/IDE/complete_pound_directive.swift
@@ -51,6 +51,7 @@ class C {
 // CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               arch({#(name)#}); name=arch(); sourcetext=arch(<#T##name#>)
 // CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               canImport({#(module)#}); name=canImport(); sourcetext=canImport(<#T##module#>)
 // CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               targetEnvironment(simulator); name=targetEnvironment(simulator); sourcetext=targetEnvironment(simulator)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               targetEnvironment(macCatalyst); name=targetEnvironment(macCatalyst); sourcetext=targetEnvironment(macCatalyst)
 // CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               swift(>={#(version)#}); name=swift(>=); sourcetext=swift(>=<#T##version#>)
 // CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               swift(<{#(version)#}); name=swift(<); sourcetext=swift(<<#T##version#>)
 // CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               compiler(>={#(version)#}); name=compiler(>=); sourcetext=compiler(>=<#T##version#>)


### PR DESCRIPTION
* **Explanation**: Adds `targetEnvironment(macCatalyst)` as a completion for platform conditions.
* **Scope**: Completion
* **Risk**: Very low. Just adds a text based completion item.
* **Testing**: Added a check for the new completion.
* **Original PR**:  https://github.com/apple/swift/pull/66875