### PR TITLE
[Test] Commented two tests and added one.

### DIFF
--- a/test/Interpreter/moveonly_reinit_noncontiguous.swift
+++ b/test/Interpreter/moveonly_reinit_noncontiguous.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enforce-exclusivity=none -Xllvm -move-only-address-checker-disable-lifetime-extension=true) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enforce-exclusivity=none -Xllvm -move-only-address-checker-disable-lifetime-extension=true) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+struct S: ~Copyable {
+  let s: String
+  init(_ s: String) { self.s = s }
+  deinit { print("deiniting \(s)") }
+}
+
+struct M4 : ~Copyable {
+  var s1: S
+  var s2: S
+  var s3: S
+  var s4: S
+  init(_ s: String) {
+    self.s1 = S("\(s).s1")
+    self.s2 = S("\(s).s2")
+    self.s3 = S("\(s).s3")
+    self.s4 = S("\(s).s4")
+  }
+}
+
+func rewriteTwo(_ one: inout S, _ two: inout S) {
+  print("entering \(#function)")
+  one = S("new1")
+  two = S("new2")
+  print("exiting \(#function)")
+}
+
+func doit() {
+  var m = M4("1")
+  // CHECK: deiniting 1.s1
+  // CHECK: deiniting 1.s2
+  // CHECK: deiniting new1
+  // CHECK: deiniting new2
+  rewriteTwo(&m.s1, &m.s2)
+}
+
+doit()

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -66,11 +66,15 @@ bb0:
   return %22 : $()
 }
 
+// Two non-contiguous fields (#M4.s2, #M4.s4) are reinitialized by @replace_2.
+//
+// Verify that #M4.s4 is not destroyed before being passed to replace_2.
 // CHECK-LABEL: sil [ossa] @rdar111356251 : $@convention(thin) () -> () {
 // CHECK:         [[STACK:%[^,]+]] = alloc_stack $M4
 // CHECK:         [[GET_M4:%[^,]+]] = function_ref @get_M4 : $@convention(thin) () -> @owned M4
 // CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_M4]]() : $@convention(thin) () -> @owned M4
 // CHECK:         store [[INSTANCE]] to [init] [[STACK]] : $*M4
+// CHECK-NOT:     destroy_addr
 // CHECK:         [[S2_ADDR:%[^,]+]] = struct_element_addr [[STACK]] : $*M4, #M4.s2
 // CHECK:         [[S4_ADDR:%[^,]+]] = struct_element_addr [[STACK]] : $*M4, #M4.s4
 // CHECK:         [[REPLACE_2:%[^,]+]] = function_ref @replace_2 : $@convention(thin) (@inout M, @inout M) -> ()
@@ -109,6 +113,8 @@ bb0:
   return %22 : $()
 }
 
+// Two non-contiguous fields (#M4.s2, #M4.s4) are initialized by @get_out_2.
+//
 // Verify that M4.s4 is not leaked after it is set.
 // CHECK-LABEL: sil [ossa] @rdar111391893 : $@convention(thin) () -> () {
 // CHECK:         [[GET_OUT_2:%[^,]+]] = function_ref @get_out_2


### PR DESCRIPTION
Added comments clarifying what's tested in the new testcases in `moveonly_addresschecker_unmaximized.sil`.

Also, added a new interpreter test case that was prior to https://github.com/apple/swift/pull/66945 the MoveOnlyAddressChecker miscompiled:

```
SIL memory lifetime failure in @$s4main4doityyF: memory is not initialized, but should be
memory location:   %21 = struct_element_addr %20 : $*M4, #M4.s2    // user: %23
at instruction:   %23 = apply %22(%19, %21) : $@convention(thin) (@inout S, @inout S) -> ()

[...]

4.      While running pass #173 SILFunctionTransform "MoveOnlyChecker" on SILFunction "@$s4main4doityyF".
 for 'doit()' (at test/Interpreter/moveonly_reinit_noncontiguous.swift:32:1)
```

