### PR TITLE
RequirementMachine: Same-type requirements imply same-shape requirements [5.9]

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1357,7 +1357,7 @@ public:
   GenericEnvironment *getGenericEnvironment() const;
 
   /// Retrieve the innermost generic parameter types.
-  TypeArrayView<GenericTypeParamType> getInnermostGenericParamTypes() const;
+  ArrayRef<GenericTypeParamType *> getInnermostGenericParamTypes() const;
 
   /// Retrieve the generic requirements.
   ArrayRef<Requirement> getGenericRequirements() const;
@@ -3147,7 +3147,7 @@ public:
 
   /// Retrieve the generic parameters that represent the opaque types described by this opaque
   /// type declaration.
-  TypeArrayView<GenericTypeParamType> getOpaqueGenericParams() const {
+  ArrayRef<GenericTypeParamType *> getOpaqueGenericParams() const {
     return OpaqueInterfaceGenericSignature.getInnermostGenericParams();
   }
 

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -177,7 +177,7 @@ public:
 
   Kind getKind() const { return SignatureAndKind.getInt(); }
 
-  TypeArrayView<GenericTypeParamType> getGenericParams() const;
+  ArrayRef<GenericTypeParamType *> getGenericParams() const;
 
   /// Retrieve the existential type for an opened existential environment.
   Type getOpenedExistentialType() const;

--- a/include/swift/AST/GenericParamKey.h
+++ b/include/swift/AST/GenericParamKey.h
@@ -93,7 +93,7 @@ struct GenericParamKey {
 
   /// Find the index that this key would have into an array of
   /// generic type parameters
-  unsigned findIndexIn(TypeArrayView<GenericTypeParamType> genericParams) const;
+  unsigned findIndexIn(ArrayRef<GenericTypeParamType *> genericParams) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -661,17 +661,6 @@ inline CanTypeWrapper<X> dyn_cast_or_null(CanTypeWrapper<P> type) {
   return CanTypeWrapper<X>(dyn_cast_or_null<X>(type.getPointer()));
 }
 
-template <typename T>
-inline T *staticCastHelper(const Type &Ty) {
-  // The constructor of the ArrayRef<Type> must guarantee this invariant.
-  // XXX -- We use reinterpret_cast instead of static_cast so that files
-  // can avoid including Types.h if they want to.
-  return reinterpret_cast<T*>(Ty.getPointer());
-}
-/// TypeArrayView allows arrays of 'Type' to have a static type.
-template <typename T>
-using TypeArrayView = ArrayRefView<Type, T*, staticCastHelper,
-                                   /*AllowOrigAccess*/true>;
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3792,7 +3792,7 @@ public:
   }
   
   /// Retrieve the generic parameters of this polymorphic function type.
-  TypeArrayView<GenericTypeParamType> getGenericParams() const;
+  ArrayRef<GenericTypeParamType *> getGenericParams() const;
 
   /// Retrieve the requirements of this polymorphic function type.
   ArrayRef<Requirement> getRequirements() const;
@@ -6869,7 +6869,7 @@ public:
   static PackType *getSingletonPackExpansion(Type packParameter);
 
   static SmallVector<Type, 2> getExpandedGenericArgs(
-      TypeArrayView<GenericTypeParamType> params,
+      ArrayRef<GenericTypeParamType *> params,
       ArrayRef<Type> args);
 
 public:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4366,7 +4366,7 @@ GenericTypeParamType *GenericTypeParamType::get(bool isParameterPack,
   return result;
 }
 
-TypeArrayView<GenericTypeParamType>
+ArrayRef<GenericTypeParamType *>
 GenericFunctionType::getGenericParams() const {
   return Signature.getGenericParams();
 }
@@ -5077,7 +5077,7 @@ SubstitutionMap::Storage *SubstitutionMap::Storage::get(
 }
 
 void GenericSignatureImpl::Profile(llvm::FoldingSetNodeID &ID,
-                              TypeArrayView<GenericTypeParamType> genericParams,
+                              ArrayRef<GenericTypeParamType *> genericParams,
                               ArrayRef<Requirement> requirements) {
   for (auto p : genericParams)
     ID.AddPointer(p);
@@ -5092,19 +5092,8 @@ void GenericSignatureImpl::Profile(llvm::FoldingSetNodeID &ID,
   }
 }
 
-GenericSignature 
-GenericSignature::get(ArrayRef<GenericTypeParamType *> params,
-                      ArrayRef<Requirement> requirements,
-                      bool isKnownCanonical) {
-  SmallVector<Type, 4> paramTypes;
-  for (auto param : params)
-    paramTypes.push_back(param);
-  auto paramsView = TypeArrayView<GenericTypeParamType>(paramTypes);
-  return get(paramsView, requirements, isKnownCanonical);
-}
-
 GenericSignature
-GenericSignature::get(TypeArrayView<GenericTypeParamType> params,
+GenericSignature::get(ArrayRef<GenericTypeParamType *> params,
                       ArrayRef<Requirement> requirements,
                       bool isKnownCanonical) {
   assert(!params.empty());
@@ -5134,7 +5123,8 @@ GenericSignature::get(TypeArrayView<GenericTypeParamType> params,
 
   // Allocate and construct the new signature.
   size_t bytes =
-      GenericSignatureImpl::template totalSizeToAlloc<Type, Requirement>(
+      GenericSignatureImpl::template totalSizeToAlloc<
+        GenericTypeParamType *, Requirement>(
           params.size(), requirements.size());
   void *mem = ctx.Allocate(bytes, alignof(GenericSignatureImpl));
   auto *newSig =

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -911,11 +911,11 @@ public:
   printGenericSignature(GenericSignature genericSig, unsigned flags,
                         llvm::function_ref<bool(const Requirement &)> filter);
   void printSingleDepthOfGenericSignature(
-      TypeArrayView<GenericTypeParamType> genericParams,
+      ArrayRef<GenericTypeParamType *> genericParams,
       ArrayRef<Requirement> requirements, unsigned flags,
       llvm::function_ref<bool(const Requirement &)> filter);
   void printSingleDepthOfGenericSignature(
-      TypeArrayView<GenericTypeParamType> genericParams,
+      ArrayRef<GenericTypeParamType *> genericParams,
       ArrayRef<Requirement> requirements, bool &isFirstReq, unsigned flags,
       llvm::function_ref<bool(const Requirement &)> filter);
   void printRequirement(const Requirement &req);
@@ -1642,7 +1642,7 @@ void PrintAST::printGenericSignature(
 }
 
 void PrintAST::printSingleDepthOfGenericSignature(
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     ArrayRef<Requirement> requirements, unsigned flags,
     llvm::function_ref<bool(const Requirement &)> filter) {
   bool isFirstReq = true;
@@ -1651,7 +1651,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
 }
 
 void PrintAST::printSingleDepthOfGenericSignature(
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     ArrayRef<Requirement> requirements, bool &isFirstReq, unsigned flags,
     llvm::function_ref<bool(const Requirement &)> filter) {
   bool printParams = (flags & PrintParams);
@@ -1693,7 +1693,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
 
   /// Separate the explicit generic parameters from the implicit, opaque
   /// generic parameters. We only print the former.
-  TypeArrayView<GenericTypeParamType> opaqueGenericParams;
+  ArrayRef<GenericTypeParamType *> opaqueGenericParams;
   for (unsigned index : indices(genericParams)) {
     auto gpDecl = genericParams[index]->getDecl();
     if (!gpDecl)
@@ -5672,7 +5672,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
   }
 
   void printGenericArgs(ASTContext &ctx,
-                        TypeArrayView<GenericTypeParamType> params,
+                        ArrayRef<GenericTypeParamType *> params,
                         ArrayRef<Type> args) {
     printGenericArgs(PackType::getExpandedGenericArgs(params, args));
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1220,7 +1220,7 @@ GenericContext::GenericContext(DeclContextKind Kind, DeclContext *Parent,
   }
 }
 
-TypeArrayView<GenericTypeParamType>
+ArrayRef<GenericTypeParamType *>
 GenericContext::getInnermostGenericParamTypes() const {
   return getGenericSignature().getInnermostGenericParams();
 }

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -98,7 +98,7 @@ ArrayRef<Type> GenericEnvironment::getOpenedPackParams() const {
   return ArrayRef<Type>(begin, getNumOpenedPackParams());
 }
 
-TypeArrayView<GenericTypeParamType>
+ArrayRef<GenericTypeParamType *>
 GenericEnvironment::getGenericParams() const {
   return getGenericSignature().getGenericParams();
 }
@@ -152,7 +152,7 @@ namespace {
 
 struct FindOpenedElementParam {
   ArrayRef<Type> openedPacks;
-  TypeArrayView<GenericTypeParamType> packElementParams;
+  ArrayRef<GenericTypeParamType *> packElementParams;
 
   FindOpenedElementParam(const GenericEnvironment *env,
                          ArrayRef<Type> openedPacks)

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -351,14 +351,13 @@ SmallVector<Type, 2> BoundGenericType::getExpandedGenericArgs() {
   // It would be nicer to use genericSig.getInnermostGenericParams() here,
   // but that triggers a request cycle if we're in the middle of computing
   // the generic signature already.
-  SmallVector<Type, 2> params;
+  SmallVector<GenericTypeParamType *, 2> params;
   for (auto *paramDecl : getDecl()->getGenericParams()->getParams()) {
-    params.push_back(paramDecl->getDeclaredInterfaceType());
+    params.push_back(paramDecl->getDeclaredInterfaceType()
+                         ->castTo<GenericTypeParamType>());
   }
 
-  return PackType::getExpandedGenericArgs(
-                       TypeArrayView<GenericTypeParamType>(params),
-                       getGenericArgs());
+  return PackType::getExpandedGenericArgs(params, getGenericArgs());
 }
 
 /// <T...> Foo<T, Pack{Int, String}> => Pack{T..., Int, String}
@@ -374,7 +373,7 @@ SmallVector<Type, 2> TypeAliasType::getExpandedGenericArgs() {
 
 /// <T...> Pack{T, Pack{Int, String}} => {T..., Int, String}
 SmallVector<Type, 2>
-PackType::getExpandedGenericArgs(TypeArrayView<GenericTypeParamType> params,
+PackType::getExpandedGenericArgs(ArrayRef<GenericTypeParamType *> params,
                                  ArrayRef<Type> args) {
   SmallVector<Type, 2> wrappedArgs;
 

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -405,7 +405,7 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
 static Requirement
 getRequirementForDiagnostics(Type subject, Symbol property,
                              const PropertyMap &map,
-                             TypeArrayView<GenericTypeParamType> genericParams,
+                             ArrayRef<GenericTypeParamType *> genericParams,
                              const MutableTerm &prefix) {
   switch (property.getKind()) {
   case Symbol::Kind::ConcreteType: {
@@ -439,7 +439,7 @@ getRequirementForDiagnostics(Type subject, Symbol property,
 void RewriteSystem::computeConflictingRequirementDiagnostics(
     SmallVectorImpl<RequirementError> &errors, SourceLoc signatureLoc,
     const PropertyMap &propertyMap,
-    TypeArrayView<GenericTypeParamType> genericParams) {
+    ArrayRef<GenericTypeParamType *> genericParams) {
   for (auto pair : ConflictingRules) {
     const auto &firstRule = getRule(pair.first);
     const auto &secondRule = getRule(pair.second);
@@ -476,7 +476,7 @@ void RewriteSystem::computeConflictingRequirementDiagnostics(
 void RewriteSystem::computeRecursiveRequirementDiagnostics(
     SmallVectorImpl<RequirementError> &errors, SourceLoc signatureLoc,
     const PropertyMap &propertyMap,
-    TypeArrayView<GenericTypeParamType> genericParams) {
+    ArrayRef<GenericTypeParamType *> genericParams) {
   for (unsigned ruleID : RecursiveRules) {
     const auto &rule = getRule(ruleID);
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -49,7 +49,7 @@ using namespace rewriting;
 GenericSignature::LocalRequirements
 RequirementMachine::getLocalRequirements(
     Type depType,
-    TypeArrayView<GenericTypeParamType> genericParams) const {
+    ArrayRef<GenericTypeParamType *> genericParams) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
                                             /*proto=*/nullptr);
   System.simplify(term);
@@ -158,7 +158,7 @@ RequirementMachine::getRequiredProtocols(Type depType) const {
 
 Type RequirementMachine::
 getSuperclassBound(Type depType,
-                   TypeArrayView<GenericTypeParamType> genericParams) const {
+                   ArrayRef<GenericTypeParamType *> genericParams) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
                                             /*proto=*/nullptr);
   System.simplify(term);
@@ -198,7 +198,7 @@ bool RequirementMachine::isConcreteType(Type depType,
 /// `Self` generic parameter here.
 Type RequirementMachine::
 getConcreteType(Type depType,
-                TypeArrayView<GenericTypeParamType> genericParams,
+                ArrayRef<GenericTypeParamType *> genericParams,
                 const ProtocolDecl *proto) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
                                             proto);
@@ -359,7 +359,7 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
 /// as well, and so on.
 Type RequirementMachine::getReducedType(
     Type type,
-    TypeArrayView<GenericTypeParamType> genericParams) const {
+    ArrayRef<GenericTypeParamType *> genericParams) const {
 
   return type.transformRec([&](Type t) -> Optional<Type> {
     if (!t->hasTypeParameter())
@@ -739,7 +739,7 @@ RequirementMachine::getReducedShapeTerm(Type type) const {
 }
 
 Type RequirementMachine::getReducedShape(Type type,
-                      TypeArrayView<GenericTypeParamType> genericParams) const {
+                      ArrayRef<GenericTypeParamType *> genericParams) const {
   if (!type->isParameterPack())
     return Type();
 
@@ -759,7 +759,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
   // generic parameter.
   if (term.begin()->getKind() == Symbol::Kind::GenericParam) {
     auto *genericParam = term.begin()->getGenericParam();
-    TypeArrayView<GenericTypeParamType> genericParams = getGenericParams();
+    auto genericParams = getGenericParams();
     auto found = std::find_if(genericParams.begin(),
                               genericParams.end(),
                               [&](GenericTypeParamType *otherType) {

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -241,7 +241,7 @@ AssociatedTypeDecl *PropertyBag::getAssociatedType(Identifier name) {
 /// Compute the interface type for a range of symbols.
 static Type
 getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
-                      TypeArrayView<GenericTypeParamType> genericParams,
+                      ArrayRef<GenericTypeParamType *> genericParams,
                       const PropertyMap &map) {
   auto &ctx = map.getRewriteContext();
   Type result;
@@ -391,12 +391,12 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
 }
 
 Type PropertyMap::getTypeForTerm(Term term,
-                      TypeArrayView<GenericTypeParamType> genericParams) const {
+                      ArrayRef<GenericTypeParamType *> genericParams) const {
   return getTypeForSymbolRange(term.begin(), term.end(), genericParams, *this);
 }
 
 Type PropertyMap::getTypeForTerm(const MutableTerm &term,
-                      TypeArrayView<GenericTypeParamType> genericParams) const {
+                      ArrayRef<GenericTypeParamType *> genericParams) const {
   return getTypeForSymbolRange(term.begin(), term.end(), genericParams, *this);
 }
 
@@ -474,7 +474,7 @@ RewriteContext::getRelativeTermForType(CanType typeWitness,
 /// RewriteSystemBuilder::getConcreteSubstitutionSchema().
 Type PropertyMap::getTypeFromSubstitutionSchema(
     Type schema, ArrayRef<Term> substitutions,
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     const MutableTerm &prefix) const {
   assert(!schema->isTypeParameter() && "Must have a concrete type here");
 

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -158,7 +158,7 @@ PropertyBag::getPrefixAfterStrippingKey(const MutableTerm &lookupTerm) const {
 ///
 /// Asserts if this property bag does not have a superclass bound.
 Type PropertyBag::getSuperclassBound(
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     const MutableTerm &lookupTerm,
     const PropertyMap &map) const {
   MutableTerm prefix = getPrefixAfterStrippingKey(lookupTerm);
@@ -179,7 +179,7 @@ Type PropertyBag::getSuperclassBound(
 ///
 /// Asserts if this property bag is not concrete.
 Type PropertyBag::getConcreteType(
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     const MutableTerm &lookupTerm,
     const PropertyMap &map) const {
   MutableTerm prefix = getPrefixAfterStrippingKey(lookupTerm);

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -123,7 +123,7 @@ public:
   }
 
   Type getSuperclassBound(
-      TypeArrayView<GenericTypeParamType> genericParams,
+      ArrayRef<GenericTypeParamType *> genericParams,
       const MutableTerm &lookupTerm,
       const PropertyMap &map) const;
 
@@ -136,7 +136,7 @@ public:
   }
 
   Type getConcreteType(
-      TypeArrayView<GenericTypeParamType> genericParams,
+      ArrayRef<GenericTypeParamType *> genericParams,
       const MutableTerm &lookupTerm,
       const PropertyMap &map) const;
 
@@ -227,15 +227,15 @@ public:
   //////////////////////////////////////////////////////////////////////////////
 
   Type getTypeForTerm(Term term,
-                      TypeArrayView<GenericTypeParamType> genericParams) const;
+                      ArrayRef<GenericTypeParamType *> genericParams) const;
 
   Type getTypeForTerm(const MutableTerm &term,
-                      TypeArrayView<GenericTypeParamType> genericParams) const;
+                      ArrayRef<GenericTypeParamType *> genericParams) const;
 
   Type getTypeFromSubstitutionSchema(
                       Type schema,
                       ArrayRef<Term> substitutions,
-                      TypeArrayView<GenericTypeParamType> genericParams,
+                      ArrayRef<GenericTypeParamType *> genericParams,
                       const MutableTerm &prefix) const;
 
 private:

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -133,7 +133,7 @@ class RequirementBuilder {
   // Input parameters.
   const RewriteSystem &System;
   const PropertyMap &Map;
-  TypeArrayView<GenericTypeParamType> GenericParams;
+  ArrayRef<GenericTypeParamType *> GenericParams;
   bool ReconstituteSugar;
   bool Debug;
 
@@ -147,7 +147,7 @@ public:
   std::vector<ProtocolTypeAlias> Aliases;
 
   RequirementBuilder(const RewriteSystem &system, const PropertyMap &map,
-                     TypeArrayView<GenericTypeParamType> genericParams,
+                     ArrayRef<GenericTypeParamType *> genericParams,
                      bool reconstituteSugar)
     : System(system), Map(map),
       GenericParams(genericParams),
@@ -380,7 +380,7 @@ void
 RequirementMachine::buildRequirementsFromRules(
     ArrayRef<unsigned> requirementRules,
     ArrayRef<unsigned> typeAliasRules,
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     bool reconstituteSugar,
     std::vector<Requirement> &reqs,
     std::vector<ProtocolTypeAlias> &aliases) const {

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -362,9 +362,7 @@ static void desugarConformanceRequirement(Requirement req,
     desugarRequirement(subReq, loc, result, errors);
 }
 
-/// Desugar same-shape requirements by equating the shapes of the
-/// root pack types, and diagnose shape requirements on non-pack
-/// types.
+/// Diagnose shape requirements on non-pack types.
 static void desugarSameShapeRequirement(Requirement req, SourceLoc loc,
                                         SmallVectorImpl<Requirement> &result,
                                         SmallVectorImpl<RequirementError> &errors) {
@@ -376,8 +374,7 @@ static void desugarSameShapeRequirement(Requirement req, SourceLoc loc,
   }
 
   result.emplace_back(RequirementKind::SameShape,
-                      req.getFirstType()->getRootGenericParam(),
-                      req.getSecondType()->getRootGenericParam());
+                      req.getFirstType(), req.getSecondType());
 }
 
 /// Convert a requirement where the subject type might not be a type parameter,

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -307,7 +307,7 @@ RequirementMachine::initWithProtocolSignatureRequirements(
 ///
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
-RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
+RequirementMachine::initWithGenericSignature(GenericSignature sig) {
   Sig = sig;
   Params.append(sig.getGenericParams().begin(),
                 sig.getGenericParams().end());
@@ -323,7 +323,8 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
   // Collect the top-level requirements, and all transitively-referenced
   // protocol requirement signatures.
   RuleBuilder builder(Context, System.getReferencedProtocols());
-  builder.initWithGenericSignatureRequirements(sig.getRequirements());
+  builder.initWithGenericSignature(sig.getGenericParams(),
+                                   sig.getRequirements());
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/false,
@@ -425,7 +426,7 @@ RequirementMachine::initWithWrittenRequirements(
   // Collect the top-level requirements, and all transitively-referenced
   // protocol requirement signatures.
   RuleBuilder builder(Context, System.getReferencedProtocols());
-  builder.initWithWrittenRequirements(requirements);
+  builder.initWithWrittenRequirements(genericParams, requirements);
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true,

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -366,7 +366,7 @@ RequirementMachine::initWithProtocolWrittenRequirements(
 
   // For RequirementMachine::verify() when called by generic signature queries;
   // We have a single valid generic parameter at depth 0, index 0.
-  Params.push_back(component[0]->getSelfInterfaceType());
+  Params.push_back(component[0]->getSelfInterfaceType()->castTo<GenericTypeParamType>());
 
   if (Dump) {
     llvm::dbgs() << "Adding protocols";
@@ -557,8 +557,8 @@ void RequirementMachine::dump(llvm::raw_ostream &out) const {
   } else {
     out << "fresh signature <";
     for (auto paramTy : Params) {
-      out << " " << paramTy;
-      if (paramTy->castTo<GenericTypeParamType>()->isParameterPack())
+      out << " " << Type(paramTy);
+      if (paramTy->isParameterPack())
         out << "…";
     }
     out << " >";

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -54,7 +54,7 @@ class RequirementMachine final {
   friend class swift::AbstractGenericSignatureRequest;
   friend class swift::InferredGenericSignatureRequest;
 
-  CanGenericSignature Sig;
+  GenericSignature Sig;
   SmallVector<GenericTypeParamType *, 2> Params;
 
   RewriteContext &Context;
@@ -95,7 +95,7 @@ class RequirementMachine final {
       ArrayRef<const ProtocolDecl *> protos);
 
   std::pair<CompletionResult, unsigned>
-  initWithGenericSignature(CanGenericSignature sig);
+  initWithGenericSignature(GenericSignature sig);
 
   std::pair<CompletionResult, unsigned>
   initWithProtocolWrittenRequirements(

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -55,7 +55,7 @@ class RequirementMachine final {
   friend class swift::InferredGenericSignatureRequest;
 
   CanGenericSignature Sig;
-  SmallVector<Type, 2> Params;
+  SmallVector<GenericTypeParamType *, 2> Params;
 
   RewriteContext &Context;
   RewriteSystem System;
@@ -123,14 +123,13 @@ class RequirementMachine final {
   void buildRequirementsFromRules(
     ArrayRef<unsigned> requirementRules,
     ArrayRef<unsigned> typeAliasRules,
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     bool reconstituteSugar,
     std::vector<Requirement> &reqs,
     std::vector<ProtocolTypeAlias> &aliases) const;
 
-  TypeArrayView<GenericTypeParamType> getGenericParams() const {
-    return TypeArrayView<GenericTypeParamType>(
-      ArrayRef<Type>(Params));
+  ArrayRef<GenericTypeParamType *> getGenericParams() const {
+    return Params;
   }
 
 public:
@@ -140,22 +139,22 @@ public:
   // RequirementMachine instance; instead, call the corresponding methods on
   // GenericSignature, which lazily create a RequirementMachine for you.
   GenericSignature::LocalRequirements getLocalRequirements(Type depType,
-                      TypeArrayView<GenericTypeParamType> genericParams) const;
+                      ArrayRef<GenericTypeParamType *> genericParams) const;
   bool requiresClass(Type depType) const;
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
   GenericSignature::RequiredProtocols getRequiredProtocols(Type depType) const;
   Type getSuperclassBound(Type depType,
-                          TypeArrayView<GenericTypeParamType> genericParams) const;
+                          ArrayRef<GenericTypeParamType *> genericParams) const;
   bool isConcreteType(Type depType,
                       const ProtocolDecl *proto=nullptr) const;
   Type getConcreteType(Type depType,
-                       TypeArrayView<GenericTypeParamType> genericParams,
+                       ArrayRef<GenericTypeParamType *> genericParams,
                        const ProtocolDecl *proto=nullptr) const;
   bool areReducedTypeParametersEqual(Type depType1, Type depType2) const;
   bool isReducedType(Type type) const;
   Type getReducedType(Type type,
-                      TypeArrayView<GenericTypeParamType> genericParams) const;
+                      ArrayRef<GenericTypeParamType *> genericParams) const;
   bool isValidTypeParameter(Type type) const;
   ConformancePath getConformancePath(Type type, ProtocolDecl *protocol);
   TypeDecl *lookupNestedType(Type depType, Identifier name) const;
@@ -165,7 +164,7 @@ private:
 
 public:
   Type getReducedShape(Type type,
-                       TypeArrayView<GenericTypeParamType> genericParams) const;
+                       ArrayRef<GenericTypeParamType *> genericParams) const;
 
   bool haveSameShape(Type type1, Type type2) const;
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -152,7 +152,7 @@ static void splitConcreteEquivalenceClasses(
     ArrayRef<Requirement> requirements,
     const ProtocolDecl *proto,
     const RequirementMachine *machine,
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     SmallVectorImpl<StructuralRequirement> &splitRequirements,
     unsigned &attempt) {
   bool debug = machine->getDebugOptions().contains(

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -503,8 +503,16 @@ void RewriteSystem::recordRewriteLoop(MutableTerm basepoint,
     return;
 
   // Ignore the rewrite loop if it is not part of our minimization domain.
-  if (!isInMinimizationDomain(basepoint.getRootProtocol()))
+  //
+  // Completion might record a rewrite loop where the basepoint is just
+  // the term [shape]. In this case though, we know it's in our domain,
+  // since completion only checks local rules for overlap. Other callers
+  // of recordRewriteLoop() always pass in a valid basepoint, so we
+  // check.
+  if (basepoint[0].getKind() != Symbol::Kind::Shape &&
+      !isInMinimizationDomain(basepoint.getRootProtocol())) {
     return;
+  }
 
   Loops.push_back(loop);
 }
@@ -554,11 +562,6 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Shape);
       }
 
-      // A shape symbol must follow a generic param symbol
-      if (symbol.getKind() == Symbol::Kind::Shape) {
-        ASSERT_RULE(index > 0 && lhs[index - 1].getKind() == Symbol::Kind::GenericParam);
-      }
-
       if (!rule.isLHSSimplified() &&
           index != lhs.size() - 1) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::ConcreteConformance);
@@ -601,13 +604,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
       ASSERT_RULE(symbol.getKind() != Symbol::Kind::Superclass);
       ASSERT_RULE(symbol.getKind() != Symbol::Kind::ConcreteType);
 
-      if (index != lhs.size() - 1) {
+      if (index != rhs.size() - 1) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Shape);
-      }
-
-      // A shape symbol must follow a generic param symbol
-      if (symbol.getKind() == Symbol::Kind::Shape) {
-        ASSERT_RULE(index > 0 && rhs[index - 1].getKind() == Symbol::Kind::GenericParam);
       }
 
       // Completion can introduce a rule of the form
@@ -634,10 +632,15 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
       }
     }
 
-    auto lhsDomain = lhs.getRootProtocol();
-    auto rhsDomain = rhs.getRootProtocol();
-
-    ASSERT_RULE(lhsDomain == rhsDomain);
+    if (rhs.size() == 1 && rhs[0].getKind() == Symbol::Kind::Shape) {
+      // We can have a rule like T.[shape] => [shape].
+      ASSERT_RULE(lhs.back().getKind() == Symbol::Kind::Shape);
+    } else {
+      // Otherwise, LHS and RHS must have the same domain.
+      auto lhsDomain = lhs.getRootProtocol();
+      auto rhsDomain = rhs.getRootProtocol();
+      ASSERT_RULE(lhsDomain == rhsDomain);
+    }
   }
 
 #undef ASSERT_RULE

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -711,6 +711,7 @@ void RewriteSystem::dump(llvm::raw_ostream &out) const {
       loop.dump(out, *this);
       out << "\n";
     }
+    out << "}\n";
   }
   if (!WrittenRequirements.empty()) {
     out << "Written requirements: {\n";

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -232,12 +232,12 @@ public:
   void computeConflictingRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors,
                                                 SourceLoc signatureLoc,
                                                 const PropertyMap &map,
-                                                TypeArrayView<GenericTypeParamType> genericParams);
+                                                ArrayRef<GenericTypeParamType *> genericParams);
 
   void computeRecursiveRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors,
                                               SourceLoc signatureLoc,
                                               const PropertyMap &map,
-                                              TypeArrayView<GenericTypeParamType> genericParams);
+                                              ArrayRef<GenericTypeParamType *> genericParams);
 
 private:
   struct CriticalPair {

--- a/lib/AST/RequirementMachine/RuleBuilder.h
+++ b/lib/AST/RequirementMachine/RuleBuilder.h
@@ -95,8 +95,10 @@ struct RuleBuilder {
     Initialized = 0;
   }
 
-  void initWithGenericSignatureRequirements(ArrayRef<Requirement> requirements);
-  void initWithWrittenRequirements(ArrayRef<StructuralRequirement> requirements);
+  void initWithGenericSignature(ArrayRef<GenericTypeParamType *> genericParams,
+                                ArrayRef<Requirement> requirements);
+  void initWithWrittenRequirements(ArrayRef<GenericTypeParamType *> genericParams,
+                                   ArrayRef<StructuralRequirement> requirements);
   void initWithProtocolSignatureRequirements(ArrayRef<const ProtocolDecl *> proto);
   void initWithProtocolWrittenRequirements(
       ArrayRef<const ProtocolDecl *> component,
@@ -106,6 +108,7 @@ struct RuleBuilder {
                                        ArrayRef<Term> substitutions);
   void addReferencedProtocol(const ProtocolDecl *proto);
   void collectRulesFromReferencedProtocols();
+  void collectPackShapeRules(ArrayRef<GenericTypeParamType *> genericParams);
 
 private:
   void addPermanentProtocolRules(const ProtocolDecl *proto);

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -700,12 +700,7 @@ void Symbol::dump(llvm::raw_ostream &out) const {
   }
 
   case Kind::GenericParam: {
-    auto *gp = getGenericParam();
-    if (gp->isParameterPack()) {
-      out << "(" << Type(gp) << "…)";
-    } else {
-      out << Type(gp);
-    }
+    out << Type(getGenericParam());
     return;
   }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -819,7 +819,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
 /// substitutions that will have been applied to these types.
 /// These are used to produce the "parameter = argument" bindings in the test.
 static std::string gatherGenericParamBindingsText(
-    ArrayRef<Type> types, TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<Type> types, ArrayRef<GenericTypeParamType *> genericParams,
     TypeSubstitutionFn substitutions) {
   llvm::SmallPtrSet<GenericTypeParamType *, 2> knownGenericParams;
   for (auto type : types) {
@@ -871,7 +871,7 @@ static std::string gatherGenericParamBindingsText(
 void TypeChecker::diagnoseRequirementFailure(
     const CheckGenericArgumentsResult::RequirementFailureInfo &reqFailureInfo,
     SourceLoc errorLoc, SourceLoc noteLoc, Type targetTy,
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     TypeSubstitutionFn substitutions, ModuleDecl *module) {
   assert(errorLoc.isValid() && noteLoc.isValid());
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5061,7 +5061,8 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       if (result == CheckGenericArgumentsResult::RequirementFailure) {
         TypeChecker::diagnoseRequirementFailure(
             result.getRequirementFailureInfo(), Loc, Loc,
-            proto->getDeclaredInterfaceType(), {proto->getSelfInterfaceType()},
+            proto->getDeclaredInterfaceType(),
+            {proto->getSelfInterfaceType()->castTo<GenericTypeParamType>()},
             QuerySubstitutionMap{substitutions}, module);
       }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -515,7 +515,7 @@ void checkShadowedGenericParams(GenericContext *dc);
 void diagnoseRequirementFailure(
     const CheckGenericArgumentsResult::RequirementFailureInfo &reqFailureInfo,
     SourceLoc errorLoc, SourceLoc noteLoc, Type targetTy,
-    TypeArrayView<GenericTypeParamType> genericParams,
+    ArrayRef<GenericTypeParamType *> genericParams,
     TypeSubstitutionFn substitutions, ModuleDecl *module);
 
 /// Check the given generic parameter substitutions against the given

--- a/lib/SymbolGraphGen/JSON.cpp
+++ b/lib/SymbolGraphGen/JSON.cpp
@@ -170,7 +170,7 @@ void swift::symbolgraphgen::serialize(const ModuleDecl &Module,
 
 void
 swift::symbolgraphgen::filterGenericParams(
-    TypeArrayView<GenericTypeParamType> GenericParams,
+    ArrayRef<GenericTypeParamType *> GenericParams,
     SmallVectorImpl<const GenericTypeParamType*> &FilteredParams,
     SubstitutionMap SubMap) {
 

--- a/lib/SymbolGraphGen/JSON.h
+++ b/lib/SymbolGraphGen/JSON.h
@@ -46,7 +46,7 @@ void serialize(const swift::GenericTypeParamType *Param, llvm::json::OStream &OS
 void serialize(const ModuleDecl &M, llvm::json::OStream &OS, llvm::Triple Target);
 
 void filterGenericParams(
-    TypeArrayView<GenericTypeParamType> GenericParams,
+    ArrayRef<GenericTypeParamType *> GenericParams,
     SmallVectorImpl<const GenericTypeParamType*> &FilteredParams,
     SubstitutionMap SubMap = {});
 

--- a/validation-test/compiler_crashers_2_fixed/rdar108319167.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar108319167.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol P {}
+
+public protocol Q {
+  associatedtype A: P
+}
+
+public func f<T: P>(_: T) {}
+
+public func foo1<each T: Q, each U>(t: repeat each T, u: repeat each U)
+    where repeat (each U) == (each T).A {
+  repeat f(each u)
+}
+
+public func foo2<each T: Q>(t: repeat each T, u: repeat each T.A) {
+  repeat f(each u)
+}


### PR DESCRIPTION
* Description: A same-type requirement between two member types did not imply a same-shape requirement between the root generic parameters. This could produce an incorrect mangling (if the same-shape requirement was inferred by some other means, it would not be minimized away), cause the type checker to reject valid code (if the user tried to do something with the two packs that required them to have the same shape), or possibly other unforeseen soundness issues.

* Scope of the issue: You need a generic signature with at least two generic parameter packs to observe any difference in behavior.

* Risk: This only impacts variadic generics type checking, for the most part. It introduces new rewrite rules in the Requirement Machine, but to reduce the chance of regressions with unrelated code, the new rules are only added if the generic signature declares at least one generic parameter pack.

  I also cherry-picked a refactoring PR which changes `GenericSignature::getGenericParams()` to return `ArrayRef` instead of `TypeArrayView`. Without this change, the new logic in this PR would require some ugly casts, and it would cause main and release/5.9 to diverge in a way that is likely to lead to merge conflicts. This refactoring touches a number of source files but it's a purely mechanical change that probably doesn't even affect generated code. I'm pretty confident it is safe.

* Tested: Some new tests added

* Radar: rdar://101813873 and rdar://108319167

* Reviewed by: @hborla 