### PR TITLE
[AutoDiff] Fix test/Constraints/noderivative.swift

### DIFF
--- a/test/Constraints/noderivative.swift
+++ b/test/Constraints/noderivative.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// REQUIRES: differentiable_programming
 
 import _Differentiation
 


### PR DESCRIPTION
The test from #67121 imports _Differentiation, so it needs the REQUIRES line or people that build without that feature will fail this test.

