### PR TITLE
Add missing 'iterator' include to StableHasher

### DIFF
--- a/include/swift/Basic/StableHasher.h
+++ b/include/swift/Basic/StableHasher.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <tuple>
 #include <utility>
+#include <iterator>
 
 namespace swift {
 


### PR DESCRIPTION
StableHasher uses std::distance, which should be included via iterator. Getting reports of it not getting pulled in correctly with some newer libstdc++ versions.
