### PR TITLE
[interop] do not warn about a template with too many specializations …

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -128,10 +128,6 @@ WARNING(libstdcxx_modulemap_not_found, none,
         "module map for libstdc++ not found for '%0'; C++ stdlib may be unavailable",
         (StringRef))
 
-WARNING(too_many_class_template_instantiations, none,
-        "template instantiation for '%0' not imported: too many instantiations",
-        (StringRef))
-
 WARNING(api_pattern_attr_ignored, none,
         "'%0' swift attribute ignored on type '%1': type is not copyable or destructible",
         (StringRef, StringRef))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2889,12 +2889,12 @@ namespace {
       if (size_t(
               llvm::size(decl->getSpecializedTemplate()->specializations())) >
           specializationLimit) {
-        std::string name;
-        llvm::raw_string_ostream os(name);
-        decl->printQualifiedName(os);
-        // Emit a warning if we haven't warned about this decl yet.
-        if (Impl.tooDeepTemplateSpecializations.insert(name).second)
-          Impl.diagnose({}, diag::too_many_class_template_instantiations, name);
+        // Note: it would be nice to import a dummy unavailable struct,
+        // but we would then need to instantiate the template here,
+        // as we cannot import a struct without a definition. That would
+        // defeat the purpose. Also, we can't make the dummy
+        // struct simply unavailable, as that still makes the
+        // typelias that references it available.
         return nullptr;
       }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -655,10 +655,6 @@ public:
   llvm::DenseMap<clang::FunctionDecl *, ValueDecl *>
       specializedFunctionTemplates;
 
-  /// Stores qualified names of C++ template specializations that were too deep
-  /// to import into Swift.
-  llvm::StringSet<> tooDeepTemplateSpecializations;
-
   /// Keeps track of the Clang functions that have been turned into
   /// properties.
   llvm::DenseMap<const clang::FunctionDecl *, VarDecl *> FunctionsAsProperties;

--- a/test/Interop/Cxx/templates/Inputs/many-specializations.h
+++ b/test/Interop/Cxx/templates/Inputs/many-specializations.h
@@ -1,0 +1,3015 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_MANY_SPECIALIZATIONS_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_MANY_SPECIALIZATIONS_H
+
+template<class T>
+struct TemplateStruct {
+    T x;
+};
+
+struct S1 {};
+using T1 = TemplateStruct<S1>;
+
+struct S2 {};
+using T2 = TemplateStruct<S2>;
+
+struct S3 {};
+using T3 = TemplateStruct<S3>;
+
+struct S4 {};
+using T4 = TemplateStruct<S4>;
+
+struct S5 {};
+using T5 = TemplateStruct<S5>;
+
+struct S6 {};
+using T6 = TemplateStruct<S6>;
+
+struct S7 {};
+using T7 = TemplateStruct<S7>;
+
+struct S8 {};
+using T8 = TemplateStruct<S8>;
+
+struct S9 {};
+using T9 = TemplateStruct<S9>;
+
+struct S10 {};
+using T10 = TemplateStruct<S10>;
+
+struct S11 {};
+using T11 = TemplateStruct<S11>;
+
+struct S12 {};
+using T12 = TemplateStruct<S12>;
+
+struct S13 {};
+using T13 = TemplateStruct<S13>;
+
+struct S14 {};
+using T14 = TemplateStruct<S14>;
+
+struct S15 {};
+using T15 = TemplateStruct<S15>;
+
+struct S16 {};
+using T16 = TemplateStruct<S16>;
+
+struct S17 {};
+using T17 = TemplateStruct<S17>;
+
+struct S18 {};
+using T18 = TemplateStruct<S18>;
+
+struct S19 {};
+using T19 = TemplateStruct<S19>;
+
+struct S20 {};
+using T20 = TemplateStruct<S20>;
+
+struct S21 {};
+using T21 = TemplateStruct<S21>;
+
+struct S22 {};
+using T22 = TemplateStruct<S22>;
+
+struct S23 {};
+using T23 = TemplateStruct<S23>;
+
+struct S24 {};
+using T24 = TemplateStruct<S24>;
+
+struct S25 {};
+using T25 = TemplateStruct<S25>;
+
+struct S26 {};
+using T26 = TemplateStruct<S26>;
+
+struct S27 {};
+using T27 = TemplateStruct<S27>;
+
+struct S28 {};
+using T28 = TemplateStruct<S28>;
+
+struct S29 {};
+using T29 = TemplateStruct<S29>;
+
+struct S30 {};
+using T30 = TemplateStruct<S30>;
+
+struct S31 {};
+using T31 = TemplateStruct<S31>;
+
+struct S32 {};
+using T32 = TemplateStruct<S32>;
+
+struct S33 {};
+using T33 = TemplateStruct<S33>;
+
+struct S34 {};
+using T34 = TemplateStruct<S34>;
+
+struct S35 {};
+using T35 = TemplateStruct<S35>;
+
+struct S36 {};
+using T36 = TemplateStruct<S36>;
+
+struct S37 {};
+using T37 = TemplateStruct<S37>;
+
+struct S38 {};
+using T38 = TemplateStruct<S38>;
+
+struct S39 {};
+using T39 = TemplateStruct<S39>;
+
+struct S40 {};
+using T40 = TemplateStruct<S40>;
+
+struct S41 {};
+using T41 = TemplateStruct<S41>;
+
+struct S42 {};
+using T42 = TemplateStruct<S42>;
+
+struct S43 {};
+using T43 = TemplateStruct<S43>;
+
+struct S44 {};
+using T44 = TemplateStruct<S44>;
+
+struct S45 {};
+using T45 = TemplateStruct<S45>;
+
+struct S46 {};
+using T46 = TemplateStruct<S46>;
+
+struct S47 {};
+using T47 = TemplateStruct<S47>;
+
+struct S48 {};
+using T48 = TemplateStruct<S48>;
+
+struct S49 {};
+using T49 = TemplateStruct<S49>;
+
+struct S50 {};
+using T50 = TemplateStruct<S50>;
+
+struct S51 {};
+using T51 = TemplateStruct<S51>;
+
+struct S52 {};
+using T52 = TemplateStruct<S52>;
+
+struct S53 {};
+using T53 = TemplateStruct<S53>;
+
+struct S54 {};
+using T54 = TemplateStruct<S54>;
+
+struct S55 {};
+using T55 = TemplateStruct<S55>;
+
+struct S56 {};
+using T56 = TemplateStruct<S56>;
+
+struct S57 {};
+using T57 = TemplateStruct<S57>;
+
+struct S58 {};
+using T58 = TemplateStruct<S58>;
+
+struct S59 {};
+using T59 = TemplateStruct<S59>;
+
+struct S60 {};
+using T60 = TemplateStruct<S60>;
+
+struct S61 {};
+using T61 = TemplateStruct<S61>;
+
+struct S62 {};
+using T62 = TemplateStruct<S62>;
+
+struct S63 {};
+using T63 = TemplateStruct<S63>;
+
+struct S64 {};
+using T64 = TemplateStruct<S64>;
+
+struct S65 {};
+using T65 = TemplateStruct<S65>;
+
+struct S66 {};
+using T66 = TemplateStruct<S66>;
+
+struct S67 {};
+using T67 = TemplateStruct<S67>;
+
+struct S68 {};
+using T68 = TemplateStruct<S68>;
+
+struct S69 {};
+using T69 = TemplateStruct<S69>;
+
+struct S70 {};
+using T70 = TemplateStruct<S70>;
+
+struct S71 {};
+using T71 = TemplateStruct<S71>;
+
+struct S72 {};
+using T72 = TemplateStruct<S72>;
+
+struct S73 {};
+using T73 = TemplateStruct<S73>;
+
+struct S74 {};
+using T74 = TemplateStruct<S74>;
+
+struct S75 {};
+using T75 = TemplateStruct<S75>;
+
+struct S76 {};
+using T76 = TemplateStruct<S76>;
+
+struct S77 {};
+using T77 = TemplateStruct<S77>;
+
+struct S78 {};
+using T78 = TemplateStruct<S78>;
+
+struct S79 {};
+using T79 = TemplateStruct<S79>;
+
+struct S80 {};
+using T80 = TemplateStruct<S80>;
+
+struct S81 {};
+using T81 = TemplateStruct<S81>;
+
+struct S82 {};
+using T82 = TemplateStruct<S82>;
+
+struct S83 {};
+using T83 = TemplateStruct<S83>;
+
+struct S84 {};
+using T84 = TemplateStruct<S84>;
+
+struct S85 {};
+using T85 = TemplateStruct<S85>;
+
+struct S86 {};
+using T86 = TemplateStruct<S86>;
+
+struct S87 {};
+using T87 = TemplateStruct<S87>;
+
+struct S88 {};
+using T88 = TemplateStruct<S88>;
+
+struct S89 {};
+using T89 = TemplateStruct<S89>;
+
+struct S90 {};
+using T90 = TemplateStruct<S90>;
+
+struct S91 {};
+using T91 = TemplateStruct<S91>;
+
+struct S92 {};
+using T92 = TemplateStruct<S92>;
+
+struct S93 {};
+using T93 = TemplateStruct<S93>;
+
+struct S94 {};
+using T94 = TemplateStruct<S94>;
+
+struct S95 {};
+using T95 = TemplateStruct<S95>;
+
+struct S96 {};
+using T96 = TemplateStruct<S96>;
+
+struct S97 {};
+using T97 = TemplateStruct<S97>;
+
+struct S98 {};
+using T98 = TemplateStruct<S98>;
+
+struct S99 {};
+using T99 = TemplateStruct<S99>;
+
+struct S100 {};
+using T100 = TemplateStruct<S100>;
+
+struct S101 {};
+using T101 = TemplateStruct<S101>;
+
+struct S102 {};
+using T102 = TemplateStruct<S102>;
+
+struct S103 {};
+using T103 = TemplateStruct<S103>;
+
+struct S104 {};
+using T104 = TemplateStruct<S104>;
+
+struct S105 {};
+using T105 = TemplateStruct<S105>;
+
+struct S106 {};
+using T106 = TemplateStruct<S106>;
+
+struct S107 {};
+using T107 = TemplateStruct<S107>;
+
+struct S108 {};
+using T108 = TemplateStruct<S108>;
+
+struct S109 {};
+using T109 = TemplateStruct<S109>;
+
+struct S110 {};
+using T110 = TemplateStruct<S110>;
+
+struct S111 {};
+using T111 = TemplateStruct<S111>;
+
+struct S112 {};
+using T112 = TemplateStruct<S112>;
+
+struct S113 {};
+using T113 = TemplateStruct<S113>;
+
+struct S114 {};
+using T114 = TemplateStruct<S114>;
+
+struct S115 {};
+using T115 = TemplateStruct<S115>;
+
+struct S116 {};
+using T116 = TemplateStruct<S116>;
+
+struct S117 {};
+using T117 = TemplateStruct<S117>;
+
+struct S118 {};
+using T118 = TemplateStruct<S118>;
+
+struct S119 {};
+using T119 = TemplateStruct<S119>;
+
+struct S120 {};
+using T120 = TemplateStruct<S120>;
+
+struct S121 {};
+using T121 = TemplateStruct<S121>;
+
+struct S122 {};
+using T122 = TemplateStruct<S122>;
+
+struct S123 {};
+using T123 = TemplateStruct<S123>;
+
+struct S124 {};
+using T124 = TemplateStruct<S124>;
+
+struct S125 {};
+using T125 = TemplateStruct<S125>;
+
+struct S126 {};
+using T126 = TemplateStruct<S126>;
+
+struct S127 {};
+using T127 = TemplateStruct<S127>;
+
+struct S128 {};
+using T128 = TemplateStruct<S128>;
+
+struct S129 {};
+using T129 = TemplateStruct<S129>;
+
+struct S130 {};
+using T130 = TemplateStruct<S130>;
+
+struct S131 {};
+using T131 = TemplateStruct<S131>;
+
+struct S132 {};
+using T132 = TemplateStruct<S132>;
+
+struct S133 {};
+using T133 = TemplateStruct<S133>;
+
+struct S134 {};
+using T134 = TemplateStruct<S134>;
+
+struct S135 {};
+using T135 = TemplateStruct<S135>;
+
+struct S136 {};
+using T136 = TemplateStruct<S136>;
+
+struct S137 {};
+using T137 = TemplateStruct<S137>;
+
+struct S138 {};
+using T138 = TemplateStruct<S138>;
+
+struct S139 {};
+using T139 = TemplateStruct<S139>;
+
+struct S140 {};
+using T140 = TemplateStruct<S140>;
+
+struct S141 {};
+using T141 = TemplateStruct<S141>;
+
+struct S142 {};
+using T142 = TemplateStruct<S142>;
+
+struct S143 {};
+using T143 = TemplateStruct<S143>;
+
+struct S144 {};
+using T144 = TemplateStruct<S144>;
+
+struct S145 {};
+using T145 = TemplateStruct<S145>;
+
+struct S146 {};
+using T146 = TemplateStruct<S146>;
+
+struct S147 {};
+using T147 = TemplateStruct<S147>;
+
+struct S148 {};
+using T148 = TemplateStruct<S148>;
+
+struct S149 {};
+using T149 = TemplateStruct<S149>;
+
+struct S150 {};
+using T150 = TemplateStruct<S150>;
+
+struct S151 {};
+using T151 = TemplateStruct<S151>;
+
+struct S152 {};
+using T152 = TemplateStruct<S152>;
+
+struct S153 {};
+using T153 = TemplateStruct<S153>;
+
+struct S154 {};
+using T154 = TemplateStruct<S154>;
+
+struct S155 {};
+using T155 = TemplateStruct<S155>;
+
+struct S156 {};
+using T156 = TemplateStruct<S156>;
+
+struct S157 {};
+using T157 = TemplateStruct<S157>;
+
+struct S158 {};
+using T158 = TemplateStruct<S158>;
+
+struct S159 {};
+using T159 = TemplateStruct<S159>;
+
+struct S160 {};
+using T160 = TemplateStruct<S160>;
+
+struct S161 {};
+using T161 = TemplateStruct<S161>;
+
+struct S162 {};
+using T162 = TemplateStruct<S162>;
+
+struct S163 {};
+using T163 = TemplateStruct<S163>;
+
+struct S164 {};
+using T164 = TemplateStruct<S164>;
+
+struct S165 {};
+using T165 = TemplateStruct<S165>;
+
+struct S166 {};
+using T166 = TemplateStruct<S166>;
+
+struct S167 {};
+using T167 = TemplateStruct<S167>;
+
+struct S168 {};
+using T168 = TemplateStruct<S168>;
+
+struct S169 {};
+using T169 = TemplateStruct<S169>;
+
+struct S170 {};
+using T170 = TemplateStruct<S170>;
+
+struct S171 {};
+using T171 = TemplateStruct<S171>;
+
+struct S172 {};
+using T172 = TemplateStruct<S172>;
+
+struct S173 {};
+using T173 = TemplateStruct<S173>;
+
+struct S174 {};
+using T174 = TemplateStruct<S174>;
+
+struct S175 {};
+using T175 = TemplateStruct<S175>;
+
+struct S176 {};
+using T176 = TemplateStruct<S176>;
+
+struct S177 {};
+using T177 = TemplateStruct<S177>;
+
+struct S178 {};
+using T178 = TemplateStruct<S178>;
+
+struct S179 {};
+using T179 = TemplateStruct<S179>;
+
+struct S180 {};
+using T180 = TemplateStruct<S180>;
+
+struct S181 {};
+using T181 = TemplateStruct<S181>;
+
+struct S182 {};
+using T182 = TemplateStruct<S182>;
+
+struct S183 {};
+using T183 = TemplateStruct<S183>;
+
+struct S184 {};
+using T184 = TemplateStruct<S184>;
+
+struct S185 {};
+using T185 = TemplateStruct<S185>;
+
+struct S186 {};
+using T186 = TemplateStruct<S186>;
+
+struct S187 {};
+using T187 = TemplateStruct<S187>;
+
+struct S188 {};
+using T188 = TemplateStruct<S188>;
+
+struct S189 {};
+using T189 = TemplateStruct<S189>;
+
+struct S190 {};
+using T190 = TemplateStruct<S190>;
+
+struct S191 {};
+using T191 = TemplateStruct<S191>;
+
+struct S192 {};
+using T192 = TemplateStruct<S192>;
+
+struct S193 {};
+using T193 = TemplateStruct<S193>;
+
+struct S194 {};
+using T194 = TemplateStruct<S194>;
+
+struct S195 {};
+using T195 = TemplateStruct<S195>;
+
+struct S196 {};
+using T196 = TemplateStruct<S196>;
+
+struct S197 {};
+using T197 = TemplateStruct<S197>;
+
+struct S198 {};
+using T198 = TemplateStruct<S198>;
+
+struct S199 {};
+using T199 = TemplateStruct<S199>;
+
+struct S200 {};
+using T200 = TemplateStruct<S200>;
+
+struct S201 {};
+using T201 = TemplateStruct<S201>;
+
+struct S202 {};
+using T202 = TemplateStruct<S202>;
+
+struct S203 {};
+using T203 = TemplateStruct<S203>;
+
+struct S204 {};
+using T204 = TemplateStruct<S204>;
+
+struct S205 {};
+using T205 = TemplateStruct<S205>;
+
+struct S206 {};
+using T206 = TemplateStruct<S206>;
+
+struct S207 {};
+using T207 = TemplateStruct<S207>;
+
+struct S208 {};
+using T208 = TemplateStruct<S208>;
+
+struct S209 {};
+using T209 = TemplateStruct<S209>;
+
+struct S210 {};
+using T210 = TemplateStruct<S210>;
+
+struct S211 {};
+using T211 = TemplateStruct<S211>;
+
+struct S212 {};
+using T212 = TemplateStruct<S212>;
+
+struct S213 {};
+using T213 = TemplateStruct<S213>;
+
+struct S214 {};
+using T214 = TemplateStruct<S214>;
+
+struct S215 {};
+using T215 = TemplateStruct<S215>;
+
+struct S216 {};
+using T216 = TemplateStruct<S216>;
+
+struct S217 {};
+using T217 = TemplateStruct<S217>;
+
+struct S218 {};
+using T218 = TemplateStruct<S218>;
+
+struct S219 {};
+using T219 = TemplateStruct<S219>;
+
+struct S220 {};
+using T220 = TemplateStruct<S220>;
+
+struct S221 {};
+using T221 = TemplateStruct<S221>;
+
+struct S222 {};
+using T222 = TemplateStruct<S222>;
+
+struct S223 {};
+using T223 = TemplateStruct<S223>;
+
+struct S224 {};
+using T224 = TemplateStruct<S224>;
+
+struct S225 {};
+using T225 = TemplateStruct<S225>;
+
+struct S226 {};
+using T226 = TemplateStruct<S226>;
+
+struct S227 {};
+using T227 = TemplateStruct<S227>;
+
+struct S228 {};
+using T228 = TemplateStruct<S228>;
+
+struct S229 {};
+using T229 = TemplateStruct<S229>;
+
+struct S230 {};
+using T230 = TemplateStruct<S230>;
+
+struct S231 {};
+using T231 = TemplateStruct<S231>;
+
+struct S232 {};
+using T232 = TemplateStruct<S232>;
+
+struct S233 {};
+using T233 = TemplateStruct<S233>;
+
+struct S234 {};
+using T234 = TemplateStruct<S234>;
+
+struct S235 {};
+using T235 = TemplateStruct<S235>;
+
+struct S236 {};
+using T236 = TemplateStruct<S236>;
+
+struct S237 {};
+using T237 = TemplateStruct<S237>;
+
+struct S238 {};
+using T238 = TemplateStruct<S238>;
+
+struct S239 {};
+using T239 = TemplateStruct<S239>;
+
+struct S240 {};
+using T240 = TemplateStruct<S240>;
+
+struct S241 {};
+using T241 = TemplateStruct<S241>;
+
+struct S242 {};
+using T242 = TemplateStruct<S242>;
+
+struct S243 {};
+using T243 = TemplateStruct<S243>;
+
+struct S244 {};
+using T244 = TemplateStruct<S244>;
+
+struct S245 {};
+using T245 = TemplateStruct<S245>;
+
+struct S246 {};
+using T246 = TemplateStruct<S246>;
+
+struct S247 {};
+using T247 = TemplateStruct<S247>;
+
+struct S248 {};
+using T248 = TemplateStruct<S248>;
+
+struct S249 {};
+using T249 = TemplateStruct<S249>;
+
+struct S250 {};
+using T250 = TemplateStruct<S250>;
+
+struct S251 {};
+using T251 = TemplateStruct<S251>;
+
+struct S252 {};
+using T252 = TemplateStruct<S252>;
+
+struct S253 {};
+using T253 = TemplateStruct<S253>;
+
+struct S254 {};
+using T254 = TemplateStruct<S254>;
+
+struct S255 {};
+using T255 = TemplateStruct<S255>;
+
+struct S256 {};
+using T256 = TemplateStruct<S256>;
+
+struct S257 {};
+using T257 = TemplateStruct<S257>;
+
+struct S258 {};
+using T258 = TemplateStruct<S258>;
+
+struct S259 {};
+using T259 = TemplateStruct<S259>;
+
+struct S260 {};
+using T260 = TemplateStruct<S260>;
+
+struct S261 {};
+using T261 = TemplateStruct<S261>;
+
+struct S262 {};
+using T262 = TemplateStruct<S262>;
+
+struct S263 {};
+using T263 = TemplateStruct<S263>;
+
+struct S264 {};
+using T264 = TemplateStruct<S264>;
+
+struct S265 {};
+using T265 = TemplateStruct<S265>;
+
+struct S266 {};
+using T266 = TemplateStruct<S266>;
+
+struct S267 {};
+using T267 = TemplateStruct<S267>;
+
+struct S268 {};
+using T268 = TemplateStruct<S268>;
+
+struct S269 {};
+using T269 = TemplateStruct<S269>;
+
+struct S270 {};
+using T270 = TemplateStruct<S270>;
+
+struct S271 {};
+using T271 = TemplateStruct<S271>;
+
+struct S272 {};
+using T272 = TemplateStruct<S272>;
+
+struct S273 {};
+using T273 = TemplateStruct<S273>;
+
+struct S274 {};
+using T274 = TemplateStruct<S274>;
+
+struct S275 {};
+using T275 = TemplateStruct<S275>;
+
+struct S276 {};
+using T276 = TemplateStruct<S276>;
+
+struct S277 {};
+using T277 = TemplateStruct<S277>;
+
+struct S278 {};
+using T278 = TemplateStruct<S278>;
+
+struct S279 {};
+using T279 = TemplateStruct<S279>;
+
+struct S280 {};
+using T280 = TemplateStruct<S280>;
+
+struct S281 {};
+using T281 = TemplateStruct<S281>;
+
+struct S282 {};
+using T282 = TemplateStruct<S282>;
+
+struct S283 {};
+using T283 = TemplateStruct<S283>;
+
+struct S284 {};
+using T284 = TemplateStruct<S284>;
+
+struct S285 {};
+using T285 = TemplateStruct<S285>;
+
+struct S286 {};
+using T286 = TemplateStruct<S286>;
+
+struct S287 {};
+using T287 = TemplateStruct<S287>;
+
+struct S288 {};
+using T288 = TemplateStruct<S288>;
+
+struct S289 {};
+using T289 = TemplateStruct<S289>;
+
+struct S290 {};
+using T290 = TemplateStruct<S290>;
+
+struct S291 {};
+using T291 = TemplateStruct<S291>;
+
+struct S292 {};
+using T292 = TemplateStruct<S292>;
+
+struct S293 {};
+using T293 = TemplateStruct<S293>;
+
+struct S294 {};
+using T294 = TemplateStruct<S294>;
+
+struct S295 {};
+using T295 = TemplateStruct<S295>;
+
+struct S296 {};
+using T296 = TemplateStruct<S296>;
+
+struct S297 {};
+using T297 = TemplateStruct<S297>;
+
+struct S298 {};
+using T298 = TemplateStruct<S298>;
+
+struct S299 {};
+using T299 = TemplateStruct<S299>;
+
+struct S300 {};
+using T300 = TemplateStruct<S300>;
+
+struct S301 {};
+using T301 = TemplateStruct<S301>;
+
+struct S302 {};
+using T302 = TemplateStruct<S302>;
+
+struct S303 {};
+using T303 = TemplateStruct<S303>;
+
+struct S304 {};
+using T304 = TemplateStruct<S304>;
+
+struct S305 {};
+using T305 = TemplateStruct<S305>;
+
+struct S306 {};
+using T306 = TemplateStruct<S306>;
+
+struct S307 {};
+using T307 = TemplateStruct<S307>;
+
+struct S308 {};
+using T308 = TemplateStruct<S308>;
+
+struct S309 {};
+using T309 = TemplateStruct<S309>;
+
+struct S310 {};
+using T310 = TemplateStruct<S310>;
+
+struct S311 {};
+using T311 = TemplateStruct<S311>;
+
+struct S312 {};
+using T312 = TemplateStruct<S312>;
+
+struct S313 {};
+using T313 = TemplateStruct<S313>;
+
+struct S314 {};
+using T314 = TemplateStruct<S314>;
+
+struct S315 {};
+using T315 = TemplateStruct<S315>;
+
+struct S316 {};
+using T316 = TemplateStruct<S316>;
+
+struct S317 {};
+using T317 = TemplateStruct<S317>;
+
+struct S318 {};
+using T318 = TemplateStruct<S318>;
+
+struct S319 {};
+using T319 = TemplateStruct<S319>;
+
+struct S320 {};
+using T320 = TemplateStruct<S320>;
+
+struct S321 {};
+using T321 = TemplateStruct<S321>;
+
+struct S322 {};
+using T322 = TemplateStruct<S322>;
+
+struct S323 {};
+using T323 = TemplateStruct<S323>;
+
+struct S324 {};
+using T324 = TemplateStruct<S324>;
+
+struct S325 {};
+using T325 = TemplateStruct<S325>;
+
+struct S326 {};
+using T326 = TemplateStruct<S326>;
+
+struct S327 {};
+using T327 = TemplateStruct<S327>;
+
+struct S328 {};
+using T328 = TemplateStruct<S328>;
+
+struct S329 {};
+using T329 = TemplateStruct<S329>;
+
+struct S330 {};
+using T330 = TemplateStruct<S330>;
+
+struct S331 {};
+using T331 = TemplateStruct<S331>;
+
+struct S332 {};
+using T332 = TemplateStruct<S332>;
+
+struct S333 {};
+using T333 = TemplateStruct<S333>;
+
+struct S334 {};
+using T334 = TemplateStruct<S334>;
+
+struct S335 {};
+using T335 = TemplateStruct<S335>;
+
+struct S336 {};
+using T336 = TemplateStruct<S336>;
+
+struct S337 {};
+using T337 = TemplateStruct<S337>;
+
+struct S338 {};
+using T338 = TemplateStruct<S338>;
+
+struct S339 {};
+using T339 = TemplateStruct<S339>;
+
+struct S340 {};
+using T340 = TemplateStruct<S340>;
+
+struct S341 {};
+using T341 = TemplateStruct<S341>;
+
+struct S342 {};
+using T342 = TemplateStruct<S342>;
+
+struct S343 {};
+using T343 = TemplateStruct<S343>;
+
+struct S344 {};
+using T344 = TemplateStruct<S344>;
+
+struct S345 {};
+using T345 = TemplateStruct<S345>;
+
+struct S346 {};
+using T346 = TemplateStruct<S346>;
+
+struct S347 {};
+using T347 = TemplateStruct<S347>;
+
+struct S348 {};
+using T348 = TemplateStruct<S348>;
+
+struct S349 {};
+using T349 = TemplateStruct<S349>;
+
+struct S350 {};
+using T350 = TemplateStruct<S350>;
+
+struct S351 {};
+using T351 = TemplateStruct<S351>;
+
+struct S352 {};
+using T352 = TemplateStruct<S352>;
+
+struct S353 {};
+using T353 = TemplateStruct<S353>;
+
+struct S354 {};
+using T354 = TemplateStruct<S354>;
+
+struct S355 {};
+using T355 = TemplateStruct<S355>;
+
+struct S356 {};
+using T356 = TemplateStruct<S356>;
+
+struct S357 {};
+using T357 = TemplateStruct<S357>;
+
+struct S358 {};
+using T358 = TemplateStruct<S358>;
+
+struct S359 {};
+using T359 = TemplateStruct<S359>;
+
+struct S360 {};
+using T360 = TemplateStruct<S360>;
+
+struct S361 {};
+using T361 = TemplateStruct<S361>;
+
+struct S362 {};
+using T362 = TemplateStruct<S362>;
+
+struct S363 {};
+using T363 = TemplateStruct<S363>;
+
+struct S364 {};
+using T364 = TemplateStruct<S364>;
+
+struct S365 {};
+using T365 = TemplateStruct<S365>;
+
+struct S366 {};
+using T366 = TemplateStruct<S366>;
+
+struct S367 {};
+using T367 = TemplateStruct<S367>;
+
+struct S368 {};
+using T368 = TemplateStruct<S368>;
+
+struct S369 {};
+using T369 = TemplateStruct<S369>;
+
+struct S370 {};
+using T370 = TemplateStruct<S370>;
+
+struct S371 {};
+using T371 = TemplateStruct<S371>;
+
+struct S372 {};
+using T372 = TemplateStruct<S372>;
+
+struct S373 {};
+using T373 = TemplateStruct<S373>;
+
+struct S374 {};
+using T374 = TemplateStruct<S374>;
+
+struct S375 {};
+using T375 = TemplateStruct<S375>;
+
+struct S376 {};
+using T376 = TemplateStruct<S376>;
+
+struct S377 {};
+using T377 = TemplateStruct<S377>;
+
+struct S378 {};
+using T378 = TemplateStruct<S378>;
+
+struct S379 {};
+using T379 = TemplateStruct<S379>;
+
+struct S380 {};
+using T380 = TemplateStruct<S380>;
+
+struct S381 {};
+using T381 = TemplateStruct<S381>;
+
+struct S382 {};
+using T382 = TemplateStruct<S382>;
+
+struct S383 {};
+using T383 = TemplateStruct<S383>;
+
+struct S384 {};
+using T384 = TemplateStruct<S384>;
+
+struct S385 {};
+using T385 = TemplateStruct<S385>;
+
+struct S386 {};
+using T386 = TemplateStruct<S386>;
+
+struct S387 {};
+using T387 = TemplateStruct<S387>;
+
+struct S388 {};
+using T388 = TemplateStruct<S388>;
+
+struct S389 {};
+using T389 = TemplateStruct<S389>;
+
+struct S390 {};
+using T390 = TemplateStruct<S390>;
+
+struct S391 {};
+using T391 = TemplateStruct<S391>;
+
+struct S392 {};
+using T392 = TemplateStruct<S392>;
+
+struct S393 {};
+using T393 = TemplateStruct<S393>;
+
+struct S394 {};
+using T394 = TemplateStruct<S394>;
+
+struct S395 {};
+using T395 = TemplateStruct<S395>;
+
+struct S396 {};
+using T396 = TemplateStruct<S396>;
+
+struct S397 {};
+using T397 = TemplateStruct<S397>;
+
+struct S398 {};
+using T398 = TemplateStruct<S398>;
+
+struct S399 {};
+using T399 = TemplateStruct<S399>;
+
+struct S400 {};
+using T400 = TemplateStruct<S400>;
+
+struct S401 {};
+using T401 = TemplateStruct<S401>;
+
+struct S402 {};
+using T402 = TemplateStruct<S402>;
+
+struct S403 {};
+using T403 = TemplateStruct<S403>;
+
+struct S404 {};
+using T404 = TemplateStruct<S404>;
+
+struct S405 {};
+using T405 = TemplateStruct<S405>;
+
+struct S406 {};
+using T406 = TemplateStruct<S406>;
+
+struct S407 {};
+using T407 = TemplateStruct<S407>;
+
+struct S408 {};
+using T408 = TemplateStruct<S408>;
+
+struct S409 {};
+using T409 = TemplateStruct<S409>;
+
+struct S410 {};
+using T410 = TemplateStruct<S410>;
+
+struct S411 {};
+using T411 = TemplateStruct<S411>;
+
+struct S412 {};
+using T412 = TemplateStruct<S412>;
+
+struct S413 {};
+using T413 = TemplateStruct<S413>;
+
+struct S414 {};
+using T414 = TemplateStruct<S414>;
+
+struct S415 {};
+using T415 = TemplateStruct<S415>;
+
+struct S416 {};
+using T416 = TemplateStruct<S416>;
+
+struct S417 {};
+using T417 = TemplateStruct<S417>;
+
+struct S418 {};
+using T418 = TemplateStruct<S418>;
+
+struct S419 {};
+using T419 = TemplateStruct<S419>;
+
+struct S420 {};
+using T420 = TemplateStruct<S420>;
+
+struct S421 {};
+using T421 = TemplateStruct<S421>;
+
+struct S422 {};
+using T422 = TemplateStruct<S422>;
+
+struct S423 {};
+using T423 = TemplateStruct<S423>;
+
+struct S424 {};
+using T424 = TemplateStruct<S424>;
+
+struct S425 {};
+using T425 = TemplateStruct<S425>;
+
+struct S426 {};
+using T426 = TemplateStruct<S426>;
+
+struct S427 {};
+using T427 = TemplateStruct<S427>;
+
+struct S428 {};
+using T428 = TemplateStruct<S428>;
+
+struct S429 {};
+using T429 = TemplateStruct<S429>;
+
+struct S430 {};
+using T430 = TemplateStruct<S430>;
+
+struct S431 {};
+using T431 = TemplateStruct<S431>;
+
+struct S432 {};
+using T432 = TemplateStruct<S432>;
+
+struct S433 {};
+using T433 = TemplateStruct<S433>;
+
+struct S434 {};
+using T434 = TemplateStruct<S434>;
+
+struct S435 {};
+using T435 = TemplateStruct<S435>;
+
+struct S436 {};
+using T436 = TemplateStruct<S436>;
+
+struct S437 {};
+using T437 = TemplateStruct<S437>;
+
+struct S438 {};
+using T438 = TemplateStruct<S438>;
+
+struct S439 {};
+using T439 = TemplateStruct<S439>;
+
+struct S440 {};
+using T440 = TemplateStruct<S440>;
+
+struct S441 {};
+using T441 = TemplateStruct<S441>;
+
+struct S442 {};
+using T442 = TemplateStruct<S442>;
+
+struct S443 {};
+using T443 = TemplateStruct<S443>;
+
+struct S444 {};
+using T444 = TemplateStruct<S444>;
+
+struct S445 {};
+using T445 = TemplateStruct<S445>;
+
+struct S446 {};
+using T446 = TemplateStruct<S446>;
+
+struct S447 {};
+using T447 = TemplateStruct<S447>;
+
+struct S448 {};
+using T448 = TemplateStruct<S448>;
+
+struct S449 {};
+using T449 = TemplateStruct<S449>;
+
+struct S450 {};
+using T450 = TemplateStruct<S450>;
+
+struct S451 {};
+using T451 = TemplateStruct<S451>;
+
+struct S452 {};
+using T452 = TemplateStruct<S452>;
+
+struct S453 {};
+using T453 = TemplateStruct<S453>;
+
+struct S454 {};
+using T454 = TemplateStruct<S454>;
+
+struct S455 {};
+using T455 = TemplateStruct<S455>;
+
+struct S456 {};
+using T456 = TemplateStruct<S456>;
+
+struct S457 {};
+using T457 = TemplateStruct<S457>;
+
+struct S458 {};
+using T458 = TemplateStruct<S458>;
+
+struct S459 {};
+using T459 = TemplateStruct<S459>;
+
+struct S460 {};
+using T460 = TemplateStruct<S460>;
+
+struct S461 {};
+using T461 = TemplateStruct<S461>;
+
+struct S462 {};
+using T462 = TemplateStruct<S462>;
+
+struct S463 {};
+using T463 = TemplateStruct<S463>;
+
+struct S464 {};
+using T464 = TemplateStruct<S464>;
+
+struct S465 {};
+using T465 = TemplateStruct<S465>;
+
+struct S466 {};
+using T466 = TemplateStruct<S466>;
+
+struct S467 {};
+using T467 = TemplateStruct<S467>;
+
+struct S468 {};
+using T468 = TemplateStruct<S468>;
+
+struct S469 {};
+using T469 = TemplateStruct<S469>;
+
+struct S470 {};
+using T470 = TemplateStruct<S470>;
+
+struct S471 {};
+using T471 = TemplateStruct<S471>;
+
+struct S472 {};
+using T472 = TemplateStruct<S472>;
+
+struct S473 {};
+using T473 = TemplateStruct<S473>;
+
+struct S474 {};
+using T474 = TemplateStruct<S474>;
+
+struct S475 {};
+using T475 = TemplateStruct<S475>;
+
+struct S476 {};
+using T476 = TemplateStruct<S476>;
+
+struct S477 {};
+using T477 = TemplateStruct<S477>;
+
+struct S478 {};
+using T478 = TemplateStruct<S478>;
+
+struct S479 {};
+using T479 = TemplateStruct<S479>;
+
+struct S480 {};
+using T480 = TemplateStruct<S480>;
+
+struct S481 {};
+using T481 = TemplateStruct<S481>;
+
+struct S482 {};
+using T482 = TemplateStruct<S482>;
+
+struct S483 {};
+using T483 = TemplateStruct<S483>;
+
+struct S484 {};
+using T484 = TemplateStruct<S484>;
+
+struct S485 {};
+using T485 = TemplateStruct<S485>;
+
+struct S486 {};
+using T486 = TemplateStruct<S486>;
+
+struct S487 {};
+using T487 = TemplateStruct<S487>;
+
+struct S488 {};
+using T488 = TemplateStruct<S488>;
+
+struct S489 {};
+using T489 = TemplateStruct<S489>;
+
+struct S490 {};
+using T490 = TemplateStruct<S490>;
+
+struct S491 {};
+using T491 = TemplateStruct<S491>;
+
+struct S492 {};
+using T492 = TemplateStruct<S492>;
+
+struct S493 {};
+using T493 = TemplateStruct<S493>;
+
+struct S494 {};
+using T494 = TemplateStruct<S494>;
+
+struct S495 {};
+using T495 = TemplateStruct<S495>;
+
+struct S496 {};
+using T496 = TemplateStruct<S496>;
+
+struct S497 {};
+using T497 = TemplateStruct<S497>;
+
+struct S498 {};
+using T498 = TemplateStruct<S498>;
+
+struct S499 {};
+using T499 = TemplateStruct<S499>;
+
+struct S500 {};
+using T500 = TemplateStruct<S500>;
+
+struct S501 {};
+using T501 = TemplateStruct<S501>;
+
+struct S502 {};
+using T502 = TemplateStruct<S502>;
+
+struct S503 {};
+using T503 = TemplateStruct<S503>;
+
+struct S504 {};
+using T504 = TemplateStruct<S504>;
+
+struct S505 {};
+using T505 = TemplateStruct<S505>;
+
+struct S506 {};
+using T506 = TemplateStruct<S506>;
+
+struct S507 {};
+using T507 = TemplateStruct<S507>;
+
+struct S508 {};
+using T508 = TemplateStruct<S508>;
+
+struct S509 {};
+using T509 = TemplateStruct<S509>;
+
+struct S510 {};
+using T510 = TemplateStruct<S510>;
+
+struct S511 {};
+using T511 = TemplateStruct<S511>;
+
+struct S512 {};
+using T512 = TemplateStruct<S512>;
+
+struct S513 {};
+using T513 = TemplateStruct<S513>;
+
+struct S514 {};
+using T514 = TemplateStruct<S514>;
+
+struct S515 {};
+using T515 = TemplateStruct<S515>;
+
+struct S516 {};
+using T516 = TemplateStruct<S516>;
+
+struct S517 {};
+using T517 = TemplateStruct<S517>;
+
+struct S518 {};
+using T518 = TemplateStruct<S518>;
+
+struct S519 {};
+using T519 = TemplateStruct<S519>;
+
+struct S520 {};
+using T520 = TemplateStruct<S520>;
+
+struct S521 {};
+using T521 = TemplateStruct<S521>;
+
+struct S522 {};
+using T522 = TemplateStruct<S522>;
+
+struct S523 {};
+using T523 = TemplateStruct<S523>;
+
+struct S524 {};
+using T524 = TemplateStruct<S524>;
+
+struct S525 {};
+using T525 = TemplateStruct<S525>;
+
+struct S526 {};
+using T526 = TemplateStruct<S526>;
+
+struct S527 {};
+using T527 = TemplateStruct<S527>;
+
+struct S528 {};
+using T528 = TemplateStruct<S528>;
+
+struct S529 {};
+using T529 = TemplateStruct<S529>;
+
+struct S530 {};
+using T530 = TemplateStruct<S530>;
+
+struct S531 {};
+using T531 = TemplateStruct<S531>;
+
+struct S532 {};
+using T532 = TemplateStruct<S532>;
+
+struct S533 {};
+using T533 = TemplateStruct<S533>;
+
+struct S534 {};
+using T534 = TemplateStruct<S534>;
+
+struct S535 {};
+using T535 = TemplateStruct<S535>;
+
+struct S536 {};
+using T536 = TemplateStruct<S536>;
+
+struct S537 {};
+using T537 = TemplateStruct<S537>;
+
+struct S538 {};
+using T538 = TemplateStruct<S538>;
+
+struct S539 {};
+using T539 = TemplateStruct<S539>;
+
+struct S540 {};
+using T540 = TemplateStruct<S540>;
+
+struct S541 {};
+using T541 = TemplateStruct<S541>;
+
+struct S542 {};
+using T542 = TemplateStruct<S542>;
+
+struct S543 {};
+using T543 = TemplateStruct<S543>;
+
+struct S544 {};
+using T544 = TemplateStruct<S544>;
+
+struct S545 {};
+using T545 = TemplateStruct<S545>;
+
+struct S546 {};
+using T546 = TemplateStruct<S546>;
+
+struct S547 {};
+using T547 = TemplateStruct<S547>;
+
+struct S548 {};
+using T548 = TemplateStruct<S548>;
+
+struct S549 {};
+using T549 = TemplateStruct<S549>;
+
+struct S550 {};
+using T550 = TemplateStruct<S550>;
+
+struct S551 {};
+using T551 = TemplateStruct<S551>;
+
+struct S552 {};
+using T552 = TemplateStruct<S552>;
+
+struct S553 {};
+using T553 = TemplateStruct<S553>;
+
+struct S554 {};
+using T554 = TemplateStruct<S554>;
+
+struct S555 {};
+using T555 = TemplateStruct<S555>;
+
+struct S556 {};
+using T556 = TemplateStruct<S556>;
+
+struct S557 {};
+using T557 = TemplateStruct<S557>;
+
+struct S558 {};
+using T558 = TemplateStruct<S558>;
+
+struct S559 {};
+using T559 = TemplateStruct<S559>;
+
+struct S560 {};
+using T560 = TemplateStruct<S560>;
+
+struct S561 {};
+using T561 = TemplateStruct<S561>;
+
+struct S562 {};
+using T562 = TemplateStruct<S562>;
+
+struct S563 {};
+using T563 = TemplateStruct<S563>;
+
+struct S564 {};
+using T564 = TemplateStruct<S564>;
+
+struct S565 {};
+using T565 = TemplateStruct<S565>;
+
+struct S566 {};
+using T566 = TemplateStruct<S566>;
+
+struct S567 {};
+using T567 = TemplateStruct<S567>;
+
+struct S568 {};
+using T568 = TemplateStruct<S568>;
+
+struct S569 {};
+using T569 = TemplateStruct<S569>;
+
+struct S570 {};
+using T570 = TemplateStruct<S570>;
+
+struct S571 {};
+using T571 = TemplateStruct<S571>;
+
+struct S572 {};
+using T572 = TemplateStruct<S572>;
+
+struct S573 {};
+using T573 = TemplateStruct<S573>;
+
+struct S574 {};
+using T574 = TemplateStruct<S574>;
+
+struct S575 {};
+using T575 = TemplateStruct<S575>;
+
+struct S576 {};
+using T576 = TemplateStruct<S576>;
+
+struct S577 {};
+using T577 = TemplateStruct<S577>;
+
+struct S578 {};
+using T578 = TemplateStruct<S578>;
+
+struct S579 {};
+using T579 = TemplateStruct<S579>;
+
+struct S580 {};
+using T580 = TemplateStruct<S580>;
+
+struct S581 {};
+using T581 = TemplateStruct<S581>;
+
+struct S582 {};
+using T582 = TemplateStruct<S582>;
+
+struct S583 {};
+using T583 = TemplateStruct<S583>;
+
+struct S584 {};
+using T584 = TemplateStruct<S584>;
+
+struct S585 {};
+using T585 = TemplateStruct<S585>;
+
+struct S586 {};
+using T586 = TemplateStruct<S586>;
+
+struct S587 {};
+using T587 = TemplateStruct<S587>;
+
+struct S588 {};
+using T588 = TemplateStruct<S588>;
+
+struct S589 {};
+using T589 = TemplateStruct<S589>;
+
+struct S590 {};
+using T590 = TemplateStruct<S590>;
+
+struct S591 {};
+using T591 = TemplateStruct<S591>;
+
+struct S592 {};
+using T592 = TemplateStruct<S592>;
+
+struct S593 {};
+using T593 = TemplateStruct<S593>;
+
+struct S594 {};
+using T594 = TemplateStruct<S594>;
+
+struct S595 {};
+using T595 = TemplateStruct<S595>;
+
+struct S596 {};
+using T596 = TemplateStruct<S596>;
+
+struct S597 {};
+using T597 = TemplateStruct<S597>;
+
+struct S598 {};
+using T598 = TemplateStruct<S598>;
+
+struct S599 {};
+using T599 = TemplateStruct<S599>;
+
+struct S600 {};
+using T600 = TemplateStruct<S600>;
+
+struct S601 {};
+using T601 = TemplateStruct<S601>;
+
+struct S602 {};
+using T602 = TemplateStruct<S602>;
+
+struct S603 {};
+using T603 = TemplateStruct<S603>;
+
+struct S604 {};
+using T604 = TemplateStruct<S604>;
+
+struct S605 {};
+using T605 = TemplateStruct<S605>;
+
+struct S606 {};
+using T606 = TemplateStruct<S606>;
+
+struct S607 {};
+using T607 = TemplateStruct<S607>;
+
+struct S608 {};
+using T608 = TemplateStruct<S608>;
+
+struct S609 {};
+using T609 = TemplateStruct<S609>;
+
+struct S610 {};
+using T610 = TemplateStruct<S610>;
+
+struct S611 {};
+using T611 = TemplateStruct<S611>;
+
+struct S612 {};
+using T612 = TemplateStruct<S612>;
+
+struct S613 {};
+using T613 = TemplateStruct<S613>;
+
+struct S614 {};
+using T614 = TemplateStruct<S614>;
+
+struct S615 {};
+using T615 = TemplateStruct<S615>;
+
+struct S616 {};
+using T616 = TemplateStruct<S616>;
+
+struct S617 {};
+using T617 = TemplateStruct<S617>;
+
+struct S618 {};
+using T618 = TemplateStruct<S618>;
+
+struct S619 {};
+using T619 = TemplateStruct<S619>;
+
+struct S620 {};
+using T620 = TemplateStruct<S620>;
+
+struct S621 {};
+using T621 = TemplateStruct<S621>;
+
+struct S622 {};
+using T622 = TemplateStruct<S622>;
+
+struct S623 {};
+using T623 = TemplateStruct<S623>;
+
+struct S624 {};
+using T624 = TemplateStruct<S624>;
+
+struct S625 {};
+using T625 = TemplateStruct<S625>;
+
+struct S626 {};
+using T626 = TemplateStruct<S626>;
+
+struct S627 {};
+using T627 = TemplateStruct<S627>;
+
+struct S628 {};
+using T628 = TemplateStruct<S628>;
+
+struct S629 {};
+using T629 = TemplateStruct<S629>;
+
+struct S630 {};
+using T630 = TemplateStruct<S630>;
+
+struct S631 {};
+using T631 = TemplateStruct<S631>;
+
+struct S632 {};
+using T632 = TemplateStruct<S632>;
+
+struct S633 {};
+using T633 = TemplateStruct<S633>;
+
+struct S634 {};
+using T634 = TemplateStruct<S634>;
+
+struct S635 {};
+using T635 = TemplateStruct<S635>;
+
+struct S636 {};
+using T636 = TemplateStruct<S636>;
+
+struct S637 {};
+using T637 = TemplateStruct<S637>;
+
+struct S638 {};
+using T638 = TemplateStruct<S638>;
+
+struct S639 {};
+using T639 = TemplateStruct<S639>;
+
+struct S640 {};
+using T640 = TemplateStruct<S640>;
+
+struct S641 {};
+using T641 = TemplateStruct<S641>;
+
+struct S642 {};
+using T642 = TemplateStruct<S642>;
+
+struct S643 {};
+using T643 = TemplateStruct<S643>;
+
+struct S644 {};
+using T644 = TemplateStruct<S644>;
+
+struct S645 {};
+using T645 = TemplateStruct<S645>;
+
+struct S646 {};
+using T646 = TemplateStruct<S646>;
+
+struct S647 {};
+using T647 = TemplateStruct<S647>;
+
+struct S648 {};
+using T648 = TemplateStruct<S648>;
+
+struct S649 {};
+using T649 = TemplateStruct<S649>;
+
+struct S650 {};
+using T650 = TemplateStruct<S650>;
+
+struct S651 {};
+using T651 = TemplateStruct<S651>;
+
+struct S652 {};
+using T652 = TemplateStruct<S652>;
+
+struct S653 {};
+using T653 = TemplateStruct<S653>;
+
+struct S654 {};
+using T654 = TemplateStruct<S654>;
+
+struct S655 {};
+using T655 = TemplateStruct<S655>;
+
+struct S656 {};
+using T656 = TemplateStruct<S656>;
+
+struct S657 {};
+using T657 = TemplateStruct<S657>;
+
+struct S658 {};
+using T658 = TemplateStruct<S658>;
+
+struct S659 {};
+using T659 = TemplateStruct<S659>;
+
+struct S660 {};
+using T660 = TemplateStruct<S660>;
+
+struct S661 {};
+using T661 = TemplateStruct<S661>;
+
+struct S662 {};
+using T662 = TemplateStruct<S662>;
+
+struct S663 {};
+using T663 = TemplateStruct<S663>;
+
+struct S664 {};
+using T664 = TemplateStruct<S664>;
+
+struct S665 {};
+using T665 = TemplateStruct<S665>;
+
+struct S666 {};
+using T666 = TemplateStruct<S666>;
+
+struct S667 {};
+using T667 = TemplateStruct<S667>;
+
+struct S668 {};
+using T668 = TemplateStruct<S668>;
+
+struct S669 {};
+using T669 = TemplateStruct<S669>;
+
+struct S670 {};
+using T670 = TemplateStruct<S670>;
+
+struct S671 {};
+using T671 = TemplateStruct<S671>;
+
+struct S672 {};
+using T672 = TemplateStruct<S672>;
+
+struct S673 {};
+using T673 = TemplateStruct<S673>;
+
+struct S674 {};
+using T674 = TemplateStruct<S674>;
+
+struct S675 {};
+using T675 = TemplateStruct<S675>;
+
+struct S676 {};
+using T676 = TemplateStruct<S676>;
+
+struct S677 {};
+using T677 = TemplateStruct<S677>;
+
+struct S678 {};
+using T678 = TemplateStruct<S678>;
+
+struct S679 {};
+using T679 = TemplateStruct<S679>;
+
+struct S680 {};
+using T680 = TemplateStruct<S680>;
+
+struct S681 {};
+using T681 = TemplateStruct<S681>;
+
+struct S682 {};
+using T682 = TemplateStruct<S682>;
+
+struct S683 {};
+using T683 = TemplateStruct<S683>;
+
+struct S684 {};
+using T684 = TemplateStruct<S684>;
+
+struct S685 {};
+using T685 = TemplateStruct<S685>;
+
+struct S686 {};
+using T686 = TemplateStruct<S686>;
+
+struct S687 {};
+using T687 = TemplateStruct<S687>;
+
+struct S688 {};
+using T688 = TemplateStruct<S688>;
+
+struct S689 {};
+using T689 = TemplateStruct<S689>;
+
+struct S690 {};
+using T690 = TemplateStruct<S690>;
+
+struct S691 {};
+using T691 = TemplateStruct<S691>;
+
+struct S692 {};
+using T692 = TemplateStruct<S692>;
+
+struct S693 {};
+using T693 = TemplateStruct<S693>;
+
+struct S694 {};
+using T694 = TemplateStruct<S694>;
+
+struct S695 {};
+using T695 = TemplateStruct<S695>;
+
+struct S696 {};
+using T696 = TemplateStruct<S696>;
+
+struct S697 {};
+using T697 = TemplateStruct<S697>;
+
+struct S698 {};
+using T698 = TemplateStruct<S698>;
+
+struct S699 {};
+using T699 = TemplateStruct<S699>;
+
+struct S700 {};
+using T700 = TemplateStruct<S700>;
+
+struct S701 {};
+using T701 = TemplateStruct<S701>;
+
+struct S702 {};
+using T702 = TemplateStruct<S702>;
+
+struct S703 {};
+using T703 = TemplateStruct<S703>;
+
+struct S704 {};
+using T704 = TemplateStruct<S704>;
+
+struct S705 {};
+using T705 = TemplateStruct<S705>;
+
+struct S706 {};
+using T706 = TemplateStruct<S706>;
+
+struct S707 {};
+using T707 = TemplateStruct<S707>;
+
+struct S708 {};
+using T708 = TemplateStruct<S708>;
+
+struct S709 {};
+using T709 = TemplateStruct<S709>;
+
+struct S710 {};
+using T710 = TemplateStruct<S710>;
+
+struct S711 {};
+using T711 = TemplateStruct<S711>;
+
+struct S712 {};
+using T712 = TemplateStruct<S712>;
+
+struct S713 {};
+using T713 = TemplateStruct<S713>;
+
+struct S714 {};
+using T714 = TemplateStruct<S714>;
+
+struct S715 {};
+using T715 = TemplateStruct<S715>;
+
+struct S716 {};
+using T716 = TemplateStruct<S716>;
+
+struct S717 {};
+using T717 = TemplateStruct<S717>;
+
+struct S718 {};
+using T718 = TemplateStruct<S718>;
+
+struct S719 {};
+using T719 = TemplateStruct<S719>;
+
+struct S720 {};
+using T720 = TemplateStruct<S720>;
+
+struct S721 {};
+using T721 = TemplateStruct<S721>;
+
+struct S722 {};
+using T722 = TemplateStruct<S722>;
+
+struct S723 {};
+using T723 = TemplateStruct<S723>;
+
+struct S724 {};
+using T724 = TemplateStruct<S724>;
+
+struct S725 {};
+using T725 = TemplateStruct<S725>;
+
+struct S726 {};
+using T726 = TemplateStruct<S726>;
+
+struct S727 {};
+using T727 = TemplateStruct<S727>;
+
+struct S728 {};
+using T728 = TemplateStruct<S728>;
+
+struct S729 {};
+using T729 = TemplateStruct<S729>;
+
+struct S730 {};
+using T730 = TemplateStruct<S730>;
+
+struct S731 {};
+using T731 = TemplateStruct<S731>;
+
+struct S732 {};
+using T732 = TemplateStruct<S732>;
+
+struct S733 {};
+using T733 = TemplateStruct<S733>;
+
+struct S734 {};
+using T734 = TemplateStruct<S734>;
+
+struct S735 {};
+using T735 = TemplateStruct<S735>;
+
+struct S736 {};
+using T736 = TemplateStruct<S736>;
+
+struct S737 {};
+using T737 = TemplateStruct<S737>;
+
+struct S738 {};
+using T738 = TemplateStruct<S738>;
+
+struct S739 {};
+using T739 = TemplateStruct<S739>;
+
+struct S740 {};
+using T740 = TemplateStruct<S740>;
+
+struct S741 {};
+using T741 = TemplateStruct<S741>;
+
+struct S742 {};
+using T742 = TemplateStruct<S742>;
+
+struct S743 {};
+using T743 = TemplateStruct<S743>;
+
+struct S744 {};
+using T744 = TemplateStruct<S744>;
+
+struct S745 {};
+using T745 = TemplateStruct<S745>;
+
+struct S746 {};
+using T746 = TemplateStruct<S746>;
+
+struct S747 {};
+using T747 = TemplateStruct<S747>;
+
+struct S748 {};
+using T748 = TemplateStruct<S748>;
+
+struct S749 {};
+using T749 = TemplateStruct<S749>;
+
+struct S750 {};
+using T750 = TemplateStruct<S750>;
+
+struct S751 {};
+using T751 = TemplateStruct<S751>;
+
+struct S752 {};
+using T752 = TemplateStruct<S752>;
+
+struct S753 {};
+using T753 = TemplateStruct<S753>;
+
+struct S754 {};
+using T754 = TemplateStruct<S754>;
+
+struct S755 {};
+using T755 = TemplateStruct<S755>;
+
+struct S756 {};
+using T756 = TemplateStruct<S756>;
+
+struct S757 {};
+using T757 = TemplateStruct<S757>;
+
+struct S758 {};
+using T758 = TemplateStruct<S758>;
+
+struct S759 {};
+using T759 = TemplateStruct<S759>;
+
+struct S760 {};
+using T760 = TemplateStruct<S760>;
+
+struct S761 {};
+using T761 = TemplateStruct<S761>;
+
+struct S762 {};
+using T762 = TemplateStruct<S762>;
+
+struct S763 {};
+using T763 = TemplateStruct<S763>;
+
+struct S764 {};
+using T764 = TemplateStruct<S764>;
+
+struct S765 {};
+using T765 = TemplateStruct<S765>;
+
+struct S766 {};
+using T766 = TemplateStruct<S766>;
+
+struct S767 {};
+using T767 = TemplateStruct<S767>;
+
+struct S768 {};
+using T768 = TemplateStruct<S768>;
+
+struct S769 {};
+using T769 = TemplateStruct<S769>;
+
+struct S770 {};
+using T770 = TemplateStruct<S770>;
+
+struct S771 {};
+using T771 = TemplateStruct<S771>;
+
+struct S772 {};
+using T772 = TemplateStruct<S772>;
+
+struct S773 {};
+using T773 = TemplateStruct<S773>;
+
+struct S774 {};
+using T774 = TemplateStruct<S774>;
+
+struct S775 {};
+using T775 = TemplateStruct<S775>;
+
+struct S776 {};
+using T776 = TemplateStruct<S776>;
+
+struct S777 {};
+using T777 = TemplateStruct<S777>;
+
+struct S778 {};
+using T778 = TemplateStruct<S778>;
+
+struct S779 {};
+using T779 = TemplateStruct<S779>;
+
+struct S780 {};
+using T780 = TemplateStruct<S780>;
+
+struct S781 {};
+using T781 = TemplateStruct<S781>;
+
+struct S782 {};
+using T782 = TemplateStruct<S782>;
+
+struct S783 {};
+using T783 = TemplateStruct<S783>;
+
+struct S784 {};
+using T784 = TemplateStruct<S784>;
+
+struct S785 {};
+using T785 = TemplateStruct<S785>;
+
+struct S786 {};
+using T786 = TemplateStruct<S786>;
+
+struct S787 {};
+using T787 = TemplateStruct<S787>;
+
+struct S788 {};
+using T788 = TemplateStruct<S788>;
+
+struct S789 {};
+using T789 = TemplateStruct<S789>;
+
+struct S790 {};
+using T790 = TemplateStruct<S790>;
+
+struct S791 {};
+using T791 = TemplateStruct<S791>;
+
+struct S792 {};
+using T792 = TemplateStruct<S792>;
+
+struct S793 {};
+using T793 = TemplateStruct<S793>;
+
+struct S794 {};
+using T794 = TemplateStruct<S794>;
+
+struct S795 {};
+using T795 = TemplateStruct<S795>;
+
+struct S796 {};
+using T796 = TemplateStruct<S796>;
+
+struct S797 {};
+using T797 = TemplateStruct<S797>;
+
+struct S798 {};
+using T798 = TemplateStruct<S798>;
+
+struct S799 {};
+using T799 = TemplateStruct<S799>;
+
+struct S800 {};
+using T800 = TemplateStruct<S800>;
+
+struct S801 {};
+using T801 = TemplateStruct<S801>;
+
+struct S802 {};
+using T802 = TemplateStruct<S802>;
+
+struct S803 {};
+using T803 = TemplateStruct<S803>;
+
+struct S804 {};
+using T804 = TemplateStruct<S804>;
+
+struct S805 {};
+using T805 = TemplateStruct<S805>;
+
+struct S806 {};
+using T806 = TemplateStruct<S806>;
+
+struct S807 {};
+using T807 = TemplateStruct<S807>;
+
+struct S808 {};
+using T808 = TemplateStruct<S808>;
+
+struct S809 {};
+using T809 = TemplateStruct<S809>;
+
+struct S810 {};
+using T810 = TemplateStruct<S810>;
+
+struct S811 {};
+using T811 = TemplateStruct<S811>;
+
+struct S812 {};
+using T812 = TemplateStruct<S812>;
+
+struct S813 {};
+using T813 = TemplateStruct<S813>;
+
+struct S814 {};
+using T814 = TemplateStruct<S814>;
+
+struct S815 {};
+using T815 = TemplateStruct<S815>;
+
+struct S816 {};
+using T816 = TemplateStruct<S816>;
+
+struct S817 {};
+using T817 = TemplateStruct<S817>;
+
+struct S818 {};
+using T818 = TemplateStruct<S818>;
+
+struct S819 {};
+using T819 = TemplateStruct<S819>;
+
+struct S820 {};
+using T820 = TemplateStruct<S820>;
+
+struct S821 {};
+using T821 = TemplateStruct<S821>;
+
+struct S822 {};
+using T822 = TemplateStruct<S822>;
+
+struct S823 {};
+using T823 = TemplateStruct<S823>;
+
+struct S824 {};
+using T824 = TemplateStruct<S824>;
+
+struct S825 {};
+using T825 = TemplateStruct<S825>;
+
+struct S826 {};
+using T826 = TemplateStruct<S826>;
+
+struct S827 {};
+using T827 = TemplateStruct<S827>;
+
+struct S828 {};
+using T828 = TemplateStruct<S828>;
+
+struct S829 {};
+using T829 = TemplateStruct<S829>;
+
+struct S830 {};
+using T830 = TemplateStruct<S830>;
+
+struct S831 {};
+using T831 = TemplateStruct<S831>;
+
+struct S832 {};
+using T832 = TemplateStruct<S832>;
+
+struct S833 {};
+using T833 = TemplateStruct<S833>;
+
+struct S834 {};
+using T834 = TemplateStruct<S834>;
+
+struct S835 {};
+using T835 = TemplateStruct<S835>;
+
+struct S836 {};
+using T836 = TemplateStruct<S836>;
+
+struct S837 {};
+using T837 = TemplateStruct<S837>;
+
+struct S838 {};
+using T838 = TemplateStruct<S838>;
+
+struct S839 {};
+using T839 = TemplateStruct<S839>;
+
+struct S840 {};
+using T840 = TemplateStruct<S840>;
+
+struct S841 {};
+using T841 = TemplateStruct<S841>;
+
+struct S842 {};
+using T842 = TemplateStruct<S842>;
+
+struct S843 {};
+using T843 = TemplateStruct<S843>;
+
+struct S844 {};
+using T844 = TemplateStruct<S844>;
+
+struct S845 {};
+using T845 = TemplateStruct<S845>;
+
+struct S846 {};
+using T846 = TemplateStruct<S846>;
+
+struct S847 {};
+using T847 = TemplateStruct<S847>;
+
+struct S848 {};
+using T848 = TemplateStruct<S848>;
+
+struct S849 {};
+using T849 = TemplateStruct<S849>;
+
+struct S850 {};
+using T850 = TemplateStruct<S850>;
+
+struct S851 {};
+using T851 = TemplateStruct<S851>;
+
+struct S852 {};
+using T852 = TemplateStruct<S852>;
+
+struct S853 {};
+using T853 = TemplateStruct<S853>;
+
+struct S854 {};
+using T854 = TemplateStruct<S854>;
+
+struct S855 {};
+using T855 = TemplateStruct<S855>;
+
+struct S856 {};
+using T856 = TemplateStruct<S856>;
+
+struct S857 {};
+using T857 = TemplateStruct<S857>;
+
+struct S858 {};
+using T858 = TemplateStruct<S858>;
+
+struct S859 {};
+using T859 = TemplateStruct<S859>;
+
+struct S860 {};
+using T860 = TemplateStruct<S860>;
+
+struct S861 {};
+using T861 = TemplateStruct<S861>;
+
+struct S862 {};
+using T862 = TemplateStruct<S862>;
+
+struct S863 {};
+using T863 = TemplateStruct<S863>;
+
+struct S864 {};
+using T864 = TemplateStruct<S864>;
+
+struct S865 {};
+using T865 = TemplateStruct<S865>;
+
+struct S866 {};
+using T866 = TemplateStruct<S866>;
+
+struct S867 {};
+using T867 = TemplateStruct<S867>;
+
+struct S868 {};
+using T868 = TemplateStruct<S868>;
+
+struct S869 {};
+using T869 = TemplateStruct<S869>;
+
+struct S870 {};
+using T870 = TemplateStruct<S870>;
+
+struct S871 {};
+using T871 = TemplateStruct<S871>;
+
+struct S872 {};
+using T872 = TemplateStruct<S872>;
+
+struct S873 {};
+using T873 = TemplateStruct<S873>;
+
+struct S874 {};
+using T874 = TemplateStruct<S874>;
+
+struct S875 {};
+using T875 = TemplateStruct<S875>;
+
+struct S876 {};
+using T876 = TemplateStruct<S876>;
+
+struct S877 {};
+using T877 = TemplateStruct<S877>;
+
+struct S878 {};
+using T878 = TemplateStruct<S878>;
+
+struct S879 {};
+using T879 = TemplateStruct<S879>;
+
+struct S880 {};
+using T880 = TemplateStruct<S880>;
+
+struct S881 {};
+using T881 = TemplateStruct<S881>;
+
+struct S882 {};
+using T882 = TemplateStruct<S882>;
+
+struct S883 {};
+using T883 = TemplateStruct<S883>;
+
+struct S884 {};
+using T884 = TemplateStruct<S884>;
+
+struct S885 {};
+using T885 = TemplateStruct<S885>;
+
+struct S886 {};
+using T886 = TemplateStruct<S886>;
+
+struct S887 {};
+using T887 = TemplateStruct<S887>;
+
+struct S888 {};
+using T888 = TemplateStruct<S888>;
+
+struct S889 {};
+using T889 = TemplateStruct<S889>;
+
+struct S890 {};
+using T890 = TemplateStruct<S890>;
+
+struct S891 {};
+using T891 = TemplateStruct<S891>;
+
+struct S892 {};
+using T892 = TemplateStruct<S892>;
+
+struct S893 {};
+using T893 = TemplateStruct<S893>;
+
+struct S894 {};
+using T894 = TemplateStruct<S894>;
+
+struct S895 {};
+using T895 = TemplateStruct<S895>;
+
+struct S896 {};
+using T896 = TemplateStruct<S896>;
+
+struct S897 {};
+using T897 = TemplateStruct<S897>;
+
+struct S898 {};
+using T898 = TemplateStruct<S898>;
+
+struct S899 {};
+using T899 = TemplateStruct<S899>;
+
+struct S900 {};
+using T900 = TemplateStruct<S900>;
+
+struct S901 {};
+using T901 = TemplateStruct<S901>;
+
+struct S902 {};
+using T902 = TemplateStruct<S902>;
+
+struct S903 {};
+using T903 = TemplateStruct<S903>;
+
+struct S904 {};
+using T904 = TemplateStruct<S904>;
+
+struct S905 {};
+using T905 = TemplateStruct<S905>;
+
+struct S906 {};
+using T906 = TemplateStruct<S906>;
+
+struct S907 {};
+using T907 = TemplateStruct<S907>;
+
+struct S908 {};
+using T908 = TemplateStruct<S908>;
+
+struct S909 {};
+using T909 = TemplateStruct<S909>;
+
+struct S910 {};
+using T910 = TemplateStruct<S910>;
+
+struct S911 {};
+using T911 = TemplateStruct<S911>;
+
+struct S912 {};
+using T912 = TemplateStruct<S912>;
+
+struct S913 {};
+using T913 = TemplateStruct<S913>;
+
+struct S914 {};
+using T914 = TemplateStruct<S914>;
+
+struct S915 {};
+using T915 = TemplateStruct<S915>;
+
+struct S916 {};
+using T916 = TemplateStruct<S916>;
+
+struct S917 {};
+using T917 = TemplateStruct<S917>;
+
+struct S918 {};
+using T918 = TemplateStruct<S918>;
+
+struct S919 {};
+using T919 = TemplateStruct<S919>;
+
+struct S920 {};
+using T920 = TemplateStruct<S920>;
+
+struct S921 {};
+using T921 = TemplateStruct<S921>;
+
+struct S922 {};
+using T922 = TemplateStruct<S922>;
+
+struct S923 {};
+using T923 = TemplateStruct<S923>;
+
+struct S924 {};
+using T924 = TemplateStruct<S924>;
+
+struct S925 {};
+using T925 = TemplateStruct<S925>;
+
+struct S926 {};
+using T926 = TemplateStruct<S926>;
+
+struct S927 {};
+using T927 = TemplateStruct<S927>;
+
+struct S928 {};
+using T928 = TemplateStruct<S928>;
+
+struct S929 {};
+using T929 = TemplateStruct<S929>;
+
+struct S930 {};
+using T930 = TemplateStruct<S930>;
+
+struct S931 {};
+using T931 = TemplateStruct<S931>;
+
+struct S932 {};
+using T932 = TemplateStruct<S932>;
+
+struct S933 {};
+using T933 = TemplateStruct<S933>;
+
+struct S934 {};
+using T934 = TemplateStruct<S934>;
+
+struct S935 {};
+using T935 = TemplateStruct<S935>;
+
+struct S936 {};
+using T936 = TemplateStruct<S936>;
+
+struct S937 {};
+using T937 = TemplateStruct<S937>;
+
+struct S938 {};
+using T938 = TemplateStruct<S938>;
+
+struct S939 {};
+using T939 = TemplateStruct<S939>;
+
+struct S940 {};
+using T940 = TemplateStruct<S940>;
+
+struct S941 {};
+using T941 = TemplateStruct<S941>;
+
+struct S942 {};
+using T942 = TemplateStruct<S942>;
+
+struct S943 {};
+using T943 = TemplateStruct<S943>;
+
+struct S944 {};
+using T944 = TemplateStruct<S944>;
+
+struct S945 {};
+using T945 = TemplateStruct<S945>;
+
+struct S946 {};
+using T946 = TemplateStruct<S946>;
+
+struct S947 {};
+using T947 = TemplateStruct<S947>;
+
+struct S948 {};
+using T948 = TemplateStruct<S948>;
+
+struct S949 {};
+using T949 = TemplateStruct<S949>;
+
+struct S950 {};
+using T950 = TemplateStruct<S950>;
+
+struct S951 {};
+using T951 = TemplateStruct<S951>;
+
+struct S952 {};
+using T952 = TemplateStruct<S952>;
+
+struct S953 {};
+using T953 = TemplateStruct<S953>;
+
+struct S954 {};
+using T954 = TemplateStruct<S954>;
+
+struct S955 {};
+using T955 = TemplateStruct<S955>;
+
+struct S956 {};
+using T956 = TemplateStruct<S956>;
+
+struct S957 {};
+using T957 = TemplateStruct<S957>;
+
+struct S958 {};
+using T958 = TemplateStruct<S958>;
+
+struct S959 {};
+using T959 = TemplateStruct<S959>;
+
+struct S960 {};
+using T960 = TemplateStruct<S960>;
+
+struct S961 {};
+using T961 = TemplateStruct<S961>;
+
+struct S962 {};
+using T962 = TemplateStruct<S962>;
+
+struct S963 {};
+using T963 = TemplateStruct<S963>;
+
+struct S964 {};
+using T964 = TemplateStruct<S964>;
+
+struct S965 {};
+using T965 = TemplateStruct<S965>;
+
+struct S966 {};
+using T966 = TemplateStruct<S966>;
+
+struct S967 {};
+using T967 = TemplateStruct<S967>;
+
+struct S968 {};
+using T968 = TemplateStruct<S968>;
+
+struct S969 {};
+using T969 = TemplateStruct<S969>;
+
+struct S970 {};
+using T970 = TemplateStruct<S970>;
+
+struct S971 {};
+using T971 = TemplateStruct<S971>;
+
+struct S972 {};
+using T972 = TemplateStruct<S972>;
+
+struct S973 {};
+using T973 = TemplateStruct<S973>;
+
+struct S974 {};
+using T974 = TemplateStruct<S974>;
+
+struct S975 {};
+using T975 = TemplateStruct<S975>;
+
+struct S976 {};
+using T976 = TemplateStruct<S976>;
+
+struct S977 {};
+using T977 = TemplateStruct<S977>;
+
+struct S978 {};
+using T978 = TemplateStruct<S978>;
+
+struct S979 {};
+using T979 = TemplateStruct<S979>;
+
+struct S980 {};
+using T980 = TemplateStruct<S980>;
+
+struct S981 {};
+using T981 = TemplateStruct<S981>;
+
+struct S982 {};
+using T982 = TemplateStruct<S982>;
+
+struct S983 {};
+using T983 = TemplateStruct<S983>;
+
+struct S984 {};
+using T984 = TemplateStruct<S984>;
+
+struct S985 {};
+using T985 = TemplateStruct<S985>;
+
+struct S986 {};
+using T986 = TemplateStruct<S986>;
+
+struct S987 {};
+using T987 = TemplateStruct<S987>;
+
+struct S988 {};
+using T988 = TemplateStruct<S988>;
+
+struct S989 {};
+using T989 = TemplateStruct<S989>;
+
+struct S990 {};
+using T990 = TemplateStruct<S990>;
+
+struct S991 {};
+using T991 = TemplateStruct<S991>;
+
+struct S992 {};
+using T992 = TemplateStruct<S992>;
+
+struct S993 {};
+using T993 = TemplateStruct<S993>;
+
+struct S994 {};
+using T994 = TemplateStruct<S994>;
+
+struct S995 {};
+using T995 = TemplateStruct<S995>;
+
+struct S996 {};
+using T996 = TemplateStruct<S996>;
+
+struct S997 {};
+using T997 = TemplateStruct<S997>;
+
+struct S998 {};
+using T998 = TemplateStruct<S998>;
+
+struct S999 {};
+using T999 = TemplateStruct<S999>;
+
+struct S1000 {};
+using T1000 = TemplateStruct<S1000>;
+
+struct S1001 {};
+using T1001 = TemplateStruct<S1001>;
+
+struct S1002 {};
+using T1002 = TemplateStruct<S1002>;
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_MANY_SPECIALIZATIONS_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -152,3 +152,8 @@ module UnevaluatedContext {
   header "unevaluated-context.h"
   requires cplusplus
 }
+
+module ManySpecializations {
+  header "many-specializations.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/many-specializations.swift
+++ b/test/Interop/Cxx/templates/many-specializations.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ManySpecializations -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+
+// CHECK: @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
+// CHECK-NEXT: struct TemplateStruct<T> {
+// CHECK-NEXT: }
+
+// CHECK-NOT: typealias


### PR DESCRIPTION
…that can't be imported

(cherry picked from commit 8ed840f9c1c537dba15dea079cde1d669dd4ac8c)

rdar://111821814

- Explanation: Swift doesn't import class template specializations that have more than 1000 specializations. It warns about them in the compiler's output. However this warning is not helpful to the user as it doesn't offer a solution, and instead if generates noisy build output which annoys our adopters. We should remove it.
- Scope: C++ interop, clang importer, C++ template specialization import.
- Risk: Low, this only drops a warning and otherwise is NFC.
- Original PR: https://github.com/apple/swift/pull/67167
