### PR TITLE
[Macros] Enable freestanding macros at module scope in script mode

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8449,7 +8449,7 @@ class MissingDecl : public Decl {
   /// \c unexpandedMacro contains the macro reference and the base declaration
   /// where the macro expansion applies.
   struct {
-    llvm::PointerUnion<MacroExpansionDecl *, CustomAttr *> macroRef;
+    llvm::PointerUnion<FreestandingMacroExpansion *, CustomAttr *> macroRef;
     Decl *baseDecl;
   } unexpandedMacro;
 
@@ -8473,7 +8473,7 @@ public:
 
   static MissingDecl *
   forUnexpandedMacro(
-      llvm::PointerUnion<MacroExpansionDecl *, CustomAttr *> macroRef,
+      llvm::PointerUnion<FreestandingMacroExpansion *, CustomAttr *> macroRef,
       Decl *baseDecl) {
     auto &ctx = baseDecl->getASTContext();
     auto *dc = baseDecl->getDeclContext();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7244,9 +7244,6 @@ ERROR(literal_type_in_macro_expansion,none,
 ERROR(invalid_macro_introduced_name,none,
       "declaration name %0 is not covered by macro %1",
       (DeclName, DeclName))
-ERROR(global_freestanding_macro_script,none,
-      "global freestanding macros not yet supported in script mode",
-      ())
 ERROR(invalid_macro_role_for_macro_syntax,none,
       "invalid macro role for %{a freestanding|an attached}0 macro",
       (unsigned))

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3926,11 +3926,5 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
       !roles.contains(MacroRole::CodeItem))
     return llvm::None;
 
-  // For now, restrict global freestanding macros in script mode.
-  if (dc->isModuleScopeContext() &&
-      dc->getParentSourceFile()->isScriptMode()) {
-    MED->diagnose(diag::global_freestanding_macro_script);
-  }
-
   return expandFreestandingMacro(MED);
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -469,8 +469,7 @@ ExpandMacroExpansionExprRequest::evaluate(Evaluator &evaluator,
   else if (macro->getMacroRoles().contains(MacroRole::Declaration) ||
            macro->getMacroRoles().contains(MacroRole::CodeItem)) {
     if (!mee->getSubstituteDecl()) {
-      auto *med = mee->createSubstituteDecl();
-      TypeChecker::typeCheckDecl(med);
+      (void)mee->createSubstituteDecl();
     }
     // Return the expanded buffer ID.
     return evaluateOrDefault(

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -336,14 +336,11 @@ let blah = false
 #endif
 
 // Test unqualified lookup from within a macro expansion
-// FIXME: Global freestanding macros not yet supported in script mode.
-#if false
 let world = 3 // to be used by the macro expansion below
 #structWithUnqualifiedLookup()
 _ = StructWithUnqualifiedLookup().foo()
 
 #anonymousTypes { "hello" }
-#endif
 
 func testFreestandingMacroExpansion() {
   // Explicit structs to force macros to be parsed as decl.


### PR DESCRIPTION
Eliminate the error message

    error: global freestanding macros not yet supported in script mode

by implementing name lookup, type checking, and code emission for freestanding macros. The key problem here is that, in script mode, it is ambiguous whether a use of a freestanding macro is an expression or a declaration. We parse as an expression (as we do within a function body), which then gets wrapped in a top-level code declaration.

Teach various parts of the compiler to look through a top-level code declaration wrapping a macro expansion expression that is for a declaration or code-item macro, e.g., by recording these for global name lookup and treating their expansions as "auxiliary" declarations.

Fixes rdar://109699501.
