### PR TITLE
[Observation] Avoid using T since it is a common generic name, instead use a very specific generic return value name

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -59,10 +59,10 @@ public struct ObservableMacro {
   static func withMutationFunction(_ observableType: TokenSyntax) -> DeclSyntax {
     return 
       """
-      internal nonisolated func withMutation<Member, T>(
+      internal nonisolated func withMutation<Member, MutationResult>(
         keyPath: KeyPath<\(observableType), Member>,
-        _ mutation: () throws -> T
-      ) rethrows -> T {
+        _ mutation: () throws -> MutationResult
+      ) rethrows -> MutationResult {
         try \(raw: registrarVariableName).withMutation(of: self, keyPath: keyPath, mutation)
       }
       """


### PR DESCRIPTION
If a type is generic AND `@Observable` with a generic of `T` it claims warnings/errors about shadowing of the types. This renames the `T` of `withMutation` to be `MutationResult` which is significantly specific to not pose any real shadowing risk.