### PR TITLE
🍒[cxx-interop] Allow inserting elements into `std::set` from Swift

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -114,6 +114,7 @@ PROTOCOL(CxxPair)
 PROTOCOL(CxxSet)
 PROTOCOL(CxxRandomAccessCollection)
 PROTOCOL(CxxSequence)
+PROTOCOL(CxxUniqueSet)
 PROTOCOL(UnsafeCxxInputIterator)
 PROTOCOL(UnsafeCxxRandomAccessIterator)
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1128,6 +1128,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSet:
   case KnownProtocolKind::CxxSequence:
+  case KnownProtocolKind::CxxUniqueSet:
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
     M = getLoadedModule(Id_Cxx);

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -631,6 +631,34 @@ void swift::conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("InsertionResult"),
                                insert->getResultInterfaceType());
   impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxSet});
+
+  // If this isn't a std::multiset, try to also synthesize the conformance to
+  // CxxUniqueSet.
+  if (!isStdDecl(clangDecl, {"set", "unordered_set"}))
+    return;
+
+  ProtocolDecl *cxxIteratorProto =
+      ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator);
+  if (!cxxIteratorProto)
+    return;
+
+  auto rawMutableIteratorType =
+      lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+          decl, ctx.getIdentifier("iterator"));
+  if (!rawMutableIteratorType)
+    return;
+
+  auto rawMutableIteratorTy = rawMutableIteratorType->getUnderlyingType();
+  // Check if RawMutableIterator conforms to UnsafeCxxInputIterator.
+  ModuleDecl *module = decl->getModuleContext();
+  auto rawIteratorConformanceRef =
+      module->lookupConformance(rawMutableIteratorTy, cxxIteratorProto);
+  if (!isConcreteAndValid(rawIteratorConformanceRef, module))
+    return;
+
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawMutableIterator"),
+                               rawMutableIteratorTy);
+  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxUniqueSet});
 }
 
 void swift::conformToCxxPairIfNeeded(ClangImporter::Implementation &impl,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6272,6 +6272,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSet:
   case KnownProtocolKind::CxxSequence:
+  case KnownProtocolKind::CxxUniqueSet:
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
   case KnownProtocolKind::Executor:

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -61,4 +61,32 @@ StdSetTestSuite.test("UnorderedSetOfCInt.init()") {
     expectTrue(s.contains(3))
 }
 
+StdSetTestSuite.test("SetOfCInt.insert") {
+    var s = SetOfCInt()
+    expectFalse(s.contains(123))
+
+    let res1 = s.insert(123)
+    expectTrue(res1.inserted)
+    expectTrue(s.contains(123))
+
+    let res2 = s.insert(123)
+    expectFalse(res2.inserted)
+    expectTrue(s.contains(123))
+}
+
+#if !os(Linux) // FIXME: https://github.com/apple/swift/issues/66767 / rdar://105220600
+StdSetTestSuite.test("UnorderedSetOfCInt.insert") {
+    var s = UnorderedSetOfCInt()
+    expectFalse(s.contains(123))
+
+    let res1 = s.insert(123)
+    expectTrue(res1.inserted)
+    expectTrue(s.contains(123))
+
+    let res2 = s.insert(123)
+    expectFalse(res2.inserted)
+    expectTrue(s.contains(123))
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
**Explanation**: `std::set::insert` isn't exposed into Swift, because it returns an instance of an unsafe type. This change adds a Swift overload of `insert` for `std::set` and `std::unordered_set` that has the return type identical to `Swift.Set.insert`: a tuple of `(inserted: Bool, memberAfterInsert: Element)`.
**Scope**: This adds extra logic to the C++ stdlib overlay, and adjusts ClangImporter's auto-conformance mechanism to account for the new protocol requirement of `CxxSet`.
**Risk**: Low, this only has an effect when C++ interop is enabled.

Original PR: https://github.com/apple/swift/pull/66764

rdar://111036912
(cherry picked from commit b79b65c0567bb464d8f6a03ae514e50132acaeaa)