### PR TITLE
[NFC] Fix check lines in jumpthreadtest.swift

### DIFF
--- a/test/SILOptimizer/jumpthreadtest.swift
+++ b/test/SILOptimizer/jumpthreadtest.swift
@@ -5,7 +5,7 @@ import Swift
 
 // CHECK-LABEL: sil [noinline] @$s14jumpthreadtest3fooys6UInt64Vs5UInt8VF :
 // CHECK: bb0
-// CHECK:  [[FUNC:%.*]] = function_ref @$ss17FixedWidthIntegerPsE15_truncatingInityxqd__SzRd__lFZs6UInt64V_s5UInt8VTgq5Tf4nd_n : 
+// CHECK:  [[FUNC:%.*]] = function_ref @$ss17FixedWidthIntegerPsE15_truncatingInityxqd__SzRd__lFZs6UInt64V_s5UInt8VTgmq5 :
 // CHECK: apply [[FUNC]]
 // CHECK-NOT: bb1
 // CHECK-LABEL: } // end sil function '$s14jumpthreadtest3fooys6UInt64Vs5UInt8VF'


### PR DESCRIPTION
Recent optimizer changes has caused a change in the specialized function name in the test. This PR updates it.

Fixes rdar://111810214

