### PR TITLE
[🍒][cxx-interop][nfc] Disable test for strstr on Linux.

### DIFF
--- a/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
+++ b/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
@@ -15,7 +15,13 @@ func test() {
     // let _ = div(42, 2)
     let _ = sin(x)
     let _ = cos(x)
+
+    // strstr comes from stdlib.h or cstdlib on *some* flavors of linux, so it
+    // won't get imported. We may need a more fine grained approach for those
+    // platforms.
+#if !os(Linux)
     let _ = strstr("a", "aaa")
-  
+#endif
+
     exit(0)
 }


### PR DESCRIPTION
**Explanation:** strstr comes from stdlib.h or cstdlib on *some* flavors of linux, so it won't get imported. We may need a more fine grained approach for those platforms. Until then, disable this part of the test on Linux.
**Scope:** C++ interoperability test
**Risk:** None: this is a test-only change.
**Testing:** Swift unit tests.
**PR:**  https://github.com/apple/swift/pull/67053