### PR TITLE
[5.9] [move-only] Emit an error if we /ever/ partially consume a noncopyable type.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -785,6 +785,9 @@ ERROR(sil_movechecking_notconsumable_but_assignable_was_consumed, none,
 ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
       "cannot partially consume '%0' when it has a deinitializer",
       (StringRef))
+ERROR(sil_movechecking_cannot_destructure, none,
+      "cannot partially consume '%0'",
+      (StringRef))
 ERROR(sil_movechecking_discard_missing_consume_self, none,
       "must consume 'self' before exiting method that discards self", ())
 ERROR(sil_movechecking_reinit_after_discard, none,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -130,6 +130,7 @@ EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
 EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
 EXPERIMENTAL_FEATURE(MoveOnlyResilientTypes, true)
+EXPERIMENTAL_FEATURE(MoveOnlyPartialConsumption, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -446,6 +446,8 @@ PASS(MoveOnlyAddressChecker, "sil-move-only-address-checker",
      "Utility pass that enforces move only invariants on raw SIL for addresses for testing purposes")
 PASS(MoveOnlyChecker, "sil-move-only-checker",
      "Pass that enforces move only invariants on raw SIL for addresses and objects")
+PASS(MoveOnlyTempAllocationFromLetTester, "sil-move-only-temp-allocation-from-let-tester",
+     "Pass that allows us to run separately SIL test cases for the eliminateTemporaryAllocationsFromLet utility")
 PASS(ConsumeOperatorCopyableValuesChecker, "sil-consume-operator-copyable-values-checker",
      "Pass that performs checking of the consume operator for copyable values")
 PASS(TrivialMoveOnlyTypeEliminator, "sil-trivial-move-only-type-eliminator",

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3300,6 +3300,11 @@ static bool usesFeatureMoveOnlyResilientTypes(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureMoveOnlyPartialConsumption(Decl *decl) {
+  // Partial consumption does not affect declarations directly.
+  return false;
+}
+
 static bool usesFeatureOneWayClosureParameters(Decl *decl) {
   return false;
 }

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(swiftSILOptimizer PRIVATE
   MoveOnlyDiagnostics.cpp
   MoveOnlyObjectCheckerTester.cpp
   MoveOnlyObjectCheckerUtils.cpp
+  MoveOnlyTempAllocationFromLetTester.cpp
   MoveOnlyTypeUtils.cpp
   MoveOnlyUtils.cpp
   MovedAsyncVarDebugInfoPropagator.cpp

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -861,3 +861,38 @@ void DiagnosticEmitter::emitCannotDestructureDeinitNominalError(
       deinitedNominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
     astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
 }
+
+void DiagnosticEmitter::emitCannotDestructureNominalError(
+    MarkMustCheckInst *markedValue, StringRef pathString,
+    NominalTypeDecl *nominal, SILInstruction *consumingUser,
+    bool isDueToDeinit) {
+  auto &astContext = fn->getASTContext();
+
+  SmallString<64> varName;
+  getVariableNameForValue(markedValue, varName);
+
+  if (!pathString.empty())
+    varName.append(pathString);
+
+  assert(
+      astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ==
+          isDueToDeinit &&
+      "Should only emit deinit error if we have partial consumption enabled");
+  if (isDueToDeinit) {
+    diagnose(astContext, consumingUser,
+             diag::sil_movechecking_cannot_destructure_has_deinit, varName);
+  } else {
+    diagnose(astContext, consumingUser,
+             diag::sil_movechecking_cannot_destructure, varName);
+  }
+  registerDiagnosticEmitted(markedValue);
+
+  if (!isDueToDeinit)
+    return;
+
+  // Point to the deinit if we know where it is.
+  assert(nominal);
+  if (auto deinitLoc =
+          nominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
+    astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
+}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -169,6 +169,11 @@ public:
                                                StringRef pathString,
                                                NominalTypeDecl *deinitedNominal,
                                                SILInstruction *consumingUser);
+  void emitCannotDestructureNominalError(MarkMustCheckInst *markedValue,
+                                         StringRef pathString,
+                                         NominalTypeDecl *nominal,
+                                         SILInstruction *consumingUser,
+                                         bool isDueToDeinit);
 
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTempAllocationFromLetTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTempAllocationFromLetTester.cpp
@@ -1,0 +1,78 @@
+//===--- MoveOnlyTempAllocationFromLetTester.cpp --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file A simple tester for the utility function
+/// eliminateTemporaryAllocationsFromLet that allows us to write separate SIL
+/// test cases for the utility.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-move-only-checker"
+
+#include "MoveOnlyAddressCheckerUtils.h"
+#include "MoveOnlyDiagnostics.h"
+#include "MoveOnlyUtils.h"
+
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+using namespace swift::siloptimizer;
+
+namespace {
+
+struct MoveOnlyTempAllocationFromLetTester : SILFunctionTransform {
+  void run() override {
+    auto *fn = getFunction();
+
+    // Only run this pass if the move only language feature is enabled.
+    if (!fn->getASTContext().supportsMoveOnlyTypes())
+      return;
+
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
+    assert(fn->getModule().getStage() == SILStage::Raw &&
+           "Should only run on Raw SIL");
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "===> MoveOnlyTempAllocationFromLetTester. Visiting: "
+               << fn->getName() << '\n');
+
+    SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+    DiagnosticEmitter diagnosticEmitter(getFunction());
+
+    unsigned diagCount = diagnosticEmitter.getDiagnosticCount();
+    searchForCandidateAddressMarkMustChecks(
+        getFunction(), moveIntroducersToProcess, diagnosticEmitter);
+
+    // Return early if we emitted a diagnostic.
+    if (diagCount != diagnosticEmitter.getDiagnosticCount())
+      return;
+
+    bool madeChange = false;
+    while (!moveIntroducersToProcess.empty()) {
+      auto *next = moveIntroducersToProcess.pop_back_val();
+      madeChange |= eliminateTemporaryAllocationsFromLet(next);
+    }
+
+    if (madeChange)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+};
+
+} // namespace
+
+SILTransform *swift::createMoveOnlyTempAllocationFromLetTester() {
+  return new MoveOnlyTempAllocationFromLetTester();
+}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -174,3 +174,524 @@ bool swift::siloptimizer::cleanupNonCopyableCopiesAfterEmittingDiagnostic(
 
   return changed;
 }
+
+//===----------------------------------------------------------------------===//
+//                           MARK: Memory Utilities
+//===----------------------------------------------------------------------===//
+
+bool noncopyable::memInstMustInitialize(Operand *memOper) {
+  SILValue address = memOper->get();
+
+  SILInstruction *memInst = memOper->getUser();
+
+  switch (memInst->getKind()) {
+  default:
+    return false;
+
+  case SILInstructionKind::CopyAddrInst: {
+    auto *CAI = cast<CopyAddrInst>(memInst);
+    return CAI->getDest() == address && CAI->isInitializationOfDest();
+  }
+  case SILInstructionKind::ExplicitCopyAddrInst: {
+    auto *CAI = cast<ExplicitCopyAddrInst>(memInst);
+    return CAI->getDest() == address && CAI->isInitializationOfDest();
+  }
+  case SILInstructionKind::MarkUnresolvedMoveAddrInst: {
+    return cast<MarkUnresolvedMoveAddrInst>(memInst)->getDest() == address;
+  }
+  case SILInstructionKind::InitExistentialAddrInst:
+  case SILInstructionKind::InitEnumDataAddrInst:
+  case SILInstructionKind::InjectEnumAddrInst:
+    return true;
+
+  case SILInstructionKind::BeginApplyInst:
+  case SILInstructionKind::TryApplyInst:
+  case SILInstructionKind::ApplyInst: {
+    FullApplySite applySite(memInst);
+    return applySite.isIndirectResultOperand(*memOper);
+  }
+  case SILInstructionKind::StoreInst: {
+    auto qual = cast<StoreInst>(memInst)->getOwnershipQualifier();
+    return qual == StoreOwnershipQualifier::Init ||
+           qual == StoreOwnershipQualifier::Trivial;
+  }
+
+#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
+  case SILInstructionKind::Store##Name##Inst:                                  \
+    return cast<Store##Name##Inst>(memInst)->isInitializationOfDest();
+#include "swift/AST/ReferenceStorage.def"
+  }
+}
+
+bool noncopyable::memInstMustReinitialize(Operand *memOper) {
+  SILValue address = memOper->get();
+
+  SILInstruction *memInst = memOper->getUser();
+
+  switch (memInst->getKind()) {
+  default:
+    return false;
+
+  case SILInstructionKind::CopyAddrInst: {
+    auto *CAI = cast<CopyAddrInst>(memInst);
+    return CAI->getDest() == address && !CAI->isInitializationOfDest();
+  }
+  case SILInstructionKind::ExplicitCopyAddrInst: {
+    auto *CAI = cast<ExplicitCopyAddrInst>(memInst);
+    return CAI->getDest() == address && !CAI->isInitializationOfDest();
+  }
+  case SILInstructionKind::YieldInst: {
+    auto *yield = cast<YieldInst>(memInst);
+    return yield->getYieldInfoForOperand(*memOper).isIndirectInOut();
+  }
+  case SILInstructionKind::BeginApplyInst:
+  case SILInstructionKind::TryApplyInst:
+  case SILInstructionKind::ApplyInst: {
+    FullApplySite applySite(memInst);
+    return applySite.getArgumentOperandConvention(*memOper).isInoutConvention();
+  }
+  case SILInstructionKind::StoreInst:
+    return cast<StoreInst>(memInst)->getOwnershipQualifier() ==
+           StoreOwnershipQualifier::Assign;
+
+#define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
+  case SILInstructionKind::Store##Name##Inst:                                  \
+    return !cast<Store##Name##Inst>(memInst)->isInitializationOfDest();
+#include "swift/AST/ReferenceStorage.def"
+  }
+}
+
+bool noncopyable::memInstMustConsume(Operand *memOper) {
+  SILValue address = memOper->get();
+
+  SILInstruction *memInst = memOper->getUser();
+
+  // FIXME: drop_deinit must be handled here!
+  switch (memInst->getKind()) {
+  default:
+    return false;
+
+  case SILInstructionKind::CopyAddrInst: {
+    auto *CAI = cast<CopyAddrInst>(memInst);
+    return (CAI->getSrc() == address && CAI->isTakeOfSrc()) ||
+           (CAI->getDest() == address && !CAI->isInitializationOfDest());
+  }
+  case SILInstructionKind::ExplicitCopyAddrInst: {
+    auto *CAI = cast<ExplicitCopyAddrInst>(memInst);
+    return (CAI->getSrc() == address && CAI->isTakeOfSrc()) ||
+           (CAI->getDest() == address && !CAI->isInitializationOfDest());
+  }
+  case SILInstructionKind::BeginApplyInst:
+  case SILInstructionKind::TryApplyInst:
+  case SILInstructionKind::ApplyInst: {
+    FullApplySite applySite(memInst);
+    return applySite.getArgumentOperandConvention(*memOper).isOwnedConvention();
+  }
+  case SILInstructionKind::PartialApplyInst: {
+    // If we are on the stack or have an inout convention, we do not
+    // consume. Otherwise, we do.
+    auto *pai = cast<PartialApplyInst>(memInst);
+    if (pai->isOnStack())
+      return false;
+    ApplySite applySite(pai);
+    auto convention = applySite.getArgumentConvention(*memOper);
+    return !convention.isInoutConvention();
+  }
+  case SILInstructionKind::DestroyAddrInst:
+    return true;
+  case SILInstructionKind::LoadInst:
+    return cast<LoadInst>(memInst)->getOwnershipQualifier() ==
+           LoadOwnershipQualifier::Take;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                  Simple Temporary AllocStack Elimination
+//===----------------------------------------------------------------------===//
+
+static bool isLetAllocation(MarkMustCheckInst *mmci) {
+  if (auto *pbi = dyn_cast<ProjectBoxInst>(mmci)) {
+    auto *box = cast<AllocBoxInst>(stripBorrow(pbi->getOperand()));
+    return !box->getBoxType()->getLayout()->isMutable();
+  }
+
+  if (auto *asi = dyn_cast<AllocStackInst>(mmci->getOperand()))
+    if (auto varInfo = asi->getVarInfo())
+      return varInfo->isLet();
+
+  return false;
+}
+
+static bool walkUseToDefsStructTupleProjections(
+    SILValue startPoint, SILValue endPoint,
+    llvm::function_ref<void(SingleValueInstruction *)> visitor) {
+  while (startPoint != endPoint) {
+    if (auto *sei = dyn_cast<StructElementAddrInst>(startPoint)) {
+      visitor(sei);
+      startPoint = sei->getOperand();
+      continue;
+    }
+
+    if (auto *tei = dyn_cast<TupleElementAddrInst>(startPoint)) {
+      visitor(tei);
+      startPoint = tei->getOperand();
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+namespace {
+
+struct SimpleTemporaryAllocStackElimState {
+  SmallVector<SingleValueInstruction *, 8> projectionList;
+  StackList<SILInstruction *> instsToDelete;
+
+  /// We use this set to walk from our initial copy to our final use and ensure
+  /// that there aren't any instructions we did not visit in between them. This
+  /// is to ensure that there aren't any instructions we didn't scan and
+  /// analyze.
+  InstructionSet visitedInsts;
+
+  SILValue rootAddress;
+  Operand *finalUse = nullptr;
+
+  SimpleTemporaryAllocStackElimState(SILValue rootAddress)
+      : instsToDelete(rootAddress->getFunction()),
+        visitedInsts(rootAddress->getFunction()), rootAddress(rootAddress) {}
+
+  bool setFinalUser(Operand *newFinalUse) {
+    if (finalUse)
+      return false;
+    finalUse = newFinalUse;
+    return true;
+  }
+
+  /// Walk from use->def pattern matching struct_element_addr/tuple_element_addr
+  /// from \p useAddress until it is \p allocationAddress. If we see a different
+  /// instruction, we return false to signal failure. Returns true if all
+  /// instructions along use->def walk are said instructions.
+  bool appendProjections(SILValue useAddress, SILValue allocationAddress) {
+    return walkUseToDefsStructTupleProjections(
+        useAddress, allocationAddress,
+        [&](SingleValueInstruction *sei) { projectionList.push_back(sei); });
+  }
+};
+
+struct SimpleTemporaryAllocStackElimVisitor final
+    : public TransitiveAddressWalker {
+  SimpleTemporaryAllocStackElimState &state;
+  CopyAddrInst *caiToVisit;
+  CopyAddrInst *&nextCAI;
+
+  SimpleTemporaryAllocStackElimVisitor(
+      SimpleTemporaryAllocStackElimState &state, CopyAddrInst *cai,
+      CopyAddrInst *&nextCAI)
+      : state(state), caiToVisit(cai), nextCAI(nextCAI) {
+    assert(nextCAI == nullptr);
+  }
+
+  AllocStackInst *getAllocation() const {
+    return cast<AllocStackInst>(caiToVisit->getDest());
+  }
+
+  bool setNextCAI(CopyAddrInst *newCAI) {
+    // If we already have a CAI, bail. We should only ever have one.
+    if (nextCAI)
+      return false;
+    nextCAI = newCAI;
+    return true;
+  }
+
+  bool visitUse(Operand *op) override {
+    LLVM_DEBUG(llvm::dbgs() << "SimpleTemporaryAllocStackElimVisitor visiting: "
+                            << *op->getUser());
+
+    state.visitedInsts.insert(op->getUser());
+
+    // We do not care about type dependent uses.
+    if (op->isTypeDependent())
+      return true;
+
+    auto *user = op->getUser();
+
+    // We should never see a debug_value use since this should be a temporary.
+    if (user->isDebugInstruction()) {
+      LLVM_DEBUG(llvm::dbgs() << "Found a debug_value?! This should be a "
+                                 "temporary which implies no debug info!\n");
+      return false;
+    }
+
+    // If we are visiting our own copy_addr, then just return true. We do not
+    // need to do any further work. If we successfully process this, then we
+    // shouldn't need anything.
+    if (user == caiToVisit) {
+      return true;
+    }
+
+    // Skip destroy_addr and dealloc_stack. We will remove them if we succeed in
+    // our mission. We require they are directly on the temporary allocation.
+    if (isa<DestroyAddrInst>(user) || isa<DeallocStackInst>(user)) {
+      if (op->get() != getAllocation())
+        return false;
+      return true;
+    }
+
+    // If our operand is an initialization, we bail. We never have multiple
+    // initializations for these sorts of temporaries. Our initial copy_addr is
+    // our single initialization.
+    if (noncopyable::memInstMustInitialize(op)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Found extra initializer! Bailing!: " << *user);
+      return false;
+    }
+
+    // We do not allow for reinitialization since we are working with
+    // specifically lets.
+    if (noncopyable::memInstMustReinitialize(op)) {
+      LLVM_DEBUG(llvm::dbgs() << "Found reinit: " << *user);
+      return false;
+    }
+
+    // If we see a consuming instruction, then this must be a final allocation
+    // in our chain of temporary allocations.
+    if (noncopyable::memInstMustConsume(op)) {
+      // If we already found a CAI, bail.
+      if (nextCAI)
+        return false;
+
+      // We do not append projections here since we handle the projections
+      // associated with the final user once we visit everything. This ensures
+      // that if we have multiple projections on the final allocation, we can
+      // tell these projections apart from projections from earlier allocations.
+      return state.setFinalUser(state.finalUse);
+    }
+
+    // If we see a load operation, stash it. This load operation will become a
+    // copy.
+    if (auto *li = dyn_cast<LoadInst>(user)) {
+      // If we already found a CAI, bail.
+      if (nextCAI)
+        return false;
+
+      // We do not handle takes for now.
+      if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take)
+        return false;
+
+      // We do not append projections here since we handle the projections
+      // associated with the final user once we visit everything. This ensures
+      // that if we have multiple projections on the final allocation, we can
+      // tell these projections apart from projections from earlier allocations.
+      return state.setFinalUser(op);
+    }
+
+    if (auto *cai = dyn_cast<CopyAddrInst>(user)) {
+      // If we already found a copy, bail. We always only visit one of these
+      // regardless if they are a final user or a temporary copy.
+      if (!setNextCAI(cai))
+        return false;
+
+      // If our address is not the src or we are taking the src, bail. We do not
+      // handle this.
+      if (cai->getSrc() != op->get() || cai->isTakeOfSrc() ||
+          cai->getSrc() == cai->getDest())
+        return false;
+
+      // If we are not initializing our dest, then we know that we do not have
+      // another iterative temporary. Treat this as a final user.
+      if (!cai->isInitializationOfDest()) {
+        return state.setFinalUser(op);
+      }
+
+      // Ok, we are initializing some other memory. Check if our dest is another
+      // temporary alloc_stack. If not, treat this as the final user.
+      auto *newTemp = dyn_cast<AllocStackInst>(cai->getDest());
+      if (!newTemp || newTemp->isLexical()) {
+        return state.setFinalUser(op);
+      }
+
+      // Ok, we have another temporary allocation copy, add the copy_addr to the
+      // worklist and add this allocation to the dead allocation list.
+      if (!state.appendProjections(cai->getSrc(), caiToVisit->getDest()))
+        return false;
+      state.instsToDelete.push_back(getAllocation());
+      return true;
+    }
+
+    // Otherwise, we have a potential liveness use. If the use writes to memory,
+    // bail, we do not support it.
+    if (user->mayWriteToMemory()) {
+      return false;
+    }
+
+    // Liveness use.
+    state.setFinalUser(op);
+
+    // We found an instruction that we did not understand.
+    return true;
+  }
+};
+
+} // namespace
+
+/// Returns false if we saw something we did not understand and the copy_addr
+/// should be inserted into UseState::copyInst to be conservative.
+bool siloptimizer::eliminateTemporaryAllocationsFromLet(
+    MarkMustCheckInst *markedInst) {
+  if (!isLetAllocation(markedInst))
+    return false;
+
+  StackList<CopyAddrInst *> copiesToVisit(markedInst->getFunction());
+  struct FindCopyAddrWalker final : public TransitiveAddressWalker {
+    StackList<CopyAddrInst *> &copiesToVisit;
+    FindCopyAddrWalker(StackList<CopyAddrInst *> &copiesToVisit)
+        : TransitiveAddressWalker(), copiesToVisit(copiesToVisit) {}
+
+    bool visitUse(Operand *op) override {
+      auto *cai = dyn_cast<CopyAddrInst>(op->getUser());
+      // We want copy_addr that are not a take of src and are an init of their
+      // dest.
+      if (!cai || cai->isTakeOfSrc() || !cai->isInitializationOfDest())
+        return true;
+      copiesToVisit.push_back(cai);
+      return true;
+    };
+  };
+  FindCopyAddrWalker walker(copiesToVisit);
+  std::move(walker).walk(markedInst);
+
+  bool madeChange = false;
+
+  while (!copiesToVisit.empty()) {
+    auto *initialCAI = copiesToVisit.pop_back_val();
+    SimpleTemporaryAllocStackElimState state(markedInst);
+    auto *asi = dyn_cast<AllocStackInst>(initialCAI->getDest());
+    if (!asi || asi->isLexical())
+      continue;
+
+    if ( // If we have that our dest/src are the same, just bail. We shouldn't
+         // see this, but lets just be careful.
+        initialCAI->getSrc() == initialCAI->getDest())
+      continue;
+
+    // For now, just handle if we have an init/no take. We should add support
+    // for a take in the future.
+    if (!initialCAI->isInitializationOfDest() || initialCAI->isTakeOfSrc())
+      continue;
+
+    AllocStackInst *finalAllocation = nullptr;
+    CopyAddrInst *nextCAI = initialCAI;
+    unsigned numLastProjections = 0;
+    unsigned numProjectionsPrevIteration = 0;
+    do {
+      auto *cai = nextCAI;
+      nextCAI = nullptr;
+      SimpleTemporaryAllocStackElimVisitor visitor(state, cai, nextCAI);
+
+      if (AddressUseKind::Unknown == std::move(visitor).walk(cai->getDest()))
+        return false;
+
+      // If we did not find a nextCAI, do not have a final use, and we already
+      // saw at least one allocation, make cai our last user. We treat that last
+      // allocation as our true last allocation, so we break.
+      //
+      // DISCUSSION: This occurs if we have a temporary copy that ends in a
+      // copyable address only type.
+      if (!nextCAI && !state.finalUse && finalAllocation) {
+        state.finalUse = &cai->getAllOperands()[CopyLikeInstruction::Src];
+        state.projectionList.pop_back_n(state.projectionList.size() -
+                                        numProjectionsPrevIteration);
+        break;
+      }
+
+      finalAllocation = cast<AllocStackInst>(cai->getDest());
+      numProjectionsPrevIteration = numLastProjections;
+      numLastProjections = state.projectionList.size();
+    } while (nextCAI);
+
+    assert(finalAllocation);
+
+    // If we did not actually find a final use, just bail. We can't rewrite.
+    auto *finalUse = state.finalUse;
+    if (!finalUse)
+      continue;
+
+    // Then check that our final use and initialCAI are in the same block and
+    // that all instructions in between them with side-effects are instructions
+    // that we visited. This is a sanity check.
+    if (finalUse->getParentBlock() != initialCAI->getParent() ||
+        llvm::any_of(llvm::make_range(initialCAI->getIterator(),
+                                      finalUse->getUser()->getIterator()),
+                     [&](SILInstruction &inst) {
+                       return !state.visitedInsts.contains(&inst) &&
+                              inst.mayHaveSideEffects();
+                     }))
+      continue;
+
+    // Now that we have succeeded in our analysis, we perform our
+    // transformation. First if we do not have a finalUse, just bail.
+
+    // Otherwise, begin rewriting. First see if we our final use is directly on
+    // the final allocation or if it has intervening projections. If it has
+    // intervening projections, we need to rewrite the final projection.
+    SingleValueInstruction *finalProjection = nullptr;
+    if (!walkUseToDefsStructTupleProjections(
+            finalUse->get(), finalAllocation,
+            [&](SingleValueInstruction *proj) { finalProjection = proj; }))
+      continue;
+
+    // Now that we have looked through all potential projections on our final
+    // use, now walk and fix up the projections.
+    auto &projList = state.projectionList;
+
+    madeChange = true;
+
+    // First set our initial projection to initialCAI.
+    if (!projList.empty()) {
+      (*projList.begin())->setOperand(0, initialCAI->getSrc());
+    } else {
+      if (finalProjection) {
+        finalProjection->setOperand(0, initialCAI->getSrc());
+      } else {
+        finalUse->set(initialCAI->getSrc());
+      }
+    }
+
+    for (auto ii = projList.begin(), ie = projList.end(); ii != ie;) {
+      auto *proj = *ii;
+      ++ii;
+
+      // If next ii is ie, then make finalProjection/final use, use this
+      // value.
+      if (ii == ie) {
+        if (finalProjection) {
+          finalProjection->setOperand(0, proj);
+        } else {
+          finalUse->set(proj);
+        }
+        break;
+      }
+
+      // Otherwise, see if the next projection has this projection as its
+      // operand. If so, just continue, we do not need to update
+      // anything.
+      if ((*ii)->getOperand(0) == SILValue(proj))
+        continue;
+
+      // Otherwise, we jumped to another allocation, set ii's operand to proj.
+      (*ii)->setOperand(0, proj);
+    }
+
+    // Now go through all of the instructions to delete and delete them. They
+    // should consist only of alloc_stack, destroy_addr, and dealloc_stack.
+    InstructionDeleter deleter;
+    while (!state.instsToDelete.empty())
+      deleter.forceDeleteWithUsers(state.instsToDelete.pop_back_val());
+    deleter.forceDeleteWithUsers(finalAllocation);
+  }
+
+  return madeChange;
+}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.h
@@ -16,6 +16,8 @@
 namespace swift {
 
 class SILFunction;
+class MarkMustCheckInst;
+class Operand;
 
 namespace siloptimizer {
 
@@ -27,6 +29,16 @@ bool cleanupNonCopyableCopiesAfterEmittingDiagnostic(SILFunction *fn);
 /// diagnostic was emitted, use \p diagnosticEmitter.getDiagnosticCount().
 void emitCheckerMissedCopyOfNonCopyableTypeErrors(
     SILFunction *fn, DiagnosticEmitter &diagnosticEmitter);
+
+bool eliminateTemporaryAllocationsFromLet(MarkMustCheckInst *markedInst);
+
+namespace noncopyable {
+
+bool memInstMustConsume(Operand *memOper);
+bool memInstMustReinitialize(Operand *memOper);
+bool memInstMustInitialize(Operand *memOper);
+
+} // namespace noncopyable
 
 } // namespace siloptimizer
 

--- a/test/Interpreter/moveonly_address_maximize.swift
+++ b/test/Interpreter/moveonly_address_maximize.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution %s
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyPartialConsumption -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
 
 // This test validates that we properly emit errors if we partially invalidate
 // through a type with a deinit.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
 // TODO: Add FileCheck
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_maximize.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_maximize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-sil-verify-all %s | %FileCheck %s
 sil_stage raw
 
 import Builtin

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -move-only-address-checker-disable-lifetime-extension=true | %FileCheck %s
+// RUN: %target-sil-opt -module-name moveonly_addresschecker -enable-experimental-feature MoveOnlyPartialConsumption -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -move-only-address-checker-disable-lifetime-extension=true | %FileCheck %s
 
 @_moveOnly
 struct M {

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 class CopyableKlass {}
 protocol P {}

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 class CopyableKlass {}
 

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_partial_consumption.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption.swift
@@ -1,0 +1,287 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+
+// This test makes sure when -enable-experimental-feature
+// MoveOnlyPartialConsumption is disabled, we emit errors whenever we perform
+// partial consumption.
+
+public class Klass {}
+
+public struct Empty : ~Copyable {}
+public struct SingleFieldLoadable : ~Copyable {
+    var e = Empty()
+    var k = Klass()
+}
+public enum LoadableEnum : ~Copyable {
+    case first(Empty)
+    case second(Klass)
+}
+public struct LoadableType : ~Copyable {
+    var e = Empty()
+    var l = SingleFieldLoadable()
+    var k = Klass()
+    var lEnum: LoadableEnum = .first(Empty())
+}
+
+public protocol P {}
+
+public struct SingleFieldAddressOnly2 : ~Copyable {
+    var e = Empty()
+    var k: P? = nil
+}
+
+public struct SingleFieldAddressOnly : ~Copyable {
+    var e = Empty()
+    var k: P? = nil
+    var e2 = SingleFieldAddressOnly2()
+}
+public enum AddressOnlyEnum : ~Copyable {
+    case first(Empty)
+    case second(P?)
+}
+public struct AddressOnlyType : ~Copyable {
+    var e = Empty()
+    var l = SingleFieldAddressOnly()
+    var k: P? = nil
+    var lEnum: AddressOnlyEnum = .first(Empty())
+}
+
+func consumeVal(_ x: consuming LoadableType) {}
+func consumeVal(_ x: consuming LoadableEnum) {}
+func consumeVal(_ x: consuming Empty) {}
+func consumeVal(_ x: consuming AddressOnlyType) {}
+func consumeVal(_ x: consuming SingleFieldAddressOnly) {}
+func consumeVal(_ x: consuming P) {}
+func mutateVal(_ x: inout Empty) {}
+func mutateVal(_ x: inout LoadableType) {}
+func mutateVal(_ x: inout AddressOnlyType) {}
+func mutateVal(_ x: inout SingleFieldAddressOnly) {}
+func mutateVal(_ x: inout SingleFieldAddressOnly2) {}
+func mutateVal(_ x: inout P) {}
+func borrowVal(_ x: borrowing Empty) {}
+func borrowVal(_ x: borrowing LoadableType) {}
+func borrowVal(_ x: borrowing AddressOnlyType) {}
+func borrowVal(_ x: borrowing P) {}
+
+//////////////////////////
+// MARK: Loadable Tests //
+//////////////////////////
+
+func loadableTestLet() {
+    let x = LoadableType()
+    consumeVal(x)
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.e) // expected-error {{cannot partially consume 'x'}}
+    borrowVal(x.e)
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.l.e) // expected-error {{cannot partially consume 'x'}}
+    borrowVal(x.e)
+    let _ = x.l.k
+
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func loadableTestLet2() {
+    let x = LoadableType() // expected-error {{'x' used after consume}}
+    consumeVal(x) // expected-note {{consumed here}}
+    borrowVal(x) // expected-note {{used here}}
+}
+
+func loadableTestVar() {
+    var x = LoadableType()
+    x = LoadableType()
+    consumeVal(x)
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.e) // expected-error {{cannot partially consume 'x'}}
+    borrowVal(x.e)
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.l.e) // expected-error {{cannot partially consume 'x'}}
+    borrowVal(x.l.e)
+    let _ = x.l.k
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+    consumeVal(x.lEnum) // expected-error {{cannot partially consume 'x'}}
+}
+
+func loadableTestVar2() {
+    var x = LoadableType()
+    x = LoadableType()
+    mutateVal(&x)
+    mutateVal(&x.e)
+    x.e = Empty()
+    x = LoadableType()
+    consumeVal(x)
+}
+
+// We do not emit an error here since we emit an early error for x.e.
+func loadableTestArg(_ x: borrowing LoadableType) {
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    let _ = x.e // expected-note {{consumed here}}
+    let _ = x.k
+    let _ = x.l.e
+    let _ = x.l.k
+    switch x.lEnum {
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func loadableTestInOutArg(_ x: inout LoadableType) {
+    consumeVal(x)
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.e) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    let _ = x.l.k
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func loadableTestInOutArg(_ x: consuming LoadableType) {
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    let _ = x.l.k
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+//////////////////////////////
+// MARK: Address Only Tests //
+//////////////////////////////
+
+func addressOnlyTestLet() {
+    let x = AddressOnlyType()
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.e) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.l.e) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.l.k
+
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func addressOnlyTestVar() {
+    var x = AddressOnlyType()
+    x = AddressOnlyType()
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    let _ = x.l.k
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func addressOnlyTestVar2() {
+    var x = AddressOnlyType()
+    x = AddressOnlyType()
+    x.e = Empty()
+    x = AddressOnlyType()
+    mutateVal(&x)
+    mutateVal(&x.e)
+}
+
+// We do not emit an error here since we emit an early error for x.e.
+func addressOnlyTestArg(_ x: borrowing AddressOnlyType) {
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-3 {{'x' is borrowed and cannot be consumed}}
+    let _ = x.k
+    let _ = x.l.e // expected-note {{consumed here}}
+    let _ = x.l.k // expected-note {{consumed here}}
+    switch x.lEnum { // expected-note {{consumed here}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func addressOnlyTestInOutArg(_ x: inout AddressOnlyType) {
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    x.e = Empty()
+    consumeVal(x.e) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.k
+    x.k = nil
+    x.l = SingleFieldAddressOnly()
+    consumeVal(x.l) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.l.e) // expected-error {{cannot partially consume 'x'}}
+    x.l.e = Empty()
+    let _ = x.l.k
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func addressOnlyTestInOutArg2(_ x: inout AddressOnlyType) {
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    x.e = Empty()
+    mutateVal(&x.e)
+    let _ = x.k
+    x.k = nil
+    x.l = SingleFieldAddressOnly()
+    mutateVal(&x.l)
+    mutateVal(&x.l.e)
+    mutateVal(&x.l.e2)
+    consumeVal(x.l) // expected-error {{cannot partially consume 'x'}}
+}
+
+func addressOnlyTestConsumingArg(_ x: consuming AddressOnlyType) {
+    let _ = x.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.e) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.k
+    let _ = x.l.e // expected-error {{cannot partially consume 'x'}}
+    consumeVal(x.l.e) // expected-error {{cannot partially consume 'x'}}
+    let _ = x.l.k
+    consumeVal(x.l.k!)
+    switch x.lEnum { // expected-error {{cannot partially consume 'x'}}
+    case .first:
+        break
+    case .second:
+        break
+    }
+}
+
+func addressOnlyTestConsumingArg2(_ x: consuming AddressOnlyType) {
+    x.e = Empty()
+    let _ = x
+    x = AddressOnlyType()
+    mutateVal(&x)
+    mutateVal(&x.e)
+    mutateVal(&x.l.e)
+    mutateVal(&x.l.e2)
+}

--- a/test/SILOptimizer/moveonly_temp_allocation_elim.sil
+++ b/test/SILOptimizer/moveonly_temp_allocation_elim.sil
@@ -1,0 +1,190 @@
+// RUN: %target-sil-opt -sil-verify-all -sil-move-only-temp-allocation-from-let-tester %s | %FileCheck %s
+
+sil_stage raw
+
+public class Klass {}
+
+public struct Empty : ~Copyable {}
+public struct SingleFieldLoadable : ~Copyable {
+    var e: Empty
+    var k: Klass
+}
+public enum LoadableEnum : ~Copyable {
+    case first(Empty)
+    case second(Klass)
+}
+public struct LoadableType : ~Copyable {
+    var e: Empty
+    var l: SingleFieldLoadable
+    var k: Klass
+    var lEnum: LoadableEnum
+}
+
+public protocol P {}
+
+public struct SingleFieldAddressOnly : ~Copyable {
+    var e: Empty
+    var k: P
+    var en: AddressOnlyEnum
+}
+public struct SingleFieldAddressOnly2 : ~Copyable {
+    var e: Empty
+    var k: P
+    var en: AddressOnlyEnum
+    var s2: SingleFieldAddressOnly
+}
+public enum AddressOnlyEnum : ~Copyable {
+    case first(Empty)
+    case second(P)
+}
+public struct AddressOnlyType : ~Copyable {
+    var e: Empty
+    var l: SingleFieldAddressOnly2
+    var l2: SingleFieldAddressOnly
+    var k: P
+    var lEnum: AddressOnlyEnum
+}
+
+sil @get_addressonly_type : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+sil @sideeffect : $@convention(thin) () -> ()
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK-LABEL: sil hidden [ossa] @accessGrandLoadableField : $@convention(thin) () -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack
+// CHECK: [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ALLOC]]
+// CHECK: apply {{%.*}}([[MARK]], {{%.*}})
+// CHECK: [[GEP1:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[GEP1]]
+// CHECK: [[GEP3:%.*]] = struct_element_addr [[GEP2]]
+// CHECK: [[LOAD:%.*]] = load [copy] [[GEP3]]
+// CHECK: move_value [[LOAD]]
+// CHECK: } // end sil function 'accessGrandLoadableField'
+sil hidden [ossa] @accessGrandLoadableField : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $AddressOnlyType, let, name "x"
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*AddressOnlyType
+  %2 = metatype $@thin AddressOnlyType.Type
+  %3 = function_ref @get_addressonly_type : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %4 = apply %3(%1, %2) : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %5 = struct_element_addr %1 : $*AddressOnlyType, #AddressOnlyType.l
+  %6 = alloc_stack $SingleFieldAddressOnly2
+  copy_addr %5 to [init] %6 : $*SingleFieldAddressOnly2
+  %8 = struct_element_addr %6 : $*SingleFieldAddressOnly2, #SingleFieldAddressOnly2.s2
+  %9 = alloc_stack $SingleFieldAddressOnly
+  copy_addr %8 to [init] %9 : $*SingleFieldAddressOnly
+  destroy_addr %6 : $*SingleFieldAddressOnly2
+  %12 = struct_element_addr %9 : $*SingleFieldAddressOnly, #SingleFieldAddressOnly.e
+  %13 = load [copy] %12 : $*Empty
+  destroy_addr %9 : $*SingleFieldAddressOnly
+  %15 = move_value %13 : $Empty
+  destroy_value %15 : $Empty
+  dealloc_stack %9 : $*SingleFieldAddressOnly
+  dealloc_stack %6 : $*SingleFieldAddressOnly2
+  destroy_addr %1 : $*AddressOnlyType
+  dealloc_stack %0 : $*AddressOnlyType
+  %21 = tuple ()
+  return %21 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @accessChildLoadableField : $@convention(thin) () -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack
+// CHECK: [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ALLOC]]
+// CHECK: apply {{%.*}}([[MARK]], {{%.*}})
+// CHECK: [[GEP1:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[GEP1]]
+// CHECK: [[LOAD:%.*]] = load [copy] [[GEP2]]
+// CHECK: move_value [[LOAD]]
+// CHECK: } // end sil function 'accessChildLoadableField'
+sil hidden [ossa] @accessChildLoadableField : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $AddressOnlyType, let, name "x"
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*AddressOnlyType
+  %2 = metatype $@thin AddressOnlyType.Type
+  %3 = function_ref @get_addressonly_type : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %4 = apply %3(%1, %2) : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %5 = struct_element_addr %1 : $*AddressOnlyType, #AddressOnlyType.l
+  %6 = alloc_stack $SingleFieldAddressOnly2
+  copy_addr %5 to [init] %6 : $*SingleFieldAddressOnly2
+  %8 = struct_element_addr %6 : $*SingleFieldAddressOnly2, #SingleFieldAddressOnly2.e
+  %9 = load [copy] %8 : $*Empty
+  destroy_addr %6 : $*SingleFieldAddressOnly2
+  %11 = move_value %9 : $Empty
+  destroy_value %11 : $Empty
+  dealloc_stack %6 : $*SingleFieldAddressOnly2
+  destroy_addr %1 : $*AddressOnlyType
+  dealloc_stack %0 : $*AddressOnlyType
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @accessChildLoadableFieldWithBlockingSideEffect : $@convention(thin) () -> () {
+// CHECK: [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ALLOC]]
+// CHECK: apply {{%.*}}([[MARK]], {{%.*}})
+// CHECK: [[GEP1:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $SingleFieldAddressOnly2
+// CHECK: copy_addr [[GEP1]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}() :
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[TEMP]]
+// CHECK: [[LOAD:%.*]] = load [copy] [[GEP2]]
+// CHECK: move_value [[LOAD]]
+// CHECK: } // end sil function 'accessChildLoadableFieldWithBlockingSideEffect'
+sil hidden [ossa] @accessChildLoadableFieldWithBlockingSideEffect : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $AddressOnlyType, let, name "x"
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*AddressOnlyType
+  %2 = metatype $@thin AddressOnlyType.Type
+  %3 = function_ref @get_addressonly_type : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %4 = apply %3(%1, %2) : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %5 = struct_element_addr %1 : $*AddressOnlyType, #AddressOnlyType.l
+  %6 = alloc_stack $SingleFieldAddressOnly2
+  // This is our original copy_addr. If there is a side effect in between it
+  // and %9 (our final use), then we conservatively bail.
+  copy_addr %5 to [init] %6 : $*SingleFieldAddressOnly2
+  %f = function_ref @sideeffect : $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) () -> ()
+  %8 = struct_element_addr %6 : $*SingleFieldAddressOnly2, #SingleFieldAddressOnly2.e
+  %9 = load [copy] %8 : $*Empty
+  destroy_addr %6 : $*SingleFieldAddressOnly2
+  %11 = move_value %9 : $Empty
+  destroy_value %11 : $Empty
+  dealloc_stack %6 : $*SingleFieldAddressOnly2
+  destroy_addr %1 : $*AddressOnlyType
+  dealloc_stack %0 : $*AddressOnlyType
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @copyableAddressOnlyTest : $@convention(thin) () -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack
+// CHECK: [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ALLOC]]
+// CHECK: apply {{%.*}}([[MARK]], {{%.*}})
+// CHECK: [[GEP1:%.*]] = struct_element_addr [[MARK]]
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[GEP1]]
+// CHECK: [[RESULT:%.*]] = alloc_stack $any P
+// CHECK: copy_addr [[GEP2]] to [init] [[RESULT]]
+// CHECK: } // end sil function 'copyableAddressOnlyTest'
+sil hidden [ossa] @copyableAddressOnlyTest : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $AddressOnlyType, let, name "x"
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*AddressOnlyType
+  %2 = metatype $@thin AddressOnlyType.Type
+  %3 = function_ref @get_addressonly_type : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %4 = apply %3(%1, %2) : $@convention(method) (@thin AddressOnlyType.Type) -> @out AddressOnlyType
+  %5 = struct_element_addr %1 : $*AddressOnlyType, #AddressOnlyType.l
+  %6 = alloc_stack $SingleFieldAddressOnly2
+  copy_addr %5 to [init] %6 : $*SingleFieldAddressOnly2
+  %8 = struct_element_addr %6 : $*SingleFieldAddressOnly2, #SingleFieldAddressOnly2.k
+  %9 = alloc_stack $any P
+  copy_addr %8 to [init] %9 : $*any P
+  destroy_addr %6 : $*SingleFieldAddressOnly2
+  destroy_addr %9 : $*any P
+  dealloc_stack %9 : $*any P
+  dealloc_stack %6 : $*SingleFieldAddressOnly2
+  destroy_addr %1 : $*AddressOnlyType
+  dealloc_stack %0 : $*AddressOnlyType
+  %17 = tuple ()
+  return %17 : $()
+}

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //


### PR DESCRIPTION
• Description: [move-only] Emit an error if we /ever/ partially consume a noncopyable type
• Risk: This is low risk since it only affects noncopyable types. It also is important for us to land since otherwise, we will be shipping part of noncopyable types that did not go through evolution.
• Original PR: https://github.com/apple/swift/pull/66952
• Reviewed By: @jckarter
• Testing: Added regression tests
• Resolves: rdar://111353459