### PR TITLE
[AutoDiff] Prevent crash when using @differentiable without importing _Differentiation

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5780,8 +5780,10 @@ IndexSubset *DifferentiableAttributeTypeCheckRequest::evaluate(
 
   // `@differentiable` attribute requires experimental differentiable
   // programming to be enabled.
-  if (checkIfDifferentiableProgrammingEnabled(attr, D))
+  if (checkIfDifferentiableProgrammingEnabled(attr, D)) {
+    attr->setInvalid();
     return nullptr;
+  }
 
   // If `@differentiable` attribute is declared directly on a
   // `AbstractStorageDecl` (a stored/computed property or subscript),
@@ -5791,8 +5793,10 @@ IndexSubset *DifferentiableAttributeTypeCheckRequest::evaluate(
 
   // Resolve the original `AbstractFunctionDecl`.
   auto *original = resolveDifferentiableAttrOriginalFunction(attr);
-  if (!original)
+  if (!original) {
+    attr->setInvalid();
     return nullptr;
+  }
 
   return typecheckDifferentiableAttrforDecl(original, attr);
 }

--- a/test/AutoDiff/Sema/differentiable_swift_without_import.swift
+++ b/test/AutoDiff/Sema/differentiable_swift_without_import.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  @differentiable(reverse) // expected-error {{@differentiable attribute used without importing module '_Differentiation'}}
+  func req()
+}
+
+struct S: P {
+  // Had the `_Differentiation` module been imported, this conformance 
+  // requirement would have generated an error, complaining about the 
+  // missing `@derivative` attribute. However, because the `_Differentiation`
+  // module import is missing, the `@differential` attribute on `P` is marked
+  // invalid and therefore not used while validating witnesses (specifically `S.req()`) 
+  // for the `P.req()` requirement.
+  public func req() {}
+}


### PR DESCRIPTION
The above referenced issue was causing a compiler crash when writing differentiable protocols and corresponding implementers, without importing the `_Differentiation` module.

Changes in this CR fix the issue by marking any `@differentiable` attributes as invalid, if the `_Differentiation` module has not been imported. This ignores the `@differentiable` attributes when the protocol witnesses are being verified. Witness verification was previously leading to an error (due to missing `@differentiable` attribute on the protocol requirement implementer), and the corresponding diagnostic emission code was then leading to a crash, because it was expecting the `_Differentiation` module to be present.

Fixes #59100