### PR TITLE
[Macros] Include plugin stderr in diagnostics

### DIFF
--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -53,17 +53,23 @@ class LoadedExecutablePlugin {
   /// Represents the current process of the executable plugin.
   struct PluginProcess {
     const llvm::sys::procid_t pid;
+    // Plugin's STDOUT.
     const int inputFileDescriptor;
+    // Plugin's STDIN.
     const int outputFileDescriptor;
+    // Plugin's STDERR.
+    const int errorFileDescriptor;
     bool isStale = false;
 
     PluginProcess(llvm::sys::procid_t pid, int inputFileDescriptor,
-                  int outputFileDescriptor);
+                  int outputFileDescriptor, int errorFileDescriptor);
 
     ~PluginProcess();
 
+    void readErrorAppendingTo(std::string &errStr) const;
+
     ssize_t write(const void *buf, size_t nbyte) const;
-    ssize_t read(void *buf, size_t nbyte) const;
+    ssize_t read(void *buf, size_t nbyte, std::string &error) const;
   };
 
   /// Launched current process.

--- a/include/swift/Basic/Program.h
+++ b/include/swift/Basic/Program.h
@@ -43,11 +43,13 @@ struct ChildProcessInfo {
   llvm::sys::procid_t Pid;
   int WriteFileDescriptor;
   int ReadFileDescriptor;
+  int ErrOutFileDescriptor;
 
   ChildProcessInfo(llvm::sys::procid_t Pid, int WriteFileDescriptor,
-                   int ReadFileDescriptor)
+                   int ReadFileDescriptor, int ErrOutFileDescriptor)
       : Pid(Pid), WriteFileDescriptor(WriteFileDescriptor),
-        ReadFileDescriptor(ReadFileDescriptor) {}
+        ReadFileDescriptor(ReadFileDescriptor),
+        ErrOutFileDescriptor(ErrOutFileDescriptor) {}
 };
 
 /// This function executes the program using the argument provided.

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -861,11 +861,16 @@ bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   auto result = plugin->waitForNextMessage();
   if (!result) {
-    // FIXME: Pass the error message back to the caller.
-    llvm::consumeError(result.takeError());
-//    llvm::handleAllErrors(result.takeError(), [](const llvm::ErrorInfoBase &err) {
-//      llvm::errs() << err.message() << "\n";
-//    });
+    std::string errMsg;
+    llvm::handleAllErrors(
+        result.takeError(),
+        [&](const llvm::ErrorInfoBase &err) { errMsg.append(err.message()); });
+    if (!errMsg.empty()) {
+      auto size = errMsg.size();
+      auto outPtr = malloc(size);
+      memcpy(outPtr, errMsg.data(), size);
+      *out = BridgedData{(const char *)outPtr, (unsigned long)size};
+    }
     return true;
   }
   auto &message = result.get();

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -15,13 +15,31 @@ import CBasicBridging
 import SwiftSyntax
 import swiftLLVMJSON
 
-enum PluginError: String, Error, CustomStringConvertible {
-  case stalePlugin = "plugin is stale"
-  case failedToSendMessage = "failed to send request to plugin"
-  case failedToReceiveMessage = "failed to receive result from plugin"
-  case invalidReponseKind = "plugin returned invalid result"
+enum PluginError: Error, CustomStringConvertible {
+  case stalePlugin
+  case failedToSendMessage
+  case failedToReceiveMessage(String?)
+  case invalidReponseKind
 
-  var description: String { rawValue }
+  var description: String {
+    switch self {
+    case .stalePlugin:
+      return "plugin is stale"
+    case .failedToSendMessage:
+      return "failed to send request to plugin"
+    case .failedToReceiveMessage(let message):
+      var description = "failed to receive result from plugin"
+      if let message = message {
+        let message = message
+          .dropPrefix(in: ["\n", "\r", "\r\n"])
+          .dropSuffix(in: ["\n", "\r", "\r\n"])
+        description += "; " + message
+      }
+      return description
+    case .invalidReponseKind:
+      return "plugin returned invalid result"
+    }
+  }
 }
 
 @_cdecl("swift_ASTGen_initializePlugin")
@@ -132,7 +150,7 @@ struct CompilerPlugin {
     let hadError = Plugin_waitForNextMessage(opaqueHandle, &result)
     defer { BridgedData_free(result) }
     guard !hadError else {
-      throw PluginError.failedToReceiveMessage
+      throw PluginError.failedToReceiveMessage(String(result))
     }
     let data = UnsafeBufferPointer(start: result.baseAddress, count: Int(result.size))
     return try LLVMJSON.decode(PluginToHostMessage.self, from: data)
@@ -377,5 +395,34 @@ extension PluginMessage.Syntax {
         offset: loc.offset,
         line: loc.line,
         column: loc.column))
+  }
+}
+
+extension String {
+  init?(_ data: BridgedData) {
+    if data.baseAddress == nil {
+      return nil
+    }
+    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: Int(data.size))
+    self = buffer.withMemoryRebound(to: UInt8.self) { buffer in
+      String(decoding: buffer, as: UTF8.self)
+    }
+  }
+}
+
+extension StringProtocol where SubSequence == Substring {
+  func dropPrefix(in characters: Set<Character>) -> Substring {
+    var i = startIndex
+    while characters.contains(self[i]) {
+      i = index(after: i)
+    }
+    return self[i...]
+  }
+  func dropSuffix(in characters: Set<Character>) -> Substring {
+    var i = index(before: endIndex)
+    while characters.contains(self[i]) {
+      i = index(before: i)
+    }
+    return self[...i]
   }
 }

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -40,7 +40,7 @@ func test() {
   let _: String = #fooMacro(1)
   // expected-error @-1 {{typeMismatch(swiftASTGen.PluginToHostMessage}}
   let _: String = #fooMacro(2)
-  // expected-error @-1 {{failed to receive result from plugin (from macro 'fooMacro')}}
+  // expected-error @-1 {{failed to receive result from plugin; cound't find matching item for request}}
   let _: String = #fooMacro(3)
   // ^ This should succeed.
 }


### PR DESCRIPTION
Capture stderr from exectuable plugins, and include it in diagnostics when the compiler fails to receive response from plugins.

rdar://111224872
