### PR TITLE
[Parse] Fix a typo in the new parser diagnostics

### DIFF
--- a/test/Parse/new_parser_diagnostics.swift
+++ b/test/Parse/new_parser_diagnostics.swift
@@ -5,5 +5,5 @@
 // REQUIRES: asserts
 
 _ = [(Int) -> async throws Int]()
-// expected-error@-1{{'async throws' must preceed '->'}}
+// expected-error@-1{{'async throws' must precede '->'}}
 // expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1841