### PR TITLE
[5.9] [Macros] Enable freestanding macros at module scope in script mode

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8446,7 +8446,7 @@ class MissingDecl : public Decl {
   /// \c unexpandedMacro contains the macro reference and the base declaration
   /// where the macro expansion applies.
   struct {
-    llvm::PointerUnion<MacroExpansionDecl *, CustomAttr *> macroRef;
+    llvm::PointerUnion<FreestandingMacroExpansion *, CustomAttr *> macroRef;
     Decl *baseDecl;
   } unexpandedMacro;
 
@@ -8470,7 +8470,7 @@ public:
 
   static MissingDecl *
   forUnexpandedMacro(
-      llvm::PointerUnion<MacroExpansionDecl *, CustomAttr *> macroRef,
+      llvm::PointerUnion<FreestandingMacroExpansion *, CustomAttr *> macroRef,
       Decl *baseDecl) {
     auto &ctx = baseDecl->getASTContext();
     auto *dc = baseDecl->getDeclContext();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7173,9 +7173,6 @@ ERROR(literal_type_in_macro_expansion,none,
 ERROR(invalid_macro_introduced_name,none,
       "declaration name %0 is not covered by macro %1",
       (DeclName, DeclName))
-ERROR(global_freestanding_macro_script,none,
-      "global freestanding macros not yet supported in script mode",
-      ())
 ERROR(invalid_macro_role_for_macro_syntax,none,
       "invalid macro role for %{a freestanding|an attached}0 macro",
       (unsigned))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -408,7 +408,25 @@ void Decl::visitAuxiliaryDecls(
   }
 
   if (visitFreestandingExpanded) {
-    if (auto *med = dyn_cast<MacroExpansionDecl>(mutableThis)) {
+    Decl *thisDecl = mutableThis;
+
+    // If this is a top-level code decl consisting of a macro expansion
+    // expression that substituted with a macro expansion declaration, use
+    // that instead.
+    if (auto *tlcd = dyn_cast<TopLevelCodeDecl>(thisDecl)) {
+      if (auto body = tlcd->getBody()) {
+        if (body->getNumElements() == 1) {
+          if (auto expr = body->getFirstElement().dyn_cast<Expr *>()) {
+            if (auto expansion = dyn_cast<MacroExpansionExpr>(expr)) {
+              if (auto substitute = expansion->getSubstituteDecl())
+                thisDecl = substitute;
+            }
+          }
+        }
+      }
+    }
+
+    if (auto *med = dyn_cast<MacroExpansionDecl>(thisDecl)) {
       if (auto bufferID = evaluateOrDefault(
               ctx.evaluator, ExpandMacroExpansionDeclRequest{med}, {})) {
         auto startLoc = sourceMgr.getLocForBufferStart(*bufferID);
@@ -10482,6 +10500,45 @@ bool swift::isMacroSupported(MacroRole role, ASTContext &ctx) {
 void MissingDecl::forEachMacroExpandedDecl(MacroExpandedDeclCallback callback) {
   auto macroRef = unexpandedMacro.macroRef;
   auto *baseDecl = unexpandedMacro.baseDecl;
+
+  // If the macro itself is a macro expansion expression, it should come with
+  // a top-level code declaration that we can use for resolution. For such
+  // cases, resolve the macro to determine whether it is a declaration or
+  // code-item macro, meaning that it can produce declarations. In such cases,
+  // expand the macro and use its substituted declaration (a MacroExpansionDecl)
+  // instead.
+  if (auto freestanding = macroRef.dyn_cast<FreestandingMacroExpansion *>()) {
+    if (auto expr = dyn_cast<MacroExpansionExpr>(freestanding)) {
+      bool replacedWithDecl = false;
+      if (auto tlcd = dyn_cast_or_null<TopLevelCodeDecl>(baseDecl)) {
+        ASTContext &ctx = tlcd->getASTContext();
+        if (auto macro = evaluateOrDefault(
+                ctx.evaluator,
+                ResolveMacroRequest{macroRef, tlcd->getDeclContext()},
+                nullptr)) {
+          auto macroDecl = cast<MacroDecl>(macro.getDecl());
+          auto roles = macroDecl->getMacroRoles();
+          if (roles.contains(MacroRole::Declaration) ||
+              roles.contains(MacroRole::CodeItem)) {
+            (void)evaluateOrDefault(ctx.evaluator,
+                                    ExpandMacroExpansionExprRequest{expr},
+                                    llvm::None);
+            if (auto substituted = expr->getSubstituteDecl()) {
+              macroRef = substituted;
+              baseDecl = substituted;
+              replacedWithDecl = true;
+            }
+          }
+        }
+      }
+
+      // If we didn't end up replacing the macro expansion expression with
+      // a declaration, we're done.
+      if (!replacedWithDecl)
+        return;
+    }
+  }
+
   if (!macroRef || !baseDecl)
     return;
   auto *module = getModuleContext();
@@ -10492,9 +10549,12 @@ void MissingDecl::forEachMacroExpandedDecl(MacroExpandedDeclCallback callback) {
         : auxiliaryDecl->getInnermostDeclContext()->getParentSourceFile();
     // We only visit auxiliary decls that are macro expansions associated with
     // this macro reference.
-    if (auto *med = macroRef.dyn_cast<MacroExpansionDecl *>()) {
-     if (med != sf->getMacroExpansion().dyn_cast<Decl *>())
-       return;
+    if (auto *med = macroRef.dyn_cast<FreestandingMacroExpansion *>()) {
+      auto medAsDecl = dyn_cast<MacroExpansionDecl>(med);
+      auto medAsExpr = dyn_cast<MacroExpansionExpr>(med);
+      if ((!medAsDecl || medAsDecl != sf->getMacroExpansion().dyn_cast<Decl *>()) &&
+          (!medAsExpr || medAsExpr != sf->getMacroExpansion().dyn_cast<Expr *>()))
+        return;
     } else if (auto *attr = macroRef.dyn_cast<CustomAttr *>()) {
      if (attr != sf->getAttachedMacroAttribute())
        return;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3932,11 +3932,5 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
       !roles.contains(MacroRole::CodeItem))
     return None;
 
-  // For now, restrict global freestanding macros in script mode.
-  if (dc->isModuleScopeContext() &&
-      dc->getParentSourceFile()->isScriptMode()) {
-    MED->diagnose(diag::global_freestanding_macro_script);
-  }
-
   return expandFreestandingMacro(MED);
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -471,8 +471,7 @@ ExpandMacroExpansionExprRequest::evaluate(Evaluator &evaluator,
   else if (macro->getMacroRoles().contains(MacroRole::Declaration) ||
            macro->getMacroRoles().contains(MacroRole::CodeItem)) {
     if (!mee->getSubstituteDecl()) {
-      auto *med = mee->createSubstituteDecl();
-      TypeChecker::typeCheckDecl(med);
+      (void)mee->createSubstituteDecl();
     }
     // Return the expanded buffer ID.
     return evaluateOrDefault(

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -335,14 +335,11 @@ let blah = false
 #endif
 
 // Test unqualified lookup from within a macro expansion
-// FIXME: Global freestanding macros not yet supported in script mode.
-#if false
 let world = 3 // to be used by the macro expansion below
 #structWithUnqualifiedLookup()
 _ = StructWithUnqualifiedLookup().foo()
 
 #anonymousTypes { "hello" }
-#endif
 
 func testFreestandingMacroExpansion() {
   // Explicit structs to force macros to be parsed as decl.


### PR DESCRIPTION
Eliminate the error message

    error: global freestanding macros not yet supported in script mode

by implementing name lookup, type checking, and code emission for freestanding macros. The key problem here is that, in script mode, it is ambiguous whether a use of a freestanding macro is an expression or a declaration. We parse as an expression (as we do within a function body), which then gets wrapped in a top-level code declaration.

Teach various parts of the compiler to look through a top-level code declaration wrapping a macro expansion expression that is for a declaration or code-item macro, e.g., by recording these for global name lookup and treating their expansions as "auxiliary" declarations.

Fixes rdar://109699501.
