### PR TITLE
[ConstraintSystem] Fix a couple of issues related to generic specialization

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -454,6 +454,9 @@ enum class FixKind : uint8_t {
   /// Ignore the fact that member couldn't be referenced within init accessor
   /// because its name doesn't appear in 'initializes' or 'accesses' attributes.
   AllowInvalidMemberReferenceInInitAccessor,
+
+  /// Ignore an attempt to specialize non-generic type.
+  AllowConcreteTypeSpecialization,
 };
 
 class ConstraintFix {
@@ -3644,6 +3647,33 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInvalidMemberReferenceInInitAccessor;
+  }
+};
+
+class AllowConcreteTypeSpecialization final : public ConstraintFix {
+  Type ConcreteType;
+
+  AllowConcreteTypeSpecialization(ConstraintSystem &cs, Type concreteTy,
+                                  ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowConcreteTypeSpecialization, locator),
+        ConcreteType(concreteTy) {}
+
+public:
+  std::string getName() const override {
+    return "allow concrete type specialization";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static AllowConcreteTypeSpecialization *
+  create(ConstraintSystem &cs, Type concreteTy, ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowConcreteTypeSpecialization;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9162,3 +9162,8 @@ bool InvalidMemberReferenceWithinInitAccessor::diagnoseAsError() {
   emitDiagnostic(diag::init_accessor_invalid_member_ref, MemberName);
   return true;
 }
+
+bool ConcreteTypeSpecialization::diagnoseAsError() {
+  emitDiagnostic(diag::not_a_generic_type, ConcreteType);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9167,3 +9167,9 @@ bool ConcreteTypeSpecialization::diagnoseAsError() {
   emitDiagnostic(diag::not_a_generic_type, ConcreteType);
   return true;
 }
+
+bool InvalidTypeSpecializationArity::diagnoseAsError() {
+  emitDiagnostic(diag::type_parameter_count_mismatch, D->getBaseIdentifier(),
+                 NumParams, NumArgs, NumArgs < NumParams, HasParameterPack);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3069,6 +3069,30 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose attempts to specialize with invalid number of generic arguments:
+///
+/// \code
+/// struct Test<T, U> {}
+///
+/// _ = Test<Int>() // error
+/// \endcode
+class InvalidTypeSpecializationArity final : public FailureDiagnostic {
+  ValueDecl *D;
+  unsigned NumParams;
+  unsigned NumArgs;
+  bool HasParameterPack;
+
+public:
+  InvalidTypeSpecializationArity(const Solution &solution, ValueDecl *decl,
+                                 unsigned numParams, unsigned numArgs,
+                                 bool hasParameterPack,
+                                 ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), D(decl), NumParams(numParams),
+        NumArgs(numArgs), HasParameterPack(hasParameterPack) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3049,6 +3049,26 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose attempts to specialize a concrete type or its alias:
+///
+/// \code
+/// struct Test {}
+/// typealias X = Test
+///
+/// _ = X<Int>() // error
+/// \endcode
+class ConcreteTypeSpecialization final : public FailureDiagnostic {
+  Type ConcreteType;
+
+public:
+  ConcreteTypeSpecialization(const Solution &solution, Type concreteTy,
+                             ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        ConcreteType(resolveType(concreteTy)) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2842,3 +2842,19 @@ AllowConcreteTypeSpecialization::create(ConstraintSystem &cs, Type concreteTy,
   return new (cs.getAllocator())
       AllowConcreteTypeSpecialization(cs, concreteTy, locator);
 }
+
+bool IgnoreGenericSpecializationArityMismatch::diagnose(
+    const Solution &solution, bool asNote) const {
+  return false;
+}
+
+IgnoreGenericSpecializationArityMismatch *
+IgnoreGenericSpecializationArityMismatch::create(ConstraintSystem &cs,
+                                                 ValueDecl *decl,
+                                                 unsigned numParams,
+                                                 unsigned numArgs,
+                                                 bool hasParameterPack,
+                                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator()) IgnoreGenericSpecializationArityMismatch(
+      cs, decl, numParams, numArgs, hasParameterPack, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2829,3 +2829,15 @@ AllowInvalidMemberReferenceInInitAccessor::create(ConstraintSystem &cs,
   return new (cs.getAllocator())
       AllowInvalidMemberReferenceInInitAccessor(cs, memberName, locator);
 }
+
+bool AllowConcreteTypeSpecialization::diagnose(const Solution &solution,
+                                               bool asNote) const {
+  return false;
+}
+
+AllowConcreteTypeSpecialization *
+AllowConcreteTypeSpecialization::create(ConstraintSystem &cs, Type concreteTy,
+                                        ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowConcreteTypeSpecialization(cs, concreteTy, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2832,7 +2832,8 @@ AllowInvalidMemberReferenceInInitAccessor::create(ConstraintSystem &cs,
 
 bool AllowConcreteTypeSpecialization::diagnose(const Solution &solution,
                                                bool asNote) const {
-  return false;
+  ConcreteTypeSpecialization failure(solution, ConcreteType, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowConcreteTypeSpecialization *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2845,7 +2845,9 @@ AllowConcreteTypeSpecialization::create(ConstraintSystem &cs, Type concreteTy,
 
 bool IgnoreGenericSpecializationArityMismatch::diagnose(
     const Solution &solution, bool asNote) const {
-  return false;
+  InvalidTypeSpecializationArity failure(solution, D, NumParams, NumArgs,
+                                         HasParameterPack, getLocator());
+  return failure.diagnose(asNote);
 }
 
 IgnoreGenericSpecializationArityMismatch *

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13658,8 +13658,15 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
     }
   }
 
-  if (openedGenericParams.empty())
-    return SolutionKind::Error;
+  if (openedGenericParams.empty()) {
+    if (!shouldAttemptFixes())
+      return SolutionKind::Error;
+
+    return recordFix(AllowConcreteTypeSpecialization::create(
+               *this, type1, getConstraintLocator(locator)))
+               ? SolutionKind::Error
+               : SolutionKind::Solved;
+  }
 
   assert(openedGenericParams.size() == genericParams->size());
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -14776,7 +14776,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowGlobalActorMismatch:
   case FixKind::AllowAssociatedValueMismatch:
   case FixKind::GenericArgumentsMismatch:
-  case FixKind::AllowConcreteTypeSpecialization: {
+  case FixKind::AllowConcreteTypeSpecialization:
+  case FixKind::IgnoreGenericSpecializationArityMismatch: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
   case FixKind::IgnoreInvalidASTNode: {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13607,14 +13607,12 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
       return nullptr;
 
     auto genericParams = genericContext->getGenericParams();
-    if (!genericParams || genericParams->size() == 0) {
+    if (!genericParams) {
       // If declaration is a non-generic typealias, let's point
       // to the underlying generic declaration.
       if (auto *TA = dyn_cast<TypeAliasDecl>(decl)) {
-        if (TA->isGeneric())
-          return nullptr;
-        if (auto underlying = TA->getUnderlyingType()->getAnyNominal())
-          return getGenericParams(underlying);
+        if (auto *UGT = TA->getUnderlyingType()->getAs<AnyGenericType>())
+          return getGenericParams(UGT->getDecl());
       }
     }
 
@@ -13625,7 +13623,7 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
     return SolutionKind::Error;
 
   auto genericParams = getGenericParams(decl);
-  if (!genericParams || genericParams->size() == 0) {
+  if (!genericParams) {
     // FIXME: Record an error here that we're ignoring the parameters.
     return SolutionKind::Solved;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13657,6 +13657,10 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
       }
     }
   }
+
+  if (openedGenericParams.empty())
+    return SolutionKind::Error;
+
   assert(openedGenericParams.size() == genericParams->size());
 
   // Match the opened generic parameters to the specialized arguments.
@@ -14764,7 +14768,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::MacroMissingPound:
   case FixKind::AllowGlobalActorMismatch:
   case FixKind::AllowAssociatedValueMismatch:
-  case FixKind::GenericArgumentsMismatch: {
+  case FixKind::GenericArgumentsMismatch:
+  case FixKind::AllowConcreteTypeSpecialization: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
   case FixKind::IgnoreInvalidASTNode: {

--- a/test/Macros/macro_and_typealias.swift
+++ b/test/Macros/macro_and_typealias.swift
@@ -6,6 +6,7 @@
 
 @freestanding(expression) public macro Print<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
 @freestanding(expression) public macro OtherPrint<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
+@freestanding(expression) public macro ConcretePrint(_ value: Any) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
 
 public struct Printer<Value> {
   init(_: (Value) -> Void) {}
@@ -13,6 +14,7 @@ public struct Printer<Value> {
 
 typealias Print = Printer
 typealias OtherPrint<T> = Printer<T>
+typealias ConcretePrint = Printer<Any>
 
 struct Test {
   struct Object {
@@ -26,6 +28,11 @@ struct Test {
 
     let _ = OtherPrint<Object> { // Ok
       compute(root: $0, \.prop)
+    }
+
+    let _ = ConcretePrint<Object> { // expected-error {{cannot specialize non-generic type 'ConcretePrint' (aka 'Printer<Any>')}}
+      compute(root: $0, \.prop) // expected-error {{value of type 'Any' has no member 'prop'}}
+      // expected-note@-1 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
     }
   }
 

--- a/test/Macros/macro_and_typealias.swift
+++ b/test/Macros/macro_and_typealias.swift
@@ -7,14 +7,21 @@
 @freestanding(expression) public macro Print<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
 @freestanding(expression) public macro OtherPrint<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
 @freestanding(expression) public macro ConcretePrint(_ value: Any) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
+@freestanding(expression) public macro MultiPrint(_ value: Any) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
 
 public struct Printer<Value> {
   init(_: (Value) -> Void) {}
 }
 
+public struct MultiPrinter<T, U> {
+  // expected-note@-1 {{'T' declared as parameter to type 'MultiPrinter'}}
+  // expected-note@-2 {{'U' declared as parameter to type 'MultiPrinter'}}
+}
+
 typealias Print = Printer
 typealias OtherPrint<T> = Printer<T>
 typealias ConcretePrint = Printer<Any>
+typealias MultiPrint = MultiPrinter
 
 struct Test {
   struct Object {
@@ -26,6 +33,10 @@ struct Test {
       compute(root: $0, \.prop)
     }
 
+    let _ = Print<Object, Int> {
+      // expected-error@-1 {{generic type 'Print' specialized with too many type parameters (got 2, but expected 1)}}
+    }
+
     let _ = OtherPrint<Object> { // Ok
       compute(root: $0, \.prop)
     }
@@ -34,6 +45,11 @@ struct Test {
       compute(root: $0, \.prop) // expected-error {{value of type 'Any' has no member 'prop'}}
       // expected-note@-1 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
     }
+
+    let _ = MultiPrint<Int>()
+    // expected-error@-1 {{generic type 'MultiPrint' specialized with too few type parameters (got 1, but expected 2)}}
+    // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+    // expected-error@-3 {{generic parameter 'U' could not be inferred}}
   }
 
   func compute<R, V>(root: R, _: KeyPath<R, V>) {}

--- a/test/Macros/macro_and_typealias.swift
+++ b/test/Macros/macro_and_typealias.swift
@@ -1,0 +1,33 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/variadic_macros.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+
+@freestanding(expression) public macro Print<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
+@freestanding(expression) public macro OtherPrint<each Value>(_ value: repeat each Value) = #externalMacro(module: "MacroDefinition", type: "PrintMacro")
+
+public struct Printer<Value> {
+  init(_: (Value) -> Void) {}
+}
+
+typealias Print = Printer
+typealias OtherPrint<T> = Printer<T>
+
+struct Test {
+  struct Object {
+    var prop: Int
+  }
+
+  func test() {
+    let _ = Print<Object> { // Ok
+      compute(root: $0, \.prop)
+    }
+
+    let _ = OtherPrint<Object> { // Ok
+      compute(root: $0, \.prop)
+    }
+  }
+
+  func compute<R, V>(root: R, _: KeyPath<R, V>) {}
+}

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -96,8 +96,7 @@ macro genericDeclMacro<T: Numeric, U: Numeric>(_ x: T, _ y: U)
 // expected-note @-2 {{where 'U' = 'String'}}
 
 func testDiags(a: Int, b: Int) {
-  // FIXME: Bad diagnostic.
-  let s = #stringify<Int, Int>(a + b) // expected-error{{type of expression is ambiguous without a type annotation}}
+  let s = #stringify<Int, Int>(a + b) // expected-error{{generic type 'stringify' specialized with too many type parameters (got 2, but expected 1)}}
 
   _ = #stringify()
   // expected-error@-1{{missing argument for parameter #1 in macro expansion}}


### PR DESCRIPTION
- Teach specialization constraint to look through non-generic typealiases
- Detect and diagnose attempts to specialize non-generic types/aliases
- Detect and diagnose attempts to specialize types with invalid number of arguments

Resolves: rdar://111239949

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
