### PR TITLE
[5.9] Exclude GenericParam Constraints

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -697,7 +697,7 @@ Type GenericSignatureImpl::getUpperBound(Type type,
           abort();
         }
 
-        if (!hasInnerGenericParam)
+        if (!hasInnerGenericParam && (wantDependentBound || !hasOuterGenericParam))
           argTypes.push_back(reducedType);
       }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 protocol Q { }
 
@@ -368,4 +368,53 @@ func testPrimaryAssocReturn(p: any P4<Int>) {
 
 func testPrimaryAssocCollection(p: any P4<Float>) {
   let _: any Collection<Float> = p.returnAssocTypeCollection()
+}
+
+protocol P5<X> {
+  associatedtype X = Void
+}
+
+struct K<T>: P5 {
+  typealias X = T
+}
+
+extension P5 {
+  @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  func foo() -> some P5<X>{
+    K<X>()
+  }
+  func bar(_ handler: @escaping (X) -> Void) -> some P5<X> {
+    K<X>()
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+func testFoo(_ p: any P5<String>) -> any P5 {
+  p.foo()
+}
+
+func testFooGeneric<U>(_ p: any P5<Result<U, Error>>) -> any P5 {
+  p.foo()
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+func testBar<U>(_ p: any P5<Result<U, Error>>) -> any P5 {
+  p.bar { _ in }
+}
+
+enum Node<T> {
+  case e(any P5)
+  case f(any P5<Result<T, Error>>)
+}
+
+struct S<T, U> {
+  @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  func foo(_ elt: Node<U>) -> Node<T>? {
+    switch elt {
+    case let .e(p):
+      return .e(p)
+    case let .f(p):
+      return .e(p.bar { _ in })
+    }
+  }
 }


### PR DESCRIPTION
* **Explanation**: Only preserve primary associated types during type erasure if the generic context does not contain outer generic pramaters. 
    * Given `func foo {  ... any P <Int> ... }` getNonDependentUpperBounds()
should produce `any P<Int>`
    * However, given func `foo<T> { ... any P<T> ... }` getNonDependentUpperBounds()
should produce `any P`
* **Scope**: Narrow; effects existential parameterized protocol type erasure
* **Risk**: Low, this adds support for parameterized protocol type to generic signature
* **Reviewers**: @slavapestov @xedin 
* **Issue**: rdar://110262754
* **Original pull request**: https://github.com/apple/swift/pull/66864
