### PR TITLE
Implement correct NS_OPTIONS type import inside objc interface (5.9)

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -818,6 +818,31 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
 using MirroredMethodEntry =
   std::tuple<const clang::ObjCMethodDecl*, ProtocolDecl*, bool /*isAsync*/>;
 
+ImportedType tryImportOptionsTypeForField(const clang::QualType type,
+                                          ClangImporter::Implementation &Impl) {
+  ImportedType importedType;
+  auto fieldType = type;
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
+    fieldType = elaborated->desugar();
+  if (auto typedefType = dyn_cast<clang::TypedefType>(fieldType)) {
+    if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
+      if (auto clangEnum =
+              findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
+        // If this fails, it means that we need a stronger predicate for
+        // determining the relationship between an enum and typedef.
+        assert(
+            clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
+            typedefType->getCanonicalTypeInternal());
+        if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
+          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
+                          false};
+        }
+      }
+    }
+  }
+  return importedType;
+}
+
 namespace {
   /// Customized llvm::DenseMapInfo for storing borrowed APSInts.
   struct APSIntRefDenseMapInfo {
@@ -3650,23 +3675,8 @@ namespace {
           return nullptr;
       }
 
-      ImportedType importedType;
       auto fieldType = decl->getType();
-      if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
-        fieldType = elaborated->desugar();
-      if (auto typedefType = dyn_cast<clang::TypedefType>(fieldType)) {
-        if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
-          if (auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
-            // If this fails, it means that we need a stronger predicate for
-            // determining the relationship between an enum and typedef.
-            assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-                   typedefType->getCanonicalTypeInternal());
-            if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-              importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
-            }
-          }
-        }
-      }
+      ImportedType importedType = tryImportOptionsTypeForField(fieldType, Impl);
 
       if (!importedType)
         importedType =

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5201,7 +5201,11 @@ namespace {
         }
       }
 
-      auto importedType = Impl.importPropertyType(decl, isInSystemModule(dc));
+      auto fieldType = decl->getType();
+      ImportedType importedType = tryImportOptionsTypeForField(fieldType, Impl);
+
+      if (!importedType)
+        importedType = Impl.importPropertyType(decl, isInSystemModule(dc));
       if (!importedType) {
         Impl.addImportDiagnostic(
             decl, Diagnostic(diag::objc_property_not_imported, decl),

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -818,8 +818,8 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
 using MirroredMethodEntry =
   std::tuple<const clang::ObjCMethodDecl*, ProtocolDecl*, bool /*isAsync*/>;
 
-ImportedType tryImportOptionsTypeForField(const clang::QualType type,
-                                          ClangImporter::Implementation &Impl) {
+ImportedType findOptionSetType(clang::QualType type,
+                               ClangImporter::Implementation &Impl) {
   ImportedType importedType;
   auto fieldType = type;
   if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
@@ -3676,7 +3676,7 @@ namespace {
       }
 
       auto fieldType = decl->getType();
-      ImportedType importedType = tryImportOptionsTypeForField(fieldType, Impl);
+      ImportedType importedType = findOptionSetType(fieldType, Impl);
 
       if (!importedType)
         importedType =
@@ -5202,7 +5202,7 @@ namespace {
       }
 
       auto fieldType = decl->getType();
-      ImportedType importedType = tryImportOptionsTypeForField(fieldType, Impl);
+      ImportedType importedType = findOptionSetType(fieldType, Impl);
 
       if (!importedType)
         importedType = Impl.importPropertyType(decl, isInSystemModule(dc));

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3212,8 +3212,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
           importedType.isImplicitlyUnwrapped()};
 }
 
-ImportedType tryImportOptionsTypeForField(const clang::QualType type,
-                                          ClangImporter::Implementation &Impl);
+ImportedType findOptionSetType(clang::QualType type,
+                               ClangImporter::Implementation &Impl);
 
 ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
     const DeclContext *dc, const clang::ObjCPropertyDecl *property,
@@ -3238,13 +3238,13 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   DeclContext *origDC = importDeclContextOf(property,
                                             property->getDeclContext());
   assert(origDC);
-  auto fieldType = isGetter ? clangDecl->getReturnType() : clangDecl->getParamDecl(0)->getType();
-  ImportedType importedNSOptionsType = tryImportOptionsTypeForField(fieldType, *this);
+  auto fieldType = isGetter ? clangDecl->getReturnType()
+                            : clangDecl->getParamDecl(0)->getType();
 
   // Import the property type, independent of what kind of accessor this is.
-  auto importedType = importPropertyType(property, isFromSystemModule);
-  if (importedNSOptionsType)
-    importedType = importedNSOptionsType;
+  ImportedType importedType = findOptionSetType(fieldType, *this);
+  if (!importedType)
+    importedType = importPropertyType(property, isFromSystemModule);
   if (!importedType)
     return {Type(), false};
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3212,6 +3212,9 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
           importedType.isImplicitlyUnwrapped()};
 }
 
+ImportedType tryImportOptionsTypeForField(const clang::QualType type,
+                                          ClangImporter::Implementation &Impl);
+
 ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
     const DeclContext *dc, const clang::ObjCPropertyDecl *property,
     const clang::ObjCMethodDecl *clangDecl, bool isFromSystemModule,
@@ -3235,9 +3238,13 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   DeclContext *origDC = importDeclContextOf(property,
                                             property->getDeclContext());
   assert(origDC);
+  auto fieldType = isGetter ? clangDecl->getReturnType() : clangDecl->getParamDecl(0)->getType();
+  ImportedType importedNSOptionsType = tryImportOptionsTypeForField(fieldType, *this);
 
   // Import the property type, independent of what kind of accessor this is.
   auto importedType = importPropertyType(property, isFromSystemModule);
+  if (importedNSOptionsType)
+    importedType = importedNSOptionsType;
   if (!importedType)
     return {Type(), false};
 

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -86,6 +86,10 @@ struct HasNSOptionField {
 @property Bar bar;
 @end
 
+@interface HasNSOptionFieldObjC2
+- (void)setBar:(Bar)bar;
+@end
+
 Baz CFunctionReturningNSOption();
 void CFunctionTakingNSOption(Baz);
 

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -82,6 +82,10 @@ struct HasNSOptionField {
   Bar bar;
 };
 
+@interface HasNSOptionFieldObjC
+@property Bar bar;
+@end
+
 Baz CFunctionReturningNSOption();
 void CFunctionTakingNSOption(Baz);
 

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -31,3 +31,8 @@ import CenumsNSOptions
 // CHECK-NEXT:   class func bar() -> Bar
 // CHECK-NEXT:   class func setBar(_ bar: Bar)
 // CHECK-NEXT: }
+
+// CHECK: class HasNSOptionFieldObjC2 {
+// CHECK-NEXT:   class func setBar(_ bar: Bar)
+// CHECK-NEXT:   func setBar(_ bar: Bar)
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -25,3 +25,9 @@ import CenumsNSOptions
 // CHECK: struct HasNSOptionField {
 // CHECK:   var bar: Bar
 // CHECK: }
+
+// CHECK: class HasNSOptionFieldObjC {
+// CHECK-NEXT:   var bar: Bar
+// CHECK-NEXT:   class func bar() -> Bar
+// CHECK-NEXT:   class func setBar(_ bar: Bar)
+// CHECK-NEXT: }


### PR DESCRIPTION
This this PR refactors a code pattern to check for an NS_OPTIONS type inside a RecordDecl etc, and reuses the check to also ensure that NS_OPTIONS types used inside of ObjC interfaces. The failing code example happened with assigning a UIKit UISwipeGestureRecognizer Direction type:

```
import UIKit

public func foo(gesture: UISwipeGestureRecognizer, direction: UISwipeGestureRecognizer.Direction) {
  gesture.direction = direction // error
}
```


## Release Branch Checklist:
* **Explanation:** This this PR refactors a code pattern to check for an NS_OPTIONS type inside a RecordDecl etc, and reuses the check to also ensure that NS_OPTIONS types used inside of ObjC interfaces as property or method types are also properly imported with the correct type in the presents of C++-interop.
* **Scope:** C++-Interop NS_OPTIONS type import inside of ObjC `@interface` property getters/setters.
* **Issue:** None filed externally, used code example from above from internal bug report.
* **Risk:** low, only triggers if attribute unavailable+anonymous enum pattern is followed, same as existing patches already landed.
* **Testing:** lit test, checks that correct type name is used in the ObjC class as it is in the C/C++ struct.
* **Reviewer:** @hyp @zoecarver @NuriAmari  @DougGregor 