### PR TITLE
[5.9] [stdlib] Add support for classes in _createOffsetBasedKeyPath

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3912,7 +3912,7 @@ public func _createOffsetBasedKeyPath(
   // The buffer header is 32 bits, but components must start on a word
   // boundary.
   let kpBufferSize = MemoryLayout<Int>.size + MemoryLayout<Int32>.size
-  return kpTy._create(capacityInBytes: kpBufferSize) {
+  let kp = kpTy._create(capacityInBytes: kpBufferSize) {
     var builder = KeyPathBuffer.Builder($0)
     let header = KeyPathBuffer.Header(
       size: kpBufferSize - MemoryLayout<Int>.size,
@@ -3923,7 +3923,7 @@ public func _createOffsetBasedKeyPath(
     builder.pushHeader(header)
 
     let componentHeader = RawKeyPathComponent.Header(
-      stored: .struct,
+      stored: _MetadataKind(root) == .struct ? .struct : .class,
       mutable: false,
       inlineOffset: UInt32(offset)
     )
@@ -3935,6 +3935,12 @@ public func _createOffsetBasedKeyPath(
 
     component.clone(into: &builder.buffer, endOfReferencePrefix: false)
   }
+
+  if _MetadataKind(root) == .struct {
+    kp.assignOffsetToStorage(offset: offset)
+  }
+
+  return kp
 }
 
 #if SWIFT_ENABLE_REFLECTION

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3893,6 +3893,8 @@ internal func _instantiateKeyPathBuffer(
   return offset
 }
 
+#if SWIFT_ENABLE_REFLECTION
+
 @available(SwiftStdlib 5.9, *)
 public func _createOffsetBasedKeyPath(
   root: Any.Type,
@@ -3942,8 +3944,6 @@ public func _createOffsetBasedKeyPath(
 
   return kp
 }
-
-#if SWIFT_ENABLE_REFLECTION
 
 @_silgen_name("swift_keyPath_copySymbolName")
 fileprivate func keyPath_copySymbolName(

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1070,6 +1070,16 @@ struct Dog {
   var age: Int
 }
 
+class Cat {
+  var name: String
+  var age: Int
+
+  init(name: String, age: Int) {
+    self.name = name
+    self.age = age
+  }
+}
+
 if #available(SwiftStdlib 5.9, *) {
   keyPath.test("_createOffsetBasedKeyPath") {
     let dogAgeKp = _createOffsetBasedKeyPath(
@@ -1083,6 +1093,18 @@ if #available(SwiftStdlib 5.9, *) {
     let sparky = Dog(name: "Sparky", age: 7)
 
     expectEqual(sparky[keyPath: dogAgeKp!], 7)
+
+    let catNameKp = _createOffsetBasedKeyPath(
+      root: Cat.self,
+      value: String.self,
+      offset: 16
+    ) as? KeyPath<Cat, String>
+
+    expectNotNil(catNameKp)
+
+    let chloe = Cat(name: "Chloe", age: 4)
+
+    expectEqual(chloe[keyPath: catNameKp!], "Chloe")
   }
 }
 


### PR DESCRIPTION


• Explanation: This adds support for classes to be used in this SPI as well as adding the offset optimization for struct type key paths.
• Scope of Issue: Fixes a bug when using this API with class root types.
• Origination: Reflection work.
• Risk: Low -- New underscored API who isn't inlined who is only being used by reflection.
• Reviewed By: @stephentyrone 
• Automated Testing: Swift CI
• Dependencies: None
• Builder Impact: Not applicable
• Directions for QE: None

Resolves: rdar://110547963