### PR TITLE
Add `StrictConcurrency` as an always-enabled experimental feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -210,6 +210,9 @@ EXPERIMENTAL_FEATURE(ReferenceBindings, false)
 /// Enable the explicit 'import Builtin' and allow Builtin usage.
 EXPERIMENTAL_FEATURE(BuiltinModule, true)
 
+// Enable strict concurrency.
+EXPERIMENTAL_FEATURE(StrictConcurrency, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3173,6 +3173,10 @@ static bool usesFeatureExistentialAny(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureStrictConcurrency(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureImportObjcForwardDeclarations(Decl *decl) {
   ClangNode clangNode = decl->getClangNode();
   if (!clangNode)

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency=complete
+// REQUIRES: concurrency
+
+class C1 { } // expected-note{{class 'C1' does not conform to the 'Sendable' protocol}}
+class C2 { }
+
+@available(*, unavailable)
+extension C2: Sendable {} // expected-note{{conformance of 'C2' to 'Sendable' has been explicitly marked unavailable here}}
+
+protocol TestProtocol {
+  associatedtype Value: Sendable
+}
+
+struct Test1: TestProtocol { // expected-warning{{type 'Test1.Value' (aka 'C1') does not conform to the 'Sendable' protocol}}
+  typealias Value = C1
+}
+
+struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendable' is unavailable}}
+  // expected-note@-1{{in associated type 'Self.Value' (inferred as 'C2')}}
+  typealias Value = C2
+}

--- a/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency=targeted
+// REQUIRES: concurrency
+
+class C { // expected-note{{class 'C' does not conform to the 'Sendable' protocol}}
+  var counter = 0
+}
+
+func acceptsSendable<T: Sendable>(_: T) { }
+
+func testNoConcurrency(c: C) {
+  acceptsSendable(c)
+}
+
+@available(SwiftStdlib 5.1, *)
+func testConcurrency(c: C) async {
+  acceptsSendable(c) // expected-warning{{type 'C' does not conform to the 'Sendable' protocol}}
+}
+


### PR DESCRIPTION
Upcoming and experimental features are supported via command-line flags and also in the SwiftPM manifest. Introduce it as an experimental feature so that it can be enabled via SwiftPM without having to resort to unsafe flags.

The `StrictConcurrency` experimental feature can also provide a strictness level in the same manner as `-strict-concurrency`, e.g., `StrictConcurrency=targeted`. If the level is not provided, it'll be `complete`.

Note that we do not introduce this as an "upcoming" feature, because upcoming features should be in their final "Swift 6" form before becoming available. We are still tuning the checking for concurrency.
