### PR TITLE
5.9: [MoveOnlyAddressChecker] Fixed two use-before-def handlings.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -509,6 +509,17 @@ public:
 
   void printAsOperand(raw_ostream &OS, bool PrintType = true);
 
+#ifndef NDEBUG
+  /// Print the ID of the block, bbN.
+  void dumpID() const;
+
+  /// Print the ID of the block with \p OS, bbN.
+  void printID(llvm::raw_ostream &OS) const;
+
+  /// Print the ID of the block with \p Ctx, bbN.
+  void printID(SILPrintContext &Ctx) const;
+#endif
+
   /// getSublistAccess() - returns pointer to member of instruction list
   static InstListType SILBasicBlock::*getSublistAccess() {
     return &SILBasicBlock::InstList;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -832,6 +832,12 @@ public:
     *this << ')';
   }
 
+#ifndef NDEBUG
+  void printID(const SILBasicBlock *BB) {
+    *this << Ctx.getID(BB) << "\n";
+  }
+#endif
+
   void print(const SILBasicBlock *BB) {
     // Output uses for BB arguments. These are put into place as comments before
     // the block header.
@@ -3069,6 +3075,21 @@ void SILBasicBlock::print(raw_ostream &OS) const {
 void SILBasicBlock::print(SILPrintContext &Ctx) const {
   SILPrinter(Ctx).print(this);
 }
+
+#ifndef NDEBUG
+void SILBasicBlock::dumpID() const {
+  printID(llvm::errs());
+}
+
+void SILBasicBlock::printID(llvm::raw_ostream &OS) const {
+  SILPrintContext Ctx(OS);
+  printID(Ctx);
+}
+
+void SILBasicBlock::printID(SILPrintContext &Ctx) const {
+  SILPrinter(Ctx).printID(this);
+}
+#endif
 
 /// Pretty-print the SILFunction to errs.
 void SILFunction::dump(bool Verbose) const {

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -505,6 +505,7 @@ void FieldSensitivePrunedLiveBlocks::computeScalarUseBlockLiveness(
 /// Terminators are not live out of the block.
 void FieldSensitivePrunedLiveBlocks::updateForUse(
     SILInstruction *user, unsigned startBitNo, unsigned endBitNo,
+    SmallBitVector const &useBeforeDefBits,
     SmallVectorImpl<IsLive> &resultingLivenessInfo) {
   assert(isInitialized());
   resultingLivenessInfo.clear();
@@ -517,10 +518,15 @@ void FieldSensitivePrunedLiveBlocks::updateForUse(
 
   for (unsigned index : indices(resultingLivenessInfo)) {
     unsigned specificBitNo = startBitNo + index;
+    auto isUseBeforeDef = useBeforeDefBits.test(specificBitNo);
     switch (resultingLivenessInfo[index]) {
     case LiveOut:
     case LiveWithin:
-      continue;
+      if (!isUseBeforeDef) {
+        continue;
+      } else {
+        LLVM_FALLTHROUGH;
+      }
     case Dead: {
       // This use block has not yet been marked live. Mark it and its
       // predecessor blocks live.
@@ -599,21 +605,21 @@ void FieldSensitivePrunedLivenessBoundary::dump() const {
 //                        MARK: FieldSensitiveLiveness
 //===----------------------------------------------------------------------===//
 
-void FieldSensitivePrunedLiveness::updateForUse(SILInstruction *user,
-                                                TypeTreeLeafTypeRange range,
-                                                bool lifetimeEnding) {
+void FieldSensitivePrunedLiveness::updateForUse(
+    SILInstruction *user, TypeTreeLeafTypeRange range, bool lifetimeEnding,
+    SmallBitVector const &useBeforeDefBits) {
   SmallVector<FieldSensitivePrunedLiveBlocks::IsLive, 8> resultingLiveness;
   liveBlocks.updateForUse(user, range.startEltOffset, range.endEltOffset,
-                          resultingLiveness);
+                          useBeforeDefBits, resultingLiveness);
 
   addInterestingUser(user, range, lifetimeEnding);
 }
 
-void FieldSensitivePrunedLiveness::updateForUse(SILInstruction *user,
-                                                SmallBitVector const &bits,
-                                                bool lifetimeEnding) {
+void FieldSensitivePrunedLiveness::updateForUse(
+    SILInstruction *user, SmallBitVector const &bits, bool lifetimeEnding,
+    SmallBitVector const &useBeforeDefBits) {
   for (auto bit : bits.set_bits()) {
-    liveBlocks.updateForUse(user, bit);
+    liveBlocks.updateForUse(user, bit, useBeforeDefBits.test(bit));
   }
 
   addInterestingUser(user, bits, lifetimeEnding);
@@ -798,74 +804,46 @@ void FieldSensitivePrunedLiveRange<LivenessWithDefs>::computeBoundary(
   }
 }
 
+bool FieldSensitiveMultiDefPrunedLiveRange::isUserBeforeDef(
+    SILInstruction *user, unsigned element) const {
+  auto *block = user->getParent();
+  if (!isDefBlock(block, element))
+    return false;
+
+  if (llvm::any_of(block->getArguments(), [this, element](SILArgument *arg) {
+        return isDef(arg, element);
+      })) {
+    return false;
+  }
+
+  auto *current = user;
+  while (true) {
+    // If user is also a def, then the use is considered before the def.
+    current = current->getPreviousInstruction();
+    if (!current)
+      return true;
+
+    if (isDef(current, element))
+      return false;
+  }
+}
+
 template <typename LivenessWithDefs>
 void FieldSensitivePrunedLiveRange<LivenessWithDefs>::updateForUse(
     SILInstruction *user, TypeTreeLeafTypeRange range, bool lifetimeEnding) {
-  PRUNED_LIVENESS_LOG(
-      llvm::dbgs()
-      << "Begin FieldSensitivePrunedLiveRange<LivenessWithDefs>::updateForUse "
-         "for: "
-      << *user);
-  PRUNED_LIVENESS_LOG(
-      llvm::dbgs() << "Looking for def instruction earlier in the block!\n");
-
-  auto *parentBlock = user->getParent();
-  for (auto ii = std::next(user->getReverseIterator()),
-            ie = parentBlock->rend();
-       ii != ie; ++ii) {
-    // If we find the def, just mark this instruction as being an interesting
-    // instruction.
-    if (asImpl().isDef(&*ii, range)) {
-      PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Found def: " << *ii);
-      PRUNED_LIVENESS_LOG(llvm::dbgs()
-                 << "    Marking inst as interesting user and returning!\n");
-      addInterestingUser(user, range, lifetimeEnding);
-      return;
-    }
-  }
-
-  // Otherwise, just delegate to our parent class's update for use. This will
-  // update liveness for our predecessor blocks and add this instruction as an
-  // interesting user.
-  PRUNED_LIVENESS_LOG(llvm::dbgs() << "No defs found! Delegating to "
-                             "FieldSensitivePrunedLiveness::updateForUse.\n");
-  FieldSensitivePrunedLiveness::updateForUse(user, range, lifetimeEnding);
+  SmallBitVector useBeforeDefBits(getNumSubElements());
+  asImpl().isUserBeforeDef(user, range.getRange(), useBeforeDefBits);
+  FieldSensitivePrunedLiveness::updateForUse(user, range, lifetimeEnding,
+                                             useBeforeDefBits);
 }
 
 template <typename LivenessWithDefs>
 void FieldSensitivePrunedLiveRange<LivenessWithDefs>::updateForUse(
     SILInstruction *user, SmallBitVector const &bits, bool lifetimeEnding) {
-  PRUNED_LIVENESS_LOG(
-      llvm::dbgs()
-      << "Begin FieldSensitivePrunedLiveRange<LivenessWithDefs>::updateForUse "
-         "for: "
-      << *user);
-  PRUNED_LIVENESS_LOG(llvm::dbgs()
-                      << "Looking for def instruction earlier in the block!\n");
-
-  auto *parentBlock = user->getParent();
-  for (auto ii = std::next(user->getReverseIterator()),
-            ie = parentBlock->rend();
-       ii != ie; ++ii) {
-    // If we find the def, just mark this instruction as being an interesting
-    // instruction.
-    if (asImpl().isDef(&*ii, bits)) {
-      PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Found def: " << *ii);
-      PRUNED_LIVENESS_LOG(
-          llvm::dbgs()
-          << "    Marking inst as interesting user and returning!\n");
-      addInterestingUser(user, bits, lifetimeEnding);
-      return;
-    }
-  }
-
-  // Otherwise, just delegate to our parent class's update for use. This will
-  // update liveness for our predecessor blocks and add this instruction as an
-  // interesting user.
-  PRUNED_LIVENESS_LOG(llvm::dbgs()
-                      << "No defs found! Delegating to "
-                         "FieldSensitivePrunedLiveness::updateForUse.\n");
-  FieldSensitivePrunedLiveness::updateForUse(user, bits, lifetimeEnding);
+  SmallBitVector useBeforeDefBits(getNumSubElements());
+  asImpl().isUserBeforeDef(user, bits.set_bits(), useBeforeDefBits);
+  FieldSensitivePrunedLiveness::updateForUse(user, bits, lifetimeEnding,
+                                             useBeforeDefBits);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1414,6 +1414,8 @@ public:
 
 private:
   bool hasDefAfter(SILInstruction *inst, unsigned element);
+  bool isLiveAtBegin(SILBasicBlock *block, unsigned element, bool isLiveAtEnd,
+                     DestroysCollection const &destroys);
 
   bool
   shouldAddDestroyToLiveness(SILInstruction *destroy, unsigned element,
@@ -2967,7 +2969,14 @@ void ExtendUnconsumedLiveness::runOnField(
     // as the other consuming uses).
     BasicBlockWorklist worklist(currentDef->getFunction());
     for (auto *consumingBlock : consumingBlocks) {
-      worklist.push(consumingBlock);
+      if (!originalLiveBlocks.insert(consumingBlock)
+          // Don't walk into the predecessors of blocks which kill liveness.
+          && !isLiveAtBegin(consumingBlock, element, /*isLiveAtEnd=*/true, destroys)) {
+        continue;
+      }
+      for (auto *predecessor : consumingBlock->getPredecessorBlocks()) {
+        worklist.pushIfNotVisited(predecessor);
+      }
     }
 
     // Walk backwards from consuming blocks.
@@ -2976,10 +2985,6 @@ void ExtendUnconsumedLiveness::runOnField(
         continue;
       }
       for (auto *predecessor : block->getPredecessorBlocks()) {
-        // If the block was discovered by liveness, we already added it to the
-        // set.
-        if (originalLiveBlocks.contains(predecessor))
-          continue;
         worklist.pushIfNotVisited(predecessor);
       }
     }
@@ -3094,6 +3099,37 @@ bool ExtendUnconsumedLiveness::shouldAddDestroyToLiveness(
   // Found no uses or defs between the destroy and the top of the block.  If the
   // block was not consumed at entry, liveness can be extended to the destroy.
   return !consumedAtEntryBlocks.contains(block);
+}
+
+/// Compute the block's effect on liveness and apply it to \p isLiveAtEnd.
+bool ExtendUnconsumedLiveness::isLiveAtBegin(SILBasicBlock *block,
+                                             unsigned element, bool isLiveAtEnd,
+                                             DestroysCollection const &destroys) {
+  enum class Effect {
+    None, // 0
+    Kill, // 1
+    Gen,  // 2
+  };
+  auto effect = Effect::None;
+  for (auto &instruction : llvm::reverse(*block)) {
+    // An instruction can be both a destroy and a def.  If it is, its
+    // behavior is first to destroy and then to init.  So when walking
+    // backwards, its last action is to destroy, so its effect is that of any
+    // destroy.
+    if (destroys.find(&instruction) != destroys.end()) {
+      effect = Effect::Gen;
+    } else if (liveness.isDef(&instruction, element)) {
+      effect = Effect::Kill;
+    }
+  }
+  switch (effect) {
+  case Effect::None:
+    return isLiveAtEnd;
+  case Effect::Kill:
+    return false;
+  case Effect::Gen:
+    return true;
+  }
 }
 
 bool ExtendUnconsumedLiveness::hasDefAfter(SILInstruction *start,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1070,11 +1070,11 @@ void UseState::initializeLiveness(
   // Now at this point, we have defined all of our defs so we can start adding
   // uses to the liveness.
   for (auto reinitInstAndValue : reinitInsts) {
+    recordConsumingBlock(reinitInstAndValue.first->getParent(),
+                         reinitInstAndValue.second);
     if (!isReinitToInitConvertibleInst(reinitInstAndValue.first)) {
       liveness.updateForUse(reinitInstAndValue.first, reinitInstAndValue.second,
                             false /*lifetime ending*/);
-      recordConsumingBlock(reinitInstAndValue.first->getParent(),
-                           reinitInstAndValue.second);
       LLVM_DEBUG(llvm::dbgs() << "Added liveness for reinit: "
                               << *reinitInstAndValue.first;
                  liveness.print(llvm::dbgs()));

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -73,6 +73,7 @@
 #include "swift/SIL/OwnershipLiveness.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PrunedLiveness.h"
+#include "swift/SIL/FieldSensitivePrunedLiveness.h"
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBridging.h"
@@ -474,6 +475,85 @@ struct MultiDefUseLivenessTest : UnitTest {
     PrunedLivenessBoundary boundary;
     liveness.computeBoundary(boundary);
     boundary.print(llvm::outs());
+  }
+};
+
+// Arguments:
+// - value: entity whose fields' livenesses are being computed
+// - string: "defs:"
+// - variadic list of triples consisting of 
+//   - value: a live-range defining value
+//   - int: the beginning of the range of fields defined by the value
+//   - int: the end of the range of the fields defined by the value
+// - the string "uses:"
+// - variadic list of quadruples consisting of
+//   - instruction: a live-range user
+//   - bool: whether the user is lifetime-ending
+//   - int: the beginning of the range of fields used by the instruction
+//   - int: the end of the range of fields used by the instruction
+// Dumps:
+// - the liveness result and boundary
+//
+// Computes liveness for the specified def nodes by considering the
+// specified uses. The actual uses of the def nodes are ignored.
+//
+// This is useful for testing non-ssa liveness, for example, of memory
+// locations. In that case, the def nodes may be stores and the uses may be
+// destroy_addrs.
+struct FieldSensitiveMultiDefUseLiveRangeTest : UnitTest {
+  FieldSensitiveMultiDefUseLiveRangeTest(UnitTestRunner *pass) : UnitTest(pass) {}
+
+  void invoke(Arguments &arguments) override {
+    SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+    auto value = arguments.takeValue();
+    FieldSensitiveMultiDefPrunedLiveRange liveness(getFunction(), value, &discoveredBlocks);
+
+    llvm::outs() << "FieldSensitive MultiDef lifetime analysis:\n";
+    if (arguments.takeString() != "defs:") {
+      llvm::report_fatal_error(
+        "test specification expects the 'defs:' label\n");
+    }
+    while (true) {
+      auto argument = arguments.takeArgument();
+      if (isa<StringArgument>(argument)) {
+        if(cast<StringArgument>(argument).getValue() != "uses:") {
+          llvm::report_fatal_error(
+            "test specification expects the 'uses:' label\n");
+        }
+        break;
+      }
+      auto begin = arguments.takeUInt();
+      auto end = arguments.takeUInt();
+      TypeTreeLeafTypeRange range(begin, end);
+      if (isa<InstructionArgument>(argument)) {
+        auto *instruction = cast<InstructionArgument>(argument).getValue();
+        llvm::outs() << "  def in range [" << begin << ", " << end << ") instruction: " << *instruction;
+        liveness.initializeDef(instruction, range);
+        continue;
+      }
+      if (isa<ValueArgument>(argument)) {
+        SILValue value = cast<ValueArgument>(argument).getValue();
+        llvm::outs() << "  def in range [" << begin << ", " << end << ") value: " << value;
+        liveness.initializeDef(value, range);
+        continue;
+      }
+      llvm::report_fatal_error(
+        "test specification expects the 'uses:' label\n");
+    }
+    liveness.finishedInitializationOfDefs();
+    while (arguments.hasUntaken()) {
+      auto *inst = arguments.takeInstruction();
+      auto lifetimeEnding = arguments.takeBool();
+      auto begin = arguments.takeUInt();
+      auto end = arguments.takeUInt();
+      TypeTreeLeafTypeRange range(begin, end);
+      liveness.updateForUse(inst, range, lifetimeEnding);
+    }
+    liveness.print(llvm::errs());
+
+    FieldSensitivePrunedLivenessBoundary boundary(liveness.getNumSubElements());
+    liveness.computeBoundary(boundary);
+    boundary.print(llvm::errs());
   }
 };
 
@@ -901,6 +981,7 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("linear-liveness", LinearLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("multidef-liveness", MultiDefLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("multidefuse-liveness", MultiDefUseLivenessTest)
+    ADD_UNIT_TEST_SUBCLASS("fieldsensitive-multidefuse-liverange", FieldSensitiveMultiDefUseLiveRangeTest)
     ADD_UNIT_TEST_SUBCLASS("ossa-lifetime-completion", OSSALifetimeCompletionTest)
     ADD_UNIT_TEST_SUBCLASS("pruned-liveness-boundary-with-list-of-last-users-insertion-points", PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest)
     ADD_UNIT_TEST_SUBCLASS("shrink-borrow-scope", ShrinkBorrowScopeTest)

--- a/test/Interpreter/moveonly_loop.swift
+++ b/test/Interpreter/moveonly_loop.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+struct S: ~Copyable {
+  let s: String
+  init(_ s: String) { self.s = s }
+  deinit { print("deiniting \(s)") }
+}
+
+func use(_ s: borrowing S) {
+  print("using: \(s.s)")
+}
+
+@_silgen_name("f")
+func f(_ c: consuming S) {
+  repeat {
+    use(c)
+    c = S("2")
+  } while false
+}
+
+func doit() {
+  let s = S("1")
+  f(s)
+}
+
+//      CHECK: using: 1
+// CHECK-NEXT: deiniting 1
+// CHECK-NEXT: deiniting 2
+doit()

--- a/test/SILOptimizer/discard_checking.swift
+++ b/test/SILOptimizer/discard_checking.swift
@@ -473,14 +473,11 @@ struct Basics: ~Copyable {
   }
 
   consuming func reinitAfterDiscard3_bad(_ c: Color) throws {
-    // expected-error@-1 {{must consume 'self' before exiting method that discards self}}
-    // FIXME: ^ this error is related to rdar://110239087
-
     repeat {
       self = Basics() // expected-error {{cannot reinitialize 'self' after 'discard self'}}
       discard self // expected-note 2{{discarded self here}}
     } while false
-  }
+  } // expected-error {{must consume 'self' before exiting method that discards self}}
 
   consuming func reinitAfterDiscard3_ok(_ c: Color) throws {
     self = Basics()

--- a/test/SILOptimizer/field_sensitive_liverange_unit.sil
+++ b/test/SILOptimizer/field_sensitive_liverange_unit.sil
@@ -1,0 +1,202 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+class C {}
+sil @getC : $@convention(thin) () -> (@owned C)
+
+// Test a live range that is extended through reborrows,
+// considering them new defs.
+// (e.g. BorrowedValue::visitTransitiveLifetimeEndingUses)
+//
+// This live range is not dominated by the original borrow.
+//
+// CHECK-LABEL: testReborrow: fieldsensitive-multidefuse-liverange
+// CHECK: FieldSensitive MultiDef lifetime analysis:
+// CHECK:   def in range [0, 1) value:   [[B:%.*]] = load_borrow %0 : $*C
+// CHECK:   def in range [0, 1) value:   [[RB:%.*]] = argument of bb3 : $C
+// CHECK-NEXT: bb2: LiveWithin
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: last user:   br bb3([[B]] : $C)
+// CHECK-NEXT: at 1
+// CHECK-NEXT: last user:   end_borrow [[RB]] : $C
+// CHECK-NEXT: at 1
+sil [ossa] @testReborrow : $@convention(thin) () -> () {
+bb0:
+  test_specification """
+                     fieldsensitive-multidefuse-liverange
+                     @instruction
+                     defs: 
+                     @trace[0] 0 1
+                     @trace[1] 0 1
+                     uses:
+                     @block[2].instruction[3] true 0 1
+                     @block[3].instruction[0] true 0 1
+                     """
+  %stack = alloc_stack $C
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, bb1, bb2
+
+bb1:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  store %c1 to [init] %stack : $*C
+  %borrow1 = load_borrow %stack : $*C
+  br bb3(%borrow1 : $C)
+
+bb2:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  store %c2 to [init] %stack : $*C
+  %borrow2 = load_borrow %stack : $*C
+  debug_value [trace] %borrow2 : $C
+  br bb3(%borrow2 : $C)
+
+bb3(%reborrow : @guaranteed $C):
+  debug_value [trace] %reborrow : $C
+  end_borrow %reborrow : $C
+  br bb4
+
+bb4:
+  destroy_addr %stack : $*C
+  dealloc_stack %stack : $*C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testMultiDefUseAddressReinit
+// CHECK: MultiDef lifetime analysis:
+// CHECK:   def in range [0, 1) instruction:   store %{{.*}} to [init] [[ADDR:%.*]] : $*C
+// CHECK:   def in range [0, 1) instruction:   store %0 to [init] [[ADDR]] : $*C
+
+// FIXME: rdar://111118843 : bb0 is live-out, but FieldSensitivePL incorrectly
+//        determines it to be LiveWithin because of its mishandling of
+//        uses-before-defs.
+//        
+//        The following HECK lines are the correct CHECK lines.  The subsequent
+//        CHECK lines capture the current erroneous behavior.
+//  HECK: bb0: LiveOut
+//  HECK: bb1: LiveWithin
+//  HECK: last user:    %{{.*}} = load [copy] [[ADDR]] : $*C
+//  HECK: boundary edge: bb2
+//  HECK: dead def:   store %0 to [init] %1 : $*C
+
+// FIXME: bb0 is not LiveWithin, it is LiveOut
+// CHECK: bb0: LiveWithin,
+// CHECK: bb1: LiveWithin,
+// CHECK: last user: %{{.*}} = load [copy] [[ADDR]] : $*C 
+// FIXME: the store of the copy is not a dead-def, it is used in bb1, by the
+//        only user added.
+// CHECK: dead def: store %2 to [init] %1 : $*C
+// CHECK: dead def: store %0 to [init] %1 : $*C
+
+// CHECK-LABEL: end running test 1 of 1 on testMultiDefUseAddressReinit
+sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
+bb0(%0: @owned $C):
+  test_specification """
+                     fieldsensitive-multidefuse-liverange
+                     @instruction
+                     defs: 
+                     @instruction[+2] 0 1
+                     @block[1].instruction[2] 0 1
+                     uses: 
+                     @block[1].instruction[0] false 0 1
+                     """
+  %1 = alloc_stack $C
+  %2 = copy_value %0 : $C
+  store %2 to [init] %1 : $*C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = load [copy] %1 : $*C
+  destroy_addr %1 : $*C
+  store %0 to [init] %1 : $*C
+  destroy_value %5 : $C
+  br bb3
+
+bb2:
+  destroy_value %0 : $C
+  br bb3
+
+bb3:
+  destroy_addr %1 : $*C
+  dealloc_stack %1 : $*C
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// A single instruction occurs twice on the same liverange
+// boundary. Once as a last use, and once as a dead def.
+// This is a particularly problematic corner case.
+//
+// CHECK-LABEL: testDeadSelfKill: fieldsensitive-multidefuse-liverange
+// CHECK: FieldSensitive MultiDef lifetime analysis:
+// CHECK: def in range [0, 1) instruction: store {{%[^,]+}} to [init] [[STACK:%[^,]+]] :
+// CHECK: def in range [0, 1) instruction: store {{%[^,]+}} to [assign] [[STACK]]
+// CHECK: bb1: LiveWithin
+// CHECK: last user:   store {{%[^,]+}} to [assign] [[STACK]]
+// CHECK: dead def:   store {{%[^,]+}} to [assign] [[STACK]]
+sil [ossa] @testDeadSelfKill : $@convention(thin) () -> () {
+bb0:
+  br bb3
+
+bb1(%1 : @owned $C, %2 : @owned $C):
+  test_specification """
+                     fieldsensitive-multidefuse-liverange
+                     @instruction
+                     defs: 
+                     @instruction[+1] 0 1
+                     @instruction[+2] 0 1
+                     uses:
+                     @instruction[+2] true 0 1
+                     """
+  %stack = alloc_stack $C
+  store %1 to [init] %stack : $*C
+  store %2 to [assign] %stack : $*C
+  unreachable
+
+bb3:
+  %99 = tuple()
+  return %99 : $()
+}
+
+// A dead-end block with a def can still be a boundary edge. This can
+// only happen in OSSA with incomplete lifetimes.
+//
+// CHECK-LABEL: testMultiDefDeadDefBoundaryEdge: fieldsensitive-multidefuse-liverange
+// CHECK: FieldSensitive MultiDef lifetime analysis:
+// CHECK:   def in range [0, 1) instruction: store {{%[^,]+}} to [init] [[STACK:%[^,]+]] :
+// CHECK:   def in range [0, 1) instruction: store {{%[^,]+}} to [assign] [[STACK]]
+// CHECK: bb0: LiveOut
+// CHECK: bb1: LiveWithin
+// CHECK: bb2: LiveWithin
+// CHECK: last user:   destroy_addr [[STACK]]
+// CHECK-NEXT: at 1
+// CHECK-NEXT: boundary edge: bb1
+// CHECK-NEXT: at 1
+// CHECK-NEXT: dead def: store {{%[^,]+}} to [assign] [[STACK]]
+// CHECK-NEXT: at 1
+sil [ossa] @testMultiDefDeadDefBoundaryEdge : $@convention(thin) () -> () {
+bb0:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  %stack = alloc_stack $C
+  %c = apply %getC() : $@convention(thin) () -> (@owned C)
+  store %c to [init] %stack : $*C
+  test_specification """
+                     fieldsensitive-multidefuse-liverange
+                     @instruction[-3]
+                     defs: 
+                     @instruction[-1] 0 1
+                     @block[1].instruction[1] 0 1
+                     uses:
+                     @block[2].instruction[0] true 0 1
+                     """
+  cond_br undef, bb1, bb3
+
+bb1:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  store %c2 to [assign] %stack : $*C
+  unreachable
+
+bb3:
+  destroy_addr %stack : $*C
+  dealloc_stack %stack : $*C
+  %99 = tuple()
+  return %99 : $()
+}

--- a/test/SILOptimizer/field_sensitive_liverange_unit.sil
+++ b/test/SILOptimizer/field_sensitive_liverange_unit.sil
@@ -64,28 +64,11 @@ bb4:
 // CHECK: MultiDef lifetime analysis:
 // CHECK:   def in range [0, 1) instruction:   store %{{.*}} to [init] [[ADDR:%.*]] : $*C
 // CHECK:   def in range [0, 1) instruction:   store %0 to [init] [[ADDR]] : $*C
-
-// FIXME: rdar://111118843 : bb0 is live-out, but FieldSensitivePL incorrectly
-//        determines it to be LiveWithin because of its mishandling of
-//        uses-before-defs.
-//        
-//        The following HECK lines are the correct CHECK lines.  The subsequent
-//        CHECK lines capture the current erroneous behavior.
-//  HECK: bb0: LiveOut
-//  HECK: bb1: LiveWithin
-//  HECK: last user:    %{{.*}} = load [copy] [[ADDR]] : $*C
-//  HECK: boundary edge: bb2
-//  HECK: dead def:   store %0 to [init] %1 : $*C
-
-// FIXME: bb0 is not LiveWithin, it is LiveOut
-// CHECK: bb0: LiveWithin,
-// CHECK: bb1: LiveWithin,
-// CHECK: last user: %{{.*}} = load [copy] [[ADDR]] : $*C 
-// FIXME: the store of the copy is not a dead-def, it is used in bb1, by the
-//        only user added.
-// CHECK: dead def: store %2 to [init] %1 : $*C
-// CHECK: dead def: store %0 to [init] %1 : $*C
-
+// CHECK: bb0: LiveOut
+// CHECK: bb1: LiveWithin
+// CHECK: last user:    %{{.*}} = load [copy] [[ADDR]] : $*C
+// CHECK: boundary edge: bb2
+// CHECK: dead def:   store %0 to [init] %1 : $*C
 // CHECK-LABEL: end running test 1 of 1 on testMultiDefUseAddressReinit
 sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
 bb0(%0: @owned $C):


### PR DESCRIPTION
Description: Fix two classes of miscompiles in the move-only address checker.

Back in https://github.com/apple/swift/pull/65000, Andrew added support for addreses (by way of handling for uses before defs) to PrunedLiveness.  Here, the unit tests that Andrew wrote to verify that support is ported to FieldSensitivePrunedLiveness.

One of those unit tests revealed a bug in FieldSensitivePrunedLiveness's handling of uses before defs.  That issue resulted in miscompiles for simple Swift programs featuring move-only values and loops; see the new test `Interpreter/moveonly_loop.swift`.  Here, that is fixed by replacing FieldSensitivePrunedLiveness' own attempt to handle uses-before-defs with a copy of the implementation from PrunedLiveness and a straightforward vectorization.

Finally, fixing that bug in FieldSensitivePrunedLiveness revealed a bug in the multi-def lifetime extension for move-only values stored in addresses.  The important difference between the algorithm used by the address checker and the algorithm used by the value checker is that the former is multi-def and so must handle uses-before-defs.  The discovery of consumed blocks was properly handling that case, but the discovery of original live blocks was not.  Here, that is fixed by walking through already discovered blocks if those blocks do not kill liveness.

Risk: Low.  The first fix straightforwardly vectorizes a copy of the scalar code that determines whether there's a use before a def.  The second fix amounts to using a variation of the normal way to compute liveness.
Scope: Narrow.  This only affects move-only types.
Original PR: https://github.com/apple/swift/pull/66892
Reviewed By: Andrew Trick ( @atrick )
Testing: Added test that the move-only address checker previously miscompiled.
Resolves: rdar://110862719&111118843&111221183

