### PR TITLE
[cxx-interop] Tweak C++ type semantics detection

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -306,13 +306,8 @@ enum class CxxRecordSemanticsKind {
   MoveOnly,
   Reference,
   Iterator,
-  // An API that has be annotated as explicitly unsafe, but still importable.
-  // TODO: we should rename these APIs.
-  ExplicitlyUnsafe,
   // A record that is either not copyable or not destructible.
   MissingLifetimeOperation,
-  // A record that contains a pointer (aka non-trivial type).
-  UnsafePointerMember,
   // A C++ record that represents a Swift class type exposed to C++ from Swift.
   SwiftClassType
 };

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6712,10 +6712,6 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
     return CxxRecordSemanticsKind::MissingLifetimeOperation;
   }
 
-  if (hasUnsafeAPIAttr(cxxDecl)) {
-    return CxxRecordSemanticsKind::ExplicitlyUnsafe;
-  }
-
   if (hasOwnedValueAttr(cxxDecl)) {
     return CxxRecordSemanticsKind::Owned;
   }
@@ -6724,11 +6720,6 @@ CxxRecordSemantics::evaluate(Evaluator &evaluator,
     return CxxRecordSemanticsKind::Iterator;
   }
   
-  if (!hasCustomCopyOrMoveConstructor(cxxDecl) &&
-      hasPointerInSubobjects(cxxDecl)) {
-    return CxxRecordSemanticsKind::UnsafePointerMember;
-  }
-
   if (hasCopyTypeOperations(cxxDecl)) {
     return CxxRecordSemanticsKind::Owned;
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4073,9 +4073,6 @@ void MissingMemberFailure::diagnoseUnsafeCxxMethod(SourceLoc loc,
                              name.getBaseIdentifier().str());
           ctx.Diags.diagnose(loc, diag::iterator_potentially_unsafe);
         } else {
-          assert(methodSemantics ==
-                 CxxRecordSemanticsKind::UnsafePointerMember);
-
           auto baseSwiftLoc = ctx.getClangModuleLoader()->importSourceLocation(
               cxxRecord->getLocation());
 

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -112,6 +112,20 @@ struct StructWithSubobjectPrivateDefaultedDestructor {
   StructWithPrivateDefaultedDestructor subobject;
 };
 
+struct StructWithDeletedCopyConstructor {
+  StructWithDeletedCopyConstructor(
+      const StructWithDeletedCopyConstructor &other) = delete;
+};
+
+struct StructWithMoveConstructorAndDeletedCopyConstructor {
+  StructWithMoveConstructorAndDeletedCopyConstructor() {}
+  StructWithMoveConstructorAndDeletedCopyConstructor(
+      const StructWithMoveConstructorAndDeletedCopyConstructor &other) = delete;
+  StructWithMoveConstructorAndDeletedCopyConstructor(
+      StructWithMoveConstructorAndDeletedCopyConstructor &&other) {}
+  ~StructWithMoveConstructorAndDeletedCopyConstructor(){};
+};
+
 struct StructWithDeletedDestructor {
   ~StructWithDeletedDestructor() = delete;
 };
@@ -146,6 +160,22 @@ struct StructNonCopyableTriviallyMovable {
   StructNonCopyableTriviallyMovable &
   operator=(StructNonCopyableTriviallyMovable &&) = default;
   ~StructNonCopyableTriviallyMovable() = default;
+};
+
+/// Similar to std::unique_ptr
+struct StructWithPointerNonCopyableTriviallyMovable {
+  int *ptr = nullptr;
+
+  StructWithPointerNonCopyableTriviallyMovable() = default;
+  StructWithPointerNonCopyableTriviallyMovable(
+      const StructWithPointerNonCopyableTriviallyMovable &other) = delete;
+  StructWithPointerNonCopyableTriviallyMovable(
+      StructWithPointerNonCopyableTriviallyMovable &&other) = default;
+  ~StructWithPointerNonCopyableTriviallyMovable() = default;
+};
+
+struct StructWithPointerNonCopyableTriviallyMovableField {
+  StructWithPointerNonCopyableTriviallyMovable p = {};
 };
 
 struct StructNonCopyableNonMovable {

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -6,6 +6,8 @@
 // CHECK-NOT: StructWithInheritedPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructNonCopyableTriviallyMovable
+// CHECK-NOT: StructWithPointerNonCopyableTriviallyMovable
+// CHECK-NOT: StructWithPointerNonCopyableTriviallyMovableField
 // CHECK-NOT: StructNonCopyableNonMovable
 // CHECK-NOT: StructWithMoveConstructor
 // CHECK-NOT: StructWithInheritedMoveConstructor
@@ -16,6 +18,8 @@
 // CHECK-NOT: StructWithPrivateDefaultedDestructor
 // CHECK-NOT: StructWithInheritedPrivateDefaultedDestructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedDestructor
+// CHECK-NOT: StructWithDeletedCopyConstructor
+// CHECK-NOT: StructWithMoveConstructorAndDeletedCopyConstructor
 // CHECK-NOT: StructWithDeletedDestructor
 // CHECK-NOT: StructWithInheritedDeletedDestructor
 // CHECK-NOT: StructWithSubobjectDeletedDestructor


### PR DESCRIPTION
`CxxRecordSemanticsKind::ExplicitlyUnsafe` and `CxxRecordSemanticsKind::UnsafePointerMember` were never directly used, and those do not indicate semantics: they indicate safety of the type when used from Swift, which should be handled by another request `IsSafeUseOfCxxDecl` instead of `CxxRecordSemantics`.

Having `ExplicitlyUnsafe` and `UnsafePointerMember` as semantics indicators was problematic, for instance, for types that are move-only and store a pointer at the same time. Swift allowed the usage of these types (under the rules for `UnsafePointerMember` types) when move-only types are disabled, and did not apply the move-only attribute on such types when move-only types are enabled.

rdar://110644300