### PR TITLE
[5.9][ConstraintSystem] Adjust the way pack parameters are opened

### DIFF
--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -29,3 +29,30 @@ struct MissingMemberError<each T> {
     // expected-error@-1 {{value of type 'MissingMemberError<repeat each T>' has no member 'doesNotExist'}}
   }
 }
+
+// https://github.com/apple/swift/issues/66095
+do {
+  struct Test<each S> {
+    init(_ s: repeat each S) {}
+  }
+
+  func test1<each T>(_ v: repeat each T) -> Test<repeat each T> {
+    return Test(repeat each v) // Ok
+  }
+
+  func test2<each T>(_ v: repeat each T) -> Test<repeat each T> {
+    return Test<repeat each T>(repeat each v) // Ok
+  }
+
+  func test3<each T>(_ v: repeat each T) -> Test<String, repeat each T, Int> {
+    return Test("a", repeat each v, 42) // Ok
+  }
+
+  func test4<each T>(_ v: repeat each T) -> Test<repeat each T, String, Int> {
+    return Test<repeat each T, String, Int>(repeat each v, "a", 42) // Ok
+  }
+
+  func test5<each T>(_ v: repeat each T) -> Test<String, Int, repeat each T> {
+    return Test<String, Int, repeat each T>("a", 42, repeat each v) // Ok
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66910

---

- Explanation:

  Although variadic type is declared without `repeat` each of its
  generic arguments is supposed to be a PackType which is modeled
  in the interface type as `Pack{repeat ...}`. When reference to such
  a type is opened by the constraint solver we need to drop the Pack{repeat ...}
  structure because the type variable would represent a pack type so `S<each T>` 
  is opened as `S<$T0>` instead of `S<Pack{repeat $T0}>`.

- Scope: Expressions with references to variadic generic types. 

- Main Branch PR: https://github.com/apple/swift/pull/66796

- Risk: Low

- Resolves: https://github.com/apple/swift/pull/66910

- Reviewed By: @hborla 

- Testing: Added regression test-cases to the suite.

Resolves: https://github.com/apple/swift/issues/66095 
(cherry picked from commit 2227930d039d509546e83f1508b29eae67888cb5)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
