### PR TITLE
[Parse] Accept 'self' after 'each'

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1399,6 +1399,10 @@ ERROR(expected_expr_after_copy, none,
       "expected expression after 'copy'", ())
 ERROR(expected_expr_after_borrow, none,
       "expected expression after '_borrow'", ())
+ERROR(expected_expr_after_each, none,
+      "expected expression after 'each'", ())
+ERROR(expected_expr_after_repeat, none,
+      "expected expression after 'repeat'", ())
 
 WARNING(move_consume_final_spelling, none,
         "'_move' has been renamed to 'consume', and the '_move' spelling will be removed shortly", ())

--- a/test/Interpreter/Inputs/variadic_generic_library.swift
+++ b/test/Interpreter/Inputs/variadic_generic_library.swift
@@ -44,14 +44,14 @@ public struct Predicate<each Input> {
     builder: (repeat Variable<each Input>) -> Expr
   ) where Expr: Expression<Bool> {
     self.variables = (repeat Variable<each Input>())
-    self.expression = builder(repeat each variables)
+    self.expression = builder(repeat each self.variables)
   }
 
   public func evaluate(
     _ input: repeat each Input
   ) throws -> Bool  {
     return try expression.evaluate(
-      .init(repeat (each variables, each input))
+      .init(repeat (each self.variables, each input))
     )
   }
 }


### PR DESCRIPTION
Also move 'repeat', 'each', and 'any' expression parsing to 'parseExprSequenceElement'

rdar://107450487
