### PR TITLE
Add DirectInput

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -225,6 +225,13 @@ module WinSDK [system] {
 
       link "xinput.lib"
     }
+    
+    module DirectInput8 {
+      header "dinput.h"
+      export *
+
+      link "dinput.lib"
+    }
 
     link "dxguid.lib"
   }


### PR DESCRIPTION
Adds DirectInput8 to the WinSDK modulemap

Though Microsoft claims XInput replaced DirectInput, they are actually completely separate things and DirectInput is still largely used on Windows for popular first party game controllers, like PS4 and PS5.