### PR TITLE
[5.9][Macros] PluginMessages aren't @_spi anymore

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -18,7 +18,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
-@_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
+import SwiftCompilerPluginMessageHandling
 
 extension SyntaxProtocol {
   func token(at position: AbsolutePosition) -> TokenSyntax? {

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -14,7 +14,7 @@ import CASTBridging
 import CBasicBridging
 import SwiftSyntax
 import swiftLLVMJSON
-@_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
+import SwiftCompilerPluginMessageHandling
 
 enum PluginError: String, Error, CustomStringConvertible {
   case stalePlugin = "plugin is stale"


### PR DESCRIPTION
Cherry-pick #67135 into release/5.9

`swift-syntax` repo change: https://github.com/apple/swift-syntax/pull/1877

* **Explanation**:  Since #67038  `PluginMessage` types are marked as `@_spi(PluginMessage)` which was not necessary, and it caused a failure in a build. Since we don't really need to mark it `@_spi`, just remove it and make it normal `public`
* **Scope**: Macro plugin messaging
* **Risk**: Low. This should be NFC
* **Testing**: Passes the current test suite
* **Issue**: rdar://111748087
* **Reviewer**: Ben Barham (@bnbarham)