### PR TITLE
AST: Fill in ASTContext::getSwift59Availability() [5.9]

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -673,8 +673,20 @@ AvailabilityContext ASTContext::getSwift58Availability() {
 }
 
 AvailabilityContext ASTContext::getSwift59Availability() {
-  // TODO: Update Availability impl when Swift 5.9 is released
-  return getSwiftFutureAvailability();
+  auto target = LangOpts.Target;
+
+  if (target.isMacOSX()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(14, 0, 0)));
+  } else if (target.isiOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(17, 0, 0)));
+  } else if (target.isWatchOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(10, 0, 0)));
+  } else {
+    return AvailabilityContext::alwaysAvailable();
+  }
 }
 
 AvailabilityContext ASTContext::getSwiftFutureAvailability() {

--- a/test/Generics/variadic_generic_types_availability.swift
+++ b/test/Generics/variadic_generic_types_availability.swift
@@ -4,7 +4,7 @@
 
 struct G<each T> {}
 // expected-note@-1 {{add @available attribute to enclosing generic struct}}
-// expected-error@-2 {{parameter packs in generic types are only available in macOS 99.99.0 or newer}}
+// expected-error@-2 {{parameter packs in generic types are only available in macOS 14.0.0 or newer}}
 
 // Type aliases are OK
 typealias A<each T> = (repeat each T)


### PR DESCRIPTION
* Description: Fill in stub implementation of ASTContext::getSwift59Availability().

* Scope of the issue: Provides a more meaningful error message when you attempt to declare a variadic nominal type on an older deployment target.

* Risk: None, hopefully!

* Reviewed by: @lorentey 