### PR TITLE
🍒[cxx-interop] Import `OS_OBJECT_DECL` consistently with and without C++ interop enabled

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3418,7 +3418,7 @@ static Type getNamedProtocolType(ClangImporter::Implementation &impl,
   clang::LookupResult lookupResult(sema, clangName, clang::SourceLocation(),
                                    clang::Sema::LookupObjCProtocolName);
   lookupResult.setAllowHidden(true);
-  if (!sema.LookupName(lookupResult, /*Scope=*/nullptr))
+  if (!sema.LookupName(lookupResult, /*Scope=*/sema.TUScope))
     return Type();
 
   for (auto decl : lookupResult) {

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -18,3 +18,9 @@ module NSNofiticationBridging {
   requires objc
   requires cplusplus
 }
+
+module OSObject {
+  header "os-object.h"
+  requires objc
+  requires cplusplus
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/os-object.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/os-object.h
@@ -1,0 +1,4 @@
+#include <os/object.h>
+
+/// Similar to xpc_object_t
+OS_OBJECT_DECL(my_object);

--- a/test/Interop/Cxx/objc-correctness/os-object.swift
+++ b/test/Interop/Cxx/objc-correctness/os-object.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=swift-5.9 %s
+// REQUIRES: objc_interop
+
+import OSObject
+
+extension my_object_t {
+  func dummy() {}
+}


### PR DESCRIPTION
**Explanation**: ClangImporter was not able to lookup `NSObject` when C++ interop is enabled, which caused types such as `xpc_object_t` from system module XPC to be imported differently: `any OS_xpc_object` without C++ interop vs `any NSObject & OS_xpc_object` with C++ interop enabled.
**Scope**: This alters the way `NSObject` type is looked up by ClangImporter.
**Risk**: Medium, this alters the code path that can be taken without having C++ interop enabled.

Original PR: https://github.com/apple/swift/pull/67116

rdar://110000787
(cherry picked from commit 5a6203251c7b9ae897ff74317921a191132adc39)