### PR TITLE
[move-only] When adding implicit liveness uses for class field/global accesses, do not use the terminator, use the end access.

### DIFF
--- a/test/Interpreter/moveonly_linkedlist.swift
+++ b/test/Interpreter/moveonly_linkedlist.swift
@@ -1,0 +1,136 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
+
+// REQUIRES: executable_test
+
+/// A class that we use as a box to store the memory for one of our linked list
+/// nodes. It is on purpose fileprivate since it is an implementation detail of
+/// \p NodeBox.
+fileprivate final class _Box<T> {
+  var value: _Node<T>
+
+  init(_ value: consuming _Node<T>) { self.value = value }
+}
+
+struct _Node<T> : ~Copyable {
+  var value: T
+  var _next: ListEntry<T> = ListEntry<T>()
+
+  init(_ newValue: T) {
+    value = newValue
+  }
+}
+
+/// A noncopyable box that contains the memory for a linked list node. Can be
+/// embedded within other noncopyable data structures to point at a Node data
+/// structure.
+///
+/// Internally uses a class as the actual box.
+struct ListEntry<T> : ~Copyable {
+  private var innerBox: _Box<T>?
+
+  init() { innerBox = nil }
+  init(initialValue value: consuming T) {
+    innerBox = _Box<T>(_Node(value))
+  }
+
+  mutating func push(value newValue: consuming T) {
+    if innerBox == nil {
+      // If we do not already have a head, just take on this value and return.
+      innerBox = _Box<T>(_Node(newValue))
+      return
+    }
+
+    // Otherwise, we need to create a new node and fix things up.
+    var nodeEntry = ListEntry<T>(initialValue: newValue)
+    nodeEntry.next = self
+    self = nodeEntry
+  }
+
+  mutating func pop() -> T? {
+    guard let innerBox = innerBox else {
+      return nil
+    }
+
+    let result = innerBox.value.value
+    func fixNext(_ lhs: inout ListEntry<T>, _ rhs: inout ListEntry<T>) {
+      lhs = rhs
+      rhs = ListEntry<T>()
+    }
+    fixNext(&self, &innerBox.value._next)
+    return result
+  }
+
+  var hasNext: Bool {
+    return innerBox != nil
+  }
+  var next: ListEntry<T> {
+    _modify {
+      yield &innerBox!.value._next
+    }
+    _read {
+      yield innerBox!.value._next
+    }
+  }
+
+  var value: T? {
+    return innerBox?.value.value
+  }
+}
+
+let target = "ogyfbssvlh"
+let strings = [
+  "nulbhqylps",
+  "hpdovhuybl",
+  "bjjvpakqbm",
+  "rqyozjzkyz",
+  "qpzghmdcag",
+  "lqefxvulvn",
+  "wtokfqarxm",
+  "acdcrzxpdg",
+  "bxgfacpjic",
+  "acblrvoego",
+  "msevhriohn",
+  "bamfcnbqvx",
+  "wimkkqhryd",
+  "dounctqkiw",
+  "zxmyxcabhq",
+  "ljerkuhlgy",
+  "cettadahue",
+  "cuummvmwly",
+  "kdebludzsh",
+  "ogyfbssvlh",
+  "lrowrxwufj",
+  "rftifkqggr",
+  "ktjeeeobca",
+  "xqlbnswmjr",
+  "zpuxfbtmip",
+  "rljcxrvdgh",
+  "twkgardobr",
+  "zrogczpzem",
+  "bkuzjugksg",
+  "eqanimdywo"
+]
+
+func buildList() -> ListEntry<String> {
+  var head = ListEntry<String>()
+
+  for i in strings {
+    head.push(value: i)
+  }
+
+  return head
+}
+
+func main() {
+  var head = buildList()
+  var count = 0
+
+  var strCount = strings.count
+  while let x = head.pop() {
+      assert(x == strings[strCount - count - 1])
+      count = count + 1
+  }
+}
+
+main()

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -732,3 +732,39 @@ bb0(%0 : @owned $FixedSizeQueue):
   dealloc_stack %1 : $*FixedSizeQueue
   return %11 : $Builtin.Int32
 }
+
+// Make sure that we set the end_access as the implicit end lifetime use instead
+// of the terminator.
+// CHECK-LABEL: sil [ossa] @assignableButNotConsumableEndAccessImplicitLifetimeTest : $@convention(thin) (@guaranteed ClassContainingMoveOnly, @owned NonTrivialStruct2) -> () {
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $ClassContainingMoveOnly, [[ARG1:%.*]] : @owned
+// CHECK: bb2:
+// CHECK-NEXT:   [[ADDR:%.*]] = ref_element_addr [[ARG0]]
+// CHECK-NEXT:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]]
+// CHECK-NEXT:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK-NEXT:   [[GEP2:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK-NEXT:   destroy_addr [[GEP2]]
+// CHECK-NEXT:   store [[ARG1]] to [init] [[GEP1]]
+// CHECK-NEXT:   end_access [[ACCESS]]
+// CHECK-NEXT:   br bb3
+// CHECK: } // end sil function 'assignableButNotConsumableEndAccessImplicitLifetimeTest'
+sil [ossa] @assignableButNotConsumableEndAccessImplicitLifetimeTest : $@convention(thin) (@guaranteed ClassContainingMoveOnly, @owned NonTrivialStruct2) -> () {
+bb0(%0 : @guaranteed $ClassContainingMoveOnly, %1 : @owned $NonTrivialStruct2):
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1 : $NonTrivialStruct2
+  br bb3
+
+bb2:
+  %2 = ref_element_addr %0 : $ClassContainingMoveOnly, #ClassContainingMoveOnly.value
+  %3 = begin_access [modify] [dynamic] %2 : $*NonTrivialStruct
+  %4 = mark_must_check [assignable_but_not_consumable] %3 : $*NonTrivialStruct
+  %4a = struct_element_addr %4 : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+  store %1 to [assign] %4a : $*NonTrivialStruct2
+  end_access %3 : $*NonTrivialStruct
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_di_interactions.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_di_interactions.sil
@@ -1,0 +1,59 @@
+// RUN: %target-sil-opt -definite-init %s | %FileCheck %s
+
+// Make sure that DI properly converts mark_must_check
+// [assignable_but_not_consumable] -> mark_must_check
+// [initable_but_not_consumable].
+
+sil_stage raw
+
+fileprivate final class _Box<T> {
+  var value: _Node<T>
+
+  init(_ value: consuming _Node<T>)
+}
+
+struct _Node<T> : ~Copyable {
+  var value: T
+  var _next: ListEntry<T>
+
+  init(_ newValue: T)
+}
+
+struct ListEntry<T> : ~Copyable {
+  private var innerBox: _Box<T>
+}
+
+// CHECK-LABEL: sil private [ossa] @boxInit : $@convention(method) <T> (@in _Node<T>, @owned _Box<T>) -> @owned _Box<T> {
+// CHECK: bb0([[INPUT:%.*]] : $*_Node<T>, [[SELF:%.*]] : @owned
+// CHECK:   [[BORROW_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_SELF]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [initable_but_not_consumable] [[ACCESS]]
+// CHECK:   copy_addr [take] {{%.*}} to [init] [[MARK]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function 'boxInit'
+sil private [ossa] @boxInit : $@convention(method) <T> (@in _Node<T>, @owned _Box<T>) -> @owned _Box<T> {
+bb0(%0 : $*_Node<T>, %1 : @owned $_Box<T>):
+  %2 = alloc_stack [lexical] $_Node<T>, var, name "value"
+  %3 = mark_must_check [consumable_and_assignable] %2 : $*_Node<T>
+  copy_addr [take] %0 to [init] %3 : $*_Node<T>
+  debug_value %1 : $_Box<T>, let, name "self", argno 2, implicit
+  %6 = mark_uninitialized [rootself] %1 : $_Box<T>
+  %7 = begin_borrow %6 : $_Box<T>
+  %8 = begin_access [read] [static] %3 : $*_Node<T>
+  %9 = alloc_stack $_Node<T>
+  copy_addr %8 to [init] %9 : $*_Node<T>
+  end_access %8 : $*_Node<T>
+  %12 = ref_element_addr %7 : $_Box<T>, #_Box.value
+  %13 = begin_access [modify] [dynamic] %12 : $*_Node<T>
+  %14 = mark_must_check [assignable_but_not_consumable] %13 : $*_Node<T>
+  copy_addr [take] %9 to %14 : $*_Node<T>
+  end_access %13 : $*_Node<T>
+  dealloc_stack %9 : $*_Node<T>
+  end_borrow %7 : $_Box<T>
+  %19 = copy_value %6 : $_Box<T>
+  destroy_value %6 : $_Box<T>
+  destroy_addr %3 : $*_Node<T>
+  dealloc_stack %2 : $*_Node<T>
+  return %19 : $_Box<T>
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -4551,3 +4551,14 @@ public class NonFinalCopyableKlassWithMoveOnlyField {
     var moveOnlyVarProt = AddressOnlyProtocol()
     let moveOnlyLetProt = AddressOnlyProtocol()
 }
+
+//////////////////////
+// MARK: Misc Tests //
+//////////////////////
+
+// For misc tests associated with specific radars.
+func assignableButNotConsumableEndAccessImplicitLifetimeTest(_ x: CopyableKlassWithMoveOnlyField) {
+    if boolValue {
+        x.moveOnlyVarStruct.nonTrivialStruct2 = NonTrivialStruct2()
+    }
+}


### PR DESCRIPTION
Previously, when doing this I could just use the terminator both in cases of
inout and for class field/global accesses... but after some recent changes to
field sensitive pruned liveness, this seems to no longer work. So just do the
right thing and use the field access.

The specific bug was that we would introduce a destroy_addr along one of the
paths where the value wasn't defined resulting in a dominance error.

I added a SIL test that shows this fixes the issue, a swift test, and also an
Interpreter test that validates the correctness.

rdar://111659649