### PR TITLE
Runtime demangler support for pack expansions

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -124,8 +124,6 @@ public:
 
   Type createSILPackType(ArrayRef<Type> eltTypes, bool isElementAddress);
 
-  Type createPackExpansionType(Type patternType, Type countType);
-
   size_t beginPackExpansion(Type countType);
 
   void advancePackExpansion(size_t index);

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -64,12 +64,20 @@ class ASTBuilder {
   /// is a pack or not, so we have to find it here.
   GenericSignature GenericSig;
 
+  /// This builder doesn't perform "on the fly" substitutions, so we preserve
+  /// all pack expansions. We still need an active expansion stack though,
+  /// for the dummy implementation of these methods:
+  /// - beginPackExpansion()
+  /// - advancePackExpansion()
+  /// - createExpandedPackElement()
+  /// - endPackExpansion()
+  llvm::SmallVector<Type> ActivePackExpansions;
+
 public:
   using BuiltType = swift::Type;
   using BuiltTypeDecl = swift::GenericTypeDecl *; // nominal or type alias
   using BuiltProtocolDecl = swift::ProtocolDecl *;
   using BuiltGenericSignature = swift::GenericSignature;
-  using BuiltGenericTypeParam = swift::GenericTypeParamType *;
   using BuiltRequirement = swift::Requirement;
   using BuiltSubstitutionMap = swift::SubstitutionMap;
 
@@ -117,6 +125,14 @@ public:
   Type createSILPackType(ArrayRef<Type> eltTypes, bool isElementAddress);
 
   Type createPackExpansionType(Type patternType, Type countType);
+
+  size_t beginPackExpansion(Type countType);
+
+  void advancePackExpansion(size_t index);
+
+  Type createExpandedPackElement(Type patternType);
+
+  void endPackExpansion();
 
   Type createFunctionType(
       ArrayRef<Demangle::FunctionParam<Type>> params,

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -110,7 +110,7 @@ public:
   Type createBoundGenericType(GenericTypeDecl *decl, ArrayRef<Type> args,
                               Type parent);
 
-  Type createTupleType(ArrayRef<Type> eltTypes, StringRef labels);
+  Type createTupleType(ArrayRef<Type> eltTypes, ArrayRef<StringRef> labels);
 
   Type createPackType(ArrayRef<Type> eltTypes);
 

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1106,16 +1106,8 @@ protected:
     }
 
     case NodeKind::PackExpansion: {
-      if (Node->getNumChildren() < 2)
-        return MAKE_NODE_TYPE_ERROR(Node,
-                                    "fewer children (%zu) than required (2)",
-                                    Node->getNumChildren());
-
-      auto patternType = decodeMangledType(Node->getChild(0), depth + 1);
-      auto countType = decodeMangledType(Node->getChild(1), depth + 1);
-
-      return Builder.createPackExpansionType(patternType.getType(),
-                                             countType.getType());
+      return MAKE_NODE_TYPE_ERROR0(Node,
+                                   "pack expansion type in unsupported position");
     }
 
     case NodeKind::DependentGenericType: {

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -478,7 +478,6 @@ class TypeDecoder {
   using BuiltSubstitution = typename BuilderType::BuiltSubstitution;
   using BuiltRequirement = typename BuilderType::BuiltRequirement;
   using BuiltLayoutConstraint = typename BuilderType::BuiltLayoutConstraint;
-  using BuiltGenericTypeParam = typename BuilderType::BuiltGenericTypeParam;
   using BuiltGenericSignature = typename BuilderType::BuiltGenericSignature;
   using BuiltSubstitutionMap = typename BuilderType::BuiltSubstitutionMap;
   using NodeKind = Demangle::Node::Kind;
@@ -886,10 +885,11 @@ protected:
 
       bool hasParamFlags = false;
       llvm::SmallVector<FunctionParam<BuiltType>, 8> parameters;
-      if (!decodeMangledFunctionInputType(Node->getChild(firstChildIdx),
-                                          depth + 1, parameters, hasParamFlags))
-        return MAKE_NODE_TYPE_ERROR0(Node->getChild(firstChildIdx),
-                                     "failed to decode function type");
+      auto optError = decodeMangledFunctionInputType(Node->getChild(firstChildIdx),
+                                                     depth + 1, parameters, hasParamFlags);
+      if (optError)
+        return *optError;
+
       flags =
           flags.withNumParameters(parameters.size())
               .withParameterFlags(hasParamFlags)
@@ -1034,24 +1034,31 @@ protected:
           return MAKE_NODE_TYPE_ERROR0(element->getChild(typeChildIndex),
                                        "no children");
         }
-        if (element->getChild(typeChildIndex)->getKind() == NodeKind::TupleElementName) {
-          labels.push_back(element->getChild(typeChildIndex)->getText());
-          typeChildIndex++;
 
-        // Otherwise, add an empty label.
-        } else {
-          labels.push_back(StringRef());
+        StringRef label;
+        if (element->getChild(typeChildIndex)->getKind() == NodeKind::TupleElementName) {
+          label = element->getChild(typeChildIndex)->getText();
+          typeChildIndex++;
         }
 
         // Decode the element type.
-        auto elementType =
-            decodeMangledType(element->getChild(typeChildIndex), depth + 1,
-                              /*forRequirement=*/false);
-        if (elementType.isError())
-          return elementType;
-
-        elements.push_back(elementType.getType());
+        auto optError = decodeTypeSequenceElement(
+            element->getChild(typeChildIndex), depth + 1,
+            [&](BuiltType type) {
+              elements.push_back(type);
+              labels.push_back(label);
+            });
+        if (optError)
+          return *optError;
       }
+
+      // Unwrap one-element tuples.
+      //
+      // FIXME: The behavior of one-element labeled tuples is inconsistent throughout
+      // the different re-implementations of type substitution and pack expansion.
+      // if (elements.size() == 1)
+      //  return elements[0];
+
       return Builder.createTupleType(elements, labels);
     }
     case NodeKind::TupleElement:
@@ -1077,12 +1084,13 @@ protected:
 
       for (auto &element : *Node) {
         // Decode the element type.
-        auto elementType =
-            decodeMangledType(element, depth + 1, /*forRequirement=*/false);
-        if (elementType.isError())
-          return elementType;
-
-        elements.push_back(elementType.getType());
+        auto optError = decodeTypeSequenceElement(
+            element, depth + 1,
+            [&](BuiltType elementType) {
+              elements.push_back(elementType);
+            });
+        if (optError)
+          return *optError;
       }
 
       switch (Node->getKind()) {
@@ -1259,9 +1267,9 @@ return {}; // Not Implemented!
                                            /*forRequirement=*/false);
           if (substTy.isError())
             return substTy;
-          substitutions.emplace_back(
-              Builder.createGenericTypeParameterType(paramDepth, index),
-              substTy.getType());
+          auto paramTy = Builder.createGenericTypeParameterType(
+              paramDepth, index);
+          substitutions.emplace_back(paramTy, substTy.getType());
           ++index;
         }
       }
@@ -1364,6 +1372,58 @@ return {}; // Not Implemented!
   }
 
 private:
+  template<typename Fn>
+  llvm::Optional<TypeLookupError>
+  decodeTypeSequenceElement(Demangle::NodePointer node, unsigned depth,
+                            Fn resultCallback) {
+    if (node->getKind() == NodeKind::Type)
+      node = node->getChild(0);
+
+    if (node->getKind() == NodeKind::PackExpansion) {
+      if (node->getNumChildren() < 2)
+        return MAKE_NODE_TYPE_ERROR(node,
+                                    "fewer children (%zu) than required (2)",
+                                    node->getNumChildren());
+
+      auto patternType = node->getChild(0);
+
+      // Decode the shape pack first, to form a metadata pack.
+      auto countType = decodeMangledType(node->getChild(1), depth);
+      if (countType.isError())
+        return *countType.getError();
+
+      // Push the pack expansion on the active expansion stack inside the
+      // builder concept.
+      size_t numElements = Builder.beginPackExpansion(countType.getType());
+
+      for (size_t i = 0; i < numElements; ++i) {
+        // Advance the lane index inside the builder concept.
+        Builder.advancePackExpansion(i);
+
+        // Decode the pattern type, taking the ith element of each pack
+        // referenced therein.
+        auto expandedElementType = decodeMangledType(patternType, depth);
+        if (expandedElementType.isError())
+          return *expandedElementType.getError();
+
+        resultCallback(Builder.createExpandedPackElement(
+            expandedElementType.getType()));
+      }
+
+      // Pop the active expansion stack inside the builder concept.
+      Builder.endPackExpansion();
+    } else {
+      auto elementType =
+          decodeMangledType(node, depth, /*forRequirement=*/false);
+      if (elementType.isError())
+        return *elementType.getError();
+
+      resultCallback(elementType.getType());
+    }
+
+    return llvm::None;
+  }
+
   template <typename T>
   bool decodeImplFunctionPart(Demangle::NodePointer node, unsigned depth,
                               llvm::SmallVectorImpl<T> &results) {
@@ -1527,12 +1587,12 @@ private:
     return Builder.createProtocolDecl(node);
   }
 
-  bool decodeMangledFunctionInputType(
+  llvm::Optional<TypeLookupError> decodeMangledFunctionInputType(
       Demangle::NodePointer node, unsigned depth,
       llvm::SmallVectorImpl<FunctionParam<BuiltType>> &params,
       bool &hasParamFlags) {
     if (depth > TypeDecoder::MaxDepth)
-      return false;
+      return llvm::None;
 
     // Look through a couple of sugar nodes.
     if (node->getKind() == NodeKind::Type ||
@@ -1543,7 +1603,7 @@ private:
 
     auto decodeParamTypeAndFlags =
         [&](Demangle::NodePointer typeNode,
-            FunctionParam<BuiltType> &param) -> bool {
+            FunctionParam<BuiltType> &param) -> llvm::Optional<TypeLookupError> {
       Demangle::NodePointer node = typeNode;
 
       bool recurse = true;
@@ -1592,17 +1652,15 @@ private:
         }
       }
 
-      auto paramType = decodeMangledType(node, depth + 1,
-                                         /*forRequirement=*/false);
-      if (paramType.isError())
-        return false;
-
-      param.setType(paramType.getType());
-      return true;
+      return decodeTypeSequenceElement(node, depth + 1,
+                                       [&](BuiltType paramType) {
+                                         param.setType(paramType);
+                                         params.push_back(param);
+                                       });
     };
 
     auto decodeParam =
-        [&](NodePointer paramNode) -> llvm::Optional<FunctionParam<BuiltType>> {
+        [&](NodePointer paramNode) -> llvm::Optional<TypeLookupError> {
       if (paramNode->getKind() != NodeKind::TupleElement)
         return llvm::None;
 
@@ -1618,40 +1676,41 @@ private:
           hasParamFlags = true;
           break;
 
-        case NodeKind::Type:
-          if (!decodeParamTypeAndFlags(child->getFirstChild(), param))
-            return llvm::None;
+        case NodeKind::Type: {
+          auto optError = decodeParamTypeAndFlags(
+              child->getFirstChild(), param);
+          if (optError)
+            return optError;
           break;
+        }
 
         default:
-          return llvm::None;
+          return TYPE_LOOKUP_ERROR_FMT("unknown node");
         }
       }
 
-      return param;
+      return llvm::None;
     };
 
     // Expand a single level of tuple.
     if (node->getKind() == NodeKind::Tuple) {
       // Decode all the elements as separate arguments.
       for (const auto &elt : *node) {
-        auto param = decodeParam(elt);
-        if (!param)
-          return false;
-
-        params.push_back(std::move(*param));
+        auto optError = decodeParam(elt);
+        if (optError)
+          return *optError;
       }
 
-      return true;
+      return llvm::None;
     }
 
     // Otherwise, handle the type as a single argument.
     FunctionParam<BuiltType> param;
-    if (!decodeParamTypeAndFlags(node, param))
-      return false;
+    auto optError = decodeParamTypeAndFlags(node, param);
+    if (optError)
+      return *optError;
 
-    params.push_back(std::move(param));
-    return true;
+    return llvm::None;
   }
 };
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -179,7 +179,6 @@ public:
   using BuiltRequirement = typename BuilderType::BuiltRequirement;
   using BuiltSubstitution = typename BuilderType::BuiltSubstitution;
   using BuiltSubstitutionMap = typename BuilderType::BuiltSubstitutionMap;
-  using BuiltGenericTypeParam = typename BuilderType::BuiltGenericTypeParam;
   using BuiltGenericSignature = typename BuilderType::BuiltGenericSignature;
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -871,13 +871,26 @@ public:
       }
 
       // Read the labels string.
-      std::string labels;
+      std::string labelStr;
       if (tupleMeta->Labels &&
-          !Reader->readString(RemoteAddress(tupleMeta->Labels), labels))
+          !Reader->readString(RemoteAddress(tupleMeta->Labels), labelStr))
         return BuiltType();
 
+      std::vector<llvm::StringRef> labels;
+      std::string::size_type end, start = 0;
+      while (true) {
+        end = labelStr.find(' ', start);
+        if (end == std::string::npos)
+          break;
+        labels.push_back(llvm::StringRef(labelStr.data() + start, end - start));
+        start = end + 1;
+      }
+      // Pad the vector with empty labels.
+      for (unsigned i = labels.size(); i < elementTypes.size(); ++i)
+        labels.push_back(StringRef());
+
       auto BuiltTuple =
-          Builder.createTupleType(elementTypes, std::move(labels));
+          Builder.createTupleType(elementTypes, labels);
       TypeCache[MetadataAddress] = BuiltTuple;
       return BuiltTuple;
     }

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -364,10 +364,10 @@ public:
 class TupleTypeRef final : public TypeRef {
 protected:
   std::vector<const TypeRef *> Elements;
-  std::vector<StringRef> Labels;
+  std::vector<std::string> Labels;
 
   static TypeRefID Profile(const std::vector<const TypeRef *> &Elements,
-                           const std::vector<StringRef> &Labels) {
+                           const std::vector<std::string> &Labels) {
     TypeRefID ID;
     for (auto Element : Elements)
       ID.addPointer(Element);
@@ -378,20 +378,20 @@ protected:
 
 public:
   TupleTypeRef(std::vector<const TypeRef *> Elements,
-               std::vector<StringRef> Labels)
+               std::vector<std::string> Labels)
       : TypeRef(TypeRefKind::Tuple), Elements(std::move(Elements)),
         Labels(std::move(Labels)) {}
 
   template <typename Allocator>
   static const TupleTypeRef *create(Allocator &A,
                                     std::vector<const TypeRef *> Elements,
-                                    const std::vector<StringRef> Labels) {
+                                    const std::vector<std::string> Labels) {
     FIND_OR_CREATE_TYPEREF(A, TupleTypeRef, Elements, Labels);
   }
 
   const std::vector<const TypeRef *> &getElements() const { return Elements; };
 
-  const std::vector<llvm::StringRef> &getLabels() const { return Labels; }
+  const std::vector<std::string> &getLabels() const { return Labels; }
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Tuple;

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -83,7 +83,7 @@ public:
     Bits.push_back(Integer >> 32);
   }
 
-  void addString(const std::string &String) {
+  void addString(llvm::StringRef String) {
     if (String.empty()) {
       Bits.push_back(0);
     } else {
@@ -364,47 +364,34 @@ public:
 class TupleTypeRef final : public TypeRef {
 protected:
   std::vector<const TypeRef *> Elements;
-  std::string Labels;
+  std::vector<StringRef> Labels;
 
   static TypeRefID Profile(const std::vector<const TypeRef *> &Elements,
-                           const std::string &Labels) {
+                           const std::vector<StringRef> &Labels) {
     TypeRefID ID;
     for (auto Element : Elements)
       ID.addPointer(Element);
-    ID.addString(Labels);
+    for (auto Label : Labels)
+      ID.addString(Label);
     return ID;
   }
 
 public:
-  TupleTypeRef(std::vector<const TypeRef *> Elements, std::string &&Labels)
+  TupleTypeRef(std::vector<const TypeRef *> Elements,
+               std::vector<StringRef> Labels)
       : TypeRef(TypeRefKind::Tuple), Elements(std::move(Elements)),
-        Labels(Labels) {}
+        Labels(std::move(Labels)) {}
 
   template <typename Allocator>
   static const TupleTypeRef *create(Allocator &A,
                                     std::vector<const TypeRef *> Elements,
-                                    std::string &&Labels) {
+                                    const std::vector<StringRef> Labels) {
     FIND_OR_CREATE_TYPEREF(A, TupleTypeRef, Elements, Labels);
   }
 
   const std::vector<const TypeRef *> &getElements() const { return Elements; };
-  const std::string &getLabelString() const { return Labels; };
-  std::vector<llvm::StringRef> getLabels() const {
-    std::vector<llvm::StringRef> Vec;
-    std::string::size_type End, Start = 0;
-    while (true) {
-      End = Labels.find(' ', Start);
-      if (End == std::string::npos)
-        break;
-      Vec.push_back(llvm::StringRef(Labels.data() + Start, End - Start));
-      Start = End + 1;
-    }
-    // A canonicalized TypeRef has an empty label string.
-    // Pad the vector with empty labels.
-    for (unsigned N = Vec.size(); N < Elements.size(); ++N)
-      Vec.push_back({});
-    return Vec;
-  };
+
+  const std::vector<llvm::StringRef> &getLabels() const { return Labels; }
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Tuple;

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -743,8 +743,8 @@ public:
   }
 
   const TupleTypeRef *createTupleType(llvm::ArrayRef<const TypeRef *> elements,
-                                      std::string &&labels) {
-    return TupleTypeRef::create(*this, elements, std::move(labels));
+                                      llvm::ArrayRef<StringRef> labels) {
+    return TupleTypeRef::create(*this, elements, labels);
   }
 
   const TypeRef *createPackType(llvm::ArrayRef<const TypeRef *> elements) {
@@ -825,7 +825,7 @@ public:
       break;
     }
 
-    auto result = createTupleType({}, "");
+    auto result = createTupleType({}, llvm::ArrayRef<llvm::StringRef>());
     return FunctionTypeRef::create(
         *this, {}, result, funcFlags, diffKind, nullptr);
   }

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -744,7 +744,8 @@ public:
 
   const TupleTypeRef *createTupleType(llvm::ArrayRef<const TypeRef *> elements,
                                       llvm::ArrayRef<StringRef> labels) {
-    return TupleTypeRef::create(*this, elements, labels);
+    std::vector<std::string> labelsVec(labels.begin(), labels.end());
+    return TupleTypeRef::create(*this, elements, labelsVec);
   }
 
   const TypeRef *createPackType(llvm::ArrayRef<const TypeRef *> elements) {

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -758,12 +758,6 @@ public:
     return nullptr;
   }
 
-  const TypeRef *createPackExpansionType(const TypeRef *patternType,
-                                         const TypeRef *countType) {
-    // FIXME: Remote mirrors support for variadic generics.
-    return nullptr;
-  }
-
   size_t beginPackExpansion(const TypeRef *countType) {
     // FIXME: Remote mirrors support for variadic generics.
     return 0;

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -764,6 +764,24 @@ public:
     return nullptr;
   }
 
+  size_t beginPackExpansion(const TypeRef *countType) {
+    // FIXME: Remote mirrors support for variadic generics.
+    return 0;
+  }
+
+  void advancePackExpansion(size_t index) {
+    // FIXME: Remote mirrors support for variadic generics.
+  }
+
+  const TypeRef *createExpandedPackElement(const TypeRef *patternType) {
+    // FIXME: Remote mirrors support for variadic generics.
+    return nullptr;
+  }
+
+  void endPackExpansion() {
+    // FIXME: Remote mirrors support for variadic generics.
+  }
+
   const FunctionTypeRef *createFunctionType(
       llvm::ArrayRef<remote::FunctionParam<const TypeRef *>> params,
       const TypeRef *result, FunctionTypeFlags flags,

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -327,18 +327,14 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
   return aliasDecl->getDeclaredInterfaceType().subst(subMap);
 }
 
-Type ASTBuilder::createTupleType(ArrayRef<Type> eltTypes, StringRef labels) {
+Type ASTBuilder::createTupleType(ArrayRef<Type> eltTypes, ArrayRef<StringRef> labels) {
   SmallVector<TupleTypeElt, 4> elements;
   elements.reserve(eltTypes.size());
-  for (auto eltType : eltTypes) {
+  for (unsigned i : indices(eltTypes)) {
     Identifier label;
-    if (!labels.empty()) {
-      auto split = labels.split(' ');
-      if (!split.first.empty())
-        label = Ctx.getIdentifier(split.first);
-      labels = split.second;
-    }
-    elements.emplace_back(eltType, label);
+    if (!labels[i].empty())
+      label = Ctx.getIdentifier(labels[i]);
+    elements.emplace_back(eltTypes[i], label);
   }
 
   return TupleType::get(elements, Ctx);

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -355,10 +355,6 @@ Type ASTBuilder::createSILPackType(ArrayRef<Type> eltTypes,
   return SILPackType::get(Ctx, extInfo, elements);
 }
 
-Type ASTBuilder::createPackExpansionType(Type patternType, Type countType) {
-  return PackExpansionType::get(patternType, countType);
-}
-
 size_t ASTBuilder::beginPackExpansion(Type countType) {
   ActivePackExpansions.push_back(countType);
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -359,6 +359,26 @@ Type ASTBuilder::createPackExpansionType(Type patternType, Type countType) {
   return PackExpansionType::get(patternType, countType);
 }
 
+size_t ASTBuilder::beginPackExpansion(Type countType) {
+  ActivePackExpansions.push_back(countType);
+
+  return 1;
+}
+
+void ASTBuilder::advancePackExpansion(size_t index) {
+  assert(index == 0);
+}
+
+Type ASTBuilder::createExpandedPackElement(Type patternType) {
+  assert(!ActivePackExpansions.empty());
+  auto countType = ActivePackExpansions.back();
+  return PackExpansionType::get(patternType, countType);
+}
+
+void ASTBuilder::endPackExpansion() {
+  ActivePackExpansions.pop_back();
+}
+
 Type ASTBuilder::createFunctionType(
     ArrayRef<Demangle::FunctionParam<Type>> params,
     Type output, FunctionTypeFlags flags,
@@ -876,7 +896,7 @@ Type ASTBuilder::createParenType(Type base) {
 GenericSignature
 ASTBuilder::createGenericSignature(ArrayRef<BuiltType> builtParams,
                                    ArrayRef<BuiltRequirement> requirements) {
-  std::vector<BuiltGenericTypeParam> params;
+  std::vector<GenericTypeParamType *> params;
   for (auto &param : builtParams) {
     auto paramTy = param->getAs<GenericTypeParamType>();
     if (!paramTy)

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -238,9 +238,6 @@ static void collectVisibleMemberDecls(const DeclContext *CurrDC, LookupState LS,
   }
 }
 
-static void
-synthesizePropertyWrapperVariables(IterableDeclContext *IDC);
-
 /// Lookup members in extensions of \p LookupType, using \p BaseType as the
 /// underlying type when checking any constraints on the extensions.
 static void doGlobalExtensionLookup(Type BaseType,
@@ -566,22 +563,6 @@ static void
   for (auto Proto : PD->getInheritedProtocols())
     lookupVisibleProtocolMemberDecls(BaseTy, Proto, Consumer, CurrDC, LS,
                                      getReasonForSuper(Reason), Sig, Visited);
-}
-
-// Generate '$' and '_' prefixed variables for members that have attached property
-// wrappers.
-static void
-synthesizePropertyWrapperVariables(IterableDeclContext *IDC) {
-  auto SF = IDC->getAsGenericContext()->getParentSourceFile();
-  if (!SF || SF->Kind == SourceFileKind::Interface)
-    return;
-
-  for (auto Member : IDC->getMembers())
-    if (auto var = dyn_cast<VarDecl>(Member))
-      if (var->hasAttachedPropertyWrapper()) {
-        (void)var->getPropertyWrapperAuxiliaryVariables();
-        (void)var->getPropertyWrapperInitializerInfo();
-      }
 }
 
 static void lookupVisibleMemberDeclsImpl(

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -116,7 +116,7 @@ public:
     for (auto NameElement : llvm::zip_first(Labels, T->getElements())) {
       auto Label = std::get<0>(NameElement);
       if (!Label.empty())
-        stream << Label.str() << " = ";
+        stream << Label << " = ";
       printRec(std::get<1>(NameElement));
     }
     stream << ")";

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -111,7 +111,7 @@ public:
 
   void visitTupleTypeRef(const TupleTypeRef *T) {
     printHeader("tuple");
-    T->getLabels();
+
     auto Labels = T->getLabels();
     for (auto NameElement : llvm::zip_first(Labels, T->getElements())) {
       auto Label = std::get<0>(NameElement);
@@ -1133,8 +1133,8 @@ public:
     std::vector<const TypeRef *> Elements;
     for (auto Element : T->getElements())
       Elements.push_back(visit(Element));
-    std::string Labels = T->getLabelString();
-    return TupleTypeRef::create(Builder, Elements, std::move(Labels));
+    auto Labels = T->getLabels();
+    return TupleTypeRef::create(Builder, Elements, Labels);
   }
 
   const TypeRef *visitFunctionTypeRef(const FunctionTypeRef *F) {
@@ -1268,8 +1268,8 @@ public:
     std::vector<const TypeRef *> Elements;
     for (auto Element : T->getElements())
       Elements.push_back(visit(Element));
-    std::string Labels = T->getLabelString();
-    return TupleTypeRef::create(Builder, Elements, std::move(Labels));
+    auto Labels = T->getLabels();
+    return TupleTypeRef::create(Builder, Elements, Labels);
   }
 
   const TypeRef *visitFunctionTypeRef(const FunctionTypeRef *F) {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3556,8 +3556,7 @@ getSuperclassMetadata(MetadataRequest request, const ClassMetadata *self) {
     auto result = swift_getTypeByMangledName(
         request, superclassName, substitutions.getGenericArgs(),
         [&substitutions](unsigned depth, unsigned index) {
-          // FIXME: Variadic generics
-          return substitutions.getMetadata(depth, index).getMetadata();
+          return substitutions.getMetadata(depth, index).Ptr;
         },
         [&substitutions](const Metadata *type, unsigned index) {
           return substitutions.getWitnessTable(type, index);
@@ -6291,8 +6290,7 @@ swift_getAssociatedTypeWitnessSlowImpl(
     result = swift_getTypeByMangledName(
         request, mangledName, substitutions.getGenericArgs(),
         [&substitutions](unsigned depth, unsigned index) {
-          // FIXME: Variadic generics
-          return substitutions.getMetadata(depth, index).getMetadata();
+          return substitutions.getMetadata(depth, index).Ptr;
         },
         [&substitutions](const Metadata *type, unsigned index) {
           return substitutions.getWitnessTable(type, index);
@@ -6438,8 +6436,7 @@ swift_getAssociatedTypeWitnessRelativeSlowImpl(
   auto result = swift_getTypeByMangledName(
       request, mangledName, substitutions.getGenericArgs(),
       [&substitutions](unsigned depth, unsigned index) {
-        // FIXME: Variadic generics
-        return substitutions.getMetadata(depth, index).getMetadata();
+        return substitutions.getMetadata(depth, index).Ptr;
       },
       [&substitutions](const Metadata *type, unsigned index) {
         return substitutions.getWitnessTable(type, index);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1624,8 +1624,7 @@ public:
         swift_getTypeByMangledName(MetadataState::Complete,
                                    mangledName, allGenericArgsVec.data(),
         [&substitutions](unsigned depth, unsigned index) {
-          // FIXME: Variadic generics
-          return substitutions.getMetadata(depth, index).getMetadataOrNull();
+          return substitutions.getMetadata(depth, index).Ptr;
         },
         [&substitutions](const Metadata *type, unsigned index) {
           return substitutions.getWitnessTable(type, index);
@@ -2300,8 +2299,7 @@ swift_getTypeByMangledNameInEnvironment(
     MetadataState::Complete, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
-      // FIXME: Variadic generics
-      return substitutions.getMetadata(depth, index).getMetadataOrNull();
+      return substitutions.getMetadata(depth, index).Ptr;
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
@@ -2333,8 +2331,7 @@ swift_getTypeByMangledNameInEnvironmentInMetadataState(
     (MetadataState)metadataState, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
-      // FIXME: Variadic generics
-      return substitutions.getMetadata(depth, index).getMetadataOrNull();
+      return substitutions.getMetadata(depth, index).Ptr;
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
@@ -2365,8 +2362,7 @@ swift_getTypeByMangledNameInContext(
     MetadataState::Complete, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
-      // FIXME: Variadic generics
-      return substitutions.getMetadata(depth, index).getMetadataOrNull();
+      return substitutions.getMetadata(depth, index).Ptr;
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
@@ -2398,8 +2394,7 @@ swift_getTypeByMangledNameInContextInMetadataState(
     (MetadataState)metadataState, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
-      // FIXME: Variadic generics
-      return substitutions.getMetadata(depth, index).getMetadataOrNull();
+      return substitutions.getMetadata(depth, index).Ptr;
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
@@ -2585,8 +2580,7 @@ swift_func_getReturnTypeInfo(const char *typeNameStart, size_t typeNameLength,
       demangler,
       /*substGenericParam=*/
       [&substFn](unsigned depth, unsigned index) {
-        // FIXME: Variadic generics
-        return substFn.getMetadata(depth, index).getMetadataOrNull();
+        return substFn.getMetadata(depth, index).Ptr;
       },
       /*SubstDependentWitnessTableFn=*/
       [&substFn](const Metadata *type, unsigned index) {
@@ -2627,8 +2621,7 @@ swift_func_getParameterTypeInfo(
       demangler,
       /*substGenericParam=*/
       [&substFn](unsigned depth, unsigned index) {
-        // FIXME: Variadic generics
-        return substFn.getMetadata(depth, index).getMetadataOrNull();
+        return substFn.getMetadata(depth, index).Ptr;
       },
       /*SubstDependentWitnessTableFn=*/
       [&substFn](const Metadata *type, unsigned index) {
@@ -2671,8 +2664,7 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
   auto error = _checkGenericRequirements(
       genericEnv->getGenericRequirements(), witnessTables,
       [&substFn](unsigned depth, unsigned index) {
-        // FIXME: Variadic generics
-        return substFn.getMetadata(depth, index).getMetadataOrNull();
+        return substFn.getMetadata(depth, index).Ptr;
       },
       [&substFn](const Metadata *type, unsigned index) {
         return substFn.getWitnessTable(type, index);
@@ -2706,8 +2698,7 @@ swift_getOpaqueTypeMetadata(MetadataRequest request,
   return swift_getTypeByMangledName(request.getState(),
                                     mangledName, arguments,
     [&substitutions](unsigned depth, unsigned index) {
-      // FIXME: Variadic generics
-      return substitutions.getMetadata(depth, index).getMetadataOrNull();
+      return substitutions.getMetadata(depth, index).Ptr;
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
@@ -3149,8 +3140,7 @@ static void _gatherWrittenGenericArgs(
             req.getMangledTypeName(),
             (const void * const *)allGenericArgs.data(),
             [&substitutions](unsigned depth, unsigned index) {
-              // FIXME: Variadic generics
-              return substitutions.getMetadata(depth, index).getMetadataOrNull();
+              return substitutions.getMetadata(depth, index).Ptr;
             },
             [&substitutions](const Metadata *type, unsigned index) {
               return substitutions.getWitnessTable(type, index);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2021,12 +2021,6 @@ public:
     return TYPE_LOOKUP_ERROR_FMT("Lowered SILPackType cannot be demangled");
   }
 
-  TypeLookupErrorOr<BuiltType>
-  createPackExpansionType(BuiltType patternType, BuiltType countType) const {
-    // FIXME: Runtime support for variadic generics.
-    return BuiltType();
-  }
-
   size_t beginPackExpansion(BuiltType countType) {
     if (!countType.isMetadataPack()) {
       swift::fatalError(0, "Pack expansion count type should be a pack\n");

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1514,6 +1514,9 @@ private:
   /// Ownership information related to the metadata we are trying to lookup.
   TypeReferenceOwnership ReferenceOwnership;
 
+  /// Stack of shape pack/current index pairs.
+  std::vector<std::pair<MetadataPackPointer, size_t>> ActivePackExpansions;
+
 public:
   using BuiltType = MetadataOrPack;
 
@@ -1870,9 +1873,26 @@ public:
   BuiltType
   createGenericTypeParameterType(unsigned depth, unsigned index) const {
     // Use the callback, when provided.
-    // FIXME: variadic-generics
-    if (substGenericParameter)
-      return BuiltType(substGenericParameter(depth, index));
+    if (substGenericParameter) {
+      BuiltType substType(substGenericParameter(depth, index));
+
+      // If we're in the middle of a pack expansion, return the correct element
+      // from the substituted pack type.
+      if (!ActivePackExpansions.empty()) {
+        size_t index = ActivePackExpansions.back().second;
+        if (substType.isMetadataPack()) {
+          auto substPack = substType.getMetadataPack();
+          if (index >= substPack.getNumElements()) {
+            swift::fatalError(0, "Pack index %zu exceeds pack length %zu\n",
+                              index, substPack.getNumElements());
+          }
+
+          return BuiltType(substPack.getElements()[index]);
+        }
+      }
+
+      return substType;
+    }
 
     return BuiltType();
   }
@@ -2006,6 +2026,37 @@ public:
   createPackExpansionType(BuiltType patternType, BuiltType countType) const {
     // FIXME: Runtime support for variadic generics.
     return BuiltType();
+  }
+
+  size_t beginPackExpansion(BuiltType countType) {
+    if (!countType.isMetadataPack()) {
+      swift::fatalError(0, "Pack expansion count type should be a pack\n");
+    }
+
+    auto pack = countType.getMetadataPack();
+    ActivePackExpansions.emplace_back(pack, /*index=*/0);
+
+    return pack.getNumElements();
+  }
+
+  void advancePackExpansion(size_t index) {
+    if (ActivePackExpansions.empty()) {
+      swift::fatalError(0, "advancePackExpansion() without beginPackExpansion()\n");
+    }
+
+    ActivePackExpansions.back().second = index;
+  }
+
+  BuiltType createExpandedPackElement(BuiltType patternType) {
+    return patternType;
+  }
+
+  void endPackExpansion() {
+    if (ActivePackExpansions.empty()) {
+      swift::fatalError(0, "endPackExpansion() without beginPackExpansion()\n");
+    }
+
+    ActivePackExpansions.pop_back();
   }
 
   TypeLookupErrorOr<BuiltType> createDependentMemberType(StringRef name,

--- a/test/Interpreter/variadic_generic_conformances.swift
+++ b/test/Interpreter/variadic_generic_conformances.swift
@@ -31,19 +31,13 @@ struct ElementTupleMaker<each T: Sequence> : TypeMaker {
 
 conformances.test("makeTuple1") {
   expectEqual("()", _typeName(makeTypeIndirectly(TupleMaker< >())))
-
-  // FIXME: This should unwrap the one-element tuple!
-  // expectEqual("(Swift.Int)", _typeName(makeTypeIndirectly(TupleMaker<Int>())))
-
+  expectEqual("Swift.Int", _typeName(makeTypeIndirectly(TupleMaker<Int>())))
   expectEqual("(Swift.Int, Swift.Bool)", _typeName(makeTypeIndirectly(TupleMaker<Int, Bool>())))
 }
 
 conformances.test("makeTuple2") {
   expectEqual("()", _typeName(makeTypeIndirectly(ElementTupleMaker< >())))
-
-  // FIXME: This should unwrap the one-element tuple!
-  // expectEqual("(Swift.Int)", _typeName(makeTypeIndirectly(ElementTupleMaker<Array<Int>>())))
-
+  expectEqual("Swift.Int", _typeName(makeTypeIndirectly(ElementTupleMaker<Array<Int>>())))
   expectEqual("(Swift.Int, Swift.Bool)", _typeName(makeTypeIndirectly(ElementTupleMaker<Array<Int>, Set<Bool>>())))
 }
 

--- a/test/Interpreter/variadic_generic_type_witnesses.swift
+++ b/test/Interpreter/variadic_generic_type_witnesses.swift
@@ -1,0 +1,89 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+var conformances = TestSuite("VariadicGenericConformances")
+
+protocol P {
+  associatedtype A
+  associatedtype B
+  associatedtype C
+}
+
+struct H<T> {}
+struct G<each T> {}
+
+struct TupleWitnesses<each T: Sequence>: P {
+  typealias A = (Bool, repeat each T)
+  typealias B = (repeat each T.Element, x: Bool)
+  typealias C = (x: Bool, repeat H<each T.Element>)
+}
+
+struct SingletonTupleWitnesses<each T>: P {
+  typealias A = (repeat each T)
+  typealias B = (repeat each T, Int)
+  typealias C = (Int, repeat each T)
+}
+
+struct FunctionWitnesses<each T: Sequence>: P {
+  typealias A = (Bool, repeat each T) -> ()
+  typealias B = (repeat each T.Element, Bool) -> ()
+  typealias C = (Bool, repeat H<each T.Element>) -> ()
+}
+
+struct NominalWitnesses<each T: Sequence>: P {
+  typealias A = G<Bool, repeat each T>
+  typealias B = G<repeat each T.Element, Bool>
+  typealias C = G<Bool, repeat H<each T.Element>>
+}
+
+func getA<T: P>(_: T.Type) -> Any.Type {
+  return T.A.self
+}
+
+func getB<T: P>(_: T.Type) -> Any.Type {
+  return T.B.self
+}
+
+func getC<T: P>(_: T.Type) -> Any.Type {
+  return T.C.self
+}
+
+conformances.test("tupleWitnesses") {
+  let g = TupleWitnesses<Array<Int>, Set<String>>.self
+  expectEqual((Bool, Array<Int>, Set<String>).self, getA(g))
+  expectEqual((Int, String, x: Bool).self, getB(g))
+  expectEqual((x: Bool, H<Int>, H<String>).self, getC(g))
+}
+
+conformances.test("singletonTupleWitnesses") {
+  let g1 = SingletonTupleWitnesses<Bool>.self
+  // FIXME: Unwrap one-element tuples
+  // expectEqual(Bool.self, getA(g1))
+
+  let g2 = SingletonTupleWitnesses< >.self
+  // FIXME: Unwrap one-element tuples
+  // expectEqual(Int.self, getB(g2))
+  // expectEqual(Int.self, getC(g2))
+}
+
+conformances.test("functionWitnesses") {
+  let g = FunctionWitnesses<Array<Int>, Set<String>>.self
+  expectEqual(((Bool, Array<Int>, Set<String>) -> ()).self, getA(g))
+  expectEqual(((Int, String, Bool) -> ()).self, getB(g))
+  expectEqual(((Bool, H<Int>, H<String>) -> ()).self, getC(g))
+}
+
+conformances.test("nominalWitnesses") {
+  let g = NominalWitnesses<Array<Int>, Set<String>>.self
+  expectEqual(G<Bool, Array<Int>, Set<String>>.self, getA(g))
+  expectEqual(G<Int, String, Bool>.self, getB(g))
+  expectEqual(G<Bool, H<Int>, H<String>>.self, getC(g))
+}
+
+runAllTests()

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -99,17 +99,17 @@ TEST(TypeRefTest, UniqueTupleTypeRef) {
   auto N2 = Builder.createNominalType(XYZ_decl, nullptr);
 
   std::vector<const TypeRef *> Void;
-  auto Void1 = Builder.createTupleType(Void, "");
-  auto Void2 = Builder.createTupleType(Void, "");
+  auto Void1 = Builder.createTupleType(Void, ArrayRef<StringRef>());
+  auto Void2 = Builder.createTupleType(Void, ArrayRef<StringRef>());
 
   EXPECT_EQ(Void1, Void2);
 
   std::vector<const TypeRef *> Elements1 { N1, N2 };
   std::vector<const TypeRef *> Elements2 { N1, N2, N2 };
 
-  auto T1 = Builder.createTupleType(Elements1, "");
-  auto T2 = Builder.createTupleType(Elements1, "");
-  auto T3 = Builder.createTupleType(Elements2, "");
+  auto T1 = Builder.createTupleType(Elements1, ArrayRef<StringRef>());
+  auto T2 = Builder.createTupleType(Elements1, ArrayRef<StringRef>());
+  auto T3 = Builder.createTupleType(Elements2, ArrayRef<StringRef>());
 
   EXPECT_EQ(T1, T2);
   EXPECT_NE(T2, T3);
@@ -121,7 +121,7 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   std::vector<const TypeRef *> Void;
-  auto VoidResult = Builder.createTupleType(Void, "");
+  auto VoidResult = Builder.createTupleType(Void, ArrayRef<StringRef>());
   Param Param1 = Builder.createNominalType(ABC_decl, nullptr);
   Param Param2 = Builder.createNominalType(XYZ_decl, nullptr);
 
@@ -130,7 +130,8 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
   std::vector<Param> Parameters2{Param1, Param1};
 
   auto Result =
-      Builder.createTupleType({Param1.getType(), Param2.getType()}, "");
+      Builder.createTupleType({Param1.getType(), Param2.getType()},
+                              ArrayRef<StringRef>());
 
   auto F1 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags(),
@@ -517,7 +518,8 @@ TEST(TypeRefTest, DeriveSubstitutions) {
   auto Nominal = Builder.createBoundGenericType(NominalName, NominalArgs,
                                                /*parent*/ nullptr);
 
-  auto Result = Builder.createTupleType({GTP00, GTP01}, "");
+  auto Result = Builder.createTupleType({GTP00, GTP01},
+                                        ArrayRef<StringRef>());
   auto Func = Builder.createFunctionType(
       {Nominal}, Result, FunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr);


### PR DESCRIPTION
This doesn't perform unwrapping of one-element tuples and doesn't support PackElementType for references to outer pack expansions yet, but I will address those in the next PR.

Fixes rdar://111694735.