### PR TITLE
[Concurrency] Check sendability of the original argument expressions in a call

### DIFF
--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -289,29 +289,29 @@ func blender(_ peeler : () -> Void) {
 
 
   await wisk({})
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '() -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   await wisk(1)
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (peelBanana)()
   await (((((peelBanana)))))()
   await (((wisk)))((wisk)((wisk)(1)))
-  // expected-warning@-1 3{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
 
   blender((peelBanana))
   // expected-warning@-1 2{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
 
   await wisk(peelBanana)
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '() -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   await wisk(wisk)
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '(Any) -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   await (((wisk)))(((wisk)))
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '(Any) -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-  // expected-warning@+1 {{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await {wisk}()(1)
 
-  // expected-warning@+1 {{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (true ? wisk : {n in return})(1)
 }
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -216,3 +216,17 @@ class SubWUnsafeSubscript : SuperWUnsafeSubscript {
     }
   }
 }
+
+
+// Test implicit conversions getting in the way
+@available(SwiftStdlib 5.1, *)
+extension MyActor {
+  func f(_: Any) { }
+  func g(_: () -> Void) { }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> Void) async {
+  await a.f(s)
+  await a.g(f)
+}


### PR DESCRIPTION
When checking for the sendability in a call, use the sendability of the
original argument expressions rather than the parameter type, looking
through any implicit conversions that might remove `Sendable`.

Fixes rdar://110763694 / FB12343467.