### PR TITLE
[5.9] Fix Sendable checking for overrides, witnesses, and calls that involving sub typing or implicit conversions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5163,8 +5163,8 @@ WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %4 %2 %3|"
         "exiting %4 context in call to non-isolated %2 %3|"
         "passed in implicitly asynchronous call to %4 %2 %3|"
-        "in parameter of %4 %2 %3 satisfying protocol requirement|"
-        "in parameter of %4 overriding %2 %3|"
+        "in parameter of the protocol requirement satisfied by %4 %2 %3|"
+        "in parameter of superclass method overridden by %4 %2 %3|"
         "in parameter of %4 '@objc' %2 %3}1 cannot cross actor boundary",
         (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
 WARNING(non_sendable_call_param_type,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5167,9 +5167,9 @@ WARNING(non_sendable_param_type,none,
         "in parameter of superclass method overridden by %4 %2 %3|"
         "in parameter of %4 '@objc' %2 %3}1 cannot cross actor boundary",
         (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
-WARNING(non_sendable_call_param_type,none,
-        "non-sendable type %0 passed in %select{implicitly asynchronous |}1"
-        "call to %2 function cannot cross actor boundary",
+WARNING(non_sendable_call_argument,none,
+        "passing argument of non-sendable type %0 %select{into %2 context|"
+        "outside of %2 context}1 may introduce data races",
         (Type, bool, ActorIsolation))
 WARNING(non_sendable_result_type,none,
         "non-sendable type %0 returned by %select{call to %4 %2 %3|"

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -246,6 +246,17 @@ public:
   operator Kind() const { return kind; }
 };
 
+/// Specifies whether checks applied to function types should
+/// apply to their params, results, or both
+enum class FunctionCheckKind {
+  /// Check params and results
+  ParamsResults,
+  /// Check params only
+  Params,
+  /// Check results only
+  Results,
+};
+
 /// Diagnose the presence of any non-sendable types when referencing a
 /// given declaration from a particular declaration context.
 ///
@@ -260,17 +271,26 @@ public:
 ///
 /// \param fromDC The context from which the reference occurs.
 ///
-/// \param loc The location at which the reference occurs, which will be
+/// \param refLoc The location at which the reference occurs, which will be
 /// used when emitting diagnostics.
 ///
 /// \param refKind Describes what kind of reference is being made, which is
 /// used to tailor the diagnostic.
 ///
+/// \param funcCheckKind Describes whether function types in this reference
+/// should be checked for sendability of their results, params, or both
+///
+/// \param diagnoseLoc Provides an alternative source location to `refLoc`
+/// to be used for reporting the top level diagnostic while auxiliary
+/// warnings and diagnostics are reported at `refLoc`.
+///
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonSendableTypesInReference(
-    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
+    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc refLoc,
     SendableCheckReason refKind,
-    Optional<ActorIsolation> knownIsolation = None);
+    Optional<ActorIsolation> knownIsolation = None,
+    FunctionCheckKind funcCheckKind = FunctionCheckKind::ParamsResults,
+    SourceLoc diagnoseLoc = SourceLoc());
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(
@@ -282,6 +302,9 @@ void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
 
 /// Warn about deprecated `Executor.enqueue` implementations.
 void tryDiagnoseExecutorConformance(ASTContext &C, const NominalTypeDecl *nominal, ProtocolDecl *proto);
+
+// Get a concrete reference to a declaration
+ConcreteDeclRef getDeclRefInContext(ValueDecl *value);
 
 /// How the Sendable check should be performed.
 enum class SendableCheck {
@@ -362,6 +385,37 @@ namespace detail {
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
 ///
+/// \param typeLoc is the source location of the type being diagnosed
+///
+/// \param diagnoseLoc is the source location at which the main diagnostic should
+/// be reported, which can differ from typeLoc
+///
+/// \returns \c true if any errors were produced, \c false if no diagnostics or
+/// only warnings and notes were produced.
+template<typename ...DiagArgs>
+bool diagnoseNonSendableTypes(
+    Type type, SendableCheckContext fromContext,
+    SourceLoc typeLoc, SourceLoc diagnoseLoc,
+    Diag<Type, DiagArgs...> diag,
+    typename detail::Identity<DiagArgs>::type ...diagArgs) {
+
+    ASTContext &ctx = fromContext.fromDC->getASTContext();
+    return diagnoseNonSendableTypes(
+        type, fromContext, typeLoc, [&](Type specificType,
+                                        DiagnosticBehavior behavior) {
+
+          if (behavior != DiagnosticBehavior::Ignore) {
+            ctx.Diags.diagnose(diagnoseLoc, diag, type, diagArgs...)
+                .limitBehavior(behavior);
+          }
+
+          return false;
+        });
+}
+
+/// Diagnose any non-Sendable types that occur within the given type, using
+/// the given diagnostic.
+///
 /// \returns \c true if any errors were produced, \c false if no diagnostics or
 /// only warnings and notes were produced.
 template<typename ...DiagArgs>
@@ -369,17 +423,9 @@ bool diagnoseNonSendableTypes(
     Type type, SendableCheckContext fromContext, SourceLoc loc,
     Diag<Type, DiagArgs...> diag,
     typename detail::Identity<DiagArgs>::type ...diagArgs) {
-  ASTContext &ctx = fromContext.fromDC->getASTContext();
-  return diagnoseNonSendableTypes(
-      type, fromContext, loc, [&](Type specificType,
-      DiagnosticBehavior behavior) {
-    if (behavior != DiagnosticBehavior::Ignore) {
-      ctx.Diags.diagnose(loc, diag, type, diagArgs...)
-        .limitBehavior(behavior);
-    }
 
-    return false;
-  });
+    return diagnoseNonSendableTypes(type, fromContext, loc, loc, diag,
+                             std::forward<decltype(diagArgs)>(diagArgs)...);
 }
 
 /// Diagnose this sendability error with behavior based on the import of

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -165,14 +165,14 @@ actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
   func syncMethod() { } // expected-note 2{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
 
   nonisolated func independentMethod() {
-    syncMethod() // expected-error{{ctor-isolated instance method 'syncMethod()' can not be referenced from a non-isolated context}}
+    syncMethod() // expected-error{{call to actor-isolated instance method 'syncMethod()' in a synchronous nonisolated context}}
   }
 
   nonisolated func nonisolatedMethod() {
   }
 
   @MainActor func mainActorMethod() {
-    syncMethod() // expected-error{{actor-isolated instance method 'syncMethod()' can not be referenced from the main actor}}
+    syncMethod() // expected-error{{call to actor-isolated instance method 'syncMethod()' in a synchronous main actor-isolated context}}
   }
 
   @MainActor func uiActorMethod() { }

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -289,29 +289,29 @@ func blender(_ peeler : () -> Void) {
 
 
   await wisk({})
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '() -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   await wisk(1)
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (peelBanana)()
   await (((((peelBanana)))))()
   await (((wisk)))((wisk)((wisk)(1)))
-  // expected-warning@-1 3{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
 
   blender((peelBanana))
   // expected-warning@-1 2{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
 
   await wisk(peelBanana)
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '() -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   await wisk(wisk)
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '(Any) -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   await (((wisk)))(((wisk)))
-  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-warning@-1{{passing argument of non-sendable type '(Any) -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-  // expected-warning@+1 {{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await {wisk}()(1)
 
-  // expected-warning@+1 {{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (true ? wisk : {n in return})(1)
 }
 

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -244,7 +244,7 @@ func regularFunc() {
 
   _ = a.deposit //expected-error{{actor-isolated instance method 'deposit' can not be partially applied}}
 
-  _ = a.deposit(1)  // expected-error{{actor-isolated instance method 'deposit' can not be referenced from a non-isolated context}}
+  _ = a.deposit(1)  // expected-error{{call to actor-isolated instance method 'deposit' in a synchronous nonisolated context}}
 }
 
 
@@ -289,29 +289,29 @@ func blender(_ peeler : () -> Void) {
 
 
   await wisk({})
-  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await wisk(1)
-  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (peelBanana)()
   await (((((peelBanana)))))()
   await (((wisk)))((wisk)((wisk)(1)))
-  // expected-warning@-1 3{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1 3{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
 
   blender((peelBanana))
   // expected-warning@-1 2{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
 
   await wisk(peelBanana)
-  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
 
   await wisk(wisk)
-  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (((wisk)))(((wisk)))
-  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@-1{{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
 
-  // expected-warning@+1 {{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@+1 {{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await {wisk}()(1)
 
-  // expected-warning@+1 {{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
+  // expected-warning@+1 {{passing argument of non-sendable type 'Any' into global actor 'BananaActor'-isolated context may introduce data races}}
   await (true ? wisk : {n in return})(1)
 }
 
@@ -368,14 +368,14 @@ actor Calculator {
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly asynchronous call to actor-isolated instance method 'addCurried' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by call to actor-isolated function cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly asynchronous call to actor-isolated instance method 'addCurried' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by call to actor-isolated function cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let plusOne = await calc.addCurried(await calc.add(0, 1))
-  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly asynchronous call to actor-isolated instance method 'addCurried' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by call to actor-isolated function cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = plusOne(2)
 }

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -106,17 +106,16 @@ enum E {
 }
 
 struct SomeStruct {
-  @MainActor init(asyncMainActor: Int) async {} // expected-note{{calls to initializer 'init(asyncMainActor:)' from outside of its actor context are implicitly asynchronous}}
+  @MainActor init(asyncMainActor: Int) async {}
   @MainActor init(mainActor: Int) {} // expected-note {{calls to initializer 'init(mainActor:)' from outside of its actor context are implicitly asynchronous}}
   @MainActor(unsafe) init(asyncMainActorUnsafe: Int) async {}
   @MainActor(unsafe) init(mainActorUnsafe: Int) {}
 }
 
-// expected-note@+2 2{{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
+// expected-note@+2 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
 // expected-note@+1 2 {{add 'async' to function 'globActorTest1()' to make it asynchronous}}
 func globActorTest1() {
   _ = SomeStruct(asyncMainActor: 0) // expected-error {{'async' call in a function that does not support concurrency}}
-  // expected-error@-1{{call to main actor-isolated initializer 'init(asyncMainActor:)' in a synchronous nonisolated context}}
 
   _ = SomeStruct(mainActor: 0) // expected-error {{call to main actor-isolated initializer 'init(mainActor:)' in a synchronous nonisolated context}}
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -59,15 +59,15 @@ actor A2 {
 }
 
 func testActorCreation(value: NotConcurrent) async {
-  _ = A2(value: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to nonisolated initializer 'init(value:)' cannot cross actor boundary}}
+  _ = A2(value: value) // expected-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
 
-  _ = await A2(valueAsync: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to actor-isolated initializer 'init(valueAsync:)' cannot cross actor boundary}}
+  _ = await A2(valueAsync: value) // expected-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
 
-  _ = A2(delegatingSync: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to nonisolated initializer 'init(delegatingSync:)' cannot cross actor boundary}}
+  _ = A2(delegatingSync: value) // expected-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
 
-  _ = await A2(delegatingAsync: value, 9) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to actor-isolated initializer 'init(delegatingAsync:_:)' cannot cross actor boundary}}
+  _ = await A2(delegatingAsync: value, 9) // expected-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
 
-  _ = await A2(nonisoAsync: value, 3) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to nonisolated initializer 'init(nonisoAsync:_:)' cannot cross actor boundary}}
+  _ = await A2(nonisoAsync: value, 3) // expected-warning{{passing argument of non-sendable type 'NotConcurrent' into actor-isolated context may introduce data races}}
 }
 
 extension A1 {
@@ -83,8 +83,8 @@ extension A1 {
 
     // Across to a different actor, so Sendable restriction is enforced.
     _ = other.localLet // expected-warning{{non-sendable type 'NotConcurrent' in asynchronous access to actor-isolated property 'localLet' cannot cross actor boundary}}
-    _ = await other.synchronous() // expected-warning{{non-sendable type 'NotConcurrent?' returned by implicitly asynchronous call to actor-isolated instance method 'synchronous()' cannot cross actor boundary}}
-    _ = await other.asynchronous(nil) // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to actor-isolated instance method 'asynchronous' cannot cross actor boundary}}
+    _ = await other.synchronous() // expected-warning{{non-sendable type 'NotConcurrent?' returned by call to actor-isolated function cannot cross actor boundary}}
+    _ = await other.asynchronous(nil) // expected-warning{{passing argument of non-sendable type 'NotConcurrent?' into actor-isolated context may introduce data races}}
   }
 }
 
@@ -113,8 +113,8 @@ func globalAsync(_: NotConcurrent?) async {
 
 func globalTest() async {
   let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
-  await globalAsync(a) // expected-warning{{non-sendable type 'NotConcurrent?' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
-  await globalSync(a)  // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  await globalAsync(a) // expected-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
+  await globalSync(a)  // expected-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
 }
 
 struct HasSubscript {
@@ -134,9 +134,9 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 @MainActor
 func globalTestMain(nc: NotConcurrent) async {
   let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
-  await globalAsync(a) // expected-warning{{non-sendable type 'NotConcurrent?' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
-  await globalSync(a)  // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
-  _ = await ClassWithGlobalActorInits(nc) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  await globalAsync(a) // expected-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
+  await globalSync(a)  // expected-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
+  _ = await ClassWithGlobalActorInits(nc) // expected-warning{{passing argument of non-sendable type 'NotConcurrent' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   // expected-warning@-1{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
   _ = await ClassWithGlobalActorInits() // expected-warning{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
 }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -223,7 +223,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of actor-isolated instance method 'asyncMethod' satisfying protocol requirement cannot cross actor boundary}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of the protocol requirement satisfied by actor-isolated instance method 'asyncMethod' cannot cross actor boundary}}
 }
 
 protocol MainActorProto {
@@ -232,7 +232,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' satisfying protocol requirement cannot cross actor boundary}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of the protocol requirement satisfied by global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' cannot cross actor boundary}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -51,12 +51,10 @@ func referenceGlobalActor2() {
 }
 
 
-// expected-note@+2 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}} {{33-33= async}}
-// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'referenceAsyncGlobalActor()' part of global actor 'SomeGlobalActor'}}
+// expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}} {{33-33= async}}
 func referenceAsyncGlobalActor() {
-  let y = asyncGlobalActFn // expected-note{{calls to let 'y' from outside of its actor context are implicitly asynchronous}}
+  let y = asyncGlobalActFn
   y() // expected-error{{'async' call in a function that does not support concurrency}}
-  // expected-error@-1{{call to global actor 'SomeGlobalActor'-isolated let 'y' in a synchronous nonisolated context}}
 }
 
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -201,7 +201,7 @@ actor GenericSub<T> : GenericSuper<[T]> { // expected-error{{actor types do not 
   nonisolated override func method3() { } // expected-error{{instance method overrides a 'final' instance method}}
 
   @OtherGlobalActor func testMethod() {
-    method() // expected-error{{actor-isolated instance method 'method()' can not be referenced from global actor 'OtherGlobalActor'}}
+    method() // expected-error{{call to actor-isolated instance method 'method()' in a synchronous global actor 'OtherGlobalActor'-isolated context}}
     _ = method // expected-error{{actor-isolated instance method 'method()' can not be partially applied}}
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -86,11 +86,11 @@ func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
 @available(SwiftStdlib 5.1, *)
 func testIsolatedParamCaptures(a: isolated A) async {
   let _ = { @MainActor in
-    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from the main actor}}
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
   }
 
   let _: @MainActor () -> () = {
-    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from the main actor}}
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous main actor-isolated context}}
   }
 
   let _ = {
@@ -98,7 +98,7 @@ func testIsolatedParamCaptures(a: isolated A) async {
   }
 
   let _ = { @Sendable in
-    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from a Sendable closure}}
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   }
 
 }
@@ -139,7 +139,7 @@ struct S: P {
   func j(isolated: Int) -> Int { return isolated }
   func k(isolated y: Int) -> Int { return j(isolated: y) }
   func l(isolated _: Int) -> Int { return k(isolated: 0) }
-  func m(thing: MyActor) { thing.hello() } // expected-error {{actor-isolated instance method 'hello()' can not be referenced from a non-isolated context}}
+  func m(thing: MyActor) { thing.hello() } // expected-error {{call to actor-isolated instance method 'hello()' in a synchronous nonisolated context}}
 }
 
 func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
@@ -267,7 +267,7 @@ extension TestActor {
   // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
   nonisolated func isolatedToParameter(_ other: isolated TestActor) {
     isolatedMethod()
-    // expected-error@-1{{actor-isolated instance method 'isolatedMethod()' can not be referenced on a non-isolated actor instance}}
+    // expected-error@-1{{call to actor-isolated instance method 'isolatedMethod()' in a synchronous actor-isolated context}}
 
     other.isolatedMethod()
   }
@@ -305,8 +305,8 @@ func isolatedClosures() {
   // expected-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
   nonisolated subscript(_ a: isolated A, _ b: isolated A) -> Int {
     // FIXME: wrong isolation. should be isolated to `a`.
-    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced on a non-isolated actor instance}}
-    b.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced on a non-isolated actor instance}}
+    a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
+    b.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
     return 0
   }
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -113,3 +113,106 @@ class SendableSubclass: NSClass, @unchecked Sendable { }
 func testSubclassing(obj: SendableSubclass) async {
   acceptCV(obj) // okay!
 }
+
+
+@available(SwiftStdlib 5.1, *)
+protocol P {
+  func foo (x : @Sendable () -> ()) async -> ()
+
+  func bar(x : () -> ()) async -> ()
+  // expected-note@-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+  func foo2<T : Sendable>(x : T) async -> ()
+
+  func bar2<T>(x : T) async -> ()
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+}
+
+// Make sure conformance to protocols checks sendability of
+// requirement parameters not witness parameters
+@available(SwiftStdlib 5.1, *)
+        actor A : P {
+  func foo(x : () -> ()) -> () {}
+
+  func bar(x : () -> ()) -> () {}
+  // expected-warning@-1 {{non-sendable type '() -> ()' in parameter of the protocol requirement satisfied by actor-isolated instance method 'bar(x:)' cannot cross actor boundary}}
+
+  func foo2<T>(x : T) -> () {}
+
+  func bar2<T>(x : T) -> () {}
+  // expected-warning@-1 {{non-sendable type 'T' in parameter of the protocol requirement satisfied by actor-isolated instance method 'bar2(x:)' cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+class Super {
+  @MainActor
+  func foo (x : @Sendable () -> ()) async {}
+
+  @MainActor
+  func bar (x : () -> ()) async {}
+  // expected-note@-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+  @MainActor
+  func foo2<T : Sendable>(x: T) async {}
+
+  @MainActor
+  func bar2<T>(x: T) async {}
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+}
+
+// Make sure isolation crossing overrides check sendability
+// of superclass parameters not subclass parameters
+@available(SwiftStdlib 5.1, *)
+class Sub : Super {
+  override nonisolated func foo(x : () -> ()) async {}
+
+  override nonisolated func bar(x : () -> ()) async {}
+  // expected-warning@-1 {{non-sendable type '() -> ()' in parameter of superclass method overridden by nonisolated instance method 'bar(x:)' cannot cross actor boundary}}
+
+  override nonisolated func foo2<T>(x: T) async {}
+
+  override nonisolated func bar2<T>(x: T) async {}
+  // expected-warning@-1 {{non-sendable type 'T' in parameter of superclass method overridden by nonisolated instance method 'bar2(x:)' cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+class SuperWSafeSubscript {
+  @MainActor
+  subscript<T : Sendable>(x : T) -> Int {
+    get async {
+      return 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+class SubWSafeSubscript : SuperWSafeSubscript {
+  override nonisolated subscript<T>(x : T) -> Int {
+    get async {
+      return 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+class SuperWUnsafeSubscript {
+  @MainActor
+  subscript<T>(x : T) -> Int {
+    // expected-note@-1 2{{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+    get async {
+      return 0
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+class SubWUnsafeSubscript : SuperWUnsafeSubscript {
+  override nonisolated subscript<T>(x : T) -> Int {
+    get async {
+      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated subscript 'subscript(_:)' cannot cross actor boundary}}
+      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated getter '_' cannot cross actor boundary}}
+      // there really shouldn't be two warnings produced here, see rdar://110846040 (Sendable diagnostics reported twice for subscript getters)
+      return 0
+    }
+  }
+}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -216,3 +216,17 @@ class SubWUnsafeSubscript : SuperWUnsafeSubscript {
     }
   }
 }
+
+
+// Test implicit conversions getting in the way
+@available(SwiftStdlib 5.1, *)
+extension MyActor {
+  func f(_: Any) { }
+  func g(_: () -> Void) { }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> Void) async {
+  await a.f(s)
+  await a.g(f)
+}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -81,8 +81,8 @@ public actor MyActor: MyProto {
   public func bar<B>(aBar: B) async where B: Sendable { }
 
   func g(ns1: NS1) async {
-    await nonisolatedAsyncFunc1(ns1) // expected-warning{{non-sendable type 'NS1' exiting actor-isolated context in call to non-isolated global function 'nonisolatedAsyncFunc1' cannot cross actor boundary}}
-    _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by call from actor-isolated context to non-isolated global function 'nonisolatedAsyncFunc2()' cannot cross actor boundary}}
+    await nonisolatedAsyncFunc1(ns1) // expected-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
+    _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
 }
 

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -19,10 +19,10 @@ class Super {
 @available(SwiftStdlib 5.1, *)
 class Sub: Super {
   @MainActor override func f(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of main actor-isolated overriding instance method 'f' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of superclass method overridden by main actor-isolated instance method 'f' cannot cross actor boundary}}
 
   nonisolated override func g1(_: NotSendable) { } // okay, synchronous
 
   nonisolated override func g2(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of nonisolated overriding instance method 'g2' cannot cross actor boundary}}
+  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of superclass method overridden by nonisolated instance method 'g2' cannot cross actor boundary}}
 }

--- a/test/Concurrency/toplevel/no-async-5-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-5-top-level.swift
@@ -24,7 +24,7 @@ func nonIsolatedAsync() async {
 }
 
 @MainActor
-func isolatedAsync() async { // expected-note 2 {{calls to global function 'isolatedAsync()' from outside of its actor context are implicitly asynchronous}}
+func isolatedAsync() async {
     print(a)
     a = a + 10
 }
@@ -32,8 +32,7 @@ func isolatedAsync() async { // expected-note 2 {{calls to global function 'isol
 nonIsolatedSync()
 isolatedSync() // expected-error {{call to main actor-isolated global function 'isolatedSync()' in a synchronous nonisolated context}}
 nonIsolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
-isolatedAsync() // expected-error {{call to main actor-isolated global function 'isolatedAsync()' in a synchronous nonisolated context}}
-// expected-error@-1 {{'async' call in a function that does not support concurrency}}
+isolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
 
 print(a)
 
@@ -41,8 +40,7 @@ if a > 10 {
     nonIsolatedSync()
     isolatedSync() // expected-error {{call to main actor-isolated global function 'isolatedSync()' in a synchronous nonisolated context}}
     nonIsolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
-    isolatedAsync() // expected-error {{call to main actor-isolated global function 'isolatedAsync()' in a synchronous nonisolated context}}
-    // expected-error@-1 {{'async' call in a function that does not support concurrency}}
+    isolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
 
     print(a)
 }

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -207,10 +207,10 @@ distributed actor DijonMustard {
 
   convenience init(conv: FakeActorSystem) { // expected-warning {{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
     self.init(system: conv)
-    self.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from a non-isolated context}}
+    self.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   }
 
-  func f() {} // expected-note {{distributed actor-isolated instance method 'f()' declared here}}
+  func f() {} // expected-note {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
   nonisolated init(conv2: FakeActorSystem) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
     self.init(system: conv2)

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -49,8 +49,8 @@ func processFiles(_ a: A, _ anotherFile: borrowing FileDescriptor) async {
   await a.takeMaybeFile(.available(anotherFile))
   _ = A(.available(anotherFile))
 
-  let ns = await a.getRef() // expected-warning {{non-sendable type 'NotSendableMO' returned by implicitly asynchronous call to actor-isolated instance method 'getRef()' cannot cross actor boundary}}
-  await takeNotSendable(ns) // expected-warning {{non-sendable type 'NotSendableMO' exiting main actor-isolated context in call to non-isolated global function 'takeNotSendable' cannot cross actor boundary}}
+  let ns = await a.getRef() // expected-warning {{non-sendable type 'NotSendableMO' returned by call to actor-isolated function cannot cross actor boundary}}
+  await takeNotSendable(ns) // expected-warning {{passing argument of non-sendable type 'NotSendableMO' outside of main actor-isolated context may introduce data races}}
 
   switch (await a.giveFileDescriptor()) {
   case let .available(fd):


### PR DESCRIPTION
* **Explanation**: Sendable checking had three places where we were checking for `Sendable` conformances with the "wrong" end of a sub typing relationship or implicit conversion, causing spurious `Sendable`-related diagnostics. Overriding and witnesses need to check the overridden method or protocol requirement's parameters for `Sendable`, not the overriding method and witness. For function calls, we need to look at the argument expression before any implicit conversions are applied, so that we diagnose sendability based on the argument itself---not the parameter it's initializing.
* **Scope**: Narrow. Only affects sendability and actor-isolation checking.
* **Risk**: Low. Should remove spurious warnings but otherwise does not change translation.
* **Reviewed by**: @kavon, @ktoso
* **Issue**:  rdar://110763694 / FB12343467.
* **Original pull request**: https://github.com/apple/swift/pull/66640, https://github.com/apple/swift/pull/66928, https://github.com/apple/swift/pull/66939
