### PR TITLE
SIL: Pass SubstFlags::PreservePackExpansionLevel in a few places [5.9]

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -168,7 +168,7 @@ public:
 
   /// Query whether any replacement types in the map contain an opened
   /// existential.
-  bool hasOpenedExistential() const;
+  bool hasLocalArchetypes() const;
 
   /// Query whether any replacement types in the map contain dynamic Self.
   bool hasDynamicSelf() const;

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -192,15 +192,12 @@ public:
     // If we have local archetypes to substitute, check whether that's
     // relevant to this particular substitution.
     if (!LocalArchetypeSubs.empty()) {
-      for (auto ty : Subs.getReplacementTypes()) {
+      if (Subs.hasLocalArchetypes()) {
         // If we found a type containing a local archetype, substitute
         // open existentials throughout the substitution map.
-        if (ty->hasLocalArchetype()) {
-          Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{
-                              LocalArchetypeSubs},
-                            MakeAbstractConformanceForGenericType());
-          break;
-        }
+        Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{
+                            LocalArchetypeSubs},
+                          MakeAbstractConformanceForGenericType());
       }
     }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -195,9 +195,9 @@ public:
       if (Subs.hasLocalArchetypes()) {
         // If we found a type containing a local archetype, substitute
         // open existentials throughout the substitution map.
-        Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{
-                            LocalArchetypeSubs},
-                          MakeAbstractConformanceForGenericType());
+        Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
+                          MakeAbstractConformanceForGenericType(),
+                          SubstFlags::PreservePackExpansionLevel);
       }
     }
 
@@ -220,7 +220,9 @@ public:
     return Ty.subst(
       Builder.getModule(),
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractConformanceForGenericType());
+      MakeAbstractConformanceForGenericType(),
+      CanGenericSignature(),
+      SubstFlags::PreservePackExpansionLevel);
   }
   SILType getOpType(SILType Ty) {
     Ty = getTypeInClonedContext(Ty);
@@ -239,7 +241,8 @@ public:
 
     return ty.subst(
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractConformanceForGenericType()
+      MakeAbstractConformanceForGenericType(),
+      SubstFlags::PreservePackExpansionLevel
     )->getCanonicalType();
   }
 
@@ -352,7 +355,8 @@ public:
         conformance.subst(ty,
                           QueryTypeSubstitutionMapOrIdentity{
                                                         LocalArchetypeSubs},
-                          MakeAbstractConformanceForGenericType());
+                          MakeAbstractConformanceForGenericType(),
+                          SubstFlags::PreservePackExpansionLevel);
     }
 
     return asImpl().remapConformance(getASTTypeInClonedContext(ty),

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -132,9 +132,9 @@ bool SubstitutionMap::hasArchetypes() const {
   return false;
 }
 
-bool SubstitutionMap::hasOpenedExistential() const {
+bool SubstitutionMap::hasLocalArchetypes() const {
   for (Type replacementTy : getReplacementTypesBuffer()) {
-    if (replacementTy && replacementTy->hasOpenedExistential())
+    if (replacementTy && replacementTy->hasLocalArchetype())
       return true;
   }
   return false;

--- a/test/SILOptimizer/variadic_generics_sil_cloner.swift
+++ b/test/SILOptimizer/variadic_generics_sil_cloner.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+
+@_optimize(none)
+public func callee<T, each X>(_: T, _: repeat each X) {}
+
+@_transparent
+public func caller<each X>(_ x: repeat each X) {
+  repeat callee(each x, repeat each x)
+}
+
+public func outerCaller<each X>(_ x: repeat each X) {
+  caller(repeat each x)
+}
+
+// CHECK-LABEL: sil @$s28variadic_generics_sil_cloner11outerCalleryyxxQpRvzlF : $@convention(thin) <each X> (@pack_guaranteed Pack{repeat each X}) -> () {
+// CHECK: [[CALLEE:%.*]] = function_ref @$s28variadic_generics_sil_cloner6calleeyyx_q_q_QptRv_r0_lF : $@convention(thin) <τ_0_0, each τ_0_1> (@in_guaranteed τ_0_0, @pack_guaranteed Pack{repeat each τ_0_1}) -> ()
+// CHECK: apply [[CALLEE]]<@pack_element("{{.*}}") each X, Pack{repeat each X}>(
+// CHECK: // end sil function '$s28variadic_generics_sil_cloner11outerCalleryyxxQpRvzlF'


### PR DESCRIPTION
* Description: In a few places we do a substitution with a callback that doesn't wrap a pack parameter `T` in a `PackType{PackExpansionType{T}}`. This no longer works with the PackElementType refactoring that landed recently because we get confused if we see a free pack parameter that is outside of an expansion. These callbacks should be refactored to do the pack wrapping correctly, but in the meantime the easiest fix is to pass a temporary flag which reverts to the old behavior.

* Scope of the issue: There was an easy test case that crashed in the SIL optimizer.

* Risk: Only impacts variadic generic code paths.

* Radar: rdar://problem/111219086

* Reviewed by: @hborla 