### PR TITLE
handle parsing `~` before a type in more places

### DIFF
--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -99,7 +99,7 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
       ParserResult<TypeRepr> Ty;
 
       if (Tok.isAny(tok::identifier, tok::code_complete, tok::kw_protocol,
-                    tok::kw_Any)) {
+                    tok::kw_Any) || Tok.isTilde()) {
         Ty = parseType();
       } else if (Tok.is(tok::kw_class)) {
         diagnose(Tok, diag::unexpected_class_constraint);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -154,6 +154,15 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     Diag<> MessageID, ParseTypeReason reason) {
   ParserResult<TypeRepr> ty;
 
+
+  // Prevent the use of ~ as prefix for a type. We specially parse them
+  // in inheritance clauses elsewhere.
+  if (Tok.isTilde()) {
+    auto tildeLoc = consumeToken();
+    diagnose(tildeLoc, diag::cannot_suppress_here)
+        .fixItRemoveChars(tildeLoc, tildeLoc);
+  }
+
   if (Tok.is(tok::kw_inout)
       || (canHaveParameterSpecifierContextualKeyword()
           && (Tok.getRawText().equals("__shared")

--- a/test/Parse/without_copyable.swift
+++ b/test/Parse/without_copyable.swift
@@ -35,7 +35,8 @@ protocol Rope<Element>: ~Copyable { // expected-error {{cannot suppress conforma
 extension S: ~Copyable {} // expected-error {{cannot suppress conformances here}}
                           // expected-error@-1 {{cannot find type 'Copyable' in scope}}
 
-func takeNoncopyableGeneric<T: ~Copyable>(_ t: T) {} // expected-error {{expected a class type or protocol-constrained type restricting 'T'}}
+func takeNoncopyableGeneric<T: ~Copyable>(_ t: T) {} // expected-error {{cannot suppress conformances here}}
+                                                     // expected-error@-1 {{cannot find type 'Copyable' in scope}}
 
 @_moveOnly struct ExtraNonCopyable:         // expected-error {{duplicate attribute}}{{1-12=}}
                                   ~Copyable // expected-note {{attribute already specified here}}
@@ -57,3 +58,24 @@ public enum MoveOnlyE2<T: Equatable> : ~Copyable {
   case holding(s: MoveOnlyS1<T>)
   consuming func x() {}
 }
+
+func more() {
+  let foo: any ~Copyable = 19  // expected-error@:16 {{cannot suppress conformances here}}
+                               // expected-error@-1 {{cannot find type 'Copyable' in scope}}
+
+  let foo: any ~Equatable = 19  // expected-error@:16 {{cannot suppress conformances here}}
+}
+
+func blah<T>(_ t: T) where T: ~Copyable,    // expected-error@:31 {{cannot suppress conformances here}}
+                                            // expected-error@-1 {{cannot find type 'Copyable' in scope}}
+
+                           T: ~Hashable {}  // expected-error@:31 {{cannot suppress conformances here}}
+
+func foo<T: ~Copyable>(x: T) {} // expected-error {{cannot suppress conformances here}}
+                                // expected-error@-1 {{cannot find type 'Copyable' in scope}}
+
+struct Buurap<T: ~Copyable> {} // expected-error {{cannot suppress conformances here}}
+                               // expected-error@-1 {{cannot find type 'Copyable' in scope}}
+
+protocol Foo where Self: ~Copyable {} // expected-error {{cannot suppress conformances here}}
+                                      // expected-error@-1 {{cannot find type 'Copyable' in scope}}


### PR DESCRIPTION
It's still an error in most places, but now we don't give as bizzare of an error message.

rdar://110421020