### PR TITLE
[test] Make KeyPath test pointer-size agnostic part 2

### DIFF
--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1100,7 +1100,7 @@ if #available(SwiftStdlib 5.9, *) {
     let catNameKp = _createOffsetBasedKeyPath(
       root: Cat.self,
       value: String.self,
-      offset: 16
+      offset: 2 * MemoryLayout<UnsafeRawPointer>.size
     ) as? KeyPath<Cat, String>
 
     expectNotNil(catNameKp)


### PR DESCRIPTION
This is a follow-up fix of https://github.com/apple/swift/pull/66771