### PR TITLE
[SILGen/DI] Add support for init accessor properties without setters

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4925,6 +4925,7 @@ public:
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 
+  StringRef getPropertyName() const;
   AccessorDecl *getReferencedInitAccessor() const;
 };
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2395,10 +2395,15 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
 static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   switch (storage->getWriteImpl()) {
-  case WriteImplKind::Immutable:
+  case WriteImplKind::Immutable: {
+    if (storage->hasInitAccessor())
+      return AccessStrategy::getAccessor(AccessorKind::Init,
+                                         /*dispatch=*/false);
+
     assert(isa<VarDecl>(storage) && cast<VarDecl>(storage)->isLet() &&
            "mutation of a immutable variable that isn't a let");
     return AccessStrategy::getStorage();
+  }
   case WriteImplKind::Stored:
     return AccessStrategy::getStorage();
   case WriteImplKind::StoredWithObservers:
@@ -2475,7 +2480,9 @@ getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) {
 }
 
 static AccessStrategy
-getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch){
+getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) {
+  if (storage->hasInitAccessor() && !storage->getAccessor(AccessorKind::Set))
+    return AccessStrategy::getAccessor(AccessorKind::Init, dispatch);
   return AccessStrategy::getAccessor(AccessorKind::Set, dispatch);
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6755,8 +6755,17 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
 
   // If this is a 'var' decl, then we're settable if we have storage or a
   // setter.
-  if (!isLet())
+  if (!isLet()) {
+    if (hasInitAccessor()) {
+      if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(UseDC)) {
+        if (base && ctor->getImplicitSelfDecl() != base->getDecl())
+          return supportsMutation();
+        return true;
+      }
+    }
+
     return supportsMutation();
+  }
 
   // Static 'let's are always immutable.
   if (isStatic()) {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1290,6 +1290,12 @@ bool AssignOrInitInst::isPropertyAlreadyInitialized(unsigned propertyIdx) {
   return Assignments.test(propertyIdx);
 }
 
+StringRef AssignOrInitInst::getPropertyName() const {
+  auto *accessor = getReferencedInitAccessor();
+  assert(accessor);
+  return cast<VarDecl>(accessor->getStorage())->getNameStr();
+}
+
 AccessorDecl *AssignOrInitInst::getReferencedInitAccessor() const {
   SILValue initRef = getInitializer();
   SILFunction *accessorFn = nullptr;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2737,6 +2737,9 @@ public:
       checkAssigOrInitInstAccessorArgs(Src->getType(), initConv);
     }
 
+    if (isa<SILUndef>(setterFn))
+      return;
+
     // Check setter - it's a partially applied reference which takes
     // `initialValue`.
     CanSILFunctionType setterTy = setterFn->getType().castTo<SILFunctionType>();

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -115,6 +115,7 @@ public:
     WritebackPseudoKind,        // a fake component to customize writeback
     OpenNonOpaqueExistentialKind,  // opened class or metatype existential
     LogicalKeyPathApplicationKind, // applying a key path
+    InitAccessorKind,           // init accessor
     
     // Translation LValue kinds (a subtype of logical)
     OrigToSubstKind,            // generic type substitution

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -462,3 +462,57 @@ test_memberwise_with_default_args()
 // CHECK-NEXT: test-defaulted-1: TestDefaulted(_a: 0, _b: 0)
 // CHECK-NEXT: test-defaulted-2: TestDefaulted(_a: 3, _b: 4)
 // CHECK-NEXT: test-defaulted-class: ("<<default>>", 1)
+
+func test_init_accessors_without_setters() {
+  struct TestStruct<T> {
+    var _x: T
+
+    var x: T {
+      init(initialValue) initializes(_x) {
+        _x = initialValue
+      }
+
+      get { _x }
+    }
+
+    init(value: T) {
+      x = value
+    }
+  }
+
+  let test1 = TestStruct(value: 42)
+  print("test-without-setter1: \(test1.x)")
+
+  class Base<T: Collection> {
+    private var _v: T
+
+    var data: T {
+      init(initialValue) initializes(_v) {
+        _v = initialValue
+      }
+
+      get { _v }
+    }
+
+    init(data: T) {
+      self.data = data
+    }
+  }
+
+  let test2 = Base(data: [1, 2, 3])
+  print("test-without-setter2: \(test2.data)")
+
+  class Sub<U> : Base<U> where U: Collection, U.Element == String {
+    init(other: U) {
+      super.init(data: other)
+    }
+  }
+
+  let test3 = Sub(other: ["a", "b", "c"])
+  print("test-without-setter3: \(test3.data)")
+}
+
+test_init_accessors_without_setters()
+// CHECK: test-without-setter1: 42
+// CHECK-NEXT: test-without-setter2: [1, 2, 3]
+// CHECK-NEXT: test-without-setter3: ["a", "b", "c"]

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -179,3 +179,58 @@ class TestInitWithGuard {
     self.pair2 = (a, b)
   }
 }
+
+do {
+  class Base<T: Collection> {
+    private var _v: T
+
+    var data: T {
+      init(initialValue) initializes(_v) {
+        _v = initialValue
+      }
+
+      get { _v }
+    }
+
+    init(data: T) {
+      self.data = data
+    }
+
+    init(reinit: T) {
+      self.data = reinit
+      self.data = reinit // expected-error {{immutable value 'data' may only be initialized once}}
+    }
+  }
+
+  class Sub<U> : Base<U> where U: Collection, U.Element == String {
+    init(other: U) {
+      super.init(data: other)
+    }
+
+    init(error: U) {
+      super.init(data: error)
+      data = error // expected-error {{immutable value 'data' may only be initialized once}}
+    }
+  }
+
+  // Make sure that re-initialization is not allowed when there is no setter.
+  struct TestPartialWithoutSetter {
+    var _a: Int
+
+    var a: Int {
+      init(initialValue) initializes(_a) {
+        self._a = initialValue
+      }
+
+      get { _a }
+    }
+
+    var b: Int
+
+    init(v: Int) {
+      self.a = v
+      self.a = v // expected-error {{immutable value 'a' may only be initialized once}}
+      self.b = v
+    }
+  }
+}

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -465,3 +465,59 @@ func test_default_arguments_are_analyzed() {
     }
   }
 }
+
+struct TestStructPropWithoutSetter {
+  var _x: Int
+
+  var x: Int {
+    init(initialValue) initializes(_x) {
+      self._x = initialValue
+    }
+
+    get { _x }
+  }
+
+  init(v: Int) {
+    x = v // Ok
+  }
+}
+
+extension TestStructPropWithoutSetter {
+  init(other: Int) {
+    x = other // Ok
+  }
+
+  init(other: inout TestStructPropWithoutSetter, v: Int) {
+    other.x = v // expected-error {{cannot assign to property: 'x' is immutable}}
+  }
+}
+
+do {
+  class TestClassPropWithoutSetter {
+    var x: Int {
+      init {
+      }
+
+      get { 0 }
+    }
+  }
+
+  class SubTestPropWithoutSetter : TestClassPropWithoutSetter {
+    init(otherV: Int) {
+      x = otherV // Ok
+    }
+  }
+
+  class OtherWithoutSetter<U> {
+    var data: U {
+      init {
+      }
+
+      get { fatalError() }
+    }
+
+    init(data: U) {
+      self.data = data // Ok
+    }
+  }
+}


### PR DESCRIPTION
- Allow mutation of init accessor properties without setters in initializer context when the base is `self`.
- Factor out `assign_or_init` emission for init accessors into `InitAccessorComponent` 
- Add new `InitAccessor` write strategy for init accessor properties without setters
- Adjust DI to detect and reject re-initialization if init accessor property doesn't have a setter (such properties behave like `let` properties).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
