### PR TITLE
Cleanup and document SIL memory behavior APIs.

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -137,8 +137,13 @@
 ///   NAME is the name of the instruction in SIL assembly.
 ///   The argument will be a bare identifier, not a string literal.
 ///
-///   MEMBEHAVIOR is an enum value that reflects the memory behavior of
-///   the instruction.
+///   MEMBEHAVIOR is an enum value that reflects the memory behavior of the
+///   instruction. It is only used in the implementation of
+///   SILInstruction::getMemoryBehavior(). Memory behavior is relative, so
+///   whenever possible, clients should instead use
+///   AliasAnalysis::computeMemoryBehavior(SILInstruction, SILValue) which only
+///   defaults to SILInstruction::getMemoryBehavior() when AliasAnalysis cannot
+///   disambiguate the instruction's effects from the value of interest.
 ///
 ///   MAYRELEASE indicates whether the execution of the
 ///   instruction may result in memory being released.

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -711,7 +711,7 @@ void BridgedAliasAnalysis::registerAnalysis(GetMemEffectFn getMemEffectsFn,
   canReferenceSameFieldFunction = canReferenceSameFieldFn;
 }
 
-MemoryBehavior AliasAnalysis::getMemoryBehaviorOfInst(
+MemoryBehavior AliasAnalysis::getMemoryEffectOnEscapedAddress(
             SILValue addr, SILInstruction *toInst) {
   if (getMemEffectsFunction) {
     return (MemoryBehavior)getMemEffectsFunction({PM->getSwiftPassInvocation()}, {addr},

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -317,50 +317,50 @@ MemBehavior MemoryBehaviorVisitor::visitMarkUnresolvedMoveAddrInst(
 MemBehavior MemoryBehaviorVisitor::visitBuiltinInst(BuiltinInst *BI) {
   MemBehavior mb = BI->getMemoryBehavior();
   if (mb != MemBehavior::None) {
-    return AA->getMemoryBehaviorOfInst(V, BI);
+    return AA->getMemoryEffectOnEscapedAddress(V, BI);
   }
   return MemBehavior::None;
 }
 
 MemBehavior MemoryBehaviorVisitor::visitTryApplyInst(TryApplyInst *AI) {
-  return AA->getMemoryBehaviorOfInst(V, AI);
+  return AA->getMemoryEffectOnEscapedAddress(V, AI);
 }
 
 MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
-  return AA->getMemoryBehaviorOfInst(V, AI);
+  return AA->getMemoryEffectOnEscapedAddress(V, AI);
 }
 
 MemBehavior MemoryBehaviorVisitor::visitBeginApplyInst(BeginApplyInst *AI) {
-  return AA->getMemoryBehaviorOfInst(V, AI);
+  return AA->getMemoryEffectOnEscapedAddress(V, AI);
 }
 
 MemBehavior MemoryBehaviorVisitor::visitEndApplyInst(EndApplyInst *EAI) {
-  return AA->getMemoryBehaviorOfInst(V, EAI->getBeginApply());
+  return AA->getMemoryEffectOnEscapedAddress(V, EAI->getBeginApply());
 }
 
 MemBehavior MemoryBehaviorVisitor::visitAbortApplyInst(AbortApplyInst *AAI) {
-  return AA->getMemoryBehaviorOfInst(V, AAI->getBeginApply());
+  return AA->getMemoryEffectOnEscapedAddress(V, AAI->getBeginApply());
 }
 
 MemBehavior
 MemoryBehaviorVisitor::visitStrongReleaseInst(StrongReleaseInst *SI) {
-  return AA->getMemoryBehaviorOfInst(V, SI);
+  return AA->getMemoryEffectOnEscapedAddress(V, SI);
 }
 
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
 MemBehavior \
 MemoryBehaviorVisitor::visit##Name##ReleaseInst(Name##ReleaseInst *SI) { \
-  return AA->getMemoryBehaviorOfInst(V, SI); \
+  return AA->getMemoryEffectOnEscapedAddress(V, SI); \
 }
 #include "swift/AST/ReferenceStorage.def"
 
 MemBehavior MemoryBehaviorVisitor::visitReleaseValueInst(ReleaseValueInst *SI) {
-  return AA->getMemoryBehaviorOfInst(V, SI);
+  return AA->getMemoryEffectOnEscapedAddress(V, SI);
 }
 
 MemBehavior
 MemoryBehaviorVisitor::visitDestroyValueInst(DestroyValueInst *DVI) {
-  return AA->getMemoryBehaviorOfInst(V, DVI);
+  return AA->getMemoryEffectOnEscapedAddress(V, DVI);
 }
 
 MemBehavior MemoryBehaviorVisitor::visitSetDeallocatingInst(SetDeallocatingInst *SDI) {


### PR DESCRIPTION
This is code that I am fairly familiar with but it still took a day of investigation to figure out how it is supposed to be used now in the presence of bridging.

This primarily involved ruling out the possibity that the mid-level Swift APIs could at some point call into the lower-level C++ APIs.

The biggest problem was that AliasAnalysis::getMemoryBehaviorOfInst() was declared as a public interface, and it's name indicates that it computes the memory behavior. But it is just a wrapper around a Swift API and never actually calls into any of the C++ logic that is responsible for computing memory behavior!
