### PR TITLE
[5.9][CursorInfo] Re-use already built ASTs when possible

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_after_edit.swift
+++ b/test/SourceKit/CursorInfo/cursor_after_edit.swift
@@ -8,4 +8,6 @@
 // RUN: %sourcekitd-test \
 // RUN:   -req=open -text-input %t/empty.swift %t/func.swift -- %t/func.swift == \
 // RUN:   -req=edit -offset=0 -length=0 -replace="func foo() {}" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/func.swift -- %t/func.swift == \
-// RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift
+// RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift == \
+// RUN:   -req=edit -offset=0 -length=0 -replace="// some comment\n" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/func.swift -- %t/func.swift == \
+// RUN:   -req=cursor -offset=21 %t/func.swift -- %t/func.swift

--- a/test/SourceKit/CursorInfo/cursor_after_edit.swift
+++ b/test/SourceKit/CursorInfo/cursor_after_edit.swift
@@ -8,6 +8,4 @@
 // RUN: %sourcekitd-test \
 // RUN:   -req=open -text-input %t/empty.swift %t/func.swift -- %t/func.swift == \
 // RUN:   -req=edit -offset=0 -length=0 -replace="func foo() {}" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/func.swift -- %t/func.swift == \
-// RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift == \
-// RUN:   -req=edit -offset=0 -length=0 -replace="// some comment\n" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/func.swift -- %t/func.swift == \
-// RUN:   -req=cursor -offset=21 %t/func.swift -- %t/func.swift
+// RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift

--- a/test/SourceKit/CursorInfo/cursor_reuses_ast.swift
+++ b/test/SourceKit/CursorInfo/cursor_reuses_ast.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/empty.swift %t/func.swift
+
+// Check that cursor info re-uses the underlying AST if it's able to based
+// off edit snapshots.
+
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## State 1' == \
+// RUN:   -req=open -text-input %t/empty.swift %t/func.swift -- %t/func.swift == \
+// RUN:   -req=edit -offset=0 -length=0 -replace="func foo() {}" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0,syntactic_only=1 %t/func.swift -- %t/func.swift == \
+// RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift == \
+// RUN:   -shell -- echo '## State 2' == \
+// RUN:   -req=edit -offset=0 -length=0 -replace="/* some comment */ " -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0,syntactic_only=1 %t/func.swift -- %t/func.swift == \
+// RUN:   -req=cursor -offset=24 %t/func.swift -- %t/func.swift | %FileCheck %s
+
+// CHECK: ## State 1
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: foo()
+// CHECK: DID REUSE AST CONTEXT: 0
+// CHECK: ## State 2
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: foo()
+// CHECK: DID REUSE AST CONTEXT: 1

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -1086,7 +1086,8 @@ public:
                      Receiver) = 0;
 
   virtual void
-  getNameInfo(StringRef Filename, unsigned Offset, NameTranslatingInfo &Input,
+  getNameInfo(StringRef PrimaryFilePath, StringRef InputBufferName,
+              unsigned Offset, NameTranslatingInfo &Input,
               ArrayRef<const char *> Args,
               SourceKitCancellationToken CancellationToken,
               std::function<void(const RequestResult<NameTranslatingInfo> &)>

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -660,8 +660,9 @@ public:
                      Receiver) override;
 
   void getNameInfo(
-      StringRef Filename, unsigned Offset, NameTranslatingInfo &Input,
-      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+      StringRef PrimaryFilePath, StringRef InputBufferName, unsigned Offset,
+      NameTranslatingInfo &Input, ArrayRef<const char *> Args,
+      SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<NameTranslatingInfo> &)> Receiver)
       override;
 

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -1735,7 +1735,7 @@ handleRequestNameTranslation(const RequestDict &Req,
     llvm::transform(Selectors, std::back_inserter(Input.ArgNames),
                     [](const char *C) { return StringRef(C); });
     return Lang.getNameInfo(
-        *PrimaryFilePath, Offset, Input, Args, CancellationToken,
+        *PrimaryFilePath, "", Offset, Input, Args, CancellationToken,
         [Rec](const RequestResult<NameTranslatingInfo> &Result) {
           reportNameInfo(Result, Rec);
         });


### PR DESCRIPTION
* **Explanation**: Cursor info should re-use ASTs if we're able to map the location back to the original AST. These two cherry-picks fix two regressions that caused this to fail:
  1. If an AST was being built that also matched, the already built AST would be ignored
  2. The input buffer name was being used to find snapshots rather than the primary file, preventing any snapshots from being found.
* **Scope**: Any SourceKit request that allows using snapshots (eg. cursor info)
* **Risk**: Zero for the compiler, low for SourceKit. (2) was a regression introduced in main/5.9. (1) only matters if an AST is being built and thus we would have still exercised the re-use code path most of the time.
* **Testing**: Added a new test for a second cursor info request re-using the original AST
* **Original PR**:  https://github.com/apple/swift/pull/66839 and https://github.com/apple/swift/pull/66907