### PR TITLE
[move-only] Ban partial reinitialization after consuming a value.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -788,6 +788,12 @@ ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
 ERROR(sil_movechecking_cannot_destructure, none,
       "cannot partially consume '%0'",
       (StringRef))
+ERROR(sil_movechecking_cannot_partially_reinit_has_deinit, none,
+      "cannot partially reinitialize '%0' when it has a deinitializer; only full reinitialization is allowed",
+      (StringRef))
+ERROR(sil_movechecking_cannot_partially_reinit, none,
+      "cannot partially reinitialize '%0' after it has been consumed; only full reinitialization is allowed",
+      (StringRef))
 ERROR(sil_movechecking_discard_missing_consume_self, none,
       "must consume 'self' before exiting method that discards self", ())
 ERROR(sil_movechecking_reinit_after_discard, none,

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -1107,7 +1107,107 @@ void FieldSensitiveMultiDefPrunedLiveRange::findBoundariesInBlock(
                << "    Live at beginning of block! No dead args!\n");
   }
 
-  assert((isLiveOut ||
-          prevCount < boundary.getNumLastUsersAndDeadDefs(bitNo)) &&
-         "findBoundariesInBlock must be called on a live block");
+  assert(
+      (isLiveOut || prevCount < boundary.getNumLastUsersAndDeadDefs(bitNo)) &&
+      "findBoundariesInBlock must be called on a live block");
+}
+
+bool FieldSensitiveMultiDefPrunedLiveRange::findEarlierConsumingUse(
+    SILInstruction *inst, unsigned index,
+    llvm::function_ref<bool(SILInstruction *)> callback) const {
+  PRUNED_LIVENESS_LOG(
+      llvm::dbgs()
+      << "Performing single block search for consuming use for bit: " << index
+      << "!\n");
+
+  // Walk our block back from inst looking for defs or a consuming use. If we
+  // see a def, return true. If we see a use, we keep processing if the callback
+  // returns true... and return false early if the callback returns false.
+  for (auto ii = std::next(inst->getReverseIterator()),
+            ie = inst->getParent()->rend();
+       ii != ie; ++ii) {
+    PRUNED_LIVENESS_LOG(llvm::dbgs() << "Visiting: " << *ii);
+    // If we have a def, then we are automatically done.
+    if (isDef(&*ii, index)) {
+      PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Is Def! Returning true!\n");
+      return true;
+    }
+
+    // If we have a consuming use, emit the error.
+    if (isInterestingUser(&*ii, index) ==
+        IsInterestingUser::LifetimeEndingUse) {
+      PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Is Lifetime Ending Use!\n");
+      if (!callback(&*ii)) {
+        PRUNED_LIVENESS_LOG(llvm::dbgs()
+                            << "    Callback returned false... exiting!\n");
+        return false;
+      }
+      PRUNED_LIVENESS_LOG(llvm::dbgs()
+                          << "    Callback returned true... continuing!\n");
+    }
+
+    // Otherwise, keep going.
+  }
+
+  // Then check our argument defs.
+  for (auto *arg : inst->getParent()->getArguments()) {
+    PRUNED_LIVENESS_LOG(llvm::dbgs() << "Visiting arg: " << *arg);
+    if (isDef(arg, index)) {
+      PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Found def. Returning true!\n");
+      return true;
+    }
+  }
+
+  PRUNED_LIVENESS_LOG(llvm::dbgs() << "Finished single block. Didn't find "
+                                      "anything... Performing interprocedural");
+
+  // Ok, we now know that we need to look further back.
+  BasicBlockWorklist worklist(inst->getFunction());
+  for (auto *predBlock : inst->getParent()->getPredecessorBlocks()) {
+    worklist.pushIfNotVisited(predBlock);
+  }
+
+  while (auto *next = worklist.pop()) {
+    PRUNED_LIVENESS_LOG(llvm::dbgs()
+                        << "Checking block bb" << next->getDebugID() << '\n');
+    for (auto ii = next->rbegin(), ie = next->rend(); ii != ie; ++ii) {
+      PRUNED_LIVENESS_LOG(llvm::dbgs() << "Visiting: " << *ii);
+      // If we have a def, then we are automatically done.
+      if (isDef(&*ii, index)) {
+        PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Is Def! Returning true!\n");
+        return true;
+      }
+
+      // If we have a consuming use, emit the error.
+      if (isInterestingUser(&*ii, index) ==
+          IsInterestingUser::LifetimeEndingUse) {
+        PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Is Lifetime Ending Use!\n");
+        if (!callback(&*ii)) {
+          PRUNED_LIVENESS_LOG(llvm::dbgs()
+                              << "    Callback returned false... exiting!\n");
+          return false;
+        }
+        PRUNED_LIVENESS_LOG(llvm::dbgs()
+                            << "    Callback returned true... continuing!\n");
+      }
+
+      // Otherwise, keep going.
+    }
+
+    for (auto *arg : next->getArguments()) {
+      PRUNED_LIVENESS_LOG(llvm::dbgs() << "Visiting arg: " << *arg);
+      if (isDef(arg, index)) {
+        PRUNED_LIVENESS_LOG(llvm::dbgs() << "    Found def. Returning true!\n");
+        return true;
+      }
+    }
+
+    PRUNED_LIVENESS_LOG(llvm::dbgs()
+                        << "Didn't find anything... visiting predecessors!\n");
+    for (auto *predBlock : next->getPredecessorBlocks()) {
+      worklist.pushIfNotVisited(predBlock);
+    }
+  }
+
+  return true;
 }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -506,9 +506,13 @@ struct UseState {
   /// the part of the type tree that it initializes.
   InstToBitMap initInsts;
 
+  SmallFrozenMultiMap<SILInstruction *, SILValue, 8> initToValueMultiMap;
+
   /// memInstMustReinitialize insts. Contains both insts like copy_addr/store
   /// [assign] that are reinits that we will convert to inits and true reinits.
   InstToBitMap reinitInsts;
+
+  SmallFrozenMultiMap<SILInstruction *, SILValue, 8> reinitToValueMultiMap;
 
   /// The set of drop_deinits of this mark_must_check
   SmallSetVector<SILInstruction *, 2> dropDeinitInsts;
@@ -562,11 +566,15 @@ struct UseState {
     setAffectedBits(inst, range, livenessUses);
   }
 
-  void recordReinitUse(SILInstruction *inst, TypeTreeLeafTypeRange range) {
+  void recordReinitUse(SILInstruction *inst, SILValue value,
+                       TypeTreeLeafTypeRange range) {
+    reinitToValueMultiMap.insert(inst, value);
     setAffectedBits(inst, range, reinitInsts);
   }
 
-  void recordInitUse(SILInstruction *inst, TypeTreeLeafTypeRange range) {
+  void recordInitUse(SILInstruction *inst, SILValue value,
+                     TypeTreeLeafTypeRange range) {
+    initToValueMultiMap.insert(inst, value);
     setAffectedBits(inst, range, initInsts);
   }
 
@@ -618,7 +626,9 @@ struct UseState {
     copyInsts.clear();
     takeInsts.clear();
     initInsts.clear();
+    initToValueMultiMap.reset();
     reinitInsts.clear();
+    reinitToValueMultiMap.reset();
     dropDeinitInsts.clear();
     implicitEndOfLifetimeLivenessUses.clear();
     debugValue = nullptr;
@@ -666,6 +676,11 @@ struct UseState {
     if (debugValue) {
       llvm::dbgs() << *debugValue;
     }
+  }
+
+  void freezeMultiMaps() {
+    initToValueMultiMap.setFrozen();
+    reinitToValueMultiMap.setFrozen();
   }
 
   SmallBitVector &getOrCreateConsumingBlock(SILBasicBlock *block) {
@@ -790,6 +805,28 @@ struct UseState {
       auto iter = reinitInsts.find(inst);
       if (iter != reinitInsts.end()) {
         if (span.intersects(iter->second))
+          return true;
+      }
+    }
+    return false;
+  }
+
+  bool isInitUse(SILInstruction *inst, const SmallBitVector &requiredBits,
+                 SmallBitVector &foundInitBits) const {
+    {
+      auto iter = initInsts.find(inst);
+      if (iter != initInsts.end()) {
+        foundInitBits = iter->second & requiredBits;
+        if (foundInitBits.any())
+          return true;
+      }
+    }
+
+    if (isReinitToInitConvertibleInst(inst)) {
+      auto iter = reinitInsts.find(inst);
+      if (iter != reinitInsts.end()) {
+        foundInitBits = iter->second & requiredBits;
+        if (foundInitBits.any())
           return true;
       }
     }
@@ -927,7 +964,8 @@ void UseState::initializeLiveness(
             llvm::dbgs()
             << "Found in/in_guaranteed/inout/inout_aliasable argument as "
                "an init... adding mark_must_check as init!\n");
-        recordInitUse(address, liveness.getTopLevelSpan());
+        // We cheat here slightly and use our address's operand.
+        recordInitUse(address, address, liveness.getTopLevelSpan());
         liveness.initializeDef(address, liveness.getTopLevelSpan());
         break;
       case swift::SILArgumentConvention::Indirect_Out:
@@ -958,14 +996,14 @@ void UseState::initializeLiveness(
         // later invariants that we assert upon remain true.
         LLVM_DEBUG(llvm::dbgs() << "Found move only arg closure box use... "
                                    "adding mark_must_check as init!\n");
-        recordInitUse(address, liveness.getTopLevelSpan());
+        recordInitUse(address, address, liveness.getTopLevelSpan());
         liveness.initializeDef(address, liveness.getTopLevelSpan());
       }
     } else if (auto *box = dyn_cast<AllocBoxInst>(
                    lookThroughOwnershipInsts(projectBox->getOperand()))) {
       LLVM_DEBUG(llvm::dbgs() << "Found move only var allocbox use... "
                  "adding mark_must_check as init!\n");
-      recordInitUse(address, liveness.getTopLevelSpan());
+      recordInitUse(address, address, liveness.getTopLevelSpan());
       liveness.initializeDef(address, liveness.getTopLevelSpan());
     }
   }
@@ -976,7 +1014,7 @@ void UseState::initializeLiveness(
           stripAccessMarkers(address->getOperand()))) {
     LLVM_DEBUG(llvm::dbgs() << "Found ref_element_addr use... "
                                "adding mark_must_check as init!\n");
-    recordInitUse(address, liveness.getTopLevelSpan());
+    recordInitUse(address, address, liveness.getTopLevelSpan());
     liveness.initializeDef(address, liveness.getTopLevelSpan());
   }
 
@@ -986,7 +1024,7 @@ void UseState::initializeLiveness(
           dyn_cast<GlobalAddrInst>(stripAccessMarkers(address->getOperand()))) {
     LLVM_DEBUG(llvm::dbgs() << "Found global_addr use... "
                                "adding mark_must_check as init!\n");
-    recordInitUse(address, liveness.getTopLevelSpan());
+    recordInitUse(address, address, liveness.getTopLevelSpan());
     liveness.initializeDef(address, liveness.getTopLevelSpan());
   }
 
@@ -1625,6 +1663,150 @@ checkForPartialConsume(UseState &useState, DiagnosticEmitter &diagnosticEmitter,
                                 isPartialConsumeOrReinit);
 }
 
+static void diagnosePartialReinitError(UseState &useState,
+                                       DiagnosticEmitter &diagnosticEmitter,
+                                       SILInstruction *user, SILType errorType,
+                                       NominalTypeDecl *nom,
+                                       SILInstruction *earlierConsumingUse,
+                                       TypeTreeLeafTypeRange usedBits) {
+  SILFunction *fn = useState.getFunction();
+
+  // We walk down from our ancestor to our projection, emitting an error if
+  // any of our types have a deinit.
+  TypeOffsetSizePair pair(usedBits);
+  if (!fn->getModule().getASTContext().LangOpts.hasFeature(
+          Feature::MoveOnlyPartialConsumption)) {
+    // Otherwise, build up the path string and emit the error.
+    SmallString<128> pathString;
+    auto rootType = useState.address->getType();
+    if (errorType != rootType) {
+      llvm::raw_svector_ostream os(pathString);
+      pair.constructPathString(errorType, {rootType, fn}, rootType, fn, os);
+    }
+
+    diagnosticEmitter.emitCannotPartiallyReinitError(
+        useState.address, pathString, nullptr /*nominal*/, user,
+        earlierConsumingUse, false /*deinit only*/);
+    return;
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "    MoveOnlyPartialConsumption enabled!\n");
+
+  SmallString<128> pathString;
+  auto rootType = useState.address->getType();
+  if (errorType != rootType) {
+    llvm::raw_svector_ostream os(pathString);
+    pair.constructPathString(errorType, {rootType, fn}, rootType, fn, os);
+  }
+
+  diagnosticEmitter.emitCannotPartiallyReinitError(
+      useState.address, pathString, nom, user, earlierConsumingUse,
+      true /*deinit only*/);
+}
+
+namespace {
+
+struct PartialReinitChecker {
+  UseState &useState;
+  DiagnosticEmitter &diagnosticEmitter;
+
+  PartialReinitChecker(UseState &useState, DiagnosticEmitter &diagnosticEmitter)
+      : useState(useState), diagnosticEmitter(diagnosticEmitter) {}
+
+  void
+  performPartialReinitChecking(FieldSensitiveMultiDefPrunedLiveRange &liveness);
+
+private:
+  void checkForPartialConsumeOrInitError(
+      SILInstruction *user, SILType useType, TypeTreeLeafTypeRange usedBits,
+      IsPartialConsumeOrReinit_t isPartialConsumeOrReinit) {
+    ::checkForPartialConsume(useState, diagnosticEmitter, user, useType,
+                             usedBits, isPartialConsumeOrReinit);
+  }
+};
+
+} // namespace
+
+void PartialReinitChecker::performPartialReinitChecking(
+    FieldSensitiveMultiDefPrunedLiveRange &liveness) {
+  // Perform checks that rely on liveness information.
+  for (auto initToValues : useState.initToValueMultiMap.getRange()) {
+    LLVM_DEBUG(llvm::dbgs() << "Checking init: " << *initToValues.first);
+    bool emittedError = false;
+    for (SILValue value : initToValues.second) {
+      LLVM_DEBUG(llvm::dbgs() << "    Checking operand value: " << value);
+      // By computing the bits here directly, we do not need to worry about
+      // having to split contiguous ranges into separate representable SILTypes.
+      SmallBitVector neededElements(useState.getNumSubelements());
+      auto range = *TypeTreeLeafTypeRange::get(value, useState.address);
+      for (unsigned index : range.getRange()) {
+        emittedError = !liveness.findEarlierConsumingUse(
+            initToValues.first, index,
+            [&](SILInstruction *consumingInst) -> bool {
+              SILType errorType;
+              NominalTypeDecl *nom;
+              std::tie(errorType, nom) = shouldEmitPartialError(
+                  useState, initToValues.first, value->getType(),
+                  TypeTreeLeafTypeRange(index, index + 1));
+              if (!errorType)
+                return true;
+
+              diagnosePartialReinitError(
+                  useState, diagnosticEmitter, initToValues.first, errorType,
+                  nom, consumingInst, TypeTreeLeafTypeRange(index, index + 1));
+              return false;
+            });
+
+        // If we emitted an error for this index break. We only want to emit one
+        // error per value.
+        if (emittedError)
+          break;
+      }
+
+      // If we emitted an error for this value break. We only want to emit one
+      // error per instruction.
+      if (emittedError)
+        break;
+    }
+  }
+
+  for (auto reinitToValues : useState.reinitToValueMultiMap.getRange()) {
+    if (!isReinitToInitConvertibleInst(reinitToValues.first))
+      continue;
+
+    LLVM_DEBUG(llvm::dbgs() << "Checking reinit: " << *reinitToValues.first);
+    bool emittedError = false;
+    for (SILValue value : reinitToValues.second) {
+      LLVM_DEBUG(llvm::dbgs() << "    Checking operand value: " << value);
+      // By computing the bits here directly, we do not need to worry about
+      // having to split contiguous ranges into separate representable SILTypes.
+      SmallBitVector neededElements(useState.getNumSubelements());
+      auto range = *TypeTreeLeafTypeRange::get(value, useState.address);
+      for (unsigned index : range.getRange()) {
+        emittedError = !liveness.findEarlierConsumingUse(
+            reinitToValues.first, index,
+            [&](SILInstruction *consumingInst) -> bool {
+              SILType errorType;
+              NominalTypeDecl *nom;
+              std::tie(errorType, nom) = shouldEmitPartialError(
+                  useState, reinitToValues.first, value->getType(),
+                  TypeTreeLeafTypeRange(index, index + 1));
+              if (!errorType)
+                return true;
+
+              diagnosePartialReinitError(
+                  useState, diagnosticEmitter, reinitToValues.first, errorType,
+                  nom, consumingInst, TypeTreeLeafTypeRange(index, index + 1));
+              return false;
+            });
+        if (emittedError)
+          break;
+      }
+      if (emittedError)
+        break;
+    }
+  }
+}
 //===----------------------------------------------------------------------===//
 //                   MARK: GatherLexicalLifetimeUseVisitor
 //===----------------------------------------------------------------------===//
@@ -1729,7 +1911,7 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
     if (!leafRange)
       return false;
 
-    useState.recordInitUse(user, *leafRange);
+    useState.recordInitUse(user, op->get(), *leafRange);
     return true;
   }
 
@@ -1738,7 +1920,7 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
     auto leafRange = TypeTreeLeafTypeRange::get(op->get(), getRootAddress());
     if (!leafRange)
       return false;
-    useState.recordReinitUse(user, *leafRange);
+    useState.recordReinitUse(user, op->get(), *leafRange);
     return true;
   }
 
@@ -3294,11 +3476,26 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
     addressUseState.initializeLiveness(liveness);
   }
 
-  {
-    RAIILLVMDebug l("global liveness checking");
+  // Now freeze our multimaps.
+  addressUseState.freezeMultiMaps();
 
+  {
+    RAIILLVMDebug l("checking for partial reinits");
+    PartialReinitChecker checker(addressUseState, diagnosticEmitter);
+    unsigned count = diagnosticEmitter.getDiagnosticCount();
+    checker.performPartialReinitChecking(liveness);
+    if (count != diagnosticEmitter.getDiagnosticCount()) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Found a partial reinit error! Ending early!\n");
+      return true;
+    }
+  }
+
+  {
+    RAIILLVMDebug l("performing global liveness checks");
     // Then compute the takes that are within the cumulative boundary of
-    // liveness that we have computed. If we find any, they are the errors ones.
+    // liveness that we have computed. If we find any, they are the errors
+    // ones.
     GlobalLivenessChecker emitter(addressUseState, diagnosticEmitter, liveness);
 
     // If we had any errors, we do not want to modify the SIL... just bail.
@@ -3307,19 +3504,11 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
     }
   }
 
-  //===
-  // Final Transformation
-  //
-
-  // Ok, we now know that we fit our model since we did not emit errors and thus
-  // can begin the transformation.
-  SWIFT_DEFER { consumes.clear(); };
-
   // First add any debug_values that we saw as liveness uses. This is important
   // since the debugger wants to see live values when we define a debug_value,
   // but we do not want to use them earlier when emitting diagnostic errors.
   if (auto *di = addressUseState.debugValue) {
-    // Move the debug_value to right before the markedAddress to ensure that we
+    // Move the debug_value to right after the markedAddress to ensure that we
     // do not actually change our liveness computation.
     //
     // NOTE: The author is not sure if this can ever happen with SILGen output,
@@ -3329,14 +3518,28 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
                           false /*lifetime ending*/);
   }
 
+  // Compute our initial boundary.
   FieldSensitivePrunedLivenessBoundary boundary(liveness.getNumSubElements());
   liveness.computeBoundary(boundary);
+  LLVM_DEBUG(llvm::dbgs() << "Initial use based boundary:\n"; boundary.dump());
+
   if (!DisableMoveOnlyAddressCheckerLifetimeExtension) {
     ExtendUnconsumedLiveness extension(addressUseState, liveness, boundary);
     extension.run();
   }
   boundary.clear();
   liveness.computeBoundary(boundary);
+
+  LLVM_DEBUG(llvm::dbgs() << "Final maximized boundary:\n"; boundary.dump());
+
+  //===
+  // Final Transformation
+  //
+
+  // Ok, we now know that we fit our model since we did not emit errors and thus
+  // can begin the transformation.
+  SWIFT_DEFER { consumes.clear(); };
+
   insertDestroysOnBoundary(markedAddress, liveness, boundary);
   checkForReinitAfterDiscard();
   rewriteUses(markedAddress, liveness, boundary);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -878,10 +878,10 @@ void DiagnosticEmitter::emitCannotPartiallyConsumeError(
     astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
 }
 
-void DiagnosticEmitter::emitCannotDestructureNominalError(
+void DiagnosticEmitter::emitCannotPartiallyReinitError(
     MarkMustCheckInst *markedValue, StringRef pathString,
-    NominalTypeDecl *nominal, SILInstruction *consumingUser,
-    bool isDueToDeinit) {
+    NominalTypeDecl *nominal, SILInstruction *initingUser,
+    SILInstruction *consumingUser, bool isForDeinit) {
   auto &astContext = fn->getASTContext();
 
   SmallString<64> varName;
@@ -890,20 +890,28 @@ void DiagnosticEmitter::emitCannotDestructureNominalError(
   if (!pathString.empty())
     varName.append(pathString);
 
-  assert(
-      astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ==
-          isDueToDeinit &&
-      "Should only emit deinit error if we have partial consumption enabled");
-  if (isDueToDeinit) {
-    diagnose(astContext, consumingUser,
-             diag::sil_movechecking_cannot_destructure_has_deinit, varName);
+  bool hasPartialConsumption =
+      astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption);
+  (void)hasPartialConsumption;
+
+  if (isForDeinit) {
+    assert(hasPartialConsumption);
+    diagnose(astContext, initingUser,
+             diag::sil_movechecking_cannot_partially_reinit_has_deinit,
+             varName);
+
   } else {
-    diagnose(astContext, consumingUser,
-             diag::sil_movechecking_cannot_destructure, varName);
+    assert(!hasPartialConsumption);
+    diagnose(astContext, initingUser,
+             diag::sil_movechecking_cannot_partially_reinit, varName);
   }
+
+  diagnose(astContext, consumingUser,
+           diag::sil_movechecking_consuming_use_here);
+
   registerDiagnosticEmitted(markedValue);
 
-  if (!isDueToDeinit)
+  if (!isForDeinit)
     return;
 
   // Point to the deinit if we know where it is.

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -840,9 +840,9 @@ void DiagnosticEmitter::emitPromotedBoxArgumentError(
   }
 }
 
-void DiagnosticEmitter::emitCannotDestructureDeinitNominalError(
+void DiagnosticEmitter::emitCannotPartiallyConsumeError(
     MarkMustCheckInst *markedValue, StringRef pathString,
-    NominalTypeDecl *deinitedNominal, SILInstruction *consumingUser) {
+    NominalTypeDecl *nominal, SILInstruction *consumingUser, bool isForDeinit) {
   auto &astContext = fn->getASTContext();
 
   SmallString<64> varName;
@@ -851,15 +851,30 @@ void DiagnosticEmitter::emitCannotDestructureDeinitNominalError(
   if (!pathString.empty())
     varName.append(pathString);
 
-  diagnose(
-      astContext, consumingUser,
-      diag::sil_movechecking_cannot_destructure_has_deinit,
-      varName);
+  bool hasPartialConsumption =
+      astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption);
+  (void)hasPartialConsumption;
+
+  if (isForDeinit) {
+    assert(hasPartialConsumption);
+    diagnose(astContext, consumingUser,
+             diag::sil_movechecking_cannot_destructure_has_deinit, varName);
+
+  } else {
+    assert(!hasPartialConsumption);
+    diagnose(astContext, consumingUser,
+             diag::sil_movechecking_cannot_destructure, varName);
+  }
+
   registerDiagnosticEmitted(markedValue);
 
-  // point to the deinit if we know where it is.
+  if (!isForDeinit)
+    return;
+
+  // Point to the deinit if we know where it is.
+  assert(nominal);
   if (auto deinitLoc =
-      deinitedNominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
+          nominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
     astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
 }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -176,16 +176,18 @@ public:
   void emitPromotedBoxArgumentError(MarkMustCheckInst *markedValue,
                                     SILFunctionArgument *arg);
 
-  void emitCannotDestructureNominalError(MarkMustCheckInst *markedValue,
-                                         StringRef pathString,
-                                         NominalTypeDecl *nominal,
-                                         SILInstruction *consumingUser,
-                                         bool isDueToDeinit);
   void emitCannotPartiallyConsumeError(MarkMustCheckInst *markedValue,
                                        StringRef pathString,
                                        NominalTypeDecl *nominal,
                                        SILInstruction *consumingUser,
                                        bool dueToDeinit);
+
+  void emitCannotPartiallyReinitError(MarkMustCheckInst *markedValue,
+                                      StringRef pathString,
+                                      NominalTypeDecl *nominal,
+                                      SILInstruction *initUser,
+                                      SILInstruction *consumingUser,
+                                      bool dueToDeinit);
 
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -176,15 +176,16 @@ public:
   void emitPromotedBoxArgumentError(MarkMustCheckInst *markedValue,
                                     SILFunctionArgument *arg);
 
-  void emitCannotDestructureDeinitNominalError(MarkMustCheckInst *markedValue,
-                                               StringRef pathString,
-                                               NominalTypeDecl *deinitedNominal,
-                                               SILInstruction *consumingUser);
   void emitCannotDestructureNominalError(MarkMustCheckInst *markedValue,
                                          StringRef pathString,
                                          NominalTypeDecl *nominal,
                                          SILInstruction *consumingUser,
                                          bool isDueToDeinit);
+  void emitCannotPartiallyConsumeError(MarkMustCheckInst *markedValue,
+                                       StringRef pathString,
+                                       NominalTypeDecl *nominal,
+                                       SILInstruction *consumingUser,
+                                       bool dueToDeinit);
 
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing

--- a/test/SILOptimizer/moveonly_partial_consumption.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption.swift
@@ -7,6 +7,12 @@
 public class Klass {}
 
 public struct Empty : ~Copyable {}
+public struct SingleFieldInt : ~Copyable {
+    var y = 5
+}
+public struct SingleFieldLoadable2 : ~Copyable {
+    var e = Empty()
+}
 public struct SingleFieldLoadable : ~Copyable {
     var e = Empty()
     var k = Klass()
@@ -61,6 +67,8 @@ func borrowVal(_ x: borrowing Empty) {}
 func borrowVal(_ x: borrowing LoadableType) {}
 func borrowVal(_ x: borrowing AddressOnlyType) {}
 func borrowVal(_ x: borrowing P) {}
+
+var bool: Bool { false }
 
 //////////////////////////
 // MARK: Loadable Tests //
@@ -286,4 +294,780 @@ func addressOnlyTestConsumingArg2(_ x: consuming AddressOnlyType) {
     mutateVal(&x.e)
     mutateVal(&x.l.e)
     mutateVal(&x.l.e2)
+}
+
+///////////////////////////////////////////
+// MARK: Partial Reinit Single Field Int //
+///////////////////////////////////////////
+
+func partialReinitTestSingleFieldIntConsuming(x: consuming SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntConsuming2(x: consuming SingleFieldInt) {
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntConsuming3(x: consuming SingleFieldInt) {
+    let _ = consume x
+    x = SingleFieldInt()
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntConsuming4(x: consuming SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntConsuming5(x: consuming SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldInt()
+    }
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntConsuming5a(x: consuming SingleFieldInt) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldInt()
+    } else {
+        x = SingleFieldInt()
+    }
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntConsuming5b(x: consuming SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldInt()
+    }
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntConsuming6(x: consuming SingleFieldInt) {
+    let _ = consume x
+    x = SingleFieldInt()
+    if bool {
+        x = SingleFieldInt()
+    }
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntConsuming6a(x: consuming SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntConsuming6b(x: consuming SingleFieldInt) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldInt()
+    }
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntConsuming6c(x: consuming SingleFieldInt) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldInt()
+    }
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntInOut(x: inout SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntInOut2(x: inout SingleFieldInt) {
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntInOut3(x: inout SingleFieldInt) {
+    let _ = consume x
+    x = SingleFieldInt()
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntInOut4(x: inout SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntInOut5(x: inout SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldInt()
+    }
+
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntInOut5a(x: inout SingleFieldInt) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldInt()
+    } else {
+        x = SingleFieldInt()
+    }
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntInOut5b(x: inout SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldInt()
+    }
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntInOut6(x: inout SingleFieldInt) {
+    let _ = consume x
+    x = SingleFieldInt()
+    if bool {
+        x = SingleFieldInt()
+    }
+    x.y = 5
+}
+
+func partialReinitTestSingleFieldIntInOut6a(x: inout SingleFieldInt) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntInOut6b(x: inout SingleFieldInt) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldInt()
+    }
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldIntInOut6c(x: inout SingleFieldInt) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldInt()
+    }
+    x.y = 5 // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+////////////////////////////////////////////////
+// MARK: Partial Reinit Single Field Loadable //
+////////////////////////////////////////////////
+
+// Test both a true single field (SingleFieldLoadable2) and a pair
+// (SingleFieldLoadable).
+func partialReinitTestSingleFieldLoadable2Consuming(x: consuming SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming2(x: consuming SingleFieldLoadable2) {
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming3(x: consuming SingleFieldLoadable2) {
+    let _ = consume x
+    x = SingleFieldLoadable2()
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming4(x: consuming SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming5(x: consuming SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming5a(x: consuming SingleFieldLoadable2) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldLoadable2()
+    } else {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming5b(x: consuming SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming6(x: consuming SingleFieldLoadable2) {
+    let _ = consume x
+    x = SingleFieldLoadable2()
+    if bool {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming6a(x: consuming SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming6b(x: consuming SingleFieldLoadable2) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2Consuming6c(x: consuming SingleFieldLoadable2) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2InOut(x: inout SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2InOut2(x: inout SingleFieldLoadable2) {
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2InOut3(x: inout SingleFieldLoadable2) {
+    let _ = consume x
+    x = SingleFieldLoadable2()
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2InOut4(x: inout SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2InOut5(x: inout SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldLoadable2()
+    }
+
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2InOut5a(x: inout SingleFieldLoadable2) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldLoadable2()
+    } else {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2InOut5b(x: inout SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2InOut6(x: inout SingleFieldLoadable2) {
+    let _ = consume x
+    x = SingleFieldLoadable2()
+    if bool {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadable2InOut6a(x: inout SingleFieldLoadable2) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2InOut6b(x: inout SingleFieldLoadable2) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadable2InOut6c(x: inout SingleFieldLoadable2) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable2()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableConsuming(x: consuming SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableConsuming2(x: consuming SingleFieldLoadable) {
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableConsuming3(x: consuming SingleFieldLoadable) {
+    let _ = consume x
+    x = SingleFieldLoadable()
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableConsuming4(x: consuming SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableConsuming5(x: consuming SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableConsuming5a(x: consuming SingleFieldLoadable) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldLoadable()
+    } else {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableConsuming5b(x: consuming SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableConsuming6(x: consuming SingleFieldLoadable) {
+    let _ = consume x
+    x = SingleFieldLoadable()
+    if bool {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableConsuming6a(x: consuming SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableConsuming6b(x: consuming SingleFieldLoadable) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableConsuming6c(x: consuming SingleFieldLoadable) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut(x: inout SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut2(x: inout SingleFieldLoadable) {
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableInOut3(x: inout SingleFieldLoadable) {
+    let _ = consume x
+    x = SingleFieldLoadable()
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableInOut4(x: inout SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut5(x: inout SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldLoadable()
+    }
+
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut5a(x: inout SingleFieldLoadable) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldLoadable()
+    } else {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableInOut5b(x: inout SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableInOut6(x: inout SingleFieldLoadable) {
+    let _ = consume x
+    x = SingleFieldLoadable()
+    if bool {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldLoadableInOut6a(x: inout SingleFieldLoadable) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut6b(x: inout SingleFieldLoadable) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut6c(x: inout SingleFieldLoadable) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldLoadableInOut6d(x: inout SingleFieldLoadable) {
+    for _ in 0..<1024 {
+        x = SingleFieldLoadable()
+    }
+    x = SingleFieldLoadable()
+    if bool {}
+    x.e = Empty()
+}
+
+///////////////////////////////////////
+// MARK: Partial Reinit Address Only //
+///////////////////////////////////////
+
+func partialReinitTestSingleFieldAddressOnlyConsuming(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming2(x: consuming SingleFieldAddressOnly) {
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming3(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x
+    x = SingleFieldAddressOnly()
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming4(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming5(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming5a(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldAddressOnly()
+    } else {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming5b(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming6(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x
+    x = SingleFieldAddressOnly()
+    if bool {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming6a(x: consuming SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming6b(x: consuming SingleFieldAddressOnly) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyConsuming6c(x: consuming SingleFieldAddressOnly) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut(x: inout SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut2(x: inout SingleFieldAddressOnly) {
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut3(x: inout SingleFieldAddressOnly) {
+    let _ = consume x
+    x = SingleFieldAddressOnly()
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut4(x: inout SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut5(x: inout SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x = SingleFieldAddressOnly()
+    }
+
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut5a(x: inout SingleFieldAddressOnly) {
+    let _ = consume x
+
+    if bool {
+        x = SingleFieldAddressOnly()
+    } else {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut5b(x: inout SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut5c(x: inout SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+
+    if bool {
+        x.e2 = SingleFieldAddressOnly2() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    } else {
+        x = SingleFieldAddressOnly()
+    }
+    x.e2 = SingleFieldAddressOnly2()
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut6(x: inout SingleFieldAddressOnly) {
+    let _ = consume x
+    x = SingleFieldAddressOnly()
+    if bool {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty()
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut6a(x: inout SingleFieldAddressOnly) {
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {}
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut6b(x: inout SingleFieldAddressOnly) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+func partialReinitTestSingleFieldAddressOnlyInOut6c(x: inout SingleFieldAddressOnly) {
+    // We error here since we /could/ skip the loop entirely.
+    let _ = consume x // expected-note {{consumed here}}
+    for _ in 0..<1024 {
+        x = SingleFieldAddressOnly()
+    }
+    x.e = Empty() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+}
+
+/////////////////////////////////////////////////
+// MARK: Partial Reinit Error on Copyable Type //
+/////////////////////////////////////////////////
+
+func partialReinitTestErrorOnCopyableField() {
+    var x = LoadableType()
+    _ = consume x // expected-note {{consumed here}}
+    x.k = Klass() // expected-error {{cannot partially reinitialize 'x' after it has been consumed; only full reinitialization is allowed}}
+    x = LoadableType()
+    x.k = Klass()
+}
+
+////////////////////////////////////
+// MARK: Partial Reinit Test Self //
+////////////////////////////////////
+
+struct TestTrivialReturnValue : ~Copyable {
+    var i: Int = 5
+
+    deinit {}
+
+    mutating func drain2() -> Int {
+        let buffer = (consume self).i // expected-note {{consumed here}}
+        i = 5 // expected-error {{cannot partially reinitialize 'self' after it has been consumed; only full reinitialization is allowed}}
+        return buffer
+    }
+}
+
+struct TestAddressOnlyReturnValue : ~Copyable {
+    var i: Int = 5
+    var p: P? = nil
+
+    deinit {}
+
+    mutating func drain2() -> Int {
+        let buffer = (consume self).i // expected-note {{consumed here}}
+        p = nil // expected-error {{cannot partially reinitialize 'self' after it has been consumed; only full reinitialization is allowed}}
+        return buffer
+    }
 }


### PR DESCRIPTION
This is similar to our ban on partial consuming a value for this release. The
reason for this is that, one can achieve a similar affect as partial consumption
via a consumption of the entire value and then a partial reinitialization. Example:

```swift
struct X : ~Copyable { var i = 5, var i2 = Klass() }
var x = X()
_ = consume x
x.i = 5
```

in the case above, we now have a value that is in a partially initialized state.

We still allow for move only types to have their fields initialized as long as
there is an intervening init.

rdar://111498740
