### PR TITLE
[NFC] Escape an @ that throws spurious warnings

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -578,7 +578,7 @@ struct PrintOptions {
   /// If false, we print them as ordinary associated types.
   bool PrintPrimaryAssociatedTypes = true;
 
-  /// Whether or not to print \c @attached(extension) attributes on
+  /// Whether or not to print \c \@attached(extension) attributes on
   /// macro declarations. This is used for feature suppression in
   /// Swift interface printing.
   bool PrintExtensionMacroAttributes = true;


### PR DESCRIPTION
This @ being unescaped throws a LOT of spurious warnings during build.