### PR TITLE
Skip build system tests when targeting remote executors

### DIFF
--- a/validation-test/BuildSystem/lit.local.cfg
+++ b/validation-test/BuildSystem/lit.local.cfg
@@ -1,0 +1,4 @@
+if ("remote_run" in config.available_features or
+    "device_run" in config.available_features):
+    lit_config.note("Skipping build system tests, since they are not supported on remote executors")
+    config.unsupported = True


### PR DESCRIPTION
These will be still exercised when targeting macOS, Linux and Windows.

Addresses rdar://111854328