### PR TITLE
Allow the path where macro expansions are emitted to be customized.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -482,6 +482,9 @@ public:
   /// The calling convention used to perform non-swift calls.
   llvm::CallingConv::ID PlatformCCallingConvention;
 
+  /// The directory where macro source buffers will be expanded into files.
+  std::string MacroExpansionFilesPath;
+
   IRGenOptions()
       : DWARFVersion(2),
         OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
@@ -523,7 +526,8 @@ public:
         UseRelativeProtocolWitnessTables(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
-        PlatformCCallingConvention(llvm::CallingConv::C) {
+        PlatformCCallingConvention(llvm::CallingConv::C),
+        MacroExpansionFilesPath() {
 #ifndef NDEBUG
     DisableRoundTripDebugTypes = false;
 #else

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_BASIC_DIAGNOSTICOPTIONS_H
 #define SWIFT_BASIC_DIAGNOSTICOPTIONS_H
 
+#include "swift/Basic/MacroExpansionOptions.h"
 #include "llvm/ADT/Hashing.h"
 
 namespace swift {
@@ -73,8 +74,8 @@ public:
   /// descriptive style that's specific to Swift (currently experimental).
   FormattingStyle PrintedFormattingStyle = FormattingStyle::LLVM;
 
-  /// Whether to emit macro expansion buffers into separate, temporary files.
-  bool EmitMacroExpansionFiles = true;
+  /// Whether, and where, to emit macro expansion buffers into separate files.
+  MacroExpansionOptions MacroExpansionOpts = {true, ""};
 
   std::string DiagnosticDocumentationPath = "";
 

--- a/include/swift/Basic/MacroExpansionOptions.h
+++ b/include/swift/Basic/MacroExpansionOptions.h
@@ -1,0 +1,34 @@
+//===--- MacroExpansionOptions.h --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_MACROEXPANSIONOPTIONS_H
+#define SWIFT_BASIC_MACROEXPANSIONOPTIONS_H
+
+#include <string>
+
+namespace swift {
+
+/// Describes how macro expansion buffers should be emitted.
+struct MacroExpansionOptions {
+  /// Whether to emit macro expansion buffers into separate, temporary files.
+  bool EmitFiles = false;
+
+  /// The path to the directory into which macro expansion files should be
+  /// written.
+  ///
+  /// If empty, a subdirectory of the system temp directory will be used.
+  std::string Path = "";
+};
+
+} // end namespace swift
+
+#endif // SWIFT_BASIC_MACROEXPANSIONOPTIONS_H

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_SOURCEMANAGER_H
 
 #include "swift/Basic/FileSystem.h"
+#include "swift/Basic/MacroExpansionOptions.h"
 #include "swift/Basic/SourceLoc.h"
 #include "clang/Basic/FileManager.h"
 #include "llvm/ADT/DenseSet.h"
@@ -296,18 +297,17 @@ public:
   ///
   /// \p BufferID must be a valid buffer ID.
   ///
-  /// \p ForceGeneratedSourceToDisk can be set to true to create a temporary
-  /// file on-disk for buffers containing generated source code, returning the
-  /// name of that temporary file.
+  /// \p MacroExpansionOptions can be passed to create a file on-disk for
+  /// buffers containing generated source code, returning the name of that
+  /// generated file.
   ///
   /// This should not be used for displaying information about the \e contents
   /// of a buffer, since lines within the buffer may be marked as coming from
   /// other files using \c #sourceLocation. Use #getDisplayNameForLoc instead
   /// in that case.
-  StringRef getIdentifierForBuffer(
-      unsigned BufferID,
-      bool ForceGeneratedSourceToDisk = false
-  ) const;
+  StringRef
+  getIdentifierForBuffer(unsigned BufferID,
+                         MacroExpansionOptions MacroExpansionOpts = {}) const;
 
   /// Returns a SourceRange covering the entire specified buffer.
   ///
@@ -339,15 +339,16 @@ public:
   /// Returns a buffer identifier suitable for display to the user containing
   /// the given source location.
   ///
-  /// \p ForceGeneratedSourceToDisk can be set to true to create a temporary
-  /// file on-disk for buffers containing generated source code, returning the
-  /// name of that temporary file.
+  /// \p MacroExpansionOptions can be passed to create a file on-disk for
+  /// buffers containing generated source code, returning the name of that
+  /// generated file.
   ///
   /// This respects \c #sourceLocation directives and the 'use-external-names'
   /// directive in VFS overlay files. If you need an on-disk file name, use
   /// #getIdentifierForBuffer instead.
-  StringRef getDisplayNameForLoc(
-      SourceLoc Loc, bool ForceGeneratedSourceToDisk = false) const;
+  StringRef
+  getDisplayNameForLoc(SourceLoc Loc,
+                       MacroExpansionOptions MacroExpansionOpts = {}) const;
 
   /// Returns the line and column represented by the given source location.
   ///
@@ -383,11 +384,10 @@ public:
   StringRef extractText(CharSourceRange Range,
                         llvm::Optional<unsigned> BufferID = llvm::None) const;
 
-  llvm::SMDiagnostic GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
-                                const Twine &Msg,
-                                ArrayRef<llvm::SMRange> Ranges,
-                                ArrayRef<llvm::SMFixIt> FixIts,
-                                bool EmitMacroExpansionFiles = false) const;
+  llvm::SMDiagnostic
+  GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind, const Twine &Msg,
+             ArrayRef<llvm::SMRange> Ranges, ArrayRef<llvm::SMFixIt> FixIts,
+             MacroExpansionOptions MacroExpansionOpts = {}) const;
 
   /// Verifies that all buffers are still valid.
   void verifyAllBuffers() const;

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -34,7 +34,7 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   llvm::raw_ostream &Stream;
   bool ForceColors = false;
   bool PrintEducationalNotes = false;
-  bool EmitMacroExpansionFiles = false;
+  MacroExpansionOptions MacroExpansionOpts;
   bool DidErrorOccur = false;
   DiagnosticOptions::FormattingStyle FormattingStyle =
       DiagnosticOptions::FormattingStyle::LLVM;
@@ -83,8 +83,8 @@ public:
     FormattingStyle = style;
   }
 
-  void setEmitMacroExpansionFiles(bool ShouldEmit) {
-    EmitMacroExpansionFiles = ShouldEmit;
+  void setMacroExpansionOpts(const MacroExpansionOptions &macroExpansionOpts) {
+    MacroExpansionOpts = macroExpansionOpts;
   }
 
   bool didErrorOccur() {

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -27,6 +27,7 @@ namespace llvm {
 namespace swift {
 
   class DiagnosticConsumer;
+  struct MacroExpansionOptions;
 
   namespace serialized_diagnostics {
     /// Create a DiagnosticConsumer that serializes diagnostics to a file, using
@@ -35,8 +36,9 @@ namespace swift {
     /// \param outputPath the file path to write the diagnostics to.
     ///
     /// \returns A new diagnostic consumer that serializes diagnostics.
-    std::unique_ptr<DiagnosticConsumer>
-    createConsumer(llvm::StringRef outputPath, bool emitMacroExpansionFiles);
+  std::unique_ptr<DiagnosticConsumer>
+  createConsumer(llvm::StringRef outputPath,
+                 const MacroExpansionOptions &macroExpansionOpts);
   }
 }
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -351,6 +351,8 @@ def dump_macro_expansions : Flag<["-"], "dump-macro-expansions">,
   HelpText<"Dumps the results of each macro expansion">;
 def emit_macro_expansion_files : Separate<["-"], "emit-macro-expansion-files">,
   HelpText<"Specify when to emit macro expansion file: 'none', 'debug', or 'diagnostics'">;
+def emit_macro_expansion_files_path : Joined<["-"], "emit-macro-expansion-files-path=">,
+  HelpText<"Specify the directory where macro expansions will be dumped">;
 
 def analyze_requirement_machine : Flag<["-"], "analyze-requirement-machine">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -13,10 +13,11 @@
 #ifndef SWIFT_SIL_LOCATION_H
 #define SWIFT_SIL_LOCATION_H
 
-#include "llvm/ADT/PointerUnion.h"
+#include "swift/AST/TypeAlignments.h"
+#include "swift/Basic/MacroExpansionOptions.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/SIL/SILAllocated.h"
-#include "swift/AST/TypeAlignments.h"
+#include "llvm/ADT/PointerUnion.h"
 
 #include <cstddef>
 #include <type_traits>
@@ -438,11 +439,12 @@ public:
 
   /// Extract the line, column, and filename from \p Loc.
   ///
-  /// \p ForceGeneratedSourceToDisk can be set to true to create a temporary
-  /// file on-disk for buffers containing generated source code, returning the
-  /// name of that temporary file.
-  static FilenameAndLocation decode(SourceLoc Loc, const SourceManager &SM,
-                                    bool ForceGeneratedSourceToDisk = false);
+  /// \p MacroExpansionOptions can be passed to create a file on-disk for
+  /// buffers containing generated source code, returning the name of that
+  /// generated file.
+  static FilenameAndLocation
+  decode(SourceLoc Loc, const SourceManager &SM,
+         MacroExpansionOptions MacroExpansionOpts = {});
 
   /// Return the decoded FilenameAndLocation.
   /// In case the location has a separate AST node for debugging, this node is

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -70,14 +70,15 @@ bool SourceManager::rangeContainsRespectingReplacedRanges(
          containsRespectingReplacedRanges(Enclosing, Inner.End);
 }
 
-StringRef SourceManager::getDisplayNameForLoc(SourceLoc Loc, bool ForceGeneratedSourceToDisk) const {
+StringRef SourceManager::getDisplayNameForLoc(
+    SourceLoc Loc, MacroExpansionOptions MacroExpansionOpts) const {
   // Respect #line first
   if (auto VFile = getVirtualFile(Loc))
     return VFile->Name;
 
   // Next, try the stat cache
-  auto Ident = getIdentifierForBuffer(
-      findBufferContainingLoc(Loc), ForceGeneratedSourceToDisk);
+  auto Ident =
+      getIdentifierForBuffer(findBufferContainingLoc(Loc), MacroExpansionOpts);
   auto found = StatusCache.find(Ident);
   if (found != StatusCache.end()) {
     return found->second.getName();
@@ -220,14 +221,18 @@ SourceManager::~SourceManager() {
 
 /// Dump the contents of the given memory buffer to a file, returning the
 /// name of that file (when successful) and \c None otherwise.
-static llvm::Optional<std::string>
-dumpBufferToFile(const llvm::MemoryBuffer *buffer,
-                 const SourceManager &sourceMgr,
-                 CharSourceRange originalSourceRange) {
-  // Create file in the system temporary directory.
+static llvm::Optional<std::string> dumpBufferToFile(
+    const llvm::MemoryBuffer *buffer, const SourceManager &sourceMgr,
+    CharSourceRange originalSourceRange, llvm::StringRef ExpansionPath) {
+  // Create file in the system temporary directory unless an explicit
+  // path was provided.
   SmallString<128> outputFileName;
-  llvm::sys::path::system_temp_directory(true, outputFileName);
-  llvm::sys::path::append(outputFileName, "swift-generated-sources");
+  if (ExpansionPath.empty()) {
+    llvm::sys::path::system_temp_directory(true, outputFileName);
+    llvm::sys::path::append(outputFileName, "swift-generated-sources");
+  } else {
+    outputFileName = ExpansionPath;
+  }
   if (llvm::sys::fs::create_directory(outputFileName))
     return llvm::None;
 
@@ -249,9 +254,9 @@ dumpBufferToFile(const llvm::MemoryBuffer *buffer,
         if (originalSourceRange.isValid()) {
           out << "\n";
 
-          auto originalFilename =
-            sourceMgr.getDisplayNameForLoc(originalSourceRange.getStart(),
-                                           true);
+          auto originalFilename = sourceMgr.getDisplayNameForLoc(
+              originalSourceRange.getStart(),
+              {true, std::string(ExpansionPath)});
           unsigned startLine, startColumn, endLine, endColumn;
           std::tie(startLine, startColumn) =
               sourceMgr.getPresumedLineAndColumnForLoc(
@@ -273,14 +278,13 @@ dumpBufferToFile(const llvm::MemoryBuffer *buffer,
 }
 
 StringRef SourceManager::getIdentifierForBuffer(
-    unsigned bufferID, bool ForceGeneratedSourceToDisk
-) const {
+    unsigned bufferID, MacroExpansionOptions MacroExpansionOpts) const {
   auto *buffer = LLVMSourceMgr.getMemoryBuffer(bufferID);
   assert(buffer && "invalid buffer ID");
 
   // If this is generated source code, and we're supposed to force it to disk
   // so external clients can see it, do so now.
-  if (ForceGeneratedSourceToDisk) {
+  if (MacroExpansionOpts.EmitFiles) {
     if (auto generatedInfo = getGeneratedSourceInfo(bufferID)) {
       // We only care about macros, so skip everything else.
       if (generatedInfo->kind == GeneratedSourceInfo::ReplacedFunctionBody ||
@@ -289,7 +293,8 @@ StringRef SourceManager::getIdentifierForBuffer(
 
       if (generatedInfo->onDiskBufferCopyFileName.empty()) {
         if (auto newFileNameOpt = dumpBufferToFile(
-                buffer, *this,  generatedInfo->originalSourceRange)) {
+                buffer, *this, generatedInfo->originalSourceRange,
+                MacroExpansionOpts.Path)) {
           generatedInfo->onDiskBufferCopyFileName =
               strdup(newFileNameOpt->c_str());
         }

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -1851,7 +1851,8 @@ createDiagConsumer(llvm::raw_ostream &OS, bool &FailOnError, bool DisableFailOnE
   if (!SerializedDiagPath.empty()) {
     FailOnError = !DisableFailOnError;
     results.emplace_back(std::make_unique<PrintingDiagnosticConsumer>());
-    results.emplace_back(serialized_diagnostics::createConsumer(SerializedDiagPath, false));
+    results.emplace_back(
+        serialized_diagnostics::createConsumer(SerializedDiagPath, {}));
   } else if (CompilerStyleDiags) {
     FailOnError = !DisableFailOnError;
     results.emplace_back(std::make_unique<PrintingDiagnosticConsumer>());

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1800,7 +1800,10 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
     if (negated)
       contents = contents.drop_front(3);
     if (contents == "diagnostics")
-      Opts.EmitMacroExpansionFiles = !negated;
+      Opts.MacroExpansionOpts.EmitFiles = !negated;
+  }
+  if (Arg *A = Args.getLastArg(OPT_emit_macro_expansion_files_path)) {
+    Opts.MacroExpansionOpts.Path = A->getValue();
   }
 
   Opts.FixitCodeForAllDiagnostics |= Args.hasArg(OPT_fixit_all);
@@ -2860,6 +2863,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
         .Case("arm_aapcs", llvm::CallingConv::ARM_AAPCS)
         .Case("arm_aapcs_vfp", llvm::CallingConv::ARM_AAPCS_VFP)
         .Default(llvm::CallingConv::C);
+  }
+
+  if (Arg *A = Args.getLastArg(OPT_emit_macro_expansion_files_path)) {
+    Opts.MacroExpansionFilesPath = A->getValue();
   }
 
   return false;

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -1271,17 +1271,16 @@ void PrintingDiagnosticConsumer::printDiagnostic(SourceManager &SM,
                                            Info.FormatArgs);
   }
 
-  auto Msg = SM.GetMessage(Info.Loc, SMKind, Text, Ranges, FixIts,
-                           EmitMacroExpansionFiles);
+  auto Msg =
+      SM.GetMessage(Info.Loc, SMKind, Text, Ranges, FixIts, MacroExpansionOpts);
   rawSM.PrintMessage(out, Msg, ForceColors);
 }
 
 llvm::SMDiagnostic
 SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
-                          const Twine &Msg,
-                          ArrayRef<llvm::SMRange> Ranges,
+                          const Twine &Msg, ArrayRef<llvm::SMRange> Ranges,
                           ArrayRef<llvm::SMFixIt> FixIts,
-                          bool EmitMacroExpansionFiles) const {
+                          MacroExpansionOptions MacroExpansionOpts) const {
 
   // First thing to do: find the current buffer containing the specified
   // location to pull out the source line.
@@ -1291,7 +1290,7 @@ SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
   std::string LineStr;
 
   if (Loc.isValid()) {
-    BufferID = getDisplayNameForLoc(Loc, EmitMacroExpansionFiles);
+    BufferID = getDisplayNameForLoc(Loc, MacroExpansionOpts);
     auto CurMB = LLVMSourceMgr.getMemoryBuffer(findBufferContainingLoc(Loc));
 
     // Scan backward to find the start of the line.

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -103,15 +103,15 @@ struct SharedState : llvm::RefCountedBase<SharedState> {
 class SerializedDiagnosticConsumer : public DiagnosticConsumer {
   /// State shared among the various clones of this diagnostic consumer.
   llvm::IntrusiveRefCntPtr<SharedState> State;
-  bool EmitMacroExpansionFiles = false;
+  MacroExpansionOptions MacroExpansionOpts;
   bool CalledFinishProcessing = false;
   bool CompilationWasComplete = true;
 
 public:
   SerializedDiagnosticConsumer(StringRef serializedDiagnosticsPath,
-                               bool emitMacroExpansionFiles)
+                               const MacroExpansionOptions &macroExpansionOpts)
       : State(new SharedState(serializedDiagnosticsPath)),
-        EmitMacroExpansionFiles(emitMacroExpansionFiles) {
+        MacroExpansionOpts(macroExpansionOpts) {
     emitPreamble();
   }
 
@@ -216,12 +216,12 @@ private:
 
 namespace swift {
 namespace serialized_diagnostics {
-  std::unique_ptr<DiagnosticConsumer> createConsumer(
-      StringRef outputPath, bool emitMacroExpansionFiles
-  ) {
-    return std::make_unique<SerializedDiagnosticConsumer>(
-        outputPath, emitMacroExpansionFiles);
-  }
+std::unique_ptr<DiagnosticConsumer>
+createConsumer(StringRef outputPath,
+               const MacroExpansionOptions &macroExpansionOpts) {
+  return std::make_unique<SerializedDiagnosticConsumer>(outputPath,
+                                                        macroExpansionOpts);
+}
 } // namespace serialized_diagnostics
 } // namespace swift
 
@@ -264,8 +264,8 @@ unsigned SerializedDiagnosticConsumer::getEmitFile(
   // The source range that this buffer was generated from, expressed as
   // offsets into the original buffer.
   if (generatedInfo->originalSourceRange.isValid()) {
-    auto originalFilename = SM.getDisplayNameForLoc(generatedInfo->originalSourceRange.getStart(),
-                                EmitMacroExpansionFiles);
+    auto originalFilename = SM.getDisplayNameForLoc(
+        generatedInfo->originalSourceRange.getStart(), MacroExpansionOpts);
     addRangeToRecord(
         generatedInfo->originalSourceRange,
         SM, originalFilename, Record
@@ -540,7 +540,7 @@ emitDiagnosticMessage(SourceManager &SM,
 
   StringRef filename = "";
   if (Loc.isValid())
-    filename = SM.getDisplayNameForLoc(Loc, EmitMacroExpansionFiles);
+    filename = SM.getDisplayNameForLoc(Loc, MacroExpansionOpts);
 
   // Emit the RECORD_DIAG record.
   Record.clear();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1980,18 +1980,16 @@ createDispatchingDiagnosticConsumerIfNeeded(
 static std::unique_ptr<DiagnosticConsumer>
 createSerializedDiagnosticConsumerIfNeeded(
     const FrontendInputsAndOutputs &inputsAndOutputs,
-    bool emitMacroExpansionFiles
-) {
+    const MacroExpansionOptions &macroExpansionOpts) {
   return createDispatchingDiagnosticConsumerIfNeeded(
       inputsAndOutputs,
-      [emitMacroExpansionFiles](
-          const InputFile &input
-      ) -> std::unique_ptr<DiagnosticConsumer> {
+      [&macroExpansionOpts](
+          const InputFile &input) -> std::unique_ptr<DiagnosticConsumer> {
         auto serializedDiagnosticsPath = input.getSerializedDiagnosticsPath();
         if (serializedDiagnosticsPath.empty())
           return nullptr;
-        return serialized_diagnostics::createConsumer(
-            serializedDiagnosticsPath, emitMacroExpansionFiles);
+        return serialized_diagnostics::createConsumer(serializedDiagnosticsPath,
+                                                      macroExpansionOpts);
       });
 }
 
@@ -2327,8 +2325,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   // See https://github.com/apple/swift/issues/45288 for details.
   std::unique_ptr<DiagnosticConsumer> SerializedConsumerDispatcher =
       createSerializedDiagnosticConsumerIfNeeded(
-        Invocation.getFrontendOptions().InputsAndOutputs,
-        Invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
+          Invocation.getFrontendOptions().InputsAndOutputs,
+          Invocation.getDiagnosticOptions().MacroExpansionOpts);
   if (SerializedConsumerDispatcher)
     Instance->addDiagnosticConsumer(SerializedConsumerDispatcher.get());
 
@@ -2346,8 +2344,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   PDC.setFormattingStyle(
       Invocation.getDiagnosticOptions().PrintedFormattingStyle);
 
-  PDC.setEmitMacroExpansionFiles(
-      Invocation.getDiagnosticOptions().EmitMacroExpansionFiles);
+  PDC.setMacroExpansionOpts(
+      Invocation.getDiagnosticOptions().MacroExpansionOpts);
 
   if (Invocation.getFrontendOptions().PrintStats) {
     llvm::EnableStatistics();

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -55,11 +55,13 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/StringSaver.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Local.h"
 
@@ -134,6 +136,8 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   llvm::StringMap<llvm::TrackingMDNodeRef> RuntimeErrorFnCache;
   TrackingDIRefMap DIRefMap;
   TrackingDIRefMap InnerTypeCache;
+  llvm::BumpPtrAllocator RemappedSILLocationPathAllocator;
+  llvm::StringSaver RemappedSILLocationPathSaver;
   /// \}
 
   /// A list of replaceable fwddecls that need to be RAUWed at the end.
@@ -1963,7 +1967,8 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
                                        StringRef MainOutputFilenameForDebugInfo,
                                        StringRef PD)
     : Opts(Opts), CI(CI), SM(IGM.Context.SourceMgr), M(M), DBuilder(M),
-      IGM(IGM), DebugPrefixMap(Opts.DebugPrefixMap) {
+      IGM(IGM), DebugPrefixMap(Opts.DebugPrefixMap),
+      RemappedSILLocationPathSaver(RemappedSILLocationPathAllocator) {
   assert(Opts.DebugInfoLevel > IRGenDebugInfoLevel::None &&
          "no debug info should be generated");
   llvm::SmallString<256> SourcePath;
@@ -3075,8 +3080,18 @@ SILLocation::FilenameAndLocation
 IRGenDebugInfoImpl::decodeSourceLoc(SourceLoc SL) {
   auto &Cached = FilenameAndLocationCache[SL.getOpaquePointerValue()];
   if (Cached.filename.empty()) {
-    Cached = sanitizeCodeViewFilenameAndLocation(
-        SILLocation::decode(SL, SM, /*ForceGeneratedSourceToDisk=*/true));
+    Cached = sanitizeCodeViewFilenameAndLocation(SILLocation::decode(
+        SL, SM, /*MacroExpansionOpts=*/{true, Opts.MacroExpansionFilesPath}));
+
+    // If `-debug-prefix-map` would change the path, handle that here.
+    // This is necessary to handle macro expansions correctly.
+    if (!Opts.MacroExpansionFilesPath.empty() &&
+        Cached.filename.startswith(Opts.MacroExpansionFilesPath)) {
+      std::string remapped = DebugPrefixMap.remapPath(Cached.filename);
+      if (remapped != Cached.filename) {
+        Cached.filename = RemappedSILLocationPathSaver.save(remapped);
+      }
+    }
   }
   return Cached;
 }

--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -184,12 +184,12 @@ DeclContext *SILLocation::getAsDeclContext() const {
   return nullptr;
 }
 
-SILLocation::FilenameAndLocation SILLocation::decode(SourceLoc Loc,
-                                              const SourceManager &SM,
-                                              bool ForceGeneratedSourceToDisk) {
+SILLocation::FilenameAndLocation
+SILLocation::decode(SourceLoc Loc, const SourceManager &SM,
+                    MacroExpansionOptions MacroExpansionOpts) {
   FilenameAndLocation DL;
   if (Loc.isValid()) {
-    DL.filename = SM.getDisplayNameForLoc(Loc, ForceGeneratedSourceToDisk);
+    DL.filename = SM.getDisplayNameForLoc(Loc, MacroExpansionOpts);
     std::tie(DL.line, DL.column) = SM.getPresumedLineAndColumnForLoc(Loc);
   }
   return DL;

--- a/test/Macros/macro_expansion_custom_path.swift
+++ b/test/Macros/macro_expansion_custom_path.swift
@@ -1,0 +1,16 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+
+// Debug info IR path remapping testing
+// RUN: %target-swift-frontend -swift-version 5 -emit-ir -I%t -verify -primary-file %s -verify-ignore-unknown -load-plugin-library %t/%target-library-name(MacroDefinition) -emit-macro-expansion-files-path=%t/custom-expansions -debug-prefix-map %t/custom-expansions=REMAPPED -o - -g | %FileCheck --check-prefix CHECK-IR %s
+// RUN: ls %t/custom-expansions | %FileCheck --check-prefix CHECK-FILES %s
+
+import macro_library
+
+// CHECK-IR: !{{[0-9]+}} = !DIFile(filename: "REMAPPED{{(/|\\\\)}}@__swiftmacro
+@Observable
+class C: Observable {}
+
+// CHECK-FILES: @__swiftmacro_


### PR DESCRIPTION
This PR is an attempt to make macro expansions more hermetic w.r.t. DebugInfo.

Since the paths to macro expansions are emitted into DebugInfo, the default tempdir logic will produce non-hermetic/non-reproducible DI that would likely negatively impact the debugging experience for remote/distributed builds. This adds a
`-emit-macro-expansion-files-path=` flag that allows that location to be explicitly pointed to a predetermined location.

Furthermore, this change ensures that `-debug-prefix-map` remappings are applied to the macro expansion paths when they are written to DebugInfo.
