### PR TITLE
Rebind Memory Idiomatically

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -313,17 +313,7 @@ extension _SmallString {
   ) rethrows {
     self.init()
     try self.withMutableCapacity {
-      let capacity = $0.count
-      let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
-      // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the
-      // duration of the closure. Accessing self after this rebind is undefined.
-      let ptr = rawPtr.bindMemory(to: UInt8.self, capacity: capacity)
-      defer {
-        // Restore the memory type of self._storage
-        _ = rawPtr.bindMemory(to: RawBitPattern.self, capacity: 1)
-      }
-      return try initializer(
-        UnsafeMutableBufferPointer<UInt8>(start: ptr, count: capacity))
+      try $0.withMemoryRebound(to: UInt8.self, initializer)
     }
     self._invariantCheck()
   }


### PR DESCRIPTION
While working on `String` stuff, I came across many lines that could be replaced by a single, more modern utterance.

(no related issue)