### PR TITLE
[SE-0400] All properties with init accessors become part of the memberwise init

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7180,7 +7180,7 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   // other stored properties.
   if (hasInitAccessor()) {
     if (auto *init = getAccessor(AccessorKind::Init))
-      return init->getAttrs().hasAttribute<InitializesAttr>();
+      return true;
   }
 
   // If this is a computed property, it's not memberwise initialized unless

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1300,10 +1300,6 @@ HasMemberwiseInitRequest::evaluate(Evaluator &evaluator,
       if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
         continue;
 
-      // If init accessors are not involved, we are done.
-      if (initializedViaAccessor.empty())
-        return true;
-
       // Check whether use of init accessors results in access to uninitialized
       // properties.
 

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -385,7 +385,7 @@ func test_memberwise_ordering() {
     var _c: Int
   }
 
-  let test3 = Test3(_a: 1, _b: 2, _c: 3)
+  let test3 = Test3(_a: 1, _b: 2, pair: (1, 2), _c: 3)
   print("test-memberwise-ordering-3: \(test3)")
 }
 

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -425,7 +425,7 @@ func test_memberwise_ordering() {
     var _c: Int
   }
 
-  _ = Test4(_a: 0, _b: 1, _c: 2) // Ok
+  _ = Test4(_a: 0, _b: 1, pair: (1, 2), _c: 2) // Ok
 
   struct Test5 {
     var _a: Int


### PR DESCRIPTION
Per the clarification during the review thread, all properties with init accessors (including those that do not initialize any underlying storage) are part of the memberwise initializer.
