### PR TITLE
[build-preset] Fix stdlib standalone build

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2488,7 +2488,9 @@ skip-test-cmark
 # This triggers the stdlib standalone build: don't build the native tools from
 # scratch, ie the compiler.
 build-swift-tools=0
+build-swift-libexec=0
 skip-early-swift-driver
+skip-early-swiftsyntax
 
 # Then set the paths to our native tools. If compiling against a toolchain,
 # these should all be the ./usr/bin directory.
@@ -2499,6 +2501,26 @@ native-clang-tools-path=%(toolchain_path)s
 build-ninja
 lit-args=--filter=':: (stdlib/|Concurrency/)' -v
 only-executable-test
+
+[preset: stdlib_R_standalone,build]
+mixin-preset=stdlib_base_standalone
+
+release
+no-assertions
+
+verbose-build
+
+[preset: stdlib_R_standalone,build,asan]
+mixin-preset=stdlib_R_standalone,build
+
+build-subdir=stdlib_R_standalone_asan
+enable-asan
+
+[preset: stdlib_R_standalone,build,test]
+mixin-preset=stdlib_R_standalone,build
+
+test
+validation-test
 
 [preset: stdlib_RD_standalone,build]
 mixin-preset=stdlib_base_standalone


### PR DESCRIPTION
Don't try and build early swiftsyntax and don't build libexec. Also, add a release configuration for the standalone stdlib.