### PR TITLE
[CAS][DependencyScanning] Don't keep a shared state of common file deps

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -18,8 +18,9 @@
 #ifndef SWIFT_AST_MODULE_DEPENDENCIES_H
 #define SWIFT_AST_MODULE_DEPENDENCIES_H
 
-#include "swift/Basic/LLVM.h"
 #include "swift/AST/Import.h"
+#include "swift/AST/SearchPathOptions.h"
+#include "swift/Basic/LLVM.h"
 #include "clang/CAS/CASOptions.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
 #include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
@@ -31,12 +32,12 @@
 #include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/Mutex.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/Mutex.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace swift {
 
@@ -733,17 +734,16 @@ using ModuleDependenciesKindRefMap =
 /// Track swift dependency
 class SwiftDependencyTracker {
 public:
-  SwiftDependencyTracker(llvm::cas::CachingOnDiskFileSystem &FS,
-                         const std::vector<std::string> &CommonFiles)
-      : FS(FS.createProxyFS()), Files(CommonFiles) {}
+  SwiftDependencyTracker(llvm::cas::CachingOnDiskFileSystem &FS)
+      : FS(FS.createProxyFS()) {}
 
   void startTracking();
+  void addCommonSearchPathDeps(const SearchPathOptions& Opts);
   void trackFile(const Twine &path) { (void)FS->status(path); }
   llvm::Expected<llvm::cas::ObjectProxy> createTreeFromDependencies();
 
 private:
   llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
-  const std::vector<std::string> &Files;
 };
 
 // MARK: SwiftDependencyScanningService
@@ -848,7 +848,7 @@ public:
     if (!CacheFS)
       return None;
 
-    return SwiftDependencyTracker(*CacheFS, CommonDependencyFiles);
+    return SwiftDependencyTracker(*CacheFS);
   }
 
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> getClangScanningFS() const {

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -174,6 +174,14 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
     std::string RootID;
     if (dependencyTracker) {
       dependencyTracker->startTracking();
+      dependencyTracker->addCommonSearchPathDeps(Ctx.SearchPathOpts);
+      std::vector<std::string> clangDependencyFiles;
+      auto clangImporter =
+          static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+      clangImporter->addClangInvovcationDependencies(clangDependencyFiles);
+      llvm::for_each(clangDependencyFiles, [&](std::string &file) {
+        dependencyTracker->trackFile(file);
+      });
       dependencyTracker->trackFile(moduleInterfacePath);
       auto RootOrError = dependencyTracker->createTreeFromDependencies();
       if (!RootOrError)

--- a/test/CAS/module_deps_clang_extras.swift
+++ b/test/CAS/module_deps_clang_extras.swift
@@ -1,0 +1,48 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/cas
+// RUN: split-file %s %t
+// RUN: %hmaptool write %t/hmap.json %t/empty.hmap
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache \
+// RUN:   %t/Test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -clang-include-tree \
+// RUN:   -Xcc -fmodule-map-file=%t/module.modulemap -Xcc -ivfsoverlay -Xcc %t/empty.yaml \
+// RUN:   -Xcc -I%t/empty.hmap
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps casFSRootID > %t/fs.casid
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/fs.casid | %FileCheck %s -DDIR=%basename_t -check-prefix FS_ROOT
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:Dummy clangIncludeTree > %t/tree.casid
+// RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/tree.casid | %FileCheck %s -DDIR=%basename_t -check-prefix INCLUDE_TREE
+
+// FS_ROOT: [[DIR]].tmp/empty.hmap
+// FS_ROOT: [[DIR]].tmp/empty.yaml
+
+// INCLUDE_TREE: [[DIR]].tmp/Dummy.h
+
+//--- Test.swift
+import Dummy
+func test() {}
+
+//--- module.modulemap
+module Dummy {
+ umbrella header "Dummy.h"
+}
+
+//--- Dummy.h
+void dummy(void);
+
+//--- hmap.json
+{
+  "mappings": {} 
+}
+
+//--- empty.yaml
+{
+  "version": 0,
+  "case-sensitive": "false",
+  "use-external-names": true,
+  "roots": []
+}
+

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2640,6 +2640,7 @@ config.substitutions.append(('%target-resilience-test', config.target_resilience
 
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
+config.substitutions.append(('%hmaptool', os.path.join(config.llvm_src_root, '..', 'clang', 'utils', 'hmaptool', 'hmaptool')))
 
 # Set up the host library environment.
 if hasattr(config, 'target_library_path_var'):


### PR DESCRIPTION
Unlike `swift-frontend -scan-dependencies` option, when dependency scanner is used as a library by swift driver, the SwiftScanningService is shared for multiple driver invocations. It can't keep states (like common file dependencies) that can change from one invocation to another.

Instead, the clang/SDK file dependencies are computed from each driver invocations to avoid out-of-date information when scanning service is reused.

The test case for a shared Service will be added to swift-driver repo since there is no tool to test it within swift compiler.
