### PR TITLE
[5.9] SILGen: Don't emit key path property descriptors for properties in or of noncopyable types.

### DIFF
--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -300,6 +300,21 @@ bool AbstractStorageDecl::exportsPropertyDescriptor() const {
   // The storage needs a descriptor if it sits at a module's ABI boundary,
   // meaning it has public linkage.
   
+  // Noncopyable types aren't supported by key paths in their current form.
+  // They would also need a new ABI that's yet to be implemented in order to
+  // be properly supported, so let's suppress the descriptor for now if either
+  // the container or storage type of the declaration is non-copyable.
+  if (getValueInterfaceType()->isPureMoveOnly()) {
+    return false;
+  }
+  if (!isStatic()) {
+    if (auto contextTy = getDeclContext()->getDeclaredTypeInContext()) {
+      if (contextTy->isPureMoveOnly()) {
+        return false;
+      }
+    }
+  }
+  
   // TODO: Global and static properties ought to eventually be referenceable
   // as key paths from () or T.Type too.
   if (!getDeclContext()->isTypeContext() || isStatic())

--- a/test/SILGen/no_property_descriptor_for_move_only.swift
+++ b/test/SILGen/no_property_descriptor_for_move_only.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-silgen %s > %t/fragile-out.sil
+// %FileCheck --check-prefix=POS %s < %t/fragile-out.sil
+// %FileCheck --check-prefix=NEG %s < %t/fragile-out.sil
+// RUN: %target-swift-emit-silgen -enable-library-evolution %s > %t/resilient-out.sil
+// %FileCheck --check-prefix=POS %s < %t/resilient-out.sil
+// %FileCheck --check-prefix=NEG %s < %t/resilient-out.sil
+
+@frozen
+public struct IsCopyable {
+    public init() {}
+
+    // Shouldn't get a property descriptor since property type is noncopyable
+    // NEG-NOT: sil_property #IsCopyable.noncopyable
+    public var noncopyable: IsntCopyable {
+        get { IsntCopyable() }
+        set { }
+    }
+
+    // Should get a property descriptor, copyable container and property
+    // POS: sil_property #IsCopyable.copyable
+    public var copyable: IsCopyable {
+        get { IsCopyable() }
+        set { }
+    }
+
+    // Shouldn't get a property descriptor since it's static
+    // NEG-NOT: sil_property #IsCopyable.staticCopyable
+    public static var staticCopyable: IsCopyable = IsCopyable()
+
+    // Shouldn't get a property descriptor since it's static
+    // NEG-NOT: sil_property #IsCopyable.staticNoncopyable
+    public static var staticNoncopyable: IsntCopyable = IsntCopyable()
+}
+
+@frozen
+public struct IsntCopyable: ~Copyable {
+    public init() {}
+
+    // Shouldn't get a property descriptor since container and property type are both noncopyable
+    // NEG-NOT: sil_property #IsntCopyable.noncopyable
+    public var noncopyable: IsntCopyable {
+        get { IsntCopyable() }
+        set { }
+    }
+
+    // Shouldn't get a property descriptor since container type is noncopyable
+    // NEG-NOT: sil_property #IsntCopyable.copyable
+    public var copyable: IsCopyable {
+        get { IsCopyable() }
+        set { }
+    }
+
+    // Shouldn't get a property descriptor since it's static
+    // NEG-NOT: sil_property #IsntCopyable.staticCopyable
+    public static var staticCopyable: IsCopyable = IsCopyable()
+
+    // Shouldn't get a property descriptor since it's static
+    // NEG-NOT: sil_property #IsntCopyable.staticNoncopyable
+    public static var staticNoncopyable: IsntCopyable = IsntCopyable()
+}
+
+// Shouldn't get a property descriptor since it's global
+// NEG-NOT: sil_property #{{.*}}globalCopyable
+public var globalCopyable: IsCopyable = IsCopyable()
+
+// Shouldn't get a property descriptor since it's global
+// NEG-NOT: sil_property #{{.*}}globalNoncopyable
+public var globalNoncopyable: IsntCopyable = IsntCopyable()


### PR DESCRIPTION
Issue: rdar://111171284
• Explanation: Key paths don't support noncopyable types yet, and the current component representation is inadequate to handle them without requiring internal copying in all cases, so generating property descriptors for them is unhelpful and occasionally leads to invalid code generation. This patch disables property descriptors for noncopyable types.
• Scope of Issue: Fixes a bug where public properties in noncopyable types, or of noncopyable type, could lead to spurious diagnostics or compiler crashes.
• Origination: Noncopyable types feature work
• Risk: low -- disables invalid code generation paths. Should have no impact on existing code not using noncopyable types.
• Reviewed By: @gottesmm
• Automated Testing: Swift CI
• Dependencies: None
• Builder Impact: Not applicable
• Directions for QE: None
