### PR TITLE
🍒[cxx-interop] Mangle numeric template arguments

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2195,6 +2195,37 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       return importNameImpl(classTemplateSpecDecl->getSpecializedTemplate(),
                             version, givenName);
     if (!isa<clang::ClassTemplatePartialSpecializationDecl>(D)) {
+      auto getSwiftBuiltinTypeName =
+          [&](const clang::BuiltinType *builtin) -> std::optional<StringRef> {
+        Type swiftType = nullptr;
+        switch (builtin->getKind()) {
+        case clang::BuiltinType::Void:
+          swiftType = swiftCtx.getNamedSwiftType(swiftCtx.getStdlibModule(),
+                                                 "Void");
+          break;
+#define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)                  \
+        case clang::BuiltinType::CLANG_BUILTIN_KIND:                           \
+          swiftType = swiftCtx.getNamedSwiftType(swiftCtx.getStdlibModule(),   \
+                                                 #SWIFT_TYPE_NAME);            \
+          break;
+#define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)            \
+        case clang::BuiltinType::CLANG_BUILTIN_KIND:                           \
+          swiftType = swiftCtx.getNamedSwiftType(swiftCtx.getStdlibModule(),   \
+                                                 #SWIFT_TYPE_NAME);            \
+          break;
+#include "swift/ClangImporter/BuiltinMappedTypes.def"
+        default:
+          break;
+        }
+
+        if (swiftType) {
+          if (auto nominal = swiftType->getAs<NominalType>()) {
+            return nominal->getDecl()->getNameStr();
+          }
+        }
+        return std::nullopt;
+      };
+
       // When constructing the name of a C++ template, don't expand all the
       // template, only expand one layer. Here we want to prioritize
       // readability over total completeness.
@@ -2204,38 +2235,16 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       buffer << "<";
       llvm::interleaveComma(classTemplateSpecDecl->getTemplateArgs().asArray(),
                             buffer,
-                            [&buffer, this, version](const clang::TemplateArgument& arg) {
+                            [&buffer, this, version, &getSwiftBuiltinTypeName](const clang::TemplateArgument& arg) {
         // Use import name here so builtin types such as "int" map to their
         // Swift equivalent ("Int32").
         if (arg.getKind() == clang::TemplateArgument::Type) {
           auto ty = arg.getAsType().getTypePtr();
           if (auto builtin = dyn_cast<clang::BuiltinType>(ty)) {
             auto &ctx = swiftCtx;
-            Type swiftType = nullptr;
-            switch (builtin->getKind()) {
-            case clang::BuiltinType::Void:
-              swiftType = ctx.getNamedSwiftType(ctx.getStdlibModule(), "Void");
-              break;
-      #define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)            \
-            case clang::BuiltinType::CLANG_BUILTIN_KIND:                       \
-              swiftType = ctx.getNamedSwiftType(ctx.getStdlibModule(),         \
-                                                #SWIFT_TYPE_NAME);             \
-              break;
-      #define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)      \
-            case clang::BuiltinType::CLANG_BUILTIN_KIND:                       \
-              swiftType = ctx.getNamedSwiftType(ctx.getStdlibModule(),         \
-                                                #SWIFT_TYPE_NAME);             \
-              break;
-      #include "swift/ClangImporter/BuiltinMappedTypes.def"
-              default:
-                break;
-            }
-            
-            if (swiftType) {
-              if (auto nominal = dyn_cast<NominalType>(swiftType->getCanonicalType())) {
-                buffer << nominal->getDecl()->getNameStr();
-                return;
-              }
+            if (auto swiftTypeName = getSwiftBuiltinTypeName(builtin)) {
+              buffer << *swiftTypeName;
+              return;
             }
           } else {
             // FIXME: Generalize this to cover pointer to
@@ -2276,6 +2285,16 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
               return;
             }
           }
+        } else if (arg.getKind() == clang::TemplateArgument::Integral) {
+          buffer << "_";
+          if (arg.getIntegralType()->isBuiltinType()) {
+            if (auto swiftTypeName = getSwiftBuiltinTypeName(
+                    arg.getIntegralType()->getAs<clang::BuiltinType>())) {
+              buffer << *swiftTypeName << "_";
+            }
+          }
+          arg.getAsIntegral().print(buffer, true);
+          return;
         }
         buffer << "_";
       });

--- a/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
@@ -8,5 +8,6 @@ using size_t = __SIZE_TYPE__;
 template <class T, size_t Size> struct MagicArray { T t[Size]; };
 
 typedef MagicArray<int, 2> MagicIntPair;
+typedef MagicArray<int, 3> MagicIntTriple;
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+
+import ClassTemplateNonTypeParameter
+
+let p = MagicIntPair()
+let t = MagicIntTriple()
+
+// CHECK: @"${{s4main1pSo0034MagicArrayInt32_UInt_2_zoAFhhiEngcVvp|s4main1pSo0036MagicArrayInt32_UInt64_2_JsAEiFiuomcVvp}}"
+// CHECK: @"${{s4main1tSo0034MagicArrayInt32_UInt_3_zoAFhhiEngcVvp|s4main1tSo0036MagicArrayInt32_UInt64_3_JsAEiFiuomcVvp}}"

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateNonTypeParameter -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK: struct MagicArray<T, Size> {
+// CHECK: }
+
+// CHECK: struct MagicArray<Int32, _UInt{{.*}}_2> {
+// CHECK:   init()
+// CHECK:   init(t: (Int32, Int32))
+// CHECK:   var t: (Int32, Int32)
+// CHECK: }
+
+// CHECK: struct MagicArray<Int32, _UInt{{.*}}_3> {
+// CHECK:   init()
+// CHECK:   init(t: (Int32, Int32, Int32))
+// CHECK:   var t: (Int32, Int32, Int32)
+// CHECK: }
+
+// CHECK: typealias MagicIntPair = MagicArray<Int32, _UInt{{.*}}_2>
+// CHECK: typealias MagicIntTriple = MagicArray<Int32, _UInt{{.*}}_3>

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
@@ -10,6 +10,9 @@ var TemplatesTestSuite = TestSuite("TemplatesTestSuite")
 TemplatesTestSuite.test("typedeffed-non-type-parameter") {
   let pair = MagicIntPair(t: (1, 2))
   expectEqual(pair.t, (1, 2))
+
+  let triple = MagicIntTriple(t: (1, 2, 3))
+  expectEqual(triple.t, (1, 2, 3))
 }
 
 // TODO: This test doesn't work because Swift doesn't support defaulted generic

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -12,4 +12,4 @@
 
 // TODO: we should not be importing functions that use this type in their
 // signature (such as the function below).
-// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<Int32>, _>, _>>
+// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<Int32>, _Int32_1>, _Int32_1>>


### PR DESCRIPTION
**Explanation**: When mangling the name of a C++ template specialization, we ignored non-type templated parameters. This causes two different instantiations of the same templated type to have the same mangled name, triggering linker errors. This change makes sure the compiler adds the numeric arguments into the Swift type name, so they become a part of the mangled type name as well.
**Scope**: This alters the way templated C++ types with numeric template parameter are imported into Swift, specifically, it changes their type name as seen from Swift code.
**Risk**: Low, this only has an effect when C++ interop is enabled.

Original PR: https://github.com/apple/swift/pull/67101

rdar://107757051
(cherry picked from commit d4e8551281e60281bc5fd7e35fa618cd33c17af7)