### PR TITLE
[Test] Re-enable distributed-actor

### DIFF
--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar111572280
-
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library


### PR DESCRIPTION
It was `distributed-actors.swift` failing, not
`distributed-actor.swift`. That commit has since been reverted.