### PR TITLE
lit.cfg: simplify driver arguments when testing for WASI

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1829,8 +1829,7 @@ elif run_os == 'wasi':
     config.target_build_swift = ' '.join([
         config.swiftc,
         '-target', config.variant_triple,
-        '-Xcc', '--sysroot=%s' % config.variant_sdk,
-        '-Xclang-linker', '--sysroot=%s' % config.variant_sdk,
+        '-sdk', config.variant_sdk,
         '-toolchain-stdlib-rpath', config.resource_dir_opt,
         mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
@@ -1842,7 +1841,7 @@ elif run_os == 'wasi':
     config.target_swift_frontend = ' '.join([
         config.swift_frontend,
         '-target', config.variant_triple,
-        '-Xcc', '--sysroot=%s' % config.variant_sdk,
+	'-sdk', config.variant_sdk,
         config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend


### PR DESCRIPTION
We can pass a single `-sdk` argument instead of passing identical values to both `-Xcc --sysroot` and `-Xclang-linker --sysroot`.