### PR TITLE
Inherit -strict-implicit-module-context when build sub swiftinterface

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1634,6 +1634,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // Configure front-end input.
   auto &SubFEOpts = genericSubInvocation.getFrontendOptions();
   SubFEOpts.RequestedAction = LoaderOpts.requestedAction;
+  SubFEOpts.StrictImplicitModuleContext =
+      LoaderOpts.strictImplicitModuleContext;
   if (!moduleCachePath.empty()) {
     genericSubInvocation.setClangModuleCachePath(moduleCachePath);
   }
@@ -1830,6 +1832,10 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   // invocation.
   CompilerInvocation subInvocation = genericSubInvocation;
 
+  // save `StrictImplicitModuleContext`
+  bool StrictImplicitModuleContext =
+      subInvocation.getFrontendOptions().StrictImplicitModuleContext;
+
   // Save the target triple from the original context.
   llvm::Triple originalTargetTriple(subInvocation.getLangOptions().Target);
 
@@ -1913,6 +1919,10 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
     BuildArgs.push_back("-target");
     BuildArgs.push_back(parsedTargetTriple.str());
   }
+
+  // restore `StrictImplicitModuleContext`
+  subInvocation.getFrontendOptions().StrictImplicitModuleContext =
+      StrictImplicitModuleContext;
 
   CompilerInstance subInstance;
   SubCompilerInstanceInfo info;

--- a/test/ModuleInterface/Inputs/macro-only-module/ImportsMacroSpecificClangModule.swiftinterface
+++ b/test/ModuleInterface/Inputs/macro-only-module/ImportsMacroSpecificClangModule.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -enable-library-evolution -module-name ImportsMacroSpecificClangModule
 
-import OnlyWithMacro
+import SubImportsMacroSpecificClangModule

--- a/test/ModuleInterface/Inputs/macro-only-module/SubImportsMacroSpecificClangModule.swiftinterface
+++ b/test/ModuleInterface/Inputs/macro-only-module/SubImportsMacroSpecificClangModule.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution -module-name SubImportsMacroSpecificClangModule
+
+import OnlyWithMacro

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -30,6 +30,19 @@ import ImportsMacroSpecificClangModule
 //CHECK-NEXT:      ],
 //CHECK-NEXT:      "directDependencies": [
 //CHECK-NEXT:        {
+//CHECK-NEXT:          "swift": "SubImportsMacroSpecificClangModule"
+//CHECK-NEXT:        },
+//CHECK-NEXT:        {
+//CHECK-NEXT:          "swift": "SwiftOnoneSupport"
+
+//CHECK:      "swift": "SubImportsMacroSpecificClangModule"
+//CHECK-NEXT:    },
+//CHECK-NEXT:    {
+//CHECK-NEXT:      "modulePath": "{{.*}}{{/|\\}}SubImportsMacroSpecificClangModule-{{.*}}.swiftmodule",
+//CHECK-NEXT:      "sourceFiles": [
+//CHECK-NEXT:      ],
+//CHECK-NEXT:      "directDependencies": [
+//CHECK-NEXT:        {
 //CHECK-NEXT:          "clang": "OnlyWithMacro"
 
 // CHECK:      "clang": "OnlyWithMacro"


### PR DESCRIPTION
# Cherry-pick of #67009


- **Release**: Swift 5.9
- **Explanation**: when run sub compiler instance to build sub swiftinterface file，we lose `strict-implicit-module-context` flag which causes sub invocation build clang module in the swiftinterface  failed.
- **Scope**: only affects the case which pass `-strict-implicit-module-context`  to swift-frontend
- **Issue**:  [#66743](https://github.com/apple/swift/issues/66743)
- **Risk**: Minimal, this is a relatively-new opt-in feature
- **Reviewer**: @artemcm 
