### PR TITLE
[5.9 🍒][Compile Time Constant Extraction] Refactor collection of opaque type requirements

### DIFF
--- a/test/ConstExtraction/ExtractOpaqueGenericTypealias.swift
+++ b/test/ConstExtraction/ExtractOpaqueGenericTypealias.swift
@@ -1,0 +1,57 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/includes)
+// RUN: echo "[myProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -typecheck -emit-const-values-path %t/ExtractOpaqueGenericTypealias.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s -I %t/includes
+// RUN: cat %t/ExtractOpaqueGenericTypealias.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol myProto {
+    associatedtype T
+    func foo() -> T
+}
+
+protocol protoA<T> {
+    associatedtype T
+}
+
+struct A<K> : protoA {
+    typealias T = K
+}
+
+struct Foo<L : Hashable> : myProto {
+    func foo() -> some protoA<Int> { return A() }
+    func bar(_ param : L) {}
+}
+
+// CHECK: [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "typeName": "ExtractOpaqueGenericTypealias.Foo<L>",
+// CHECK-NEXT:     "mangledTypeName": "29ExtractOpaqueGenericTypealias3FooVyxG",
+// CHECK-NEXT:     "kind": "generic struct",
+// CHECK-NEXT:     "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractOpaqueGenericTypealias.swift",
+// CHECK-NEXT:     "line": 22,
+// CHECK-NEXT:     "conformances": [
+// CHECK-NEXT:       "ExtractOpaqueGenericTypealias.myProto",
+// CHECK-NEXT:       "Swift.Sendable"
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "associatedTypeAliases": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "typeAliasName": "T",
+// CHECK-NEXT:         "substitutedTypeName": "some ExtractOpaqueGenericTypealias.protoA<Swift.Int>",
+// CHECK-NEXT:         "substitutedMangledTypeName": "29ExtractOpaqueGenericTypealias3FooV3fooQryFQOyx_Qo_",
+// CHECK-NEXT:         "opaqueTypeProtocolRequirements": [
+// CHECK-NEXT:           "ExtractOpaqueGenericTypealias.protoA"
+// CHECK-NEXT:         ],
+// CHECK-NEXT:         "opaqueTypeSameTypeRequirements": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "typeAliasName": "ExtractOpaqueGenericTypealias.protoA.T",
+// CHECK-NEXT:             "substitutedTypeName": "Swift.Int",
+// CHECK-NEXT:             "substitutedMangledTypeName": "Si"
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "properties": []
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/test/ConstExtraction/ExtractOpaqueTypealias.swift
+++ b/test/ConstExtraction/ExtractOpaqueTypealias.swift
@@ -56,14 +56,14 @@ private func baz() -> some protoA<testModBStruct> & protoB<Float> & testModBProt
 // CHECK-NEXT:        ],
 // CHECK-NEXT:        "opaqueTypeSameTypeRequirements": [
 // CHECK-NEXT:          {
-// CHECK-NEXT:            "typeAliasName": "ExtractOpaqueTypealias.protoA.T",
-// CHECK-NEXT:            "substitutedTypeName": "testModB.testModBStruct",
-// CHECK-NEXT:            "substitutedMangledTypeName": "8testModB0aB7BStructV"
-// CHECK-NEXT:          },
-// CHECK-NEXT:          {
 // CHECK-NEXT:            "typeAliasName": "ExtractOpaqueTypealias.protoB.K",
 // CHECK-NEXT:            "substitutedTypeName": "Swift.Float",
 // CHECK-NEXT:            "substitutedMangledTypeName": "Sf"
+// CHECK-NEXT:          }
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "typeAliasName": "ExtractOpaqueTypealias.protoA.T",
+// CHECK-NEXT:            "substitutedTypeName": "testModB.testModBStruct",
+// CHECK-NEXT:            "substitutedMangledTypeName": "8testModB0aB7BStructV"
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ]
 // CHECK-NEXT:      }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/67034
----------------------------------------
**• Release**: 5.9
**• Explanation**: To reduce duplication of logic with other parts of the compiler, instead of destructuring the constraint type, write the requirements in the opaque type declaration's generic signature. This also carries a functional fix of correctly aligning the type alias name with the corresponding type witness, instead of attempting to align those from different sources. 
**• Reviewed by**: @slavapestov 
**• Scope of Issue**: Incorrect mapping of opaque return type type alias same-type requirements to the corresponding protocol associated type label may lead to incorrect values in the extracted metadata. 
**• Risk**: Low. This change is a refactor and a fix to the additional metadata gathered (added in https://github.com/apple/swift/pull/66781). As such, it does not affect compilation which does not request extraction of metadata conformances. For compilation that does request extraction of metadata conformances, the change is small in scope and replaces a fragile code-path with one that should be much more robust.
**• Testing**: Automated tests added to the compiler test suite.