### PR TITLE
[5.9] Observable protocol non-marker, @Observable class only

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -275,4 +275,8 @@ extension DeclGroupSyntax {
   var isEnum: Bool {
     return self.is(EnumDeclSyntax.self)
   }
+  
+  var isStruct: Bool {
+    return self.is(StructDeclSyntax.self)
+  }
 }

--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -58,7 +58,7 @@ extension VariableDeclSyntax {
       guard let decl = accessor.as(AccessorDeclSyntax.self) else {
         return nil
       }
-      if predicate(decl.accessorKind.tokenKind) {
+      if predicate(decl.accessorSpecifier.tokenKind) {
         return decl
       } else {
         return nil
@@ -85,7 +85,7 @@ extension VariableDeclSyntax {
   
   
   var isImmutable: Bool {
-    return bindingKeyword.tokenKind == .keyword(.let)
+    return bindingSpecifier.tokenKind == .keyword(.let)
   }
   
   func isEquivalent(to other: VariableDeclSyntax) -> Bool {
@@ -198,9 +198,9 @@ extension FunctionDeclSyntax {
   var signatureStandin: SignatureStandin {
     var parameters = [String]()
     for parameter in signature.input.parameterList {
-      parameters.append(parameter.firstName.text + ":" + (parameter.type.genericSubstitution(genericParameterClause?.genericParameterList) ?? "" ))
+      parameters.append(parameter.firstName.text + ":" + (parameter.type.genericSubstitution(genericParameterClause?.parameters) ?? "" ))
     }
-    let returnType = signature.output?.returnType.genericSubstitution(genericParameterClause?.genericParameterList) ?? "Void"
+    let returnType = signature.output?.returnType.genericSubstitution(genericParameterClause?.parameters) ?? "Void"
     return SignatureStandin(isInstance: isInstance, identifier: identifier.text, parameters: parameters, returnType: returnType)
   }
   

--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -58,7 +58,7 @@ extension VariableDeclSyntax {
       guard let decl = accessor.as(AccessorDeclSyntax.self) else {
         return nil
       }
-      if predicate(decl.accessorSpecifier.tokenKind) {
+      if predicate(decl.accessorKind.tokenKind) {
         return decl
       } else {
         return nil
@@ -85,7 +85,7 @@ extension VariableDeclSyntax {
   
   
   var isImmutable: Bool {
-    return bindingSpecifier.tokenKind == .keyword(.let)
+    return bindingKeyword.tokenKind == .keyword(.let)
   }
   
   func isEquivalent(to other: VariableDeclSyntax) -> Bool {
@@ -198,9 +198,9 @@ extension FunctionDeclSyntax {
   var signatureStandin: SignatureStandin {
     var parameters = [String]()
     for parameter in signature.input.parameterList {
-      parameters.append(parameter.firstName.text + ":" + (parameter.type.genericSubstitution(genericParameterClause?.parameters) ?? "" ))
+      parameters.append(parameter.firstName.text + ":" + (parameter.type.genericSubstitution(genericParameterClause?.genericParameterList) ?? "" ))
     }
-    let returnType = signature.output?.returnType.genericSubstitution(genericParameterClause?.parameters) ?? "Void"
+    let returnType = signature.output?.returnType.genericSubstitution(genericParameterClause?.genericParameterList) ?? "Void"
     return SignatureStandin(isInstance: isInstance, identifier: identifier.text, parameters: parameters, returnType: returnType)
   }
   

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -206,11 +206,15 @@ extension ObservableMacro: MemberMacro {
     
     if declaration.isEnum {
       // enumerations cannot store properties
-      throw DiagnosticsError(syntax: node, message: "@Observable cannot be applied to enumeration type \(observableType.text)", id: .invalidApplication)
+      throw DiagnosticsError(syntax: node, message: "'@Observable' cannot be applied to enumeration type '\(observableType.text)'", id: .invalidApplication)
+    }
+    if declaration.isStruct {
+      // structs are not yet supported; copying/mutation semantics tbd
+      throw DiagnosticsError(syntax: node, message: "'@Observable' cannot be applied to struct type '\(observableType.text)'", id: .invalidApplication)
     }
     if declaration.isActor {
       // actors cannot yet be supported for their isolation
-      throw DiagnosticsError(syntax: node, message: "@Observable cannot be applied to actor type \(observableType.text)", id: .invalidApplication) 
+      throw DiagnosticsError(syntax: node, message: "'@Observable' cannot be applied to actor type '\(observableType.text)'", id: .invalidApplication)
     }
     
     var declarations = [DeclSyntax]()

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -71,7 +71,7 @@ public struct ObservableMacro {
   static var ignoredAttribute: AttributeSyntax {
     AttributeSyntax(
       leadingTrivia: .space,
-      atSignToken: .atSignToken(),
+      atSign: .atSignToken(),
       attributeName: SimpleTypeIdentifierSyntax(name: .identifier(ignoredMacroName)),
       trailingTrivia: .space
     )
@@ -173,12 +173,14 @@ extension PatternBindingListSyntax {
 }
 
 extension VariableDeclSyntax {
-    func privatePrefixed(_ prefix: String, addingAttribute attribute: AttributeSyntax) -> VariableDeclSyntax {
-    VariableDeclSyntax(
+  func privatePrefixed(_ prefix: String, addingAttribute attribute: AttributeSyntax) -> VariableDeclSyntax {
+    let newAttributes = AttributeListSyntax(
+      (attributes.map(Array.init) ?? []) + [.attribute(attribute)])
+    return VariableDeclSyntax(
       leadingTrivia: leadingTrivia,
-      attributes: attributes?.appending(.attribute(attribute)) ?? [.attribute(attribute)],
+      attributes: newAttributes,
       modifiers: modifiers?.privatePrefixed(prefix) ?? ModifierListSyntax(keyword: .private),
-      bindingKeyword: TokenSyntax(bindingKeyword.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
+      bindingSpecifier: TokenSyntax(bindingSpecifier.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
       bindings: bindings.privatePrefixed(prefix),
       trailingTrivia: trailingTrivia
     )
@@ -265,30 +267,27 @@ extension ObservableMacro: MemberAttributeMacro {
   }
 }
 
-extension ObservableMacro: ConformanceMacro {
-  public static func expansion<Declaration: DeclGroupSyntax, Context: MacroExpansionContext>(
+extension ObservableMacro: ExtensionMacro {
+  public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf declaration: Declaration,
-    in context: Context
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    let inheritanceList: InheritedTypeListSyntax?
-    if let classDecl = declaration.as(ClassDeclSyntax.self) {
-      inheritanceList = classDecl.inheritanceClause?.inheritedTypeCollection
-    } else if let structDecl = declaration.as(StructDeclSyntax.self) {
-      inheritanceList = structDecl.inheritanceClause?.inheritedTypeCollection
-    } else {
-      inheritanceList = nil
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    // This method can be called twice - first with an empty `protocols` when
+    // no conformance is needed, and second with a `MissingTypeSyntax` instance.
+    if protocols.isEmpty {
+      return []
     }
-    
-    if let inheritanceList {
-      for inheritance in inheritanceList {
-        if inheritance.typeName.identifier == ObservableMacro.conformanceName {
-          return []
-        }
-      }
-    }
-    
-    return [(ObservableMacro.observableConformanceType, nil)]
+
+    let decl: DeclSyntax = """
+      extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
   }
 }
 

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -71,7 +71,7 @@ public struct ObservableMacro {
   static var ignoredAttribute: AttributeSyntax {
     AttributeSyntax(
       leadingTrivia: .space,
-      atSign: .atSignToken(),
+      atSignToken: .atSignToken(),
       attributeName: SimpleTypeIdentifierSyntax(name: .identifier(ignoredMacroName)),
       trailingTrivia: .space
     )
@@ -180,7 +180,7 @@ extension VariableDeclSyntax {
       leadingTrivia: leadingTrivia,
       attributes: newAttributes,
       modifiers: modifiers?.privatePrefixed(prefix) ?? ModifierListSyntax(keyword: .private),
-      bindingSpecifier: TokenSyntax(bindingSpecifier.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
+      bindingKeyword: TokenSyntax(bindingKeyword.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
       bindings: bindings.privatePrefixed(prefix),
       trailingTrivia: trailingTrivia
     )

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -24,6 +24,7 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     "-enable-experimental-feature" "Macros"
+    "-enable-experimental-feature" "ExtensionMacros"
     -Xfrontend -disable-implicit-string-processing-module-import
 
   C_COMPILE_FLAGS

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -11,7 +11,7 @@
 
 
 @available(SwiftStdlib 5.9, *)
-@_marker public protocol Observable { }
+public protocol Observable { }
 
 #if $Macros && hasAttribute(attached)
 
@@ -22,7 +22,7 @@
 @attached(member, names: named(_$observationRegistrar), named(access), named(withMutation), arbitrary)
 #endif
 @attached(memberAttribute)
-@attached(conformance)
+@attached(extension, conformances: Observable)
 public macro Observable() =
   #externalMacro(module: "ObservationMacros", type: "ObservableMacro")
 

--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -130,3 +130,28 @@ public struct ObservationRegistrar: Sendable {
     return try mutation()
   }
 }
+
+@available(SwiftStdlib 5.9, *)
+extension ObservationRegistrar: Codable {
+  public init(from decoder: any Decoder) throws {
+    self.init()
+  }
+  
+  public func encode(to encoder: any Encoder) {
+    // Don't encode a registrar's transient state.
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+extension ObservationRegistrar: Hashable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    // A registrar should be ignored for the purposes of determining its
+    // parent type's equality.
+    return true
+  }
+  
+  public func hash(into hasher: inout Hasher) {
+    // Don't include a registrar's transient state in its parent type's
+    // hash value.
+  }
+}

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -1,6 +1,9 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+
+// Run this test via the swift-plugin-server
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -external-plugin-path -Xfrontend %swift-host-lib-dir/plugins#%swift-plugin-server)
 
 // Asserts is required for '-enable-experimental-feature InitAccessors'.
 // REQUIRES: asserts

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -20,29 +20,6 @@ func _blackHole<T>(_ value: T) { }
 class ContainsNothing { }
 
 @Observable
-struct Structure {
-  var field: Int = 0
-}
-
-@Observable
-struct MemberwiseInitializers {
-  var field: Int
-}
-
-func validateMemberwiseInitializers() {
-  _ = MemberwiseInitializers(field: 3)
-}
-
-@Observable
-struct DefiniteInitialization {
-  var field: Int
-
-  init(field: Int) {
-    self.field = field
-  }
-}
-
-@Observable
 class ContainsWeak {
   weak var obj: AnyObject? = nil
 }
@@ -84,6 +61,31 @@ struct NonObservableContainer {
   @Observable
   class ObservableContents {
     var field: Int = 3
+  }
+}
+
+@Observable
+final class SendableClass: Sendable {
+  var field: Int = 3
+}
+
+@Observable
+class CodableClass: Codable {
+  var field: Int = 3
+}
+
+@Observable
+final class HashableClass {
+  var field: Int = 3
+}
+
+extension HashableClass: Hashable {
+  static func == (lhs: HashableClass, rhs: HashableClass) -> Bool {
+    lhs.field == rhs.field
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(field)
   }
 }
 
@@ -154,9 +156,6 @@ class IsolatedInstance {
 }
 
 @Observable
-struct StructHasExistingConformance: Observable { }
-
-@Observable
 class ClassHasExistingConformance: Observable { }
 
 protocol Intermediary: Observable { }
@@ -201,23 +200,6 @@ struct Validator {
       expectEqual(changed.state, true)
       changed.state = false
       test.firstName = "c"
-      expectEqual(changed.state, false)
-    }
-
-    suite.test("tracking structure changes") {
-      let changed = CapturedState(state: false)
-      
-      var test = Structure()
-      withObservationTracking {
-        _blackHole(test.field)
-      } onChange: {
-        changed.state = true
-      }
-      
-      test.field = 4
-      expectEqual(changed.state, true)
-      changed.state = false
-      test.field = 5
       expectEqual(changed.state, false)
     }
 

--- a/test/stdlib/Observation/ObservableDidSetWillSet.swift
+++ b/test/stdlib/Observation/ObservableDidSetWillSet.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins) | %FileCheck %s
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins) | %FileCheck %s
 
 // Asserts is required for '-enable-experimental-feature InitAccessors'.
 // REQUIRES: asserts


### PR DESCRIPTION
- Explanation: Three top-level changes:
    - Converts `Observable` to be a non-marker protocol, which in turns requires a change in the `@Observable` macro to emit a conformance extension only when the target type doesn't already provide conformance
    - Makes the `@Observable` macro only applicable to classes (adding structs to the already-prohibited enums and actors)
    - Adds trivial `Sendable`/`Hashable`/`Codable` conformances for the `ObservationRegistrar` type
- Scope: Impacts adopters of the `@Observable` macro.
- Risk: Adopters that have applied `@Observable` to structs will receive a new compile-time error.
- Testing: Modified test cases to work with the new protocol.
- Reviewer: @stephentyrone 
- Main branch PRs: https://github.com/apple/swift/pull/66993 and https://github.com/apple/swift/pull/67033
