### PR TITLE
[5.9🍒] Be more specific than "noncopyable type T can't be used with generics yet"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7210,6 +7210,15 @@ ERROR(noncopyable_generics_erasure, none,
 ERROR(noncopyable_generics_metatype_cast, none,
       "metatype %0 cannot be cast to %1 because %2 is noncopyable",
       (Type, Type, Type))
+ERROR(noncopyable_generics_generic_param, none,
+      "noncopyable type %0 cannot be substituted for copyable %1 %2 in %3",
+      (Type, DescriptiveDeclKind, Type, DeclName))
+ERROR(noncopyable_generics_generic_param_metatype, none,
+      "metatype %4 of noncopyable type %0 cannot be substituted for copyable %1 %2 in %3",
+      (Type, DescriptiveDeclKind, Type, DeclName, Type))
+NOTE(noncopyable_generics_implicit_copyable, none,
+      "%0 %1 has an implicit Copyable requirement",
+      (DescriptiveDeclKind, Type))
 ERROR(noncopyable_effectful_getter,none,
       "%0 of noncopyable type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
 ERROR(noncopyable_enums_do_not_support_indirect,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7204,6 +7204,12 @@ ERROR(noncopyable_generics_variadic, none,
 ERROR(noncopyable_generics_specific, none,
       "noncopyable type %0 cannot be used with generic type %1 yet",
       (Type, Type))
+ERROR(noncopyable_generics_erasure, none,
+      "noncopyable type %0 cannot be erased to copyable existential type %1",
+      (Type, Type))
+ERROR(noncopyable_generics_metatype_cast, none,
+      "metatype %0 cannot be cast to %1 because %2 is noncopyable",
+      (Type, Type, Type))
 ERROR(noncopyable_effectful_getter,none,
       "%0 of noncopyable type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
 ERROR(noncopyable_enums_do_not_support_indirect,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7195,7 +7195,15 @@ ERROR(self_ownership_specifier_copyable,none,
       (SelfAccessKind, DescriptiveDeclKind))
 ERROR(ownership_specifier_nonescaping_closure,none,
       "'%0' cannot be applied to nonescaping closure", (StringRef))
-ERROR(noncopyable_generics, none, "noncopyable type %0 cannot be used with generics yet", (Type))
+ERROR(noncopyable_generics, none,
+      "noncopyable type %0 cannot be used with generics yet",
+      (Type))
+ERROR(noncopyable_generics_variadic, none,
+      "noncopyable type %0 cannot be used within a variadic type yet",
+      (Type))
+ERROR(noncopyable_generics_specific, none,
+      "noncopyable type %0 cannot be used with generic type %1 yet",
+      (Type, Type))
 ERROR(noncopyable_effectful_getter,none,
       "%0 of noncopyable type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
 ERROR(noncopyable_enums_do_not_support_indirect,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7221,6 +7221,9 @@ ERROR(noncopyable_generics_generic_param_metatype, none,
 NOTE(noncopyable_generics_implicit_copyable, none,
       "%0 %1 has an implicit Copyable requirement",
       (DescriptiveDeclKind, Type))
+ERROR(noncopyable_element_of_pack_not_supported,none,
+      "parameter pack containing noncopyable element %0 is not supported",
+      (Type))
 ERROR(noncopyable_effectful_getter,none,
       "%0 of noncopyable type cannot be 'async' or 'throws'", (DescriptiveDeclKind))
 ERROR(noncopyable_enums_do_not_support_indirect,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5448,7 +5448,9 @@ ERROR(tuple_pack_element_label,none,
       "cannot use label with pack expansion tuple element",
       ())
 ERROR(tuple_move_only_not_supported,none,
-      "tuples with noncopyable elements are not supported", ())
+      "tuple with noncopyable element type %0 is not supported", (Type))
+ERROR(tuple_containing_move_only_not_supported,none,
+      "type %0 containing noncopyable element is not supported", (Type))
 ERROR(vararg_not_allowed,none,
       "variadic parameter cannot appear outside of a function parameter list",
       ())

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2082,10 +2082,29 @@ public:
   }
 };
 
+/// Describes the reason why the type must be copyable
+struct NoncopyableMatchFailure {
+  enum Reason {
+    Unknown,
+    CastToExistential,
+  };
+
+  Type type;
+  Reason reason;
+
+  NoncopyableMatchFailure() : type(Type()), reason(Unknown) {}
+  NoncopyableMatchFailure(Type type, Reason reason)
+      : type(type), reason(reason) {}
+};
+
 class MustBeCopyable final : public ConstraintFix {
   Type noncopyableTy;
+  NoncopyableMatchFailure failure;
 
-  MustBeCopyable(ConstraintSystem &cs, Type noncopyableTy, ConstraintLocator *locator);
+  MustBeCopyable(ConstraintSystem &cs,
+                 Type noncopyableTy,
+                 NoncopyableMatchFailure failure,
+                 ConstraintLocator *locator);
 
 public:
   std::string getName() const override { return "remove move-only from type"; }
@@ -2096,6 +2115,7 @@ public:
 
   static MustBeCopyable *create(ConstraintSystem &cs,
                              Type noncopyableTy,
+                             NoncopyableMatchFailure failure,
                              ConstraintLocator *locator);
 
   static bool classof(const ConstraintFix *fix) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6118,6 +6118,12 @@ bool NotCopyableFailure::diagnoseAsError() {
       return true;
     }
 
+    if (loc->isLastElement<LocatorPathElt::PackElement>()) {
+      emitDiagnostic(diag::noncopyable_element_of_pack_not_supported,
+                     noncopyableTy);
+      return true;
+    }
+
     // a bit paranoid of nulls and such...
     if (auto *genericParam = loc->getGenericParameter()) {
       if (auto *paramDecl = genericParam->getDecl()) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6111,6 +6111,13 @@ bool NotCopyableFailure::diagnoseAsError() {
 
   case NoncopyableMatchFailure::CopyableConstraint: {
     auto *loc = getLocator();
+
+    if (loc->isLastElement<LocatorPathElt::AnyTupleElement>()) {
+      assert(!noncopyableTy->is<TupleType>() && "will use poor wording");
+      emitDiagnostic(diag::tuple_move_only_not_supported, noncopyableTy);
+      return true;
+    }
+
     // a bit paranoid of nulls and such...
     if (auto *genericParam = loc->getGenericParameter()) {
       if (auto *paramDecl = genericParam->getDecl()) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6095,7 +6095,27 @@ bool NotCompileTimeConstFailure::diagnoseAsError() {
 }
 
 bool NotCopyableFailure::diagnoseAsError() {
-  emitDiagnostic(diag::noncopyable_generics, noncopyableTy);
+  switch (failure.reason) {
+  case NoncopyableMatchFailure::CastToExistential: {
+    assert(failure.type->is<ExistentialType>());
+
+    if (noncopyableTy->is<AnyMetatypeType>())
+      emitDiagnostic(diag::noncopyable_generics_metatype_cast,
+                     noncopyableTy,
+                     failure.type,
+                     noncopyableTy->getMetatypeInstanceType());
+    else
+      emitDiagnostic(diag::noncopyable_generics_erasure,
+                     noncopyableTy,
+                     failure.type);
+    break;
+  }
+  case NoncopyableMatchFailure::Unknown:
+    emitDiagnostic(diag::noncopyable_generics,
+                   noncopyableTy);
+    break;
+  }
+
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -539,16 +539,16 @@ public:
         ResultTypeIsOptional(resultOptional) {}
 
   bool diagnoseAsError() override;
-  
+
   Type getMemberBaseType() const {
     return MemberBaseType;
   }
-  
+
   SourceLoc getLoc() const override {
     // The end location points to the dot in the member access.
     return getSourceRange().End;
   }
-  
+
   SourceRange getSourceRange() const override;
 
 };
@@ -670,7 +670,7 @@ public:
 
   /// If we're trying to convert something to `nil`.
   bool diagnoseConversionToNil() const;
-  
+
   /// Diagnose failed conversion in a `CoerceExpr`.
   bool diagnoseCoercionToUnrelatedType() const;
 
@@ -1816,9 +1816,14 @@ public:
 
 class NotCopyableFailure final : public FailureDiagnostic {
   Type noncopyableTy;
+  NoncopyableMatchFailure failure;
 public:
-  NotCopyableFailure(const Solution &solution, Type noncopyableTy, ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), noncopyableTy(noncopyableTy) {}
+  NotCopyableFailure(const Solution &solution,
+                     Type noncopyableTy,
+                     NoncopyableMatchFailure failure,
+                     ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        noncopyableTy(noncopyableTy), failure(failure) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1368,19 +1368,24 @@ bool NotCompileTimeConst::diagnose(const Solution &solution, bool asNote) const 
   return failure.diagnose(asNote);
 }
 
-MustBeCopyable::MustBeCopyable(ConstraintSystem &cs, Type noncopyableTy, ConstraintLocator *locator)
+MustBeCopyable::MustBeCopyable(ConstraintSystem &cs,
+                               Type noncopyableTy,
+                               NoncopyableMatchFailure failure,
+                               ConstraintLocator *locator)
     : ConstraintFix(cs, FixKind::MustBeCopyable, locator, FixBehavior::Error),
-      noncopyableTy(noncopyableTy) {}
+      noncopyableTy(noncopyableTy), failure(failure) {}
 
 bool MustBeCopyable::diagnose(const Solution &solution, bool asNote) const {
-  NotCopyableFailure failure(solution, noncopyableTy, getLocator());
-  return failure.diagnose(asNote);
+  NotCopyableFailure failDiag(solution, noncopyableTy, failure, getLocator());
+  return failDiag.diagnose(asNote);
 }
 
 MustBeCopyable* MustBeCopyable::create(ConstraintSystem &cs,
                                               Type noncopyableTy,
+                                              NoncopyableMatchFailure failure,
                                               ConstraintLocator *locator) {
-  return new (cs.getAllocator()) MustBeCopyable(cs, noncopyableTy, locator);
+  return new (cs.getAllocator()) MustBeCopyable(cs, noncopyableTy,
+                                                failure, locator);
 }
 
 bool MustBeCopyable::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3832,8 +3832,11 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
   if (type1->getMetatypeInstanceType()->isPureMoveOnly()) {
     // tailor error message
     if (shouldAttemptFixes()) {
-      auto *fix = MustBeCopyable::create(*this, type1,
-                                        getConstraintLocator(locator));
+      auto *fix =
+          MustBeCopyable::create(*this, type1,
+                                 {type2,
+                                  NoncopyableMatchFailure::CastToExistential},
+                                 getConstraintLocator(locator));
       if (!recordFix(fix))
         return getTypeMatchSuccess();
     }
@@ -8495,7 +8498,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // If this is a failure to conform to Copyable, tailor the error message.
     if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
       auto *fix =
-          MustBeCopyable::create(*this, type, getConstraintLocator(locator));
+          MustBeCopyable::create(*this, type, {}, getConstraintLocator(locator));
       if (!recordFix(fix))
         return SolutionKind::Solved;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3832,11 +3832,11 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
   if (type1->getMetatypeInstanceType()->isPureMoveOnly()) {
     // tailor error message
     if (shouldAttemptFixes()) {
-      auto *fix =
-          MustBeCopyable::create(*this, type1,
-                                 {type2,
-                                  NoncopyableMatchFailure::CastToExistential},
-                                 getConstraintLocator(locator));
+      auto *fix = MustBeCopyable::create(*this,
+                                         type1,
+                                         NoncopyableMatchFailure::forExistentialCast(
+                                             type2),
+                                         getConstraintLocator(locator));
       if (!recordFix(fix))
         return getTypeMatchSuccess();
     }
@@ -8498,7 +8498,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // If this is a failure to conform to Copyable, tailor the error message.
     if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
       auto *fix =
-          MustBeCopyable::create(*this, type, {}, getConstraintLocator(locator));
+          MustBeCopyable::create(*this,
+                                 type,
+                                 NoncopyableMatchFailure::forCopyableConstraint(),
+                                 getConstraintLocator(locator));
       if (!recordFix(fix))
         return SolutionKind::Solved;
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -329,7 +329,11 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         // Diagnose attempts to form a tuple with any noncopyable elements.
         if (E->getType()->isPureMoveOnly()
             && !Ctx.LangOpts.hasFeature(Feature::MoveOnlyTuples)) {
-          Ctx.Diags.diagnose(E->getLoc(), diag::tuple_move_only_not_supported);
+          auto noncopyableTy = E->getType();
+          assert(noncopyableTy->is<TupleType>() && "will use poor wording");
+          Ctx.Diags.diagnose(E->getLoc(),
+                             diag::tuple_containing_move_only_not_supported,
+                             noncopyableTy);
         }
       }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -999,13 +999,14 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
 /// returns true iff an error diagnostic was emitted
 static bool didDiagnoseMoveOnlyGenericArgs(ASTContext &ctx,
                                          SourceLoc loc,
+                                         Type unboundTy,
                                          ArrayRef<Type> genericArgs) {
   bool didEmitDiag = false;
   for (auto t: genericArgs) {
     if (!t->isPureMoveOnly())
       continue;
 
-    ctx.Diags.diagnose(loc, diag::noncopyable_generics, t);
+    ctx.Diags.diagnose(loc, diag::noncopyable_generics_specific, t, unboundTy);
     didEmitDiag = true;
   }
 
@@ -1033,8 +1034,9 @@ Type TypeResolution::applyUnboundGenericArguments(
   bool skipRequirementsCheck = false;
 
   // check for generic args that are move-only
-  if (didDiagnoseMoveOnlyGenericArgs(getASTContext(), loc, genericArgs))
-    return ErrorType::get(getASTContext());
+  auto &ctx = getASTContext();
+  if (didDiagnoseMoveOnlyGenericArgs(ctx, loc, resultType, genericArgs))
+    return ErrorType::get(ctx);
 
   // Get the substitutions for outer generic parameters from the parent
   // type.
@@ -2022,7 +2024,8 @@ namespace {
       return diags.diagnose(std::forward<ArgTypes>(Args)...);
     }
 
-    bool diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy);
+    bool diagnoseMoveOnlyGeneric(TypeRepr *repr,
+                                 Type unboundTy, Type genericArgTy);
     bool diagnoseMoveOnlyMissingOwnership(TypeRepr *repr,
                                           TypeResolutionOptions options);
     
@@ -2276,10 +2279,17 @@ bool TypeResolver::diagnoseInvalidPlaceHolder(OpaqueReturnTypeRepr *repr) {
 /// as an argument for type parameters.
 ///
 /// returns true if an error diagnostic was emitted
-bool TypeResolver::diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy) {
+bool TypeResolver::diagnoseMoveOnlyGeneric(TypeRepr *repr,
+                                           Type unboundTy,
+                                           Type genericArgTy) {
   if (genericArgTy->isPureMoveOnly()) {
-    diagnoseInvalid(repr, repr->getLoc(), diag::noncopyable_generics,
-                    genericArgTy);
+    if (unboundTy) {
+      diagnoseInvalid(repr, repr->getLoc(), diag::noncopyable_generics_specific,
+                      genericArgTy, unboundTy);
+    } else {
+      diagnoseInvalid(repr, repr->getLoc(), diag::noncopyable_generics,
+                      genericArgTy);
+    }
     return true;
   }
   return false;
@@ -4364,8 +4374,11 @@ NeverNullType TypeResolver::resolveArrayType(ArrayTypeRepr *repr,
   }
 
   // do not allow move-only types in an array
-  if (diagnoseMoveOnly(repr, baseTy))
+  if (diagnoseMoveOnlyGeneric(repr,
+                              ctx.getArrayDecl()->getDeclaredInterfaceType(),
+                              baseTy)) {
     return ErrorType::get(ctx);
+  }
 
   return ArraySliceType::get(baseTy);
 }
@@ -4405,21 +4418,25 @@ NeverNullType TypeResolver::resolveOptionalType(OptionalTypeRepr *repr,
                                                 TypeResolutionOptions options) {
   TypeResolutionOptions elementOptions = options.withoutContext(true);
   elementOptions.setContext(TypeResolverContext::ImmediateOptionalTypeArgument);
+  ASTContext &ctx = getASTContext();
 
   auto baseTy = resolveType(repr->getBase(), elementOptions);
   if (baseTy->hasError()) {
-    return ErrorType::get(getASTContext());
+    return ErrorType::get(ctx);
   }
 
   auto optionalTy = TypeChecker::getOptionalType(repr->getQuestionLoc(),
                                                  baseTy);
   if (optionalTy->hasError()) {
-    return ErrorType::get(getASTContext());
+    return ErrorType::get(ctx);
   }
 
   // do not allow move-only types in an optional
-  if (diagnoseMoveOnly(repr, baseTy))
-    return ErrorType::get(getASTContext());
+  if (diagnoseMoveOnlyGeneric(repr,
+                              ctx.getOptionalDecl()->getDeclaredInterfaceType(),
+                              baseTy)) {
+    return ErrorType::get(ctx);
+  }
 
   return optionalTy;
 }
@@ -4427,6 +4444,7 @@ NeverNullType TypeResolver::resolveOptionalType(OptionalTypeRepr *repr,
 NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     ImplicitlyUnwrappedOptionalTypeRepr *repr, TypeResolutionOptions options,
     bool isDirect) {
+  ASTContext &ctx = getASTContext();
   TypeResolutionFlags allowIUO = TypeResolutionFlags::SILType;
 
   bool doDiag = false;
@@ -4475,7 +4493,7 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
 
   if (doDiag && !options.contains(TypeResolutionFlags::SilenceErrors)) {
     // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
-    if (getASTContext().isSwiftVersionAtLeast(5)) {
+    if (ctx.isSwiftVersionAtLeast(5)) {
       // Mark this repr as invalid. This is the only way to indicate that
       // something went wrong without supressing checking other reprs in
       // the same type. For example:
@@ -4509,18 +4527,21 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
 
   auto baseTy = resolveType(repr->getBase(), elementOptions);
   if (baseTy->hasError()) {
-    return ErrorType::get(getASTContext());
+    return ErrorType::get(ctx);
   }
 
   auto uncheckedOptionalTy =
       TypeChecker::getOptionalType(repr->getExclamationLoc(), baseTy);
   if (uncheckedOptionalTy->hasError()) {
-    return ErrorType::get(getASTContext());
+    return ErrorType::get(ctx);
   }
 
   // do not allow move-only types in an implicitly-unwrapped optional
-  if (diagnoseMoveOnly(repr, baseTy))
-    return ErrorType::get(getASTContext());
+  if (diagnoseMoveOnlyGeneric(repr,
+                              ctx.getOptionalDecl()->getDeclaredInterfaceType(),
+                              baseTy)) {
+    return ErrorType::get(ctx);
+  }
 
   return uncheckedOptionalTy;
 }
@@ -4537,8 +4558,11 @@ NeverNullType TypeResolver::resolveVarargType(VarargTypeRepr *repr,
   }
 
   // do not allow move-only types as the element of a vararg
-  if (diagnoseMoveOnly(repr, element))
+  if (element->isPureMoveOnly()) {
+    diagnoseInvalid(repr, repr->getLoc(), diag::noncopyable_generics_variadic,
+                    element);
     return ErrorType::get(getASTContext());
+  }
 
   return element;
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4786,8 +4786,10 @@ NeverNullType TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   if (moveOnlyElementIndex.has_value()
       && !options.contains(TypeResolutionFlags::SILType)
       && !ctx.LangOpts.hasFeature(Feature::MoveOnlyTuples)) {
-    diagnose(repr->getElementType(*moveOnlyElementIndex)->getLoc(),
-             diag::tuple_move_only_not_supported);
+    auto noncopyableTy = elements[*moveOnlyElementIndex].getType();
+    auto loc = repr->getElementType(*moveOnlyElementIndex)->getLoc();
+    assert(!noncopyableTy->is<TupleType>() && "will use poor wording");
+    diagnose(loc, diag::tuple_move_only_not_supported, noncopyableTy);
   }
 
   return TupleType::get(elements, ctx);

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -88,8 +88,9 @@ func testBasic(_ mo: borrowing MO) {
   genericVarArg(5)
   genericVarArg(mo) // expected-error {{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'T' in 'genericVarArg'}}
 
-  takeGeneric( (mo, 5) ) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  takeGenericSendable((mo, mo)) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
+  takeGeneric( (mo, 5) ) // expected-error {{tuple with noncopyable element type 'MO' is not supported}}
+  takeGeneric( ((mo, 5), 19) ) // expected-error {{tuple with noncopyable element type 'MO' is not supported}}
+  takeGenericSendable((mo, mo)) // expected-error 2{{tuple with noncopyable element type 'MO' is not supported}}
 
   let singleton : (MO) = (mo)
   takeGeneric(singleton) // expected-error {{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'T' in 'takeGeneric'}}
@@ -235,7 +236,7 @@ func checkStdlibTypes(_ mo: borrowing MO) {
   let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
       []
   let _: [String: MO] = // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Dictionary<Key, Value>' yet}}
-      ["hello" : MO()]  // expected-error{{tuples with noncopyable elements are not supported}}
+      ["hello" : MO()]  // expected-error{{type '(String, MO)' containing noncopyable element is not supported}}
 
   _ = [MO()] // expected-error {{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'Element' in 'Array'}}
 

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -67,8 +67,8 @@ takeGeneric(globalMO) // expected-error {{noncopyable type 'MO' cannot be used w
 
 
 func testAny() {
-  let _: Any = MO() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  takeAny(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Any = MO() // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
+  takeAny(MO()) // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
 }
 
 func testBasic(_ mo: borrowing MO) {
@@ -79,8 +79,8 @@ func testBasic(_ mo: borrowing MO) {
   takeGeneric(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   takeGeneric(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeAny(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  print(mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  takeAny(mo) // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
+  print(mo) // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
   _ = "\(mo)" // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
   let _: String = String(describing: mo) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
@@ -94,8 +94,8 @@ func testBasic(_ mo: borrowing MO) {
   let singleton : (MO) = (mo)
   takeGeneric(singleton) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  takeAny((mo)) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  takeAny((mo, mo)) // expected-error {{noncopyable type '(MO, MO)' cannot be used with generics yet}}
+  takeAny((mo)) // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
+  takeAny((mo, mo)) // expected-error {{noncopyable type '(MO, MO)' cannot be erased to copyable existential type 'Any'}}
 }
 
 func checkBasicBoxes() {
@@ -148,23 +148,23 @@ func checkCasting(_ b: any Box, _ mo: borrowing MO, _ a: Any) {
   let _: MO = dup.get()
   let _: MO = dup.val
 
-  let _: Any = MO.self // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
-  let _: AnyObject = MO.self // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
-  let _ = MO.self as Any // expected-error {{noncopyable type 'MO.Type' cannot be used with generics yet}}
+  let _: Any = MO.self // expected-error {{metatype 'MO.Type' cannot be cast to 'Any' because 'MO' is noncopyable}}
+  let _: AnyObject = MO.self // expected-error {{metatype 'MO.Type' cannot be cast to 'AnyObject' because 'MO' is noncopyable}}
+  let _ = MO.self as Any // expected-error {{metatype 'MO.Type' cannot be cast to 'Any' because 'MO' is noncopyable}}
   let _ = MO.self is Any // expected-warning {{cast from 'MO.Type' to unrelated type 'Any' always fails}}
 
-  let _: Sendable = (MO(), MO()) // expected-error {{noncopyable type '(MO, MO)' cannot be used with generics yet}}
-  let _: Sendable = MO() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Sendable = (MO(), MO()) // expected-error {{noncopyable type '(MO, MO)' cannot be erased to copyable existential type 'any Sendable'}}
+  let _: Sendable = MO() // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'any Sendable'}}
   let _: _Copyable = mo // expected-error {{'_Copyable' is unavailable}}
-                        // expected-error@-1 {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: AnyObject = MO() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: Any = mo // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+                        // expected-error@-1 {{noncopyable type 'MO' cannot be erased to copyable existential type 'any _Copyable'}}
+  let _: AnyObject = MO() // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'AnyObject'}}
+  let _: Any = mo // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
 
-  _ = MO() as P // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  _ = MO() as any P // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  _ = MO() as Any // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = MO() as P // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'any P'}}
+  _ = MO() as any P // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'any P'}}
+  _ = MO() as Any // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'Any'}}
   _ = MO() as MO
-  _ = MO() as AnyObject // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = MO() as AnyObject // expected-error {{noncopyable type 'MO' cannot be erased to copyable existential type 'AnyObject'}}
   _ = 5 as MO // expected-error {{cannot convert value of type 'Int' to type 'MO' in coercion}}
   _ = a as MO // expected-error {{cannot convert value of type 'Any' to type 'MO' in coercion}}
   _ = b as MO // expected-error {{cannot convert value of type 'any Box' to type 'MO' in coercion}}

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -109,7 +109,7 @@ func checkBasicBoxes() {
   _ = rb.get()
   _ = rb.val
 
-  let vb2: ValBox<MO> = .init(MO())  // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let vb2: ValBox<MO> = .init(MO())  // expected-error {{noncopyable type 'MO' cannot be used with generic type 'ValBox<T>' yet}}
 }
 
 func checkExistential() {
@@ -127,13 +127,13 @@ func checkExistential() {
 }
 
 func checkMethodCalls() {
-  let tg: NotStoredGenerically<MO> = NotStoredGenerically() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let tg: NotStoredGenerically<MO> = NotStoredGenerically() // expected-error {{noncopyable type 'MO' cannot be used with generic type 'NotStoredGenerically<T>' yet}}
   tg.take(MO())
   tg.give()
 
-  let _: Maybe<MO> = .none // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _ = Maybe<MO>.just(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: Maybe<MO> = .just(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Maybe<MO> = .none // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Maybe<T>' yet}}
+  let _ = Maybe<MO>.just(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Maybe<T>' yet}}
+  let _: Maybe<MO> = .just(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Maybe<T>' yet}}
   takeMaybe(.just(MO())) // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
 
   takeMaybe(true ? .none : .just(MO())) // expected-error 3{{noncopyable type 'MO' cannot be used with generics yet}}
@@ -142,7 +142,7 @@ func checkMethodCalls() {
 func checkCasting(_ b: any Box, _ mo: borrowing MO, _ a: Any) {
   // casting dynamically is allowed, but should always fail since you can't
   // construct such a type.
-  let box = b as! ValBox<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let box = b as! ValBox<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'ValBox<T>' yet}}
   let dup = box
 
   let _: MO = dup.get()
@@ -226,18 +226,18 @@ func checkCasting(_ b: any Box, _ mo: borrowing MO, _ a: Any) {
 }
 
 func checkStdlibTypes(_ mo: borrowing MO) {
-  let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
       [MO(), MO()]
-  let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [MO] = // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
       []
-  let _: [String: MO] = // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: [String: MO] = // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Dictionary<Key, Value>' yet}}
       ["hello" : MO()]  // expected-error{{tuples with noncopyable elements are not supported}}
 
   // i think this one's only caught b/c of the 'Any' change
   _ = [MO()] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 
-  let _: Array<MO> = .init() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  _ = [MO]() // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Array<MO> = .init() // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
+  _ = [MO]() // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
 
   let s: String = "hello \(mo)" // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
 }

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -289,5 +289,5 @@ func tryToDoBadMetatypeStuff() {
 
 func packingHeat<each T>(_ t: repeat each T) {}
 func packIt() {
-  packingHeat(MO())  // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  packingHeat(MO())  // expected-error {{parameter pack containing noncopyable element 'MO' is not supported}}
 }

--- a/test/Constraints/moveonly_tuples.swift
+++ b/test/Constraints/moveonly_tuples.swift
@@ -9,18 +9,18 @@
 
 @_moveOnly
 struct Foo {
-    var t: (Int, Butt) // expected-error{{tuples with noncopyable elements are not supported}}
+    var t: (Int, Butt) // expected-error{{tuple with noncopyable element type 'Butt' is not supported}}
 }
 @_moveOnly
 struct Bar<T> {
-    var t: (T, Butt) // expected-error{{tuples with noncopyable elements are not supported}}
-    var u: (Int, (T, Butt)) // expected-error{{tuples with noncopyable elements are not supported}}
+    var t: (T, Butt) // expected-error{{tuple with noncopyable element type 'Butt' is not supported}}
+    var u: (Int, (T, Butt)) // expected-error{{tuple with noncopyable element type 'Butt' is not supported}}
 }
 
 func inferredTuples<T>(x: Int, y: borrowing Butt, z: T) {
-    let a = (x, y) // expected-error{{tuples with noncopyable elements are not supported}}
-    let b = (y, z) // expected-error{{tuples with noncopyable elements are not supported}}
-    let c = (x, y, z) // expected-error{{tuples with noncopyable elements are not supported}}
+    let a = (x, y) // expected-error{{type '(Int, Butt)' containing noncopyable element is not supported}}
+    let b = (y, z) // expected-error{{type '(Butt, T)' containing noncopyable element is not supported}}
+    let c = (x, y, z) // expected-error{{type '(Int, Butt, T)' containing noncopyable element is not supported}}
     _ = a
     _ = b
     _ = c

--- a/test/Sema/copyable_constraint.swift
+++ b/test/Sema/copyable_constraint.swift
@@ -7,8 +7,8 @@
 
 @_marker public protocol _Copyable {}
 
-func nextTime<T>(_ t: T) {}
+func nextTime<T>(_ t: T) {} // expected-note {{generic parameter 'T' has an implicit Copyable requirement}}
 
 @_moveOnly struct MO {}
 
-nextTime(MO()) // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+nextTime(MO()) // expected-error {{noncopyable type 'MO' cannot be substituted for copyable generic parameter 'T' in 'nextTime'}}

--- a/test/Sema/moveonly_illegal_types.swift
+++ b/test/Sema/moveonly_illegal_types.swift
@@ -47,33 +47,33 @@ struct CerebralValley<T> {
 // --- now some tests ---
 // ----------------------
 
-func basic_vararg(_ va: MO...) {} // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+func basic_vararg(_ va: MO...) {} // expected-error {{noncopyable type 'MO' cannot be used within a variadic type yet}}
 
 func illegalTypes<T>(_ t: T) {
-  let _: Array<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: Maybe<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: Dictionary<MO, String> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: [MO] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: [String : MO] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: [MO : MO] // expected-error 2{{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: [MO : T] // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Array<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
+  let _: Maybe<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Maybe<T>' yet}}
+  let _: Dictionary<MO, String> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Dictionary<Key, Value>' yet}}
+  let _: [MO] // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Array<Element>' yet}}
+  let _: [String : MO] // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Dictionary<Key, Value>' yet}}
+  let _: [MO : MO] // expected-error 2{{noncopyable type 'MO' cannot be used with generic type 'Dictionary<Key, Value>' yet}}
+  let _: [MO : T] // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Dictionary<Key, Value>' yet}}
 
-  _ = t as! ValBox<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  _ = t as! ValBox<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'ValBox<T>' yet}}
 
-  let _: Optional<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: MO? // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: MO?? // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: MO! // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: MO?! // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: Optional<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Optional<Wrapped>' yet}}
+  let _: MO? // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Optional<Wrapped>' yet}}
+  let _: MO?? // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Optional<Wrapped>' yet}}
+  let _: MO! // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Optional<Wrapped>' yet}}
+  let _: MO?! // expected-error {{noncopyable type 'MO' cannot be used with generic type 'Optional<Wrapped>' yet}}
 
   let _: Klass & MO // expected-error {{non-protocol, non-class type 'MO' cannot be used within a protocol-constrained type}}
   let _: any MO // expected-error {{'any' has no effect on concrete type 'MO'}}
   let _: any GenericMO<T> // expected-error {{'any' has no effect on concrete type 'GenericMO<T>'}}
 
-  let _: CerebralValley<MO>.TechBro // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
-  let _: CerebralValley<Int>.GenericBro<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: CerebralValley<MO>.TechBro // expected-error {{noncopyable type 'MO' cannot be used with generic type 'CerebralValley<T>' yet}}
+  let _: CerebralValley<Int>.GenericBro<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'CerebralValley<T>.GenericBro<U>' yet}}
 
-  let _: GenericMO<MO> // expected-error {{noncopyable type 'MO' cannot be used with generics yet}}
+  let _: GenericMO<MO> // expected-error {{noncopyable type 'MO' cannot be used with generic type 'GenericMO<T>' yet}}
 }
 
 func illegalInExpr() {

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -17,15 +17,15 @@ class MoveOnlyStruct {
 
 class C {
     var copyable: CopyableKlass? = nil
-    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'Optional<Wrapped>' yet}}
+    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generic type 'Optional<Wrapped>' yet}}
 }
 
 @_moveOnly
 class CMoveOnly {
     var copyable: CopyableKlass? = nil
-    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'Optional<Wrapped>' yet}}
+    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generic type 'Optional<Wrapped>' yet}}
 }
 
 struct OptionalGrandField<T> { // expected-error {{generic struct 'OptionalGrandField' cannot contain a noncopyable type without also being noncopyable}}
@@ -34,8 +34,8 @@ struct OptionalGrandField<T> { // expected-error {{generic struct 'OptionalGrand
 }
 
 struct S0 {
-    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnly4: OptionalGrandField<MoveOnlyStruct> // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'OptionalGrandField<T>' yet}}
+    var moveOnly4: OptionalGrandField<MoveOnlyStruct> // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generic type 'OptionalGrandField<T>' yet}}
 }
 
 struct SCopyable {
@@ -44,10 +44,10 @@ struct SCopyable {
 
 struct S { // expected-error {{struct 'S' cannot contain a noncopyable type without also being noncopyable}}
     var copyable: CopyableKlass
-    var moveOnly2: MoveOnlyStruct? // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly2: MoveOnlyStruct? // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generic type 'Optional<Wrapped>' yet}}
     var moveOnly: MoveOnlyStruct // expected-note {{contained noncopyable property 'S.moveOnly'}}
-    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
-    var moveOnly3: OptionalGrandField<MoveOnlyStruct> // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'OptionalGrandField<T>' yet}}
+    var moveOnly3: OptionalGrandField<MoveOnlyStruct> // expected-error {{noncopyable type 'MoveOnlyStruct' cannot be used with generic type 'OptionalGrandField<T>' yet}}
 }
 
 @_moveOnly
@@ -59,7 +59,7 @@ struct SMoveOnly {
 enum E { // expected-error {{enum 'E' cannot contain a noncopyable type without also being noncopyable}}
     case lhs(CopyableKlass)
     case rhs(MoveOnlyKlass) // expected-note {{contained noncopyable enum case 'E.rhs'}}
-    case rhs2(OptionalGrandField<MoveOnlyKlass>) // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+    case rhs2(OptionalGrandField<MoveOnlyKlass>) // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'OptionalGrandField<T>' yet}}
 }
 
 @_moveOnly
@@ -81,13 +81,13 @@ extension MoveOnlyStruct {
 func foo() {
     class C2 {
         var copyable: CopyableKlass? = nil
-        var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+        var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'Optional<Wrapped>' yet}}
     }
 
     @_moveOnly
     class C2MoveOnly {
         var copyable: CopyableKlass? = nil
-        var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+        var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'Optional<Wrapped>' yet}}
     }
 
     struct S2 { // expected-error {{struct 'S2' cannot contain a noncopyable type without also being noncopyable}}
@@ -114,13 +114,13 @@ func foo() {
     {
         class C3 {
             var copyable: CopyableKlass? = nil
-            var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+            var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'Optional<Wrapped>' yet}}
         }
 
         @_moveOnly
         class C3MoveOnly {
             var copyable: CopyableKlass? = nil
-            var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generics yet}}
+            var moveOnly: MoveOnlyKlass? = nil // expected-error {{noncopyable type 'MoveOnlyKlass' cannot be used with generic type 'Optional<Wrapped>' yet}}
         }
 
         struct S3 { // expected-error {{struct 'S3' cannot contain a noncopyable type without also being noncopyable}}

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -93,17 +93,17 @@ enum Wrong_NoncopyableOption<T> : Sendable { // expected-note {{consider making 
 func takeAnySendable(_ s: any Sendable) {}
 func takeSomeSendable(_ s: some Sendable) {}
 
-// expected-error@+1 {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+// expected-error@+1 {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
 func mkSendable() -> Sendable { return FileDescriptor(id: 0) }
 
 func tryToCastIt(_ fd: borrowing FileDescriptor) {
-  let _: any Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
-  let _: Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  let _: any Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
+  let _: Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
 
-  takeAnySendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  takeAnySendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
   takeSomeSendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
 
-  let _ = fd as Sendable // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  let _ = fd as Sendable // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
 
   let _ = fd as? Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
   // expected-error@-1 {{noncopyable types cannot be conditionally cast}}
@@ -146,7 +146,7 @@ class Container<T> where T:Sendable {
 }
 
 func createContainer(_ fd: borrowing FileDescriptor) {
-  let _: Container<Sendable> = Container(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  let _: Container<Sendable> = Container(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
   let _: Container<Sendable> = Container(CopyableStruct())
 }
 

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -91,7 +91,7 @@ enum Wrong_NoncopyableOption<T> : Sendable { // expected-note {{consider making 
 }
 
 func takeAnySendable(_ s: any Sendable) {}
-func takeSomeSendable(_ s: some Sendable) {}
+func takeSomeSendable(_ s: some Sendable) {} // expected-note {{generic parameter 'some Sendable' has an implicit Copyable requirement}}
 
 // expected-error@+1 {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
 func mkSendable() -> Sendable { return FileDescriptor(id: 0) }
@@ -101,7 +101,7 @@ func tryToCastIt(_ fd: borrowing FileDescriptor) {
   let _: Sendable = fd // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
 
   takeAnySendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
-  takeSomeSendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  takeSomeSendable(fd) // expected-error {{noncopyable type 'FileDescriptor' cannot be substituted for copyable generic parameter 'some Sendable' in 'takeSomeSendable'}}
 
   let _ = fd as Sendable // expected-error {{noncopyable type 'FileDescriptor' cannot be erased to copyable existential type 'any Sendable'}}
 
@@ -159,7 +159,8 @@ extension Sendable {
 }
 
 func tryToDupe(_ fd: borrowing FileDescriptor) {
-  fd.doIllegalThings() // expected-error {{noncopyable type 'FileDescriptor' cannot be used with generics yet}}
+  // FIXME: this should describe 'Self' as 'any Sendable' or something.
+  fd.doIllegalThings() // expected-error {{noncopyable type 'FileDescriptor' cannot be substituted for copyable generic parameter 'Self' in 'Sendable'}}
 }
 
 @_moveOnly


### PR DESCRIPTION
• Description: Important polish work to be more helpful about the reason why a noncopyable can't be used, example:
```diff
- let x = [MO()]  // error: noncopyable type 'MO' cannot be used with generics yet
+ let x = [MO()] // error: noncopyable type 'MO' cannot be substituted for copyable generic parameter 'Element' in 'Array'
```
• Risk: Very Low. Only changes the diagnostics to be more useful. When encountering a case it doesn't know how to handle, we fall back on the old, vague message.
• Original PR: https://github.com/apple/swift/pull/66871
• Reviewed By: @slavapestov 
• Testing: regression tests included
• Resolves: rdar://108914588