### PR TITLE
Add `StrictConcurrency` as an always-enabled experimental feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -202,6 +202,9 @@ EXPERIMENTAL_FEATURE(ReferenceBindings, false)
 /// Enable the explicit 'import Builtin' and allow Builtin usage.
 EXPERIMENTAL_FEATURE(BuiltinModule, true)
 
+// Enable strict concurrency.
+EXPERIMENTAL_FEATURE(StrictConcurrency, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3174,6 +3174,10 @@ static bool usesFeatureExistentialAny(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureStrictConcurrency(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureImportObjcForwardDeclarations(Decl *decl) {
   ClangNode clangNode = decl->getClangNode();
   if (!clangNode)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -508,6 +508,15 @@ static void diagnoseCxxInteropCompatMode(Arg *verArg, ArgList &Args,
   diags.diagnose(SourceLoc(), diag::valid_cxx_interop_modes, versStr);
 }
 
+static llvm::Optional<StrictConcurrency>
+parseStrictConcurrency(StringRef value) {
+  return llvm::StringSwitch<llvm::Optional<StrictConcurrency>>(value)
+      .Case("minimal", StrictConcurrency::Minimal)
+      .Case("targeted", StrictConcurrency::Targeted)
+      .Case("complete", StrictConcurrency::Complete)
+      .Default(llvm::None);
+}
+
 static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                           DiagnosticEngine &Diags,
                           const FrontendOptions &FrontendOpts) {
@@ -753,9 +762,33 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     addFutureFeatureIfNotImplied(Feature::BareSlashRegexLiterals);
 
   for (const Arg *A : Args.filtered(OPT_enable_experimental_feature)) {
+    // Allow StrictConcurrency to have a value that corresponds to the
+    // -strict-concurrency=<blah> settings.
+    StringRef value = A->getValue();
+    if (value.startswith("StrictConcurrency")) {
+      auto decomposed = value.split("=");
+      if (decomposed.first == "StrictConcurrency") {
+        bool handled;
+        if (decomposed.second == "") {
+          Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
+          handled = true;
+        } else if (auto level = parseStrictConcurrency(decomposed.second)) {
+          Opts.StrictConcurrencyLevel = *level;
+          handled = true;
+        } else {
+          handled = false;
+        }
+
+        if (handled) {
+          Opts.Features.insert(Feature::StrictConcurrency);
+          continue;
+        }
+      }
+    }
+
     // If this is a known experimental feature, allow it in +Asserts
     // (non-release) builds for testing purposes.
-    if (auto feature = getExperimentalFeature(A->getValue())) {
+    if (auto feature = getExperimentalFeature(value)) {
 #ifdef NDEBUG
       if (!isFeatureAvailableInProduction(*feature)) {
         Diags.diagnose(SourceLoc(),
@@ -913,6 +946,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   } else if (Args.hasArg(OPT_warn_concurrency)) {
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
+  } else if (Opts.hasFeature(Feature::StrictConcurrency)) {
+    // Already set above.
   } else {
     // Default to minimal checking in Swift 5.x.
     Opts.StrictConcurrencyLevel = StrictConcurrency::Minimal;

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency=complete
+// REQUIRES: concurrency
+
+class C1 { } // expected-note{{class 'C1' does not conform to the 'Sendable' protocol}}
+class C2 { }
+
+@available(*, unavailable)
+extension C2: Sendable {} // expected-note{{conformance of 'C2' to 'Sendable' has been explicitly marked unavailable here}}
+
+protocol TestProtocol {
+  associatedtype Value: Sendable
+}
+
+struct Test1: TestProtocol { // expected-warning{{type 'Test1.Value' (aka 'C1') does not conform to the 'Sendable' protocol}}
+  typealias Value = C1
+}
+
+struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendable' is unavailable}}
+  // expected-note@-1{{in associated type 'Self.Value' (inferred as 'C2')}}
+  typealias Value = C2
+}

--- a/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency=targeted
+// REQUIRES: concurrency
+
+class C { // expected-note{{class 'C' does not conform to the 'Sendable' protocol}}
+  var counter = 0
+}
+
+func acceptsSendable<T: Sendable>(_: T) { }
+
+func testNoConcurrency(c: C) {
+  acceptsSendable(c)
+}
+
+@available(SwiftStdlib 5.1, *)
+func testConcurrency(c: C) async {
+  acceptsSendable(c) // expected-warning{{type 'C' does not conform to the 'Sendable' protocol}}
+}
+


### PR DESCRIPTION
Upcoming and experimental features are supported via command-line flags and also in the SwiftPM manifest. Introduce it as an experimental feature so that it can be enabled via SwiftPM without having to resort to unsafe flags.

The `StrictConcurrency` experimental feature can also provide a strictness level in the same manner as `-strict-concurrency`, e.g., `StrictConcurrency=targeted`. If the level is not provided, it'll be `complete`.

Note that we do not introduce this as an "upcoming" feature, because upcoming features should be in their final "Swift 6" form before becoming available. We are still tuning the checking for concurrency.
