### PR TITLE
[Sema] Warn on `@_implementationOnly` imports from a module without library-evolution

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1098,6 +1098,10 @@ ERROR(module_not_compiled_with_library_evolution,none,
       "module %0 was not compiled with library evolution support; "
       "using it means binary compatibility for %1 can't be guaranteed",
       (Identifier, Identifier))
+WARNING(implementation_only_requires_library_evolution,none,
+        "using '@_implementationOnly' without enabling library evolution "
+        "for %0 may lead to instability during execution",
+        (Identifier))
 
 ERROR(module_allowable_client_violation,none,
       "module %0 doesn't allow importation from module %1",

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -781,25 +781,24 @@ void UnboundImport::validateInterfaceWithPackageName(ModuleDecl *topLevelModule,
 
 void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
                                        SourceFile &SF) {
-  if (import.options.contains(ImportFlags::ImplementationOnly) ||
-      import.accessLevel < AccessLevel::Public)
-    return;
+  ASTContext &ctx = SF.getASTContext();
 
   // Per getTopLevelModule(), we'll only get nullptr here for non-Swift modules,
   // so these two really mean the same thing.
   if (!topLevelModule || topLevelModule.get()->isNonSwiftModule())
     return;
 
-  ASTContext &ctx = SF.getASTContext();
-
   // If the module we're validating is the builtin one, then just return because
   // this module is essentially a header only import and does not concern
   // itself with resiliency. This can occur when one has passed
   // '-enable-builtin-module' and is explicitly importing the Builtin module in
   // their sources.
-  if (topLevelModule.get() == ctx.TheBuiltinModule) {
+  if (topLevelModule.get() == ctx.TheBuiltinModule)
     return;
-  }
+
+  if (import.options.contains(ImportFlags::ImplementationOnly) ||
+      import.accessLevel < AccessLevel::Public)
+    return;
 
   if (!SF.getParentModule()->isResilient() ||
       topLevelModule.get()->isResilient())

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -796,6 +796,18 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
   if (topLevelModule.get() == ctx.TheBuiltinModule)
     return;
 
+  // @_implementationOnly is only supported when used from modules built with
+  // library-evolution. Otherwise it can lead to runtime crashes from a lack
+  // of memory layout information when building clients unaware of the
+  // dependency. The missing information is provided at run time by resilient
+  // modules.
+  if (import.options.contains(ImportFlags::ImplementationOnly) &&
+      !SF.getParentModule()->isResilient() && topLevelModule) {
+    ctx.Diags.diagnose(import.importLoc,
+                       diag::implementation_only_requires_library_evolution,
+                       SF.getParentModule()->getName());
+  }
+
   if (import.options.contains(ImportFlags::ImplementationOnly) ||
       import.accessLevel < AccessLevel::Public)
     return;

--- a/test/Concurrency/preconcurrency_implementationonly_override.swift
+++ b/test/Concurrency/preconcurrency_implementationonly_override.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/ImplementationOnlyDefs.swiftmodule -module-name ImplementationOnlyDefs %S/Inputs/ImplementationOnlyDefs.swift
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/ImplementationOnlyDefs.swiftmodule -module-name ImplementationOnlyDefs %S/Inputs/ImplementationOnlyDefs.swift \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t \
+// RUN:   -enable-library-evolution -swift-version 5
 
 // REQUIRES: concurrency
 

--- a/test/SPI/implementation_only_spi_import_exposability.swift
+++ b/test/SPI/implementation_only_spi_import_exposability.swift
@@ -1,8 +1,10 @@
 /// @_implementationOnly imported decls (SPI or not) should not be exposed in SPI.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -DLIB %s -module-name Lib -emit-module-path %t/Lib.swiftmodule
-// RUN: %target-typecheck-verify-swift -DCLIENT -I %t
+// RUN: %target-swift-frontend -emit-module -DLIB %s -module-name Lib -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -DCLIENT -I %t \
+// RUN:   -swift-version 5 -enable-library-evolution
 
 #if LIB
 

--- a/test/SPI/report-ioi-in-spi.swift
+++ b/test/SPI/report-ioi-in-spi.swift
@@ -2,20 +2,24 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -I %t \
+// RUN:   -enable-library-evolution \
 // RUN:   -module-name Lib -emit-module-path %t/Lib.swiftmodule \
 // RUN:   -swift-version 5
 
 /// Use of IOI types in SPI signatures is an error with -experimental-spi-only-imports
 // RUN: %target-swift-frontend -emit-module %t/ClientSPIOnlyMode.swift -I %t \
+// RUN:   -enable-library-evolution \
 // RUN:   -swift-version 5 -verify \
 // RUN:   -experimental-spi-only-imports
 
 /// Use of IOI types in SPI signatures is a warning without -experimental-spi-only-imports
 // RUN: %target-swift-frontend -emit-module %t/ClientDefaultMode.swift -I %t \
+// RUN:   -enable-library-evolution \
 // RUN:   -swift-version 5 -verify
 
 /// This is a warning in swiftinterfaces
 // R UN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
+// RUN:   -enable-library-evolution \
 // R UN:   -I %t -module-name Client
 
 //--- Lib.swift

--- a/test/SPI/report-ioi-in-spi.swift
+++ b/test/SPI/report-ioi-in-spi.swift
@@ -17,11 +17,6 @@
 // RUN:   -enable-library-evolution \
 // RUN:   -swift-version 5 -verify
 
-/// This is a warning in swiftinterfaces
-// R UN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
-// RUN:   -enable-library-evolution \
-// R UN:   -I %t -module-name Client
-
 //--- Lib.swift
 
 public struct IOIStruct {
@@ -53,12 +48,3 @@ public struct IOIStruct {
     return IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
     // expected-error @-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
 }
-
-//--- Client.private.swiftinterface
-
-// swift-interface-format-version: 1.0
-// swift-compiler-version: Swift version 5.8-dev effective-4.1.50
-// swift-module-flags: -swift-version 4 -module-name Client
-@_implementationOnly import Lib
-
-@_spi(X) public func spiClient() -> IOIStruct { fatalError() }

--- a/test/SPI/spi-only-import-conflicting.swift
+++ b/test/SPI/spi-only-import-conflicting.swift
@@ -10,21 +10,29 @@
 
 /// Build clients.
 // RUN: %target-swift-frontend -typecheck %t/SPIOnly_Default.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/Default_SPIOnly.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/SPIOnly_Exported.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/Exported_SPIOnly.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/SPIOnly_IOI.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/SPIOnly_IOI_Exported_Default.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck -primary-file %t/SPIOnly_Default_FileA.swift \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   %t/SPIOnly_Default_FileB.swift -I %t -verify \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck -primary-file %t/IOI_Default_FileA.swift \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   %t/IOI_Default_FileB.swift -I %t -verify \
 // RUN:   -experimental-spi-only-imports -verify
 

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build 2 libs.
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -o %t/A.swiftmodule \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -o %t/B.swiftmodule \
+// RUN:   -enable-library-evolution -swift-version 5
+
+/// Build a client with and without library-evolution.
+// RUN: %target-swift-frontend -typecheck %t/client-non-resilient.swift -I %t -verify
+// RUN: %target-swift-frontend -typecheck %t/client-resilient.swift -I %t -verify \
+// RUN:   -enable-library-evolution -swift-version 5
+
+//--- empty.swift
+
+//--- client-non-resilient.swift
+@_implementationOnly import A // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}
+import B
+
+//--- client-resilient.swift
+@_implementationOnly import A
+import B

--- a/test/Sema/implementation-only-import-in-decls.swift
+++ b/test/Sema/implementation-only-import-in-decls.swift
@@ -1,8 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift
-// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t
+// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift \
+// RUN:  -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t \
+// RUN:  -enable-library-evolution -swift-version 5
 
-// RUN: %target-typecheck-verify-swift -I %t
+// RUN: %target-typecheck-verify-swift -I %t \
+// RUN:  -enable-library-evolution -swift-version 5
 
 import NormalLibrary
 @_implementationOnly import BADLibrary

--- a/test/Sema/implementation-only-import-inlinable-conformances.swift
+++ b/test/Sema/implementation-only-import-inlinable-conformances.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift
-// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t
+// RUN: %target-swift-frontend -emit-module -o %t/NormalLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-public-helper.swift \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module -o %t/BADLibrary.swiftmodule %S/Inputs/implementation-only-import-in-decls-helper.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5
 
-// RUN: %target-typecheck-verify-swift -I %t
+// RUN: %target-typecheck-verify-swift -I %t -enable-library-evolution -swift-version 5
 
 @_implementationOnly import BADLibrary
 import NormalLibrary

--- a/test/Sema/implementation-only-import-inlinable-indirect.swift
+++ b/test/Sema/implementation-only-import-inlinable-indirect.swift
@@ -1,8 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule %S/Inputs/implementation-only-imports/indirects.swift
-// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t %S/Inputs/implementation-only-imports/directs.swift
+// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule %S/Inputs/implementation-only-imports/indirects.swift \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t %S/Inputs/implementation-only-imports/directs.swift \
+// RUN:   -enable-library-evolution -swift-version 5
 
-// RUN: %target-swift-frontend -typecheck -verify %s -I %t
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t \
+// RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
 

--- a/test/Sema/implementation-only-import-inlinable-multifile.swift
+++ b/test/Sema/implementation-only-import-inlinable-multifile.swift
@@ -1,8 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule %S/Inputs/implementation-only-imports/indirects.swift
-// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t %S/Inputs/implementation-only-imports/directs.swift
+// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule %S/Inputs/implementation-only-imports/indirects.swift \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t %S/Inputs/implementation-only-imports/directs.swift \
+// RUN:   -enable-library-evolution -swift-version 5
 
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/implementation-only-imports/secondary_file.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/implementation-only-imports/secondary_file.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
 // 'indirects' is imported for re-export in a secondary file

--- a/test/Sema/implementation-only-import-inlinable.swift
+++ b/test/Sema/implementation-only-import-inlinable.swift
@@ -1,8 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule %S/Inputs/implementation-only-imports/indirects.swift
-// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t %S/Inputs/implementation-only-imports/directs.swift
+// RUN: %target-swift-frontend -emit-module -o %t/indirects.swiftmodule %S/Inputs/implementation-only-imports/indirects.swift \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -emit-module -o %t/directs.swiftmodule -I %t %S/Inputs/implementation-only-imports/directs.swift \
+// RUN:   -enable-library-evolution -swift-version 5
 
-// RUN: %target-swift-frontend -typecheck -verify %s -I %t
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t \
+// RUN:   -enable-library-evolution -swift-version 5
 
 @_implementationOnly import directs
 import indirects

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -3,18 +3,24 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name empty -o %t/empty.swiftmodule
-// RUN: %target-swift-frontend -emit-module %t/libA.swift -module-name libA -o %t/libA.swiftmodule
-// RUN: %target-swift-frontend -emit-module %t/libB.swift -module-name libB -o %t/libB.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name empty -o %t/empty.swiftmodule \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/libA.swift -module-name libA -o %t/libA.swiftmodule \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/libB.swift -module-name libB -o %t/libB.swiftmodule -I %t \
+// RUN:   -enable-library-evolution
 
 /// In pre-Swift 6, this is a warning where there's no implementation-only import present.
-// RUN: %target-swift-frontend -emit-module %t/clientFileA-Swift5.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify
+// RUN: %target-swift-frontend -emit-module %t/clientFileA-Swift5.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify \
+// RUN:   -enable-library-evolution
 
 /// In pre-Swift 6, this remains an error when there's an implementation-only import present.
-// RUN: %target-swift-frontend -emit-module %t/clientFileA-OldCheck.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify
+// RUN: %target-swift-frontend -emit-module %t/clientFileA-OldCheck.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify \
+// RUN:   -enable-library-evolution
 
 /// In Swift 6, it's an error.
-// RUN: %target-swift-frontend -emit-module %t/clientFileA-Swift6.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify -swift-version 6
+// RUN: %target-swift-frontend -emit-module %t/clientFileA-Swift6.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify -swift-version 6 \
+// RUN:   -enable-library-evolution
 
 /// The swiftinterface is broken by the missing import without the workaround.
 // RUN: %target-swift-emit-module-interface(%t/ClientBroken.swiftinterface)  %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t -disable-print-missing-imports-in-module-interface

--- a/test/Sema/restricted-imports-priorities.swift
+++ b/test/Sema/restricted-imports-priorities.swift
@@ -16,16 +16,22 @@
 // RUN:   -swift-version 5 -enable-library-evolution -I %t
 
 // RUN: %target-swift-frontend -typecheck %t/TwoIOI.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/SPIOnlyAndIOI1.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/SPIOnlyAndIOI2.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/TwoSPIOnly.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/OneSPIOnly1.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/OneSPIOnly2.swift -I %t -verify \
+// RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -experimental-spi-only-imports -verify
 
 /// Setup 2 indirect imports of LibA, allowing the same LibA to be imported

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -74,3 +74,4 @@ import func français.phoûx
 import main // expected-warning {{file 'import.swift' is part of module 'main'; ignoring import}}
 
 @_exported @_implementationOnly import empty // expected-error {{module 'empty' cannot be both exported and implementation-only}} {{12-33=}}
+// expected-warning @-1 {{using '@_implementationOnly' without enabling library evolution for 'main' may lead to instability during execution}}


### PR DESCRIPTION
Add a warning on uses of `@_implementationOnly` from an importer module without library-evolution. `@_implementationOnly` was designed for use from resilient modules only, using it from non-resilient modules is unsupported and can lead to run time crashes.

If anyone hits this warning, they should either enable library-evolution or consider adopting the new `internal import` when it is available as it handles this scenario properly.

More about what actually leads to a crash: an `@_implementationOnly` import fully hides the dependency from indirect clients. This can lead to the compiler being unaware of some internal details (mostly incomplete memory layouts) of a non-resilient module when building a client against it. In turn, this may lead to run time crashes caused by miscompilation. We don't see this problem with resilient modules as the required information is queried at run time.

In general, one could still use `@_implementationOnly` in a non-resilient modules as long as it's referenced only from function bodies. However, using imported types for even non-public properties does lead to important memory layout information being hidden from clients of the module.

rdar://78129903