### PR TITLE
Disable moveonly_split_module_source_deinit.swift on arm64e

### DIFF
--- a/test/IRGen/moveonly_split_module_source_deinit.swift
+++ b/test/IRGen/moveonly_split_module_source_deinit.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-frontend -module-name server -primary-file %s %S/Inputs/moveonly_split_module_source_input.swift -emit-ir -emit-module-path %t/server.swiftmodule | %FileCheck %s -check-prefix=REFERRING_MODULE
 // RUN: %target-swift-frontend -module-name server  %s -primary-file %S/Inputs/moveonly_split_module_source_input.swift -emit-ir -emit-module-path %t/server.swiftmodule | %FileCheck %s -check-prefix=DEFINING_MODULE
 
+// UNSUPPORTED: CPU=arm64e
+
 // Make sure we call the deinit through the value witness table in the other module.
 
 // REFERRING_MODULE-LABEL: define {{.*}}swiftcc void @"$s6serverAAV4mainyyKFZ"(%swift.refcounted* swiftself %0, %swift.error** noalias nocapture swifterror dereferenceable({{4|8}}) %1) {{.*}}{


### PR DESCRIPTION
rdar://110424902
(cherry picked from commit cfe7b69451eef9aaf0ec66e02a90b6c1fe346fbe)
