### PR TITLE
[cxx-interop] Import ObjCPropertyDecl of type NS_OPTIONS fields as struct type

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -816,6 +816,31 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
 using MirroredMethodEntry =
   std::tuple<const clang::ObjCMethodDecl*, ProtocolDecl*, bool /*isAsync*/>;
 
+ImportedType tryImportOptionsTypeForField(const clang::QualType type,
+                                          ClangImporter::Implementation &Impl) {
+  ImportedType importedType;
+  auto fieldType = type;
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
+    fieldType = elaborated->desugar();
+  if (auto typedefType = dyn_cast<clang::TypedefType>(fieldType)) {
+    if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
+      if (auto clangEnum =
+              findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
+        // If this fails, it means that we need a stronger predicate for
+        // determining the relationship between an enum and typedef.
+        assert(
+            clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
+            typedefType->getCanonicalTypeInternal());
+        if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
+          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
+                          false};
+        }
+      }
+    }
+  }
+  return importedType;
+}
+
 namespace {
   /// Customized llvm::DenseMapInfo for storing borrowed APSInts.
   struct APSIntRefDenseMapInfo {
@@ -3663,23 +3688,8 @@ namespace {
           return nullptr;
       }
 
-      ImportedType importedType;
       auto fieldType = decl->getType();
-      if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
-        fieldType = elaborated->desugar();
-      if (auto typedefType = dyn_cast<clang::TypedefType>(fieldType)) {
-        if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
-          if (auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
-            // If this fails, it means that we need a stronger predicate for
-            // determining the relationship between an enum and typedef.
-            assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-                   typedefType->getCanonicalTypeInternal());
-            if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-              importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
-            }
-          }
-        }
-      }
+      ImportedType importedType = tryImportOptionsTypeForField(fieldType, Impl);
 
       if (!importedType)
         importedType =

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5211,7 +5211,11 @@ namespace {
         }
       }
 
-      auto importedType = Impl.importPropertyType(decl, isInSystemModule(dc));
+      auto fieldType = decl->getType();
+      ImportedType importedType = tryImportOptionsTypeForField(fieldType, Impl);
+
+      if (!importedType)
+        importedType = Impl.importPropertyType(decl, isInSystemModule(dc));
       if (!importedType) {
         Impl.addImportDiagnostic(
             decl, Diagnostic(diag::objc_property_not_imported, decl),

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3224,6 +3224,9 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
           importedType.isImplicitlyUnwrapped()};
 }
 
+ImportedType tryImportOptionsTypeForField(const clang::QualType type,
+                                          ClangImporter::Implementation &Impl);
+
 ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
     const DeclContext *dc, const clang::ObjCPropertyDecl *property,
     const clang::ObjCMethodDecl *clangDecl, bool isFromSystemModule,
@@ -3247,9 +3250,13 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   DeclContext *origDC = importDeclContextOf(property,
                                             property->getDeclContext());
   assert(origDC);
+  auto fieldType = isGetter ? clangDecl->getReturnType() : clangDecl->getParamDecl(0)->getType();
+  ImportedType importedNSOptionsType = tryImportOptionsTypeForField(fieldType, *this);
 
   // Import the property type, independent of what kind of accessor this is.
   auto importedType = importPropertyType(property, isFromSystemModule);
+  if (importedNSOptionsType)
+    importedType = importedNSOptionsType;
   if (!importedType)
     return {Type(), false};
 

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -82,6 +82,10 @@ struct HasNSOptionField {
   Bar bar;
 };
 
+@interface HasNSOptionFieldObjC
+@property Bar bar;
+@end
+
 Baz CFunctionReturningNSOption();
 void CFunctionTakingNSOption(Baz);
 

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -25,3 +25,9 @@ import CenumsNSOptions
 // CHECK: struct HasNSOptionField {
 // CHECK:   var bar: Bar
 // CHECK: }
+
+// CHECK: class HasNSOptionFieldObjC {
+// CHECK-NEXT:   var bar: Bar
+// CHECK-NEXT:   class func bar() -> Bar
+// CHECK-NEXT:   class func setBar(_ bar: Bar)
+// CHECK-NEXT: }


### PR DESCRIPTION
Try importing ObjCPropertyDecl field types the C++-Interop-NS_OPTIONS way. This will fix cases such as:

```swift
import UIKit

func f(gesture: UISwipeGestureRecognizer,
       direction: UISwipeGestureRecognizer.Direction) {
  gesture.direction = direction // error
}
```

because it will make sure the field inside class UIGestureRecognizer is of the enum-struct type and not the typedef-rawValue type when importing an ObjC class.

