### PR TITLE
[AutoDiff] Check @noDerivative for function type comparison

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3505,6 +3505,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         return getTypeMatchFailure(argumentLocator);
       }
 
+      // If functions are differentiable, ensure that @noDerivative is not
+      // discarded.
+      if (func1->isDifferentiable() && func2->isDifferentiable() &&
+          func1Param.isNoDerivative() && !func2Param.isNoDerivative()) {
+        return getTypeMatchFailure(argumentLocator);
+      }
+
       // FIXME: We should check value ownership too, but it's not completely
       // trivial because of inout-to-pointer conversions.
 

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -741,6 +741,7 @@ struct TF_675 : Differentiable {
 let _: @differentiable(reverse) (Float) -> Float = TF_675().method
 
 // TF-918: Test parameter subset thunk + partially-applied original function.
+let _: @differentiable(reverse) (Float, @noDerivative Float) -> Float = (+) as @differentiable(reverse) (Float, Float) -> Float
 let _: @differentiable(reverse) (Float, @noDerivative Float) -> Float = (+) as @differentiable(reverse) (Float, @noDerivative Float) -> Float
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -741,7 +741,7 @@ struct TF_675 : Differentiable {
 let _: @differentiable(reverse) (Float) -> Float = TF_675().method
 
 // TF-918: Test parameter subset thunk + partially-applied original function.
-let _: @differentiable(reverse) (Float, Float) -> Float = (+) as @differentiable(reverse) (Float, @noDerivative Float) -> Float
+let _: @differentiable(reverse) (Float, @noDerivative Float) -> Float = (+) as @differentiable(reverse) (Float, @noDerivative Float) -> Float
 
 //===----------------------------------------------------------------------===//
 // Differentiation in fragile functions

--- a/test/Constraints/noderivative.swift
+++ b/test/Constraints/noderivative.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+import _Differentiation
+
+// Allow Type -> @noDerivative Type
+//
+func test1(_ foo: @escaping @differentiable(reverse) (Float, Float) -> Float) {
+    let fn: @differentiable(reverse) (Float, @noDerivative Float) -> Float = foo
+    _ = fn(0, 0)
+}
+
+// Allow @noDerivative Type -> Type when LHS function is not differentiable
+//
+func test2(_ foo: @escaping @differentiable(reverse) (Float, @noDerivative Float) -> Float) {
+    let fn: (Float, Float) -> Float = foo
+    _ = fn(0, 0)
+}
+
+// Disallow @noDerivative Type -> Type when LHS function is also differentiable
+//
+func test3(_ foo: @escaping @differentiable(reverse) (Float, @noDerivative Float) -> Float) {
+    // expected-error @+1 {{cannot convert value of type '@differentiable(reverse) (Float, @noDerivative Float) -> Float' to specified type '@differentiable(reverse) (Float, Float) -> Float'}}
+    let fn: @differentiable(reverse) (Float, Float) -> Float = foo
+    _ = fn(0, 0)
+}


### PR DESCRIPTION
As described in the issue #62922, the compiler should not allow to discard `@noDerivative` attribute and keep `@differentiable`. The patch adds a diagnostic for this case.

`differentiation_diagnostics.swift` LIT test already had this pattern, but I was unable to add an `expected-error` for it, because the compiler exits early and does not emit other diagnostics in this file.

Resolves #62922.