### PR TITLE
[5.9][move-only] Fix borrowing address only no consume diagnostic to not say can't capture.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -780,7 +780,7 @@ void DiagnosticEmitter::emitObjectInstConsumesAndUsesValue(
   registerDiagnosticEmitted(markedValue);
 }
 
-void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
+bool DiagnosticEmitter::emitGlobalOrClassFieldLoadedAndConsumed(
     MarkMustCheckInst *markedValue) {
   SmallString<64> varName;
   getVariableNameForValue(markedValue, varName);
@@ -794,7 +794,7 @@ void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
              diag::sil_movechecking_notconsumable_but_assignable_was_consumed,
              varName, /*isGlobal=*/false);
     registerDiagnosticEmitted(markedValue);
-    return;
+    return true;
   }
 
   // is it a global?
@@ -804,10 +804,16 @@ void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
              diag::sil_movechecking_notconsumable_but_assignable_was_consumed,
              varName, /*isGlobal=*/true);
     registerDiagnosticEmitted(markedValue);
-    return;
+    return true;
   }
 
-  // remaining cases must be a closure capture.
+  return false;
+}
+
+void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
+    MarkMustCheckInst *markedValue) {
+  SmallString<64> varName;
+  getVariableNameForValue(markedValue, varName);
   diagnose(markedValue->getModule().getASTContext(),
            markedValue,
            diag::sil_movechecking_capture_consumed,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -160,8 +160,19 @@ public:
                                           Operand *consumingUse,
                                           Operand *nonConsumingUse);
 
+  /// Emit a diagnostic for a case where we have one of the following cases:
+  ///
+  /// 1. A partial_apply formed from a borrowed address only value.
+  /// 2. A use of a captured value in a closure callee.
   void emitAddressEscapingClosureCaptureLoadedAndConsumed(
       MarkMustCheckInst *markedValue);
+
+  /// Try to emit a diagnostic for a load/consume from an
+  /// assignable_but_not_consumable access to a global or a class field. Returns
+  /// false if we did not find something we pattern matched as being either of
+  /// those cases. Returns true if we emitted a diagnostic.
+  bool emitGlobalOrClassFieldLoadedAndConsumed(MarkMustCheckInst *markedValue);
+
   void emitPromotedBoxArgumentError(MarkMustCheckInst *markedValue,
                                     SILFunctionArgument *arg);
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -2476,6 +2476,25 @@ public func addressOnlyGenericAccessConsumeGrandFieldArg4a<T>(_ x2: consuming Ad
     }
 }
 
+public func addressOnlyGenericBorrowingConsume<T>(_ x: borrowing AddressOnlyGeneric<T>) {
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    let _ = x // expected-note {{consumed here}}
+}
+
+public func addressOnlyGenericBorrowingConsumeField<T>(_ x: borrowing AddressOnlyGeneric<T>) {
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    let _ = x.moveOnly // expected-note {{consumed here}}
+}
+
+public func addressOnlyGenericBorrowingConsumeField2<T>(_ x: borrowing AddressOnlyGeneric<T>) {
+    let _ = x.copyable
+}
+
+public func addressOnlyGenericBorrowingConsumeGrandField<T>(_ x: borrowing AddressOnlyGeneric<T>) {
+    // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
+    let _ = x.moveOnly.k // expected-note {{consumed here}}
+}
+
 extension AddressOnlyGeneric {
     func testNoUseSelf() { // expected-error {{'self' is borrowed and cannot be consumed}}
         let x = self // expected-note {{consumed here}}

--- a/test/SILOptimizer/moveonly_partial_consumption.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption.swift
@@ -216,6 +216,8 @@ func addressOnlyTestArg(_ x: borrowing AddressOnlyType) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-3 {{'x' is borrowed and cannot be consumed}}
+    // expected-error @-4 {{'x' is borrowed and cannot be consumed}}
+    let _ = x.e // expected-note {{consumed here}}
     let _ = x.k
     let _ = x.l.e // expected-note {{consumed here}}
     let _ = x.l.k // expected-note {{consumed here}}


### PR DESCRIPTION
• Description: [5.9][move-only] Fix borrowing address only no consume diagnostic to not say can't capture. This may have always been here or it may have come up during the recent diagnostic reformulations.
• Risk: This is low risk since it only affects noncopyable types diagnostics.
• Original PR: https://github.com/apple/swift/pull/66988
• Reviewed By: @jckarter
• Testing: Added regression tests
• Resolves: rdar://111461837

----

We previously were emitting a consuming partial_apply diagnostic. I had to reformulate slightly the way we pattern match the diagnostics to make sure that we get the proper no consume diagnostic.


(cherry picked from commit 4591e39d029547f10a7c70b5ece2a7668d11a938)
