### PR TITLE
Add experimental feature DeferSendableChecking

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4625,6 +4625,41 @@ public:
   }
 };
 
+// ApplyIsolationCrossing records the source and target of an isolation crossing
+// within an ApplyExpr. In particular, it stores the isolation of the caller
+// and the callee of the ApplyExpr, to be used for inserting implicit actor
+// hops for implicitly async functions and to be used for diagnosing potential
+// data races that could arise when non-Sendable values are passed to calls
+// that cross isolation domains.
+struct ApplyIsolationCrossing {
+  ActorIsolation CallerIsolation;
+  ActorIsolation CalleeIsolation;
+
+  ApplyIsolationCrossing()
+      : CallerIsolation(ActorIsolation::forUnspecified()),
+        CalleeIsolation(ActorIsolation::forUnspecified()) {}
+
+  ApplyIsolationCrossing(ActorIsolation CallerIsolation,
+                         ActorIsolation CalleeIsolation)
+      : CallerIsolation(CallerIsolation), CalleeIsolation(CalleeIsolation) {}
+
+  // If the callee is not actor isolated, then this crossing exits isolation.
+  // This method returns true iff this crossing exits isolation.
+  bool exitsIsolation() const { return !CalleeIsolation.isActorIsolated(); }
+
+  // Whether to use the isolation of the caller or callee for generating
+  // informative diagnostics depends on whether this crossing is an exit.
+  // In particular, we tend to use the caller isolation for diagnostics,
+  // but if this crossing is an exit from isolation then the callee isolation
+  // is not very informative, so we use the caller isolation instead.
+  ActorIsolation getDiagnoseIsolation() const {
+    return exitsIsolation() ? CallerIsolation : CalleeIsolation;
+  }
+
+  ActorIsolation getCallerIsolation() const { return CallerIsolation; }
+  ActorIsolation getCalleeIsolation() const {return CalleeIsolation; }
+};
+
 /// ApplyExpr - Superclass of various function calls, which apply an argument to
 /// a function to get a result.
 class ApplyExpr : public Expr {
@@ -4634,13 +4669,14 @@ class ApplyExpr : public Expr {
   /// The list of arguments to call the function with.
   ArgumentList *ArgList;
 
-  ActorIsolation implicitActorHopTarget;
+  // If this apply crosses isolation boundaries, record the callee and caller
+  // isolations in this struct.
+  llvm::Optional<ApplyIsolationCrossing> IsolationCrossing;
 
 protected:
   ApplyExpr(ExprKind kind, Expr *fn, ArgumentList *argList, bool implicit,
             Type ty = Type())
-      : Expr(kind, implicit, ty), Fn(fn), ArgList(argList),
-        implicitActorHopTarget(ActorIsolation::forUnspecified()) {
+      : Expr(kind, implicit, ty), Fn(fn), ArgList(argList) {
     assert(ArgList);
     assert(classof((Expr*)this) && "ApplyExpr::classof out of date");
     Bits.ApplyExpr.ThrowsIsSet = false;
@@ -4687,6 +4723,21 @@ public:
     Bits.ApplyExpr.NoAsync = noAsync;
   }
 
+  // Return the optionally stored ApplyIsolationCrossing instance - set iff this
+  // ApplyExpr crosses isolation domains
+  const llvm::Optional<ApplyIsolationCrossing> getIsolationCrossing() const {
+    return IsolationCrossing;
+  }
+
+  // Record that this apply crosses isolation domains, noting the isolation of
+  // the caller and callee by storing them into the IsolationCrossing field
+  void setIsolationCrossing(
+      ActorIsolation callerIsolation, ActorIsolation calleeIsolation) {
+    assert(!IsolationCrossing.has_value()
+             && "IsolationCrossing should not be set twice");
+    IsolationCrossing = {callerIsolation, calleeIsolation};
+  }
+
   /// Is this application _implicitly_ required to be an async call?
   /// That is, does it need to be guarded by hop_to_executor.
   /// Note that this is _not_ a check for whether the callee is async!
@@ -4710,13 +4761,20 @@ public:
     if (!Bits.ApplyExpr.ImplicitlyAsync)
       return llvm::None;
 
-    return implicitActorHopTarget;
+    auto isolationCrossing = getIsolationCrossing();
+    assert(isolationCrossing.has_value()
+           && "Implicitly async ApplyExprs should always "
+              "have had IsolationCrossing set");
+
+    return isolationCrossing.value().CalleeIsolation;
   }
 
   /// Note that this application is implicitly async and set the target.
   void setImplicitlyAsync(ActorIsolation target) {
+    assert(getIsolationCrossing().has_value()
+           && "ApplyExprs should always call setIsolationCrossing"
+              " before setImplicitlyAsync");
     Bits.ApplyExpr.ImplicitlyAsync = true;
-    implicitActorHopTarget = target;
   }
 
   /// Is this application _implicitly_ required to be a throwing call?

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -217,6 +217,9 @@ EXPERIMENTAL_FEATURE(BuiltinModule, true)
 // Enable strict concurrency.
 EXPERIMENTAL_FEATURE(StrictConcurrency, true)
 
+/// Defer Sendable checking to SIL diagnostic phase.
+EXPERIMENTAL_FEATURE(DeferredSendableChecking, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -365,6 +365,8 @@ PASS(TempRValueOpt, "temp-rvalue-opt",
      "Remove short-lived immutable temporary copies")
 PASS(IRGenPrepare, "irgen-prepare",
      "Cleanup SIL in preparation for IRGen")
+PASS(SendNonSendable, "send-non-sendable",
+     "Checks calls that send non-sendable values between isolation domains")
 PASS(SILGenCleanup, "silgen-cleanup",
      "Cleanup SIL in preparation for diagnostics")
 PASS(SILCombine, "sil-combine",

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2715,6 +2715,25 @@ public:
       PrintWithColorRAII(OS, ExprModifierColor)
         << (E->throws() ? " throws" : " nothrow");
     }
+    PrintWithColorRAII(OS, ExprModifierColor)
+        << " isolationCrossing=";
+    auto isolationCrossing = E->getIsolationCrossing();
+    if (isolationCrossing.has_value()) {
+      PrintWithColorRAII(OS, ExprModifierColor)
+          << "{caller='";
+      simple_display(PrintWithColorRAII(OS, ExprModifierColor).getOS(),
+                     isolationCrossing.value().getCallerIsolation());
+      PrintWithColorRAII(OS, ExprModifierColor)
+          << "', callee='";
+      simple_display(PrintWithColorRAII(OS, ExprModifierColor).getOS(),
+                     isolationCrossing.value().getCalleeIsolation());
+
+      PrintWithColorRAII(OS, ExprModifierColor)
+          << "'}";
+    } else {
+      PrintWithColorRAII(OS, ExprModifierColor)
+          << "none";
+    }
     OS << '\n';
     printRec(E->getFn());
     OS << '\n';

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3465,6 +3465,10 @@ static bool usesFeatureParameterPacks(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureDeferredSendableChecking(Decl *decl) {
+  return false;
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(swiftSILOptimizer PRIVATE
   PMOMemoryUseCollector.cpp
   RawSILInstLowering.cpp
   ReferenceBindingTransform.cpp
+  SendNonSendable.cpp
   SILGenCleanup.cpp
   YieldOnceCheck.cpp
   OSLogOptimization.cpp

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1,0 +1,34 @@
+#include "../../Sema/TypeCheckConcurrency.h"
+#include "swift/AST/Expr.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+class SendNonSendable : public SILFunctionTransform {
+
+  // find any ApplyExprs in this function, and check if any of them make an
+  // unsatisfied isolation jump, emitting appropriate diagnostics if so
+  void run() override {
+    SILFunction *function = getFunction();
+
+    if (!function->getASTContext().LangOpts
+        .hasFeature(Feature::DeferredSendableChecking))
+      return;
+
+    DeclContext *declContext = function->getDeclContext();
+
+    for (SILBasicBlock &bb : *function) {
+      for (SILInstruction &instr : bb) {
+        if (ApplyExpr *apply = instr.getLoc().getAsASTNode<ApplyExpr>()) {
+          diagnoseApplyArgSendability(apply, declContext);
+        }
+      }
+    }
+  }
+};
+
+/// This pass is known to depend on the following passes having run before it:
+/// none so far
+SILTransform *swift::createSendNonSendable() {
+  return new SendNonSendable();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -132,6 +132,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addAddressLowering();
 
   P.addFlowIsolation();
+  P.addSendNonSendable();
 
   // Automatic differentiation: canonicalize all differentiability witnesses
   // and `differentiable_function` instructions.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -536,6 +536,11 @@ bool isPotentiallyIsolatedActor(
     VarDecl *var, llvm::function_ref<bool(ParamDecl *)> isIsolated =
                       [](ParamDecl *P) { return P->isIsolated(); });
 
+/// Check whether the given ApplyExpr makes an unsatisfied isolation jump
+/// and if so, emit diagnostics for any nonsendable arguments to the apply
+bool diagnoseApplyArgSendability(
+    swift::ApplyExpr *apply, const DeclContext *declContext);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKCONCURRENCY_H */

--- a/test/Concurrency/DeferredSendableChecking/defer_and_silgen.swift
+++ b/test/Concurrency/DeferredSendableChecking/defer_and_silgen.swift
@@ -1,0 +1,66 @@
+// RUN: %target-typecheck-verify-swift -emit-sil -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
+// REQUIRES: concurrency
+
+/*
+ This file tests the experimental DeferredSendableChecking feature. This features the passing
+ of non-sendable values to isolation-crossing calls to not yield diagnostics during AST passes,
+ but to instead emit them later during a mandatory SIL pass.
+
+ Together, `defer_and_silgen.swift` and `defer_and_typecheck_only.swift` test this feature by
+ testing the same code, but expecting different sets of diagnostics. The former runs -emit-sil,
+ and expects all diagnostics to be emitted, but the latter only runs AST typechecking via -typecheck,
+ and expects some sendability diagnostics but not non-sendable arg diagnostics to be emitted.
+ */
+
+class NonSendable {
+// expected-note@-1 6{{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+    var x = 0
+}
+
+let globalNS = NonSendable()
+
+@available(SwiftStdlib 5.1, *)
+func takesNS(_ : NonSendable) async {}
+
+@available(SwiftStdlib 5.1, *)
+func retsNS() async -> NonSendable { NonSendable() }
+
+@available(SwiftStdlib 5.1, *)
+func callActorFuncsFromNonisolated(a : A, ns : NonSendable) async {
+    // Non-sendable value passed from actor isolated to nonisolated
+
+    await a.actorTakesNS(ns)
+    //expected-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    _ = await a.actorRetsNS()
+    //expected-warning@-1{{non-sendable type 'NonSendable' returned by implicitly asynchronous call to actor-isolated function cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+actor A {
+    let actorNS = NonSendable()
+
+    func actorTakesNS(_ : NonSendable) async {}
+
+    func actorRetsNS() async -> NonSendable { NonSendable() }
+
+    func callNonisolatedFuncsFromActor(ns: NonSendable) async {
+        // Non-sendable value passed from nonisolated to actor isolated
+
+        await takesNS(ns)
+        //expected-warning@-1{{passing argument of non-sendable type 'NonSendable' outside of actor-isolated context may introduce data races}}
+
+        _ = await retsNS()
+        //expected-warning@-1{{non-sendable type 'NonSendable' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
+    }
+
+    func callActorFuncsFromDiffActor(ns : NonSendable, a : A) async {
+        // Non-sendable value passed between the isolation of two different actors
+
+        await a.actorTakesNS(ns)
+        //expected-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+        _ = await a.actorRetsNS()
+        //expected-warning@-1{{non-sendable type 'NonSendable' returned by implicitly asynchronous call to actor-isolated function cannot cross actor boundary}}
+    }
+}

--- a/test/Concurrency/DeferredSendableChecking/defer_and_typecheck_only.swift
+++ b/test/Concurrency/DeferredSendableChecking/defer_and_typecheck_only.swift
@@ -1,0 +1,66 @@
+// RUN: %target-typecheck-verify-swift -typecheck -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
+// REQUIRES: concurrency
+
+/*
+ This file tests the experimental DeferredSendableChecking feature. This features the passing
+ of non-sendable values to isolation-crossing calls to not yield diagnostics during AST passes,
+ but to instead emit them later during a mandatory SIL pass.
+
+ Together, `defer_and_silgen.swift` and `defer_and_typecheck_only.swift` test this feature by
+ testing the same code, but expecting different sets of diagnostics. The former runs -emit-sil,
+ and expects all diagnostics to be emitted, but the latter only runs AST typechecking via -typecheck,
+ and expects some sendability diagnostics but not non-sendable arg diagnostics to be emitted.
+ */
+
+class NonSendable {
+// expected-note@-1 3{{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+    var x = 0
+}
+
+let globalNS = NonSendable()
+
+@available(SwiftStdlib 5.1, *)
+func takesNS(_ : NonSendable) async {}
+
+@available(SwiftStdlib 5.1, *)
+func retsNS() async -> NonSendable { NonSendable() }
+
+@available(SwiftStdlib 5.1, *)
+func callActorFuncsFromNonisolated(a : A, ns : NonSendable) async {
+    // Non-sendable value passed from actor isolated to nonisolated
+
+    await a.actorTakesNS(ns)
+    //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    _ = await a.actorRetsNS()
+    //expected-warning@-1{{non-sendable type 'NonSendable' returned by implicitly asynchronous call to actor-isolated function cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+        actor A {
+    let actorNS = NonSendable()
+
+    func actorTakesNS(_ : NonSendable) async {}
+
+    func actorRetsNS() async -> NonSendable { NonSendable() }
+
+    func callNonisolatedFuncsFromActor(ns: NonSendable) async {
+        // Non-sendable value passed from nonisolated to actor isolated
+
+        await takesNS(ns)
+        //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' outside of actor-isolated context may introduce data races}}
+
+        _ = await retsNS()
+        //expected-warning@-1{{non-sendable type 'NonSendable' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
+    }
+
+    func callActorFuncsFromDiffActor(ns : NonSendable, a : A) async {
+        // Non-sendable value passed between the isolation of two different actors
+
+        await a.actorTakesNS(ns)
+        //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+        _ = await a.actorRetsNS()
+        //expected-warning@-1{{non-sendable type 'NonSendable' returned by implicitly asynchronous call to actor-isolated function cannot cross actor boundary}}
+    }
+}


### PR DESCRIPTION
This PR begins a project to add more sophisticated Sensibility checking to Swift's Concurrency model. In particular, sending non-`Sendable` values between differing isolations should only produce a diagnostic if it is possible that those values are accessible from, or permit access to, other values that would remain in scope after the send. This PR is the first step in that process. It adds an experimental feature flag `DeferSendableChecking` that, when enabled, prevents the `Sema` AST passes from emitting diagnostics about non-`Sendable` arguments passed to isolation-crossing calls. Instead, a SIL pass is added that checks `ApplyInst` instances in emitted SIL to see if their corresponding `ApplyExpr`s would've produced diagnostics. This pass will be the vehicle for more sophisticated checking in future PRs. 