### PR TITLE
[IRGen] Fix getEnumTag witness function selection

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -902,9 +902,10 @@ static bool isRuntimeInstatiatedLayoutString(IRGenModule &IGM,
 static llvm::Constant *getEnumTagFunction(IRGenModule &IGM,
                                      const EnumTypeLayoutEntry *typeLayoutEntry,
                                           GenericSignature genericSig) {
-  if ((!typeLayoutEntry->layoutString(IGM, genericSig) &&
-      !isRuntimeInstatiatedLayoutString(IGM, typeLayoutEntry)) ||
-      typeLayoutEntry->isSingleton()) {
+  if (!typeLayoutEntry->layoutString(IGM, genericSig) &&
+      !isRuntimeInstatiatedLayoutString(IGM, typeLayoutEntry)) {
+    return nullptr;
+  } else if (typeLayoutEntry->isSingleton()) {
     return IGM.getSingletonEnumGetEnumTagFn();
   } else if (!typeLayoutEntry->isFixedSize(IGM)) {
     if (typeLayoutEntry->isMultiPayloadEnum()) {


### PR DESCRIPTION
When a type is not runtime instantiated and we are not able to compute a layout string for it, we can't assign it a layout string witness function.