### PR TITLE
[5.9][Test] Add executable test requirement to moveonly_fixedqueue.swift

### DIFF
--- a/test/Interpreter/moveonly_fixedqueue.swift
+++ b/test/Interpreter/moveonly_fixedqueue.swift
@@ -1,3 +1,5 @@
+// REQUIRES: executable_test
+
 // RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
 // RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
 


### PR DESCRIPTION
* **Explanation**: Adds missing `executable_test` requirement to `moveonly_fixedqueue.swift`.
* **Scope**: Tests
* **Risk**: None, just disables a test on the non-executable jobs.
* **Original PR**: https://github.com/apple/swift/pull/67032