### PR TITLE
Experimental support for static-sized arrays in Swift; requires C++ interop.

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -117,6 +117,7 @@ PROTOCOL(CxxSequence)
 PROTOCOL(CxxUniqueSet)
 PROTOCOL(UnsafeCxxInputIterator)
 PROTOCOL(UnsafeCxxRandomAccessIterator)
+PROTOCOL(_UnsafeCxxStaticArray)
 
 PROTOCOL(AsyncSequence)
 PROTOCOL(AsyncIteratorProtocol)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -313,6 +313,9 @@ namespace swift {
     /// Imports getters and setters as computed properties.
     bool CxxInteropGettersSettersAsProperties = false;
 
+    /// Imports static arrays as collections.
+    bool CxxInteropStaticArrayAsCollection = false;
+
     /// Should the compiler require C++ interoperability to be enabled
     /// when importing Swift modules that enable C++ interoperability.
     bool RequireCxxInteropToImportCxxInteropModule = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -864,6 +864,11 @@ def cxx_interop_getters_setters_as_properties :
   Flag<["-"], "cxx-interop-getters-setters-as-properties">,
   HelpText<"Import getters and setters as computed properties in Swift">,
   Flags<[FrontendOption, HelpHidden]>;
+  
+def cxx_interop_static_array_as_collection :
+  Flag<["-"], "cxx-interop-static-array-as-collection">,
+  HelpText<"Import static arrays as RandomAccessCollections; source breaking">,
+  Flags<[FrontendOption, HelpHidden]>;
 
 def cxx_interop_disable_requirement_at_import :
   Flag<["-"], "disable-cxx-interop-requirement-at-import">,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1141,6 +1141,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::CxxUniqueSet:
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
+  case KnownProtocolKind::_UnsafeCxxStaticArray:
     M = getLoadedModule(Id_Cxx);
     break;
   default:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1043,6 +1043,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_experimental_c_foreign_reference_types);
 
   Opts.CxxInteropGettersSettersAsProperties = Args.hasArg(OPT_cxx_interop_getters_setters_as_properties);
+  Opts.CxxInteropStaticArrayAsCollection =
+      Args.hasArg(OPT_cxx_interop_static_array_as_collection);
   Opts.RequireCxxInteropToImportCxxInteropModule =
       !Args.hasArg(OPT_cxx_interop_disable_requirement_at_import);
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6291,6 +6291,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::CxxUniqueSet:
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
+  case KnownProtocolKind::_UnsafeCxxStaticArray:
   case KnownProtocolKind::Executor:
   case KnownProtocolKind::SerialExecutor:
   case KnownProtocolKind::Sendable:

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     CxxSet.swift
     CxxRandomAccessCollection.swift
     CxxSequence.swift
+    CxxStaticArray.swift
     UnsafeCxxIterators.swift
 
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}

--- a/stdlib/public/Cxx/CxxStaticArray.swift
+++ b/stdlib/public/Cxx/CxxStaticArray.swift
@@ -1,0 +1,34 @@
+public protocol _UnsafeCxxStaticArray: RandomAccessCollection {
+  override associatedtype Iterator = IndexingIterator<Self>
+  override associatedtype Index = Int
+  override associatedtype Indices = Range<Int>
+  override associatedtype SubSequence = Slice<Self>
+
+  func __dataUnsafe() -> UnsafePointer<Element>
+  mutating func getCount() -> Int
+}
+
+extension _UnsafeCxxStaticArray {
+  public var startIndex: Int { 0 }
+  public var endIndex: Int { 8 }
+  
+  public subscript(_ i: Int) -> Element {
+    _read {
+      var this = self
+      let element = UnsafeRawPointer(&this)!
+        .withMemoryRebound(to: Element.self, capacity: count) { $0[i] }
+      yield element
+    }
+    _modify {
+      var ptr = UnsafeMutableRawPointer(&self)!
+        .withMemoryRebound(to: Element.self, capacity: count) { $0 }
+      yield &ptr[i]
+    }
+  }
+  
+  public func withInnerStorage<Result>(
+    _ body: (UnsafePointer<Element>) throws -> Result
+  ) rethrows -> Result {
+    try body(__dataUnsafe())
+  }
+}

--- a/stdlib/public/Cxx/cxxshim/libcxxshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxshim.h
@@ -1,2 +1,17 @@
 template <class From, class To>
-To __swift_interopStaticCast(From from) { return static_cast<To>(from); }
+To __swift_interopStaticCast(From from) {
+  return static_cast<To>(from);
+}
+
+template <class T, long N>
+struct __attribute__((swift_attr("conforms_to:Cxx._UnsafeCxxStaticArray")))
+_UnsafeCxxStaticArrayImpl {
+  using Element = T;
+
+  inline const Element *_Nonnull data() const { return storage; }
+
+  inline long getCount() { return N; }
+
+private:
+  Element storage[N];
+};

--- a/test/Interop/Cxx/array/Inputs/module.modulemap
+++ b/test/Interop/Cxx/array/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module StaticArrayCollection {
+  header "static-array-collection.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/array/Inputs/static-array-collection.h
+++ b/test/Interop/Cxx/array/Inputs/static-array-collection.h
@@ -1,0 +1,33 @@
+#ifndef TEST_INTEROP_CXX_ARRAY_INPUTS_STATIC_ARRAY_COLLECTION_H
+#define TEST_INTEROP_CXX_ARRAY_INPUTS_STATIC_ARRAY_COLLECTION_H
+
+struct HasIntArray {
+  int array[8];
+
+  HasIntArray() {
+    for (int i = 1; i < 9; ++i) {
+      array[i - 1] = i;
+    }
+  }
+};
+
+struct HugeArray {
+  int array[64 * 1000];
+
+  HugeArray() {
+    array[0] = 0;
+    array[42] = 42;
+    array[63000] = 42;
+  }
+};
+
+struct NonTrivial {
+  int value = 42;
+  NonTrivial(const NonTrivial &) {}
+};
+
+struct NonTrivialArray {
+  NonTrivial array[8];
+};
+
+#endif // TEST_INTEROP_CXX_ARRAY_INPUTS_STATIC_ARRAY_COLLECTION_H

--- a/test/Interop/Cxx/array/static-array-collection.swift
+++ b/test/Interop/Cxx/array/static-array-collection.swift
@@ -1,0 +1,44 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -cxx-interop-static-array-as-collection)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StaticArrayCollection
+
+var StaticArrayCollectionTestSuite = TestSuite("StaticArrayCollection")
+
+StaticArrayCollectionTestSuite.test("HasIntArray.subscript") {
+  let arr = HasIntArray()
+  expectEqual(arr.array[0], 1)
+}
+
+StaticArrayCollectionTestSuite.test("HasIntArray.for-in") {
+  let arr = HasIntArray()
+  var i = CInt(1)
+  for e in arr.array {
+    expectEqual(e, i)
+    i += 1
+  }
+}
+
+StaticArrayCollectionTestSuite.test("HasIntArray.enumerated()") {
+  let arr = HasIntArray()
+  for (n, e) in arr.array.enumerated() {
+    expectEqual(CInt(n + 1), e)
+  }
+}
+
+StaticArrayCollectionTestSuite.test("HasIntArray.count") {
+  let arr = HasIntArray()
+  expectEqual(arr.array.count, 8)
+}
+
+StaticArrayCollectionTestSuite.test("HasIntArray.withInnerStorage") {
+  let arr = HasIntArray()
+  arr.array.withInnerStorage {
+    expectEqual($0.pointee, 1)
+  }
+}
+
+runAllTests()
+


### PR DESCRIPTION
Adding `-cxx-interop-static-array-as-collection` will import fixed/static size arrays as `RandomAccessCollection`s. This is a proof of concept and the implementation needs to be smoothed out. This is not yet ready for review. 