### PR TITLE
test: add missing `import WASILibc` to `cancellation_handler.swift`

### DIFF
--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -12,6 +12,8 @@
     import Darwin
 #elseif canImport(Glibc)
     import Glibc
+#elseif canImport(WASILibc)
+    import WASILibc
 #elseif os(Windows)
     import WinSDK
 #endif


### PR DESCRIPTION
This allows this test to build and run when targeting WASI.