### PR TITLE
stdlib: make deinit of `ManagedBuffer` inlinable

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -51,6 +51,9 @@ open class ManagedBuffer<Header, Element> {
   internal init(_doNotCallMe: ()) {
     _internalInvariantFailure("Only initialize these by calling create")
   }
+
+  @inlinable
+  deinit {}
 }
 
 extension ManagedBuffer {

--- a/test/SILOptimizer/dead_alloc.swift
+++ b/test/SILOptimizer/dead_alloc.swift
@@ -45,3 +45,12 @@ public class C<T> {
 public func deadClassInstance() {
     let _ = C<Int>()
 }
+
+// CHECK-LABEL: sil @$s10dead_alloc0A13ManagedBufferyyF :
+// CHECK:       bb0:
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK-NEXT:  } // end sil function '$s10dead_alloc0A13ManagedBufferyyF'
+public func deadManagedBuffer() -> () {
+  _ = ManagedBuffer<Void, Void>.create(minimumCapacity: 1, makingHeaderWith: { _ in () })
+}


### PR DESCRIPTION
This allows to eliminate dead allocations of a ManagedBuffer object.

https://github.com/apple/swift/issues/66496
