### PR TITLE
stdlib/benchmark: add `canImport(Musl)` where needed

### DIFF
--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/benchmark/single-source/Radix2CooleyTukey.swift
+++ b/benchmark/single-source/Radix2CooleyTukey.swift
@@ -2,8 +2,10 @@
 //
 // Originally written by @owensd. Used with his permission.
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/benchmark/single-source/StringEdits.swift
+++ b/benchmark/single-source/StringEdits.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/benchmark/single-source/StringMatch.swift
+++ b/benchmark/single-source/StringMatch.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/benchmark/single-source/Walsh.swift
+++ b/benchmark/single-source/Walsh.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import MSVCRT
 #else

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -43,6 +43,8 @@ import SwiftPrivateThreadExtras
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -16,6 +16,8 @@ import SwiftPrivateLibcExtras
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -22,6 +22,8 @@ import Foundation
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -19,6 +19,9 @@ let (platform_read, platform_write, platform_close) = (read, write, close)
 #elseif canImport(Glibc)
 import Glibc
 let (platform_read, platform_write, platform_close) = (read, write, close)
+#elseif canImport(Musl)
+import Musl
+let (platform_read, platform_write, platform_close) = (read, write, close)
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -15,6 +15,8 @@ import SwiftPrivate
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -15,6 +15,8 @@ import SwiftPrivate
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -19,6 +19,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)
@@ -69,7 +71,7 @@ public typealias ThreadHandle = HANDLE
 #else
 public typealias ThreadHandle = pthread_t
 
-#if os(Linux) || os(Android)
+#if (os(Linux) && !canImport(Musl)) || os(Android)
 internal func _make_pthread_t() -> pthread_t {
   return pthread_t()
 }

--- a/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/ThreadBarriers.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(WASI)
 import WASILibc
 #elseif os(Windows)

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -127,7 +127,11 @@ internal func getImageCount() -> UInt32 {
 let rtldDefault = UnsafeMutableRawPointer(bitPattern: Int(-2))
 #elseif !os(Windows)
 import SwiftShims
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 
 let rtldDefault: UnsafeMutableRawPointer? = nil
 

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -16,6 +16,8 @@ import Swift
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   import Darwin.C.tgmath
+#elseif canImport(Musl)
+  import Musl
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
 #elseif os(WASI)

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -16,6 +16,8 @@ import Swift
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif os(Windows)
 import WinSDK
 #endif


### PR DESCRIPTION
This allows compiling stdlib and benchmarks when targeting musl instead of Glibc.
