### PR TITLE
stdlib/cmake: add missing macro definitions required for WASI

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -323,7 +323,7 @@ function(_add_target_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WASI")
-    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_PROCESS_CLOCKS")
+    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_SIGNAL" "-D_WASI_EMULATED_PROCESS_CLOCKS")
   endif()
 
   if(NOT SWIFT_STDLIB_ENABLE_OBJC_INTEROP)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -323,7 +323,7 @@ function(_add_target_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WASI")
-    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_PROCESS_CLOCKS" "-D_WASI_EMULATED_SIGNAL" )
+    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_PROCESS_CLOCKS" "-D_WASI_EMULATED_SIGNAL")
   endif()
 
   if(NOT SWIFT_STDLIB_ENABLE_OBJC_INTEROP)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -323,7 +323,7 @@ function(_add_target_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WASI")
-    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_SIGNAL" "-D_WASI_EMULATED_PROCESS_CLOCKS")
+    list(APPEND result "-D_WASI_EMULATED_MMAN" "-D_WASI_EMULATED_PROCESS_CLOCKS" "-D_WASI_EMULATED_SIGNAL" )
   endif()
 
   if(NOT SWIFT_STDLIB_ENABLE_OBJC_INTEROP)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -243,6 +243,10 @@ function(_add_target_variant_swift_compile_flags
     list(APPEND result
         "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")
   endif()
+  
+  if("${sdk}" STREQUAL "WASI")
+    list(APPEND result "-Xcc" "-D_WASI_EMULATED_MMAN" "-Xcc" "-D_WASI_EMULATED_SIGNAL" "-Xcc" "-D_WASI_EMULATED_PROCESS_CLOCKS")
+  endif()
 
   if(NOT BUILD_STANDALONE)
     list(APPEND result "-resource-dir" "${SWIFTLIB_DIR}")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -243,10 +243,6 @@ function(_add_target_variant_swift_compile_flags
     list(APPEND result
         "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")
   endif()
-  
-  if("${sdk}" STREQUAL "WASI")
-    list(APPEND result "-Xcc" "-D_WASI_EMULATED_MMAN" "-Xcc" "-D_WASI_EMULATED_SIGNAL" "-Xcc" "-D_WASI_EMULATED_PROCESS_CLOCKS")
-  endif()
 
   if(NOT BUILD_STANDALONE)
     list(APPEND result "-resource-dir" "${SWIFTLIB_DIR}")


### PR DESCRIPTION
We need `-D_WASI_EMULATED_SIGNAL` passed when building for WASI to fully support it.