### PR TITLE
[Macros] Make code item macros unavailable in noasserts builds.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -119,7 +119,7 @@ UPCOMING_FEATURE(DisableActorInferenceFromPropertyWrapperUsage, 401, 6)
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
-EXPERIMENTAL_FEATURE(CodeItemMacros, true)
+EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(InitAccessors, false)
 

--- a/test/Macros/macro_expand_codeitems.swift
+++ b/test/Macros/macro_expand_codeitems.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser, executable_test
+// REQUIRES: swift_swift_parser, executable_test, asserts
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -1,4 +1,4 @@
-// REQUIRES: swift_swift_parser
+// REQUIRES: swift_swift_parser, asserts
 
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature CodeItemMacros -module-name MacrosTest
 


### PR DESCRIPTION
This was just a mistake; there's no reason for `-enable-experimental-feature CodeItemMacros` to be enablable in noasserts builds.