### PR TITLE
[Macros] Cope with local types and opaque result types in macros and expansions.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -156,6 +156,7 @@ public:
   /// ASTScopes are not created in inactive clauses and lookups to decls will fail.
   bool InInactiveClauseEnvironment = false;
   bool InSwiftKeyPath = false;
+  bool InFreestandingMacroArgument = false;
 
   /// Whether we should delay parsing nominal type, extension, and function
   /// bodies.

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1043,8 +1043,8 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
 
     // In the same file any visibility is okay.
     if (!dc->isModuleContext() &&
-        typeDecl->getDeclContext()->getParentSourceFile() ==
-        dc->getParentSourceFile())
+        typeDecl->getDeclContext()->getOutermostParentSourceFile() ==
+        dc->getOutermostParentSourceFile())
       return true;
 
     return typeDecl->getEffectiveAccess() > AccessLevel::FilePrivate;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5209,7 +5209,7 @@ void Parser::recordLocalType(TypeDecl *TD) {
   if (!TD->getDeclContext()->isLocalContext())
     return;
 
-  if (!InInactiveClauseEnvironment)
+  if (!InInactiveClauseEnvironment && !InFreestandingMacroArgument)
     SF.getOutermostParentSourceFile()->LocalTypeDecls.insert(TD);
 }
 
@@ -7980,7 +7980,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     if (auto typedPattern = dyn_cast<TypedPattern>(pattern)) {
       hasOpaqueReturnTy = typedPattern->getTypeRepr()->hasOpaque();
     }
-    auto sf = CurDeclContext->getParentSourceFile();
+    auto sf = CurDeclContext->getOutermostParentSourceFile();
     
     // Configure all vars with attributes, 'static' and parent pattern.
     pattern->forEachVariable([&](VarDecl *VD) {
@@ -7992,7 +7992,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       setOriginalDeclarationForDifferentiableAttributes(Attributes, VD);
 
       Decls.push_back(VD);
-      if (hasOpaqueReturnTy && sf && !InInactiveClauseEnvironment) {
+      if (hasOpaqueReturnTy && sf && !InInactiveClauseEnvironment
+          && !InFreestandingMacroArgument) {
         sf->addUnvalidatedDeclWithOpaqueResultType(VD);
       }
     });
@@ -8282,8 +8283,8 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
 
   // Let the source file track the opaque return type mapping, if any.
   if (FuncRetTy && FuncRetTy->hasOpaque() &&
-      !InInactiveClauseEnvironment) {
-    if (auto sf = CurDeclContext->getParentSourceFile()) {
+      !InInactiveClauseEnvironment && !InFreestandingMacroArgument) {
+    if (auto sf = CurDeclContext->getOutermostParentSourceFile()) {
       sf->addUnvalidatedDeclWithOpaqueResultType(FD);
     }
   }
@@ -9230,8 +9231,8 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
   
   // Let the source file track the opaque return type mapping, if any.
   if (ElementTy.get() && ElementTy.get()->hasOpaque() &&
-      !InInactiveClauseEnvironment) {
-    if (auto sf = CurDeclContext->getParentSourceFile()) {
+      !InInactiveClauseEnvironment && !InFreestandingMacroArgument) {
+    if (auto sf = CurDeclContext->getOutermostParentSourceFile()) {
       sf->addUnvalidatedDeclWithOpaqueResultType(Subscript);
     }
   }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2338,6 +2338,8 @@ ParserStatus Parser::parseFreestandingMacroExpansion(
       diagnose(leftAngleLoc, diag::while_parsing_as_left_angle_bracket);
   }
 
+  llvm::SaveAndRestore<bool> inMacroArgument(InFreestandingMacroArgument, true);
+
   if (Tok.isFollowingLParen()) {
     auto result = parseArgumentList(tok::l_paren, tok::r_paren, isExprBasic,
                                     /*allowTrailingClosure*/ true);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1850,6 +1850,10 @@ public:
   ASTContext &getASTContext() const { return Ctx; }
   void addDelayedFunction(AbstractFunctionDecl *AFD) {
     if (!SF) return;
+
+    while (auto enclosingSF = SF->getEnclosingSourceFile())
+      SF = enclosingSF;
+
     SF->DelayedFunctions.push_back(AFD);
   }
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -198,6 +198,22 @@ public struct Outer {
 // CHECK: (2, "a + b")
 testStringify(a: 1, b: 1)
 
+protocol P { }
+extension Int: P { }
+
+// Stringify with closures that have local types.
+@available(SwiftStdlib 5.1, *)
+func testStringifyWithLocalTypes() {
+  _ = #stringify({
+    struct LocalType: P {
+      static var name: String = "Taylor"
+      var something: some P { self }
+    }
+
+    func f() -> some P { return LocalType().something }
+  })
+}
+
 func maybeThrowing() throws -> Int { 5 }
 
 #if TEST_DIAGNOSTICS


### PR DESCRIPTION
Address a few related issues that affect local types and opaque result types within macros:
* Don't add local types or opaque types encountered while parsing the arguments of a freestanding macro to the global list. When we do add them, make sure we're adding them to the outermost source file so they'll get seen later. This avoids trying to generate code for these types, because they aren't supposed to be part of the program. Note that a similar problem remains for arguments to attached macros, which will need to be addressed with a more significant refactoring.
* When determining whether opaque types should be substituted within a resilience domain, check the outermost source files rather than the exact source file, otherwise we will end up with a mismatch in argument-passing conventions.
* When delaying the type checking of functions that occur as part of a macro expansion, make sure we record them in the outermost Swift source file. Otherwise, we won't come back to them.

There is a common theme here of using AST state on the source file in a manner that isn't ideal, and starts to break down with macros. In these cases, we're relying on side effects from earlier phases (parsing and type checking) to inform later phases, rather than properly expressing the dependencies through requests.

Fixes rdar://110674997&110713264.
