### PR TITLE
Improve DiagnosticEngine's handling of ValueDecl arguments

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -128,13 +128,25 @@ If you run into any issues or have questions while following the steps above, fe
 
 - `%0`, `%1`, etc - Formats the specified diagnostic argument based on its type.
 
-- `%select{a|b|c}0` - Chooses from a list of alternatives, separated by vertical bars, based on the value of the given argument. In this example, a value of 2 in diagnostic argument 0 would result in "c" being output. The argument to the %select may be an integer, enum, or StringRef. If it's a StringRef, the specifier acts as an emptiness check.
+- `%select{a|b|c}0` - Chooses from a list of alternatives, separated by vertical bars, based on the value of the given argument. In this example, a value of 2 in diagnostic argument 0 would result in "c" being output. The argument to the %select may be an integer, enum, StringRef, Identifier, or Decl. If it's a StringRef or Identifier, the specifier acts as an emptiness check; if it's a Decl, it acts as a null check.
 
 - `%s0` - Produces an "s" if the given argument is anything other than 1, as meant for an English plural. This isn't particularly localizable without a more general `%plural` form, but most diagnostics try to avoid cases where a plural/singular distinction would be necessary in the first place.
 
 - `%error` - Represents a branch in a `%select` that should never be taken. In debug builds of the compiler this produces an assertion failure.
 
 - `%%` - Emits a literal percent sign.
+
+There are several format specifiers that are specific to `Decl` parameters:
+
+- `%kind0` - Prefixes the declaration's name with its descriptive decl kind (e.g. `instance method 'foo(x:)'`).
+
+- `%kindonly0` - Inserts only the descriptive decl kind (e.g. `instance method`).
+
+- `%base0` - Inserts only the base name, removing any argument labels (e.g. `'foo'`).
+
+- `%kindbase0` - Combines `kind` and `base` (e.g. `instance method 'foo'`).
+
+Note: If your diagnostic could apply to accessors, be careful how you format the declaration's name; accessors have an empty name, so you need to display their accessor kind and the name of their storage decl instead. Inserting the name with a `Decl *` parameter will handle these complications automatically; if you want to use `DeclName` or `Identifier` instead, you'll probably need a separate version of the diagnostic for accessors. 
 
 ### Diagnostic Verifier ###
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -42,8 +42,10 @@ namespace swift {
   class Decl;
   class DeclAttribute;
   class DiagnosticEngine;
+  class FuncDecl;
   class GeneratedSourceInfo;
   class SourceManager;
+  class TypeAliasDecl;
   class ValueDecl;
   class SourceFile;
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1498,13 +1498,6 @@ namespace swift {
     const StringRef Message;
   };
 
-/// Returns a value that can be used to select between accessor kinds in
-/// diagnostics.
-///
-/// This is correlated with diag::availability_deprecated and others.
-std::pair<unsigned, DeclName>
-getAccessorKindAndNameForDiagnostics(const ValueDecl *D);
-
 /// Retrieve the macro name for a generated source info that represents
 /// a macro expansion.
 DeclName getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info);

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -38,6 +38,7 @@ class NamedDecl;
 }
 
 namespace swift {
+  class ConstructorDecl;
   class Decl;
   class DeclAttribute;
   class DiagnosticEngine;
@@ -109,7 +110,7 @@ namespace swift {
     Unsigned,
     Identifier,
     ObjCSelector,
-    ValueDecl,
+    Decl,
     Type,
     TypeRepr,
     FullyQualifiedType,
@@ -143,7 +144,7 @@ namespace swift {
       StringRef StringVal;
       DeclNameRef IdentifierVal;
       ObjCSelector ObjCSelectorVal;
-      const ValueDecl *TheValueDecl;
+      const Decl *TheDecl;
       Type TypeVal;
       TypeRepr *TyR;
       FullyQualified<Type> FullyQualifiedTypeVal;
@@ -194,8 +195,8 @@ namespace swift {
       : Kind(DiagnosticArgumentKind::ObjCSelector), ObjCSelectorVal(S) {
     }
 
-    DiagnosticArgument(const ValueDecl *VD)
-      : Kind(DiagnosticArgumentKind::ValueDecl), TheValueDecl(VD) {
+    DiagnosticArgument(const Decl *VD)
+      : Kind(DiagnosticArgumentKind::Decl), TheDecl(VD) {
     }
 
     DiagnosticArgument(Type T)
@@ -305,9 +306,9 @@ namespace swift {
       return ObjCSelectorVal;
     }
 
-    const ValueDecl *getAsValueDecl() const {
-      assert(Kind == DiagnosticArgumentKind::ValueDecl);
-      return TheValueDecl;
+    const Decl *getAsDecl() const {
+      assert(Kind == DiagnosticArgumentKind::Decl);
+      return TheDecl;
     }
 
     Type getAsType() const {

--- a/include/swift/AST/DiagnosticsIDE.def
+++ b/include/swift/AST/DiagnosticsIDE.def
@@ -38,17 +38,17 @@ NOTE(ide_redundant_import_indirect, none,
      "module %0 is already imported via another module import", (StringRef))
 
 WARNING(ide_availability_softdeprecated, Deprecation,
-        "%select{getter for |setter for |}0%1 will be deprecated"
-        " in %select{a future version|%select{a future version of %3|%3 %5}4}2"
-        "%select{|: %6}6",
-        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple,
+        "%0 will be deprecated"
+        " in %select{a future version|%select{a future version of %2|%2 %4}3}1"
+        "%select{|: %5}5",
+        (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple,
          StringRef))
 
 WARNING(ide_availability_softdeprecated_rename, Deprecation,
-        "%select{getter for |setter for |}0%1 will be deprecated"
-        " in %select{a future version|%select{a future version of %3|%3 %5}4}2"
-        ": renamed to '%6'",
-        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple, StringRef))
+        "%0 will be deprecated"
+        " in %select{a future version|%select{a future version of %2|%2 %4}3}1"
+        ": renamed to '%5'",
+        (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple, StringRef))
 
 WARNING(ide_recursive_accessor_reference,none,
         "attempting to %select{access|modify}1 %0 within its own "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1668,14 +1668,14 @@ ERROR(attr_objc_implementation_must_be_unconditional,none,
       "only unconditional extensions can implement an Objective-C '@interface'",
       ())
 ERROR(attr_objc_implementation_must_extend_class,none,
-      "cannot mark extension of %0 %1 with '@_objcImplementation'; it is not "
+      "cannot mark extension of %kind0 with '@_objcImplementation'; it is not "
       "an imported Objective-C class",
-      (DescriptiveDeclKind, ValueDecl *))
+      (ValueDecl *))
 ERROR(attr_objc_implementation_must_be_imported,none,
-      "'@_objcImplementation' cannot be used to extend %0 %1 because it was "
+      "'@_objcImplementation' cannot be used to extend %kind0 because it was "
       "defined by a Swift 'class' declaration, not an imported Objective-C "
       "'@interface' declaration",
-      (DescriptiveDeclKind, ValueDecl *))
+      (ValueDecl *))
 ERROR(attr_objc_implementation_category_not_found,none,
       "could not find category %0 on Objective-C class %1; make sure your "
       "umbrella or bridging header imports the header that declares it",
@@ -1702,29 +1702,28 @@ NOTE(fixit_add_final_for_objc_implementation,none,
      (DescriptiveDeclKind))
 
 ERROR(objc_implementation_wrong_category,none,
-      "%0 %1 should be implemented in extension for "
-      "%select{main class interface|category %2}2, not "
-      "%select{main class interface|category %3}3",
-      (DescriptiveDeclKind, ValueDecl *, Identifier, Identifier))
+      "%kind0 should be implemented in extension for "
+      "%select{main class interface|category %1}1, not "
+      "%select{main class interface|category %2}2",
+      (ValueDecl *, Identifier, Identifier))
 
 ERROR(objc_implementation_wrong_decl_kind,none,
-      "%0 %1 does not match the %2 declared by the header",
-      (DescriptiveDeclKind, ValueDecl *, DescriptiveDeclKind))
+      "%kind0 does not match the %1 declared by the header",
+      (ValueDecl *, DescriptiveDeclKind))
 
 ERROR(objc_implementation_must_be_settable,none,
-      "%0 %1 should be settable to match the settable %2 declared by the "
+      "%kind0 should be settable to match the settable %1 declared by the "
       "header",
-      (DescriptiveDeclKind, ValueDecl *, DescriptiveDeclKind))
+      (ValueDecl *, DescriptiveDeclKind))
 
 ERROR(objc_implementation_type_mismatch,none,
-      "%0 %1 of type %2 does not match type %3 declared by the "
-      "header",
-      (DescriptiveDeclKind, ValueDecl *, Type, Type))
+      "%kind0 of type %1 does not match type %2 declared by the header",
+      (ValueDecl *, Type, Type))
 
 ERROR(objc_implementation_required_attr_mismatch,none,
-      "%0 %1 %select{should not|should}2 be 'required' to match %0 declared by "
-      "the header",
-      (DescriptiveDeclKind, ValueDecl *, bool))
+      "%kind0 %select{should not|should}2 be 'required' to match %1 declared "
+      "by the header",
+      (ValueDecl *, DescriptiveDeclKind, bool))
 
 ERROR(objc_implementation_candidate_has_error_convention,none,
       "%0 %1 does not match the declaration in the header because it throws an "
@@ -1770,8 +1769,8 @@ ERROR(objc_implementation_mismatched_error_convention_other,none,
       (DescriptiveDeclKind, ValueDecl *))
 
 ERROR(objc_implementation_wrong_objc_name,none,
-      "selector %0 for %1 %2 not found in header; did you mean %3?",
-      (ObjCSelector, DescriptiveDeclKind, ValueDecl *, ObjCSelector))
+      "selector %0 for %kind1 not found in header; did you mean %2?",
+      (ObjCSelector, ValueDecl *, ObjCSelector))
 
 ERROR(objc_implementation_wrong_swift_name,none,
       "selector %0 used in header by an %1 with a different name; did you "
@@ -1780,30 +1779,30 @@ ERROR(objc_implementation_wrong_swift_name,none,
 
 ERROR(objc_implementation_missing_impl,none,
       "extension for %select{main class interface|category %0}0 should "
-      "provide implementation for %1 %2",
-      (Identifier, DescriptiveDeclKind, ValueDecl *))
+      "provide implementation for %kind1",
+      (Identifier, ValueDecl *))
 
 ERROR(objc_implementation_class_or_instance_mismatch,none,
-      "%0 %1 does not match %2 declared in header",
-      (DescriptiveDeclKind, ValueDecl *, DescriptiveDeclKind))
+      "%kind0 does not match %1 declared in header",
+      (ValueDecl *, DescriptiveDeclKind))
 
 ERROR(objc_implementation_multiple_matching_candidates,none,
-      "found multiple implementations that could match %0 %1 with selector %2",
-      (DescriptiveDeclKind, ValueDecl *, ObjCSelector))
+      "found multiple implementations that could match %kind0 with selector %1",
+      (ValueDecl *, ObjCSelector))
 NOTE(objc_implementation_candidate_impl_here,none,
-     "%0 %1 is a potential match%select{|; insert '@objc(%3)' to use it}2",
-     (DescriptiveDeclKind, ValueDecl *, bool, StringRef))
+     "%kind0 is a potential match%select{|; insert '@objc(%2)' to use it}1",
+     (ValueDecl *, bool, StringRef))
 NOTE(objc_implementation_requirement_here,none,
-     "%0 %1 declared in header here",
-     (DescriptiveDeclKind, ValueDecl *))
+     "%kind0 declared in header here",
+     (ValueDecl *))
 
 ERROR(objc_implementation_multiple_matching_requirements,none,
-      "%0 %1 could match several different members declared in the header",
-      (DescriptiveDeclKind, ValueDecl *))
+      "%kind0 could match several different members declared in the header",
+      (ValueDecl *))
 NOTE(objc_implementation_one_matched_requirement,none,
-     "%0 %1 (with selector %2) is a potential match%select{|; insert "
-     "'@objc(%4)' to use it}3",
-     (DescriptiveDeclKind, ValueDecl *, ObjCSelector, bool, StringRef))
+     "%kind0 (with selector %1) is a potential match%select{|; insert "
+     "'@objc(%3)' to use it}2",
+     (ValueDecl *, ObjCSelector, bool, StringRef))
 
 ERROR(cdecl_not_at_top_level,none,
       "@_cdecl can only be applied to global functions", ())
@@ -1830,19 +1829,19 @@ ERROR(expose_invalid_name_pattern_init,none,
       "invalid declaration name '%0' specified in an @_expose attribute; "
       "exposed initializer name must start with 'init'", (StringRef))
 ERROR(expose_unsupported_objc_decl_to_cxx,none,
-      "@objc %0 %1 can not yet be exposed to C++", (DescriptiveDeclKind, ValueDecl *))
+      "@objc %kind0 can not yet be exposed to C++", (ValueDecl *))
 ERROR(expose_unsupported_async_decl_to_cxx,none,
-      "async %0 %1 can not be exposed to C++", (DescriptiveDeclKind, ValueDecl *))
+      "async %kind0 can not be exposed to C++", (ValueDecl *))
 ERROR(expose_unsupported_actor_isolated_to_cxx,none,
-      "actor-isolated %0 %1 can not be exposed to C++", (DescriptiveDeclKind, ValueDecl *))
+      "actor-isolated %kind0 can not be exposed to C++", (ValueDecl *))
 ERROR(expose_unsupported_client_emission_to_cxx,none,
-      "%0 %1 can not be exposed to C++ as it requires code to be emitted into client", (DescriptiveDeclKind, ValueDecl *))
+      "%kind0 can not be exposed to C++ as it requires code to be emitted into client", (ValueDecl *))
 ERROR(expose_generic_decl_to_cxx,none,
-      "generic %0 %1 can not yet be exposed to C++", (DescriptiveDeclKind, ValueDecl *))
+      "generic %kind0 can not yet be exposed to C++", (ValueDecl *))
 ERROR(expose_generic_requirement_to_cxx,none,
-      "generic requirements for %0 %1 can not yet be represented in C++", (DescriptiveDeclKind, ValueDecl *))
+      "generic requirements for %kind0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_throwing_to_cxx,none,
-      "%0 %1 can not yet be represented in C++ as it may throw an error", (DescriptiveDeclKind, ValueDecl *))
+      "%kind0 can not yet be represented in C++ as it may throw an error", (ValueDecl *))
 ERROR(expose_indirect_enum_cxx,none,
       "indirect enum %0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_enum_case_type_to_cxx,none,
@@ -1852,11 +1851,11 @@ ERROR(expose_enum_case_tuple_to_cxx,none,
 ERROR(expose_protocol_to_cxx_unsupported,none,
       "protocol %0 can not yet be represented in C++", (ValueDecl *))
 ERROR(expose_move_only_to_cxx,none,
-      "noncopyable %0 %1 can not yet be represented in C++", (DescriptiveDeclKind, ValueDecl *))
+      "noncopyable %kind0 can not yet be represented in C++", (ValueDecl *))
 ERROR(unexposed_other_decl_in_cxx,none,
-      "%0 %1 is not yet exposed to C++", (DescriptiveDeclKind, ValueDecl *))
+      "%kind0 is not yet exposed to C++", (ValueDecl *))
 ERROR(unsupported_other_decl_in_cxx,none,
-      "Swift %0 %1 cannot be represented in C++", (DescriptiveDeclKind, ValueDecl *))
+      "Swift %kind0 cannot be represented in C++", (ValueDecl *))
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3857,16 +3857,6 @@ ERROR(differentiable_attr_duplicate,none,
       "duplicate '@differentiable' attribute with same parameters", ())
 NOTE(differentiable_attr_duplicate_note,none,
      "other attribute declared here", ())
-ERROR(differentiable_attr_function_not_same_type_context,none,
-      "%0 is not defined in the current type context", (DeclNameRef))
-ERROR(differentiable_attr_derivative_not_function,none,
-      "registered derivative %0 must be a 'func' declaration", (DeclNameRef))
-ERROR(differentiable_attr_class_derivative_not_final,none,
-      "class member derivative must be final", ())
-ERROR(differentiable_attr_invalid_access,none,
-      "derivative function %0 is required to either be public or "
-      "'@usableFromInline' because the original function %1 is public or "
-      "'@usableFromInline'", (DeclNameRef, DeclName))
 ERROR(differentiable_attr_protocol_req_where_clause,none,
       "'@differentiable' attribute on protocol requirement cannot specify "
       "'where' clause", ())
@@ -3880,7 +3870,7 @@ ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 ERROR(differentiable_attr_where_clause_for_nongeneric_original,none,
       "'where' clause is valid only when original function is generic %0",
-      (DeclName))
+      (const ValueDecl *))
 ERROR(differentiable_attr_layout_req_unsupported,none,
       "'@differentiable' attribute does not yet support layout requirements",
       ())
@@ -3890,7 +3880,7 @@ NOTE(protocol_witness_missing_differentiable_attr_invalid_context,none,
      "candidate is missing explicit '%0' attribute to satisfy requirement %1 "
      "(in protocol %3); explicit attribute is necessary because candidate is "
      "declared in a different type context or file than the conformance of %2 "
-     "to %3", (StringRef, DeclName, Type, Type))
+     "to %3", (StringRef, const ValueDecl *, Type, Type))
 
 // @derivative
 ERROR(derivative_attr_expected_result_tuple,none,
@@ -3908,11 +3898,12 @@ ERROR(derivative_attr_result_value_not_differentiable,none,
       "'@derivative(of:)' attribute requires function to return a two-element "
       "tuple; first element type %0 must conform to 'Differentiable'", (Type))
 ERROR(derivative_attr_result_func_type_mismatch,none,
-      "function result's %0 type does not match %1", (Identifier, DeclName))
+      "function result's %0 type does not match %1",
+      (Identifier, const ValueDecl *))
 NOTE(derivative_attr_result_func_type_mismatch_note,none,
      "%0 does not have expected type %1", (Identifier, Type))
 NOTE(derivative_attr_result_func_original_note,none,
-     "%0 defined here", (DeclName))
+     "%0 defined here", (const ValueDecl *))
 ERROR(derivative_attr_not_in_same_file_as_original,none,
       "derivative not in the same file as the original function", ())
 ERROR(derivative_attr_original_stored_property_unsupported,none,
@@ -3934,7 +3925,7 @@ NOTE(derivative_attr_protocol_requirement_unsupported,none,
      "cannot yet register derivative default implementation for protocol "
      "requirements", ())
 ERROR(derivative_attr_original_already_has_derivative,none,
-      "a derivative already exists for %0", (DeclName))
+      "a derivative already exists for %0", (const ValueDecl *))
 NOTE(derivative_attr_duplicate_note,none,
      "other attribute declared here", ())
 ERROR(derivative_attr_access_level_mismatch,none,
@@ -3943,8 +3934,8 @@ ERROR(derivative_attr_access_level_mismatch,none,
       "%select{private|fileprivate|internal|package|public|open}3, "
       "but original function %0 is "
       "%select{private|fileprivate|internal|package|public|open}1",
-      (/*original*/ DeclName, /*original*/ AccessLevel,
-       /*derivative*/ DeclName, /*derivative*/ AccessLevel))
+      (/*original*/ const ValueDecl *, /*original*/ AccessLevel,
+       /*derivative*/ const ValueDecl *, /*derivative*/ AccessLevel))
 NOTE(derivative_attr_fix_access,none,
      "mark the derivative function as "
      "'%select{private|fileprivate|internal|package|@usableFromInline|@usableFromInline}0' "
@@ -3952,22 +3943,20 @@ NOTE(derivative_attr_fix_access,none,
 ERROR(derivative_attr_static_method_mismatch_original,none,
       "unexpected derivative function declaration; "
       "%0 requires the derivative function %1 to be %select{an instance|a 'static'}2 method",
-      (/*original*/DeclName, /*derivative*/ DeclName,
+      (/*original*/const ValueDecl *, /*derivative*/ const ValueDecl *,
        /*originalIsStatic*/bool))
 NOTE(derivative_attr_static_method_mismatch_original_note,none,
       "original function %0 is %select{an instance|a 'static'}1 method",
-      (/*original*/ DeclName, /*originalIsStatic*/bool))
+      (/*original*/ const ValueDecl *, /*originalIsStatic*/bool))
 NOTE(derivative_attr_static_method_mismatch_fix,none,
       "make derivative function %0 %select{an instance|a 'static'}1 method",
-      (/*derivative*/ DeclName, /*mustBeStatic*/bool))
+      (/*derivative*/ const ValueDecl *, /*mustBeStatic*/bool))
 
 // @transpose
 ERROR(transpose_attr_invalid_linearity_parameter_or_result,none,
       "cannot transpose with respect to original %select{result|parameter}1 "
       "'%0' that does not conform to 'Differentiable' and satisfy "
       "'%0 == %0.TangentVector'", (StringRef, /*isParameter*/ bool))
-ERROR(transpose_attr_overload_not_found,none,
-      "could not find function %0 with expected type %1", (DeclName, Type))
 ERROR(transpose_attr_cannot_use_named_wrt_params,none,
       "cannot use named 'wrt' parameters in '@transpose(of:)' attribute, found "
       "%0", (Identifier))
@@ -3980,14 +3969,14 @@ NOTE(transpose_attr_wrt_self_self_type_mismatch_note,none,
 ERROR(transpose_attr_static_method_mismatch_original,none,
       "unexpected transpose function declaration; "
       "%0 requires the transpose function %1 to be %select{an instance|a 'static'}2 method",
-      (/*original*/DeclName, /*transpose*/ DeclName,
+      (/*original*/const ValueDecl *, /*transpose*/ const ValueDecl *,
        /*originalIsStatic*/bool))
 NOTE(transpose_attr_static_method_mismatch_original_note,none,
       "original function %0 is %select{an instance|a 'static'}1 method",
-      (/*original*/ DeclName, /*originalIsStatic*/bool))
+      (/*original*/ const ValueDecl *, /*originalIsStatic*/bool))
 NOTE(transpose_attr_static_method_mismatch_fix,none,
       "make transpose function %0 %select{an instance|a 'static'}1 method",
-      (/*transpose*/ DeclName, /*mustBeStatic*/bool))
+      (/*transpose*/ const ValueDecl *, /*mustBeStatic*/bool))
 
 // Automatic differentiation attributes
 ERROR(autodiff_attr_original_decl_ambiguous,none,
@@ -4019,7 +4008,8 @@ ERROR(autodiff_attr_opaque_result_type_unsupported,none,
 
 // differentiation `wrt` parameters clause
 ERROR(diff_function_no_parameters,none,
-      "%0 has no parameters to differentiate with respect to", (DeclName))
+      "%0 has no parameters to differentiate with respect to",
+      (const ValueDecl *))
 ERROR(diff_params_clause_param_name_unknown,none,
       "unknown parameter name %0", (Identifier))
 ERROR(diff_params_clause_self_instance_method_only,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5938,8 +5938,7 @@ NOTE(objc_inferring_on_objc_protocol_member,none,
      "inferring '@objc' because the declaration is a member of "
      "an '@objc' protocol", ())
 NOTE(objc_overriding_objc_decl,none,
-     "overriding '@objc' %select{property|subscript|initializer|method}0 %1 "
-     "here", (unsigned, DeclName))
+     "overriding '@objc' %kind0 here", (const ValueDecl *))
 NOTE(objc_witness_objc_requirement,none,
      "satisfying requirement for %0 %1 in protocol %2",
      (DescriptiveDeclKind, DeclName, Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5282,39 +5282,39 @@ ERROR(isolated_parameter_combined_nonisolated,none,
       (DescriptiveDeclKind))
 
 WARNING(non_sendable_param_type,none,
-        "non-sendable type %0 %select{passed in call to %4 %2 %3|"
-        "exiting %4 context in call to non-isolated %2 %3|"
-        "passed in implicitly asynchronous call to %4 %2 %3|"
-        "in parameter of the protocol requirement satisfied by %4 %2 %3|"
-        "in parameter of superclass method overridden by %4 %2 %3|"
-        "in parameter of %4 '@objc' %2 %3}1 cannot cross actor boundary",
-        (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
+        "non-sendable type %0 %select{passed in call to %3 %kind2|"
+        "exiting %3 context in call to non-isolated %kind2|"
+        "passed in implicitly asynchronous call to %3 %kind2|"
+        "in parameter of the protocol requirement satisfied by %3 %kind2|"
+        "in parameter of superclass method overridden by %3 %kind2|"
+        "in parameter of %3 '@objc' %kind2}1 cannot cross actor boundary",
+        (Type, unsigned, const ValueDecl *, ActorIsolation))
 WARNING(non_sendable_call_argument,none,
         "passing argument of non-sendable type %0 %select{into %2 context|"
         "outside of %2 context}1 may introduce data races",
         (Type, bool, ActorIsolation))
 WARNING(non_sendable_result_type,none,
-        "non-sendable type %0 returned by %select{call to %4 %2 %3|"
-        "call from %4 context to non-isolated %2 %3|"
-        "implicitly asynchronous call to %4 %2 %3|"
-        "%4 %2 %3 satisfying protocol requirement|"
-        "%4 overriding %2 %3|"
-        "%4 '@objc' %2 %3}1 cannot cross actor boundary",
-        (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
+        "non-sendable type %0 returned by %select{call to %3 %kind2|"
+        "call from %4 context to non-isolated %kind2|"
+        "implicitly asynchronous call to %3 %kind2|"
+        "%3 %kind2 satisfying protocol requirement|"
+        "%3 overriding %kind2|"
+        "%3 '@objc' %kind2}1 cannot cross actor boundary",
+        (Type, unsigned, const ValueDecl *, ActorIsolation))
 WARNING(non_sendable_call_result_type,none,
         "non-sendable type %0 returned by %select{implicitly asynchronous |}1"
         "call to %2 function cannot cross actor boundary",
         (Type, bool, ActorIsolation))
 WARNING(non_sendable_property_type,none,
         "non-sendable type %0 in %select{"
-        "%select{asynchronous access to %5 %1 %2|"
-        "asynchronous access from %5 context to non-isolated %1 %2|"
-        "implicitly asynchronous access to %5 %1 %2|"
-        "conformance of %5 %1 %2 to protocol requirement|"
-        "%5 overriding %1 %2|"
-        "%5 '@objc' %1 %2}4|captured local %1 %2}3 cannot "
-        "cross %select{actor|task}3 boundary",
-        (Type, DescriptiveDeclKind, DeclName, bool, unsigned, ActorIsolation))
+        "%select{asynchronous access to %4 %kind1|"
+        "asynchronous access from %4 context to non-isolated %kind1|"
+        "implicitly asynchronous access to %4 %kind1|"
+        "conformance of %4 %kind1 to protocol requirement|"
+        "%4 overriding %kind1|"
+        "%4 '@objc' %kind1}3|captured local %1}2 cannot "
+        "cross %select{actor|task}2 boundary",
+        (Type, const ValueDecl *, bool, unsigned, ActorIsolation))
 WARNING(non_sendable_keypath_capture,none,
         "cannot form key path that captures non-sendable type %0",
         (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3638,14 +3638,13 @@ ERROR(attr_not_on_decl_with_invalid_access_level,none,
       (DeclAttribute, AccessLevel))
 
 ERROR(attr_has_no_effect_decl_not_available_before,none,
-      "'%0' has no effect because %select{getter for |setter for |}1%2 is not "
-      "available before %3 %4",
-      (DeclAttribute, unsigned, DeclName, StringRef, llvm::VersionTuple))
+      "'%0' has no effect because %1 is not "
+      "available before %2 %3",
+      (DeclAttribute, const ValueDecl *, StringRef, llvm::VersionTuple))
 
 ERROR(attr_has_no_effect_on_unavailable_decl,none,
-      "'%0' has no effect because %select{getter for |setter for |}1%2 is "
-      "unavailable on %3",
-      (DeclAttribute, unsigned, DeclName, StringRef))
+      "'%0' has no effect because %1 is unavailable on %2",
+      (DeclAttribute, const ValueDecl *, StringRef))
 
 ERROR(attr_ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 in '@%1' attribute", (DeclNameRef, StringRef))
@@ -6212,52 +6211,39 @@ NOTE(type_eraser_init_spi,none,
 //------------------------------------------------------------------------------
 
 ERROR(availability_decl_unavailable, none,
-      "%select{getter for |setter for |}0%1 is unavailable"
-      "%select{ in %3|}2%select{|: %4}4",
-      (unsigned, DeclName, bool, StringRef, StringRef))
-
-WARNING(availability_decl_unavailable_warn, none,
-        "%select{getter for |setter for |}0%1 is unavailable"
-        "%select{ in %3|}2%select{|: %4}4",
-        (unsigned, DeclName, bool, StringRef, StringRef))
+      "%0 is unavailable%select{ in %2|}1%select{|: %3}3",
+      (const ValueDecl *, bool, StringRef, StringRef))
 
 #define REPLACEMENT_DECL_KIND_SELECT "select{| instance method| property}"
 ERROR(availability_decl_unavailable_rename, none,
-      "%select{getter for |setter for |}0%1 has been "
-      "%select{renamed to|replaced by}2%" REPLACEMENT_DECL_KIND_SELECT "3 "
-      "'%4'%select{|: %5}5",
-      (unsigned, DeclName, bool, unsigned, StringRef, StringRef))
-
-WARNING(availability_decl_unavailable_rename_warn, none,
-        "%select{getter for |setter for |}0%1 has been "
-        "%select{renamed to|replaced by}2%" REPLACEMENT_DECL_KIND_SELECT "3 "
-        "'%4'%select{|: %5}5",
-        (unsigned, DeclName, bool, unsigned, StringRef, StringRef))
+      "%0 has been %select{renamed to|replaced by}1"
+      "%" REPLACEMENT_DECL_KIND_SELECT "2 '%3'%select{|: %4}4",
+      (const ValueDecl *, bool, unsigned, StringRef, StringRef))
 
 NOTE(availability_marked_unavailable, none,
-     "%select{getter for |setter for |}0%1 has been explicitly marked "
-     "unavailable here", (unsigned, DeclName))
+     "%0 has been explicitly marked unavailable here",
+     (const ValueDecl *))
 
 NOTE(availability_introduced_in_version, none,
-     "%select{getter for |setter for |}0%1 was introduced in %2 %3",
-     (unsigned, DeclName, StringRef, llvm::VersionTuple))
+     "%0 was introduced in %1 %2",
+     (const ValueDecl *, StringRef, llvm::VersionTuple))
 
 NOTE(availability_obsoleted, none,
-     "%select{getter for |setter for |}0%1 was obsoleted in %2 %3",
-     (unsigned, DeclName, StringRef, llvm::VersionTuple))
+     "%0 was obsoleted in %1 %2",
+     (const ValueDecl *, StringRef, llvm::VersionTuple))
 
 WARNING(availability_deprecated, Deprecation,
-        "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
-        "deprecated%select{| in %3%select{| %5}4}2%select{|: %6}6",
-        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple,
+        "%0 %select{is|%select{is|was}3}1 "
+        "deprecated%select{| in %2%select{| %4}3}1%select{|: %5}5",
+        (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple,
          StringRef))
 
 WARNING(availability_deprecated_rename, Deprecation,
-        "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
-        "deprecated%select{| in %3%select{| %5}4}2: "
-        "%select{renamed to|replaced by}6%" REPLACEMENT_DECL_KIND_SELECT "7 "
-        "'%8'",
-        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple, bool,
+        "%0 %select{is|%select{is|was}3}1 "
+        "deprecated%select{| in %2%select{| %4}3}1: "
+        "%select{renamed to|replaced by}5%" REPLACEMENT_DECL_KIND_SELECT "6 "
+        "'%7'",
+        (const ValueDecl *, bool, StringRef, bool, llvm::VersionTuple, bool,
          unsigned, StringRef))
 #undef REPLACEMENT_DECL_KIND_SELECT
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -49,11 +49,10 @@ NOTE(default_value_declared_here,none,
 
 ERROR(ambiguous_member_overload_set,none,
       "ambiguous reference to member %0", (DeclNameRef))
-ERROR(ambiguous_reference_to_decl,none,
-      "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
 ERROR(no_overloads_match_exactly_in_call,none,
-      "no exact matches in %select{reference|call}0 to %1 %select{%3|}2",
-      (bool, DescriptiveDeclKind, bool, DeclBaseName))
+      "no exact matches in %select{reference|call}0 to %kindonly1 "
+      "%select{%base1|}2",
+      (bool, const ValueDecl *, bool))
 
 NOTE(candidate_partial_match,none,
      "candidate has partially matching parameter list %0",
@@ -115,19 +114,19 @@ NOTE(any_as_anyobject_fixit, none,
      "cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members", ())
 
 ERROR(expected_argument_in_contextual_member,none,
-      "member %0 expects argument of type %1", (DeclName, Type))
+      "member %0 expects argument of type %1", (const ValueDecl *, Type))
 ERROR(expected_parens_in_contextual_member,none,
-      "member %0 is a function; did you mean to call it?", (DeclName))
+      "member %0 is a function; did you mean to call it?", (const ValueDecl *))
 ERROR(expected_parens_in_contextual_member_type,none,
       "member %0 is a function that produces expected type %1; did you mean to "
-      "call it?", (DeclName, Type))
+      "call it?", (const ValueDecl *, Type))
 
 ERROR(expected_result_in_contextual_member,none,
       "member %0 in %2 produces result of type %1, but context expects %2",
-      (DeclName, Type, Type))
+      (const ValueDecl *, Type, Type))
 
 ERROR(unexpected_arguments_in_enum_case,none,
-      "enum case %0 has no associated values", (DeclName))
+      "enum case %base0 has no associated values", (const ValueDecl *))
 
 ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
@@ -151,14 +150,9 @@ FIXIT(replace_with_type,"%0",(Type))
 FIXIT(insert_type_qualification,"%0.",(Type))
 
 ERROR(candidate_inaccessible,none,
-      "%0 is inaccessible due to "
+      "%base0 is inaccessible due to "
       "'%select{private|fileprivate|internal|package|@_spi|@_spi}1' protection level",
-      (DeclBaseName, AccessLevel))
-
-NOTE(note_candidate_inaccessible,none,
-     "%0 is inaccessible due to "
-     "'%select{private|fileprivate|internal|package|@_spi|@_spi}1' protection level",
-     (DeclName, AccessLevel))
+      (const ValueDecl *, AccessLevel))
 
 ERROR(init_candidate_inaccessible,none,
       "%0 initializer is inaccessible due to "
@@ -437,17 +431,18 @@ ERROR(ternary_expr_cases_global_actor_mismatch,none,
 // @_nonEphemeral conversion diagnostics
 ERROR(cannot_pass_type_to_non_ephemeral,none,
       "cannot pass %0 to parameter; argument %1 must be a pointer that "
-      "outlives the call%select{| to %3}2", (Type, StringRef, bool, DeclName))
+      "outlives the call%select{| to %2}2",
+      (Type, StringRef, const ValueDecl *))
 ERROR(cannot_use_inout_non_ephemeral,none,
       "cannot use inout expression here; argument %0 must be a pointer that "
-      "outlives the call%select{| to %2}1", (StringRef, bool, DeclName))
+      "outlives the call%select{| to %1}1", (StringRef, const ValueDecl *))
 ERROR(cannot_construct_dangling_pointer,none,
       "initialization of %0 results in a dangling %select{|buffer }1pointer",
       (Type, unsigned))
 NOTE(ephemeral_pointer_argument_conversion_note,none,
      "implicit argument conversion from %0 to %1 produces a pointer valid only "
-     "for the duration of the call%select{| to %3}2",
-     (Type, Type, bool, DeclName))
+     "for the duration of the call%select{| to %2}2",
+     (Type, Type, const ValueDecl *))
 NOTE(ephemeral_use_with_unsafe_pointer,none,
      "use 'withUnsafe%select{Bytes|MutableBytes|Pointer|MutablePointer}0' in "
      "order to explicitly convert argument to %select{buffer |buffer ||}0"
@@ -594,11 +589,11 @@ ERROR(cannot_convert_subscript_assign_nil,none,
 
 NOTE(cannot_convert_candidate_result_to_contextual_type,none,
      "%0 produces %1, not the expected contextual result type %2",
-     (DeclName, Type, Type))
+     (const ValueDecl *, Type, Type))
 
 NOTE(overload_result_type_does_not_conform,none,
      "result type %1 of %0 does not conform to %2",
-     (DeclName, Type, Type))
+     (const ValueDecl *, Type, Type))
 
 // for ... in expression
 ERROR(cannot_convert_sequence_element_value,none,
@@ -646,13 +641,13 @@ ERROR(expr_keypath_not_property,none,
 ERROR(expr_keypath_mutating_getter,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to %0, "
       "which has a mutating getter",
-      (DeclName, bool))
+      (const ValueDecl *, bool))
 ERROR(expr_keypath_static_member,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to static member %0",
-      (DeclName, bool))
+      (const ValueDecl *, bool))
 ERROR(expr_keypath_enum_case,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to enum case %0",
-      (DeclName, bool))
+      (const ValueDecl *, bool))
 ERROR(expr_keypath_empty,none,
       "empty key path does not refer to a property", ())
 ERROR(expr_unsupported_objc_key_path_component,none,
@@ -693,7 +688,8 @@ ERROR(expr_keypath_multiparam_func_conversion, none,
       "cannot convert key path into a multi-argument function type %0", (Type))
 WARNING(expr_deprecated_writable_keypath,Deprecation,
         "forming a writable keypath to property %0 that is read-only in this context "
-        "is deprecated and will be removed in a future release",(DeclName))
+        "is deprecated and will be removed in a future release",
+        (const ValueDecl *))
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,
@@ -705,28 +701,28 @@ ERROR(expr_selector_no_declaration,none,
       "or initializer", ())
 ERROR(expr_selector_not_method,none,
       "argument of '#selector' cannot refer to %select{local|global}0 "
-      "function %1", (bool, DeclName))
+      "function %1", (bool, const ValueDecl *))
 ERROR(expr_selector_expected_property,none,
       "cannot reference %kind1 as a property; remove '%select{getter|setter}0:'",
       (bool, const ValueDecl *))
 ERROR(expr_selector_not_property,none,
       "argument of '#selector' cannot refer to %select{variable|parameter}0 %1",
-      (bool, DeclName))
+      (bool, const ValueDecl *))
 ERROR(expr_selector_expected_method,none,
       "use 'getter:'%select{| or 'setter:'}0 to refer to the Objective-C getter"
       "%select{| or setter}0 of property %1%select{|, respectively}0",
-      (bool, DeclName))
+      (bool, const ValueDecl *))
 NOTE(expr_selector_add_modifier,none,
      "add '%select{getter|setter}0:' to reference the Objective-C "
-     "%select{getter|setter}0 for %1", (bool, DeclName))
+     "%select{getter|setter}0 for %1", (bool, const ValueDecl *))
 ERROR(expr_selector_property_not_settable,none,
       "argument of '#selector(setter:)' refers to non-settable %kind0",
       (const ValueDecl *))
 ERROR(expr_selector_property_setter_inaccessible,none,
       "setter of %kind0 is inaccessible", (const ValueDecl *))
 ERROR(expr_selector_cannot_be_used,none,
-      "cannot use %0 as a selector because protocol %1 is not exposed to Objective-C",
-      (DeclBaseName, Identifier))
+      "cannot use %base0 as a selector because protocol %1 is not exposed to Objective-C",
+      (const ValueDecl *, const ValueDecl *))
 ERROR(expr_selector_not_objc,none,
       "argument of '#selector' refers to %kind0 that is not exposed to "
       "Objective-C",
@@ -737,7 +733,7 @@ NOTE(make_decl_objc,none,
 WARNING(expr_selector_swift3_objc_inference,Deprecation,
         "argument of '#selector' refers to %kind0 in %1 that depends on "
         "'@objc' inference deprecated in Swift 4",
-        (const ValueDecl *, Identifier))
+        (const ValueDecl *, const ValueDecl *))
 
 // Selectors-as-string-literals.
 WARNING(selector_literal_invalid,none,
@@ -950,7 +946,7 @@ NOTE(modularization_issue_worked_around,none,
 
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"
-      " 'foo.%1' expression", (DeclName, StringRef))
+      " 'foo.%1' expression", (const ValueDecl *, StringRef))
 
 NOTE(invalid_redecl_by_optionality_note,none,
       "%select{implicitly unwrapped |}0optional parameter is of "
@@ -993,10 +989,10 @@ ERROR(invalid_member_type,none,
       (DeclNameRef, DescriptiveDeclKind, FullyQualified<Type>))
 ERROR(invalid_member_type_suggest,none,
       "%0 does not have a member type named %1; did you mean %2?",
-      (Type, DeclNameRef, DeclName))
+      (Type, DeclNameRef, const TypeDecl *))
 ERROR(invalid_member_reference,none,
-      "%0 %1 is not a member type of %2",
-      (DescriptiveDeclKind, DeclName, Type))
+      "%kind0 is not a member type of %1",
+      (const ValueDecl *, Type))
 ERROR(ambiguous_member_type,none,
       "ambiguous type name %0 in %1", (DeclNameRef, Type))
 ERROR(no_module_type,none,
@@ -1007,11 +1003,11 @@ ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (DeclNameRef, unsigned))
 ERROR(unsupported_recursion_in_associated_type_reference,none,
-      "unsupported recursion for reference to %select{associated type|type alias}0 %1 of type %2",
-      (bool, Identifier, Type))
+      "unsupported recursion for reference to %kind0 of type %1",
+      (const ValueDecl *, Type))
 ERROR(broken_associated_type_witness,none,
-      "reference to invalid %select{associated type|type alias}0 %1 of type %2",
-      (bool, Identifier, Type))
+      "reference to invalid %kind0 of type %1",
+      (const ValueDecl *, Type))
 
 ERROR(unspaced_binary_operator_fixit,none,
       "missing whitespace between %0 and %1 operators",
@@ -1160,7 +1156,7 @@ ERROR(operator_in_local_scope,none,
       "operator functions can only be declared at global or in type scope", ())
 ERROR(nonstatic_operator_in_nominal,none,
       "operator %0 declared in type %1 must be 'static'",
-      (Identifier, DeclName))
+      (Identifier, const NominalTypeDecl *))
 ERROR(nonstatic_operator_in_extension,none,
       "operator %0 declared in extension%select{| of %2}1 must be 'static'",
       (Identifier, bool, TypeRepr*))
@@ -1169,7 +1165,8 @@ ERROR(nonfinal_operator_in_class,none,
       (Identifier, Type))
 ERROR(operator_in_unrelated_type,none,
       "member operator %2%select{| of protocol %0}1 must have at least one "
-      "argument of type %select{%0|'Self'}1", (Type, bool, DeclName))
+      "argument of type %select{%0|'Self'}1",
+      (Type, bool, const FuncDecl *))
 
 // Precedence groups
 ERROR(ambiguous_precedence_groups,none,
@@ -1316,16 +1313,13 @@ ERROR(optional_chain_isnt_chaining,none,
 ERROR(pattern_in_expr,none,
       "%0 cannot appear in an expression", (DescriptivePatternKind))
 NOTE(note_call_to_operator,none,
-     "in call to operator %0", (DeclName))
+     "in call to operator %0", (const ValueDecl *))
 NOTE(note_call_to_func,none,
-     "in call to function %0", (DeclName))
+     "in call to function %0", (const ValueDecl *))
 NOTE(note_call_to_subscript,none,
-     "in call to %0", (DeclName))
+     "in call to %0", (const ValueDecl *))
 NOTE(note_call_to_initializer,none,
      "in call to initializer", ())
-NOTE(note_init_parameter,none,
-     "in initialization of parameter %0", (Identifier))
-
 
 ERROR(missing_nullary_call,none,
      "function produces expected type %0; did you mean to call it with '()'?",
@@ -1502,9 +1496,6 @@ ERROR(trailing_closure_bad_param,none,
 WARNING(unlabeled_trailing_closure_deprecated,Deprecation,
         "backward matching of the unlabeled trailing closure is deprecated; label the argument with %0 to suppress this warning",
         (Identifier))
-NOTE(decl_multiple_defaulted_closure_parameters,none,
-     "%0 contains defaulted closure parameters %1 and %2",
-     (DeclName, Identifier, Identifier))
 NOTE(candidate_with_extraneous_args_closure,none,
      "candidate %0 requires %1 argument%s1, "
      "but %2 %select{were|was}3 used in closure body",
@@ -1660,7 +1651,8 @@ NOTE(fixit_rename_in_swift,none,
 NOTE(fixit_rename_in_objc,none,
      "change Objective-C selector to %0", (ObjCSelector))
 NOTE(remove_async_add_task,none,
-     "remove 'async' and wrap in 'Task' to use concurrency in %0", (DeclName))
+     "remove 'async' and wrap in 'Task' to use concurrency in %0",
+     (const FuncDecl *))
 ERROR(no_objc_tagged_pointer_not_class_protocol,none,
       "@unsafe_no_objc_tagged_pointer can only be applied to class protocols",
       ())
@@ -1828,7 +1820,8 @@ ERROR(section_empty_name,none,
 ERROR(expose_only_non_other_attr,none,
       "@_expose attribute cannot be applied to an '%0' declaration", (StringRef))
 ERROR(expose_inside_unexposed_decl,none,
-      "@_expose attribute cannot be applied inside of unexposed declaration %0", (DeclName))
+      "@_expose attribute cannot be applied inside of unexposed declaration %0",
+      (const ValueDecl *))
 ERROR(expose_invalid_name_pattern_init,none,
       "invalid declaration name '%0' specified in an @_expose attribute; "
       "exposed initializer name must start with 'init'", (StringRef))
@@ -2129,7 +2122,7 @@ ERROR(pattern_binds_no_variables,none,
       (unsigned))
 ERROR(variable_bound_by_no_pattern,none,
       "variable %0 is not bound by any pattern",
-      (DeclName))
+      (const VarDecl *))
 
 WARNING(optional_ambiguous_case_ref,none,
         "assuming you mean '%0.%2'; did you mean '%1.%2' instead?",
@@ -2157,19 +2150,19 @@ NOTE(unstable_mangled_name_add_objc,none,
 // Generic declarations
 ERROR(unsupported_type_nested_in_generic_function,none,
       "type %0 cannot be nested in generic function %1",
-      (Identifier, DeclName))
+      (const NominalTypeDecl *, const AbstractFunctionDecl *))
 ERROR(unsupported_type_nested_in_generic_closure,none,
       "type %0 cannot be nested in closure in generic context",
-      (Identifier))
+      (const NominalTypeDecl *))
 ERROR(unsupported_type_nested_in_protocol,none,
       "type %0 cannot be nested in protocol %1",
-      (Identifier, Identifier))
+      (const NominalTypeDecl *, const ProtocolDecl *))
 ERROR(unsupported_type_nested_in_protocol_extension,none,
       "type %0 cannot be nested in protocol extension of %1",
-      (Identifier, Identifier))
+      (const NominalTypeDecl *, const ProtocolDecl *))
 ERROR(unsupported_nested_protocol,none,
       "protocol %0 cannot be nested inside another declaration",
-      (Identifier))
+      (const NominalTypeDecl *))
 ERROR(where_nongeneric_ctx,none,
       "'where' clause on non-generic member declaration requires a "
       "generic context", ())
@@ -2283,10 +2276,10 @@ ERROR(spi_attribute_on_non_public,none,
 ERROR(spi_attribute_on_protocol_requirement,none,
       "protocol requirement %0 cannot be declared '@_spi' without "
       "a default implementation in a protocol extension",
-      (DeclName))
+      (const ValueDecl *))
 ERROR(spi_attribute_on_frozen_stored_properties,none,
       "stored property %0 cannot be declared '@_spi' in a '@frozen' struct",
-      (DeclName))
+      (const ValueDecl *))
 ERROR(spi_attribute_on_frozen_enum_case,none,
       "%kind0 cannot be declared '@_spi' in a '@frozen' enum",
       (const ValueDecl *))
@@ -2568,27 +2561,27 @@ ERROR(protocol_has_missing_requirements_versioned,none,
       "it has requirements that could not be loaded in Swift %3",
       (Type, Type, llvm::VersionTuple, llvm::VersionTuple))
 ERROR(requirement_restricts_self,none,
-      "%0 requirement %1 cannot add constraint '%2%select{:|:| ==|:}3 %4' on "
-      "'Self'",
-      (DescriptiveDeclKind, DeclName, StringRef, unsigned, StringRef))
+      "%kindonly0 requirement %0 cannot add constraint "
+      "'%1%select{:|:| ==|:}2 %3' on 'Self'",
+      (const ValueDecl *, StringRef, unsigned, StringRef))
 ERROR(witness_argument_name_mismatch,none,
       "%kind0 has different argument labels "
       "from those required by protocol %1 (%2)",
-      (const ValueDecl *, Type, DeclName))
+      (const ValueDecl *, Type, const ValueDecl *))
 ERROR(witness_initializer_not_required,none,
       "initializer requirement %0 can only be satisfied by a 'required' "
       "initializer in%select{| the definition of}1 non-final class %2",
-      (DeclName, bool, Type))
+      (const ValueDecl *, bool, Type))
 ERROR(witness_initializer_failability,none,
       "non-failable initializer requirement %0"
       "%select{| in Objective-C protocol}1 cannot be satisfied by a "
       "failable initializer ('init%select{?|!}1')",
-      (DeclName, bool))
+      (const ValueDecl *, bool))
 ERROR(witness_self_non_subtype,none,
       "protocol %0 requirement %1 cannot be satisfied by a non-final class "
       "(%2) because it uses 'Self' in a non-parameter, non-result type "
       "position",
-      (Type, DeclName, Type))
+      (Type, const ValueDecl *, Type))
 ERROR(witness_self_same_type,none,
       "%kind0 in non-final class %1 cannot be used to satisfy requirement %kind2"
       " (in protocol %3) due to same-type requirement involving 'Self'",
@@ -2600,23 +2593,24 @@ ERROR(witness_requires_dynamic_self,none,
       "%select{%error|method|property|subscript}0 %1 in non-final class %2 "
       "must %select{%error|return|specify type|return}0 'Self' "
       "to conform to protocol %3",
-      (RequirementKind, DeclName, Type, Type))
+      (RequirementKind, const ValueDecl *, Type, Type))
 ERROR(witness_requires_class_implementation,none,
       "%select{%error|method|%error|subscript}0 %1 in non-final class %2 "
       "cannot be implemented in a protocol extension because it returns 'Self' "
       "and has associated type requirements",
-      (RequirementKind, DeclName, Type))
+      (RequirementKind, const ValueDecl *, Type))
 ERROR(witness_not_accessible_proto,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be declared "
       "%select{%error|fileprivate|internal|package|public|%error}3 because it matches a "
       "requirement in %select{private|fileprivate|internal|package|public|%error}4 protocol "
       "%5",
-      (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
+      (RequirementKind, const ValueDecl *, bool, AccessLevel, AccessLevel,
+       const ProtocolDecl *))
 ERROR(witness_not_as_sendable,none,
       "sendability of function types in %kind0 does not match requirement in "
       "protocol %1",
-      (const ValueDecl *, Identifier))
+      (const ValueDecl *, const ProtocolDecl *))
 NOTE(less_sendable_reqt_here,none,
      "expected sendability to match requirement here",
      ())
@@ -2624,16 +2618,17 @@ ERROR(witness_not_accessible_type,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
       "type because it matches a requirement in protocol %5",
-      (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
+      (RequirementKind, const ValueDecl *, bool, AccessLevel, AccessLevel,
+       const ProtocolDecl *))
 ERROR(type_witness_not_accessible_proto,none,
       "%kind0 must be declared %select{%error|fileprivate|internal|package|public|%error}1 "
       "because it matches a requirement in "
       "%select{%error|fileprivate|internal|package|public|%error}1 protocol %2",
-      (const ValueDecl *, AccessLevel, Identifier))
+      (const ValueDecl *, AccessLevel, const ProtocolDecl *))
 ERROR(type_witness_not_accessible_type,none,
       "%kind0 must be as accessible as its enclosing type because it "
       "matches a requirement in protocol %2",
-      (const ValueDecl *, AccessLevel, Identifier))
+      (const ValueDecl *, AccessLevel, const ProtocolDecl *))
 ERROR(witness_not_usable_from_inline,none,
       "%kind0 must be declared '@usableFromInline' "
       "because it matches a requirement in protocol %1",
@@ -2641,7 +2636,7 @@ ERROR(witness_not_usable_from_inline,none,
 ERROR(type_witness_objc_generic_parameter,none,
       "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
       "used for associated type %3 of protocol %4",
-      (Type, Type, bool, Identifier, Identifier))
+      (Type, Type, bool, const AssociatedTypeDecl *, const ProtocolDecl *))
 NOTE(witness_fix_access,none,
      "mark the %0 as '%select{%error|fileprivate|internal|package|public|%error}1' to "
      "satisfy the requirement", (DescriptiveDeclKind, AccessLevel))
@@ -2651,9 +2646,10 @@ NOTE(witness_move_to_another_extension,none,
      "satisfy the requirement", (DescriptiveDeclKind, AccessLevel))
 WARNING(assoc_type_default_conformance_failed,none,
         "default type %0 for associated type %1 does not satisfy constraint "
-        "%2: %3", (Type, Identifier, Type, Type))
+        "%2: %3", (Type, const AssociatedTypeDecl *, Type, Type))
 NOTE(assoc_type_default_here,none,
-     "associated type %0 has default type %1 written here", (Identifier, Type))
+     "associated type %0 has default type %1 written here",
+     (const AssociatedTypeDecl *, Type))
 
 ERROR(protocol_access,none,
       "%select{protocol must be declared %select{"
@@ -2689,23 +2685,26 @@ NOTE(no_witnesses,none,
      "protocol requires "
      "%select{initializer %1|function %1|property %1|subscript}0 with type %2"
      "%select{|; do you want to add a stub?}3",
-     (RequirementKind, DeclName, Type, bool))
+     (RequirementKind, const ValueDecl *, Type, bool))
 NOTE(missing_witnesses_general,none, "do you want to add protocol stubs?",
      ())
 NOTE(ambiguous_witnesses,none,
      "multiple matching "
      "%select{initializers named %1|functions named %1|properties named %1|"
-     "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
+     "subscript operators}0 with type %2",
+     (RequirementKind, const ValueDecl *, Type))
 NOTE(ambiguous_witnesses_wrong_name,none,
      "multiple matching "
      "%select{initializers named %1|functions named %1|properties named %1|"
-     "subscript operators}0 with type %2", (RequirementKind, DeclName, Type))
+     "subscript operators}0 with type %2",
+     (RequirementKind, const ValueDecl *, Type))
 NOTE(no_witnesses_type,none,
-     "protocol requires nested type %0; do you want to add it?", (Identifier))
+     "protocol requires nested type %0; do you want to add it?",
+     (const AssociatedTypeDecl *))
 NOTE(default_associated_type_req_fail,none,
      "default type %0 for associated type %1 (from protocol %2) "
      "does not %select{inherit from|conform to}4 %3",
-     (Type, Identifier, Type, Type, bool))
+     (Type, const AssociatedTypeDecl *, Type, Type, bool))
 ERROR(associated_type_access,none,
       "associated type in "
       "%select{a private|a fileprivate|an internal|a package|a public|%error}0 protocol "
@@ -2732,32 +2731,32 @@ WARNING(associated_type_not_usable_from_inline_warn,none,
 
 NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
-     (Identifier, Identifier))
+     (const AssociatedTypeDecl *, const ProtocolDecl *))
 NOTE(associated_type_deduction_witness_failed,none,
      "candidate would match and infer %0 = %1 if %1 "
      "%select{inherited from|conformed to}3 %2",
-     (Identifier, Type, Type, bool))
+     (const AssociatedTypeDecl *, Type, Type, bool))
 NOTE(associated_type_witness_conform_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a nominal type and so can't conform to %2",
-     (Identifier, Type, Type))
+     (const AssociatedTypeDecl *, Type, Type))
 NOTE(suggest_opaque_type_witness,none,
      "cannot infer %0 = %1 because %1 as a type cannot "
      "conform to protocols; did you mean to use an opaque "
      "result type?",
-     (Identifier, Type, Type))
+     (const AssociatedTypeDecl *, Type, Type))
 NOTE(associated_type_witness_inherit_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a class type and so can't inherit from %2",
-     (Identifier, Type, Type))
+     (const AssociatedTypeDecl *, Type, Type))
 
 NOTE(ambiguous_associated_type_deduction,none,
      "ambiguous inference of associated type %0: %1 vs. %2",
-     (Identifier, Type, Type))
+     (const AssociatedTypeDecl *, Type, Type))
 NOTE(associated_type_deduction_witness,none,
      "matching requirement %0 to this declaration inferred associated type to "
      "%1",
-     (DeclName, Type))
+     (const ValueDecl *, Type))
 NOTE(associated_type_deduction_default,none,
      "using associated type default %0", (Type))
 NOTE(ambiguous_witnesses_type,none,
@@ -2791,12 +2790,12 @@ ERROR(err_protocol_witness_optionality,none,
       "%select{type|result|parameter|parameters|"
       "result and parameters}0 of %1 %select{has|has|has|have|have|}0"
       " different optionality than required by protocol %2",
-      (unsigned, DeclName, Identifier))
+      (unsigned, const ValueDecl *, const ProtocolDecl *))
 WARNING(warn_protocol_witness_optionality,none,
       "%select{type|result|parameter|parameters|"
       "result and parameters}0 of %1 %select{has|has|has|have|have|}0"
       " different optionality than expected by protocol %2",
-      (unsigned, DeclName, Identifier))
+      (unsigned, const ValueDecl *, const ProtocolDecl *))
 
 NOTE(protocol_witness_static_conflict,none,
      "candidate operates on %select{a type|an instance}0, not "
@@ -2950,7 +2949,7 @@ ERROR(requires_generic_param_made_equal_to_concrete,none,
       (Type))
 ERROR(shadowed_generic_param,none,
       "generic parameter %0 shadows generic parameter from outer scope with the same name",
-      (DeclName))
+      (const GenericTypeParamDecl *))
 
 ERROR(recursive_decl_reference,none,
       "%kind0 references itself", (const ValueDecl *))
@@ -3364,21 +3363,9 @@ ERROR(decl_from_hidden_module,none,
       "it is an SPI imported from %2|"
       "it is SPI|"
       "%2 was imported for SPI only|"
-      "%2 was not imported by this file}3",
-      (const ValueDecl *, unsigned, Identifier, unsigned))
-// Duplicate of above for non-ValueDecls
-ERROR(decl_from_hidden_module_name,none,
-      "cannot use %0 %1 %select{here|as property wrapper here|"
-      "as result builder here|"
-      "in an extension with public or '@usableFromInline' members|"
-      "in an extension with conditional conformances}2; "
-      "%select{%3 has been imported as implementation-only|"
-      "it is an SPI imported from %3|"
-      "it is SPI|"
-      "%3 was imported for SPI only|"
-      "%3 was not imported by this file|"
-      "C++ types from imported module %3 do not support library evolution}4",
-      (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
+      "%2 was not imported by this file|"
+      "C++ types from imported module %2 do not support library evolution}3",
+      (const Decl *, unsigned, Identifier, unsigned))
 ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "%0 aliases '%1.%2' and cannot be used %select{here|"
       "as property wrapper here|"
@@ -3391,7 +3378,7 @@ ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "%4 was imported for SPI only|"
       "%4 was not imported by this file|"
       "C++ types from imported module %4 do not support library evolution}5",
-      (DeclName, StringRef, StringRef, unsigned, Identifier, unsigned))
+      (const TypeAliasDecl *, StringRef, StringRef, unsigned, Identifier, unsigned))
 ERROR(conformance_from_implementation_only_module,none,
       "cannot use conformance of %0 to %1 %select{here|as property wrapper here|"
       "as result builder here|"
@@ -3801,7 +3788,7 @@ NOTE(attr_ApplicationMain_script_here,none,
 ERROR(attr_MainType_without_main,none,
       "%0 is annotated with @main and must provide a main static function of type %"
       SELECT_APPLICATION_MAIN_TYPES "1",
-      (DeclName, bool))
+      (const ValueDecl *, bool))
 
 #undef SELECT_APPLICATION_MAIN_TYPES
 #undef SELECT_APPLICATION_MAIN
@@ -3834,14 +3821,14 @@ ERROR(attr_for_debugger_support_only,none,
 
 // @_implements
 ERROR(implements_attr_protocol_lacks_member,none,
-      "protocol %0 has no member %1", (Identifier, DeclName))
+      "protocol %0 has no member %1", (const ProtocolDecl *, DeclName))
 
 ERROR(implements_attr_non_protocol_type,none,
       "non-protocol type in @_implements attribute", ())
 
 ERROR(implements_attr_protocol_not_conformed_to,none,
       "containing type %0 does not conform to protocol %1",
-      (Identifier, Identifier))
+      (const NominalTypeDecl *, const ProtocolDecl *))
 
 // @differentiable
 ERROR(differentiable_attr_overload_not_found,none,
@@ -4074,7 +4061,8 @@ ERROR(chain_convenience_init,none,
       (Type))
 ERROR(delegate_chain_nonoptional_to_optional,none,
       "a non-failable initializer cannot %select{delegate|chain}0 to "
-      "failable initializer %1 written with 'init?'", (bool, DeclName))
+      "failable initializer %1 written with 'init?'",
+      (bool, const ConstructorDecl *))
 NOTE(init_force_unwrap,none,
      "force potentially-failing result with '!'", ())
 NOTE(init_propagate_failure,none,
@@ -4094,16 +4082,13 @@ NOTE(convenience_init_here,none,
 ERROR(designated_init_in_extension,none,
       "designated initializer cannot be declared in an extension of %0; "
       "did you mean this to be a convenience initializer?",
-      (DeclName))
+      (const ValueDecl *))
 ERROR(designated_init_in_extension_no_convenience_tip,none,
       "designated initializer cannot be declared in an extension of %0",
-      (DeclName))
+      (const ValueDecl *))
 ERROR(no_convenience_keyword_init,none,
       "initializers in %0 are not marked with 'convenience'",
       (StringRef))
-ERROR(nonclass_convenience_init,none,
-      "convenience initializer not allowed in non-class type %0",
-      (DeclName))
 ERROR(cfclass_convenience_init,none,
       "convenience initializers are not supported in extensions of CF types",
       ())
@@ -4112,7 +4097,7 @@ ERROR(dynamic_construct_class,none,
       "a 'required' initializer", (Type))
 NOTE(note_nonrequired_initializer,none,
       "selected %select{non-required|implicit}0 initializer %1",
-     (bool, DeclName))
+     (bool, const ConstructorDecl *))
 ERROR(construct_protocol_value,none,
       "value of type %0 is a protocol; it cannot be instantiated",
       (Type))
@@ -4335,7 +4320,7 @@ ERROR(ambiguous_operator_ref,none,
 NOTE(ambiguous_because_of_trailing_closure,none,
      "%select{use an explicit argument label instead of a trailing closure|"
      "avoid using a trailing closure}0 to call %1",
-     (bool, DeclName))
+     (bool, const ValueDecl *))
 
 // Cannot capture inout-ness of a parameter
 // Partial application of foreign functions not supported
@@ -4421,13 +4406,15 @@ NOTE(fix_unqualified_access_top_level_multi,none,
      (StringRef, DescriptiveDeclKind, Identifier))
 
 WARNING(warn_deprecated_conditional_conformance_outer_access,Deprecation,
-        "use of %0 as reference to %1 in %2 %3 will change in future versions of Swift to reference %4 in %5 %6 "
-        "which comes via a conditional conformance",
-        (DeclNameRef, DescriptiveDeclKind, DescriptiveDeclKind, DeclName,
-        DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
+        "use of %0 as reference to %1 in %kind2 will change in future versions "
+        "of Swift to reference %3 in %kind4 which comes via a conditional "
+        "conformance",
+        (DeclNameRef,
+         /*current*/DescriptiveDeclKind, const ValueDecl *,
+         /*future*/ DescriptiveDeclKind, const ValueDecl *))
 NOTE(fix_deprecated_conditional_conformance_outer_access,none,
      "use '%0' to continue to reference the %1",
-     (StringRef, DescriptiveDeclKind, Identifier))
+     (StringRef, DescriptiveDeclKind))
 
 ERROR(unsupported_special_decl_ref, none,
       "referencing %0 as a function value is not implemented", (Identifier))
@@ -4561,7 +4548,7 @@ ERROR(capture_across_type_decl,none,
       (DescriptiveDeclKind, Identifier))
 
 ERROR(reference_to_invalid_decl,none,
-      "cannot reference invalid declaration %0", (DeclName))
+      "cannot reference invalid declaration %0", (const ValueDecl *))
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Statements
@@ -4583,7 +4570,8 @@ ERROR(return_expr_missing,none,
 ERROR(return_non_failable_init,none,
       "only a failable initializer can return 'nil'", ())
 NOTE(make_init_failable,none,
-      "use 'init?' to make the initializer %0 failable", (DeclName))
+      "use 'init?' to make the initializer %0 failable",
+      (const ConstructorDecl *))
 ERROR(return_init_non_nil,none,
       "'nil' is the only return value permitted in an initializer",
       ())
@@ -4614,8 +4602,10 @@ WARNING(expression_unused_lvalue,NoUsage,
       "}0 is unused",
       (unsigned))
 WARNING(expression_unused_result_call,NoUsage,
-        "result of call to %0 is unused", (DeclName))
+        "result of call to %0 is unused", (const ValueDecl *))
 WARNING(expression_unused_result_operator,NoUsage,
+        "result of operator %0 is unused", (const ValueDecl *))
+WARNING(expression_unused_result_operator_name,NoUsage,
         "result of operator %0 is unused", (DeclName))
 WARNING(expression_unused_result_unknown, NoUsage,
         "result of call to %select{function|closure}0 returning %1 is unused", (bool, Type))
@@ -4836,9 +4826,9 @@ ERROR(single_tuple_parameter_mismatch_normal,none,
       "%kindbase0 expects a single parameter of type %1%2",
       (const ValueDecl *, Type, StringRef))
 ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
-      "%0 %select{%1 |}2expects %3 separate arguments"
-      "%select{|; remove extra parentheses to change tuple into separate arguments}4",
-      (DescriptiveDeclKind, DeclName, bool, unsigned, bool))
+      "%kindonly0 %select{%base0 |}1expects %2 separate arguments"
+      "%select{|; remove extra parentheses to change tuple into separate arguments}3",
+      (const ValueDecl *, bool, unsigned, bool))
 
 ERROR(enum_element_pattern_assoc_values_mismatch,none,
       "pattern with associated values does not match enum case %0",
@@ -4991,20 +4981,20 @@ ERROR(async_in_nonasync_function,none,
       "%select{a function|an autoclosure}1 that does not support concurrency",
       (unsigned, bool))
 NOTE(note_add_async_to_function,none,
-     "add 'async' to function %0 to make it asynchronous", (DeclName))
+     "add 'async' to function %0 to make it asynchronous", (const ValueDecl *))
 NOTE(note_add_nonisolated_to_decl,none,
-     "add 'nonisolated' to %0 to make this %1 not isolated to the actor",
-     (DeclName, DescriptiveDeclKind))
+     "add 'nonisolated' to %0 to make this %kindonly0 not isolated to the actor",
+     (const ValueDecl *))
 NOTE(note_add_async_and_throws_to_decl,none,
      "mark the protocol requirement %0 '%select{|async|throws|async throws}1' "
      "to allow actor-isolated conformances",
-     (DeclName, unsigned))
+     (const ValueDecl *, unsigned))
 NOTE(note_add_distributed_to_decl,none,
-     "add 'distributed' to %0 to make this %1 satisfy the protocol requirement",
-     (DeclName, DescriptiveDeclKind))
+     "add 'distributed' to %0 to make this %kindonly0 satisfy the protocol requirement",
+     (const ValueDecl *))
 NOTE(note_add_globalactor_to_function,none,
-     "add '@%0' to make %1 %2 part of global actor %3", 
-     (StringRef, DescriptiveDeclKind, DeclName, Type))
+     "add '@%0' to make %kind1 part of global actor %2",
+     (StringRef, const ValueDecl *, Type))
 FIXIT(insert_globalactor_attr, "@%0 ", (Type))
 
 ERROR(main_function_must_be_mainActor,none,
@@ -5032,7 +5022,7 @@ ERROR(async_let_not_initialized,none,
 ERROR(async_let_no_variables,none,
       "'async let' requires at least one named variable", ())
 NOTE(async_let_without_await,none,
-      "reference to async let %0 is 'async'", (DeclName))
+      "reference to async let %0 is 'async'", (const ValueDecl *))
 
 #define EFFECTS_CONTEXT_KIND \
   "%select{<<ERROR>>|" \
@@ -5053,7 +5043,7 @@ ERROR(await_in_illegal_context,none,
       (unsigned))
 ERROR(async_let_in_illegal_context,none,
       "async let %0 cannot be referenced in " EFFECTS_CONTEXT_KIND "1",
-      (DeclName, unsigned))
+      (const ValueDecl *, unsigned))
 ERROR(async_let_binding_illegal_context,none,
       "'async let' cannot be used on declarations in " EFFECTS_CONTEXT_KIND "0",
       (unsigned))
@@ -5063,9 +5053,9 @@ ERROR(async_let_binding_illegal_context,none,
 ERROR(objc_ambiguous_async_convention,none,
       "%0 overrides or implements protocol requirements for Objective-C "
       "declarations with incompatible async conventions",
-      (DeclName))
+      (const ValueDecl *))
 NOTE(objc_ambiguous_async_convention_candidate,none,
-     "%0 provides async here", (DeclName))
+     "%0 provides async here", (const ValueDecl *))
 
 ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
@@ -5445,23 +5435,23 @@ ERROR(global_actor_non_final_class,none,
 ERROR(global_actor_top_level_var,none,
       "top-level code variables cannot have a global actor", ())
 ERROR(global_actor_access,none,
-      "%select{private|fileprivate|internal|package|public|open}0 %1 %2 "
-      "cannot have %select{private|fileprivate|internal|package|%error|%error}3 "
-      "global actor %4",
-      (AccessLevel, DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
+      "%select{private|fileprivate|internal|package|public|open}0 %kind1 "
+      "cannot have %select{private|fileprivate|internal|package|%error|%error}2 "
+      "global actor %3",
+      (AccessLevel, const ValueDecl *, AccessLevel, DeclName))
 ERROR(global_actor_not_usable_from_inline,none,
       "global actor for %kind0 must be '@usableFromInline' or public",
       (const ValueDecl *))
 
 ERROR(actor_isolation_multiple_attr,none,
-      "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",
-      (DescriptiveDeclKind, DeclName, StringRef, StringRef))
+      "%kind0 has multiple actor-isolation attributes ('%1' and '%2')",
+      (const Decl *, StringRef, StringRef))
 ERROR(actor_isolation_override_mismatch,none,
       "%0 %kind1 has different actor isolation from %2 overridden declaration",
       (ActorIsolation, const ValueDecl *, ActorIsolation))
 ERROR(actor_isolation_superclass_mismatch,none,
       "%0 class %1 has different actor isolation from %2 superclass %3",
-      (ActorIsolation, DeclName, ActorIsolation, DeclName))
+      (ActorIsolation, const ClassDecl *, ActorIsolation, const ClassDecl *))
 
 ERROR(async_decl_must_be_available_from_async,none,
         "asynchronous %0 must be available from asynchronous contexts",
@@ -5849,9 +5839,9 @@ ERROR(objc_setter_for_nonobjc_property,none,
 ERROR(objc_setter_for_nonobjc_subscript,none,
       "'@objc' setter for non-'@objc' subscript", ())
 WARNING(accessor_swift3_objc_inference,Deprecation,
-        "%select{%0 %1|%1}2 with '@objc' %select{getter|setter}3 depends on "
+        "%kind0 with '@objc' %select{getter|setter}1 depends on "
         "deprecated inference of '@objc'",
-        (DescriptiveDeclKind, DeclName, bool, bool))
+        (const AbstractStorageDecl *, bool))
 
 ERROR(objc_enum_generic,none,
       "'@objc' enum cannot be generic", ())
@@ -5940,8 +5930,8 @@ NOTE(objc_inferring_on_objc_protocol_member,none,
 NOTE(objc_overriding_objc_decl,none,
      "overriding '@objc' %kind0 here", (const ValueDecl *))
 NOTE(objc_witness_objc_requirement,none,
-     "satisfying requirement for %0 %1 in protocol %2",
-     (DescriptiveDeclKind, DeclName, Identifier))
+     "satisfying requirement for %kind0 in protocol %1",
+     (const ValueDecl *, const ProtocolDecl *))
 WARNING(witness_swift3_objc_inference,Deprecation,
         "use of %kind0 to satisfy a requirement of protocol %1 depends on "
         "'@objc' inference deprecated in Swift 4",
@@ -6010,14 +6000,14 @@ ERROR(objc_ambiguous_inference,none,
       (const ValueDecl *, ObjCSelector, ObjCSelector))
 NOTE(objc_ambiguous_inference_candidate,none,
      "%0 (in protocol %1) provides Objective-C name %2",
-     (DeclName, Identifier, ObjCSelector))
+     (const ValueDecl *, const ProtocolDecl *, ObjCSelector))
 
 ERROR(objc_ambiguous_error_convention,none,
       "%0 overrides or implements protocol requirements for Objective-C "
       "declarations with incompatible error argument conventions",
-      (DeclName))
+      (const ValueDecl *))
 NOTE(objc_ambiguous_error_convention_candidate,none,
-     "%0 provides an error argument here", (DeclName))
+     "%0 provides an error argument here", (const ValueDecl *))
 
 ERROR(nonlocal_bridged_to_objc,none,
       "conformance of %0 to %1 can only be written in module %2",
@@ -6499,7 +6489,7 @@ ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
       "%4 was imported for SPI only|"
       "%4 was not imported by this file|"
       "C++ types from imported module %4 do not support library evolution}5",
-      (DeclName, StringRef, StringRef, unsigned, Identifier, unsigned))
+      (const TypeAliasDecl *, StringRef, StringRef, unsigned, Identifier, unsigned))
 
 NOTE(missing_import_inserted,
      none, "The missing import of module %0 will be added implicitly",
@@ -6774,9 +6764,9 @@ ERROR(property_with_wrapper_conflict_attribute,none,
 ERROR(property_wrapper_not_single_var, none,
       "property wrapper can only apply to a single variable", ())
 ERROR(property_with_wrapper_in_bad_context,none,
-      "%select{|non-static|non-static}1 %2 %0 declared inside "
+      "%select{|non-static|non-static}1 %kind0 declared inside "
       "%select{a protocol|an extension|an enum}1 cannot have a wrapper",
-      (Identifier, int, DescriptiveDeclKind))
+      (const ValueDecl *, int))
 ERROR(property_with_wrapper_overrides,none,
       "property %0 with attached wrapper cannot override another property",
       (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2310,10 +2310,10 @@ NOTE(module_imported_here,none,
      "module %0 imported as '%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' here",
      (Identifier, AccessLevel))
 NOTE(decl_import_via_here,none,
-     "%0 %1 imported as "
-     "'%select{private|fileprivate|internal|package|%ERROR|%ERROR}2' "
-     "from %3 here",
-     (DescriptiveDeclKind, DeclName, AccessLevel, Identifier))
+     "%kind0 imported as "
+     "'%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' "
+     "from %2 here",
+     (const ValueDecl *, AccessLevel, Identifier))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,
@@ -6500,14 +6500,14 @@ ERROR(local_type_in_inlinable_function,
       (Identifier, unsigned))
 
 ERROR(resilience_decl_unavailable,
-      none, DECL_OR_ACCESSOR "4 %1 is %select{private|fileprivate|internal|package|%error|%error}2 and "
-      "cannot be referenced from " FRAGILE_FUNC_KIND "3",
-      (DescriptiveDeclKind, DeclName, AccessLevel, unsigned, bool))
+      none, "%kind0 is %select{private|fileprivate|internal|package|%error|%error}1 and "
+      "cannot be referenced from " FRAGILE_FUNC_KIND "2",
+      (const ValueDecl *, AccessLevel, unsigned))
 
 WARNING(resilience_decl_unavailable_warn,
-        none, DECL_OR_ACCESSOR "4 %1 is %select{private|fileprivate|internal|package|%error|%error}2 and "
-        "should not be referenced from " FRAGILE_FUNC_KIND "3",
-        (DescriptiveDeclKind, DeclName, AccessLevel, unsigned, bool))
+        none, "%kind0 is %select{private|fileprivate|internal|package|%error|%error}1 and "
+        "should not be referenced from " FRAGILE_FUNC_KIND "2",
+        (const ValueDecl *, AccessLevel, unsigned))
 
 ERROR(inlinable_decl_ref_from_hidden_module,
       none, "%0 %1 cannot be used in " FRAGILE_FUNC_KIND "2 "
@@ -6547,10 +6547,8 @@ ERROR(availability_macro_in_inlinable, none,
 #undef FRAGILE_FUNC_KIND
 
 NOTE(resilience_decl_declared_here,
-     none, DECL_OR_ACCESSOR "2 %1 is not '@usableFromInline' or public",
-     (DescriptiveDeclKind, DeclName, bool))
-
-#undef DECL_OR_ACCESSOR
+     none, "%kind0 is not '@usableFromInline' or public",
+     (const ValueDecl *))
 
 ERROR(class_designated_init_inlinable_resilient,none,
       "initializer for class %0 is "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -374,8 +374,8 @@ ERROR(cannot_convert_argument_value,none,
 
 ERROR(cannot_convert_argument_value_for_swift_func,none,
       "cannot convert value of type %0 to expected argument type %1 "
-      "because %2 %3 was not imported from C header",
-      (Type,Type, DescriptiveDeclKind, DeclName))
+      "because %kind2 was not imported from C header",
+      (Type,Type, const ValueDecl *))
 
 NOTE(candidate_has_invalid_argument_at_position,none,
      "candidate expects %select{|in-out }2value of type %0 for parameter #%1 (got %3)",
@@ -639,8 +639,8 @@ ERROR(expr_keypath_type_of_property,none,
 ERROR(expr_keypath_generic_type,none,
       "key path cannot refer to generic type %0", (Identifier))
 ERROR(expr_keypath_not_property,none,
-      "%select{key path|dynamic key path member lookup}2 cannot refer to %0 %1",
-      (DescriptiveDeclKind, DeclName, bool))
+      "%select{key path|dynamic key path member lookup}1 cannot refer to %kind0",
+      (const ValueDecl *, bool))
 ERROR(expr_keypath_mutating_getter,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to %0, "
       "which has a mutating getter",
@@ -705,8 +705,8 @@ ERROR(expr_selector_not_method,none,
       "argument of '#selector' cannot refer to %select{local|global}0 "
       "function %1", (bool, DeclName))
 ERROR(expr_selector_expected_property,none,
-      "cannot reference %1 %2 as a property; remove '%select{getter|setter}0:'",
-      (bool, DescriptiveDeclKind, DeclName))
+      "cannot reference %kind1 as a property; remove '%select{getter|setter}0:'",
+      (bool, const ValueDecl *))
 ERROR(expr_selector_not_property,none,
       "argument of '#selector' cannot refer to %select{variable|parameter}0 %1",
       (bool, DeclName))
@@ -718,24 +718,24 @@ NOTE(expr_selector_add_modifier,none,
      "add '%select{getter|setter}0:' to reference the Objective-C "
      "%select{getter|setter}0 for %1", (bool, DeclName))
 ERROR(expr_selector_property_not_settable,none,
-      "argument of '#selector(setter:)' refers to non-settable %0 %1",
-      (DescriptiveDeclKind, DeclName))
+      "argument of '#selector(setter:)' refers to non-settable %kind0",
+      (const ValueDecl *))
 ERROR(expr_selector_property_setter_inaccessible,none,
-      "setter of %0 %1 is inaccessible", (DescriptiveDeclKind, DeclName))
+      "setter of %kind0 is inaccessible", (const ValueDecl *))
 ERROR(expr_selector_cannot_be_used,none,
       "cannot use %0 as a selector because protocol %1 is not exposed to Objective-C",
       (DeclBaseName, Identifier))
 ERROR(expr_selector_not_objc,none,
-      "argument of '#selector' refers to %0 %1 that is not exposed to "
+      "argument of '#selector' refers to %kind0 that is not exposed to "
       "Objective-C",
-      (DescriptiveDeclKind, DeclName))
+      (const ValueDecl *))
 NOTE(make_decl_objc,none,
      "add '@objc' to expose this %0 to Objective-C",
      (DescriptiveDeclKind))
 WARNING(expr_selector_swift3_objc_inference,Deprecation,
-        "argument of '#selector' refers to %0 %1 in %2 that depends on "
+        "argument of '#selector' refers to %kind0 in %1 that depends on "
         "'@objc' inference deprecated in Swift 4",
-        (DescriptiveDeclKind, DeclName, Identifier))
+        (const ValueDecl *, Identifier))
 
 // Selectors-as-string-literals.
 WARNING(selector_literal_invalid,none,
@@ -1417,8 +1417,8 @@ ERROR(incorrect_property_wrapper_reference,none,
       "use %select{wrapper|wrapped value}3 instead",
       (Identifier, Type, Type, bool))
 ERROR(incorrect_property_wrapper_reference_member,none,
-      "referencing %0 %1 requires %select{wrapper|wrapped value of type}2 %3",
-      (DescriptiveDeclKind, DeclName, bool, Type))
+      "referencing %kind0 requires %select{wrapper|wrapped value of type}1 %2",
+      (const ValueDecl *, bool, Type))
 
 ERROR(missing_init_on_metatype_initialization,none,
       "initializing from a metatype value must reference 'init' explicitly",
@@ -1453,11 +1453,11 @@ NOTE(candidate_expected_different_labels,none,
      (StringRef, StringRef))
 
 ERROR(member_shadows_function,none,
-      "use of %0 refers to %1 rather than %2 %3",
-      (DeclNameRef, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
+      "use of %0 refers to %1 rather than %kind2",
+      (DeclNameRef, DescriptiveDeclKind, const ValueDecl *))
 ERROR(member_shadows_global_function,none,
-      "use of %0 refers to %1 rather than %2 %3 in module %4",
-      (DeclNameRef, DescriptiveDeclKind, DescriptiveDeclKind, DeclName, DeclName))
+      "use of %0 refers to %1 rather than %kind2 in module %3",
+      (DeclNameRef, DescriptiveDeclKind, const ValueDecl *, DeclName))
 
 ERROR(instance_member_use_on_type,none,
       "instance member %1 cannot be used on type %0; "
@@ -1589,7 +1589,7 @@ ERROR(attribute_requires_single_argument,none,
       "'%0' requires a function with one argument", (StringRef))
 
 ERROR(nominal_type_not_attribute,none,
-      "%0 %1 cannot be used as an attribute", (DescriptiveDeclKind, Identifier))
+      "%kind0 cannot be used as an attribute", (const ValueDecl *))
 
 ERROR(mutating_invalid_global_scope,none, "%0 is only valid on methods",
       (SelfAccessKind))
@@ -1977,9 +1977,9 @@ ERROR(missing_undefined_runtime,none,
       "standard library error: missing _undefined", ())
 
 WARNING(expr_dynamic_lookup_swift3_objc_inference,Deprecation,
-        "reference to %0 %1 of %2 depends on '@objc' inference "
+        "reference to %kind0 of %1 depends on '@objc' inference "
         "deprecated in Swift 4",
-        (DescriptiveDeclKind, DeclName, Identifier))
+        (const ValueDecl *, Identifier))
 
 ERROR(inherited_default_value_not_in_designated_constructor,none,
       "default value inheritance via 'super' is only valid on the parameters of "
@@ -2284,8 +2284,8 @@ ERROR(spi_attribute_on_frozen_stored_properties,none,
       "stored property %0 cannot be declared '@_spi' in a '@frozen' struct",
       (DeclName))
 ERROR(spi_attribute_on_frozen_enum_case,none,
-      "%0 %1 cannot be declared '@_spi' in a '@frozen' enum",
-      (DescriptiveDeclKind, DeclName))
+      "%kind0 cannot be declared '@_spi' in a '@frozen' enum",
+      (const ValueDecl *))
 WARNING(spi_attribute_on_import_of_public_module,none,
         "'@_spi' import of %0 will not include any SPI symbols; "
         "%0 was built from the public interface at %1",
@@ -2397,11 +2397,11 @@ NOTE(nonsendable_tuple_type,none,
      "a tuple type must be composed of 'Sendable' elements to conform to "
      "'Sendable'", ())
 NOTE(non_sendable_nominal,none,
-     "%0 %1 does not conform to the 'Sendable' protocol",
-      (DescriptiveDeclKind, DeclName))
+     "%kind0 does not conform to the 'Sendable' protocol",
+      (const ValueDecl *))
 NOTE(add_nominal_sendable_conformance,none,
-     "consider making %0 %1 conform to the 'Sendable' protocol",
-     (DescriptiveDeclKind, DeclName))
+     "consider making %kind0 conform to the 'Sendable' protocol",
+     (const ValueDecl *))
 NOTE(add_generic_parameter_sendable_conformance,none,
      "consider making generic parameter %0 conform to the 'Sendable' protocol",
      (Type))
@@ -2412,23 +2412,23 @@ REMARK(add_predates_concurrency_import,none,
 REMARK(remove_predates_concurrency_import,none,
      "'@preconcurrency' attribute on module %0 is unused", (Identifier))
 WARNING(public_decl_needs_sendable,none,
-        "public %0 %1 does not specify whether it is 'Sendable' or not",
-        (DescriptiveDeclKind, DeclName))
+        "public %kind0 does not specify whether it is 'Sendable' or not",
+        (const ValueDecl *))
 NOTE(explicit_unchecked_sendable,none,
-     "add '@unchecked Sendable' conformance to %0 %1 if this type manually implements concurrency safety",
-     (DescriptiveDeclKind, DeclName))
+     "add '@unchecked Sendable' conformance to %kind0 if this type manually implements concurrency safety",
+     (const ValueDecl *))
 NOTE(explicit_disable_sendable,none,
-     "make %0 %1 explicitly non-Sendable to suppress this warning",
-     (DescriptiveDeclKind, DeclName))
+     "make %kind0 explicitly non-Sendable to suppress this warning",
+     (const ValueDecl *))
 
 NOTE(required_by_opaque_return,none,
-    "required by opaque return type of %0 %1", (DescriptiveDeclKind, DeclName))
+    "required by opaque return type of %kind0", (const ValueDecl *))
 NOTE(required_by_decl,none,
-     "required by %0 %1 where %2 = %3",
-     (DescriptiveDeclKind, DeclName, Type, Type))
+     "required by %kind0 where %1 = %2",
+     (const ValueDecl *, Type, Type))
 NOTE(required_by_decl_ref,none,
-     "required by referencing %0 %1 on %2 where %3 = %4",
-     (DescriptiveDeclKind, DeclName, Type, Type, Type))
+     "required by referencing %kind0 on %1 where %2 = %3",
+     (const ValueDecl *, Type, Type, Type))
 
 ERROR(protocol_does_not_conform_static,none,
       "%0 cannot be used as a type conforming to protocol %1 because %1 "
@@ -2449,44 +2449,44 @@ ERROR(types_not_same_shape,none,
 ERROR(type_does_not_conform_owner,none,
       "%0 requires that %1 conform to %2", (Type, Type, Type))
 ERROR(type_does_not_conform_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires that %3 conform to %4",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %kind0 on %1 requires that %2 conform to %3",
+      (const ValueDecl *, Type, Type, Type))
 ERROR(contextual_member_ref_on_protocol_requires_self_requirement,none,
-      "contextual member reference to %0 %1 requires "
+      "contextual member reference to %kind0 requires "
       "'Self' constraint in the protocol extension",
-      (DescriptiveDeclKind, DeclName))
+      (const ValueDecl *))
 NOTE(missing_sametype_requirement_on_self,none,
       "missing same-type requirement on 'Self'", ())
 ERROR(type_does_not_conform_anyobject_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires that %3 be a class type",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %kind0 on %1 requires that %2 be a class type",
+      (const ValueDecl *, Type, Type, Type))
 ERROR(type_does_not_conform_decl_owner,none,
-      "%0 %1 requires that %2 conform to %3",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%kind0 requires that %1 conform to %2",
+      (const ValueDecl *, Type, Type))
 ERROR(type_does_not_conform_anyobject_decl_owner,none,
-      "%0 %1 requires that %2 be a class type",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%kind0 requires that %1 be a class type",
+      (const ValueDecl *, Type, Type))
 ERROR(type_does_not_conform_in_opaque_return,none,
-      "return type of %0 %1 requires that %2 %select{conform to %3|be a class type}4",
-      (DescriptiveDeclKind, DeclName, Type, Type, bool))
+      "return type of %kind0 requires that %1 %select{conform to %2|be a class type}3",
+      (const ValueDecl *, Type, Type, bool))
 ERROR(types_not_equal_decl,none,
-      "%0 %1 requires the types %2 and %3 be equivalent",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%kind0 requires the types %1 and %2 be equivalent",
+      (const ValueDecl *, Type, Type))
 ERROR(types_not_equal_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires the types %3 and %4 be equivalent",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %kind0 on %1 requires the types %2 and %3 be equivalent",
+      (const ValueDecl *, Type, Type, Type))
 ERROR(types_not_same_shape_decl,none,
-      "%0 %1 requires the type packs %2 and %3 have the same shape",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%kind0 requires the type packs %1 and %2 have the same shape",
+      (const ValueDecl *, Type, Type))
 ERROR(types_not_same_shape_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires the type packs %3 and %4 have the same shape",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %kind0 on %1 requires the type packs %2 and %3 have the same shape",
+      (const ValueDecl *, Type, Type, Type))
 ERROR(types_not_inherited_decl,none,
-      "%0 %1 requires that %2 inherit from %3",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%kind0 requires that %1 inherit from %2",
+      (const ValueDecl *, Type, Type))
 ERROR(types_not_inherited_in_decl_ref,none,
-      "referencing %0 %1 on %2 requires that %3 inherit from %4",
-      (DescriptiveDeclKind, DeclName, Type, Type, Type))
+      "referencing %kind0 on %1 requires that %2 inherit from %3",
+      (const ValueDecl *, Type, Type, Type))
 NOTE(where_requirement_failure_one_subst,none,
      "where %0 = %1", (Type, Type))
 NOTE(where_requirement_failure_both_subst,none,
@@ -2568,9 +2568,9 @@ ERROR(requirement_restricts_self,none,
       "'Self'",
       (DescriptiveDeclKind, DeclName, StringRef, unsigned, StringRef))
 ERROR(witness_argument_name_mismatch,none,
-      "%0 %1 has different argument labels "
-      "from those required by protocol %2 (%3)",
-      (DescriptiveDeclKind, DeclName, Type, DeclName))
+      "%kind0 has different argument labels "
+      "from those required by protocol %1 (%2)",
+      (const ValueDecl *, Type, DeclName))
 ERROR(witness_initializer_not_required,none,
       "initializer requirement %0 can only be satisfied by a 'required' "
       "initializer in%select{| the definition of}1 non-final class %2",
@@ -2586,10 +2586,9 @@ ERROR(witness_self_non_subtype,none,
       "position",
       (Type, DeclName, Type))
 ERROR(witness_self_same_type,none,
-      "%0 %1 in non-final class %2 cannot be used to satisfy requirement %3 %4"
-      " (in protocol %5) due to same-type requirement involving 'Self'",
-      (DescriptiveDeclKind, DeclName, Type, DescriptiveDeclKind,
-       DeclName, Type))
+      "%kind0 in non-final class %1 cannot be used to satisfy requirement %kind2"
+      " (in protocol %3) due to same-type requirement involving 'Self'",
+      (const ValueDecl *, Type, const ValueDecl *, Type))
 NOTE(witness_self_weaken_same_type,none,
       "consider weakening the same-type requirement %0 == %1 to a superclass "
       "requirement", (Type, Type))
@@ -2611,9 +2610,9 @@ ERROR(witness_not_accessible_proto,none,
       "%5",
       (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
 ERROR(witness_not_as_sendable,none,
-      "sendability of function types in %0 %1 does not match requirement in "
-      "protocol %2",
-      (DescriptiveDeclKind, DeclName, Identifier))
+      "sendability of function types in %kind0 does not match requirement in "
+      "protocol %1",
+      (const ValueDecl *, Identifier))
 NOTE(less_sendable_reqt_here,none,
      "expected sendability to match requirement here",
      ())
@@ -2623,22 +2622,22 @@ ERROR(witness_not_accessible_type,none,
       "type because it matches a requirement in protocol %5",
       (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
 ERROR(type_witness_not_accessible_proto,none,
-      "%0 %1 must be declared %select{%error|fileprivate|internal|package|public|%error}2 "
+      "%kind0 must be declared %select{%error|fileprivate|internal|package|public|%error}1 "
       "because it matches a requirement in "
-      "%select{%error|fileprivate|internal|package|public|%error}2 protocol %3",
-      (DescriptiveDeclKind, Identifier, AccessLevel, Identifier))
+      "%select{%error|fileprivate|internal|package|public|%error}1 protocol %2",
+      (const ValueDecl *, AccessLevel, Identifier))
 ERROR(type_witness_not_accessible_type,none,
-      "%0 %1 must be as accessible as its enclosing type because it "
-      "matches a requirement in protocol %3",
-      (DescriptiveDeclKind, Identifier, AccessLevel, Identifier))
+      "%kind0 must be as accessible as its enclosing type because it "
+      "matches a requirement in protocol %2",
+      (const ValueDecl *, AccessLevel, Identifier))
 ERROR(witness_not_usable_from_inline,none,
-      "%0 %1 must be declared '@usableFromInline' "
-      "because it matches a requirement in protocol %2",
-      (DescriptiveDeclKind, DeclName, Identifier))
+      "%kind0 must be declared '@usableFromInline' "
+      "because it matches a requirement in protocol %1",
+      (const ValueDecl *, Identifier))
 WARNING(witness_not_usable_from_inline_warn,none,
-        "%0 %1 should be declared '@usableFromInline' "
-        "because it matches a requirement in protocol %2",
-        (DescriptiveDeclKind, DeclName, Identifier))
+        "%kind0 should be declared '@usableFromInline' "
+        "because it matches a requirement in protocol %1",
+        (const ValueDecl *, Identifier))
 ERROR(type_witness_objc_generic_parameter,none,
       "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
       "used for associated type %3 of protocol %4",
@@ -2847,8 +2846,8 @@ NOTE(declared_protocol_conformance_here,none,
      (Type, unsigned, Identifier, Identifier))
 
 ERROR(witness_unavailable,none,
-        "unavailable %0 %1 was used to satisfy a requirement of protocol %2%select{|: %3}3",
-        (DescriptiveDeclKind, DeclName, Identifier, StringRef))
+        "unavailable %kind0 was used to satisfy a requirement of protocol %1%select{|: %2}2",
+        (const ValueDecl *, Identifier, StringRef))
 
 ERROR(redundant_conformance,none,
       "redundant conformance of %0 to protocol %1", (Type, Identifier))
@@ -2866,14 +2865,14 @@ WARNING(redundant_conformance_adhoc_conditional,none,
         "there cannot be more than one conformance, even with different conditional bounds",
         (Type, Identifier, bool, Identifier))
 NOTE(redundant_conformance_witness_ignored,none,
-     "%0 %1 will not be used to satisfy the conformance to %2",
-     (DescriptiveDeclKind, DeclName, Identifier))
+     "%kind0 will not be used to satisfy the conformance to %1",
+     (const ValueDecl *, Identifier))
 
 // "Near matches"
 WARNING(req_near_match,none,
-        "%0 %1 nearly matches %select{defaulted|optional}2 requirement %3 "
-        "of protocol %4",
-        (DescriptiveDeclKind, DeclName, bool, DeclName, Identifier))
+        "%kind0 nearly matches %select{defaulted|optional}1 requirement %2 "
+        "of protocol %3",
+        (const ValueDecl *, bool, DeclName, Identifier))
 NOTE(optional_req_nonobjc_near_match_add_objc,none,
      "add '@objc' to provide an Objective-C entrypoint", ())
 NOTE(req_near_match_move,none,
@@ -2954,11 +2953,11 @@ ERROR(shadowed_generic_param,none,
       (DeclName))
 
 ERROR(recursive_decl_reference,none,
-      "%0 %1 references itself", (DescriptiveDeclKind, DeclBaseName))
+      "%kind0 references itself", (const ValueDecl *))
 ERROR(recursive_generic_signature,none,
-      "%0 %1 has self-referential generic requirements", (DescriptiveDeclKind, DeclBaseName))
+      "%kind0 has self-referential generic requirements", (const ValueDecl *))
 ERROR(recursive_generic_signature_extension,none,
-      "extension of %0 %1 has self-referential generic requirements", (DescriptiveDeclKind, DeclBaseName))
+      "extension of %kind0 has self-referential generic requirements", (const ValueDecl *))
 ERROR(recursive_same_type_constraint,none,
       "same-type constraint %0 == %1 is recursive", (Type, Type))
 ERROR(recursive_superclass_constraint,none,
@@ -3049,13 +3048,13 @@ ERROR(override_multiple_decls_arg_mismatch,none,
       "declaration %0 has different argument labels from any potential "
       "overrides", (DeclName))
 NOTE(overridden_near_match_here,none,
-     "potential overridden %0 %1 here",
-      (DescriptiveDeclKind, DeclName))
+     "potential overridden %kind0 here",
+      (const ValueDecl *))
 ERROR(override_decl_extension,none,
-      "%select{|non-@objc}0 %2 %3 %select{"
-      "is declared in extension of %4 and cannot be overridden|"
-      "declared in %4 cannot be overridden from extension}1", 
-      (bool, bool, DescriptiveDeclKind, DeclName, DeclName))
+      "%select{|non-@objc}0 %kind2 %select{"
+      "is declared in extension of %3 and cannot be overridden|"
+      "declared in %3 cannot be overridden from extension}1",
+      (bool, bool, const ValueDecl *, DeclName))
 NOTE(overridden_here,none,
      "overridden declaration is here", ())
 NOTE(overridden_here_can_be_objc,none,
@@ -3080,12 +3079,8 @@ NOTE(suggest_removing_override, none,
      (DeclBaseName))
 
 ERROR(override_less_available,none,
-      "overriding %0 must be as available as declaration it overrides",
-      (DeclBaseName))
-
-ERROR(override_accessor_less_available,none,
-      "overriding %0 for %1 must be as available as declaration it overrides",
-      (DescriptiveDeclKind, DeclBaseName))
+      "overriding %base0 must be as available as declaration it overrides",
+      (ValueDecl *))
 
 ERROR(override_let_property,none,
       "cannot override immutable 'let' property %0 with the getter of a 'var'",
@@ -3212,9 +3207,9 @@ WARNING(implicitly_final_cannot_be_open_swift4,none,
         "'open'", (unsigned))
 
 WARNING(override_swift3_objc_inference,Deprecation,
-        "override of %0 %1 from extension of %2 depends on deprecated "
+        "override of %kind0 from extension of %1 depends on deprecated "
         "inference of '@objc'",
-        (DescriptiveDeclKind, DeclName, Identifier))
+        (const ValueDecl *, Identifier))
 
 // Inheritance
 ERROR(duplicate_inheritance,none,
@@ -3361,6 +3356,18 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
      "construct %0 from unwrapped %1 value", (Type, Type))
 
 ERROR(decl_from_hidden_module,none,
+      "cannot use %kind0 %select{here|as property wrapper here|"
+      "as result builder here|"
+      "in an extension with public or '@usableFromInline' members|"
+      "in an extension with conditional conformances}1; "
+      "%select{%2 has been imported as implementation-only|"
+      "it is an SPI imported from %2|"
+      "it is SPI|"
+      "%2 was imported for SPI only|"
+      "%2 was not imported by this file}3",
+      (const ValueDecl *, unsigned, Identifier, unsigned))
+// Duplicate of above for non-ValueDecls
+ERROR(decl_from_hidden_module_name,none,
       "cannot use %0 %1 %select{here|as property wrapper here|"
       "as result builder here|"
       "in an extension with public or '@usableFromInline' members|"
@@ -3371,15 +3378,6 @@ ERROR(decl_from_hidden_module,none,
       "%3 was imported for SPI only|"
       "%3 was not imported by this file|"
       "C++ types from imported module %3 do not support library evolution}4",
-      (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
-WARNING(decl_from_hidden_module_warn,none,
-      "cannot use %0 %1 %select{here|as property wrapper here|"
-      "as result builder here|"
-      "in an extension with public or '@usableFromInline' members|"
-      "in an extension with conditional conformances}2; "
-      "%select{%3 has been imported as implementation-only|"
-      "<<ERROR>>|<<ERROR>>|<<ERROR>>|"
-      "%3 was not imported by this file}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "%0 aliases '%1.%2' and cannot be used %select{here|"
@@ -3471,9 +3469,9 @@ ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
       "be satisfied by a 'required' initializer in the class definition",
       (Type, DeclName))
 ERROR(cannot_synthesize_in_crossfile_extension,none,
-      "extension outside of file declaring %0 %1 prevents automatic synthesis "
-      "of %2 for protocol %3",
-      (DescriptiveDeclKind, DeclName, DeclName, Type))
+      "extension outside of file declaring %kind0 prevents automatic synthesis "
+      "of %1 for protocol %2",
+      (const ValueDecl *, DeclName, Type))
 
 ERROR(broken_additive_arithmetic_requirement,none,
       "AdditiveArithmetic protocol is broken: unexpected requirement", ())
@@ -4417,8 +4415,8 @@ NOTE(add_self_to_type,none,
      "use '.self' to reference the type object", ())
 
 WARNING(warn_unqualified_access,none,
-        "use of %0 treated as a reference to %1 in %2 %3",
-        (Identifier, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
+        "use of %0 treated as a reference to %1 in %kind2",
+        (Identifier, DescriptiveDeclKind, const ValueDecl *))
 WARNING(self_refers_to_method,none,
        "'self' refers to the method '%0.self', which may be unexpected",
        (StringRef))
@@ -4515,11 +4513,11 @@ WARNING(iuo_to_any_coercion,none,
         "coercion of implicitly unwrappable value of type %0 to %1 does not "
         "unwrap optional", (Type, Type))
 NOTE(iuo_to_any_coercion_note,none,
-     "implicitly unwrapped %0 %1 declared here",
-     (DescriptiveDeclKind, DeclName))
+     "implicitly unwrapped %kind0 declared here",
+     (const ValueDecl *))
 NOTE(iuo_to_any_coercion_note_func_result,none,
-     "%0 %1 with implicitly unwrapped result type is declared here",
-     (DescriptiveDeclKind, DeclName))
+     "%kind0 with implicitly unwrapped result type is declared here",
+     (const ValueDecl *))
 NOTE(default_optional_to_any,none,
      "provide a default value to avoid this warning", ())
 NOTE(force_optional_to_any,none,
@@ -4659,8 +4657,8 @@ ERROR(assignment_bang_has_immutable_subcomponent,none,
       "cannot assign through '!': %0", (StringRef))
 
 NOTE(candidate_is_not_assignable,none,
-     "candidate is not assignable: %0 %1",
-     (DescriptiveDeclKind, DeclName))
+     "candidate is not assignable: %kind0",
+     (const ValueDecl *))
 
 NOTE(change_to_mutating,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",
@@ -4846,8 +4844,8 @@ ERROR(single_tuple_parameter_mismatch_special,none,
       "%0 expects a single parameter of type %1%2",
       (DescriptiveDeclKind, Type, StringRef))
 ERROR(single_tuple_parameter_mismatch_normal,none,
-      "%0 %1 expects a single parameter of type %2%3",
-      (DescriptiveDeclKind, DeclBaseName, Type, StringRef))
+      "%kindbase0 expects a single parameter of type %1%2",
+      (const ValueDecl *, Type, StringRef))
 ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
       "%0 %select{%1 |}2expects %3 separate arguments"
       "%select{|; remove extra parentheses to change tuple into separate arguments}4",
@@ -5028,8 +5026,8 @@ ERROR(not_objc_function_async,none,
 NOTE(not_objc_function_type_async,none,
       "'async' function types cannot be represented in Objective-C", ())
 ERROR(actor_isolated_objc,none,
-      "actor-isolated %0 %1 cannot be @objc",
-       (DescriptiveDeclKind, DeclName))
+      "actor-isolated %kind0 cannot be @objc",
+       (const ValueDecl *))
 NOTE(protocol_witness_async_conflict,none,
      "candidate is %select{not |}0'async', but%select{| @objc}1 protocol requirement is%select{| not}0",
      (bool, bool))
@@ -5107,8 +5105,8 @@ ERROR(actor_cannot_inherit_distributed_actor_protocol,none,
 ERROR(broken_distributed_actor_requirement,none,
       "DistributedActor protocol is broken: unexpected requirement", ())
 ERROR(distributed_actor_system_conformance_missing_adhoc_requirement,none,
-      "%0 %1 is missing witness for protocol requirement %2"
-      "", (DescriptiveDeclKind, DeclName, DeclName))
+      "%kind0 is missing witness for protocol requirement %1",
+      (const ValueDecl *, DeclName))
 NOTE(note_distributed_actor_system_conformance_missing_adhoc_requirement,none,
       "protocol %0 requires function %1 with signature:\n%2",
      (DeclName, DeclName, StringRef))
@@ -5117,20 +5115,20 @@ ERROR(override_implicit_unowned_executor,none,
       "cannot override an actor's 'unownedExecutor' property that wasn't "
       "explicitly defined", ())
 ERROR(actor_isolated_non_self_reference,none,
-        "%5 %0 %1 can not be "
-        "%select{referenced|mutated|used 'inout'}2 "
+        "%4 %kind0 can not be "
+        "%select{referenced|mutated|used 'inout'}1 "
         "%select{from outside the actor|on a different actor instance|"
         "on a non-isolated actor instance|"
         "from a Sendable function|from a Sendable closure|"
-        "from an 'async let' initializer|from global actor %4|"
+        "from an 'async let' initializer|from global actor %3|"
         "from the main actor|from a non-isolated context|"
-        "from a non-isolated autoclosure}3",
-        (DescriptiveDeclKind, DeclName, unsigned, unsigned, Type,
+        "from a non-isolated autoclosure}2",
+        (const ValueDecl *, unsigned, unsigned, Type,
          ActorIsolation))
 ERROR(distributed_actor_isolated_non_self_reference,none,
-      "distributed actor-isolated %0 %1 can not be accessed from a "
+      "distributed actor-isolated %kind0 can not be accessed from a "
       "non-isolated context",
-      (DescriptiveDeclKind, DeclName))
+      (const ValueDecl *))
 ERROR(distributed_actor_needs_explicit_distributed_import,none,
       "'Distributed' module not imported, required for 'distributed actor'",
       ())
@@ -5139,40 +5137,40 @@ ERROR(distributed_func_cannot_overload_on_async_only,none,
 NOTE(distributed_func_other_ambiguous_overload_here,none,
       "ambiguous distributed func %0 declared here", (DeclName))
 ERROR(actor_isolated_inout_state,none,
-      "actor-isolated %0 %1 cannot be passed 'inout' to"
-      "%select{| implicitly}2 'async' function call",
-      (DescriptiveDeclKind, DeclName, bool))
+      "actor-isolated %kind0 cannot be passed 'inout' to"
+      "%select{| implicitly}1 'async' function call",
+      (const ValueDecl *, bool))
 ERROR(actor_isolated_mutating_func,none,
-      "cannot call mutating async function %0 on actor-isolated %1 %2",
-      (DeclName, DescriptiveDeclKind, DeclName))
+      "cannot call mutating async function %0 on actor-isolated %kind1",
+      (DeclName, const ValueDecl *))
 ERROR(actor_isolated_call,none,
       "call to %0 function in a synchronous %1 context",
       (ActorIsolation, ActorIsolation))
 ERROR(actor_isolated_call_decl,none,
-      "call to %0 %1 %2 in a synchronous %3 context",
-      (ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
+      "call to %0 %kind1 in a synchronous %2 context",
+      (ActorIsolation, const ValueDecl *, ActorIsolation))
 ERROR(actor_isolated_partial_apply,none,
-        "actor-isolated %0 %1 can not be partially applied",
-        (DescriptiveDeclKind, DeclName))
+        "actor-isolated %kind0 can not be partially applied",
+        (const ValueDecl *))
 ERROR(concurrent_access_local,none,
-        "use of local %0 %1 in concurrently-executing code",
-        (DescriptiveDeclKind, DeclName))
+        "use of local %kind0 in concurrently-executing code",
+        (const ValueDecl *))
 ERROR(actor_isolated_keypath_component,none,
-      "cannot form key path to%select{| distributed}0 actor-isolated %1 %2",
-      (bool, DescriptiveDeclKind, DeclName))
+      "cannot form key path to%select{| distributed}0 actor-isolated %kind1",
+      (bool, const ValueDecl *))
 ERROR(effectful_keypath_component,none,
       "cannot form key path to %0 with 'throws' or 'async'",
       (DescriptiveDeclKind))
 ERROR(local_function_executed_concurrently,none,
-      "concurrently-executed %0 %1 must be marked as '@Sendable'",
-      (DescriptiveDeclKind, DeclName))
+      "concurrently-executed %kind0 must be marked as '@Sendable'",
+      (const ValueDecl *))
 ERROR(sendable_isolated_sync_function,none,
-      "%0 synchronous %1 %2 cannot be marked as '@Sendable'",
-      (ActorIsolation, DescriptiveDeclKind, DeclName))
+      "%0 synchronous %kind1 cannot be marked as '@Sendable'",
+      (ActorIsolation, const ValueDecl *))
 ERROR(concurrent_access_of_local_capture,none,
-      "%select{mutation of|reference to}0 captured %1 %2 in "
+      "%select{mutation of|reference to}0 captured %kind1 in "
       "concurrently-executing code",
-      (bool, DescriptiveDeclKind, DeclName))
+      (bool, const ValueDecl *))
 ERROR(concurrent_access_of_inout_param,none,
       "mutable capture of 'inout' parameter %0 is not allowed in "
       "concurrently-executing code",
@@ -5188,16 +5186,16 @@ ERROR(implicit_non_sendable_capture,none,
       (Type, DeclName))
 
 NOTE(actor_isolated_sync_func,none,
-     "calls to %0 %1 from outside of its actor context are "
+     "calls to %kind0 from outside of its actor context are "
      "implicitly asynchronous",
-     (DescriptiveDeclKind, DeclName))
+     (const ValueDecl *))
 NOTE(actor_isolated_sync_func_value,none,
      "calls function of type %0 from outside of its actor context are "
      "implicitly asynchronous",
      (Type))
 NOTE(note_distributed_actor_isolated_method,none,
-     "distributed actor-isolated %0 %1 declared here",
-     (DescriptiveDeclKind, DeclName))
+     "distributed actor-isolated %kind0 declared here",
+     (const ValueDecl *))
 ERROR(distributed_actor_isolated_method,none,
       "only 'distributed' instance methods can be called on a potentially remote distributed actor",
       ())
@@ -5208,8 +5206,8 @@ ERROR(distributed_actor_func_param_not_codable,none,
       "parameter '%0' of type %1 in %2 does not conform to serialization requirement '%3'",
       (StringRef, Type, DescriptiveDeclKind, StringRef))
 ERROR(distributed_actor_target_result_not_codable,none,
-      "result type %0 of %1 %2 does not conform to serialization requirement '%3'",
-      (Type, DescriptiveDeclKind, Identifier, StringRef))
+      "result type %0 of %kindbase1 does not conform to serialization requirement '%2'",
+      (Type, const ValueDecl *, StringRef))
 ERROR(distributed_actor_system_serialization_req_must_be_protocol,none,
       "'SerializationRequirement' type witness %0 must be a protocol type",
       (Type))
@@ -5226,17 +5224,17 @@ ERROR(distributed_actor_func_nonisolated, none,
       "cannot declare method %0 as both 'nonisolated' and 'distributed'",
       (DeclName))
 ERROR(distributed_actor_func_inout, none,
-      "cannot declare 'inout' argument %0 in %1 %2",
-      (DeclName, DescriptiveDeclKind, DeclName))
+      "cannot declare 'inout' argument %0 in %kind1",
+      (DeclName, const ValueDecl *))
 ERROR(distributed_actor_func_unsupported_specifier, none,
-      "cannot declare '%0' argument %1 in %2 %3",
-      (StringRef, DeclName, DescriptiveDeclKind, DeclName))
+      "cannot declare '%0' argument %1 in %kind2",
+      (StringRef, DeclName, const ValueDecl *))
 ERROR(distributed_actor_func_closure, none,
-      "%0 %1 cannot declare closure arguments, as they cannot be serialized",
-      (DescriptiveDeclKind, DeclName))
+      "%kind0 cannot declare closure arguments, as they cannot be serialized",
+      (const ValueDecl *))
 ERROR(distributed_actor_func_variadic, none,
-      "cannot declare variadic argument %0 in %1 %2",
-      (DeclName, DescriptiveDeclKind, DeclName))
+      "cannot declare variadic argument %0 in %kind1",
+      (DeclName, const ValueDecl *))
 ERROR(distributed_actor_remote_func_is_not_static,none,
       "remote function %0 must be static",
       (DeclName))
@@ -5250,12 +5248,12 @@ NOTE(actor_mutable_state,none,
      "mutation of this %0 is only permitted within the actor",
      (DescriptiveDeclKind))
 WARNING(shared_mutable_state_access,none,
-        "reference to %0 %1 is not concurrency-safe because it involves "
-        "shared mutable state", (DescriptiveDeclKind, DeclName))
+        "reference to %kind0 is not concurrency-safe because it involves "
+        "shared mutable state", (const ValueDecl *))
 ERROR(actor_isolated_witness,none,
-     "%select{|distributed }0%1 %2 %3 cannot be used to satisfy %4 protocol "
+     "%select{|distributed }0%1 %kind2 cannot be used to satisfy %3 protocol "
      "requirement",
-     (bool, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
+     (bool, ActorIsolation, const ValueDecl *, ActorIsolation))
 ERROR(actor_cannot_conform_to_global_actor_protocol,none,
       "actor %0 cannot conform to global actor isolated protocol %1",
       (Type, Type))
@@ -5323,15 +5321,15 @@ WARNING(non_sendable_keypath_access,none,
         (Type))
 ERROR(non_concurrent_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
-      "'Sendable'-conforming %3 %4 has non-sendable type %0",
-      (Type, bool, DeclName, DescriptiveDeclKind, DeclName))
+      "'Sendable'-conforming %kind3 has non-sendable type %0",
+      (Type, bool, DeclName, const ValueDecl *))
 ERROR(concurrent_value_class_mutable_property,none,
-      "stored property %0 of 'Sendable'-conforming %1 %2 is mutable",
-      (DeclName, DescriptiveDeclKind, DeclName))
+      "stored property %0 of 'Sendable'-conforming %kind1 is mutable",
+      (DeclName, const ValueDecl *))
 ERROR(concurrent_value_outside_source_file,none,
       "conformance to 'Sendable' must occur in the same source file as "
-      "%0 %1; use '@unchecked Sendable' for retroactive conformance",
-      (DescriptiveDeclKind, DeclName))
+      "%kind0; use '@unchecked Sendable' for retroactive conformance",
+      (const ValueDecl *))
 ERROR(concurrent_value_nonfinal_class,none,
       "non-final class %0 cannot conform to 'Sendable'; "
       "use '@unchecked Sendable'", (DeclName))
@@ -5421,17 +5419,17 @@ ERROR(distributed_property_cannot_be_static,none,
       "'distributed' property %0 cannot be 'static'",
       (DeclName))
 ERROR(distributed_property_can_only_be_computed,none,
-      "%0 %1 cannot be 'distributed', only computed properties can",
-      (DescriptiveDeclKind, DeclName))
+      "%kind0 cannot be 'distributed', only computed properties can",
+      (const ValueDecl *))
 ERROR(distributed_property_accessor_only_get_can_be_distributed,none,
       "only 'get' accessors may be 'distributed'",
       ())
 NOTE(distributed_actor_isolated_property,none,
-      "access to %0 %1 is only permitted within distributed actor %2",
-      (DescriptiveDeclKind, DeclName, DeclName))
+      "access to %kind0 is only permitted within distributed actor %1",
+      (const ValueDecl *, DeclName))
 NOTE(distributed_actor_synchronous_access_distributed_computed_property,none,
-      "access to %0 %1 from outside the distributed actor %2 must be asynchronous",
-      (DescriptiveDeclKind, DeclName, DeclName))
+      "access to %kind0 from outside the distributed actor %1 must be asynchronous",
+      (const ValueDecl *, DeclName))
 
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "
@@ -5463,15 +5461,15 @@ ERROR(global_actor_access,none,
       "global actor %4",
       (AccessLevel, DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
 ERROR(global_actor_not_usable_from_inline,none,
-      "global actor for %0 %1 must be '@usableFromInline' or public",
-      (DescriptiveDeclKind, DeclName))
+      "global actor for %kind0 must be '@usableFromInline' or public",
+      (const ValueDecl *))
 
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",
       (DescriptiveDeclKind, DeclName, StringRef, StringRef))
 ERROR(actor_isolation_override_mismatch,none,
-      "%0 %1 %2 has different actor isolation from %3 overridden declaration",
-      (ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
+      "%0 %kind1 has different actor isolation from %2 overridden declaration",
+      (ActorIsolation, const ValueDecl *, ActorIsolation))
 ERROR(actor_isolation_superclass_mismatch,none,
       "%0 class %1 has different actor isolation from %2 superclass %3",
       (ActorIsolation, DeclName, ActorIsolation, DeclName))
@@ -5480,11 +5478,11 @@ ERROR(async_decl_must_be_available_from_async,none,
         "asynchronous %0 must be available from asynchronous contexts",
         (DescriptiveDeclKind))
 ERROR(async_named_decl_must_be_available_from_async,none,
-        "asynchronous %0 %1 must be available from asynchronous contexts",
-        (DescriptiveDeclKind, DeclName))
+        "asynchronous %kind0 must be available from asynchronous contexts",
+        (const ValueDecl *))
 ERROR(async_unavailable_decl,none,
-      "%0 %1 is unavailable from asynchronous contexts%select{|; %2}2",
-      (DescriptiveDeclKind, DeclBaseName, StringRef))
+      "%kindbase0 is unavailable from asynchronous contexts%select{|; %1}1",
+      (const ValueDecl *, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: String Processing
@@ -5957,9 +5955,9 @@ NOTE(objc_witness_objc_requirement,none,
      "satisfying requirement for %0 %1 in protocol %2",
      (DescriptiveDeclKind, DeclName, Identifier))
 WARNING(witness_swift3_objc_inference,Deprecation,
-        "use of %0 %1 to satisfy a requirement of protocol %2 depends on "
+        "use of %kind0 to satisfy a requirement of protocol %1 depends on "
         "'@objc' inference deprecated in Swift 4",
-        (DescriptiveDeclKind, DeclName, Type))
+        (const ValueDecl *, Type))
 
 ERROR(no_opaque_return_type_of,none,
       "unable to resolve type for _opaqueReturnTypeOf attribute", ())
@@ -6020,8 +6018,8 @@ ERROR(objc_override_property_name_mismatch,none,
       "property it overrides (%0 vs. %1)", (Identifier, Identifier))
 
 ERROR(objc_ambiguous_inference,none,
-      "ambiguous inference of Objective-C name for %0 %1 (%2 vs %3)",
-      (DescriptiveDeclKind, DeclName, ObjCSelector, ObjCSelector))
+      "ambiguous inference of Objective-C name for %kind0 (%1 vs %2)",
+      (const ValueDecl *, ObjCSelector, ObjCSelector))
 NOTE(objc_ambiguous_inference_candidate,none,
      "%0 (in protocol %1) provides Objective-C name %2",
      (DeclName, Identifier, ObjCSelector))
@@ -6294,17 +6292,17 @@ NOTE(availability_decl_more_than_unavailable_enclosing_here, none,
 
 ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",
-      (DeclName, StringRef, llvm::VersionTuple))
+      (const ValueDecl *, StringRef, llvm::VersionTuple))
 
 ERROR(availability_decl_only_version_newer_for_clients, none,
       "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
       " deployment target",
-      (DeclName, StringRef, llvm::VersionTuple, ModuleDecl *))
+      (const ValueDecl *, StringRef, llvm::VersionTuple, ModuleDecl *))
 
 WARNING(availability_decl_only_version_newer_for_clients_warn, none,
         "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
         " deployment target",
-        (DeclName, StringRef, llvm::VersionTuple, ModuleDecl *))
+        (const ValueDecl *, StringRef, llvm::VersionTuple, ModuleDecl *))
 
 ERROR(availability_opaque_types_only_version_newer, none,
       "'some' return types are only available in %0 %1 or newer",
@@ -6332,15 +6330,9 @@ FIXIT(insert_available_attr,
       "@available(%0 %1, *)\n%2",
       (StringRef, StringRef, StringRef))
 
-ERROR(availability_accessor_only_version_newer, none,
-      "%select{getter|setter}0 for %1 is only available in %2 %3"
-      " or newer",
-      (/*AccessorKind*/unsigned, DeclName, StringRef, llvm::VersionTuple))
-
 ERROR(availability_inout_accessor_only_version_newer, none,
-      "cannot pass as inout because %select{getter|setter}0 for %1 is only "
-      "available in %2 %3 or newer",
-      (/*AccessorKind*/unsigned, DeclName, StringRef, llvm::VersionTuple))
+      "cannot pass as inout because %0 is only available in %1 %2 or newer",
+      (const ValueDecl *, StringRef, llvm::VersionTuple))
 
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))
@@ -6410,8 +6402,8 @@ ERROR(availability_string_subscript_migration, none,
       "construct a String from subscripted result", ())
 
 NOTE(availability_unavailable_implicit_init, none,
-     "call to unavailable %0 %1 from superclass %2 occurs implicitly at the "
-     "end of this initializer", (DescriptiveDeclKind, DeclName, DeclName))
+     "call to unavailable %kind0 from superclass %1 occurs implicitly at the "
+     "end of this initializer", (const ValueDecl *, DeclName))
 
 // Conformance availability checking diagnostics
 
@@ -6479,8 +6471,8 @@ ERROR(usable_from_inline_attr_with_explicit_access,
       (DeclName, AccessLevel))
 
 WARNING(inlinable_implies_usable_from_inline,none,
-        "'@usableFromInline' attribute has no effect on '@inlinable' %0 %1",
-        (DescriptiveDeclKind, DeclName))
+        "'@usableFromInline' attribute has no effect on '@inlinable' %kind0",
+        (const ValueDecl *))
 
 ERROR(usable_from_inline_attr_in_protocol,none,
       "'@usableFromInline' attribute cannot be used in protocols", ())
@@ -6492,8 +6484,6 @@ ERROR(usable_from_inline_attr_in_protocol,none,
   "a default argument value|" \
   "a property initializer in a '@frozen' type|" \
   "a '@backDeployed' function'}"
-
-#define DECL_OR_ACCESSOR "%select{%0|%0 for}"
 
 ERROR(local_type_in_inlinable_function,
       none, "type %0 cannot be nested inside " FRAGILE_FUNC_KIND "1",
@@ -6510,21 +6500,21 @@ WARNING(resilience_decl_unavailable_warn,
         (const ValueDecl *, AccessLevel, unsigned))
 
 ERROR(inlinable_decl_ref_from_hidden_module,
-      none, "%0 %1 cannot be used in " FRAGILE_FUNC_KIND "2 "
-      "because %select{%3 was imported implementation-only|"
-      "it is an SPI imported from %3|"
+      none, "%kind0 cannot be used in " FRAGILE_FUNC_KIND "1 "
+      "because %select{%2 was imported implementation-only|"
+      "it is an SPI imported from %2|"
       "it is SPI|"
-      "%3 was imported for SPI only|"
-      "%3 was not imported by this file|"
-      "C++ APIs from imported module %3 do not support library evolution}4",
-      (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
+      "%2 was imported for SPI only|"
+      "%2 was not imported by this file|"
+      "C++ APIs from imported module %2 do not support library evolution}3",
+      (const ValueDecl *, unsigned, Identifier, unsigned))
 
 WARNING(inlinable_decl_ref_from_hidden_module_warn,
-      none, "%0 %1 cannot be used in " FRAGILE_FUNC_KIND "2 "
+      none, "%kind0 cannot be used in " FRAGILE_FUNC_KIND "1 "
       "because %select{<<ERROR>>|<<ERROR>>|<<ERROR>>|<<ERROR>>|"
-      "%3 was not imported by this file}4"
+      "%2 was not imported by this file}3"
       "; this is an error in Swift 6",
-      (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
+      (const ValueDecl *, unsigned, Identifier, unsigned))
 
 ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
       none, "%0 aliases '%1.%2' and cannot be used in " FRAGILE_FUNC_KIND "3 "
@@ -6656,8 +6646,8 @@ NOTE(silence_default_magic_identifier_mismatch, none,
 //------------------------------------------------------------------------------
 
 WARNING(debug_long_function_body, none,
-        "%0 %1 took %2ms to type-check (limit: %3ms)",
-        (DescriptiveDeclKind, DeclName, unsigned, unsigned))
+        "%kind0 took %1ms to type-check (limit: %2ms)",
+        (const ValueDecl *, unsigned, unsigned))
 WARNING(debug_long_closure_body, none,
         "closure took %0ms to type-check (limit: %1ms)",
         (unsigned, unsigned))
@@ -6745,10 +6735,10 @@ ERROR(property_wrapper_wrong_initial_value_init, none,
 ERROR(property_wrapper_failable_init, none,
       "property wrapper initializer %0 cannot be failable", (DeclName))
 ERROR(property_wrapper_type_requirement_not_accessible,none,
-      "%select{private|fileprivate|internal|package|public|open}0 %1 %2 cannot have "
-      "more restrictive access than its enclosing property wrapper type %3 "
-      "(which is %select{private|fileprivate|internal|package|public|open}4)",
-      (AccessLevel, DescriptiveDeclKind, DeclName, Type, AccessLevel))
+      "%select{private|fileprivate|internal|package|public|open}0 %kind1 cannot have "
+      "more restrictive access than its enclosing property wrapper type %2 "
+      "(which is %select{private|fileprivate|internal|package|public|open}3)",
+      (AccessLevel, const ValueDecl *, Type, AccessLevel))
 ERROR(property_wrapper_ambiguous_enclosing_self_subscript, none,
       "property wrapper type %0 has multiple enclosing-self subscripts %1",
       (Type, DeclName))
@@ -6818,7 +6808,7 @@ ERROR(property_with_wrapper_overrides,none,
 
 NOTE(property_wrapper_direct_init,none,
      "initialize the property wrapper type directly with "
-     "'(...') on the attribute", ())
+     "'(...)' on the attribute", ())
 
 ERROR(property_wrapper_incompatible_property, none,
       "property type %0 does not match that of the 'wrappedValue' property of "
@@ -7146,8 +7136,8 @@ ERROR(concurrency_task_to_thread_model_global_actor_annotation,none,
 //------------------------------------------------------------------------------
 
 WARNING(has_symbol_decl_must_be_weak,none,
-        "%0 %1 is not a weakly linked declaration",
-        (DescriptiveDeclKind, DeclName))
+        "%kind0 is not a weakly linked declaration",
+        (const ValueDecl *))
 ERROR(has_symbol_invalid_expr,none,
       "'#_hasSymbol' condition must refer to a declaration", ())
 ERROR(has_symbol_invalid_decl_use_responds_to_selector,none,
@@ -7307,14 +7297,14 @@ NOTE(macro_expand_circular_reference_unnamed_through, none,
 //------------------------------------------------------------------------------
 
 ERROR(noncopyable_within_copyable, none,
-      "%0 %1 cannot contain a noncopyable type without also being noncopyable",
-      (DescriptiveDeclKind, DeclName))
+      "%kind0 cannot contain a noncopyable type without also being noncopyable",
+      (const ValueDecl *))
 NOTE(noncopyable_within_copyable_location, none,
      "contained noncopyable %0 '%1.%2'",
      (DescriptiveDeclKind, StringRef, StringRef))
 ERROR(noncopyable_cannot_conform_to_type, none,
-     "noncopyable %0 %1 cannot conform to %2",
-     (DescriptiveDeclKind, DeclName, Type))
+     "noncopyable %kind0 cannot conform to %1",
+     (const ValueDecl *, Type))
 ERROR(noncopyable_parameter_requires_ownership, none,
       "noncopyable parameter must specify its ownership", ())
 ERROR(noncopyable_parameter_subscript_unsupported, none,
@@ -7392,10 +7382,10 @@ ERROR(noimplicitcopy_attr_invalid_in_generic_context,
 ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
       "'@_noImplicitCopy' has no effect when applied to a noncopyable type", ())
 ERROR(noncopyable_types_cannot_be_resilient, none,
-      "noncopyable %0 %1 must be @frozen in library evolution mode; "
+      "noncopyable %kind0 must be @frozen in library evolution mode; "
       "non-@frozen public and @usableFromInline noncopyable types are not "
       "supported",
-      (DescriptiveDeclKind, Identifier))
+      (const ValueDecl *))
 
 //------------------------------------------------------------------------------
 // MARK: Runtime discoverable attributes (@runtimeMetadata)
@@ -7428,10 +7418,10 @@ ERROR(runtime_attribute_type_failable_init,none,
       "runtime attribute type initializer %0 cannot be failable", (DeclName))
 
 ERROR(runtime_attribute_type_requirement_not_accessible,none,
-      "%select{private|fileprivate|internal|package|public|open}0 %1 %2 cannot have "
-      "more restrictive access than its enclosing runtime attribute type %3 "
-      "(which is %select{private|fileprivate|internal|package|public|open}4)",
-      (AccessLevel, DescriptiveDeclKind, DeclName, Type, AccessLevel))
+      "%select{private|fileprivate|internal|package|public|open}0 %kind1 cannot have "
+      "more restrictive access than its enclosing runtime attribute type %2 "
+      "(which is %select{private|fileprivate|internal|package|public|open}3)",
+      (AccessLevel, const ValueDecl *, Type, AccessLevel))
 
 ERROR(cannot_use_attr_with_custom_arguments_on_protocol,none,
       "reflection metadata attributes applied to protocols cannot have"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -956,24 +956,26 @@ NOTE(invalid_redecl_by_optionality_note,none,
       "%select{implicitly unwrapped |}0optional parameter is of "
       "same type as %select{implicitly unwrapped |}1optional parameter",
       (bool, bool))
-ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))
+ERROR(invalid_redecl,none,"invalid redeclaration of %0", (const ValueDecl *))
 ERROR(invalid_redecl_init,none,
       "invalid redeclaration of synthesized %select{|memberwise }1%0",
-      (DeclName, bool))
+      (const ValueDecl *, bool))
 ERROR(invalid_redecl_implicit,none,
       "invalid redeclaration of synthesized "
       "%select{%0|implementation for protocol requirement}1 %2",
-      (DescriptiveDeclKind, bool, DeclName))
+      (DescriptiveDeclKind, bool, const ValueDecl *))
 WARNING(invalid_redecl_swift5_warning,Deprecation,
         "redeclaration of %0 is deprecated and will be an error in Swift 5",
-        (DeclName))
+        (const ValueDecl *))
 
 NOTE(invalid_redecl_prev,none,
+     "%0 previously declared here", (const ValueDecl *))
+NOTE(invalid_redecl_prev_name,none,
      "%0 previously declared here", (DeclName))
 NOTE(invalid_redecl_implicit_wrapper,none,
      "%0 synthesized for property wrapper "
      "%select{projected value|backing storage}1",
-     (DeclName, bool))
+     (const ValueDecl *, bool))
 
 ERROR(protocol_extension_in_where_clause,none,
       "%0 was defined in extension of protocol %1 and cannot be referenced "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1694,9 +1694,9 @@ ERROR(attr_objc_implementation_no_conformance,none,
       (Type, bool))
 
 ERROR(member_of_objc_implementation_not_objc_or_final,none,
-      "%0 %1 does not match any %0 declared in the headers for %2; did you use "
-      "the %0's Swift name?",
-      (DescriptiveDeclKind, ValueDecl *, ValueDecl *))
+      "%kind0 does not match any %kindonly0 declared in the headers for %1; "
+      "did you use the %kindonly0's Swift name?",
+      (ValueDecl *, ValueDecl *))
 NOTE(fixit_add_private_for_objc_implementation,none,
      "add 'private' or 'fileprivate' to define an Objective-C-compatible %0 "
      "not declared in the header",
@@ -1730,56 +1730,56 @@ ERROR(objc_implementation_required_attr_mismatch,none,
       (ValueDecl *, DescriptiveDeclKind, bool))
 
 ERROR(objc_implementation_candidate_has_error_convention,none,
-      "%0 %1 does not match the declaration in the header because it throws an "
+      "%kind0 does not match the declaration in the header because it throws an "
       "error",
-      (DescriptiveDeclKind, ValueDecl *))
+      (const ValueDecl *))
 
 ERROR(objc_implementation_candidate_lacks_error_convention,none,
-      "%0 %1 does not match the declaration in the header because it does not "
+      "%kind0 does not match the declaration in the header because it does not "
       "throw an error",
-      (DescriptiveDeclKind, ValueDecl *))
+      (const ValueDecl *))
 
 #define SELECT_FOREIGN_ERROR_CONVENTION_KIND \
       "select{returning zero|returning non-zero|returning zero or a result|" \
       "returning nil|setting the error parameter|%error}"
 
 ERROR(objc_implementation_mismatched_error_convention_kind,none,
-      "%0 %1 does not match the declaration in the header because it indicates "
-      "an error by %" SELECT_FOREIGN_ERROR_CONVENTION_KIND "2, rather than by "
-      "%" SELECT_FOREIGN_ERROR_CONVENTION_KIND "3",
-      (DescriptiveDeclKind, ValueDecl *, unsigned, unsigned))
+      "%kind0 does not match the declaration in the header because it indicates "
+      "an error by %" SELECT_FOREIGN_ERROR_CONVENTION_KIND "1, rather than by "
+      "%" SELECT_FOREIGN_ERROR_CONVENTION_KIND "2",
+      (const ValueDecl *, unsigned, unsigned))
 
 ERROR(objc_implementation_mismatched_error_convention_index,none,
-      "%0 %1 does not match the declaration in the header because it uses "
-      "parameter #%2 for the error, not parameter #%3; a selector part called "
+      "%kind0 does not match the declaration in the header because it uses "
+      "parameter #%1 for the error, not parameter #%2; a selector part called "
       "'error:' can control which parameter to use",
-      (DescriptiveDeclKind, ValueDecl *, unsigned, unsigned))
+      (const ValueDecl *, unsigned, unsigned))
 
 ERROR(objc_implementation_mismatched_error_convention_void_param,none,
-      "%0 %1 does not match the declaration in the header because it "
-      "%select{removes the error parameter|makes the error parameter 'Void'}2 "
-      "rather than %select{making it 'Void'|removing it}2",
-      (DescriptiveDeclKind, ValueDecl *, bool))
+      "%kind0 does not match the declaration in the header because it "
+      "%select{removes the error parameter|makes the error parameter 'Void'}1 "
+      "rather than %select{making it 'Void'|removing it}1",
+      (const ValueDecl *, bool))
 
 ERROR(objc_implementation_mismatched_error_convention_ownership,none,
-      "%0 %1 does not match the declaration in the header because it "
-      "%select{does not own|owns}2 the error parameter",
-      (DescriptiveDeclKind, ValueDecl *, bool))
+      "%kind0 does not match the declaration in the header because it "
+      "%select{does not own|owns}1 the error parameter",
+      (const ValueDecl *, bool))
 
 ERROR(objc_implementation_mismatched_error_convention_other,none,
-      "%0 %1 does not match the declaration in the header because it uses a "
+      "%kind0 does not match the declaration in the header because it uses a "
       "different Objective-C error convention; please file a bug report with a "
       "sample project, as the compiler should be able to describe the mismatch",
-      (DescriptiveDeclKind, ValueDecl *))
+      (const ValueDecl *))
 
 ERROR(objc_implementation_wrong_objc_name,none,
       "selector %0 for %kind1 not found in header; did you mean %2?",
       (ObjCSelector, ValueDecl *, ObjCSelector))
 
 ERROR(objc_implementation_wrong_swift_name,none,
-      "selector %0 used in header by an %1 with a different name; did you "
-      "mean %2?",
-      (ObjCSelector, DescriptiveDeclKind, DeclName))
+      "selector %0 used in header by %kindonly1 with a different name; did "
+      "you mean %1?",
+      (ObjCSelector, const ValueDecl *))
 
 ERROR(objc_implementation_missing_impl,none,
       "extension for %select{main class interface|category %0}0 should "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -34,8 +34,6 @@ NOTE(name_declared_here,none,
      "%0 declared here", (DeclName))
 NOTE(kind_declared_here,none,
      "%0 declared here", (DescriptiveDeclKind))
-NOTE(descriptive_decl_declared_here,none,
-     "'%0' declared here", (StringRef))
 NOTE(implicit_member_declared_here,none,
      "%kindbase0 is implicitly declared", (const ValueDecl *))
 NOTE(extended_type_declared_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2637,11 +2637,7 @@ ERROR(type_witness_not_accessible_type,none,
 ERROR(witness_not_usable_from_inline,none,
       "%kind0 must be declared '@usableFromInline' "
       "because it matches a requirement in protocol %1",
-      (const ValueDecl *, Identifier))
-WARNING(witness_not_usable_from_inline_warn,none,
-        "%kind0 should be declared '@usableFromInline' "
-        "because it matches a requirement in protocol %1",
-        (const ValueDecl *, Identifier))
+      (const ValueDecl *, const ProtocolDecl *))
 ERROR(type_witness_objc_generic_parameter,none,
       "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
       "used for associated type %3 of protocol %4",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -27,13 +27,17 @@ DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
 NOTE(decl_declared_here,none,
+     "%0 declared here", (const ValueDecl *))
+NOTE(decl_declared_here_base,none,
+     "%base0 declared here", (const ValueDecl *))
+NOTE(name_declared_here,none,
      "%0 declared here", (DeclName))
 NOTE(kind_declared_here,none,
      "%0 declared here", (DescriptiveDeclKind))
 NOTE(descriptive_decl_declared_here,none,
      "'%0' declared here", (StringRef))
 NOTE(implicit_member_declared_here,none,
-     "%1 '%0' is implicitly declared", (StringRef, StringRef))
+     "%kindbase0 is implicitly declared", (const ValueDecl *))
 NOTE(extended_type_declared_here,none,
      "extended type declared here", ())
 NOTE(opaque_return_type_declared_here,none,
@@ -1043,7 +1047,7 @@ ERROR(cannot_find_type_in_scope,none,
 ERROR(cannot_find_type_in_scope_did_you_mean,none,
       "cannot find type %0 in scope; did you mean to use '%1'?", (DeclNameRef, StringRef))
 NOTE(note_typo_candidate_implicit_member,none,
-     "did you mean the implicitly-synthesized %1 '%0'?", (StringRef, StringRef))
+     "did you mean the implicitly-synthesized %kindbase0?", (const ValueDecl *))
 NOTE(note_remapped_type,none,
      "did you mean to use '%0'?", (StringRef))
 NOTE(note_module_as_type,none,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1577,22 +1577,6 @@ EncodedDiagnosticMessage::EncodedDiagnosticMessage(StringRef S)
                                              /*IsLastSegment=*/true,
                                              /*IndentToStrip=*/~0U)) {}
 
-std::pair<unsigned, DeclName>
-swift::getAccessorKindAndNameForDiagnostics(const ValueDecl *D) {
-  // This should always be one more than the last AccessorKind supported in
-  // the diagnostics. If you need to change it, change the assertion below as
-  // well.
-  static const unsigned NOT_ACCESSOR_INDEX = 2;
-
-  if (auto *accessor = dyn_cast<AccessorDecl>(D)) {
-    DeclName Name = accessor->getStorage()->getName();
-    assert(accessor->isGetterOrSetter());
-    return {static_cast<unsigned>(accessor->getAccessorKind()), Name};
-  }
-
-  return {NOT_ACCESSOR_INDEX, D->getName()};
-}
-
 DeclName
 swift::getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info) {
   ASTNode expansionNode = ASTNode::getFromOpaqueValue(info.astNode);

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -1020,7 +1020,7 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
             .fixItRemove(assocTypeDecl->getSourceRange());
 
           ctx.Diags.diagnose(inheritedAssocTypeDecl, diag::decl_declared_here,
-                             inheritedAssocTypeDecl->getName());
+                             inheritedAssocTypeDecl);
 
           shouldWarnAboutRedeclaration = false;
         }
@@ -1096,7 +1096,7 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
                                   getConcreteTypeReq(type, fixItWhere.Item))
                 .fixItRemove(type->getSourceRange());
               ctx.Diags.diagnose(inheritedAssocTypeDecl, diag::decl_declared_here,
-                                 inheritedAssocTypeDecl->getName());
+                                 inheritedAssocTypeDecl);
 
               shouldWarnAboutRedeclaration = false;
             }

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -298,26 +298,19 @@ swift::cxx_translation::diagnoseRepresenationError(RepresentationError error,
                                                    ValueDecl *vd) {
   switch (error) {
   case UnrepresentableObjC:
-    return Diagnostic(diag::expose_unsupported_objc_decl_to_cxx,
-                      vd->getDescriptiveKind(), vd);
+    return Diagnostic(diag::expose_unsupported_objc_decl_to_cxx, vd);
   case UnrepresentableAsync:
-    return Diagnostic(diag::expose_unsupported_async_decl_to_cxx,
-                      vd->getDescriptiveKind(), vd);
+    return Diagnostic(diag::expose_unsupported_async_decl_to_cxx, vd);
   case UnrepresentableIsolatedInActor:
-    return Diagnostic(diag::expose_unsupported_actor_isolated_to_cxx,
-                      vd->getDescriptiveKind(), vd);
+    return Diagnostic(diag::expose_unsupported_actor_isolated_to_cxx, vd);
   case UnrepresentableRequiresClientEmission:
-    return Diagnostic(diag::expose_unsupported_client_emission_to_cxx,
-                      vd->getDescriptiveKind(), vd);
+    return Diagnostic(diag::expose_unsupported_client_emission_to_cxx, vd);
   case UnrepresentableGeneric:
-    return Diagnostic(diag::expose_generic_decl_to_cxx,
-                      vd->getDescriptiveKind(), vd);
+    return Diagnostic(diag::expose_generic_decl_to_cxx, vd);
   case UnrepresentableGenericRequirements:
-    return Diagnostic(diag::expose_generic_requirement_to_cxx,
-                      vd->getDescriptiveKind(), vd);
+    return Diagnostic(diag::expose_generic_requirement_to_cxx, vd);
   case UnrepresentableThrows:
-    return Diagnostic(diag::expose_throwing_to_cxx, vd->getDescriptiveKind(),
-                      vd);
+    return Diagnostic(diag::expose_throwing_to_cxx, vd);
   case UnrepresentableIndirectEnum:
     return Diagnostic(diag::expose_indirect_enum_cxx, vd);
   case UnrepresentableEnumCaseType:
@@ -327,7 +320,6 @@ swift::cxx_translation::diagnoseRepresenationError(RepresentationError error,
   case UnrepresentableProtocol:
     return Diagnostic(diag::expose_protocol_to_cxx_unsupported, vd);
   case UnrepresentableMoveOnly:
-    return Diagnostic(diag::expose_move_only_to_cxx, vd->getDescriptiveKind(),
-                      vd);
+    return Diagnostic(diag::expose_move_only_to_cxx, vd);
   }
 }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -811,14 +811,12 @@ void GenericSignatureRequest::diagnoseCycle(DiagnosticEngine &diags) const {
   auto *D = GC->getAsDecl();
 
   if (auto *VD = dyn_cast<ValueDecl>(D)) {
-    VD->diagnose(diag::recursive_generic_signature,
-                 VD->getDescriptiveKind(), VD->getBaseName());
+    VD->diagnose(diag::recursive_generic_signature, VD);
   } else {
     auto *ED = cast<ExtensionDecl>(D);
     auto *NTD = ED->getExtendedNominal();
 
-    ED->diagnose(diag::recursive_generic_signature_extension,
-                 NTD->getDescriptiveKind(), NTD->getName());
+    ED->diagnose(diag::recursive_generic_signature_extension, NTD);
   }
 }
 
@@ -852,9 +850,7 @@ void UnderlyingTypeRequest::cacheResult(Type value) const {
 
 void UnderlyingTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
   auto aliasDecl = std::get<0>(getStorage());
-  diags.diagnose(aliasDecl, diag::recursive_decl_reference,
-                 aliasDecl->getDescriptiveKind(),
-                 aliasDecl->getName());
+  diags.diagnose(aliasDecl, diag::recursive_decl_reference, aliasDecl);
 }
 
 //----------------------------------------------------------------------------//
@@ -863,9 +859,7 @@ void UnderlyingTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
 
 void StructuralTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
   auto aliasDecl = std::get<0>(getStorage());
-  diags.diagnose(aliasDecl, diag::recursive_decl_reference,
-                 aliasDecl->getDescriptiveKind(),
-                 aliasDecl->getName());
+  diags.diagnose(aliasDecl, diag::recursive_decl_reference, aliasDecl);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -86,11 +86,7 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
   if (!Attr)
     return true;
 
-  DeclName Name;
-  unsigned RawAccessorKind;
-  std::tie(RawAccessorKind, Name) = getAccessorKindAndNameForDiagnostics(D);
-  // FIXME: 'RawAccessorKind' is always 2 (NOT_ACCESSOR_INDEX).
-  // Code completion doesn't offer accessors. It only emits 'VarDecl's.
+  // FIXME: Code completion doesn't offer accessors. It only emits 'VarDecl's.
   // So getter/setter specific availability doesn't work in code completion.
 
   StringRef Platform = Attr->prettyPlatformString();
@@ -101,18 +97,18 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
   if (!isSoftDeprecated) {
     if (Attr->Message.empty() && Attr->Rename.empty()) {
       getDiagnostics(severity, Out, diag::availability_deprecated,
-                     RawAccessorKind, Name, Attr->hasPlatform(), Platform,
+                     D, Attr->hasPlatform(), Platform,
                      Attr->Deprecated.has_value(), DeprecatedVersion,
                      /*message*/ StringRef());
     } else if (!Attr->Message.empty()) {
       EncodedDiagnosticMessage EncodedMessage(Attr->Message);
       getDiagnostics(severity, Out, diag::availability_deprecated,
-                     RawAccessorKind, Name, Attr->hasPlatform(), Platform,
+                     D, Attr->hasPlatform(), Platform,
                      Attr->Deprecated.has_value(), DeprecatedVersion,
                      EncodedMessage.Message);
     } else {
       getDiagnostics(severity, Out, diag::availability_deprecated_rename,
-                     RawAccessorKind, Name, Attr->hasPlatform(), Platform,
+                     D, Attr->hasPlatform(), Platform,
                      Attr->Deprecated.has_value(), DeprecatedVersion, false,
                      /*ReplaceKind*/ 0, Attr->Rename);
     }
@@ -125,18 +121,18 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
 
     if (Attr->Message.empty() && Attr->Rename.empty()) {
       getDiagnostics(severity, Out, diag::ide_availability_softdeprecated,
-                     RawAccessorKind, Name, Attr->hasPlatform(), Platform,
+                     D, Attr->hasPlatform(), Platform,
                      !isDistantFuture, DeprecatedVersion,
                      /*message*/ StringRef());
     } else if (!Attr->Message.empty()) {
       EncodedDiagnosticMessage EncodedMessage(Attr->Message);
       getDiagnostics(severity, Out, diag::ide_availability_softdeprecated,
-                     RawAccessorKind, Name, Attr->hasPlatform(), Platform,
+                     D, Attr->hasPlatform(), Platform,
                      !isDistantFuture, DeprecatedVersion,
                      EncodedMessage.Message);
     } else {
       getDiagnostics(severity, Out, diag::ide_availability_softdeprecated_rename,
-                     RawAccessorKind, Name, Attr->hasPlatform(), Platform,
+                     D, Attr->hasPlatform(), Platform,
                      !isDistantFuture, DeprecatedVersion, Attr->Rename);
     }
   }

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -884,7 +884,7 @@ public:
                 : Diagnostic(
                       vd->isStdlibDecl() ? diag::unexposed_other_decl_in_cxx
                                          : diag::unsupported_other_decl_in_cxx,
-                      vd->getDescriptiveKind(), const_cast<ValueDecl *>(vd));
+                      const_cast<ValueDecl *>(vd));
         // Emit a specific unavailable message when we know why a decl can't be
         // exposed, or a generic message otherwise.
         auto diagString = M.getASTContext().Diags.diagnosticStringFor(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1647,7 +1647,7 @@ namespace {
                   Swift3ObjCInferenceWarnings::Minimal) {
             context.Diags.diagnose(
                 memberLoc, diag::expr_dynamic_lookup_swift3_objc_inference,
-                member->getDescriptiveKind(), member->getName(),
+                member,
                 member->getDeclContext()->getSelfNominalTypeDecl()->getName());
             context.Diags
                 .diagnose(member, diag::make_decl_objc,
@@ -4844,7 +4844,7 @@ namespace {
           de.diagnose(E->getModifierLoc(),
                       diag::expr_selector_expected_property,
                       E->getSelectorKind() == ObjCSelectorExpr::Setter,
-                      foundDecl->getDescriptiveKind(), foundDecl->getName())
+                      foundDecl)
               .fixItRemoveChars(E->getModifierLoc(),
                                 E->getSubExpr()->getStartLoc());
 
@@ -4914,7 +4914,7 @@ namespace {
           // Make sure we actually have a setter.
           if (!var->isSettable(dc)) {
             de.diagnose(E->getLoc(), diag::expr_selector_property_not_settable,
-                        var->getDescriptiveKind(), var->getName());
+                        var);
             de.diagnose(var, diag::decl_declared_here, var->getName());
             return E;
           }
@@ -4922,8 +4922,7 @@ namespace {
           // Make sure the setter is accessible.
           if (!var->isSetterAccessibleFrom(dc)) {
             de.diagnose(E->getLoc(),
-                        diag::expr_selector_property_setter_inaccessible,
-                        var->getDescriptiveKind(), var->getName());
+                        diag::expr_selector_property_setter_inaccessible, var);
             de.diagnose(var, diag::decl_declared_here, var->getName());
             return E;
           }
@@ -4954,8 +4953,7 @@ namespace {
           return E;
         }
 
-        de.diagnose(E->getLoc(), diag::expr_selector_not_objc,
-                    foundDecl->getDescriptiveKind(), foundDecl->getName())
+        de.diagnose(E->getLoc(), diag::expr_selector_not_objc, foundDecl)
             .highlight(subExpr->getSourceRange());
         de.diagnose(foundDecl, diag::make_decl_objc,
                     foundDecl->getDescriptiveKind())
@@ -4968,10 +4966,9 @@ namespace {
             cs.getASTContext().LangOpts.WarnSwift3ObjCInference ==
                 Swift3ObjCInferenceWarnings::Minimal) {
           de.diagnose(E->getLoc(), diag::expr_selector_swift3_objc_inference,
-                      foundDecl->getDescriptiveKind(), foundDecl->getName(),
-                      foundDecl->getDeclContext()
-                          ->getSelfNominalTypeDecl()
-                          ->getName())
+                      foundDecl, foundDecl->getDeclContext()
+                                    ->getSelfNominalTypeDecl()
+                                    ->getName())
               .highlight(subExpr->getSourceRange());
           de.diagnose(foundDecl, diag::make_decl_objc,
                       foundDecl->getDescriptiveKind())

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4828,7 +4828,7 @@ namespace {
                       func->getDeclContext()->isModuleScopeContext(),
                       func->getName())
               .highlight(subExpr->getSourceRange());
-          de.diagnose(func, diag::decl_declared_here, func->getName());
+          de.diagnose(func, diag::decl_declared_here, func);
           return E;
         }
 
@@ -4863,7 +4863,7 @@ namespace {
           de.diagnose(E->getLoc(), diag::expr_selector_not_property,
                       isa<ParamDecl>(var), var->getName())
               .highlight(subExpr->getSourceRange());
-          de.diagnose(var, diag::decl_declared_here, var->getName());
+          de.diagnose(var, diag::decl_declared_here, var);
           return E;
         }
 
@@ -4915,7 +4915,7 @@ namespace {
           if (!var->isSettable(dc)) {
             de.diagnose(E->getLoc(), diag::expr_selector_property_not_settable,
                         var);
-            de.diagnose(var, diag::decl_declared_here, var->getName());
+            de.diagnose(var, diag::decl_declared_here, var);
             return E;
           }
 
@@ -4923,7 +4923,7 @@ namespace {
           if (!var->isSetterAccessibleFrom(dc)) {
             de.diagnose(E->getLoc(),
                         diag::expr_selector_property_setter_inaccessible, var);
-            de.diagnose(var, diag::decl_declared_here, var->getName());
+            de.diagnose(var, diag::decl_declared_here, var);
             return E;
           }
 
@@ -4934,8 +4934,7 @@ namespace {
         // Cannot reference with #selector.
         de.diagnose(E->getLoc(), diag::expr_selector_no_declaration)
             .highlight(subExpr->getSourceRange());
-        de.diagnose(foundDecl, diag::decl_declared_here,
-                    foundDecl->getName());
+        de.diagnose(foundDecl, diag::decl_declared_here, foundDecl);
         return E;
       }
       assert(method && "Didn't find a method?");

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1867,8 +1867,7 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
           if (auto overload = getOverloadChoiceIfAvailable(
                   getConstraintLocator(member, ConstraintLocator::Member))) {
             if (auto *ref = overload->choice.getDeclOrNull())
-              emitDiagnosticAt(ref, diag::decl_declared_here,
-                               ref->getName());
+              emitDiagnosticAt(ref, diag::decl_declared_here, ref);
           }
           return true;
         }
@@ -5063,7 +5062,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
 
   if (auto selectedOverload = getCalleeOverloadChoiceIfAvailable(locator)) {
     if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl);
     }
   }
 
@@ -5231,7 +5230,7 @@ bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   if (auto selectedOverload =
           getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl);
     }
   }
 
@@ -5377,7 +5376,7 @@ bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   diagnostic.flush();
 
   // Add a note which points to the overload choice location.
-  emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+  emitDiagnosticAt(decl, diag::decl_declared_here, decl);
   return true;
 }
 
@@ -5867,7 +5866,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl);
     }
   }
 
@@ -5996,7 +5995,7 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
         .highlight(nameLoc.getSourceRange());
   }
 
-  emitDiagnosticAt(Member, diag::decl_declared_here, Member->getName());
+  emitDiagnosticAt(Member, diag::decl_declared_here, Member);
   return true;
 }
 
@@ -7456,7 +7455,7 @@ bool ArgumentMismatchFailure::diagnoseTrailingClosureMismatch() const {
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     if (auto *decl = overload->choice.getDeclOrNull()) {
-      emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+      emitDiagnosticAt(decl, diag::decl_declared_here, decl);
     }
   }
 
@@ -8047,7 +8046,7 @@ bool MissingQualifierInMemberRefFailure::diagnoseAsError() {
                  choice->getDescriptiveKind(), qualifier)
       .fixItInsert(UDE->getStartLoc(), namePlusDot);
 
-  emitDiagnosticAt(choice, diag::decl_declared_here, choice->getName());
+  emitDiagnosticAt(choice, diag::decl_declared_here, choice);
   return true;
 }
 
@@ -8275,7 +8274,7 @@ bool TrailingClosureRequiresExplicitLabel::diagnoseAsError() {
   }
 
   if (auto *callee = argInfo.getCallee()) {
-    emitDiagnosticAt(callee, diag::decl_declared_here, callee->getName());
+    emitDiagnosticAt(callee, diag::decl_declared_here, callee);
   }
 
   return true;
@@ -8473,7 +8472,7 @@ bool ReferenceToInvalidDeclaration::diagnoseAsError() {
   // about reference to an invalid declaration.
 
   emitDiagnostic(diag::reference_to_invalid_decl, decl->getName());
-  emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+  emitDiagnosticAt(decl, diag::decl_declared_here, decl);
   return true;
 }
 
@@ -9101,7 +9100,7 @@ bool DestructureTupleToUseWithPackExpansionParameter::diagnoseAsError() {
     return true;
 
   if (auto *decl = selectedOverload->choice.getDeclOrNull()) {
-    emitDiagnosticAt(decl, diag::decl_declared_here, decl->getName());
+    emitDiagnosticAt(decl, diag::decl_declared_here, decl);
   }
 
   return true;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -211,8 +211,8 @@ protected:
 class RequirementFailure : public FailureDiagnostic {
 protected:
   using PathEltKind = ConstraintLocator::PathElementKind;
-  using DiagOnDecl = Diag<DescriptiveDeclKind, DeclName, Type, Type>;
-  using DiagInReference = Diag<DescriptiveDeclKind, DeclName, Type, Type, Type>;
+  using DiagOnDecl = Diag<const ValueDecl *, Type, Type>;
+  using DiagInReference = Diag<const ValueDecl *, Type, Type, Type>;
   using DiagAsNote = Diag<Type, Type, Type, Type>;
 
   /// If this failure associated with one of the conditional requirements,
@@ -1700,6 +1700,8 @@ public:
     assert(locator->isInKeyPathComponent() ||
            locator->isForKeyPathDynamicMemberLookup());
   }
+
+  ValueDecl *getMember() const { return Member; }
 
   DescriptiveDeclKind getKind() const { return Member->getDescriptiveKind(); }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4739,7 +4739,7 @@ static bool diagnoseAmbiguityWithContextualType(
             contextualTy->is<ProtocolType>()
                 ? diag::overload_result_type_does_not_conform
                 : diag::cannot_convert_candidate_result_to_contextual_type,
-            decl->getName(), fnType->getResult(), contextualTy);
+            decl, fnType->getResult(), contextualTy);
       } else {
         DE.diagnose(decl, diag::found_candidate_type, type);
       }
@@ -4796,12 +4796,11 @@ static bool diagnoseAmbiguityWithGenericRequirements(
   // Produce "no exact matches" diagnostic.
   auto &ctx = cs.getASTContext();
   auto *choice = *overloadChoices.begin();
-  auto name = choice->getName();
 
   ctx.Diags.diagnose(getLoc(primaryFix.second->getLocator()->getAnchor()),
                      diag::no_overloads_match_exactly_in_call,
-                     /*isApplication=*/false, choice->getDescriptiveKind(),
-                     name.isSpecial(), name.getBaseName());
+                     /*isApplication=*/false, choice,
+                     choice->getName().isSpecial());
 
   for (const auto &entry : aggregate) {
     entry.second->diagnose(*entry.first, /*asNote=*/true);
@@ -4894,8 +4893,7 @@ static bool diagnoseAmbiguity(
       }
 
       DE.diagnose(anchor->getLoc(), diag::no_overloads_match_exactly_in_call,
-                  /*isApplication=*/false, decl->getDescriptiveKind(),
-                  name.isSpecial(), name.getBaseName());
+                  /*isApplication=*/false, decl, name.isSpecial());
     } else {
       bool isApplication = llvm::any_of(solutions, [&](const auto &S) {
           return llvm::any_of(S.argumentLists, [&](const auto &pair) {
@@ -4905,8 +4903,7 @@ static bool diagnoseAmbiguity(
 
       DE.diagnose(getLoc(commonAnchor),
                   diag::no_overloads_match_exactly_in_call, isApplication,
-                  decl->getDescriptiveKind(), name.isSpecial(),
-                  name.getBaseName());
+                  decl, name.isSpecial());
     }
 
     // Produce candidate notes

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -2088,8 +2088,7 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
     ConformanceDecl->diagnose(diag::type_does_not_conform,
                               Nominal->getDeclaredType(), getProtocolType());
     requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Func,
-                          requirement->getName(), getProtocolType(),
-                          /*AddFixIt=*/false);
+                          requirement, getProtocolType(), /*AddFixIt=*/false);
 
     return nullptr;
   }
@@ -2120,8 +2119,7 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
     ConformanceDecl->diagnose(diag::type_does_not_conform,
                               Nominal->getDeclaredType(), getProtocolType());
     requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Constructor,
-                          requirement->getName(), getProtocolType(),
-                          /*AddFixIt=*/false);
+                          requirement, getProtocolType(), /*AddFixIt=*/false);
 
     return nullptr;
   }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -641,8 +641,7 @@ ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
                             Nominal->getDeclaredType(), getProtocolType());
   requirement->diagnose(diag::no_witnesses,
                         getProtocolRequirementKind(requirement),
-                        requirement->getName(), getProtocolType(),
-                        /*AddFixIt=*/false);
+                        requirement, getProtocolType(), /*AddFixIt=*/false);
 
   // If derivation is possible, cancel the diagnostic and perform derivation.
   if (canDeriveDifferentiable(Nominal, getConformanceContext(), requirement)) {
@@ -669,7 +668,7 @@ DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
   DiagnosticTransaction diagnosticTransaction(Context.Diags);
   ConformanceDecl->diagnose(diag::type_does_not_conform,
                             Nominal->getDeclaredType(), getProtocolType());
-  requirement->diagnose(diag::no_witnesses_type, requirement->getName());
+  requirement->diagnose(diag::no_witnesses_type, requirement);
 
   // If derivation is possible, cancel the diagnostic and perform derivation.
   if (canDeriveDifferentiable(Nominal, getConformanceContext(), requirement)) {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -581,8 +581,7 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
       Nominal->getModuleScopeContext() !=
           getConformanceContext()->getModuleScopeContext()) {
     ConformanceDecl->diagnose(diag::cannot_synthesize_in_crossfile_extension,
-                              Nominal->getDescriptiveKind(), Nominal->getName(),
-                              synthesizing->getName(),
+                              Nominal, synthesizing->getName(),
                               getProtocolType());
     Nominal->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1192,7 +1192,7 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
 
     if (decls.size() == 1)
       ctx.Diags.diagnose(decls.front(), diag::decl_declared_here,
-                         decls.front()->getName());
+                         decls.front());
   }
   return ctx.AllocateCopy(decls);
 }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5295,7 +5295,7 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
               !storage->isSetterAccessibleFrom(DC)) {
             Ctx.Diags.diagnose(keyPathExpr->getLoc(),
                                swift::diag::expr_deprecated_writable_keypath,
-                               storage->getName());
+                               storage);
           }
         }
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -601,8 +601,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         .fixItInsertAfter(arg->getEndLoc(), ")");
 
       // Point to callee parameter
-      Ctx.Diags.diagnose(calleeParam, diag::decl_declared_here,
-                         calleeParam->getName());
+      Ctx.Diags.diagnose(calleeParam, diag::decl_declared_here, calleeParam);
     }
 
     llvm::Optional<MagicIdentifierLiteralExpr::Kind>
@@ -785,7 +784,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                          VD->getBaseIdentifier(),
                          VD->getDescriptiveKind(),
                          declParent);
-      Ctx.Diags.diagnose(VD, diag::decl_declared_here, VD->getName());
+      Ctx.Diags.diagnose(VD, diag::decl_declared_here, VD);
 
       if (VD->getDeclContext()->isTypeContext()) {
         Ctx.Diags.diagnose(DRE->getLoc(), diag::fix_unqualified_access_member)
@@ -2376,7 +2375,7 @@ static void diagnoseUnownedImmediateDeallocationImpl(ASTContext &ctx,
   ctx.Diags.diagnose(diagLoc, diag::unowned_assignment_requires_strong)
     .highlight(diagRange);
 
-  ctx.Diags.diagnose(varDecl, diag::decl_declared_here, varDecl->getName());
+  ctx.Diags.diagnose(varDecl, diag::decl_declared_here, varDecl);
 }
 
 void swift::diagnoseUnownedImmediateDeallocation(ASTContext &ctx,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -784,8 +784,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       Ctx.Diags.diagnose(DRE->getLoc(), diag::warn_unqualified_access,
                          VD->getBaseIdentifier(),
                          VD->getDescriptiveKind(),
-                         declParent->getDescriptiveKind(),
-                         declParent->getName());
+                         declParent);
       Ctx.Diags.diagnose(VD, diag::decl_declared_here, VD->getName());
 
       if (VD->getDeclContext()->isTypeContext()) {
@@ -4830,7 +4829,7 @@ static bool diagnoseHasSymbolCondition(PoundHasSymbolInfo *info,
     // and may indicate the developer has mis-identified the declaration
     // they want to check (or forgot to import the module weakly).
     ctx.Diags.diagnose(symbolExpr->getLoc(), diag::has_symbol_decl_must_be_weak,
-                       decl->getDescriptiveKind(), decl->getName());
+                       decl);
     return true;
   }
 
@@ -5039,8 +5038,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
                               ? diag::iuo_to_any_coercion_note_func_result
                               : diag::iuo_to_any_coercion_note;
 
-          Ctx.Diags.diagnose(decl->getLoc(), noteDiag,
-                             decl->getDescriptiveKind(), decl->getName());
+          Ctx.Diags.diagnose(decl->getLoc(), noteDiag, decl);
         }
       } else {
         Ctx.Diags.diagnose(subExpr->getStartLoc(),
@@ -6236,8 +6234,7 @@ void swift::diagnoseCopyableTypeContainingMoveOnlyType(
       DE.diagnoseWithNotes(
           copyableNominalType->diagnose(
               diag::noncopyable_within_copyable,
-              copyableNominalType->getDescriptiveKind(),
-              copyableNominalType->getBaseName()),
+              copyableNominalType),
           [&]() {
             eltDecl->diagnose(
                 diag::
@@ -6252,8 +6249,7 @@ void swift::diagnoseCopyableTypeContainingMoveOnlyType(
     DE.diagnoseWithNotes(
         copyableNominalType->diagnose(
             diag::noncopyable_within_copyable,
-            copyableNominalType->getDescriptiveKind(),
-            copyableNominalType->getBaseName()),
+            copyableNominalType),
         [&]() {
           varDecl->diagnose(
               diag::noncopyable_within_copyable_location,

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -483,7 +483,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
         if (Lookup.outerResults().empty()) {
           Context.Diags.diagnose(Loc, diag::use_local_before_declaration, Name);
           Context.Diags.diagnose(innerDecl, diag::decl_declared_here,
-                                 localDeclAfterUse->getName());
+                                 localDeclAfterUse);
           Expr *error = new (Context) ErrorExpr(UDRE->getSourceRange());
           return error;
         }
@@ -528,7 +528,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
       // module we could offer a fix-it.
       for (auto lookupResult : inaccessibleResults) {
         auto *VD = lookupResult.getValueDecl();
-        VD->diagnose(diag::decl_declared_here, VD->getName());
+        VD->diagnose(diag::decl_declared_here, VD);
       }
 
       // Don't try to recover here; we'll get more access-related diagnostics
@@ -796,7 +796,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
   Context.Diags.diagnose(Loc, diag::ambiguous_decl_ref, Name);
   for (auto Result : Lookup) {
     auto *Decl = Result.getValueDecl();
-    Context.Diags.diagnose(Decl, diag::decl_declared_here, Decl->getName());
+    Context.Diags.diagnose(Decl, diag::decl_declared_here, Decl);
   }
   return new (Context) ErrorExpr(UDRE->getSourceRange());
 }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -521,7 +521,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
       // FIXME: What if the unviable candidates have different levels of access?
       const ValueDecl *first = inaccessibleResults.front().getValueDecl();
       Context.Diags.diagnose(
-          Loc, diag::candidate_inaccessible, first->getBaseName(),
+          Loc, diag::candidate_inaccessible, first,
           first->getFormalAccessScope().accessLevelForDiagnostics());
 
       // FIXME: If any of the candidates (usually just one) are in the same

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -105,19 +105,10 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
       downgradeToWarning = DowngradeToWarning::Yes;
   }
 
-  auto diagName = D->getName();
-  bool isAccessor = false;
-
   // Swift 4.2 did not check accessor accessibility.
   if (auto accessor = dyn_cast<AccessorDecl>(D)) {
-    isAccessor = true;
-
     if (!Context.isSwiftVersionAtLeast(5))
       downgradeToWarning = DowngradeToWarning::Yes;
-
-    // For accessors, diagnose with the name of the storage instead of the
-    // implicit '_'.
-    diagName = accessor->getStorage()->getName();
   }
 
   // Swift 5.0 did not check the underlying types of local typealiases.
@@ -131,18 +122,15 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   auto diagAccessLevel = std::min(declAccessScope.accessLevelForDiagnostics(),
                                   importAccessLevel);
 
-  Context.Diags.diagnose(loc, diagID, D->getDescriptiveKind(), diagName,
-                         diagAccessLevel,
-                         fragileKind.getSelector(), isAccessor);
+  Context.Diags.diagnose(loc, diagID, D, diagAccessLevel,
+                         fragileKind.getSelector());
 
-  Context.Diags.diagnose(D, diag::resilience_decl_declared_here,
-                         D->getDescriptiveKind(), diagName, isAccessor);
+  Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
 
   if (problematicImport.has_value() &&
       diagAccessLevel == importAccessLevel) {
     Context.Diags.diagnose(problematicImport->accessLevelLoc,
-                           diag::decl_import_via_here,
-                           D->getDescriptiveKind(), diagName,
+                           diag::decl_import_via_here, D,
                            problematicImport->accessLevel,
                            problematicImport->module.importedModule->getName());
   }

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -170,7 +170,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
     auto reason = where.getExportabilityReason();
     ctx.Diags
         .diagnose(loc, diag::typealias_desugars_to_type_from_hidden_module,
-                  TAD->getName(), definingModule->getNameStr(), D->getNameStr(),
+                  TAD, definingModule->getNameStr(), D->getNameStr(),
                   static_cast<unsigned>(*reason), definingModule->getName(),
                   static_cast<unsigned>(originKind))
         .warnUntilSwiftVersionIf(originKind != DisallowedOriginKind::SPIOnly,
@@ -179,7 +179,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
     ctx.Diags
         .diagnose(loc,
                   diag::inlinable_typealias_desugars_to_type_from_hidden_module,
-                  TAD->getName(), definingModule->getNameStr(), D->getNameStr(),
+                  TAD, definingModule->getNameStr(), D->getNameStr(),
                   fragileKind.getSelector(), definingModule->getName(),
                   static_cast<unsigned>(originKind))
         .warnUntilSwiftVersionIf(originKind != DisallowedOriginKind::SPIOnly,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -494,7 +494,7 @@ void AccessControlCheckerBase::checkGlobalActorAccess(const Decl *D) {
           AccessLevel diagAccessLevel) {
         if (checkUsableFromInline) {
           auto diag = D->diagnose(diag::global_actor_not_usable_from_inline,
-                                  D->getDescriptiveKind(), VD->getName());
+                                  VD);
           highlightOffendingType(diag, complainRepr);
           noteLimitingImport(D->getASTContext(), importLimit, complainRepr);
           return;
@@ -2324,7 +2324,7 @@ public:
 
     auto &DE = PGD->getASTContext().Diags;
     auto diag =
-        DE.diagnose(diagLoc, diag::decl_from_hidden_module,
+        DE.diagnose(diagLoc, diag::decl_from_hidden_module_name,
                     PGD->getDescriptiveKind(), PGD->getName(),
                     static_cast<unsigned>(ExportabilityReason::General), M->getName(),
                     static_cast<unsigned>(DisallowedOriginKind::ImplementationOnly)

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -354,10 +354,10 @@ static void noteLimitingImport(ASTContext &ctx,
          "a public import shouldn't limit the access level of a decl");
 
   if (auto ITR = dyn_cast_or_null<IdentTypeRepr>(complainRepr)) {
-    const ValueDecl *VD = ITR->getBoundDecl();
-    ctx.Diags.diagnose(limitImport->accessLevelLoc, diag::decl_import_via_here,
-                       DescriptiveDeclKind::Type,
-                       VD->getName(),
+    ValueDecl *VD = ITR->getBoundDecl();
+    ctx.Diags.diagnose(limitImport->accessLevelLoc,
+                       diag::decl_import_via_here,
+                       VD,
                        limitImport->accessLevel,
                        limitImport->module.importedModule->getName());
   } else {

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -504,8 +504,7 @@ void AccessControlCheckerBase::checkGlobalActorAccess(const Decl *D) {
         auto declAccess = isExplicit
                               ? VD->getFormalAccess()
                               : typeAccessScope.requiredAccessForDiagnostics();
-        auto diag = D->diagnose(diag::global_actor_access, declAccess,
-                                D->getDescriptiveKind(), VD->getName(),
+        auto diag = D->diagnose(diag::global_actor_access, declAccess, VD,
                                 diagAccessLevel, globalActorDecl->getName());
         highlightOffendingType(diag, complainRepr);
         noteLimitingImport(D->getASTContext(), importLimit, complainRepr);
@@ -2324,8 +2323,7 @@ public:
 
     auto &DE = PGD->getASTContext().Diags;
     auto diag =
-        DE.diagnose(diagLoc, diag::decl_from_hidden_module_name,
-                    PGD->getDescriptiveKind(), PGD->getName(),
+        DE.diagnose(diagLoc, diag::decl_from_hidden_module, PGD,
                     static_cast<unsigned>(ExportabilityReason::General), M->getName(),
                     static_cast<unsigned>(DisallowedOriginKind::ImplementationOnly)
                     );

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2332,7 +2332,7 @@ public:
     if (refRange.isValid())
       diag.highlight(refRange);
     diag.flush();
-    PGD->diagnose(diag::decl_declared_here, PGD->getName());
+    PGD->diagnose(diag::name_declared_here, PGD->getName());
   }
 
   void visitInfixOperatorDecl(InfixOperatorDecl *IOD) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1218,7 +1218,7 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
         if (ED->getAttrs().hasAttribute<FrozenAttr>(/*allowInvalid*/ true) &&
             !ED->isSPI()) {
           diagnoseAndRemoveAttr(attr, diag::spi_attribute_on_frozen_enum_case,
-                                VD->getDescriptiveKind(), VD->getName());
+                                VD);
         }
       }
     }
@@ -1883,7 +1883,7 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       if (const ValueDecl *vd = dyn_cast<ValueDecl>(D)) {
         D->getASTContext().Diags.diagnose(
             D->getLoc(), diag::async_named_decl_must_be_available_from_async,
-            D->getDescriptiveKind(), vd->getName());
+            vd);
       } else {
         D->getASTContext().Diags.diagnose(
             D->getLoc(), diag::async_decl_must_be_available_from_async,
@@ -2909,7 +2909,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
     if (Ctx.isSwiftVersionAtLeast(4,2))
       diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline,
-                            VD->getDescriptiveKind(), VD->getName());
+                            VD);
     return;
   }
 }
@@ -3971,8 +3971,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     return;
   }
 
-  diagnose(attr->getLocation(), diag::nominal_type_not_attribute,
-           nominal->getDescriptiveKind(), nominal->getName());
+  diagnose(attr->getLocation(), diag::nominal_type_not_attribute, nominal);
   nominal->diagnose(diag::decl_declared_here, nominal->getName());
   attr->setInvalid();
 }
@@ -6703,7 +6702,7 @@ void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
     if (isolation.isActorIsolated()) {
       diagnoseAndRemoveAttr(
           attr, diag::sendable_isolated_sync_function,
-          isolation, value->getDescriptiveKind(), value->getName())
+          isolation, value)
         .warnUntilSwiftVersion(6);
     }
   }
@@ -6920,7 +6919,7 @@ void AttributeChecker::visitUnavailableFromAsyncAttr(
       if (ValueDecl *vd = dyn_cast<ValueDecl>(D)) {
         D->getASTContext().Diags.diagnose(
             D->getLoc(), diag::async_named_decl_must_be_available_from_async,
-            D->getDescriptiveKind(), vd->getName());
+            vd);
       } else {
         D->getASTContext().Diags.diagnose(
             D->getLoc(), diag::async_decl_must_be_available_from_async,
@@ -7100,8 +7099,7 @@ void AttributeChecker::visitRuntimeMetadataAttr(RuntimeMetadataAttr *attr) {
         case UnviabilityReason::Inaccessible:
           diagnose(init,
                    diag::runtime_attribute_type_requirement_not_accessible,
-                   init->getFormalAccess(), init->getDescriptiveKind(),
-                   init->getName(), nominal->getDeclaredType(),
+                   init->getFormalAccess(), init, nominal->getDeclaredType(),
                    nominal->getFormalAccess());
           break;
         }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4855,8 +4855,7 @@ static IndexSubset *computeDifferentiabilityParameters(
     // If function is not an instance method, diagnose immediately.
     if (!isInstanceMethod) {
       diags
-          .diagnose(attrLoc, diag::diff_function_no_parameters,
-                    function->getName())
+          .diagnose(attrLoc, diag::diff_function_no_parameters, function)
           .highlight(function->getSignatureSourceRange());
       return nullptr;
     }
@@ -4870,8 +4869,7 @@ static IndexSubset *computeDifferentiabilityParameters(
         selfType = function->mapTypeIntoContext(selfType);
       if (!conformsToDifferentiable(selfType, module)) {
         diags
-            .diagnose(attrLoc, diag::diff_function_no_parameters,
-                      function->getName())
+            .diagnose(attrLoc, diag::diff_function_no_parameters, function)
             .highlight(function->getSignatureSourceRange());
         return nullptr;
       }
@@ -5447,7 +5445,7 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
           .diagnose(
               attr->getLocation(),
               diag::differentiable_attr_where_clause_for_nongeneric_original,
-              original->getName())
+              original)
           .highlight(whereClause->getSourceRange());
       attr->setInvalid();
       return true;
@@ -6061,16 +6059,15 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
     diags
         .diagnose(attr->getOriginalFunctionName().Loc.getBaseNameLoc(),
                   diag::derivative_attr_static_method_mismatch_original,
-                  originalAFD->getName(), derivative->getName(),
-                  derivativeMustBeStatic)
+                  originalAFD, derivative, derivativeMustBeStatic)
         .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
     diags.diagnose(originalAFD->getNameLoc(),
                    diag::derivative_attr_static_method_mismatch_original_note,
-                   originalAFD->getName(), derivativeMustBeStatic);
+                   originalAFD, derivativeMustBeStatic);
     auto fixItDiag =
         diags.diagnose(derivative->getStartLoc(),
                        diag::derivative_attr_static_method_mismatch_fix,
-                       derivative->getName(), derivativeMustBeStatic);
+                       derivative, derivativeMustBeStatic);
     if (derivativeMustBeStatic) {
       fixItDiag.fixItInsert(derivative->getStartLoc(), "static ");
     } else {
@@ -6098,8 +6095,8 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
         derivative->getFormalAccessScope().accessLevelForDiagnostics();
     diags.diagnose(originalName.Loc,
                    diag::derivative_attr_access_level_mismatch,
-                   originalAFD->getName(), originalAccess,
-                   derivative->getName(), derivativeAccess);
+                   originalAFD, originalAccess,
+                   derivative, derivativeAccess);
     auto fixItDiag =
         derivative->diagnose(diag::derivative_attr_fix_access, originalAccess);
     // If original access is public, suggest adding `@usableFromInline` to
@@ -6207,7 +6204,7 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
     // Emit differential/pullback type mismatch error on attribute.
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_result_func_type_mismatch,
-                   funcResultElt.getName(), originalAFD->getName());
+                   funcResultElt.getName(), originalAFD);
     // Emit note with expected differential/pullback type on actual type
     // location.
     auto *tupleReturnTypeRepr =
@@ -6222,7 +6219,7 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
     if (originalAFD->getLoc().isValid())
       diags.diagnose(originalAFD->getLoc(),
                      diag::derivative_attr_result_func_original_note,
-                     originalAFD->getName());
+                     originalAFD);
     return true;
   }
 
@@ -6233,7 +6230,7 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
   if (derivativeAttrs.size() > 1) {
     diags.diagnose(attr->getLocation(),
                    diag::derivative_attr_original_already_has_derivative,
-                   originalAFD->getName());
+                   originalAFD);
     for (auto *duplicateAttr : derivativeAttrs) {
       if (duplicateAttr == attr)
         continue;
@@ -6595,15 +6592,14 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
     bool transposeMustBeStatic = !transpose->isStatic();
     diagnose(attr->getOriginalFunctionName().Loc.getBaseNameLoc(),
              diag::transpose_attr_static_method_mismatch_original,
-             originalAFD->getName(), transpose->getName(),
-             transposeMustBeStatic)
+             originalAFD, transpose, transposeMustBeStatic)
         .highlight(attr->getOriginalFunctionName().Loc.getSourceRange());
     diagnose(originalAFD->getNameLoc(),
              diag::transpose_attr_static_method_mismatch_original_note,
-             originalAFD->getName(), transposeMustBeStatic);
+             originalAFD, transposeMustBeStatic);
     auto fixItDiag = diagnose(transpose->getStartLoc(),
                               diag::transpose_attr_static_method_mismatch_fix,
-                              transpose->getName(), transposeMustBeStatic);
+                              transpose, transposeMustBeStatic);
     if (transposeMustBeStatic) {
       fixItDiag.fixItInsert(transpose->getStartLoc(), "static ");
     } else {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4406,13 +4406,10 @@ void AttributeChecker::checkBackDeployedAttrs(
 
       if (unavailableAttr->Platform == PlatformKind::none ||
           unavailableAttr->Platform == Attr->Platform) {
-        DeclName name;
-        unsigned accessorKind;
-        std::tie(accessorKind, name) = getAccessorKindAndNameForDiagnostics(VD);
         diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr,
-                 accessorKind, name, prettyPlatformString(Platform));
+                 VD, prettyPlatformString(Platform));
         diagnose(unavailableAttr->AtLoc, diag::availability_marked_unavailable,
-                 accessorKind, name)
+                 VD)
             .highlight(unavailableAttr->getRange());
         continue;
       }
@@ -4424,15 +4421,11 @@ void AttributeChecker::checkBackDeployedAttrs(
     if (auto availableRangeAttrPair = VD->getSemanticAvailableRangeAttr()) {
       auto availableAttr = availableRangeAttrPair.value().first;
       if (Attr->Version <= availableAttr->Introduced.value()) {
-        DeclName name;
-        unsigned accessorKind;
-        std::tie(accessorKind, name) = getAccessorKindAndNameForDiagnostics(VD);
         diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before,
-                 Attr, accessorKind, name, prettyPlatformString(Platform),
+                 Attr, VD, prettyPlatformString(Platform),
                  Attr->Version);
         diagnose(availableAttr->AtLoc, diag::availability_introduced_in_version,
-                 accessorKind, name,
-                 prettyPlatformString(availableAttr->Platform),
+                 VD, prettyPlatformString(availableAttr->Platform),
                  *availableAttr->Introduced)
             .highlight(availableAttr->getRange());
         continue;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1482,7 +1482,6 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
   if (!CD) {
     diagnoseAndRemoveAttr(attr,
                           diag::attr_objc_implementation_must_extend_class,
-                          ED->getExtendedNominal()->getDescriptiveKind(),
                           ED->getExtendedNominal());
     ED->getExtendedNominal()->diagnose(diag::decl_declared_here,
                                        ED->getExtendedNominal()->getName());
@@ -1491,7 +1490,7 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
 
   if (!CD->hasClangNode()) {
     diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_be_imported,
-                          CD->getDescriptiveKind(), CD);
+                          CD);
     CD->diagnose(diag::decl_declared_here, CD->getName());
     return;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1484,14 +1484,14 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
                           diag::attr_objc_implementation_must_extend_class,
                           ED->getExtendedNominal());
     ED->getExtendedNominal()->diagnose(diag::decl_declared_here,
-                                       ED->getExtendedNominal()->getName());
+                                       ED->getExtendedNominal());
     return;
   }
 
   if (!CD->hasClangNode()) {
     diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_be_imported,
                           CD);
-    CD->diagnose(diag::decl_declared_here, CD->getName());
+    CD->diagnose(diag::decl_declared_here, CD);
     return;
   }
 
@@ -3972,7 +3972,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   }
 
   diagnose(attr->getLocation(), diag::nominal_type_not_attribute, nominal);
-  nominal->diagnose(diag::decl_declared_here, nominal->getName());
+  nominal->diagnose(diag::decl_declared_here, nominal);
   attr->setInvalid();
 }
 
@@ -5987,8 +5987,7 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
       diags.diagnose(originalName.Loc,
                      diag::derivative_attr_original_stored_property_unsupported,
                      originalName.Name);
-      diags.diagnose(originalAFD->getLoc(), diag::decl_declared_here,
-                     asd->getName());
+      diags.diagnose(originalAFD->getLoc(), diag::decl_declared_here, asd);
       return true;
     }
     // Diagnose original class property and subscript setters.
@@ -5997,8 +5996,7 @@ static bool typeCheckDerivativeAttr(DerivativeAttr *attr) {
         accessorDecl->getAccessorKind() == AccessorKind::Set) {
       diags.diagnose(originalName.Loc,
                      diag::derivative_attr_class_setter_unsupported);
-      diags.diagnose(originalAFD->getLoc(), diag::decl_declared_here,
-                     asd->getName());
+      diags.diagnose(originalAFD->getLoc(), diag::decl_declared_here, asd);
       return true;
     }
   }
@@ -6875,8 +6873,7 @@ void AttributeChecker::visitMarkerAttr(MarkerAttr *attr) {
       proto->diagnose(
           diag::marker_protocol_inherit_nonmarker,
           proto->getName(), inheritedProto->getName());
-      inheritedProto->diagnose(
-          diag::decl_declared_here, inheritedProto->getName());
+      inheritedProto->diagnose( diag::decl_declared_here, inheritedProto);
     }
   }
 
@@ -7649,7 +7646,7 @@ ArrayRef<VarDecl *> InitAccessorReferencedVariablesRequest::evaluate(
                          DeclNameRef(name));
 
       for (auto *choice : propertyResults) {
-        ctx.Diags.diagnose(choice, diag::decl_declared_here, choice->getName());
+        ctx.Diags.diagnose(choice, diag::decl_declared_here, choice);
       }
 
       failed = true;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3571,15 +3571,7 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
     if (const AbstractFunctionDecl *asyncAlt = afd->getAsyncAlternative()) {
       SourceLoc diagLoc = call ? call->getLoc() : R.Start;
       ctx.Diags.diagnose(diagLoc, diag::warn_use_async_alternative);
-      if (auto *accessor = dyn_cast<AccessorDecl>(asyncAlt)) {
-        SmallString<32> name;
-        llvm::raw_svector_ostream os(name);
-        accessor->printUserFacingName(os);
-        ctx.Diags.diagnose(asyncAlt->getLoc(),
-                           diag::descriptive_decl_declared_here, name);
-      } else {
-        asyncAlt->diagnose(diag::decl_declared_here, asyncAlt);
-      }
+      asyncAlt->diagnose(diag::decl_declared_here, asyncAlt);
     }
   }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3571,7 +3571,6 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
     if (const AbstractFunctionDecl *asyncAlt = afd->getAsyncAlternative()) {
       SourceLoc diagLoc = call ? call->getLoc() : R.Start;
       ctx.Diags.diagnose(diagLoc, diag::warn_use_async_alternative);
-
       if (auto *accessor = dyn_cast<AccessorDecl>(asyncAlt)) {
         SmallString<32> name;
         llvm::raw_svector_ostream os(name);
@@ -3579,8 +3578,7 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
         ctx.Diags.diagnose(asyncAlt->getLoc(),
                            diag::descriptive_decl_declared_here, name);
       } else {
-        ctx.Diags.diagnose(asyncAlt->getLoc(), diag::decl_declared_here,
-                           asyncAlt->getName());
+        asyncAlt->diagnose(diag::decl_declared_here, asyncAlt);
       }
     }
   }
@@ -3610,7 +3608,7 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
   ctx.Diags
       .diagnose(diagLoc, diag::async_unavailable_decl, D, attr->Message)
       .warnUntilSwiftVersion(6);
-  D->diagnose(diag::decl_declared_here, D->getName());
+  D->diagnose(diag::decl_declared_here, D);
   return true;
 }
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -308,7 +308,7 @@ public:
             NTD->diagnose(diag::kind_declared_here,
                           DescriptiveDeclKind::Type);
 
-            D->diagnose(diag::decl_declared_here, D->getName());
+            D->diagnose(diag::decl_declared_here, D);
             return Action::SkipChildren(DRE);
           }
         }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1025,8 +1025,7 @@ bool swift::diagnoseNonSendableTypesInReference(
         if (diagnoseNonSendableTypes(
             paramType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
                 diag::non_sendable_param_type,
-            (unsigned)refKind, function->getDescriptiveKind(),
-            function->getName(), getActorIsolation()))
+            (unsigned)refKind, function, getActorIsolation()))
           return true;
       }
     }
@@ -1039,8 +1038,7 @@ bool swift::diagnoseNonSendableTypesInReference(
         if (diagnoseNonSendableTypes(
             resultType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
                 diag::non_sendable_result_type,
-            (unsigned)refKind, func->getDescriptiveKind(), func->getName(),
-            getActorIsolation()))
+            (unsigned)refKind, func, getActorIsolation()))
           return true;
       }
     }
@@ -1055,7 +1053,7 @@ bool swift::diagnoseNonSendableTypesInReference(
     if (diagnoseNonSendableTypes(
             propertyType, fromDC, refLoc,
             diag::non_sendable_property_type,
-            var->getDescriptiveKind(), var->getName(),
+            var,
             var->isLocalCapture(),
             (unsigned)refKind,
             getActorIsolation()))
@@ -1070,8 +1068,7 @@ bool swift::diagnoseNonSendableTypesInReference(
         if (diagnoseNonSendableTypes(
                 paramType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
                 diag::non_sendable_param_type,
-                (unsigned)refKind, subscript->getDescriptiveKind(),
-                subscript->getName(), getActorIsolation()))
+                (unsigned)refKind, subscript, getActorIsolation()))
           return true;
       }
     }
@@ -1082,8 +1079,7 @@ bool swift::diagnoseNonSendableTypesInReference(
       if (diagnoseNonSendableTypes(
           resultType, fromDC, refLoc, diagnoseLoc.isInvalid() ? refLoc : diagnoseLoc,
               diag::non_sendable_result_type,
-          (unsigned)refKind, subscript->getDescriptiveKind(),
-          subscript->getName(), getActorIsolation()))
+          (unsigned)refKind, subscript, getActorIsolation()))
         return true;
     }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -941,19 +941,14 @@ static bool diagnoseSingleNonSendableType(
       // `Sendable` if it might make sense. Otherwise, just complain.
       if (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal)) {
         auto note = nominal->diagnose(
-            diag::add_nominal_sendable_conformance,
-            nominal->getDescriptiveKind(), nominal->getName());
+            diag::add_nominal_sendable_conformance, nominal);
         addSendableFixIt(nominal, note, /*unchecked=*/false);
       } else {
-        nominal->diagnose(
-            diag::non_sendable_nominal, nominal->getDescriptiveKind(),
-            nominal->getName());
+        nominal->diagnose(diag::non_sendable_nominal, nominal);
       }
     } else if (nominal) {
       // Note which nominal type does not conform to `Sendable`.
-      nominal->diagnose(
-          diag::non_sendable_nominal, nominal->getDescriptiveKind(),
-          nominal->getName());
+      nominal->diagnose(diag::non_sendable_nominal, nominal);
     } else if (auto genericArchetype = type->getAs<ArchetypeType>()) {
       auto interfaceType = genericArchetype->getInterfaceType();
       if (auto genericParamType =
@@ -1207,9 +1202,7 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
     return;
 
   // Diagnose it.
-  nominal->diagnose(
-      diag::public_decl_needs_sendable, nominal->getDescriptiveKind(),
-      nominal->getName());
+  nominal->diagnose(diag::public_decl_needs_sendable, nominal);
 
   // Note to add a Sendable conformance, possibly an unchecked one.
   {
@@ -1227,7 +1220,7 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
     auto note = nominal->diagnose(
         isUnchecked ? diag::explicit_unchecked_sendable
                     : diag::add_nominal_sendable_conformance,
-        nominal->getDescriptiveKind(), nominal->getName());
+        nominal);
     if (canMakeSendable && !requirements.empty()) {
       // Produce a Fix-It containing a conditional conformance to Sendable,
       // based on the requirements harvested from instance storage.
@@ -1258,9 +1251,7 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
 
   // Note to disable the warning.
   {
-    auto note = nominal->diagnose(
-        diag::explicit_disable_sendable, nominal->getDescriptiveKind(),
-        nominal->getName());
+    auto note = nominal->diagnose(diag::explicit_disable_sendable, nominal);
     auto insertionLoc = nominal->getBraces().End;
     note.fixItInsertAfter(
         insertionLoc,
@@ -1513,25 +1504,21 @@ static void noteIsolatedActorMember(ValueDecl const *decl,
       if (varDecl->isDistributed()) {
         // This is an attempt to access a `distributed var` synchronously, so offer a more detailed error
         decl->diagnose(diag::distributed_actor_synchronous_access_distributed_computed_property,
-                       decl->getDescriptiveKind(), decl->getName(),
+                       decl,
                        nominal->getName());
       } else {
         // Distributed actor properties are never accessible externally.
         decl->diagnose(diag::distributed_actor_isolated_property,
-                       decl->getDescriptiveKind(), decl->getName(),
+                       decl,
                        nominal->getName());
       }
 
     } else {
       // it's a function or subscript
-      decl->diagnose(diag::note_distributed_actor_isolated_method,
-                     decl->getDescriptiveKind(),
-                     decl->getName());
+      decl->diagnose(diag::note_distributed_actor_isolated_method, decl);
     }
   } else if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-    func->diagnose(diag::actor_isolated_sync_func,
-      decl->getDescriptiveKind(),
-      decl->getName());
+    func->diagnose(diag::actor_isolated_sync_func, decl);
 
     // was it an attempt to mutate an actor instance's isolated state?
   } else if (useKind) {
@@ -1618,8 +1605,7 @@ static bool memberAccessHasSpecialPermissionInSwift5(
 
     diags.diagnose(
         memberLoc, diag::actor_isolated_non_self_reference,
-        member->getDescriptiveKind(),
-        member->getName(),
+        member,
         useKindInt,
         baseActor.kind + 1,
         baseActor.globalActor,
@@ -2554,9 +2540,7 @@ namespace {
       if (getActorIsolation(value).isActorIsolated())
         return false;
 
-      ctx.Diags.diagnose(
-          loc, diag::shared_mutable_state_access,
-          value->getDescriptiveKind(), value->getName());
+      ctx.Diags.diagnose(loc, diag::shared_mutable_state_access, value);
       value->diagnose(diag::kind_declared_here, value->getDescriptiveKind());
       return true;
     }
@@ -2587,8 +2571,7 @@ namespace {
               ValueDecl *fnDecl = declRef->getDecl();
               ctx.Diags.diagnose(call->getLoc(),
                                  diag::actor_isolated_mutating_func,
-                                 fnDecl->getName(), decl->getDescriptiveKind(),
-                                 decl->getName());
+                                 fnDecl->getName(), decl);
               result = true;
               return;
             }
@@ -2596,8 +2579,7 @@ namespace {
         }
 
         ctx.Diags.diagnose(argLoc, diag::actor_isolated_inout_state,
-                           decl->getDescriptiveKind(), decl->getName(),
-                           call->isImplicitlyAsync().has_value());
+                           decl, call->isImplicitlyAsync().has_value());
         decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
         result = true;
         return;
@@ -2685,7 +2667,7 @@ namespace {
       // This is either non-distributed variable, subscript, or something else.
       ctx.Diags.diagnose(declLoc,
                          diag::distributed_actor_isolated_non_self_reference,
-                         decl->getDescriptiveKind(), decl->getName());
+                         decl);
       noteIsolatedActorMember(decl, context);
       return llvm::None;
     }
@@ -2896,12 +2878,10 @@ namespace {
           ctx.Diags.diagnose(
               apply->getLoc(), diag::actor_isolated_call_decl,
               *unsatisfiedIsolation,
-              calleeDecl->getDescriptiveKind(), calleeDecl->getName(),
+              calleeDecl,
               getContextIsolation())
             .warnUntilSwiftVersionIf(getContextIsolation().preconcurrency(), 6);
-          calleeDecl->diagnose(
-              diag::actor_isolated_sync_func, calleeDecl->getDescriptiveKind(),
-              calleeDecl->getName());
+          calleeDecl->diagnose(diag::actor_isolated_sync_func, calleeDecl);
         } else {
           ctx.Diags.diagnose(
               apply->getLoc(), diag::actor_isolated_call, *unsatisfiedIsolation,
@@ -3019,7 +2999,7 @@ namespace {
         ctx.Diags.diagnose(
             loc, diag::concurrent_access_of_local_capture,
             parent.dyn_cast<LoadExpr *>(),
-            var->getDescriptiveKind(), var->getName())
+            var)
           .warnUntilSwiftVersionIf(preconcurrencyContext, 6);
         return true;
       }
@@ -3028,9 +3008,7 @@ namespace {
         if (func->isSendable())
           return false;
 
-        func->diagnose(
-            diag::local_function_executed_concurrently,
-            func->getDescriptiveKind(), func->getName())
+        func->diagnose(diag::local_function_executed_concurrently, func)
           .fixItInsert(func->getAttributeInsertionLoc(false), "@Sendable ")
           .warnUntilSwiftVersion(6);
 
@@ -3042,9 +3020,7 @@ namespace {
       }
 
       // Concurrent access to some other local.
-      ctx.Diags.diagnose(
-          loc, diag::concurrent_access_local,
-          value->getDescriptiveKind(), value->getName());
+      ctx.Diags.diagnose(loc, diag::concurrent_access_local, value);
       value->diagnose(
           diag::kind_declared_here, value->getDescriptiveKind());
       return true;
@@ -3094,7 +3070,7 @@ namespace {
             ctx.Diags.diagnose(component.getLoc(),
                                diag::actor_isolated_keypath_component,
                                isolation.isDistributedActor(),
-                               decl->getDescriptiveKind(), decl->getName());
+                               decl);
             diagnosed = true;
             break;
           }
@@ -3189,10 +3165,7 @@ namespace {
       // An escaping partial application of something that is part of
       // the actor's isolated state is never permitted.
       if (partialApply && partialApply->isEscaping && !isAsyncDecl(declRef)) {
-        ctx.Diags.diagnose(
-            loc, diag::actor_isolated_partial_apply,
-            decl->getDescriptiveKind(),
-            decl->getName());
+        ctx.Diags.diagnose(loc, diag::actor_isolated_partial_apply, decl);
         return true;
       }
 
@@ -3261,8 +3234,7 @@ namespace {
 
         ctx.Diags.diagnose(
             loc, diag::actor_isolated_non_self_reference,
-            decl->getDescriptiveKind(),
-            decl->getName(),
+            decl,
             useKind,
             refKind + 1, refGlobalActor,
             result.isolation)
@@ -4477,7 +4449,7 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
 
   value->diagnose(
       diag::actor_isolation_override_mismatch, isolation,
-      value->getDescriptiveKind(), value->getName(), overriddenIsolation)
+      value, overriddenIsolation)
     .limitBehavior(behavior);
   overridden->diagnose(diag::overridden_here);
 }
@@ -4631,8 +4603,7 @@ static bool checkSendableInstanceStorage(
             dc, check).defaultDiagnosticBehavior();
         if (behavior != DiagnosticBehavior::Ignore) {
           property->diagnose(diag::concurrent_value_class_mutable_property,
-                             property->getName(), nominal->getDescriptiveKind(),
-                             nominal->getName())
+                             property->getName(), nominal)
               .limitBehavior(behavior);
         }
         invalid = invalid || (behavior == DiagnosticBehavior::Unspecified);
@@ -4660,8 +4631,7 @@ static bool checkSendableInstanceStorage(
 
             property->diagnose(diag::non_concurrent_type_member,
                                propertyType, false, property->getName(),
-                               nominal->getDescriptiveKind(),
-                               nominal->getName())
+                               nominal)
                 .limitBehavior(behavior);
             return false;
           });
@@ -4696,9 +4666,7 @@ static bool checkSendableInstanceStorage(
             }
 
             element->diagnose(diag::non_concurrent_type_member, type,
-                              true, element->getName(),
-                              nominal->getDescriptiveKind(),
-                              nominal->getName())
+                              true, element->getName(), nominal)
                 .limitBehavior(behavior);
             return false;
           });
@@ -4756,8 +4724,7 @@ bool swift::checkSendableConformance(
   if (conformanceDC->getParentSourceFile() &&
       conformanceDC->getParentSourceFile() != nominal->getParentSourceFile()) {
     conformanceDecl->diagnose(diag::concurrent_value_outside_source_file,
-                              nominal->getDescriptiveKind(),
-                              nominal->getName())
+                              nominal)
       .limitBehavior(behavior);
 
     if (behavior == DiagnosticBehavior::Unspecified)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -456,7 +456,7 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
         if (classDcl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
           diags.diagnose(decl->getLoc(),
                          diag::designated_init_in_extension_no_convenience_tip,
-                         nominal->getName());
+                         nominal);
 
           // despite having reported it as an error, say that it is designated.
           return CtorInitializerKind::Designated;
@@ -465,12 +465,11 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
           // tailor the diagnostic to not mention `convenience`
           diags.diagnose(decl->getLoc(),
                          diag::designated_init_in_extension_no_convenience_tip,
-                         nominal->getName());
+                         nominal);
 
         } else {
           diags.diagnose(decl->getLoc(),
-                             diag::designated_init_in_extension,
-                             nominal->getName())
+                             diag::designated_init_in_extension, nominal)
                  .fixItInsert(decl->getLoc(), "convenience ");
         }
 
@@ -947,8 +946,7 @@ IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
                        "static ");
     } else {
       auto *NTD = cast<NominalTypeDecl>(dc->getAsDecl());
-      decl->diagnose(diag::nonstatic_operator_in_nominal, operatorName,
-                     NTD->getName())
+      decl->diagnose(diag::nonstatic_operator_in_nominal, operatorName, NTD)
           .fixItInsert(decl->getAttributeInsertionLoc(/*forModifier=*/true),
                        "static ");
     }
@@ -2690,7 +2688,7 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
     // Once that's through, this will only fire during circular validation.
     if (VD->hasInterfaceType() &&
         !VD->isInvalid() && !VD->getParentPattern()->isImplicit()) {
-      VD->diagnose(diag::variable_bound_by_no_pattern, VD->getName());
+      VD->diagnose(diag::variable_bound_by_no_pattern, VD);
     }
 
     VD->getParentPattern()->setType(ErrorType::get(Context));

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -467,8 +467,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
   case ActorIsolation::ActorInstance:
     if (!canExposeActorIsolatedAsObjC(VD, isolation)) {
       // Actor-isolated functions cannot be @objc.
-      VD->diagnose(diag::actor_isolated_objc, VD->getDescriptiveKind(),
-                   VD->getName());
+      VD->diagnose(diag::actor_isolated_objc, VD);
       Reason.describe(VD);
       if (auto FD = dyn_cast<FuncDecl>(VD)) {
         addAsyncNotes(const_cast<FuncDecl *>(FD));
@@ -1861,8 +1860,7 @@ static ObjCSelector inferObjCName(ValueDecl *decl) {
     // If this requirement has a different name from one we've seen,
     // note the ambiguity.
     if (*requirementObjCName != *req->getObjCRuntimeName()) {
-      decl->diagnose(diag::objc_ambiguous_inference,
-                     decl->getDescriptiveKind(), decl->getName(),
+      decl->diagnose(diag::objc_ambiguous_inference, decl,
                      *requirementObjCName, *req->getObjCRuntimeName());
 
       // Note the candidates and what Objective-C names they provide.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3379,8 +3379,7 @@ private:
 
     case MatchOutcome::WrongSwiftName: {
       auto diag = diagnose(cand, diag::objc_implementation_wrong_swift_name,
-                           reqObjCName, req->getDescriptiveKind(),
-                           req->getName());
+                           reqObjCName, req);
       fixDeclarationName(diag, cand, req->getName());
       if (!explicitObjCName) {
         // Changing the Swift name will probably change the implicitly-computed
@@ -3444,38 +3443,36 @@ private:
       if (reqConv && !candConv)
         diagnose(cand,
                  diag::objc_implementation_candidate_has_error_convention,
-                 cand->getDescriptiveKind(), cand);
+                 cand);
       else if (!reqConv && candConv)
         diagnose(cand,
                  diag::objc_implementation_candidate_lacks_error_convention,
-                 cand->getDescriptiveKind(), cand);
+                 cand);
       else if (reqConv->getKind() != candConv->getKind())
         diagnose(cand,
                  diag::objc_implementation_mismatched_error_convention_kind,
-                 cand->getDescriptiveKind(), cand, candConv->getKind(),
-                 reqConv->getKind());
+                 cand, candConv->getKind(), reqConv->getKind());
       else if (reqConv->getErrorParameterIndex()
                   != candConv->getErrorParameterIndex())
         diagnose(cand,
                  diag::objc_implementation_mismatched_error_convention_index,
-                 cand->getDescriptiveKind(), cand,
+                 cand,
                  candConv->getErrorParameterIndex() + 1,
                  reqConv->getErrorParameterIndex() + 1);
       else if (reqConv->isErrorParameterReplacedWithVoid()
                   != candConv->isErrorParameterReplacedWithVoid())
         diagnose(cand,
                  diag::objc_implementation_mismatched_error_convention_void_param,
-                 cand->getDescriptiveKind(), cand,
-                 candConv->isErrorParameterReplacedWithVoid());
+                 cand, candConv->isErrorParameterReplacedWithVoid());
       else if (reqConv->isErrorOwned() != candConv->isErrorOwned())
         diagnose(cand,
                  diag::objc_implementation_mismatched_error_convention_ownership,
-                 cand->getDescriptiveKind(), cand, candConv->isErrorOwned());
+                 cand, candConv->isErrorOwned());
       else
         // Catch-all; probably shouldn't happen.
         diagnose(cand,
                  diag::objc_implementation_mismatched_error_convention_other,
-                 cand->getDescriptiveKind(), cand);
+                 cand);
 
       return;
     }
@@ -3524,8 +3521,7 @@ public:
       auto cand = pair.first;
 
       diagnose(cand, diag::member_of_objc_implementation_not_objc_or_final,
-               cand->getDescriptiveKind(), cand,
-               cand->getDeclContext()->getSelfClassDecl());
+               cand, cand->getDeclContext()->getSelfClassDecl());
 
       if (canBeRepresentedInObjC(cand))
         diagnose(cand, diag::fixit_add_private_for_objc_implementation,

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2642,7 +2642,7 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
 
       if (redeclSame)
         Ctx.Diags.diagnose(originalDecl, diag::invalid_redecl_prev,
-                           originalDecl->getBaseName());
+                           originalDecl);
       else
         Ctx.Diags.diagnose(originalDecl, diag::objc_declared_here,
                            origDiagInfo.first, origDiagInfo.second);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -117,10 +117,8 @@ void ObjCReason::describe(const Decl *D) const {
 
   case ObjCReason::WitnessToObjC: {
     auto requirement = getObjCRequirement();
-    requirement->diagnose(diag::objc_witness_objc_requirement,
-                D->getDescriptiveKind(), requirement->getName(),
-                cast<ProtocolDecl>(requirement->getDeclContext())
-                  ->getName());
+    requirement->diagnose(diag::objc_witness_objc_requirement, requirement,
+                          cast<ProtocolDecl>(requirement->getDeclContext()));
     break;
   }
 
@@ -1688,9 +1686,8 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
       ASTContext &ctx = dc->getASTContext();
       auto behavior = behaviorLimitForObjCReason(*isObjC, ctx);
       if (storageObjCAttr && storageObjCAttr->isSwift3Inferred()) {
-        storage->diagnose(diag::accessor_swift3_objc_inference,
-                 storage->getDescriptiveKind(), storage->getName(),
-                 isa<SubscriptDecl>(storage), accessor->isSetter())
+        storage->diagnose(diag::accessor_swift3_objc_inference, storage,
+                          accessor->isSetter())
           .fixItInsert(storage->getAttributeInsertionLoc(/*forModifier=*/false),
                        "@objc ")
           .limitBehavior(behavior);
@@ -1861,9 +1858,7 @@ static ObjCSelector inferObjCName(ValueDecl *decl) {
       auto diagnoseCandidate = [&](ValueDecl *req) {
         auto proto = cast<ProtocolDecl>(req->getDeclContext());
         auto diag = decl->diagnose(diag::objc_ambiguous_inference_candidate,
-                                   req->getName(),
-                                   proto->getName(),
-                                   *req->getObjCRuntimeName());
+                                   req, proto, *req->getObjCRuntimeName());
         fixDeclarationObjCName(diag, decl,
                                decl->getObjCRuntimeName(/*skipIsObjC=*/true),
                                req->getObjCRuntimeName());
@@ -1950,13 +1945,12 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
           // methods.
           if (declProvidingInheritedAsyncConvention
               && inheritedAsyncConvention != reqAsyncConvention) {
-            method->diagnose(diag::objc_ambiguous_async_convention,
-                             method->getName());
+            method->diagnose(diag::objc_ambiguous_async_convention, method);
             declProvidingInheritedAsyncConvention->diagnose(
                 diag::objc_ambiguous_async_convention_candidate,
-                declProvidingInheritedAsyncConvention->getName());
+                declProvidingInheritedAsyncConvention);
             reqMethod->diagnose(diag::objc_ambiguous_async_convention_candidate,
-                                reqMethod->getName());
+                                reqMethod);
             break;
           }
 
@@ -1973,13 +1967,12 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
           // methods.
           if (declProvidingInheritedErrorConvention
               && inheritedErrorConvention != reqErrorConvention) {
-            method->diagnose(diag::objc_ambiguous_error_convention,
-                             method->getName());
+            method->diagnose(diag::objc_ambiguous_error_convention, method);
             declProvidingInheritedErrorConvention->diagnose(
                 diag::objc_ambiguous_error_convention_candidate,
-                declProvidingInheritedErrorConvention->getName());
+                declProvidingInheritedErrorConvention);
             reqMethod->diagnose(diag::objc_ambiguous_error_convention_candidate,
-                                reqMethod->getName());
+                                reqMethod);
             break;
           }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3138,14 +3138,13 @@ private:
 
       // Ambiguous match (many requirements match one candidate)
       diagnose(cand, diag::objc_implementation_multiple_matching_requirements,
-                     cand->getDescriptiveKind(), cand);
+                     cand);
 
       bool shouldOfferFix = !candExplicitObjCName;
       for (auto req : matchedRequirements.matches) {
         auto diag =
             diagnose(cand, diag::objc_implementation_one_matched_requirement,
-                           req->getDescriptiveKind(), req,
-                           *req->getObjCRuntimeName(), shouldOfferFix,
+                           req, *req->getObjCRuntimeName(), shouldOfferFix,
                            req->getObjCRuntimeName()->getString(scratch));
         if (shouldOfferFix) {
           fixDeclarationObjCName(diag, cand, cand->getObjCRuntimeName(),
@@ -3187,14 +3186,13 @@ private:
       auto ext =
           cast<ExtensionDecl>(reqIDC->getImplementationContext());
       diagnose(ext, diag::objc_implementation_multiple_matching_candidates,
-                    req->getDescriptiveKind(), req,
-                    *req->getObjCRuntimeName());
+                    req, *req->getObjCRuntimeName());
 
       for (auto cand : cands.matches) {
         bool shouldOfferFix = !unmatchedCandidates[cand];
         auto diag =
             diagnose(cand, diag::objc_implementation_candidate_impl_here,
-                           cand->getDescriptiveKind(), cand, shouldOfferFix,
+                           cand, shouldOfferFix,
                            req->getObjCRuntimeName()->getString(scratch));
 
         if (shouldOfferFix) {
@@ -3204,8 +3202,7 @@ private:
         }
       }
 
-      diagnose(req, diag::objc_implementation_requirement_here,
-                    req->getDescriptiveKind(), req);
+      diagnose(req, diag::objc_implementation_requirement_here, req);
     }
 
     // Remove matched candidates and requirements from the unmatched lists.
@@ -3377,8 +3374,7 @@ private:
     case MatchOutcome::WrongImplicitObjCName:
     case MatchOutcome::WrongExplicitObjCName: {
       auto diag = diagnose(cand, diag::objc_implementation_wrong_objc_name,
-                           *cand->getObjCRuntimeName(),
-                           cand->getDescriptiveKind(), cand, reqObjCName);
+                           *cand->getObjCRuntimeName(), cand, reqObjCName);
       fixDeclarationObjCName(diag, cand, explicitObjCName, reqObjCName);
       return;
     }
@@ -3400,34 +3396,31 @@ private:
     case MatchOutcome::WrongStaticness: {
       auto diag = diagnose(cand,
                            diag::objc_implementation_class_or_instance_mismatch,
-                           cand->getDescriptiveKind(), cand,
-                           req->getDescriptiveKind());
+                           cand, req->getDescriptiveKind());
       fixDeclarationStaticSpelling(diag, cand, getStaticSpelling(req));
       return;
     }
 
     case MatchOutcome::WrongCategory:
       diagnose(cand, diag::objc_implementation_wrong_category,
-               cand->getDescriptiveKind(), cand,
-               getCategoryName(req->getDeclContext()),
+               cand, getCategoryName(req->getDeclContext()),
                getCategoryName(cand->getDeclContext()->
                                  getImplementedObjCContext()));
       return;
 
     case MatchOutcome::WrongDeclKind:
       diagnose(cand, diag::objc_implementation_wrong_decl_kind,
-               cand->getDescriptiveKind(), cand, req->getDescriptiveKind());
+               cand, req->getDescriptiveKind());
       return;
 
     case MatchOutcome::WrongType:
       diagnose(cand, diag::objc_implementation_type_mismatch,
-               cand->getDescriptiveKind(), cand,
-               getMemberType(cand), getMemberType(req));
+               cand, getMemberType(cand), getMemberType(req));
       return;
 
     case MatchOutcome::WrongWritability:
       diagnose(cand, diag::objc_implementation_must_be_settable,
-               cand->getDescriptiveKind(), cand, req->getDescriptiveKind());
+               cand, req->getDescriptiveKind());
       return;
 
     case MatchOutcome::WrongRequiredAttr: {
@@ -3435,7 +3428,7 @@ private:
 
       auto diag =
         diagnose(cand, diag::objc_implementation_required_attr_mismatch,
-                 cand->getDescriptiveKind(), cand, shouldBeRequired);
+                 cand, req->getDescriptiveKind(),  shouldBeRequired);
       
       if (shouldBeRequired)
         diag.fixItInsert(cand->getAttributeInsertionLoc(/*forModifier=*/true),
@@ -3522,8 +3515,7 @@ public:
                         ->getImplementationContext();
 
       diagnose(ext->getDecl(), diag::objc_implementation_missing_impl,
-               getCategoryName(req->getDeclContext()),
-               req->getDescriptiveKind(), req);
+               getCategoryName(req->getDeclContext()), req);
 
       // FIXME: Should give fix-it to add stub implementation
     }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -110,14 +110,8 @@ void ObjCReason::describe(const Decl *D) const {
     break;
 
   case ObjCReason::OverridesObjC: {
-    unsigned kind = isa<VarDecl>(D) ? 0
-                  : isa<SubscriptDecl>(D) ? 1
-                  : isa<ConstructorDecl>(D) ? 2
-                  : 3;
-
     auto overridden = cast<ValueDecl>(D)->getOverriddenDecl();
-    overridden->diagnose(diag::objc_overriding_objc_decl,
-                         kind, overridden->getName());
+    overridden->diagnose(diag::objc_overriding_objc_decl, overridden);
     break;
   }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -594,8 +594,7 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
     }
 
     auto diag = diags.diagnose(matchDecl, diag::overridden_near_match_here,
-                               matchDecl->getDescriptiveKind(),
-                               matchDecl->getName());
+                               matchDecl);
     if (attempt == OverrideCheckingAttempt::BaseName) {
       fixDeclarationName(diag, decl, matchDecl->getName());
     }
@@ -1212,9 +1211,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
         diagKind = diag::initializer_does_not_override;
       diags.diagnose(decl, diagKind, isClassContext);
       noteFixableMismatchedTypes(decl, baseDecl);
-      diags.diagnose(baseDecl, diag::overridden_near_match_here,
-                     baseDecl->getDescriptiveKind(),
-                     baseDecl->getName());
+      diags.diagnose(baseDecl, diag::overridden_near_match_here, baseDecl);
       emittedMatchError = true;
 
     } else if (!isa<AccessorDecl>(method) &&
@@ -1245,9 +1242,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     if (attempt == OverrideCheckingAttempt::MismatchedTypes) {
       diags.diagnose(decl, diag::subscript_does_not_override, isClassContext);
       noteFixableMismatchedTypes(decl, baseDecl);
-      diags.diagnose(baseDecl, diag::overridden_near_match_here,
-                     baseDecl->getDescriptiveKind(),
-                     baseDecl->getName());
+      diags.diagnose(baseDecl, diag::overridden_near_match_here, baseDecl);
       emittedMatchError = true;
 
     } else if (mayHaveMismatchedOptionals) {
@@ -1688,11 +1683,9 @@ namespace  {
 
       // Complain.
       Diags.diagnose(Override, diag::override_swift3_objc_inference,
-                     Override->getDescriptiveKind(),
-                     Override->getName(),
-                     Base->getDeclContext()
-                       ->getSelfNominalTypeDecl()
-                       ->getName());
+                     Override, Base->getDeclContext()
+                                 ->getSelfNominalTypeDecl()
+                                 ->getName());
       Diags.diagnose(Base, diag::make_decl_objc, Base->getDescriptiveKind())
         .fixItInsert(Base->getAttributeInsertionLoc(false),
                      "@objc ");
@@ -1825,16 +1818,7 @@ static bool diagnoseOverrideForAvailability(ValueDecl *override,
     return false;
 
   auto &diags = override->getASTContext().Diags;
-  if (auto *accessor = dyn_cast<AccessorDecl>(override)) {
-    diags.diagnose(override, diag::override_accessor_less_available,
-                   accessor->getDescriptiveKind(),
-                   accessor->getStorage()->getBaseName());
-    diags.diagnose(base, diag::overridden_here);
-    return true;
-  }
-
-  diags.diagnose(override, diag::override_less_available,
-                 override->getBaseName());
+  diags.diagnose(override, diag::override_less_available, override);
   diags.diagnose(base, diag::overridden_here);
 
   return true;
@@ -1996,8 +1980,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     bool baseCanBeObjC = canBeRepresentedInObjC(base);
     auto nominal = base->getDeclContext()->getSelfNominalTypeDecl();
     diags.diagnose(override, diag::override_decl_extension, baseCanBeObjC,
-                   !isa<ExtensionDecl>(base->getDeclContext()),
-                   override->getDescriptiveKind(), override->getName(),
+                   !isa<ExtensionDecl>(base->getDeclContext()), override,
                    nominal->getName());
     // If the base and the override come from the same module, try to fix
     // the base declaration. Otherwise we can wind up diagnosing into e.g. the

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1929,7 +1929,7 @@ public:
           Context.SourceMgr.extractText({VD->getNameLoc(), 1}) != "`") {
         auto &DE = Context.Diags;
         DE.diagnose(VD->getNameLoc(), diag::reserved_member_name,
-                    VD->getName(), VD->getBaseIdentifier().str());
+                    VD, VD->getBaseIdentifier().str());
         DE.diagnose(VD->getNameLoc(), diag::backticks_to_escape)
             .fixItReplace(VD->getNameLoc(),
                           "`" + VD->getBaseName().userFacingName().str() + "`");
@@ -2623,7 +2623,7 @@ public:
     // We don't support protocols outside the top level of a file.
     if (isa<ProtocolDecl>(NTD) &&
         !NTD->getParent()->isModuleScopeContext()) {
-      NTD->diagnose(diag::unsupported_nested_protocol, NTD->getName());
+      NTD->diagnose(diag::unsupported_nested_protocol, NTD);
       NTD->setInvalid();
       return;
     }
@@ -2631,11 +2631,10 @@ public:
     // We don't support nested types in protocols.
     if (auto proto = DC->getSelfProtocolDecl()) {
       if (DC->getExtendedProtocolDecl()) {
-        NTD->diagnose(diag::unsupported_type_nested_in_protocol_extension,
-                      NTD->getName(), proto->getName());
+        NTD->diagnose(diag::unsupported_type_nested_in_protocol_extension, NTD,
+                      proto);
       } else {
-        NTD->diagnose(diag::unsupported_type_nested_in_protocol,
-                      NTD->getName(), proto->getName());
+        NTD->diagnose(diag::unsupported_type_nested_in_protocol, NTD, proto);
       }
     }
 
@@ -2644,11 +2643,10 @@ public:
       if (DC->isLocalContext() && DC->isGenericContext()) {
         // A local generic context is a generic function.
         if (auto AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
-          NTD->diagnose(diag::unsupported_type_nested_in_generic_function,
-                        NTD->getName(), AFD->getName());
+          NTD->diagnose(diag::unsupported_type_nested_in_generic_function, NTD,
+                        AFD);
         } else {
-          NTD->diagnose(diag::unsupported_type_nested_in_generic_closure,
-                        NTD->getName());
+          NTD->diagnose(diag::unsupported_type_nested_in_generic_closure, NTD);
         }
       }
     }
@@ -3381,8 +3379,8 @@ public:
         auto isProtocol = isa_and_nonnull<ProtocolDecl>(selfNominal);
         // We did not find 'Self'. Complain.
         FD->diagnose(diag::operator_in_unrelated_type,
-                     FD->getDeclContext()->getDeclaredInterfaceType(), isProtocol,
-                     FD->getName());
+                     FD->getDeclContext()->getDeclaredInterfaceType(),
+                     isProtocol, FD);
       }
     }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2611,8 +2611,7 @@ public:
       if (mentionsItself) {
         auto &DE = getASTContext().Diags;
         DE.diagnose(AT->getDefaultDefinitionTypeRepr()->getLoc(),
-                    diag::recursive_decl_reference, AT->getDescriptiveKind(),
-                    AT->getName());
+                    diag::recursive_decl_reference, AT);
         AT->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
       }
     }
@@ -2743,8 +2742,7 @@ public:
       if (!ED->getASTContext().LangOpts.hasFeature(
               Feature::MoveOnlyResilientTypes) &&
           ED->isResilient()) {
-        ED->diagnose(diag::noncopyable_types_cannot_be_resilient,
-                     ED->getDescriptiveKind(), ED->getBaseIdentifier());
+        ED->diagnose(diag::noncopyable_types_cannot_be_resilient, ED);
       }
     }
   }
@@ -2790,8 +2788,7 @@ public:
     if (!SD->getASTContext().LangOpts.hasFeature(
             Feature::MoveOnlyResilientTypes) &&
         SD->isResilient() && SD->isMoveOnly()) {
-      SD->diagnose(diag::noncopyable_types_cannot_be_resilient,
-                   SD->getDescriptiveKind(), SD->getBaseIdentifier());
+      SD->diagnose(diag::noncopyable_types_cannot_be_resilient, SD);
     }
   }
 
@@ -2916,11 +2913,8 @@ public:
     }
 
     auto &ctx = moveonlyType->getASTContext();
-    ctx.Diags.diagnose(loc,
-                       diag::noncopyable_cannot_conform_to_type,
-                       moveonlyType->getDescriptiveKind(),
-                       moveonlyType->getBaseName(),
-                       type);
+    ctx.Diags.diagnose(loc, diag::noncopyable_cannot_conform_to_type,
+                       moveonlyType, type);
     return true;
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -459,9 +459,8 @@ static void diagnoseDuplicateDecls(T &&decls) {
       auto *other = found.first->second;
 
       current->getASTContext().Diags.diagnoseWithNotes(
-        current->diagnose(diag::invalid_redecl,
-                          current->getName()), [&]() {
-        other->diagnose(diag::invalid_redecl_prev, other->getName());
+        current->diagnose(diag::invalid_redecl, current), [&]() {
+        other->diagnose(diag::invalid_redecl_prev, other);
       });
 
       // Mark the decl as invalid. This is needed to avoid emitting a
@@ -760,9 +759,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
                 
                 if (optionalRedecl && currIsIUO != otherIsIUO) {
                   ctx.Diags.diagnoseWithNotes(
-                    current->diagnose(diag::invalid_redecl,
-                                      current->getName()), [&]() {
-                    other->diagnose(diag::invalid_redecl_prev, other->getName());
+                    current->diagnose(diag::invalid_redecl, current), [&]() {
+                    other->diagnose(diag::invalid_redecl_prev, other);
                   });
                   current->diagnose(diag::invalid_redecl_by_optionality_note,
                                     otherIsIUO, currIsIUO);
@@ -869,9 +867,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
       // If this isn't a redeclaration in the current version of Swift, but
       // would be in Swift 5 mode, emit a warning instead of an error.
       if (wouldBeSwift5Redeclaration) {
-        current->diagnose(diag::invalid_redecl_swift5_warning,
-                          current->getName());
-        other->diagnose(diag::invalid_redecl_prev, other->getName());
+        current->diagnose(diag::invalid_redecl_swift5_warning, current);
+        other->diagnose(diag::invalid_redecl_prev, other);
       } else {
         const auto *otherInit = dyn_cast<ConstructorDecl>(other);
         // Provide a better description for implicit initializers.
@@ -881,8 +878,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
           // checker should have already taken care of emitting a more
           // productive diagnostic.
           if (!other->getOverriddenDecl())
-            current->diagnose(diag::invalid_redecl_init,
-                              current->getName(),
+            current->diagnose(diag::invalid_redecl_init, current,
                               otherInit->isMemberwiseInitializer());
         } else if (current->isImplicit() || other->isImplicit()) {
           // If both declarations are implicit, we do not diagnose anything
@@ -937,7 +933,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
             }
             declToDiagnose->diagnose(diag::invalid_redecl_implicit,
                                      current->getDescriptiveKind(),
-                                     isProtocolRequirement, other->getName());
+                                     isProtocolRequirement, other);
 
             // Emit a specialized note if the one of the declarations is
             // the backing storage property ('_foo') or projected value
@@ -965,7 +961,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
             if (varToDiagnose) {
               assert(declToDiagnose);
               varToDiagnose->diagnose(
-                  diag::invalid_redecl_implicit_wrapper, varToDiagnose->getName(),
+                  diag::invalid_redecl_implicit_wrapper, varToDiagnose,
                   kind == PropertyWrapperSynthesizedPropertyKind::Backing);
             }
 
@@ -973,9 +969,8 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
           }
         } else {
           ctx.Diags.diagnoseWithNotes(
-            current->diagnose(diag::invalid_redecl,
-                              current->getName()), [&]() {
-            other->diagnose(diag::invalid_redecl_prev, other->getName());
+            current->diagnose(diag::invalid_redecl, current), [&]() {
+            other->diagnose(diag::invalid_redecl_prev, other);
           });
 
           current->setInvalid();

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -216,13 +216,10 @@ static bool checkAdHocRequirementAccessControl(
     return false;
   }
 
-  func->diagnose(diag::witness_not_accessible_type,
-                 diag::RequirementKind::Func,
-                 func->getName(),
-                 /*isSetter=*/false,
-                 /*requiredAccess=*/AccessLevel::Public,
-                 AccessLevel::Public,
-                 proto->getName());
+  func->diagnose(diag::witness_not_accessible_type, diag::RequirementKind::Func,
+                 func, /*isSetter=*/false,
+                 /*requiredAccess=*/AccessLevel::Public, AccessLevel::Public,
+                 proto);
       return true;
 }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -245,7 +245,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
       auto identifier = C.Id_remoteCall;
       decl->diagnose(
           diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
+          decl, identifier);
       decl->diagnose(
           diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
           Proto->getName(), identifier,
@@ -272,7 +272,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
       auto identifier = C.Id_remoteCallVoid;
       decl->diagnose(
           diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
+          decl, identifier);
       decl->diagnose(
           diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
           Proto->getName(), identifier,
@@ -302,7 +302,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
       auto identifier = C.Id_recordArgument;
       decl->diagnose(
           diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
+          decl, identifier);
       decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
                      Proto->getName(), identifier,
                      "mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws\n");
@@ -317,7 +317,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
       auto identifier = C.Id_recordReturnType;
       decl->diagnose(
           diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
+          decl, identifier);
       decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
                      Proto->getName(), identifier,
                      "mutating func recordReturnType<Res: SerializationRequirement>(_ resultType: Res.Type) throws\n");
@@ -338,7 +338,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
       auto identifier = C.Id_decodeNextArgument;
       decl->diagnose(
           diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
+          decl, identifier);
       decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
                      Proto->getName(), identifier,
                      "mutating func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument\n");
@@ -359,7 +359,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
       auto identifier = C.Id_onReturn;
       decl->diagnose(
           diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
+          decl, identifier);
       decl->diagnose(
           diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
           Proto->getName(), identifier,
@@ -412,8 +412,7 @@ static bool checkDistributedTargetResultType(
         auto diag = valueDecl->diagnose(
             diag::distributed_actor_target_result_not_codable,
             resultType,
-            valueDecl->getDescriptiveKind(),
-            valueDecl->getBaseIdentifier(),
+            valueDecl,
             conformanceToSuggest
         );
 
@@ -560,7 +559,7 @@ bool CheckDistributedFunctionRequest::evaluate(
       param->diagnose(
           diag::distributed_actor_func_inout,
           param->getName(),
-          func->getDescriptiveKind(), func->getName()
+          func
       ).fixItRemove(SourceRange(param->getTypeSourceRangeForDiagnostics().Start,
                                 param->getTypeSourceRangeForDiagnostics().Start.getAdvancedLoc(1)));
       // FIXME(distributed): the fixIt should be on param->getSpecifierLoc(), but that Loc is invalid for some reason?
@@ -575,8 +574,7 @@ bool CheckDistributedFunctionRequest::evaluate(
           diag::distributed_actor_func_unsupported_specifier,
           ParamDecl::getSpecifierSpelling(param->getSpecifier()),
           param->getName(),
-          func->getDescriptiveKind(),
-          func->getName());
+          func);
       return true;
     }
 
@@ -584,7 +582,7 @@ bool CheckDistributedFunctionRequest::evaluate(
       param->diagnose(
           diag::distributed_actor_func_variadic,
           param->getName(),
-          func->getDescriptiveKind(), func->getName()
+          func
       );
     }
   }
@@ -624,8 +622,7 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
   // it is not a computed property
   if (var->isLet() || var->hasStorageOrWrapsStorage()) {
     if (diagnose)
-      var->diagnose(diag::distributed_property_can_only_be_computed,
-                    var->getDescriptiveKind(), var->getName());
+      var->diagnose(diag::distributed_property_can_only_be_computed, var);
     return true;
   }
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2927,7 +2927,7 @@ private:
            auto callee = call->getCalledValue(/*skipFunctionConversions=*/true);
            if (callee) {
              Ctx.Diags.diagnose(diag.expr.getStartLoc(), diag::actor_isolated_sync_func,
-                                callee->getDescriptiveKind(), callee->getName());
+                                callee);
            } else {
              Ctx.Diags.diagnose(
                  diag.expr.getStartLoc(), diag::actor_isolated_sync_func_value,

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1944,7 +1944,7 @@ public:
           if (var->isAsyncLet()) {
             Diags.diagnose(
                 e->getLoc(), diag::async_let_in_illegal_context,
-                var->getName(), static_cast<unsigned>(getKind()));
+                var, static_cast<unsigned>(getKind()));
             return;
           }
         }
@@ -2880,8 +2880,7 @@ private:
             if (auto var = dyn_cast<VarDecl>(declR->getDecl())) {
               if (var->isAsyncLet()) {
                 Ctx.Diags.diagnose(declR->getLoc(),
-                                   diag::async_let_without_await,
-                                   var->getName());
+                                   diag::async_let_without_await, var);
                 continue;
               }
             }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -411,8 +411,7 @@ llvm::Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     }
 
     // Declarations that cannot be part of a key-path.
-    diags.diagnose(componentNameLoc, diag::expr_keypath_not_property,
-                   found->getDescriptiveKind(), found->getName(),
+    diags.diagnose(componentNameLoc, diag::expr_keypath_not_property, found,
                    /*isForDynamicKeyPathMemberLookup=*/false);
     isInvalid = true;
     break;

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -313,7 +313,7 @@ llvm::Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
       for (auto result : lookup) {
         diags.diagnose(result.getValueDecl(), diag::decl_declared_here,
-                       result.getValueDecl()->getName());
+                       result.getValueDecl());
       }
       isInvalid = true;
       break;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -525,18 +525,16 @@ void TypeChecker::checkShadowedGenericParams(GenericContext *dc) {
       auto *existingParamDecl = found->second;
 
       if (existingParamDecl->getDeclContext() == dc) {
-        genericParamDecl->diagnose(
-            diag::invalid_redecl,
-            genericParamDecl->getName());
+        genericParamDecl->diagnose(diag::invalid_redecl, genericParamDecl);
       } else {
         genericParamDecl->diagnose(
             diag::shadowed_generic_param,
-            genericParamDecl->getName()).warnUntilSwiftVersion(6);
+            genericParamDecl).warnUntilSwiftVersion(6);
       }
 
       if (existingParamDecl->getLoc()) {
         existingParamDecl->diagnose(diag::invalid_redecl_prev,
-                                    existingParamDecl->getName());
+                                    existingParamDecl);
       }
 
       continue;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -299,9 +299,7 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
           req.getFirstType()->is<GenericTypeParamType>())
         continue;
 
-      ctx.Diags.diagnose(decl,
-                         diag::requirement_restricts_self,
-                         decl->getDescriptiveKind(), decl->getName(),
+      ctx.Diags.diagnose(decl, diag::requirement_restricts_self, decl,
                          req.getFirstType().getString(),
                          static_cast<unsigned>(req.getKind()),
                          req.getSecondType().getString());

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1022,7 +1022,7 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
       ctx.Diags.diagnose(loc, diag::external_macro_not_found,
                          external.moduleName.str(),
                          external.macroTypeName.str(), macro->getName());
-      macro->diagnose(diag::decl_declared_here, macro->getName());
+      macro->diagnose(diag::decl_declared_here, macro);
       return nullptr;
     }
 
@@ -1283,7 +1283,7 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
                         external.macroTypeName.str(),
                         macro->getName()
       );
-      macro->diagnose(diag::decl_declared_here, macro->getName());
+      macro->diagnose(diag::decl_declared_here, macro);
       return nullptr;
     }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -671,19 +671,14 @@ noteTypoCorrection(DeclNameLoc loc, ValueDecl *decl,
   }
 
   if (Decl *parentDecl = findExplicitParentForImplicitDecl(decl)) {
-    StringRef kind = (isa<VarDecl>(decl) ? "property" :
-                      isa<ConstructorDecl>(decl) ? "initializer" :
-                      isa<FuncDecl>(decl) ? "method" :
-                      "member");
-
     return parentDecl->diagnose(
                        wasClaimed ? diag::implicit_member_declared_here
                                   : diag::note_typo_candidate_implicit_member,
-                       decl->getBaseName().userFacingName(), kind);
+                       decl);
   }
 
   if (wasClaimed) {
-    return decl->diagnose(diag::decl_declared_here, decl->getBaseName());
+    return decl->diagnose(diag::decl_declared_here_base, decl);
   } else {
     return decl->diagnose(diag::note_typo_candidate,
                           decl->getBaseName().userFacingName());

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1030,8 +1030,7 @@ void repairTupleOrAssociatedValuePatternIfApplicable(
   }
 
   if (addDeclNote)
-    DE.diagnose(enumCase->getStartLoc(), diag::decl_declared_here,
-                enumCase->getName());
+    DE.diagnose(enumCase->getStartLoc(), diag::decl_declared_here, enumCase);
 }
 
 NullablePtr<Pattern> TypeChecker::trySimplifyExprPattern(ExprPattern *EP,

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -239,7 +239,7 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
         init->diagnose(diag::property_wrapper_wrong_initial_value_init,
                        init->getName(), paramType,
                        valueVar->getValueInterfaceType());
-        valueVar->diagnose(diag::decl_declared_here, valueVar->getName());
+        valueVar->diagnose(diag::decl_declared_here, valueVar);
         break;
       }
     }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -519,8 +519,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
         whichKind = 1;
       else
         whichKind = 2;
-      var->diagnose(diag::property_with_wrapper_in_bad_context,
-                    var->getName(), whichKind, var->getDescriptiveKind())
+      var->diagnose(diag::property_with_wrapper_in_bad_context, var, whichKind)
         .highlight(attr->getRange());
 
       continue;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -82,8 +82,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   VarDecl *var = vars.front();
   if (isDeclNotAsAccessibleAsParent(var, nominal)) {
     var->diagnose(diag::property_wrapper_type_requirement_not_accessible,
-                  var->getFormalAccess(), var->getDescriptiveKind(),
-                  var->getName(), nominal->getDeclaredType(),
+                  var->getFormalAccess(), var, nominal->getDeclaredType(),
                   nominal->getFormalAccess());
     return nullptr;
   }
@@ -232,9 +231,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
 
       case NonViableReason::Inaccessible:
         init->diagnose(diag::property_wrapper_type_requirement_not_accessible,
-                       init->getFormalAccess(), init->getDescriptiveKind(),
-                       init->getName(), nominal->getDeclaredType(),
-                       nominal->getFormalAccess());
+                       init->getFormalAccess(), init,
+                       nominal->getDeclaredType(), nominal->getFormalAccess());
         break;
 
       case NonViableReason::ParameterTypeMismatch:
@@ -320,8 +318,7 @@ static SubscriptDecl *findEnclosingSelfSubscript(ASTContext &ctx,
   if (isDeclNotAsAccessibleAsParent(subscript, nominal)) {
     subscript->diagnose(diag::property_wrapper_type_requirement_not_accessible,
                         subscript->getFormalAccess(),
-                        subscript->getDescriptiveKind(),
-                        subscript->getName(), nominal->getDeclaredType(),
+                        subscript, nominal->getDeclaredType(),
                         nominal->getFormalAccess());
     return nullptr;
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3167,8 +3167,7 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
   // actor isolation.
   witness->diagnose(diag::actor_isolated_witness,
                     isDistributed && !isDistributedDecl(witness),
-                    refResult.isolation, witness->getDescriptiveKind(),
-                    witness->getName(), requirementIsolation)
+                    refResult.isolation, witness, requirementIsolation)
     .limitBehavior(behavior);
 
   // If we need 'distributed' on the witness, add it.
@@ -3318,8 +3317,7 @@ public:
 
     SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
     ctx.Diags.diagnose(diagLoc, diagID,
-                       witness->getDescriptiveKind(),
-                       witness->getName(),
+                       witness,
                        proto->getName());
     emitDeclaredHereIfNeeded(ctx.Diags, diagLoc, witness);
   }
@@ -3404,8 +3402,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
         auto &diags = DC->getASTContext().Diags;
         diags.diagnose(getLocForDiagnosingWitness(conformance, typeDecl),
                        diagKind,
-                       typeDecl->getDescriptiveKind(),
-                       typeDecl->getName(),
+                       typeDecl,
                        requiredAccess,
                        proto->getName());
         diagnoseWitnessFixAccessLevel(diags, typeDecl, requiredAccess);
@@ -4166,11 +4163,9 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
       auto &diags = proto->getASTContext().Diags;
       SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, witness);
       diags.diagnose(diagLoc, diag::witness_self_same_type,
-                     witness->getDescriptiveKind(),
-                     witness->getName(),
+                     witness,
                      Conformance->getType(),
-                     requirement->getDescriptiveKind(),
-                     requirement->getName(),
+                     requirement,
                      proto->getDeclaredInterfaceType());
       emitDeclaredHereIfNeeded(diags, diagLoc, witness);
 
@@ -4284,8 +4279,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           {
             SourceLoc diagLoc = getLocForDiagnosingWitness(conformance,witness);
             auto diag = diags.diagnose(
-                diagLoc, diag::witness_argument_name_mismatch,
-                witness->getDescriptiveKind(), witness->getName(),
+                diagLoc, diag::witness_argument_name_mismatch, witness,
                 proto->getDeclaredInterfaceType(), requirement->getName());
             if (diagLoc == witness->getLoc()) {
               fixDeclarationName(diag, witness, requirement->getName());
@@ -4319,8 +4313,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
             auto &diags = DC->getASTContext().Diags;
             diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
                            diag::witness_not_as_sendable,
-                           witness->getDescriptiveKind(), witness->getName(),
-                           conformance->getProtocol()->getName())
+                           witness, conformance->getProtocol()->getName())
                 .limitBehavior(limit);
             diags.diagnose(requirement, diag::less_sendable_reqt_here)
                 .limitBehavior(limit);
@@ -4478,8 +4471,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           auto *attr = AvailableAttr::isUnavailable(witness);
           EncodedDiagnosticMessage EncodedMessage(attr->Message);
           diags.diagnose(diagLoc, diag::witness_unavailable,
-                         witness->getDescriptiveKind(), witness->getName(),
-                         conformance->getProtocol()->getName(),
+                         witness, conformance->getProtocol()->getName(),
                          EncodedMessage.Message);
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement, diag::kind_declname_declared_here,
@@ -5297,7 +5289,7 @@ void ConformanceChecker::resolveValueWitnesses() {
                   Swift3ObjCInferenceWarnings::Minimal) {
             C.Diags.diagnose(
                 Conformance->getLoc(), diag::witness_swift3_objc_inference,
-                witness->getDescriptiveKind(), witness->getName(),
+                witness,
                 Conformance->getProtocol()->getDeclaredInterfaceType());
             witness
                 ->diagnose(diag::make_decl_objc, witness->getDescriptiveKind())
@@ -6141,8 +6133,7 @@ static void diagnosePotentialWitness(NormalProtocolConformance *conformance,
   auto proto = cast<ProtocolDecl>(req->getDeclContext());
 
   // Primary warning.
-  witness->diagnose(diag::req_near_match, witness->getDescriptiveKind(),
-                    witness->getName(),
+  witness->diagnose(diag::req_near_match, witness,
                     req->getAttrs().hasAttribute<OptionalAttr>(),
                     req->getName(), proto->getName());
 
@@ -6639,8 +6630,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
             continue;
 
           value->diagnose(diag::redundant_conformance_witness_ignored,
-                          value->getDescriptiveKind(), value->getName(),
-                          diag.Protocol->getName());
+                          value, diag.Protocol->getName());
           break;
         }
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3310,14 +3310,10 @@ public:
     auto proto = conformance->getProtocol();
     ASTContext &ctx = proto->getASTContext();
 
-    auto diagID = diag::witness_not_usable_from_inline;
-    if (!ctx.isSwiftVersionAtLeast(5))
-      diagID = diag::witness_not_usable_from_inline_warn;
-
     SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
-    ctx.Diags.diagnose(diagLoc, diagID,
-                       witness,
-                       proto->getName());
+    ctx.Diags.diagnose(diagLoc, diag::witness_not_usable_from_inline, witness,
+                       proto)
+      .warnUntilSwiftVersion(5);
     emitDeclaredHereIfNeeded(ctx.Diags, diagLoc, witness);
   }
 };

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2827,9 +2827,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     diags
         .diagnose(
             witness,
-            diag::
-                protocol_witness_missing_differentiable_attr_invalid_context,
-            reqDiffAttrString, req->getName(), conformance->getType(),
+            diag::protocol_witness_missing_differentiable_attr_invalid_context,
+            reqDiffAttrString, req, conformance->getType(),
             conformance->getProtocol()->getDeclaredInterfaceType())
         .fixItInsert(match.Witness->getStartLoc(), reqDiffAttrString + ' ');
     break;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2985,7 +2985,7 @@ static void emitDeclaredHereIfNeeded(DiagnosticEngine &diags,
     return;
   if (mainDiagLoc == value->getLoc())
     return;
-  diags.diagnose(value, diag::decl_declared_here, value->getName());
+  diags.diagnose(value, diag::decl_declared_here, value);
 }
 
 /// Whether this declaration has the 'distributed' modifier on it.
@@ -3248,7 +3248,7 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
         diag.fixItInsert(insertLoc, modifiers);
     }
   } else {
-    requirement->diagnose(diag::decl_declared_here, requirement->getName());
+    requirement->diagnose(diag::decl_declared_here, requirement);
   }
 
   return llvm::None;
@@ -4092,7 +4092,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
             // defined.
             fixItDiag.value().flush();
             fixItDiag.emplace(diags.diagnose(ctor, diag::decl_declared_here,
-                                             ctor->getName()));
+                                             ctor));
           }
           if (!inExtension) {
             fixItDiag->fixItInsert(ctor->getAttributeInsertionLoc(true),
@@ -4199,8 +4199,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
                            getProtocolRequirementKind(requirement),
                            requirement->getName(),
                            conformance->getType());
-            diags.diagnose(witness, diag::decl_declared_here,
-                           witness->getName());
+            diags.diagnose(witness, diag::decl_declared_here, witness);
           });
       }
     }
@@ -4285,8 +4284,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
               fixDeclarationName(diag, witness, requirement->getName());
             } else {
               diag.flush();
-              diags.diagnose(witness, diag::decl_declared_here,
-                             witness->getName());
+              diags.diagnose(witness, diag::decl_declared_here, witness);
             }
           }
 
@@ -4433,8 +4431,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
               addOptionalityFixIts(adjustments, ctx, witness, diag);
             } else {
               diag.flush();
-              diags.diagnose(witness, diag::decl_declared_here,
-                             witness->getName());
+              diags.diagnose(witness, diag::decl_declared_here, witness);
             }
           }
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1939,7 +1939,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         diags.diagnose(failedDefaultedAssocType,
                        diag::default_associated_type_req_fail,
                        failedDefaultedWitness,
-                       failedDefaultedAssocType->getName(),
+                       failedDefaultedAssocType,
                        proto->getDeclaredInterfaceType(),
                        failedDefaultedResult.getRequirement(),
                        failedDefaultedResult.isConformanceRequirement());
@@ -1975,7 +1975,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         auto proto = conformance->getProtocol();
         auto &diags = proto->getASTContext().Diags;
         diags.diagnose(assocType, diag::bad_associated_type_deduction,
-                       assocType->getName(), proto->getName());
+                       assocType, proto);
         for (const auto &failed : failedSet) {
           if (failed.Result.isError())
             continue;
@@ -2004,7 +2004,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
                 typeRange.isValid()) {
               diags.diagnose(typeRange.Start,
                              diag::suggest_opaque_type_witness,
-                             assocType->getName(), failed.TypeWitness,
+                             assocType, failed.TypeWitness,
                              failed.Result.getRequirement())
                 .highlight(typeRange)
                 .fixItInsert(typeRange.Start, "some ");
@@ -2013,7 +2013,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
 
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_conform_impossible,
-                           assocType->getName(), failed.TypeWitness,
+                           assocType, failed.TypeWitness,
                            failed.Result.getRequirement());
             continue;
           }
@@ -2021,15 +2021,14 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
               failed.Result.isSuperclassRequirement()) {
             diags.diagnose(failed.Witness,
                            diag::associated_type_witness_inherit_impossible,
-                           assocType->getName(), failed.TypeWitness,
+                           assocType, failed.TypeWitness,
                            failed.Result.getRequirement());
             continue;
           }
 
           diags.diagnose(failed.Witness,
                          diag::associated_type_deduction_witness_failed,
-                         assocType->getName(),
-                         failed.TypeWitness,
+                         assocType, failed.TypeWitness,
                          failed.Result.getRequirement(),
                          failed.Result.isConformanceRequirement());
         }
@@ -2058,17 +2057,17 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
         auto &diags = conformance->getDeclContext()->getASTContext().Diags;
         diags.diagnose(typeWitnessConflict->AssocType,
                        diag::ambiguous_associated_type_deduction,
-                       typeWitnessConflict->AssocType->getName(),
+                       typeWitnessConflict->AssocType,
                        typeWitnessConflict->FirstType,
                        typeWitnessConflict->SecondType);
 
         diags.diagnose(typeWitnessConflict->FirstWitness,
                        diag::associated_type_deduction_witness,
-                       typeWitnessConflict->FirstRequirement->getName(),
+                       typeWitnessConflict->FirstRequirement,
                        typeWitnessConflict->FirstType);
         diags.diagnose(typeWitnessConflict->SecondWitness,
                        diag::associated_type_deduction_witness,
-                       typeWitnessConflict->SecondRequirement->getName(),
+                       typeWitnessConflict->SecondRequirement,
                        typeWitnessConflict->SecondType);
       });
 
@@ -2121,7 +2120,7 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
         NormalProtocolConformance *conformance) {
         auto &diags = assocType->getASTContext().Diags;
         diags.diagnose(assocType, diag::ambiguous_associated_type_deduction,
-                       assocType->getName(), firstType, secondType);
+                       assocType, firstType, secondType);
 
         auto diagnoseWitness = [&](std::pair<ValueDecl *, ValueDecl *> match,
                                    Type type){
@@ -2129,7 +2128,7 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
           if (match.first && match.second) {
             diags.diagnose(match.second,
                            diag::associated_type_deduction_witness,
-                           match.first->getName(), type);
+                           match.first, type);
 
             return;
           }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -606,7 +606,7 @@ emitUnresolvedLabelDiagnostics(DiagnosticEngine &DE,
       .fixItReplace(SourceRange(targetLoc),
                     corrections.begin()->Value->getLabelInfo().Name.str());
     DE.diagnose(corrections.begin()->Value->getLabelInfo().Loc,
-                diag::decl_declared_here,
+                diag::name_declared_here,
                 corrections.begin()->Value->getLabelInfo().Name);
   } else {
     // If we have multiple corrections or none, produce a generic diagnostic

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1725,7 +1725,7 @@ Stmt *PreCheckReturnStmtRequest::evaluate(Evaluator &evaluator, ReturnStmt *RS,
       ctx.Diags.diagnose(RS->getReturnLoc(), diag::return_non_failable_init)
           .highlight(E->getSourceRange());
       ctx.Diags
-          .diagnose(ctor->getLoc(), diag::make_init_failable, ctor->getName())
+          .diagnose(ctor->getLoc(), diag::make_init_failable, ctor)
           .fixItInsertAfter(ctor->getLoc(), "?");
       RS->setResult(nullptr);
       return RS;
@@ -1971,7 +1971,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
         // Translate calls to implicit functions to their user-facing names
         if (callee->getBaseName() == ctx.Id_derived_enum_equals ||
             callee->getBaseName() == ctx.Id_derived_struct_equals) {
-          DE.diagnose(fn->getLoc(), diag::expression_unused_result_operator,
+          DE.diagnose(fn->getLoc(),
+                      diag::expression_unused_result_operator_name,
                    ctx.Id_EqualsOperator)
             .highlight(SR1).highlight(SR2);
           return;
@@ -1982,7 +1983,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       if (callee->getName().isOperator())
         diagID = diag::expression_unused_result_operator;
       
-      DE.diagnose(fn->getLoc(), diagID, callee->getName())
+      DE.diagnose(fn->getLoc(), diagID, callee)
         .highlight(SR1).highlight(SR2);
     } else
       DE.diagnose(fn->getLoc(), diag::expression_unused_result_unknown,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -588,7 +588,7 @@ static void checkLabeledStmtShadowing(
       ctx.Diags.diagnose(
           ls->getLabelInfo().Loc, diag::label_shadowed, name);
       ctx.Diags.diagnose(
-          prevLS->getLabelInfo().Loc, diag::invalid_redecl_prev, name);
+          prevLS->getLabelInfo().Loc, diag::invalid_redecl_prev_name, name);
     }
   }
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -247,7 +247,7 @@ Type TypeResolution::resolveDependentMemberType(Type baseTy, DeclContext *DC,
     // We have a single type result. Suggest it.
     ctx.Diags
         .diagnose(repr->getNameLoc(), diag::invalid_member_type_suggest, baseTy,
-                  repr->getNameRef(), singleType->getBaseName())
+                  repr->getNameRef(), singleType)
         .fixItReplace(repr->getNameLoc().getSourceRange(),
                       singleType->getBaseName().userFacingName());
 
@@ -1220,8 +1220,7 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
           ? diag::unsupported_recursion_in_associated_type_reference
           : diag::broken_associated_type_witness;
 
-  ctx.Diags.diagnose(loc, diagCode, isa<TypeAliasDecl>(typeDecl),
-                     typeDecl->getName(), parentTy);
+  ctx.Diags.diagnose(loc, diagCode, typeDecl, parentTy);
 }
 
 /// Returns a valid type or ErrorType in case of an error.
@@ -1342,7 +1341,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       // FIXME: What if the unviable candidates have different levels of access?
       auto first = cast<TypeDecl>(inaccessibleResults.front().getValueDecl());
       diags.diagnose(repr->getNameLoc(), diag::candidate_inaccessible,
-                     first->getBaseName(), first->getFormalAccess());
+                     first, first->getFormalAccess());
 
       // FIXME: If any of the candidates (usually just one) are in the same
       // module we could offer a fix-it.
@@ -1419,7 +1418,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     // FIXME: What if the unviable candidates have different levels of access?
     const TypeDecl *first = inaccessibleMembers.front().Member;
     diags.diagnose(repr->getNameLoc(), diag::candidate_inaccessible,
-                   first->getBaseName(), first->getFormalAccess());
+                   first, first->getFormalAccess());
 
     // FIXME: If any of the candidates (usually just one) are in the same module
     // we could offer a fix-it.
@@ -1453,7 +1452,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       auto member = results[0];
       diags
           .diagnose(repr->getNameLoc(), diag::invalid_member_reference,
-                    member->getDescriptiveKind(), member->getName(), parentType)
+                    member, parentType)
           .highlight(parentRange);
     } else {
       const auto kind = describeDeclOfType(parentType);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -742,8 +742,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
                      protoType)
            .fixItRemove(generic->getAngleBrackets());
       if (!protoDecl->isImplicit()) {
-        diags.diagnose(protoDecl, diag::decl_declared_here,
-                       protoDecl->getName());
+        diags.diagnose(protoDecl, diag::decl_declared_here, protoDecl);
       }
       return ErrorType::get(ctx);
     }
@@ -1471,8 +1470,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       // Note where the type was defined, this can help diagnose if the user
       // expected name lookup to find a module when there's a conflicting type.
       if (auto typeDecl = parentType->getNominalOrBoundGenericNominal()) {
-        ctx.Diags.diagnose(typeDecl, diag::decl_declared_here,
-                           typeDecl->getName());
+        ctx.Diags.diagnose(typeDecl, diag::decl_declared_here, typeDecl);
       }
     }
   }

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -504,7 +504,7 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
     return (1, { _ in .zero })
   }
 
-  // expected-error @+2 {{a derivative already exists for '_'}}
+  // expected-error @+2 {{a derivative already exists for getter for 'subscript()'}}
   // expected-note @-6 {{other attribute declared here}}
   @derivative(of: subscript)
   func vjpSubscript() -> (value: Float, pullback: (Float) -> TangentVector) {
@@ -521,7 +521,7 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
     return (1, { _ in .zero })
   }
 
-  // expected-error @+2 {{a derivative already exists for '_'}}
+  // expected-error @+2 {{a derivative already exists for getter for 'subscript(float:)'}}
   // expected-note @-6 {{other attribute declared here}}
   @derivative(of: subscript(float:), wrt: self)
   func vjpSubscriptLabeled(float: Float) -> (value: Float, pullback: (Float) -> TangentVector) {
@@ -538,7 +538,7 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
     return (x, { _ in .zero })
   }
 
-  // expected-error @+2 {{a derivative already exists for '_'}}
+  // expected-error @+2 {{a derivative already exists for getter for 'subscript(_:)'}}
   // expected-note @-6 {{other attribute declared here}}
   @derivative(of: subscript(_:), wrt: self)
   func vjpSubscriptGeneric<U: Differentiable>(x: U) -> (value: U, pullback: (U.TangentVector) -> TangentVector)   {
@@ -619,7 +619,7 @@ extension Class where T: Differentiable {
     return (1, { _ in .zero })
   }
 
-  // expected-error @+2 {{a derivative already exists for '_'}}
+  // expected-error @+2 {{a derivative already exists for getter for 'subscript()'}}
   // expected-note @-6 {{other attribute declared here}}
   @derivative(of: subscript)
   func vjpSubscript() -> (value: Float, pullback: (Float) -> TangentVector) {

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -18,13 +18,13 @@ let globalConst: Float = 1
 var globalVar: Float = 1
 
 func testLocalVariables() {
-  // expected-error @+1 {{'_' has no parameters to differentiate with respect to}}
+  // expected-error @+1 {{getter for 'getter' has no parameters to differentiate with respect to}}
   @differentiable(reverse)
   var getter: Float {
     return 1
   }
 
-  // expected-error @+1 {{'_' has no parameters to differentiate with respect to}}
+  // expected-error @+1 {{getter for 'getterSetter' has no parameters to differentiate with respect to}}
   @differentiable(reverse)
   var getterSetter: Float {
     get { return 1 }

--- a/test/ClangImporter/objc_init_redundant.swift
+++ b/test/ClangImporter/objc_init_redundant.swift
@@ -11,7 +11,7 @@ import Foundation
 extension NSObject {
   @objc convenience init() { self.init() } // expected-error{{initializer 'init()' with Objective-C selector 'init' conflicts with previous declaration with the same Objective-C selector}}
 // CHECK: objc_init_redundant.swift:[[@LINE-1]]:21: error: initializer 'init()' with Objective-C selector 'init' conflicts
-// CHECK: ObjectiveC.NSObject:{{.*}}note: 'init' previously declared here
+// CHECK: ObjectiveC.NSObject:{{.*}}note: 'init()' previously declared here
 }
 
 extension NSObject {

--- a/test/Compatibility/attr_inlinable_swift42.swift
+++ b/test/Compatibility/attr_inlinable_swift42.swift
@@ -18,10 +18,10 @@ enum InternalEnum {
 }
 
 public struct HasInternalSetProperty {
-  public internal(set) var x: Int // expected-note {{setter for 'x' is not '@usableFromInline' or public}}
+  public internal(set) var x: Int // expected-note {{setter for property 'x' is not '@usableFromInline' or public}}
 
   @inlinable public mutating func setsX() {
-    x = 10 // expected-warning {{setter for 'x' is internal and should not be referenced from an '@inlinable' function}}
+    x = 10 // expected-warning {{setter for property 'x' is internal and should not be referenced from an '@inlinable' function}}
   }
 }
 

--- a/test/Compatibility/attr_usableFromInline_protocol.swift
+++ b/test/Compatibility/attr_usableFromInline_protocol.swift
@@ -7,8 +7,8 @@ public protocol PublicProtoWithReqs {
 }
 
 @usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
-// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
-// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+// expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
 extension UFIAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
@@ -18,9 +18,9 @@ extension UFIAdopter {
 
 @usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
   typealias Assoc = Int
-  // expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  // expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
   func foo() {}
-  // expected-warning@-1 {{instance method 'foo()' should be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'}} {{none}}
+  // expected-warning@-1 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
 }
 
 internal struct InternalAdopter<T> : PublicProtoWithReqs {}
@@ -36,8 +36,8 @@ extension InternalAdopter {
 }
 
 public struct PublicAdopter<T> : UFIProtoWithReqs {}
-// expected-warning@-1 {{type alias 'Assoc' should be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
-// expected-warning@-2 {{instance method 'foo()' should be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'}} {{none}}
+// expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'; this is an error in Swift 5}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'; this is an error in Swift 5}} {{none}}
 extension PublicAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -210,7 +210,7 @@ class SubWUnsafeSubscript : SuperWUnsafeSubscript {
   override nonisolated subscript<T>(x : T) -> Int {
     get async {
       // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated subscript 'subscript(_:)' cannot cross actor boundary}}
-      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated getter '_' cannot cross actor boundary}}
+      // expected-warning@-2{{non-sendable type 'T' in parameter of superclass method overridden by nonisolated getter for subscript 'subscript(_:)' cannot cross actor boundary}}
       // there really shouldn't be two warnings produced here, see rdar://110846040 (Sendable diagnostics reported twice for subscript getters)
       return 0
     }

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -37,8 +37,8 @@ func inlinable() -> SPIClass { // expected-error {{class 'SPIClass' cannot be us
   spiFunc() // expected-error {{global function 'spiFunc()' cannot be used in an '@inlinable' function because it is SPI}}
   _ = SPIClass() // expected-error {{class 'SPIClass' cannot be used in an '@inlinable' function because it is SPI}}
   // expected-error@-1 {{initializer 'init()' cannot be used in an '@inlinable' function because it is SPI}}
-  globalArrayWithSPISetter = [] // expected-error {{setter 'globalArrayWithSPISetter' cannot be used in an '@inlinable' function because it is SPI}}
-  globalArrayWithSPISetter.append(0) // expected-error {{setter 'globalArrayWithSPISetter' cannot be used in an '@inlinable' function because it is SPI}}
+  globalArrayWithSPISetter = [] // expected-error {{setter for var 'globalArrayWithSPISetter' cannot be used in an '@inlinable' function because it is SPI}}
+  globalArrayWithSPISetter.append(0) // expected-error {{setter for var 'globalArrayWithSPISetter' cannot be used in an '@inlinable' function because it is SPI}}
 }
 
 @_spi(S) public struct SPIStruct {

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -33,10 +33,10 @@ public struct PrivateImportType {}
 
 //--- Client.swift
 public import PublicLib
-package import PackageLib // expected-note {{type 'PackageImportType' imported as 'package' from 'PackageLib' here}}
-internal import InternalLib // expected-note {{type 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
-fileprivate import FileprivateLib // expected-note 2 {{type 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
-private import PrivateLib // expected-note 2 {{type 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
+package import PackageLib // expected-note {{struct 'PackageImportType' imported as 'package' from 'PackageLib' here}}
+internal import InternalLib // expected-note {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+fileprivate import FileprivateLib // expected-note 2 {{struct 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
+private import PrivateLib // expected-note 2 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
 
 /// Simple ordering
 public func publicFuncUsesPrivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType, e: PrivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a private type}}
@@ -64,7 +64,7 @@ public func publicFuncUsesPrivateScambled(_ a: PublicImportType, d: FileprivateI
 //--- LocalVsImportClient.swift
 public import PublicLib
 internal import InternalLib
-fileprivate import FileprivateLib // expected-note {{type 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
+fileprivate import FileprivateLib // expected-note {{struct 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
 
 fileprivate struct LocalType {} // expected-note 3 {{type declared here}}
 public func localVsImportedType1(a: LocalType, b: InternalImportType) {} // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -121,8 +121,8 @@ public struct PrivateLibWrapper<T> {
 //--- MinimalClient.swift
 public import PublicLib
 package import PackageLib
-internal import InternalLib // expected-note@:1 {{type 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
-fileprivate import FileprivateLib // expected-note@:1 {{type 'FileprivateImportClass' imported as 'fileprivate' from 'FileprivateLib' here}}
+internal import InternalLib // expected-note@:1 {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+fileprivate import FileprivateLib // expected-note@:1 {{class 'FileprivateImportClass' imported as 'fileprivate' from 'FileprivateLib' here}}
 private import PrivateLib
 
 public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses an internal type}}

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -118,10 +118,10 @@ struct SomeStruct {
   // expected-note@+1 2 {{'staticStructFunc()' declared here}}
   static func staticStructFunc() async { }
 
-  // expected-note@+1 3 {{'getter:instanceProp()' declared here}}
+  // expected-note@+1 3 {{getter for 'instanceProp' declared here}}
   var instanceProp: Int { get async { 1 } }
   var regInstanceProp: Int { get { 1 } set { } }
-  // expected-note@+1 {{'getter:classProp()' declared here}}
+  // expected-note@+1 {{getter for 'classProp' declared here}}
   static var classProp: Int { get async { 1 } }
 
   @available(*, renamed: "getter:instanceProp()")

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -307,10 +307,10 @@ public struct KeypathStruct {
 }
 
 public struct HasInternalSetProperty {
-  public internal(set) var x: Int // expected-note {{setter for 'x' is not '@usableFromInline' or public}}
+  public internal(set) var x: Int // expected-note {{setter for property 'x' is not '@usableFromInline' or public}}
 
   @inlinable public mutating func setsX() {
-    x = 10 // expected-error {{setter for 'x' is internal and cannot be referenced from an '@inlinable' function}}
+    x = 10 // expected-error {{setter for property 'x' is internal and cannot be referenced from an '@inlinable' function}}
   }
 }
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -364,7 +364,7 @@ protocol subject_containerObjCProtocol1 {
 @objc // access-note-move{{subject_containerObjCProtocol2}}
 protocol subject_containerObjCProtocol2 {
   init(a: Int)
-  // expected-note@-1 {{'init' previously declared here}}
+  // expected-note@-1 {{'init(a:)' previously declared here}}
 
   @objc // FIXME: Access notes can't distinguish between init(a:) overloads
   init(a: Double)

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2104,7 +2104,7 @@ class Super {
   var foo: Int { get { return 3 } } // expected-note 2{{overridden declaration is here}}
 
   @objc // access-note-move{{Super.process(i:)}}
-  func process(i: Int) -> Int { } // expected-note {{overriding '@objc' method 'process(i:)' here}}
+  func process(i: Int) -> Int { } // expected-note {{overriding '@objc' instance method 'process(i:)' here}}
 }
 
 class Sub1 : Super {

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -258,7 +258,7 @@ protocol EmptySwiftProto {}
   }
 
   func methodObjCName3() {
-    // expected-error@-1 {{selector 'methodObjCName3' used in header by an instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
+    // expected-error@-1 {{selector 'methodObjCName3' used in header by instance method with a different name; did you mean 'methodSwiftName3()'?}} {{8-23=methodSwiftName3}} {{3-3=@objc(methodObjCName3) }}
     // FIXME: probably needs an @objc too, since the name is not explicit
   }
 
@@ -267,11 +267,11 @@ protocol EmptySwiftProto {}
   }
 
   @objc(methodObjCName5) func methodWrongSwiftName5() {
-    // expected-error@-1 {{selector 'methodObjCName5' used in header by an instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
+    // expected-error@-1 {{selector 'methodObjCName5' used in header by instance method with a different name; did you mean 'methodSwiftName5()'?}} {{31-52=methodSwiftName5}}
   }
 
   @objc(methodObjCName6A) func methodSwiftName6B() {
-    // expected-error@-1 {{selector 'methodObjCName6A' used in header by an instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
+    // expected-error@-1 {{selector 'methodObjCName6A' used in header by instance method with a different name; did you mean 'methodSwiftName6A()'?}} {{32-49=methodSwiftName6A}}
   }
 }
 

--- a/test/multifile/Inputs/inlinable-other.swift
+++ b/test/multifile/Inputs/inlinable-other.swift
@@ -1,4 +1,4 @@
 public struct OtherStruct {
   public internal(set) static var staticProp = 123
-  // expected-note@-1 {{setter for 'staticProp' is not '@usableFromInline' or public}}
+  // expected-note@-1 {{setter for static property 'staticProp' is not '@usableFromInline' or public}}
 }

--- a/test/multifile/inlinable.swift
+++ b/test/multifile/inlinable.swift
@@ -2,7 +2,7 @@
 
 @frozen public struct HasInitExpr {
   public var hasInlinableInit = mutatingFunc(&OtherStruct.staticProp)
-  // expected-warning@-1 {{setter for 'staticProp' is internal and should not be referenced from a property initializer in a '@frozen' type}}
+  // expected-warning@-1 {{setter for static property 'staticProp' is internal and should not be referenced from a property initializer in a '@frozen' type}}
 }
 
 public func mutatingFunc(_: inout Int) -> Int {


### PR DESCRIPTION
This PR improves the DiagnosticEngine's handling of `Decl *` diagnostic arguments:

* Any `Decl`, not just `ValueDecl`, can now be used. This is mainly meant for decls like `OperatorDecl` which have a name but aren’t `ValueDecl`s, but it works for all `Decl`s.
* If the decl is an accessor, the diagnostic engine will automatically describe it using a phrase like `getter for 'someProperty’`; if it’s an extension, the diagnostic engine will describe it using a phrase like `extension of ’SomeType’`.
* If the `%kind` modifier is used, the diagnostic engine will prefix the name with the decl's descriptive kind; this lets you eliminate pairs of arguments.
* If the `%base` modifier is used, only the base name will be printed.
* If the `%kindbase` modifier is used, the effects of the previous two modifiers are combined.
* If the `%kindonly` modifier is used, only the kind will be inserted. This is useful when the kind and name aren’t paired together in the usual way.

I believe these changes will simplify a lot of diagnostic code that currently special-cases accessors, passes `DescriptiveDeclKind`/`ValueDecl` argument pairs that need to be kept matched up, and looks up declaration names by hand. Adopting `Decl` more broadly may also open up opportunities for future improvements to diagnostics, like turning decl names into links in clients that would support it.

I've tried to keep this PR close to NFC, but I've kept a few obvious wins where this change handled accessors better or made kinds more specific.

I’ve also removed some diagnostics that are unused and replaced some `warn_` variants of diagnostics with more modern features like `limitBehavior` or `warnUntilSwiftVersion`.