### PR TITLE
[5.9] [ASTPrinter] Stop unnecessary escaping of `init` in macro role attributes

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1386,8 +1386,9 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
               SmallString<32> buffer;
               StringRef nameText = name.getName().getString(buffer);
               bool shouldEscape =
-                  escapeKeywordInContext(nameText, PrintNameContext::Normal) ||
-                  nameText == "$";
+                  !name.getName().isSpecial() &&
+                  (escapeKeywordInContext(nameText, PrintNameContext::Normal) ||
+                   nameText == "$");
               Printer << "(";
               if (shouldEscape)
                 Printer << "`";

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -35,9 +35,19 @@
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK: @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
 // CHECK-NEXT: #endif
 @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+
+// CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
+// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInitFunc() = #externalMacro(module: "SomeModule", type: "MemberwiseInitFuncMacro")
+// CHECK-NEXT: #endif
+@attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInitFunc() = #externalMacro(module: "SomeModule", type: "MemberwiseInitFuncMacro")
+
+// CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
+// CHECK: @attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "SomeModule", type: "AccessorInitFuncMacro")
+// CHECK-NEXT: #endif
+@attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "SomeModule", type: "AccessorInitFuncMacro")
 
 // CHECK-NOT: internalStringify
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")


### PR DESCRIPTION
The excessive escaping of `init` in macro role attributes was a workaround paired with https://github.com/apple/swift/pull/65442 to smooth things over when working across Swift compiler versions. However, it's causing problems for init accessors, so stop escaping.

Fixes rdar://111190084.
