### PR TITLE
[Sema] Improve SerialExecutor diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6679,7 +6679,7 @@ WARNING(executor_enqueue_deprecated_owned_job_implementation,Deprecation,
 WARNING(executor_enqueue_unused_implementation, none,
         "'Executor.enqueue(ExecutorJob)' will never be used, due to the presence of "
         "'enqueue(UnownedJob)'",
-        (Type))
+        ())
 
 //------------------------------------------------------------------------------
 // MARK: property wrapper diagnostics

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6676,6 +6676,10 @@ WARNING(executor_enqueue_deprecated_owned_job_implementation,Deprecation,
         "'Executor.enqueue(Job)' is deprecated as a protocol requirement; "
         "conform type %0 to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead",
         (Type))
+WARNING(executor_enqueue_unused_implementation, none,
+        "'Executor.enqueue(ExecutorJob)' will never be used, due to the presence of "
+        "'enqueue(UnownedJob)'",
+        (Type))
 
 //------------------------------------------------------------------------------
 // MARK: property wrapper diagnostics

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1350,10 +1350,13 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
   // to be omitted in favor of moveOnlyEnqueueRequirement
   bool canRemoveOldDecls;
   if (!moveOnlyEnqueueRequirement) {
+    // The move only enqueue does not exist in this lib version, we must keep relying on the UnownedJob version
     canRemoveOldDecls = false;
   } else if (C.LangOpts.DisableAvailabilityChecking) {
+    // Assume we have all APIs available, and thus can use the ExecutorJob
     canRemoveOldDecls = true;
   } else {
+    // Check if the availability of nominal is high enough to be using the ExecutorJob version
     AvailabilityContext requirementInfo
         = AvailabilityInference::availableRange(moveOnlyEnqueueRequirement, C);
     AvailabilityContext declInfo =
@@ -1366,7 +1369,7 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
   if (!canRemoveOldDecls &&
       unownedEnqueueWitnessDecl && unownedEnqueueWitnessDecl->getLoc().isValid() &&
       moveOnlyEnqueueWitnessDecl && moveOnlyEnqueueWitnessDecl->getLoc().isValid()) {
-    diags.diagnose(moveOnlyEnqueueWitnessDecl->getLoc(), diag::executor_enqueue_unused_implementation, nominalTy);
+    diags.diagnose(moveOnlyEnqueueWitnessDecl->getLoc(), diag::executor_enqueue_unused_implementation);
   }
 
   // Old UnownedJob based impl is present, warn about it suggesting the new protocol requirement.

--- a/test/Concurrency/custom_executor_enqueue_availability.swift
+++ b/test/Concurrency/custom_executor_enqueue_availability.swift
@@ -2,6 +2,9 @@
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
 
+// rdar://106849189 move-only types should be supported in freestanding mode
+// UNSUPPORTED: freestanding
+
 /// Such a type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
 /// not documented, but public Executor types back then already. Allow these to be implemented
 /// without warnings.

--- a/test/Concurrency/custom_executor_enqueue_availability.swift
+++ b/test/Concurrency/custom_executor_enqueue_availability.swift
@@ -1,0 +1,67 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+/// Such a type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
+/// not documented, but public Executor types back then already. Allow these to be implemented
+/// without warnings.
+@available(SwiftStdlib 5.1, *)
+final class OldExecutorOldStdlib: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// We warn on the ExecutorJob witness if the type has a broader
+/// availability, since in this case the UnownedJob version needs to exist.
+@available(SwiftStdlib 5.1, *)
+final class BothExecutorOldStdlib: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {}
+
+  @available(SwiftStdlib 5.9, *)
+  func enqueue(_ job: __owned ExecutorJob) {} // expected-warning{{'Executor.enqueue(ExecutorJob)' will never be used, due to the presence of 'enqueue(UnownedJob)'}}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// Meanwhile, we warn on the UnownedJob overload if the availability is new enough
+/// that it can be dropped.
+@available(SwiftStdlib 5.9, *)
+final class BothExecutorNewStdlib: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutorNewStdlib' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
+  func enqueue(_ job: __owned ExecutorJob) {}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+final class TripleExecutor: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
+  // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
+  // expected-note@+1{{use 'ExecutorJob' instead}}
+  func enqueue(_ job: __owned Job) {} // expected-warning{{'Executor.enqueue(Job)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
+  func enqueue(_ job: consuming ExecutorJob) {}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// Implementing the new signature on 5.9 platforms is good, no warnings
+@available(SwiftStdlib 5.9, *)
+final class NewExecutorNewStdlib: SerialExecutor {
+  func enqueue(_ job: __owned ExecutorJob) {}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-move-only -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
 // REQUIRES: concurrency
 
 // rdar://106849189 move-only types should be supported in freestanding mode
@@ -7,12 +7,22 @@
 // FIXME: rdar://107112715 test failing on iOS simulator, investigating
 // UNSUPPORTED: OS=ios
 
-// Such type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
-// not documented, but public Executor types back then already.
-//
-// We keep support for them, but also log a deprecation warning that they should move to the new signature.
+// If the availability is recent enough, log a deprecation warning to move to the new signature.
+@available(SwiftStdlib 5.9, *)
 final class OldExecutor: SerialExecutor {
   func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'OldExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+/// Such a type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
+/// not documented, but public Executor types back then already. Allow these to be implemented
+/// without warnings.
+@available(SwiftStdlib 5.1, *)
+final class OldExecutorOldStdlib: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     UnownedSerialExecutor(ordinary: self)
@@ -23,6 +33,7 @@ final class OldExecutor: SerialExecutor {
 /// we call into the "old one"; so the Owned version is not used in such impl.
 ///
 /// That's why we do log the deprecation warning, people should use the move-only version.
+@available(SwiftStdlib 5.9, *)
 final class BothExecutor: SerialExecutor {
   func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
 
@@ -33,7 +44,22 @@ final class BothExecutor: SerialExecutor {
   }
 }
 
+/// Meanwhile, we warn on the ExecutorJob witness if the type has a broader
+/// availability, since in this case the UnownedJob version needs to exist.
+@available(SwiftStdlib 5.1, *)
+final class BothExecutorOld: SerialExecutor {
+  func enqueue(_ job: UnownedJob) {}
+
+  @available(SwiftStdlib 5.9, *)
+  func enqueue(_ job: __owned ExecutorJob) {} // expected-warning{{'Executor.enqueue(ExecutorJob)' will never be used, due to the presence of 'enqueue(UnownedJob)'}}
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
 /// For now we must keep all 3 implementation kinds and warn about deprecated ones
+@available(SwiftStdlib 5.9, *)
 final class TripleExecutor: SerialExecutor {
   func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
 
@@ -52,6 +78,7 @@ final class TripleExecutor: SerialExecutor {
 /// we manually detect and emit an error if neither of them is implemented.
 ///
 /// We do so because we implement them recursively, so one of them must be implemented basically.
+@available(SwiftStdlib 5.9, *)
 final class NoneExecutor: SerialExecutor { // expected-error{{type 'NoneExecutor' does not conform to protocol 'Executor'}}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
@@ -60,6 +87,7 @@ final class NoneExecutor: SerialExecutor { // expected-error{{type 'NoneExecutor
 }
 
 /// Job still is deprecated
+@available(SwiftStdlib 5.9, *)
 final class StillDeprecated: SerialExecutor {
   // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
   // expected-note@+1{{use 'ExecutorJob' instead}}
@@ -71,6 +99,7 @@ final class StillDeprecated: SerialExecutor {
 }
 
 /// Just implementing the new signature causes no warnings, good.
+@available(SwiftStdlib 5.9, *)
 final class NewExecutor: SerialExecutor {
   func enqueue(_ job: consuming ExecutorJob) {} // no warnings
 
@@ -80,6 +109,7 @@ final class NewExecutor: SerialExecutor {
 }
 
 // Good impl, but missing the ownership keyword
+@available(SwiftStdlib 5.9, *)
 final class MissingOwnership: SerialExecutor {
   func enqueue(_ job: ExecutorJob) {} // expected-error{{noncopyable parameter must specify its ownership}}
   // expected-note@-1{{add 'borrowing' for an immutable reference}}

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only -disable-availability-checking
 // REQUIRES: concurrency
 
 // rdar://106849189 move-only types should be supported in freestanding mode
@@ -7,22 +7,12 @@
 // FIXME: rdar://107112715 test failing on iOS simulator, investigating
 // UNSUPPORTED: OS=ios
 
-// If the availability is recent enough, log a deprecation warning to move to the new signature.
-@available(SwiftStdlib 5.9, *)
+// Such type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
+// not documented, but public Executor types back then already.
+//
+// We keep support for them, but also log a deprecation warning that they should move to the new signature.
 final class OldExecutor: SerialExecutor {
   func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'OldExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
-
-  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
-    UnownedSerialExecutor(ordinary: self)
-  }
-}
-
-/// Such a type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
-/// not documented, but public Executor types back then already. Allow these to be implemented
-/// without warnings.
-@available(SwiftStdlib 5.1, *)
-final class OldExecutorOldStdlib: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     UnownedSerialExecutor(ordinary: self)
@@ -33,7 +23,6 @@ final class OldExecutorOldStdlib: SerialExecutor {
 /// we call into the "old one"; so the Owned version is not used in such impl.
 ///
 /// That's why we do log the deprecation warning, people should use the move-only version.
-@available(SwiftStdlib 5.9, *)
 final class BothExecutor: SerialExecutor {
   func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
 
@@ -44,22 +33,7 @@ final class BothExecutor: SerialExecutor {
   }
 }
 
-/// Meanwhile, we warn on the ExecutorJob witness if the type has a broader
-/// availability, since in this case the UnownedJob version needs to exist.
-@available(SwiftStdlib 5.1, *)
-final class BothExecutorOld: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {}
-
-  @available(SwiftStdlib 5.9, *)
-  func enqueue(_ job: __owned ExecutorJob) {} // expected-warning{{'Executor.enqueue(ExecutorJob)' will never be used, due to the presence of 'enqueue(UnownedJob)'}}
-
-  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
-    UnownedSerialExecutor(ordinary: self)
-  }
-}
-
 /// For now we must keep all 3 implementation kinds and warn about deprecated ones
-@available(SwiftStdlib 5.9, *)
 final class TripleExecutor: SerialExecutor {
   func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
 
@@ -78,7 +52,6 @@ final class TripleExecutor: SerialExecutor {
 /// we manually detect and emit an error if neither of them is implemented.
 ///
 /// We do so because we implement them recursively, so one of them must be implemented basically.
-@available(SwiftStdlib 5.9, *)
 final class NoneExecutor: SerialExecutor { // expected-error{{type 'NoneExecutor' does not conform to protocol 'Executor'}}
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
@@ -87,7 +60,6 @@ final class NoneExecutor: SerialExecutor { // expected-error{{type 'NoneExecutor
 }
 
 /// Job still is deprecated
-@available(SwiftStdlib 5.9, *)
 final class StillDeprecated: SerialExecutor {
   // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
   // expected-note@+1{{use 'ExecutorJob' instead}}
@@ -99,7 +71,6 @@ final class StillDeprecated: SerialExecutor {
 }
 
 /// Just implementing the new signature causes no warnings, good.
-@available(SwiftStdlib 5.9, *)
 final class NewExecutor: SerialExecutor {
   func enqueue(_ job: consuming ExecutorJob) {} // no warnings
 
@@ -109,7 +80,6 @@ final class NewExecutor: SerialExecutor {
 }
 
 // Good impl, but missing the ownership keyword
-@available(SwiftStdlib 5.9, *)
 final class MissingOwnership: SerialExecutor {
   func enqueue(_ job: ExecutorJob) {} // expected-error{{noncopyable parameter must specify its ownership}}
   // expected-note@-1{{add 'borrowing' for an immutable reference}}


### PR DESCRIPTION
This PR tackles the case of `SerialExecutor` conformances with pre-SwiftStdlib 5.9 deployment targets. Previously, such a conformance would produce an unfixable warning about the `enqueue(UnownedJob)` requirement being deprecated — even though it's the only requirement that can be implemented without restricting the availability to SwiftStdlib 5.9. Fixing this involves two main changes:

- The aforementioned warning will now be emitted iff the witness' nominal type has a sufficiently recent availability, under which the `ExecutorJob` requirement can be used.
- There is now a new warning if both `ExecutorJob` and `UnownedJob` requirements are implemented in a pre-5.9 availability context, pointing out that the `ExecutorJob` overload will never be selected.

For one motivating example behind this change, consider the custom [ClockExecutor](https://github.com/apple/swift-async-algorithms/blob/adb12bfcccaa040778c905c5a50da9d9367fd0db/Sources/AsyncSequenceValidation/Test.swift#L70-L84) in swift-async-algorithms. This type currently has an unfixable warning about `enqueue(UnownedJob)`. Moreover, it appears that there was an attempted fix via https://github.com/apple/swift-async-algorithms/pull/274 in order to address this warning — but in fact the new overload is never selected. With this PR, the old warning disappears and typechecking should now diagnose the fact that the `ExecutorJob` overload does not work as expected. If/when swift-async-algorithms drops support for pre-5.9 targets, the original deprecation warning will correctly appear again.