### PR TITLE
[5.9][move-only] When storing a trivial field of a borrowed parameter, treat the store as a trivial use.

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+
+struct Test: ~Copyable {
+  public let baseAddress: UnsafeRawPointer
+  public let count: Int
+}
+
+extension Test {
+
+  public static func ==(lhs: borrowing Test, rhs: borrowing Test) -> Bool {
+    let count = lhs.count
+    guard count == rhs.count else { return false }
+
+    if count == 0 { return true } else if lhs.baseAddress == rhs.baseAddress { return true }
+    if count == 1 || lhs.baseAddress == rhs.baseAddress { return true }
+
+    return lhs.baseAddress.load(as: UInt8.self) == rhs.baseAddress.load(as: UInt8.self)
+  }
+}


### PR DESCRIPTION
• Description: When storing a trivial field of a borrowed parameter, treat the store as a trivial use.
• Risk: This is low risk since it only affects noncopyable types. 
• Original PR: https://github.com/apple/swift/pull/66969
• Reviewed By: @jckarter
• Testing: Added regression tests
• Resolves: rdar://111354827

(cherry picked from commit 6e850d7bce2062dc9daa3997540b8872ce9d5c23)
