### PR TITLE
[cxx-interop] Mangle numeric template arguments

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
@@ -8,5 +8,6 @@ using size_t = __SIZE_TYPE__;
 template <class T, size_t Size> struct MagicArray { T t[Size]; };
 
 typedef MagicArray<int, 2> MagicIntPair;
+typedef MagicArray<int, 3> MagicIntTriple;
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+
+import ClassTemplateNonTypeParameter
+
+let p = MagicIntPair()
+let t = MagicIntTriple()
+
+// CHECK: @"${{s4main1pSo0034MagicArrayInt32_UInt_2_zoAFhhiEngcVvp|s4main1pSo0036MagicArrayInt32_UInt64_2_JsAEiFiuomcVvp}}"
+// CHECK: @"${{s4main1tSo0034MagicArrayInt32_UInt_3_zoAFhhiEngcVvp|s4main1tSo0036MagicArrayInt32_UInt64_3_JsAEiFiuomcVvp}}"

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateNonTypeParameter -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK: struct MagicArray<T, Size> {
+// CHECK: }
+
+// CHECK: struct MagicArray<Int32, _UInt{{.*}}_2> {
+// CHECK:   init()
+// CHECK:   init(t: (Int32, Int32))
+// CHECK:   var t: (Int32, Int32)
+// CHECK: }
+
+// CHECK: struct MagicArray<Int32, _UInt{{.*}}_3> {
+// CHECK:   init()
+// CHECK:   init(t: (Int32, Int32, Int32))
+// CHECK:   var t: (Int32, Int32, Int32)
+// CHECK: }
+
+// CHECK: typealias MagicIntPair = MagicArray<Int32, _UInt{{.*}}_2>
+// CHECK: typealias MagicIntTriple = MagicArray<Int32, _UInt{{.*}}_3>

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
@@ -10,6 +10,9 @@ var TemplatesTestSuite = TestSuite("TemplatesTestSuite")
 TemplatesTestSuite.test("typedeffed-non-type-parameter") {
   let pair = MagicIntPair(t: (1, 2))
   expectEqual(pair.t, (1, 2))
+
+  let triple = MagicIntTriple(t: (1, 2, 3))
+  expectEqual(triple.t, (1, 2, 3))
 }
 
 // TODO: This test doesn't work because Swift doesn't support defaulted generic

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -12,4 +12,4 @@
 
 // TODO: we should not be importing functions that use this type in their
 // signature (such as the function below).
-// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<Int32>, _>, _>>
+// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<Int32>, _Int32_1>, _Int32_1>>


### PR DESCRIPTION
This fixes linker errors when there are multiple instantiations of a templated struct with numeric template parameters.

When mangling the name of a C++ template specialization, we currently ignore non-type templated parameters. This causes two different instantiations of the same templated type to have the same mangled name, triggering linker errors.

rdar://107757051