### PR TITLE
[Test] Add asserts requirement to tests with experimental feature

### DIFF
--- a/test/Concurrency/DeferredSendableChecking/defer_and_silgen.swift
+++ b/test/Concurrency/DeferredSendableChecking/defer_and_silgen.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -emit-sil -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
 // REQUIRES: concurrency
+// REQUIRES: asserts
+
+// RUN: %target-typecheck-verify-swift -emit-sil -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
 
 /*
  This file tests the experimental DeferredSendableChecking feature. This features the passing

--- a/test/Concurrency/DeferredSendableChecking/defer_and_typecheck_only.swift
+++ b/test/Concurrency/DeferredSendableChecking/defer_and_typecheck_only.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -typecheck -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
 // REQUIRES: concurrency
+// REQUIRES: asserts
+
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
 
 /*
  This file tests the experimental DeferredSendableChecking feature. This features the passing


### PR DESCRIPTION
Both these tests use an experimental feature, they should only be enabled in asserts builds.