### PR TITLE
🍒[5.9][Distributed] Handle composite type in generic bound in distributed accessor 

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -616,6 +616,8 @@ void DistributedAccessor::emit() {
 
   auto params = IGF.collectParameters();
 
+  GenericContextScope scope(IGM, targetTy->getInvocationGenericSignature());
+
   auto directResultTy = targetConv.getSILResultType(expansionContext);
   const auto &directResultTI = IGM.getTypeInfo(directResultTy);
 
@@ -651,8 +653,6 @@ void DistributedAccessor::emit() {
 
   // Witness table for decoder conformance to DistributedTargetInvocationDecoder
   auto *decoderProtocolWitness = params.claimNext();
-
-  GenericContextScope scope(IGM, targetTy->getInvocationGenericSignature());
 
   // Preliminary: Setup async context for this accessor.
   {

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -12,3 +12,27 @@ public distributed actor MyActor {
   public typealias ActorSystem = LocalTestingDistributedActorSystem
   // nothing
 }
+
+public protocol Kappa {}
+
+/// This combination of DistributedActor + Codable used to trigger a crash in DistributedAccessor::emit (rdar://111664985)
+/// So returning it from distributed methods in the types below covers this radar.
+public protocol ClusterSingleton: DistributedActor, Codable {}
+
+@available(SwiftStdlib 5.6, *)
+public distributed actor MyActorGenerics {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  distributed func find<Act: ClusterSingleton>(byName name: String) -> Act {
+    fatalError("mock impl")
+  }
+}
+
+@available(SwiftStdlib 5.6, *)
+public distributed actor MyActorGenericsOnType<Act: ClusterSingleton> {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  distributed func find(byName name: String) -> Act {
+    fatalError("mock impl")
+  }
+}

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -13,8 +13,6 @@ public distributed actor MyActor {
   // nothing
 }
 
-public protocol Kappa {}
-
 /// This combination of DistributedActor + Codable used to trigger a crash in DistributedAccessor::emit (rdar://111664985)
 /// So returning it from distributed methods in the types below covers this radar.
 public protocol ClusterSingleton: DistributedActor, Codable {}


### PR DESCRIPTION
**Description:** It seems a distributed accessor's emit fails for `DistributedActor & Somethign`, the crash is in `IGM.getTypeInfo(directResultTy);` because the method does not have access to a generic context; The solution is to provide it earlier during emit rather than later as we did before.
**See Also:** Resolves a FIXME in distributed cluster: https://github.com/apple/swift-distributed-actors/pull/1127/files#diff-7da4ba0dfda5902083a859fdf6d209fb5902d4926b6bee24fa7eee420b84b4e3R231
**Risk:** Low, only moves the generic scope a few lines earlier, since we use it there already
**Reviewed by**: @xedin @drexin  (original PR)
**Original PR:** https://github.com/apple/swift/pull/67117
**Testing:** CI testing
**Radar:** rdar://111664985
Resolves: https://github.com/apple/swift/issues/67090