### PR TITLE
AST: Simplify TypeBase::getTypeParameterPacks()

### DIFF
--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -100,21 +100,16 @@ void TypeBase::walkPackReferences(
 
 void TypeBase::getTypeParameterPacks(
     SmallVectorImpl<Type> &rootParameterPacks) {
-  llvm::SmallSetVector<Type, 2> rootParameterPackSet;
-
   walkPackReferences([&](Type t) {
     if (auto *paramTy = t->getAs<GenericTypeParamType>()) {
       if (paramTy->isParameterPack())
-        rootParameterPackSet.insert(paramTy);
+        rootParameterPacks.push_back(paramTy);
     } else if (auto *archetypeTy = t->getAs<PackArchetypeType>()) {
-      rootParameterPackSet.insert(archetypeTy->getRoot());
+      rootParameterPacks.push_back(archetypeTy->getRoot());
     }
 
     return false;
   });
-
-  rootParameterPacks.append(rootParameterPackSet.begin(),
-                            rootParameterPackSet.end());
 }
 
 bool GenericTypeParamType::isParameterPack() const {


### PR DESCRIPTION
Type deletes operator== so this no longer compiles on the next branch. No idea why it worked before. We could use isEqual() instead but in fact none of the callers care about uniqueness so let's do the simple thing that is guaranteed to work.