### PR TITLE
[backtracing] Mark two tests with REQUIRES

### DIFF
--- a/test/Backtracing/DwarfReader.swift
+++ b/test/Backtracing/DwarfReader.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/DwarfReader %t/Inlining | %FileCheck %s
 
 // REQUIRES: OS=linux-gnu
+// REQUIRES: backtracing
 
 @_spi(DwarfTest) import _Backtracing
 

--- a/test/Backtracing/ElfReader.swift
+++ b/test/Backtracing/ElfReader.swift
@@ -13,6 +13,7 @@
 // RUN: %S/Inputs/make-debuglink %t/fib %t/fib-stripped %t/fib.dbg && %target-run %t/ElfReader %t/fib-stripped | %FileCheck %s --check-prefix DBGLINK
 
 // REQUIRES: OS=linux-gnu
+// REQUIRES: backtracing
 
 @_spi(ElfTest) import _Backtracing
 


### PR DESCRIPTION
The test were enabled even if Backtracing was not enabled in the build settings. Backtracing is enabled with the build script, but not in the default CMake configuration.

