### PR TITLE
[Macros] Add missing macro validation.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7268,6 +7268,9 @@ ERROR(local_extension_macro,none,
 ERROR(extension_macro_invalid_conformance,none,
       "invalid protocol conformance %0 in extension macro",
       (Type))
+ERROR(macro_attached_to_invalid_decl,none,
+      "'%0' macro cannot be attached to %1",
+      (StringRef, DescriptiveDeclKind))
 
 ERROR(macro_resolve_circular_reference, none,
       "circular reference resolving %select{freestanding|attached}0 macro %1",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3665,10 +3665,17 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     Ctx.evaluator, CustomAttrNominalRequest{attr, dc}, nullptr);
 
   if (!nominal) {
-    // Try resolving an attached macro attribute.
-    auto *macro = D->getResolvedMacro(attr);
-    if (macro || !attr->isValid())
+    if (attr->isInvalid())
       return;
+
+    // Try resolving an attached macro attribute.
+    if (auto *macro = D->getResolvedMacro(attr)) {
+      for (auto *roleAttr : macro->getAttrs().getAttributes<MacroRoleAttr>()) {
+        diagnoseInvalidAttachedMacro(roleAttr->getMacroRole(), D);
+      }
+
+      return;
+    }
 
     // Diagnose errors.
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -543,6 +543,67 @@ static Identifier makeIdentifier(ASTContext &ctx, std::nullptr_t) {
   return Identifier();
 }
 
+static void diagnoseInvalidDecl(Decl *decl,
+                                MacroDecl *macro,
+                                llvm::function_ref<bool(DeclName)> coversName) {
+  auto &ctx = decl->getASTContext();
+
+  // Diagnose invalid declaration kinds.
+  if (isa<ImportDecl>(decl) ||
+      isa<OperatorDecl>(decl) ||
+      isa<PrecedenceGroupDecl>(decl) ||
+      isa<MacroDecl>(decl) ||
+      isa<ExtensionDecl>(decl)) {
+    decl->diagnose(diag::invalid_decl_in_macro_expansion,
+                   decl->getDescriptiveKind());
+    decl->setInvalid();
+
+    if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
+      extension->setExtendedNominal(nullptr);
+    }
+
+    return;
+  }
+
+  // Diagnose `@main` types.
+  if (auto *mainAttr = decl->getAttrs().getAttribute<MainTypeAttr>()) {
+    ctx.Diags.diagnose(mainAttr->getLocation(),
+                       diag::invalid_main_type_in_macro_expansion);
+    mainAttr->setInvalid();
+  }
+
+  // Diagnose default literal type overrides.
+  if (auto *typeAlias = dyn_cast<TypeAliasDecl>(decl)) {
+    auto name = typeAlias->getBaseIdentifier();
+#define EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(_, __, typeName,   \
+                                                supportsOverride)    \
+    if (supportsOverride && name == makeIdentifier(ctx, typeName)) { \
+      typeAlias->diagnose(diag::literal_type_in_macro_expansion,     \
+                          makeIdentifier(ctx, typeName));            \
+      typeAlias->setInvalid();                                       \
+      return;                                                        \
+    }
+#include "swift/AST/KnownProtocols.def"
+#undef EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME
+  }
+
+  // Diagnose value decls with names not covered by the macro
+  if (auto *value = dyn_cast<ValueDecl>(decl)) {
+    auto name = value->getName();
+
+    // Unique names are always permitted.
+    if (MacroDecl::isUniqueMacroName(name.getBaseName().userFacingName()))
+      return;
+
+    if (coversName(name)) {
+      return;
+    }
+
+    value->diagnose(diag::invalid_macro_introduced_name,
+                    name, macro->getBaseName());
+  }
+}
+
 /// Diagnose macro expansions that produce any of the following declarations:
 ///   - Import declarations
 ///   - Operator and precedence group declarations
@@ -559,75 +620,33 @@ static void validateMacroExpansion(SourceFile *expansionBuffer,
   llvm::SmallVector<DeclName, 2> introducedNames;
   macro->getIntroducedNames(role, attachedTo, introducedNames);
 
-  llvm::SmallDenseSet<DeclName, 2> coversName(introducedNames.begin(),
-                                              introducedNames.end());
+  llvm::SmallDenseSet<DeclName, 2> introducedNameSet(
+      introducedNames.begin(), introducedNames.end());
+
+  auto coversName = [&](DeclName name) -> bool {
+    return (introducedNameSet.count(name) ||
+            introducedNameSet.count(name.getBaseName()) ||
+            introducedNameSet.count(MacroDecl::getArbitraryName()));
+  };
 
   for (auto *decl : expansionBuffer->getTopLevelDecls()) {
-    auto &ctx = decl->getASTContext();
-
     // Certain macro roles can generate special declarations.
     if ((isa<AccessorDecl>(decl) && role == MacroRole::Accessor) ||
-        (isa<ExtensionDecl>(decl) && role == MacroRole::Conformance) ||
-        (isa<ExtensionDecl>(decl) && role == MacroRole::Extension)) { // FIXME: Check extension for generated names.
+        (isa<ExtensionDecl>(decl) && role == MacroRole::Conformance)) {
       continue;
     }
 
-    // Diagnose invalid declaration kinds.
-    if (isa<ImportDecl>(decl) ||
-        isa<OperatorDecl>(decl) ||
-        isa<PrecedenceGroupDecl>(decl) ||
-        isa<MacroDecl>(decl) ||
-        isa<ExtensionDecl>(decl)) {
-      decl->diagnose(diag::invalid_decl_in_macro_expansion,
-                     decl->getDescriptiveKind());
-      decl->setInvalid();
+    if (role == MacroRole::Extension) {
+      auto *extension = dyn_cast<ExtensionDecl>(decl);
 
-      if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
-        extension->setExtendedNominal(nullptr);
+      for (auto *member : extension->getMembers()) {
+        diagnoseInvalidDecl(member, macro, coversName);
       }
 
       continue;
     }
 
-    // Diagnose `@main` types.
-    if (auto *mainAttr = decl->getAttrs().getAttribute<MainTypeAttr>()) {
-      ctx.Diags.diagnose(mainAttr->getLocation(),
-                         diag::invalid_main_type_in_macro_expansion);
-      mainAttr->setInvalid();
-    }
-
-    // Diagnose default literal type overrides.
-    if (auto *typeAlias = dyn_cast<TypeAliasDecl>(decl)) {
-      auto name = typeAlias->getBaseIdentifier();
-#define EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(_, __, typeName,     \
-                                                  supportsOverride)    \
-      if (supportsOverride && name == makeIdentifier(ctx, typeName)) { \
-        typeAlias->diagnose(diag::literal_type_in_macro_expansion,     \
-                            makeIdentifier(ctx, typeName));            \
-        typeAlias->setInvalid();                                       \
-        continue;                                                      \
-      }
-#include "swift/AST/KnownProtocols.def"
-#undef EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME
-    }
-
-    // Diagnose value decls with names not covered by the macro
-    if (auto *value = dyn_cast<ValueDecl>(decl)) {
-      auto name = value->getName();
-
-      // Unique names are always permitted.
-      if (MacroDecl::isUniqueMacroName(name.getBaseName().userFacingName()))
-        continue;
-
-      if (coversName.count(name) ||
-          coversName.count(name.getBaseName()) ||
-          coversName.count(MacroDecl::getArbitraryName())) {
-        continue;
-      }
-
-      value->diagnose(diag::invalid_macro_introduced_name,
-                      name, macro->getBaseName());
-    }
+    diagnoseInvalidDecl(decl, macro, coversName);
   }
 }
 

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -90,6 +90,11 @@ bool accessorMacroOnlyIntroducesObservers(
 bool accessorMacroIntroducesInitAccessor(
     MacroDecl *macro, const MacroRoleAttr *attr);
 
+/// Diagnose an error if the given macro role does not apply
+/// to the declaration kind of \c attachedTo.
+bool diagnoseInvalidAttachedMacro(MacroRole role,
+                                  Decl *attachedTo);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKMACROS_H */

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1314,6 +1314,16 @@ public struct EmptyMacro: MemberMacro {
   }
 }
 
+public struct EmptyPeerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return []
+  }
+}
+
 public struct EquatableMacro: ConformanceMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -112,4 +112,7 @@ struct MyBrokenStruct {
   }
 }
 
+@myPropertyWrapper
+struct CannotHaveAccessors {}
+// CHECK-DIAGS: 'accessor' macro cannot be attached to struct
 #endif

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -140,3 +140,13 @@ expansionOrder.expandedMember = 27
 
 // CHECK: setting 28
 expansionOrder.originalMember = 28
+
+#if TEST_DIAGNOSTICS
+@wrapAllProperties
+typealias A = Int
+// expected-error@-1{{'memberAttribute' macro cannot be attached to type alias}}
+
+@wrapAllProperties
+func noMembers() {}
+// expected-error@-1{{'memberAttribute' macro cannot be attached to global function}}
+#endif

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -6,6 +6,10 @@
 // RUN: %target-swift-frontend -enable-experimental-feature ExtensionMacros -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature ExtensionMacros -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -I %t
+
+// RUN: not %target-swift-frontend -enable-experimental-feature ExtensionMacros -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics
+// RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS %s
+
 // RUN: %target-build-swift -enable-experimental-feature ExtensionMacros -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5 -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
@@ -106,4 +110,14 @@ func testLocal() {
   struct Local<Element> {}
   // expected-error@-1{{local type cannot have attached extension macro}}
 }
+
+
+@attached(extension, conformances: P)
+macro UndocumentedNamesInExtension() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceViaExtensionMacro")
+
+@UndocumentedNamesInExtension
+struct S<Element> {}
+// expected-note@-1 {{in expansion of macro 'UndocumentedNamesInExtension' here}}
+
+// CHECK-DIAGS: error: declaration name 'requirement()' is not covered by macro 'UndocumentedNamesInExtension'
 #endif

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -111,6 +111,13 @@ func testLocal() {
   // expected-error@-1{{local type cannot have attached extension macro}}
 }
 
+@DelegatedConformance
+typealias A = Int
+// expected-error@-1 {{'extension' macro cannot be attached to type alias}}
+
+@DelegatedConformance
+extension Int {}
+// expected-error@-1 {{'extension' macro cannot be attached to extension}}
 
 @attached(extension, conformances: P)
 macro UndocumentedNamesInExtension() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceViaExtensionMacro")

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -214,6 +214,13 @@ func testVarPeer() {
   _ = Date().value
 }
 
+#if TEST_DIAGNOSTICS
+// Macros cannot be attached to function parameters
+
+// expected-error@+1{{'peer' macro cannot be attached to parameter}}
+func test(@declareVarValuePeer x: Int) {}
+#endif
+
 // Stored properties added via peer macros.
 @attached(peer, names: named(_foo))
 macro AddPeerStoredProperty() =

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -19,6 +19,12 @@ macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers
 )
 macro addMembersQuotedInit() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
 
+#if TEST_DIAGNOSTICS
+@addMembers
+import Swift
+// expected-error@-1 {{'member' macro cannot be attached to import}}
+#endif
+
 @addMembers
 struct S {
   func useSynthesized() {


### PR DESCRIPTION
* Extension macros must document extension member names in the `@attached(extension)` attribute. Otherwise, the compiler emits an error that the generated name is not covered.
* Emit an error when an attached macro cannot apply to the declaration it's attached to, such as a member macro attached to an `import` declaration.

Resolves rdar://111685434