### PR TITLE
Don't try to hoist/sink {begin,end}_access when the loop has no exits

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -502,6 +502,11 @@ hoistSpecialInstruction(std::unique_ptr<LoopNestSummary> &LoopSummary,
   bool Changed = false;
 
   for (auto *Inst : Special) {
+    if (isa<BeginAccessInst>(Inst) && LoopSummary->Loop->hasNoExitBlocks()) {
+      // If no exit block, don't try to hoist BeginAccess because
+      // sinking EndAccess would fail later.
+      continue;
+    }
     if (!hoistInstruction(DT, Inst, Loop, Preheader)) {
       continue;
     }

--- a/test/SILOptimizer/dont_hoist_begin_access_loop_with_no_exit.swift
+++ b/test/SILOptimizer/dont_hoist_begin_access_loop_with_no_exit.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftc_driver -O %s
 
-// Issue URL
+// https://github.com/apple/swift/issues/67084
 // Don't crash failing to sink the corresponding end_access after
 // hoisting the begin_access when the loop has no exit.
 

--- a/test/SILOptimizer/dont_hoist_begin_access_loop_with_no_exit.swift
+++ b/test/SILOptimizer/dont_hoist_begin_access_loop_with_no_exit.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swiftc_driver -O %s
+
+// Issue URL
+// Don't crash failing to sink the corresponding end_access after
+// hoisting the begin_access when the loop has no exit.
+
+var i = 0
+while true {
+  i += 1
+}


### PR DESCRIPTION
This fixes compiler crash with message `LICM: Could not perform must-sink instruction`.

Fixes: #67084
