### PR TITLE
[SE-0401] [5.9] Disable global actor inference from properties with property wrappers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5364,12 +5364,6 @@ ERROR(async_unavailable_decl,none,
       "%0 %1 is unavailable from asynchronous contexts%select{|; %2}2",
       (DescriptiveDeclKind, DeclBaseName, StringRef))
 
-WARNING(actor_isolation_inferred_from_property_wrapper,none,
-        "%0 is implicitly %1 because it uses %2. This implicit isolation "
-        "will no longer happen in Swift 6.",
-        (DeclName, ActorIsolation, StringRef))
-
-
 //------------------------------------------------------------------------------
 // MARK: String Processing
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5364,6 +5364,12 @@ ERROR(async_unavailable_decl,none,
       "%0 %1 is unavailable from asynchronous contexts%select{|; %2}2",
       (DescriptiveDeclKind, DeclBaseName, StringRef))
 
+WARNING(actor_isolation_inferred_from_property_wrapper,none,
+        "%0 is implicitly %1 because it uses %2. This implicit isolation "
+        "will no longer happen in Swift 6.",
+        (DeclName, ActorIsolation, StringRef))
+
+
 //------------------------------------------------------------------------------
 // MARK: String Processing
 //------------------------------------------------------------------------------

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -113,6 +113,7 @@ UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
 UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(ExistentialAny, 335, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
+UPCOMING_FEATURE(DisableActorInferenceFromPropertyWrapperUsage, 0, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3346,6 +3346,10 @@ static bool usesFeatureFreestandingExpressionMacros(Decl *decl) {
   return macro->getMacroRoles().contains(MacroRole::Expression);
 }
 
+static bool usesFeatureDisableActorInferenceFromPropertyWrapperUsage(Decl *decl) {
+  return false;
+}
+
 static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3622,8 +3622,16 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
 
   if (!nominal->getParentSourceFile())
     return None;
-  
-  Optional<ActorIsolation> foundIsolation;
+
+  ASTContext &ctx = nominal->getASTContext();
+  if (ctx.isSwiftVersionAtLeast(6)) {
+    // In Swift 6, we no longer infer isolation of a nominal type based
+    // on property wrappers used in its stored properties
+    return None;
+  }
+
+  Optional<std::pair<ActorIsolation, Type>> foundIsolationAndType;
+
   for (auto member : nominal->getMembers()) {
     auto var = dyn_cast<VarDecl>(member);
     if (!var || !var->isInstanceMember())
@@ -3648,19 +3656,36 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
 
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
-      if (!foundIsolation) {
-        foundIsolation = isolation;
-        continue;
+      if (!foundIsolationAndType) {
+        if (auto propertyWrapperType = var->getAttachedPropertyWrapperType(0)) {
+          foundIsolationAndType = { isolation, propertyWrapperType };
+          continue;
+        }
       }
 
-      if (*foundIsolation != isolation)
+      if (foundIsolationAndType->first != isolation)
         return None;
 
       break;
     }
   }
 
-  return foundIsolation;
+  if (foundIsolationAndType) {
+    // We are inferring isolation for the type because
+    // it contains an actor-isolated property wrapper.
+    // Warn that this inferrence will be going away in
+    // Swift 6
+    const ActorIsolation isolation = foundIsolationAndType->first;
+    const Type type = foundIsolationAndType->second;
+
+    nominal->diagnose(diag::actor_isolation_inferred_from_property_wrapper,
+                      nominal->getName(), isolation, "'@"+type->getString()+"'")
+      .fixItInsert(nominal->getAttributeInsertionLoc(false), "@" + isolation.getGlobalActor().getString());
+    return isolation;
+  }
+  else {
+    return None;
+  }
 }
 
 namespace {
@@ -4236,8 +4261,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
         if (auto inferred = inferredIsolation(*conformanceIsolation))
           return inferred;
 
-      // If the declaration is a nominal type and any property wrappers on
-      // its stored properties require isolation, use that.
+      // Before Swift 6: If the declaration is a nominal type and any property
+      // wrappers on its stored properties require isolation, use that.
       if (auto wrapperIsolation = getIsolationFromWrappers(nominal)) {
         if (auto inferred = inferredIsolation(*wrapperIsolation))
           return inferred;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3624,7 +3624,7 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
     return None;
 
   ASTContext &ctx = nominal->getASTContext();
-  if (ctx.isSwiftVersionAtLeast(6)) {
+  if (ctx.LangOpts.hasFeature(Feature::DisableActorInferenceFromPropertyWrapperUsage)) {
     // In Swift 6, we no longer infer isolation of a nominal type
     // based on the property wrappers used in its stored properties
     return None;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3621,7 +3621,7 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
     return None;
 
   if (!nominal->getParentSourceFile())
-    return None;
+    return llvm::None;
 
   ASTContext &ctx = nominal->getASTContext();
   if (ctx.LangOpts.hasFeature(Feature::DisableActorInferenceFromPropertyWrapperUsage)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3627,7 +3627,7 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
   if (ctx.LangOpts.hasFeature(Feature::DisableActorInferenceFromPropertyWrapperUsage)) {
     // In Swift 6, we no longer infer isolation of a nominal type
     // based on the property wrappers used in its stored properties
-    return None;
+    return llvm::None;
   }
 
   Optional<ActorIsolation> foundIsolation;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3625,13 +3625,12 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
 
   ASTContext &ctx = nominal->getASTContext();
   if (ctx.isSwiftVersionAtLeast(6)) {
-    // In Swift 6, we no longer infer isolation of a nominal type based
-    // on property wrappers used in its stored properties
+    // In Swift 6, we no longer infer isolation of a nominal type
+    // based on the property wrappers used in its stored properties
     return None;
   }
 
-  Optional<std::pair<ActorIsolation, Type>> foundIsolationAndType;
-
+  Optional<ActorIsolation> foundIsolation;
   for (auto member : nominal->getMembers()) {
     auto var = dyn_cast<VarDecl>(member);
     if (!var || !var->isInstanceMember())
@@ -3656,36 +3655,19 @@ static Optional<ActorIsolation> getIsolationFromWrappers(
 
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
-      if (!foundIsolationAndType) {
-        if (auto propertyWrapperType = var->getAttachedPropertyWrapperType(0)) {
-          foundIsolationAndType = { isolation, propertyWrapperType };
-          continue;
-        }
+      if (!foundIsolation) {
+        foundIsolation = isolation;
+        continue;
       }
 
-      if (foundIsolationAndType->first != isolation)
+      if (*foundIsolation != isolation)
         return None;
 
       break;
     }
   }
 
-  if (foundIsolationAndType) {
-    // We are inferring isolation for the type because
-    // it contains an actor-isolated property wrapper.
-    // Warn that this inferrence will be going away in
-    // Swift 6
-    const ActorIsolation isolation = foundIsolationAndType->first;
-    const Type type = foundIsolationAndType->second;
-
-    nominal->diagnose(diag::actor_isolation_inferred_from_property_wrapper,
-                      nominal->getName(), isolation, "'@"+type->getString()+"'")
-      .fixItInsert(nominal->getAttributeInsertionLoc(false), "@" + isolation.getGlobalActor().getString());
-    return isolation;
-  }
-  else {
-    return None;
-  }
+  return foundIsolation;
 }
 
 namespace {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -78,7 +78,7 @@ struct HasMainActorWrappedProp {
 
   var plainStorage: Int
 
-  var computedProp: Int { 0 } // expected-note {{property declared here}}
+  var computedProp: Int { 0 }
 
   nonisolated func testErrors() {
     _ = thing // expected-error {{main actor-isolated property 'thing' can not be referenced from a non-isolated context}}
@@ -89,7 +89,7 @@ struct HasMainActorWrappedProp {
 
     _ = plainStorage
 
-    _ = computedProp // expected-error {{main actor-isolated property 'computedProp' can not be referenced from a non-isolated context}}
+    _ = computedProp
   }
 }
 


### PR DESCRIPTION
* **Explanation**: Implements [SE-0401](https://github.com/apple/swift-evolution/blob/main/proposals/0401-remove-property-wrapper-isolation.md), which disables global actor inference from properties with property wrappers in Swift 6 (and via an upcoming feature flag).
* **Scope**: Narrow. Disables a form of global actor inference in one place, based on an upcoming feature flag.
* **Risk**: Low. Only enabled with an upcoming feature flag.
* **Reviewed by**: @bjhomer 
* **Original pull request**: https://github.com/apple/swift/pull/63884
