### PR TITLE
[SourceKit] Don't report type for `InjectIntoOptionalExpr`

### DIFF
--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -667,6 +667,15 @@ class ExpressionTypeCollector: public SourceEntityWalker {
     if (E->getType().isNull())
       return false;
 
+    // We should not report a type for implicit expressions, except for
+    // - `OptionalEvaluationExpr` to show the correct type when there is optional chaining
+    // - `DotSyntaxCallExpr` to report the method type without the metatype
+    if (E->isImplicit() &&
+        !isa<OptionalEvaluationExpr>(E) &&
+        !isa<DotSyntaxCallExpr>(E)) {
+      return false;
+    }
+
     // If we have already reported types for this source range, we shouldn't
     // report again. This makes sure we always report the outtermost type of
     // several overlapping expressions.

--- a/test/SourceKit/ExpressionType/basic.swift
+++ b/test/SourceKit/ExpressionType/basic.swift
@@ -20,6 +20,13 @@ func DictS(_ a: [Int: S]) {
   _ = a[2]?.val.advanced(by: 1).byteSwapped
 }
 
+func optExpr(str: String?) -> String? {
+  let a: String? = str
+  let b: String? = "Hey"
+  let c: String = "Bye"
+  return c
+}
+
 // RUN: %sourcekitd-test -req=collect-type %s -- %s | %FileCheck %s
 // CHECK: (183, 202): Int
 // CHECK: (183, 196): String
@@ -31,3 +38,7 @@ func DictS(_ a: [Int: S]) {
 // CHECK: (291, 292): Int?
 // CHECK: (295, 332): Int?
 // CHECK: (295, 320): Int
+// CHECK: (395, 398): String?
+// CHECK: (418, 423): String
+// CHECK: (442, 447): String
+// CHECK: (457, 458): String


### PR DESCRIPTION
Fixes incorrectly reporting an optional type for an expression when the contextual type is optional.

fixes #66882
rdar://111462279