### PR TITLE
[5.9][Macros] Fix memory leak in PluginSearchOption

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -247,6 +247,23 @@ public:
       : kind(Kind::ExternalPluginPath) {
     storage.emplace<ExternalPluginPath>(kind, v);
   }
+  PluginSearchOption(const PluginSearchOption &o) : kind(o.kind) {
+    storage.copyConstruct(o.kind, o.storage);
+  }
+  PluginSearchOption(PluginSearchOption &&o) : kind(o.kind) {
+    storage.moveConstruct(o.kind, std::move(o.storage));
+  }
+  ~PluginSearchOption() { storage.destruct(kind); }
+  PluginSearchOption &operator=(const PluginSearchOption &o) {
+    storage.copyAssign(kind, o.kind, o.storage);
+    kind = o.kind;
+    return *this;
+  }
+  PluginSearchOption &operator=(PluginSearchOption &&o) {
+    storage.moveAssign(kind, o.kind, std::move(o.storage));
+    kind = o.kind;
+    return *this;
+  }
 
   Kind getKind() const { return kind; }
 


### PR DESCRIPTION
Cherry-pick #67007 into release/5.9

* **Explanation**: Implement special member functions in `PluginSearchOtpion`. They were not properly implemented. `ExternalUnion` requires explicit `destruct()` call to destruct the payload. This fixes a memory leak when plugin search frontend options are specified.
* **Scope**: Search path option
* **Risk**: Low. Just fixing a memory leak without changing other code
* **Testing**: Leak sanitizer enabled PR testing passed
* **Issue**: rdar://111064325
* **Reviewer**: Ben Barham (@bnbarham)