### PR TITLE
[5.9] [Macros] Cope with local types and opaque result types in macros and expansions

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -155,6 +155,7 @@ public:
   /// ASTScopes are not created in inactive clauses and lookups to decls will fail.
   bool InInactiveClauseEnvironment = false;
   bool InSwiftKeyPath = false;
+  bool InFreestandingMacroArgument = false;
 
   /// Whether we should delay parsing nominal type, extension, and function
   /// bodies.

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1036,8 +1036,8 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
 
     // In the same file any visibility is okay.
     if (!dc->isModuleContext() &&
-        typeDecl->getDeclContext()->getParentSourceFile() ==
-        dc->getParentSourceFile())
+        typeDecl->getDeclContext()->getOutermostParentSourceFile() ==
+        dc->getOutermostParentSourceFile())
       return true;
 
     return typeDecl->getEffectiveAccess() > AccessLevel::FilePrivate;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2337,6 +2337,8 @@ ParserStatus Parser::parseFreestandingMacroExpansion(
       diagnose(leftAngleLoc, diag::while_parsing_as_left_angle_bracket);
   }
 
+  llvm::SaveAndRestore<bool> inMacroArgument(InFreestandingMacroArgument, true);
+
   if (Tok.isFollowingLParen()) {
     auto result = parseArgumentList(tok::l_paren, tok::r_paren, isExprBasic,
                                     /*allowTrailingClosure*/ true);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1851,6 +1851,10 @@ public:
   ASTContext &getASTContext() const { return Ctx; }
   void addDelayedFunction(AbstractFunctionDecl *AFD) {
     if (!SF) return;
+
+    while (auto enclosingSF = SF->getEnclosingSourceFile())
+      SF = enclosingSF;
+
     SF->DelayedFunctions.push_back(AFD);
   }
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -197,6 +197,22 @@ public struct Outer {
 // CHECK: (2, "a + b")
 testStringify(a: 1, b: 1)
 
+protocol P { }
+extension Int: P { }
+
+// Stringify with closures that have local types.
+@available(SwiftStdlib 5.1, *)
+func testStringifyWithLocalTypes() {
+  _ = #stringify({
+    struct LocalType: P {
+      static var name: String = "Taylor"
+      var something: some P { self }
+    }
+
+    func f() -> some P { return LocalType().something }
+  })
+}
+
 func maybeThrowing() throws -> Int { 5 }
 
 #if TEST_DIAGNOSTICS


### PR DESCRIPTION
* **Explanation**: Fixes several issues with local types and opaque result types within macro arguments and expansions, which would manifest as link errors (missing symbols).
* **Scope**: Narrow. Only changes behavior when local types and opaque result types are used in conjunction with macros.
* **Risk**: Low due to narrow scope.
* **Original pull request**: https://github.com/apple/swift/pull/67099
* **Issue**: rdar://110674997&110713264
