### PR TITLE
[5.9] Accessor macros finishing touches

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5238,6 +5238,8 @@ private:
 
     void addOpaqueAccessor(AccessorDecl *accessor);
 
+    void removeAccessor(AccessorDecl *accessor);
+
   private:
     MutableArrayRef<AccessorDecl *> getAccessorsBuffer() {
       return { getTrailingObjects<AccessorDecl*>(), NumAccessors };
@@ -5399,6 +5401,11 @@ public:
     if (const auto *info = Accessors.getPointer())
       return info->getAllAccessors();
     return {};
+  }
+
+  void removeAccessor(AccessorDecl *accessor) {
+    if (auto *info = Accessors.getPointer())
+      return info->removeAccessor(accessor);
   }
 
   /// This is the primary mechanism by which we can easily determine whether
@@ -8911,6 +8918,9 @@ const ParamDecl *getParameterAt(const ValueDecl *source, unsigned index);
 /// Retrieve parameter declaration from the given source at given index, or
 /// nullptr if the source does not have a parameter list.
 const ParamDecl *getParameterAt(const DeclContext *source, unsigned index);
+
+StringRef getAccessorNameForDiagnostic(AccessorDecl *accessor, bool article);
+StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind, bool article);
 
 void simple_display(llvm::raw_ostream &out,
                     OptionSet<NominalTypeDecl::LookupDirectFlags> options);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6478,7 +6478,8 @@ void AbstractStorageDecl::setAccessors(SourceLoc lbraceLoc,
   auto record = Accessors.getPointer();
   if (record) {
     for (auto accessor : accessors) {
-      (void) record->addOpaqueAccessor(accessor);
+      if (!record->getAccessor(accessor->getAccessorKind()))
+        (void) record->addOpaqueAccessor(accessor);
     }
   } else {
     record = AccessorRecord::create(getASTContext(),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6411,6 +6411,38 @@ bool ProtocolDecl::hasCircularInheritedProtocols() const {
       ctx.evaluator, HasCircularInheritedProtocolsRequest{mutableThis}, true);
 }
 
+/// Returns a descriptive name for the given accessor/addressor kind.
+StringRef swift::getAccessorNameForDiagnostic(AccessorKind accessorKind,
+                                              bool article) {
+  switch (accessorKind) {
+  case AccessorKind::Get:
+    return article ? "a getter" : "getter";
+  case AccessorKind::Set:
+    return article ? "a setter" : "setter";
+  case AccessorKind::Address:
+    return article ? "an addressor" : "addressor";
+  case AccessorKind::MutableAddress:
+    return article ? "a mutable addressor" : "mutable addressor";
+  case AccessorKind::Read:
+    return article ? "a 'read' accessor" : "'read' accessor";
+  case AccessorKind::Modify:
+    return article ? "a 'modify' accessor" : "'modify' accessor";
+  case AccessorKind::WillSet:
+    return "'willSet'";
+  case AccessorKind::DidSet:
+    return "'didSet'";
+  case AccessorKind::Init:
+    return article ? "an init accessor" : "init accessor";
+  }
+  llvm_unreachable("bad accessor kind");
+}
+
+StringRef swift::getAccessorNameForDiagnostic(AccessorDecl *accessor,
+                                              bool article) {
+  return getAccessorNameForDiagnostic(accessor->getAccessorKind(),
+                                      article);
+}
+
 bool AbstractStorageDecl::hasStorage() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
@@ -6571,6 +6603,27 @@ void AbstractStorageDecl::AccessorRecord::addOpaqueAccessor(AccessorDecl *decl){
   bool isUnique = registerAccessor(decl, index);
   assert(isUnique && "adding opaque accessor that's already present");
   (void) isUnique;
+}
+
+void AbstractStorageDecl::AccessorRecord::removeAccessor(
+    AccessorDecl *accessor
+) {
+  // Remove this accessor from the list of accessors.
+  assert(getAccessor(accessor->getAccessorKind()) == accessor);
+  std::remove(getAccessorsBuffer().begin(), getAccessorsBuffer().end(),
+              accessor);
+
+  // Clear out the accessor kind -> index mapping.
+  std::memset(AccessorIndices, 0, sizeof(AccessorIndices));
+
+  // Re-add all of the remaining accessors to build up the index mapping.
+  unsigned numAccessorsLeft = NumAccessors - 1;
+  NumAccessors = numAccessorsLeft;
+  auto buffer = getAccessorsBuffer();
+  NumAccessors = 0;
+  for (auto index : range(0, numAccessorsLeft)) {
+    addOpaqueAccessor(buffer[index]);
+  }
 }
 
 /// Register that we have an accessor of the given kind.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7448,8 +7448,14 @@ void Parser::parseTopLevelAccessors(
 
   bool hadLBrace = consumeIf(tok::l_brace);
 
-  ParserStatus status;
+  // Prepopulate the field for any accessors that were already parsed parsed accessors
   ParsedAccessors accessors;
+#define ACCESSOR(ID)                                            \
+    if (auto accessor = storage->getAccessor(AccessorKind::ID)) \
+      accessors.ID = accessor;
+#include "swift/AST/AccessorKinds.def"
+
+  ParserStatus status;
   bool hasEffectfulGet = false;
   bool parsingLimitedSyntax = false;
   while (!Tok.isAny(tok::r_brace, tok::eof)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6937,38 +6937,6 @@ void Parser::skipAnyAttribute() {
   (void)canParseCustomAttribute();
 }
 
-/// Returns a descriptive name for the given accessor/addressor kind.
-static StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind,
-                                              bool article) {
-  switch (accessorKind) {
-  case AccessorKind::Get:
-    return article ? "a getter" : "getter";
-  case AccessorKind::Set:
-    return article ? "a setter" : "setter";
-  case AccessorKind::Address:
-    return article ? "an addressor" : "addressor";
-  case AccessorKind::MutableAddress:
-    return article ? "a mutable addressor" : "mutable addressor";
-  case AccessorKind::Read:
-    return article ? "a 'read' accessor" : "'read' accessor";
-  case AccessorKind::Modify:
-    return article ? "a 'modify' accessor" : "'modify' accessor";
-  case AccessorKind::WillSet:
-    return "'willSet'";
-  case AccessorKind::DidSet:
-    return "'didSet'";
-  case AccessorKind::Init:
-    return article ? "an init accessor" : "init accessor";
-  }
-  llvm_unreachable("bad accessor kind");  
-}
-
-static StringRef getAccessorNameForDiagnostic(AccessorDecl *accessor,
-                                              bool article) {
-  return getAccessorNameForDiagnostic(accessor->getAccessorKind(),
-                                      article);
-}
-
 static void diagnoseRedundantAccessors(Parser &P, SourceLoc loc,
                                        AccessorKind accessorKind,
                                        bool isSubscript,
@@ -7021,15 +6989,6 @@ struct Parser::ParsedAccessors {
     for (auto accessor : Accessors)
       if (!accessor->isGetter())
         func(accessor);
-  }
-
-  /// Find the first accessor that's not an observing accessor.
-  AccessorDecl *findFirstNonObserver() {
-    for (auto accessor : Accessors) {
-      if (!accessor->isObservingAccessor())
-        return accessor;
-    }
-    return nullptr;
   }
 
   /// Find the first accessor that can be used to perform mutation.
@@ -7727,16 +7686,10 @@ void Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
   // The observing accessors have very specific restrictions.
   // Prefer to ignore them.
   if (WillSet || DidSet) {
-    // For now, we don't support the observing accessors on subscripts.
+    // We don't support the observing accessors on subscripts.
     if (isa<SubscriptDecl>(storage)) {
       diagnoseAndIgnoreObservers(P, *this,
                                  diag::observing_accessor_in_subscript);
-
-    // The observing accessors cannot be combined with other accessors.
-    } else if (auto nonObserver = findFirstNonObserver()) {
-      diagnoseAndIgnoreObservers(P, *this,
-                   diag::observing_accessor_conflicts_with_accessor,
-                   getAccessorNameForDiagnostic(nonObserver, /*article*/ true));
     }
   }
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1347,11 +1347,7 @@ Optional<unsigned> swift::expandAccessors(
   // declaration, so there is nothing further to do.
   bool foundNonObservingAccessor = false;
   bool foundInitAccessor = false;
-  for (auto decl : macroSourceFile->getTopLevelItems()) {
-    auto accessor = dyn_cast_or_null<AccessorDecl>(decl.dyn_cast<Decl *>());
-    if (!accessor)
-      continue;
-
+  for (auto accessor : storage->getAllAccessors()) {
     if (accessor->isInitAccessor())
       foundInitAccessor = true;
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1346,19 +1346,24 @@ Optional<unsigned> swift::expandAccessors(
   // side effect of registering those accessor declarations with the storage
   // declaration, so there is nothing further to do.
   bool foundNonObservingAccessor = false;
+  bool foundNonObservingAccessorInMacro = false;
   bool foundInitAccessor = false;
   for (auto accessor : storage->getAllAccessors()) {
     if (accessor->isInitAccessor())
       foundInitAccessor = true;
 
-    if (!accessor->isObservingAccessor())
+    if (!accessor->isObservingAccessor()) {
       foundNonObservingAccessor = true;
+
+      if (accessor->isInMacroExpansionInContext())
+        foundNonObservingAccessorInMacro = true;
+    }
   }
 
   auto roleAttr = macro->getMacroRoleAttr(MacroRole::Accessor);
   bool expectedNonObservingAccessor =
     !accessorMacroOnlyIntroducesObservers(macro, roleAttr);
-  if (foundNonObservingAccessor) {
+  if (foundNonObservingAccessorInMacro) {
     // If any non-observing accessor was added, mark the initializer as
     // subsumed unless it has init accessor, because the initializer in
     // such cases could be used for memberwise initialization.
@@ -1369,6 +1374,13 @@ Optional<unsigned> swift::expandAccessors(
         binding->setInitializerSubsumed(index);
       }
     }
+
+    // Also remove didSet and willSet, because they are subsumed by a
+    // macro expansion that turns a stored property into a computed one.
+    if (auto accessor = storage->getParsedAccessor(AccessorKind::WillSet))
+      storage->removeAccessor(accessor);
+    if (auto accessor = storage->getParsedAccessor(AccessorKind::DidSet))
+      storage->removeAccessor(accessor);
   }
 
   // Make sure we got non-observing accessors exactly where we expected to.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3636,6 +3636,37 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
 
   bool hasWillSet = storage->getParsedAccessor(AccessorKind::WillSet);
   bool hasDidSet = storage->getParsedAccessor(AccessorKind::DidSet);
+  if ((hasWillSet || hasDidSet) && !isa<SubscriptDecl>(storage)) {
+    // Observers conflict with non-observers.
+    AccessorDecl *firstNonObserver = nullptr;
+    for (auto accessor : storage->getAllAccessors()) {
+      if (!accessor->isImplicit() && !accessor->isObservingAccessor()) {
+        firstNonObserver = accessor;
+        break;
+      }
+    }
+
+    if (firstNonObserver) {
+      if (auto willSet = storage->getParsedAccessor(AccessorKind::WillSet)) {
+        willSet->diagnose(
+            diag::observing_accessor_conflicts_with_accessor, 0,
+            getAccessorNameForDiagnostic(
+                firstNonObserver->getAccessorKind(), /*article=*/ true));
+        willSet->setInvalid();
+        hasWillSet = false;
+      }
+
+      if (auto didSet = storage->getParsedAccessor(AccessorKind::DidSet)) {
+        didSet->diagnose(
+            diag::observing_accessor_conflicts_with_accessor, 1,
+            getAccessorNameForDiagnostic(
+              firstNonObserver->getAccessorKind(), /*article=*/ true));
+        didSet->setInvalid();
+        hasDidSet = false;
+      }
+    }
+  }
+
   bool hasSetter = storage->getParsedAccessor(AccessorKind::Set);
   bool hasModify = storage->getParsedAccessor(AccessorKind::Modify);
   bool hasMutableAddress = storage->getParsedAccessor(AccessorKind::MutableAddress);

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -422,8 +422,7 @@ extension PropertyWrapperMacro: AccessorMacro, Macro {
   ) throws -> [AccessorDeclSyntax] {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
       let binding = varDecl.bindings.first,
-      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-      binding.accessor == nil
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier
     else {
       return []
     }

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -48,6 +48,7 @@ struct MyWrapperThingy<T> {
 struct MyStruct {
   var _name: MyWrapperThingy<String> = .init(storage: "Hello")
   var _birthDate: MyWrapperThingy<Date?> = .init(storage: nil)
+  var _favoriteColor: MyWrapperThingy<String> = .init(storage: "Blue")
 
   @myPropertyWrapper
   var name: String
@@ -73,6 +74,11 @@ struct MyStruct {
   var age: Int? {
     get { nil }
   }
+
+  @myPropertyWrapper
+  var favoriteColor: String {
+    didSet { fatalError("Boom") }
+  }
 }
 
 // Test that the fake-property-wrapper-introduced accessors execute properly at
@@ -85,6 +91,8 @@ _ = ms.name
 // CHECK-NEXT: Setting value World
 ms.name = "World"
 
+// CHECK-NEXT: Setting value Yellow
+ms.favoriteColor = "Yellow"
 
 #if TEST_DIAGNOSTICS
 struct MyBrokenStruct {

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -6,6 +6,10 @@
 // First check for no errors.
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition)
 
+// Check for expected errors.
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -DTEST_DIAGNOSTICS %s > %t/diags.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DIAGS %s < %t/diags.txt
+
 // Check that the expansion buffer are as expected.
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
@@ -72,3 +76,23 @@ _ = ms.name
 // CHECK-NEXT: Setting value World
 ms.name = "World"
 
+
+#if TEST_DIAGNOSTICS
+struct MyBrokenStruct {
+  var _birthDate: MyWrapperThingy<Date?> = .init(storage: nil)
+
+  @myPropertyWrapper
+  var birthDate: Date? {
+    // CHECK-DIAGS: variable already has a getter
+    // CHECK-DIAGS: in expansion of macro
+    // CHECK-DIAGS: previous definition of getter here
+    get { fatalError("Boom") }
+
+    // CHECK-DIAGS: variable already has a setter
+    // CHECK-DIAGS: in expansion of macro
+    // CHECK-DIAGS: previous definition of setter here
+    set { fatalError("Boom") }
+  }
+}
+
+#endif

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -23,6 +23,10 @@
 macro myPropertyWrapper() =
     #externalMacro(module: "MacroDefinition", type: "PropertyWrapperMacro")
 
+@attached(accessor)
+macro myPropertyWrapperSkipsComputed() =
+    #externalMacro(module: "MacroDefinition", type: "PropertyWrapperSkipsComputedMacro")
+
 struct Date { }
 
 struct MyWrapperThingy<T> {
@@ -64,6 +68,11 @@ struct MyStruct {
   // CHECK-DUMP: set {
   // CHECK-DUMP:   _birthDate.wrappedValue = newValue
   // CHECK-DUMP: }
+
+  @myPropertyWrapperSkipsComputed
+  var age: Int? {
+    get { nil }
+  }
 }
 
 // Test that the fake-property-wrapper-introduced accessors execute properly at


### PR DESCRIPTION
Improve accessor macros in several different related ways:
* Diagnose when a macro produces an accessor that already exists (instead of failing silently)
* Allow an accessor macro that normally converts a stored property into a computed one to do nothing when applied to a computed property
* Remove `didSet`/`willSet` when an accessor macro converts a stored property into a computed one; the macro itself takes responsibility for them.

Fixes rdar://111588129&111586568&111101833

Cherry-picked from https://github.com/apple/swift/pull/67148