### PR TITLE
[5.9][Macros] A few bug fixes for extension macros.

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -837,7 +837,7 @@ func expandAttachedMacroIPC(
   }
 
   let conformanceListSyntax: PluginMessage.Syntax?
-  if (qualifiedType.isEmpty) {
+  if (conformanceList.isEmpty) {
     conformanceListSyntax = nil
   } else {
     let placeholderDecl: DeclSyntax =

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -238,6 +238,9 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
   void addConformances(const IterableDeclContext *IDC) {
     for (auto conformance :
          IDC->getLocalConformances(ConformanceLookupKind::NonInherited)) {
+      if (conformance->getSourceKind() == ConformanceEntryKind::PreMacroExpansion)
+        continue;
+
       auto protocol = conformance->getProtocol();
       if (Ctx.getOpts().PublicSymbolsOnly &&
           getDeclLinkage(protocol) != FormalLinkage::PublicUnique)

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1715,6 +1715,10 @@ ResolveExtensionMacroConformances::evaluate(Evaluator &evaluator,
 
       typeExpr->setType(MetatypeType::get(resolved));
       protocols.push_back(resolved);
+    } else {
+      // If there's no type repr, we already have a resolved instance
+      // type, e.g. because the type expr was deserialized.
+      protocols.push_back(typeExpr->getInstanceType());
     }
   }
 

--- a/test/Macros/Inputs/macro_library.swift
+++ b/test/Macros/Inputs/macro_library.swift
@@ -28,6 +28,7 @@ public struct ObservationRegistrar<Subject: Observable> {
   names: named(_registrar), named(addObserver), named(removeObserver), named(withTransaction), named(Storage), named(_storage)
 )
 @attached(memberAttribute)
+@attached(extension, conformances: Observable)
 public macro Observable() = #externalMacro(module: "MacroDefinition", type: "ObservableMacro")
 
 @attached(accessor)

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1195,6 +1195,30 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
 
 }
 
+extension ObservableMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    if (protocols.isEmpty) {
+      return []
+    }
+
+    let decl: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription): Observable {
+      }
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
 public struct ObservablePropertyMacro: AccessorMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -5,7 +5,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DTEST_DIAGNOSTICS
 
 // Check with the imported macro library vs. the local declaration of the macro.
-// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -enable-experimental-feature ExtensionMacros -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t -DTEST_DIAGNOSTICS
 

--- a/test/Macros/macro_expand_primary.swift
+++ b/test/Macros/macro_expand_primary.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend -enable-experimental-feature ExtensionMacros -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -I%t -verify -primary-file %s %S/Inputs/macro_expand_other.swift -verify-ignore-unknown  -load-plugin-library %t/%target-library-name(MacroDefinition) -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
@@ -85,6 +85,14 @@ final class Dog: Observable {
 func test() {
   observeDog()
 }
+
+@Observable
+class Person {
+  init() {}
+}
+
+// CHECK-DUMP: extension Person: Observable {
+// CHECK-DUMP: }
 
 
 @freestanding(declaration, names: named(Foo)) macro useIdentifier(_ value: String) = #externalMacro(module: "MacroDefinition", type: "UseIdentifierMacro")


### PR DESCRIPTION
* **Explanation**: This fixes 3 small issues with extension macros that enable adopting extension macros in `@Observable`:
1. When resolving extension macro protocol conformances, handle the case where a protocol has a null type repr because it was deserialized. This fixes an issue where imported extension macros with a `conformances:` list appeared to not add any conformances, and expansion was always passed an empty protocols array.
2. In SILSymbolVisitor, skip local conformance entries from pre-expanded macros. This fixes an assertion failure in TBDGen due to duplicate conformances.
3. Fix a silly copy-paste error in ASTGen that caused a bogus conformance list to be passed to extension macro expansion on the plugin server path.
* **Scope**: Only impacts extension macros.
* **Risk**: Low due to the narrow scope.
* **Testing**: Added a test case.
* **Reviewer**: @DougGregor
* **Main branch PR**: https://github.com/apple/swift/pull/67186