### PR TITLE
SIL: add a `bare` attribute to `global_value` and `alloc_ref`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -19,4 +19,5 @@ swift_compiler_sources(Optimizer
   ReleaseDevirtualizer.swift
   SimplificationPasses.swift
   StackPromotion.swift
+  StripObjectHeaders.swift
 )

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -310,7 +310,7 @@ private func replace(object allocRef: AllocRefInstBase,
 
   // Replace the alloc_ref by global_value + strong_retain instructions.
   let builder = Builder(before: allocRef, context)
-  let globalValue = builder.createGlobalValue(global: global)
+  let globalValue = builder.createGlobalValue(global: global, isBare: false)
   builder.createStrongRetain(operand: globalValue)
 
   endCOW.uses.replaceAll(with: endCOW.instance, context)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StripObjectHeaders.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StripObjectHeaders.swift
@@ -1,0 +1,73 @@
+//===--- StripObjectHeaders.swift ------------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Sets the `[bare]` attribute for `alloc_ref` and `global_value` instructions
+/// if their header (reference count and metatype) is not used throughout the
+/// lifetime of the object.
+///
+let stripObjectHeadersPass = FunctionPass(name: "strip-object-headers") {
+  (function: Function, context: FunctionPassContext) in
+
+  for inst in function.instructions {
+    switch inst {
+    case let gv as GlobalValueInst:
+      if !gv.isBare && !gv.needObjectHeader(context) {
+        gv.setIsBare(context)
+      }
+    case let ar as AllocRefInst:
+      if !ar.isBare && !ar.needObjectHeader(context) {
+        ar.setIsBare(context)
+      }
+    default:
+      break
+    }
+  }
+}
+
+private extension Value {
+  func needObjectHeader(_ context: FunctionPassContext) -> Bool {
+    var walker = IsBareObjectWalker()
+    return walker.walkDownUses(ofValue: self, path: SmallProjectionPath()) == .abortWalk
+  }
+}
+
+private struct IsBareObjectWalker : ValueDefUseWalker {
+  var walkDownCache = WalkerCache<SmallProjectionPath>()
+
+  mutating func walkDown(value operand: Operand, path: Path) -> WalkResult {
+    switch operand.instruction {
+    case is StructInst, is TupleInst, is EnumInst,
+         is StructExtractInst, is TupleExtractInst, is UncheckedEnumDataInst,
+         is DestructureStructInst, is DestructureTupleInst,
+         is BeginBorrowInst, is MarkDependenceInst,
+         is BranchInst, is CondBranchInst, is SwitchEnumInst,
+         is UpcastInst, is UncheckedRefCastInst,
+         is EndCOWMutationInst:
+      return walkDownDefault(value: operand, path: path)
+    default:
+      return leafUse(value: operand, path: path)
+    }
+  }
+
+  mutating func leafUse(value operand: Operand, path: SmallProjectionPath) -> WalkResult {
+    switch operand.instruction {
+    case is RefElementAddrInst, is RefTailAddrInst,
+         is DeallocRefInst, is DeallocStackRefInst, is SetDeallocatingInst,
+         is DebugValueInst, is FixLifetimeInst:
+      return .continueWalk
+    default:
+      return .abortWalk
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -438,6 +438,14 @@ extension AllocRefInst {
   }
 }
 
+extension GlobalValueInst {
+  func setIsBare(_ context: some MutatingContext) {
+    context.notifyInstructionsChanged()
+    bridged.GlobalValueInst_setIsBare()
+    context.notifyInstructionChanged(self)
+  }
+}
+
 extension TermInst {
   func replaceBranchTarget(from fromBlock: BasicBlock, to toBlock: BasicBlock, _ context: some MutatingContext) {
     context.notifyBranchesChanged()

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -430,6 +430,14 @@ extension RefCountingInst {
   }
 }
 
+extension AllocRefInst {
+  func setIsBare(_ context: some MutatingContext) {
+    context.notifyInstructionsChanged()
+    bridged.AllocRefInst_setIsBare()
+    context.notifyInstructionChanged(self)
+  }
+}
+
 extension TermInst {
   func replaceBranchTarget(from fromBlock: BasicBlock, to toBlock: BasicBlock, _ context: some MutatingContext) {
     context.notifyBranchesChanged()

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -81,6 +81,7 @@ private func registerSwiftPasses() {
   registerPass(lateOnoneSimplificationPass, { lateOnoneSimplificationPass.run($0) })
   registerPass(cleanupDebugStepsPass, { cleanupDebugStepsPass.run($0) })
   registerPass(namedReturnValueOptimization, { namedReturnValueOptimization.run($0) })
+  registerPass(stripObjectHeadersPass, { stripObjectHeadersPass.run($0) })
 
   // Instruction passes
   registerForSILCombine(BeginCOWMutationInst.self, { run(BeginCOWMutationInst.self, $0) })

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -239,8 +239,8 @@ public struct Builder {
     return notifyNew(bridged.createGlobalAddr(global.bridged).getAs(GlobalAddrInst.self))
   }
 
-  public func createGlobalValue(global: GlobalVariable) -> GlobalValueInst {
-    return notifyNew(bridged.createGlobalValue(global.bridged).getAs(GlobalValueInst.self))
+  public func createGlobalValue(global: GlobalVariable, isBare: Bool) -> GlobalValueInst {
+    return notifyNew(bridged.createGlobalValue(global.bridged, isBare).getAs(GlobalValueInst.self))
   }
 
   public func createStruct(type: Type, elements: [Value]) -> StructInst {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -837,6 +837,7 @@ public class AllocRefInstBase : SingleValueInstruction, Allocation {
 }
 
 final public class AllocRefInst : AllocRefInstBase {
+  public var isBare: Bool { bridged.AllocRefInst_isBare() }
 }
 
 final public class AllocRefDynamicInst : AllocRefInstBase {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -523,7 +523,9 @@ final public class PreviousDynamicFunctionRefInst : FunctionRefBaseInst {
 
 final public class GlobalAddrInst : GlobalAccessInst {}
 
-final public class GlobalValueInst : GlobalAccessInst {}
+final public class GlobalValueInst : GlobalAccessInst {
+  public var isBare: Bool { bridged.GlobalValueInst_isBare() }
+}
 
 final public class AllocGlobalInst : Instruction {
   public var global: GlobalVariable {

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3816,6 +3816,7 @@ alloc_ref
 ::
 
   sil-instruction ::= 'alloc_ref'
+                        ('[' 'bare' ']')?
                         ('[' 'objc' ']')?
                         ('[' 'stack' ']')?
                         ('[' 'tail_elems' sil-type '*' sil-operand ']')*
@@ -3841,6 +3842,11 @@ Note that the ``stack`` attribute only specifies that stack allocation is
 possible. The final decision on stack allocation is done during llvm IR
 generation. This is because the decision also depends on the object size,
 which is not necessarily known at SIL level.
+
+The ``bare`` attribute indicates that the object header is not used throughout
+the lifetime of the object. This means, no reference counting operations are
+performed on the object and its metadata is not used. The header of bare
+objects doesn't need to be initialized.
 
 The optional ``tail_elems`` attributes specifies the amount of space to be
 reserved for tail-allocated arrays of given element types and element counts.

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5490,7 +5490,7 @@ global_value
 `````````````
 ::
 
-  sil-instruction ::= 'global_value' sil-global-name ':' sil-type
+  sil-instruction ::= 'global_value' ('[' 'bare' ']')? sil-global-name ':' sil-type
 
   %1 = global_value @v : $T
 
@@ -5498,6 +5498,11 @@ Returns the value of a global variable which has been previously initialized
 by ``alloc_global``. It is undefined behavior to perform this operation on a
 global variable which has not been initialized, except the global variable
 has a static initializer.
+
+The ``bare`` attribute indicates that the object header is not used throughout
+the lifetime of the value. This means, no reference counting operations are
+performed on the object and its metadata is not used. The header of bare
+objects doesn't need to be initialized.
 
 integer_literal
 ```````````````

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -760,6 +760,14 @@ struct BridgedInstruction {
     getAs<swift::AllocRefInstBase>()->setStackAllocatable();
   }
 
+  bool AllocRefInst_isBare() const {
+    return getAs<swift::AllocRefInst>()->isBare();
+  }
+
+  void AllocRefInst_setIsBare() const {
+    getAs<swift::AllocRefInst>()->setBare(true);
+  }
+
   inline void TermInst_replaceBranchTarget(BridgedBasicBlock from, BridgedBasicBlock to) const;
 
   SwiftInt KeyPathInst_getNumComponents() const {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -794,6 +794,14 @@ struct BridgedInstruction {
       }, [](swift::SILDeclRef) {});
   }
 
+  bool GlobalValueInst_isBare() const {
+    return getAs<swift::GlobalValueInst>()->isBare();
+  }
+
+  void GlobalValueInst_setIsBare() const {
+    getAs<swift::GlobalValueInst>()->setBare(true);
+  }
+
   SWIFT_IMPORT_UNSAFE
   inline BridgedBasicBlock CheckedCastBranch_getSuccessBlock() const;
 
@@ -1250,8 +1258,8 @@ struct BridgedBuilder{
   }
 
   SWIFT_IMPORT_UNSAFE
-  BridgedInstruction createGlobalValue(BridgedGlobalVar global) const {
-    return {builder().createGlobalValue(regularLoc(), global.getGlobal())};
+  BridgedInstruction createGlobalValue(BridgedGlobalVar global, bool isBare) const {
+    return {builder().createGlobalValue(regularLoc(), global.getGlobal(), isBare)};
   }
 
   SWIFT_IMPORT_UNSAFE

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -682,9 +682,9 @@ public:
     return insert(new (F->getModule())
                   GlobalAddrInst(getSILDebugLocation(Loc), Ty));
   }
-  GlobalValueInst *createGlobalValue(SILLocation Loc, SILGlobalVariable *g) {
+  GlobalValueInst *createGlobalValue(SILLocation Loc, SILGlobalVariable *g, bool isBare) {
     return insert(new (getModule()) GlobalValueInst(getSILDebugLocation(Loc), g,
-                                                    getTypeExpansionContext()));
+                                                    getTypeExpansionContext(), isBare));
   }
   BaseAddrForOffsetInst *createBaseAddrForOffset(SILLocation Loc, SILType Ty) {
     return insert(new (F->getModule())

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -446,14 +446,14 @@ public:
   }
 
   AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,
-                               bool objc, bool canAllocOnStack,
+                               bool objc, bool canAllocOnStack, bool isBare,
                                ArrayRef<SILType> ElementTypes,
                                ArrayRef<SILValue> ElementCountOperands) {
     // AllocRefInsts expand to function calls and can therefore not be
     // counted towards the function prologue.
     assert(!Loc.isInPrologue());
     return insert(AllocRefInst::create(getSILDebugLocation(Loc), getFunction(),
-                                       ObjectType, objc, canAllocOnStack,
+                                       ObjectType, objc, canAllocOnStack, isBare,
                                        ElementTypes, ElementCountOperands));
   }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -922,7 +922,7 @@ SILCloner<ImplClass>::visitAllocRefInst(AllocRefInst *Inst) {
   }
   auto *NewInst = getBuilder().createAllocRef(getOpLocation(Inst->getLoc()),
                                       getOpType(Inst->getType()),
-                                      Inst->isObjC(), Inst->canAllocOnStack(),
+                                      Inst->isObjC(), Inst->canAllocOnStack(), Inst->isBare(),
                                       ElemTypes, CountArgs);
   recordClonedInstruction(Inst, NewInst);
 }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1125,7 +1125,8 @@ SILCloner<ImplClass>::visitGlobalValueInst(GlobalValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createGlobalValue(getOpLocation(Inst->getLoc()),
-                                           Inst->getReferencedGlobal()));
+                                           Inst->getReferencedGlobal(),
+                                           Inst->isBare()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2206,12 +2206,20 @@ protected:
   AllocRefInstBase(SILInstructionKind Kind,
                    SILDebugLocation DebugLoc,
                    SILType ObjectType,
-                   bool objc, bool canBeOnStack,
+                   bool objc, bool canBeOnStack, bool isBare,
                    ArrayRef<SILType> ElementTypes);
 
   SILType *getTypeStorage();
   const SILType *getTypeStorage() const {
     return const_cast<AllocRefInstBase*>(this)->getTypeStorage();
+  }
+
+  bool isBare() const {
+    return sharedUInt8().AllocRefInstBase.isBare;
+  }
+
+  void setBare(bool isBare = true) {
+    sharedUInt8().AllocRefInstBase.isBare = isBare;
   }
 
 public:
@@ -2285,11 +2293,11 @@ class AllocRefInst final
 
   AllocRefInst(SILDebugLocation DebugLoc, SILFunction &F,
                SILType ObjectType,
-               bool objc, bool canBeOnStack,
+               bool objc, bool canBeOnStack, bool isBare,
                ArrayRef<SILType> ElementTypes,
                ArrayRef<SILValue> AllOperands)
       : InstructionBaseWithTrailingOperands(AllOperands, DebugLoc, ObjectType,
-                        objc, canBeOnStack, ElementTypes) {
+                        objc, canBeOnStack, isBare, ElementTypes) {
     assert(AllOperands.size() >= ElementTypes.size());
     std::uninitialized_copy(ElementTypes.begin(), ElementTypes.end(),
                             getTrailingObjects<SILType>());
@@ -2297,11 +2305,19 @@ class AllocRefInst final
 
   static AllocRefInst *create(SILDebugLocation DebugLoc, SILFunction &F,
                               SILType ObjectType,
-                              bool objc, bool canBeOnStack,
+                              bool objc, bool canBeOnStack, bool isBare,
                               ArrayRef<SILType> ElementTypes,
                               ArrayRef<SILValue> ElementCountOperands);
 
 public:
+  bool isBare() const {
+    return AllocRefInstBase::isBare();
+  }
+
+  void setBare(bool isBare = true) {
+    AllocRefInstBase::setBare(isBare);
+  }
+
   ArrayRef<Operand> getTypeDependentOperands() const {
     return getAllOperands().slice(getNumTailTypes());
   }
@@ -2332,7 +2348,7 @@ class AllocRefDynamicInst final
                       ArrayRef<SILType> ElementTypes,
                       ArrayRef<SILValue> AllOperands)
       : InstructionBaseWithTrailingOperands(AllOperands, DebugLoc, ty, objc,
-                                            canBeOnStack, ElementTypes) {
+                                            canBeOnStack, /*isBare=*/ false, ElementTypes) {
     assert(AllOperands.size() >= ElementTypes.size() + 1);
     std::uninitialized_copy(ElementTypes.begin(), ElementTypes.end(),
                             getTrailingObjects<SILType>());

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4119,9 +4119,18 @@ class GlobalValueInst
     : public InstructionBase<SILInstructionKind::GlobalValueInst,
                              GlobalAccessInst> {
   friend SILBuilder;
+  USE_SHARED_UINT8;
 
   GlobalValueInst(SILDebugLocation DebugLoc, SILGlobalVariable *Global,
-                  TypeExpansionContext context);
+                  TypeExpansionContext context, bool isBare);
+public:
+  bool isBare() const {
+    return sharedUInt8().GlobalValueInst.isBare;
+  }
+
+  void setBare(bool isBare = true) {
+    sharedUInt8().GlobalValueInst.isBare = isBare;
+  }
 };
 
 /// IntegerLiteralInst - Encapsulates an integer constant, as defined originally

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -202,6 +202,7 @@ protected:
     SHARED_FIELD(EndCOWMutationInst, bool keepUnique);
     SHARED_FIELD(ConvertFunctionInst, bool withoutActuallyEscaping);
     SHARED_FIELD(BeginCOWMutationInst, bool native);
+    SHARED_FIELD(GlobalValueInst, bool isBare);
 
     SHARED_FIELD(SILArgument, uint8_t
                  valueOwnershipKind : NumVOKindBits,

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -228,6 +228,7 @@ protected:
     SHARED_FIELD(AllocRefInstBase, uint8_t
       objC : 1,
       onStack : 1,
+      isBare : 1,   // Only used in AllocRefInst
       numTailTypes: NumAllocRefTailTypesBits);
 
     SHARED_FIELD(BeginBorrowInst, uint8_t

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -401,6 +401,8 @@ SWIFT_FUNCTION_PASS(CleanupDebugSteps, "cleanup-debug-steps",
     "Cleanup debug_step instructions for Onone")
 SWIFT_FUNCTION_PASS(NamedReturnValueOptimization, "named-return-value-optimization",
     "Optimize copies to an indirect return value")
+SWIFT_FUNCTION_PASS(StripObjectHeaders, "strip-object-headers",
+    "Sets the bare flag on objects which don't need their headers")
 PASS(SimplifyBBArgs, "simplify-bb-args",
      "SIL Block Argument Simplification")
 PASS(SimplifyCFG, "simplify-cfg",

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -166,7 +166,7 @@ namespace irgen {
   /// The returned \p StackAllocSize value is the actual size if the object is
   /// allocated on the stack or -1, if the object is allocated on the heap.
   llvm::Value *emitClassAllocation(IRGenFunction &IGF, SILType selfType,
-                  bool objc, int &StackAllocSize, TailArraysRef TailArrays);
+                  bool objc, bool isBare, int &StackAllocSize, TailArraysRef TailArrays);
 
   /// Emit an allocation of a class using a metadata value.
   llvm::Value *emitClassAllocationDynamic(IRGenFunction &IGF,

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3168,7 +3168,7 @@ void LoadableByAddress::run() {
     } else if (auto *globalVal = dyn_cast<GlobalValueInst>(inst)) {
       SILBuilderWithScope builder(inst);
       auto *newInst = builder.createGlobalValue(
-          globalVal->getLoc(), globalVal->getReferencedGlobal());
+          globalVal->getLoc(), globalVal->getReferencedGlobal(), globalVal->isBare());
       globalVal->replaceAllUsesWith(newInst);
       globalVal->eraseFromParent();
     }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1019,10 +1019,12 @@ GlobalAddrInst::GlobalAddrInst(SILDebugLocation DebugLoc,
 
 GlobalValueInst::GlobalValueInst(SILDebugLocation DebugLoc,
                                  SILGlobalVariable *Global,
-                                 TypeExpansionContext context)
+                                 TypeExpansionContext context, bool bare)
     : InstructionBase(DebugLoc,
                       Global->getLoweredTypeInContext(context).getObjectType(),
-                      Global) {}
+                      Global) {
+  sharedUInt8().GlobalValueInst.isBare = bare;
+}
 
 const IntrinsicInfo &BuiltinInst::getIntrinsicInfo() const {
   return getModule().getIntrinsicInfo(getName());

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -317,11 +317,12 @@ AllocPackInst *AllocPackInst::create(SILDebugLocation loc,
 AllocRefInstBase::AllocRefInstBase(SILInstructionKind Kind,
                                    SILDebugLocation Loc,
                                    SILType ObjectType,
-                                   bool objc, bool canBeOnStack,
+                                   bool objc, bool canBeOnStack, bool isBare,
                                    ArrayRef<SILType> ElementTypes)
     : AllocationInst(Kind, Loc, ObjectType) {
   sharedUInt8().AllocRefInstBase.objC = objc;
   sharedUInt8().AllocRefInstBase.onStack = canBeOnStack;
+  sharedUInt8().AllocRefInstBase.isBare = isBare;
   sharedUInt8().AllocRefInstBase.numTailTypes = ElementTypes.size();
   assert(sharedUInt8().AllocRefInstBase.numTailTypes ==
          ElementTypes.size() && "Truncation");
@@ -330,7 +331,7 @@ AllocRefInstBase::AllocRefInstBase(SILInstructionKind Kind,
 
 AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILFunction &F,
                                    SILType ObjectType,
-                                   bool objc, bool canBeOnStack,
+                                   bool objc, bool canBeOnStack, bool isBare,
                                    ArrayRef<SILType> ElementTypes,
                                    ArrayRef<SILValue> ElementCountOperands) {
   assert(ElementTypes.size() == ElementCountOperands.size());
@@ -341,7 +342,7 @@ AllocRefInst *AllocRefInst::create(SILDebugLocation Loc, SILFunction &F,
   auto Size = totalSizeToAlloc<swift::Operand, SILType>(AllOperands.size(),
                                                         ElementTypes.size());
   auto Buffer = F.getModule().allocateInst(Size, alignof(AllocRefInst));
-  return ::new (Buffer) AllocRefInst(Loc, F, ObjectType, objc, canBeOnStack,
+  return ::new (Buffer) AllocRefInst(Loc, F, ObjectType, objc, canBeOnStack, isBare,
                                      ElementTypes, AllOperands);
 }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1624,6 +1624,8 @@ public:
   }
 
   void visitGlobalValueInst(GlobalValueInst *GVI) {
+    if (GVI->isBare())
+      *this << "[bare] ";
     GVI->getReferencedGlobal()->printName(PrintState.OS);
     *this << " : " << GVI->getType();
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1452,6 +1452,8 @@ public:
   }
 
   void visitAllocRefInst(AllocRefInst *ARI) {
+    if (ARI->isBare())
+      *this << "[bare] ";
     printAllocRefInstBase(ARI);
     *this << ARI->getType();
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5031,6 +5031,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::AllocRefDynamicInst: {
     bool IsObjC = false;
     bool OnStack = false;
+    bool isBare = false;
     SmallVector<SILType, 2> ElementTypes;
     SmallVector<SILValue, 2> ElementCounts;
     while (P.consumeIf(tok::l_square)) {
@@ -5041,6 +5042,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         IsObjC = true;
       } else if (Optional == "stack") {
         OnStack = true;
+      } else if (Optional == "bare" && Opcode == SILInstructionKind::AllocRefInst) {
+        isBare = true;
       } else if (Optional == "tail_elems") {
         SILType ElemTy;
         if (parseSILType(ElemTy) || !P.Tok.isAnyOperator() ||
@@ -5082,7 +5085,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
                                           OnStack,
                                           ElementTypes, ElementCounts);
     } else {
-      ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack,
+      ResultVal = B.createAllocRef(InstLoc, ObjectType, IsObjC, OnStack, isBare,
                                    ElementTypes, ElementCounts);
     }
     break;

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -239,7 +239,7 @@ ManagedValue SILGenBuilder::createPhi(SILType type,
 }
 
 ManagedValue SILGenBuilder::createAllocRef(
-    SILLocation loc, SILType refType, bool objc, bool canAllocOnStack,
+    SILLocation loc, SILType refType, bool objc,
     ArrayRef<SILType> inputElementTypes,
     ArrayRef<ManagedValue> inputElementCountOperands) {
   llvm::SmallVector<SILType, 8> elementTypes(inputElementTypes.begin(),
@@ -249,7 +249,7 @@ ManagedValue SILGenBuilder::createAllocRef(
                   std::back_inserter(elementCountOperands),
                   [](ManagedValue mv) -> SILValue { return mv.getValue(); });
 
-  AllocRefInst *i = createAllocRef(loc, refType, objc, canAllocOnStack,
+  AllocRefInst *i = createAllocRef(loc, refType, objc, false, false,
                                    elementTypes, elementCountOperands);
   return SGF.emitManagedRValueWithCleanup(i);
 }

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -177,7 +177,6 @@ public:
 
   using SILBuilder::createAllocRef;
   ManagedValue createAllocRef(SILLocation loc, SILType refType, bool objc,
-                              bool canAllocOnStack,
                               ArrayRef<SILType> elementTypes,
                               ArrayRef<ManagedValue> elementCountOperands);
   using SILBuilder::createAllocRefDynamic;

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1080,7 +1080,7 @@ static ManagedValue emitBuiltinAllocWithTailElems(SILGenFunction &SGF,
     assert(InstanceType == RefType.getASTType() &&
            "substituted type does not match operand metatype");
     (void) InstanceType;
-    return SGF.B.createAllocRef(loc, RefType, false, false,
+    return SGF.B.createAllocRef(loc, RefType, false,
                                 ElemTypes, Counts);
   } else {
     return SGF.B.createAllocRefDynamic(loc, Metatype, RefType, false,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -957,7 +957,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
     // allocated is the type of the class that defines the designated
     // initializer.
     F.setIsExactSelfClass(IsExactSelfClass);
-    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false,
+    selfValue = B.createAllocRef(Loc, selfTy, useObjCAllocation, false, false,
                                  ArrayRef<SILType>(), ArrayRef<SILValue>());
   }
   args.push_back(selfValue);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -807,6 +807,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   P.addDCE();
   P.addSILCombine();
   P.addSimplifyCFG();
+  P.addStripObjectHeaders();
 
   // Try to hoist all releases, including epilogue releases. This should be
   // after FSO.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1781,6 +1781,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
 
     NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                      ARDI->isObjC(), ARDI->canAllocOnStack(),
+                                     /*isBare=*/ false,
                                      ARDI->getTailAllocatedTypes(),
                                      getCounts(ARDI));
 
@@ -1806,6 +1807,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
         return nullptr;
       NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                        ARDI->isObjC(), ARDI->canAllocOnStack(),
+                                       /*isBare=*/ false,
                                        ARDI->getTailAllocatedTypes(),
                                        getCounts(ARDI));
     }
@@ -1833,6 +1835,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
       return nullptr;
     NewInst = Builder.createAllocRef(
         ARDI->getLoc(), *instanceTy, ARDI->isObjC(), false,
+        /*isBare=*/ false,
         ARDI->getTailAllocatedTypes(), getCounts(ARDI));
     NewInst = Builder.createUncheckedRefCast(ARDI->getLoc(), NewInst,
                                              ARDI->getType());

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1702,7 +1702,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                                  TailTypes, Counts);
     } else {
       assert(i == NumVals);
-      ResultInst = Builder.createAllocRef(Loc, ClassTy, isObjC, canAllocOnStack,
+      bool isBare = (bool)((Flags >> 2) & 1);
+      ResultInst = Builder.createAllocRef(Loc, ClassTy, isObjC, canAllocOnStack, isBare,
                                           TailTypes, Counts);
     }
     break;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1854,7 +1854,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     if (OpCode == SILInstructionKind::GlobalAddrInst) {
       ResultInst = Builder.createGlobalAddr(Loc, g);
     } else {
-      ResultInst = Builder.createGlobalValue(Loc, g);
+      ResultInst = Builder.createGlobalValue(Loc, g, /*isBare=*/ (Attr & 1) != 0);
     }
     break;
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1254,9 +1254,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const GlobalAccessInst *GI = cast<GlobalAccessInst>(&SI);
     auto *G = GI->getReferencedGlobal();
     addReferencedGlobalVariable(G);
+    bool isBare = false;
+    if (auto *gv = dyn_cast<GlobalValueInst>(&SI))
+      isBare = gv->isBare();
     SILOneOperandLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneOperandLayout::Code],
-        (unsigned)SI.getKind(), 0,
+        (unsigned)SI.getKind(), isBare ? 1 : 0,
         S.addTypeRef(GI->getType().getRawASTType()),
         (unsigned)GI->getType().getCategory(),
         S.addUniquedStringRef(G->getName()));

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1057,8 +1057,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const AllocRefInstBase *ARI = cast<AllocRefInstBase>(&SI);
     unsigned abbrCode = SILAbbrCodes[SILOneTypeValuesLayout::Code];
     SmallVector<ValueID, 4> Args;
+    bool isBare = false;
+    if (auto *ar = dyn_cast<AllocRefInst>(&SI))
+      isBare = ar->isBare();
     Args.push_back((unsigned)ARI->isObjC() |
-                   ((unsigned)ARI->canAllocOnStack() << 1));
+                   ((unsigned)ARI->canAllocOnStack() << 1) |
+                   ((unsigned)isBare << 2));
     ArrayRef<SILType> TailTypes = ARI->getTailAllocatedTypes();
     ArrayRef<Operand> AllOps = ARI->getAllOperands();
     unsigned NumTailAllocs = TailTypes.size();

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -105,6 +105,20 @@ bb0:
   return %r : $()
 }
 
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bare_alloc_ref
+// CHECK:         %reference.raw = alloca %[[C:[a-zA-Z0-9_]+]], align 8
+// CHECK-NEXT:    [[O:%[0-9]+]] = bitcast %[[C]]* %reference.raw to i8*
+// CHECK-NEXT:    call void @llvm.lifetime.end.p0i8(i64 -1, i8* [[O]])
+// CHECK-NEXT:    ret void
+sil @bare_alloc_ref : $@convention(thin) () -> () {
+bb0:
+  %o1 = alloc_ref [bare] [stack] $TestClass
+  set_deallocating %o1 : $TestClass
+  dealloc_stack_ref %o1 : $TestClass
+  %r = tuple()
+  return %r : $()
+}
+
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @promoted_with_inlined_devirtualized_release
 // CHECK: %reference.raw = alloca %[[C:[a-zA-Z0-9_]+]], align 8
 // CHECK-NEXT: [[MR:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s17class_stack_alloc9TestClassCMa"([[INT]] 0)

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend %use_no_opaque_pointers %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-abi
+// RUN: %target-swift-frontend %use_no_opaque_pointers %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-abi-%target-cpu
 // RUN: %target-swift-frontend %s -emit-ir
 
-// REQUIRES: CPU=x86_64
+// REQUIRES: CPU=arm64 || CPU=x86_64
 
 // Generated from
 // var x : Int32 = 2
@@ -25,10 +25,12 @@ public struct S2 {
 // CHECK: %T18static_initializer1SV = type <{ %Ts5Int32V }>
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems0c = type { [1 x i64], %T18static_initializer16TestArrayStorageC_tailelems0 }
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems0 = type <{ %swift.refcounted, %Ts5Int32V, [4 x i8], %Ts5Int64V, %Ts5Int64V }>
-// CHECK-SYSV: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [2 x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
-// CHECK-WIN: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [1 x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
-// CHECK-SYSV: %T18static_initializer16TestArrayStorageC_tailelems1 = type <{ %swift.refcounted, %Ts5Int32V, [12 x i8], %Ts7Float80V }>
-// CHECK-WIN: %T18static_initializer16TestArrayStorageC_tailelems1 = type <{ %swift.refcounted, %Ts5Int32V, [1 x i8] }>
+// CHECK-SYSV-arm64: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [1 x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
+// CHECK-SYSV-x86_64: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [2 x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
+// CHECK-WIN-x86_64: %T18static_initializer16TestArrayStorageC_tailelems1c = type { [1 x i64], %T18static_initializer16TestArrayStorageC_tailelems1 }
+// CHECK-SYSV-arm64: %T18static_initializer16TestArrayStorageC_tailelems1 = type <{ %swift.refcounted, %Ts5Int32V, [1 x i8] }>
+// CHECK-SYSV-x86_64: %T18static_initializer16TestArrayStorageC_tailelems1 = type <{ %swift.refcounted, %Ts5Int32V, [12 x i8], %Ts7Float80V }>
+// CHECK-WIN-x86_64: %T18static_initializer16TestArrayStorageC_tailelems1 = type <{ %swift.refcounted, %Ts5Int32V, [1 x i8] }>
 // CHECK: %T18static_initializer16TestArrayStorageC_tailelems3 = type <{ %swift.refcounted, %Ts5Int32V, [1 x i8], [1 x i8] }>
 
 sil_global @$s2ch1xSiv : $Int32 = {
@@ -78,8 +80,9 @@ sil_global @static_aligned_array : $TestArrayStorage = {
   %4 = struct $Float80 (%1 : $Builtin.FPIEEE80)
   %initval = object $TestArrayStorage (%3 : $Int32, [tail_elems] %4 : $Float80)
 }
-// CHECK-SYSV: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [2 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [12 x i8] undef, %Ts7Float80V <{ x86_fp80 0xK3FFE8000000000000000 }> }> }, align 16
-// CHECK-WIN: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef }> }, align 8
+// CHECK-SYSV-arm64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef }> }, align 8
+// CHECK-SYSV-x86_64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [2 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [12 x i8] undef, %Ts7Float80V <{ x86_fp80 0xK3FFE8000000000000000 }> }> }, align 16
+// CHECK-WIN-x86_64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef }> }, align 8
 
 final class ClassWithEmptyField {
   @_hasStorage var x: Int32

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -185,6 +185,17 @@ bb0:
   return %1 : $TestArray
 }
 
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @bare_static_array() {{.*}} {
+sil @bare_static_array : $@convention(thin) () -> Int32 {
+bb0:
+  // CHECK: %0 = load i32, {{.*}}@static_array
+  // CHECK: ret i32 %0
+  %0 = global_value [bare] @static_array : $TestArrayStorage
+  %1 = ref_element_addr %0 : $TestArrayStorage, #TestArrayStorage.count
+  %2 = load %1 : $*Int32
+  return %2 : $Int32
+}
+
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T18static_initializer16TestArrayStorageC* @phi_nodes(i1 %0, %T18static_initializer16TestArrayStorageC* %1)
 // CHECK: [[T0:%.*]] = call %swift.refcounted* @swift_initStaticObject
 // CHECK: [[T1:%.*]] = bitcast %swift.refcounted* [[T0]] to %T18static_initializer16TestArrayStorageC*

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -763,6 +763,8 @@ sil @test_bare_flags : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_ref [bare] $Class1
   %0 = alloc_ref [bare] $Class1
+  // CHECK: global_value [bare] @static_array : $TestArrayStorage
+  %1 = global_value [bare] @static_array : $TestArrayStorage
   %2 = tuple ()
   return %2 : $()
 }

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -758,6 +758,15 @@ bb0:
   return %2 : $()
 }
 
+// CHECK-LABEL: sil @test_bare_flags
+sil @test_bare_flags : $@convention(thin) () -> () {
+bb0:
+  // CHECK: alloc_ref [bare] $Class1
+  %0 = alloc_ref [bare] $Class1
+  %2 = tuple ()
+  return %2 : $()
+}
+
 // CHECK-LABEL: sil @test_stack_protection_flags
 sil @test_stack_protection_flags : $@convention(thin) (@inout Builtin.Word) -> () {
 bb0(%0 : $*Builtin.Word):

--- a/test/SILOptimizer/static_arrays.swift
+++ b/test/SILOptimizer/static_arrays.swift
@@ -98,7 +98,7 @@
 public let globalVariable = [ 100, 101, 102 ]
 
 // CHECK-LABEL: sil [noinline] @$s4test11arrayLookupyS2iF
-// CHECK:   global_value @$s4test11arrayLookupyS2iFTv_
+// CHECK:   global_value [bare] @$s4test11arrayLookupyS2iFTv_
 // CHECK-NOT: retain
 // CHECK-NOT: release
 // CHECK:   } // end sil function '$s4test11arrayLookupyS2iF'

--- a/test/SILOptimizer/strip_object_header.sil
+++ b/test/SILOptimizer/strip_object_header.sil
@@ -1,0 +1,66 @@
+// RUN: %target-sil-opt  %s -strip-object-headers | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class B {
+}
+class C : B {
+  @_hasStorage var a: Int
+}
+
+sil_global @g : $C
+
+sil @unknown_func : $@convention(thin) (@guaranteed C) -> ()
+
+// CHECK-LABEL: sil @test_alloc_ref :
+// CHECK:         alloc_ref [bare] [stack] $C
+// CHECK:       } // end sil function 'test_alloc_ref'
+sil @test_alloc_ref : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] $C
+  debug_value %0 : $C, let, name "x"
+  %1 = upcast %0 : $C to $B
+  %2 = end_cow_mutation %1 : $B
+  %3 = unchecked_ref_cast %2 : $B to $C
+  %4 = ref_element_addr %3 : $C, #C.a
+  %5 = ref_tail_addr %3 : $C, $Int
+  set_deallocating %0 : $C
+  fix_lifetime %0 : $C
+  dealloc_ref %0 : $C
+  dealloc_stack_ref %0 : $C
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @test_global_value :
+// CHECK:         global_value [bare] @g
+// CHECK:       } // end sil function 'test_global_value'
+sil @test_global_value : $@convention(thin) () -> () {
+bb0:
+  %0 = global_value @g : $C
+  debug_value %0 : $C, let, name "x"
+  %4 = ref_element_addr %0 : $C, #C.a
+  %5 = ref_tail_addr %0 : $C, $Int
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @test_not_bare :
+// CHECK:         alloc_ref [stack] $C
+// CHECK:       } // end sil function 'test_not_bare'
+sil @test_not_bare : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] $C
+  %1 = function_ref @unknown_func : $@convention(thin) (@guaranteed C) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed C) -> ()
+  dealloc_stack_ref %0 : $C
+  %6 = tuple ()
+  return %6 : $()
+}
+

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -684,6 +684,15 @@ bb0:
   return %2 : $()
 }
 
+// CHECK-LABEL: sil public_external [transparent] @test_bare_flags
+sil [transparent] [serialized] @test_bare_flags : $@convention(thin) () -> () {
+bb0:
+  // CHECK: alloc_ref [bare] $Class1
+  %0 = alloc_ref [bare] $Class1
+  %2 = tuple ()
+  return %2 : $()
+}
+
 // CHECK-LABEL: sil public_external [transparent] @test_stack_protection_flags
 sil [transparent] [serialized] @test_stack_protection_flags : $@convention(thin) (@inout Builtin.Word) -> () {
 bb0(%0 : $*Builtin.Word):
@@ -1537,7 +1546,8 @@ bb0:
   %84 = function_ref @test_dealloc_partial_ref : $@convention(thin) () -> ()
   %85 = function_ref @test_dealloc_box : $@convention(thin) () -> ()
   %86 = function_ref @test_stack_flag : $@convention(thin) () -> ()
-  %86b = function_ref @test_stack_protection_flags : $@convention(thin) (@inout Builtin.Word) -> ()
+  %86b = function_ref @test_bare_flags : $@convention(thin) () -> ()
+  %86c = function_ref @test_stack_protection_flags : $@convention(thin) (@inout Builtin.Word) -> ()
   %87 = function_ref @test_tail_elems : $@convention(thin) (Builtin.Word, Builtin.Word) -> ()
   %88 = function_ref @test_tail_elems_dynamic : $@convention(thin) (Builtin.Word, Builtin.Word, @thick Class1.Type) -> ()
   %89 = function_ref @test_tail_addr : $@convention(thin) (@owned Class1, Builtin.Word) -> @owned Class1

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -689,6 +689,8 @@ sil [transparent] [serialized] @test_bare_flags : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_ref [bare] $Class1
   %0 = alloc_ref [bare] $Class1
+  // CHECK: global_value [bare] @static_global_object : $GlobalObject
+  %1 = global_value [bare] @static_global_object : $GlobalObject
   %2 = tuple ()
   return %2 : $()
 }


### PR DESCRIPTION
The `bare` attribute indicates that the object header is not used throughout the lifetime of the value.
This means, no reference counting operations are performed on the object and its metadata is not used.

The `bare` attribute is used in IRGen to omit the header initialization of such objects.
(IRGen already had a peephole optimization for `global_value`. But now it relies on the `bare` flag.)

The StripObjectHeader optimization pass sets the `[bare]` attribute for `alloc_ref` and `global_value` instructions based on their uses.
