### PR TITLE
[Concurrency] Fix code snippet on task group docs

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -149,14 +149,14 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// For example, in the code below,
 /// nothing is canceled and the group doesn't throw an error:
 ///
-///     try await withThrowingTaskGroup { group in
+///     try await withThrowingTaskGroup(of: Void.self) { group in
 ///         group.addTask { throw SomeError() }
 ///     }
 ///
 /// In contrast, this example throws `SomeError`
 /// and cancels all of the tasks in the group:
 ///
-///     try await withThrowingTaskGroup { group in
+///     try await withThrowingTaskGroup(of: Void.self) { group in
 ///         group.addTask { throw SomeError() }
 ///         try await group.next()
 ///     }


### PR DESCRIPTION
**Description:** The code snippet in docs was missing a required parameter (`of:`), fix the code snippet.
**Risk:** Low, docs only.
**Review by:** @DougGregor
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/66912/
**Radar:** rdar://111233024