### PR TITLE
[ClangImporter] Use TextAPI apis for capturing current-version

### DIFF
--- a/test/ClangImporter/Inputs/frameworks/Simple.framework/Simple.tbd
+++ b/test/ClangImporter/Inputs/frameworks/Simple.framework/Simple.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ arm64-macos, arm64-ios, arm64-watchos, arm64-tvos, 
+                   arm64-ios-simulator, arm64-watchos-simulator, arm64-tvos-simulator ]
+flags:           [ not_app_extension_safe ]
+install-name:    '/System/Library/Frameworks/Simple.framework/Versions/A/Simple'
+current-version: 1830.100
+...

--- a/test/ClangImporter/can_import_underlying_version.swift
+++ b/test/ClangImporter/can_import_underlying_version.swift
@@ -3,9 +3,6 @@
 // RUN: %empty-directory(%t/frameworks)
 
 // RUN: cp -rf %S/Inputs/frameworks/Simple.framework %t/frameworks/
-
-// RUN: echo "current-version: 1830.100" > %t/frameworks/Simple.framework/Simple.tbd
-
 // RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -F %t/frameworks
 
 import Simple

--- a/test/ClangImporter/can_import_underlying_version_ignores_swift_module_version.swift
+++ b/test/ClangImporter/can_import_underlying_version_ignores_swift_module_version.swift
@@ -11,7 +11,7 @@
 // conditional, the version in the `.tbd` should be honored. When `_version`
 // is specified, the version from the `.swiftmodule` should be honored.
 
-// RUN: echo "current-version: 3" > %t/frameworks/Simple.framework/Simple.tbd
+// RUN: sed -i -e "s/1830\.100/3/g" %t/frameworks/Simple.framework/Simple.tbd
 // RUN: echo "@_exported import Simple" > %t.overlay.swift
 // RUN: echo "public func additional() {}" >> %t.overlay.swift
 

--- a/test/ClangImporter/can_import_underlying_version_tbd_missing_version.swift
+++ b/test/ClangImporter/can_import_underlying_version_tbd_missing_version.swift
@@ -3,8 +3,7 @@
 // RUN: %empty-directory(%t/frameworks)
 
 // RUN: cp -rf %S/Inputs/frameworks/Simple.framework %t/frameworks/
-
-// RUN: echo "" > %t/frameworks/Simple.framework/Simple.tbd
+// RUN: rm -rf %t/frameworks/Simple.framework/Simple.tbd
 // RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -F %t/frameworks
 
 import Simple

--- a/test/ClangImporter/can_import_version_ignores_missing_tbd_version.swift
+++ b/test/ClangImporter/can_import_version_ignores_missing_tbd_version.swift
@@ -12,7 +12,7 @@
 // should be no diagnostics and the version in the `.swiftmodule` should be
 // honored.
 
-// RUN: echo "" > %t/frameworks/Simple.framework/Simple.tbd
+// RUN: rm -rf %t/frameworks/Simple.framework/Simple.tbd
 // RUN: echo "@_exported import Simple" > %t.overlay.swift
 // RUN: echo "public func additional() {}" >> %t.overlay.swift
 


### PR DESCRIPTION
Use LLVM apis for understanding TBD files instead of parsing the yaml directly. This prevents breaking the compiler when TBD-v5 exists which is in json.