### PR TITLE
[Features] Allow ExtensionMacros to be enabled in noasserts builds.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -123,7 +123,7 @@ EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(InitAccessors, false)
 
-EXPERIMENTAL_FEATURE(ExtensionMacros, false)
+EXPERIMENTAL_FEATURE(ExtensionMacros, true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)", true)
 
 // Whether to enable @_used and @_section attributes


### PR DESCRIPTION
This flag is adopted by the Observation module, which is built in noasserts CI configurations.