### PR TITLE
[interop] do not import function templates with template parameter no…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3299,8 +3299,16 @@ namespace {
           // then still add a generic so that it can be overrieded.
           // TODO(https://github.com/apple/swift/issues/57184): In the future we might want to import two overloads in this case so that the default type could still be used.
           if (templateTypeParam->hasDefaultArgument() &&
-              !templateParamTypeUsedInSignature(templateTypeParam))
+              !templateParamTypeUsedInSignature(templateTypeParam)) {
+            // We do not yet support instantiation of default values of template
+            // parameters when the function template is instantiated, so do not
+            // import the function template if the template parameter has
+            // dependent default value.
+            auto defaultArgumentType = templateTypeParam->getDefaultArgument();
+            if (defaultArgumentType->isDependentType())
+              return nullptr;
             continue;
+          }
 
           auto *typeParam = Impl.createDeclWithClangNode<GenericTypeParamDecl>(
               param, AccessLevel::Public, dc,

--- a/test/Interop/Cxx/templates/Inputs/enable-if.h
+++ b/test/Interop/Cxx/templates/Inputs/enable-if.h
@@ -26,4 +26,14 @@ struct HasMethodWithEnableIf {
   }
 };
 
+struct HasConstructorWithEnableIf {
+  template<class T, class _ = typename enable_if<is_bool<T>::value, bool>::type>
+  HasConstructorWithEnableIf(const T &);
+};
+
+struct HasConstructorWithEnableIfUsed {
+  template<class T, class U = typename enable_if<is_bool<T>::value, bool>::type>
+  HasConstructorWithEnableIfUsed(const T &, const U &);
+};
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_ENABLE_IF_H

--- a/test/Interop/Cxx/templates/enable-if-module-interface.swift
+++ b/test/Interop/Cxx/templates/enable-if-module-interface.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=EnableIf -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// The `init<T>` constructor template is not yet supported in Swift.
+
+// CHECK: struct HasConstructorWithEnableIf {
+// CHECK-NEXT:  @available(*, deprecated, message: "This zero-initializes the backing memory of the struct, which is unsafe for some C++ structs. Consider adding an explicit default initializer for this C++ struct.")
+// CHECK-NEXT:  init()
+// CHECK-NEXT:}
+
+// CHECK: struct HasConstructorWithEnableIfUsed {
+// CHECK-NEXT:  init<T, U>(_: T, _: U)


### PR DESCRIPTION
…t present in signature whose default value is dependent

rdar://107561753
(cherry picked from commit be65796b8634f3c129063a5c23f298330da1ab96)

- Explanation: C++ function templates are mapped to Swift generic functions. Function template parameters with default values that are not used in the function's signature are not mapped to generic arguments, as we assume we can reuse the default value instead for an instantiated function. This works unless the default value is itself a dependent type that requires instantiation as well. In such case, we do not support instantiation of the template parameter right now, so we should prohibit such templated functions in Swift instead.
- Scope: C++ interop, clang import, C++ function templates in Swift.
- Risk: Low, this only has an effect for C++ function templates with default values in template parameters.
- Original PR: https://github.com/apple/swift/pull/67134