### PR TITLE
[PlaygroundTransform] Add experimental feature `PlaygroundExtendedCallbacks` to pass more info in callbacks

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -220,6 +220,10 @@ EXPERIMENTAL_FEATURE(StrictConcurrency, true)
 /// Defer Sendable checking to SIL diagnostic phase.
 EXPERIMENTAL_FEATURE(DeferredSendableChecking, false)
 
+/// Enable extended callbacks (with additional parameters) to be used when the
+/// "playground transform" is enabled.
+EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3480,6 +3480,10 @@ static bool usesFeatureDeferredSendableChecking(Decl *decl) {
   return false;
 }
 
+static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
+  return false;
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -829,17 +829,7 @@ public:
     LoggerRef->setImplicit(true);
 
     if (ExtendedCallbacks) {
-      auto SourceLocBufferId = Context.SourceMgr.findBufferContainingLoc(SR.Start);
-      StringRef filePath;
-
-      // Use #sourceLocation if it exists.
-      SourceLoc sl = SR.Start;
-      auto *vf = Context.SourceMgr.getVirtualFile(sl);
-      if (vf) {
-        filePath = StringRef(vf->Name);
-      } else {
-        filePath = Context.SourceMgr.getIdentifierForBuffer(SourceLocBufferId);
-      }
+      StringRef filePath = Context.SourceMgr.getDisplayNameForLoc(SR.Start);
 
       Expr *FilePathExpr = new (Context) StringLiteralExpr(
           Context.AllocateCopy(filePath), SourceRange(), /*implicit=*/true);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -41,13 +41,18 @@ private:
   std::mt19937_64 &RNG;
   unsigned &TmpNameIndex;
   bool HighPerformance;
+  bool ExtendedCallbacks;
 
   DeclNameRef DebugPrintName;
   DeclNameRef PrintName;
   DeclNameRef PostPrintName;
+  DeclNameRef PostPrintExtendedName;
   DeclNameRef LogWithIDName;
+  DeclNameRef LogWithIDExtendedName;
   DeclNameRef LogScopeExitName;
+  DeclNameRef LogScopeExitExtendedName;
   DeclNameRef LogScopeEntryName;
+  DeclNameRef LogScopeEntryExtendedName;
   DeclNameRef SendDataName;
 
   struct BracePair {
@@ -126,12 +131,17 @@ public:
                unsigned &TmpNameIndex)
       : InstrumenterBase(C, DC), RNG(RNG), TmpNameIndex(TmpNameIndex),
         HighPerformance(HP),
+        ExtendedCallbacks(C.LangOpts.hasFeature(Feature::PlaygroundExtendedCallbacks)),
         DebugPrintName(C.getIdentifier("__builtin_debugPrint")),
         PrintName(C.getIdentifier("__builtin_print")),
         PostPrintName(C.getIdentifier("__builtin_postPrint")),
+        PostPrintExtendedName(C.getIdentifier("__builtin_postPrint_extended")),
         LogWithIDName(C.getIdentifier("__builtin_log_with_id")),
+        LogWithIDExtendedName(C.getIdentifier("__builtin_log_with_id_extended")),
         LogScopeExitName(C.getIdentifier("__builtin_log_scope_exit")),
+        LogScopeExitExtendedName(C.getIdentifier("__builtin_log_scope_exit_extended")),
         LogScopeEntryName(C.getIdentifier("__builtin_log_scope_entry")),
+        LogScopeEntryExtendedName(C.getIdentifier("__builtin_log_scope_entry_extended")),
         SendDataName(C.getIdentifier("__builtin_send_data")) { }
 
   Stmt *transformStmt(Stmt *S) {
@@ -736,7 +746,7 @@ public:
   }
 
   Added<Stmt *> logPostPrint(SourceRange SR) {
-    return buildLoggerCallWithArgs(PostPrintName, {}, SR);
+    return buildLoggerCallWithArgs(ExtendedCallbacks ? PostPrintExtendedName : PostPrintName, {}, SR);
   }
 
   std::pair<PatternBindingDecl *, VarDecl *>
@@ -776,15 +786,15 @@ public:
     const unsigned id_num = Distribution(RNG);
     Expr *IDExpr = IntegerLiteralExpr::createFromUnsigned(Context, id_num, SourceLoc());
 
-    return buildLoggerCallWithArgs(LogWithIDName, { *E, NameExpr, IDExpr }, SR);
+    return buildLoggerCallWithArgs(ExtendedCallbacks ? LogWithIDExtendedName : LogWithIDName, { *E, NameExpr, IDExpr }, SR);
   }
 
   Added<Stmt *> buildScopeEntry(SourceRange SR) {
-    return buildLoggerCallWithArgs(LogScopeEntryName, {}, SR);
+    return buildLoggerCallWithArgs(ExtendedCallbacks ? LogScopeEntryExtendedName : LogScopeEntryName, {}, SR);
   }
 
   Added<Stmt *> buildScopeExit(SourceRange SR) {
-    return buildLoggerCallWithArgs(LogScopeExitName, {}, SR);
+    return buildLoggerCallWithArgs(ExtendedCallbacks ? LogScopeExitExtendedName : LogScopeExitName, {}, SR);
   }
 
   Added<Stmt *> buildLoggerCallWithArgs(DeclNameRef LoggerName,
@@ -813,13 +823,37 @@ public:
 
     llvm::SmallVector<Expr *, 6> ArgsWithSourceRange(Args.begin(), Args.end());
 
-    ArgsWithSourceRange.append(
-        {StartLine, EndLine, StartColumn, EndColumn, ModuleExpr, FileExpr});
-
     UnresolvedDeclRefExpr *LoggerRef = new (Context)
         UnresolvedDeclRefExpr(LoggerName, DeclRefKind::Ordinary,
                               DeclNameLoc(SR.End));
     LoggerRef->setImplicit(true);
+
+    if (ExtendedCallbacks) {
+      auto SourceLocBufferId = Context.SourceMgr.findBufferContainingLoc(SR.Start);
+      StringRef filePath;
+
+      // Use #sourceLocation if it exists.
+      SourceLoc sl = SR.Start;
+      auto *vf = Context.SourceMgr.getVirtualFile(sl);
+      if (vf) {
+        filePath = StringRef(vf->Name);
+      } else {
+        filePath = Context.SourceMgr.getIdentifierForBuffer(SourceLocBufferId);
+      }
+
+      Expr *FilePathExpr = new (Context) StringLiteralExpr(
+          Context.AllocateCopy(filePath), SourceRange(), /*implicit=*/true);
+
+      std::string moduleName = std::string(TypeCheckDC->getParentModule()->getName());
+      Expr *ModuleNameExpr = new (Context) StringLiteralExpr(
+          Context.AllocateCopy(moduleName), SourceRange(), /*implicit=*/true);
+
+      ArgsWithSourceRange.append(
+          {StartLine, EndLine, StartColumn, EndColumn, ModuleNameExpr, FilePathExpr});
+    } else {
+      ArgsWithSourceRange.append(
+          {StartLine, EndLine, StartColumn, EndColumn, ModuleExpr, FileExpr});
+    }
 
     auto *ArgList =
         ArgumentList::forImplicitUnlabeled(Context, ArgsWithSourceRange);

--- a/test/PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
+++ b/test/PlaygroundTransform/Inputs/PlaygroundsRuntime.swift
@@ -23,6 +23,11 @@ struct ModuleFileIdentifier {
 class LogRecord {
   let text : String
 
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleName : String, filePath : String) {
+    var object_description : String = ""
+    print(object, terminator: "", to: &object_description)
+    text = range.text + " " + api + "[" + name + "='" + object_description + "'" + " module: " + moduleName + ". file: " + filePath + "]"
+  }
   init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
@@ -37,6 +42,9 @@ class LogRecord {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
     text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
+  }
+  init(api : String, range : SourceRange, moduleName : String, filePath: String) {
+    text = range.text + " " + api + " " + " module: " + moduleName + ". file: " + filePath
   }
   init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     text = moduleFileId.text + " " + range.text + " " + api
@@ -53,9 +61,17 @@ public func __builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, 
   return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
+public func __builtin_log_with_id_extended<T>(_ object: T, _ name: String, _ id: Int, _ sl: Int, _ el: Int, _ sc: Int, _ ec: Int, _ moduleName: String, _ filePath: String) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_with_id_extended", object:object, name:name, id:id, range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleName:moduleName, filePath:filePath)
+}
+
 public func __builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_log_scope_entry", range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
+}
+
+public func __builtin_log_scope_entry_extended(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleName: String, _ filePath: String) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_scope_entry_extended", range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleName:moduleName, filePath:filePath)
 }
 
 public func __builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
@@ -63,9 +79,17 @@ public func __builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: I
   return LogRecord(api:"__builtin_log_scope_exit", range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
+public func __builtin_log_scope_exit_extended(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleName: String, _ filePath: String) -> AnyObject? {
+  return LogRecord(api:"__builtin_log_scope_exit_extended", range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleName:moduleName, filePath:filePath)
+}
+
 public func __builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
   let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
   return LogRecord(api:"__builtin_postPrint", range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
+}
+
+public func __builtin_postPrint_extended(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleName: String, _ filePath: String) -> AnyObject? {
+  return LogRecord(api:"__builtin_postPrint_extended", range:SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleName:moduleName, filePath:filePath)
 }
 
 public func __builtin_send_data(_ object:AnyObject?) {

--- a/test/PlaygroundTransform/extended_callbacks.swift
+++ b/test/PlaygroundTransform/extended_callbacks.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -playground-high-performance -enable-experimental-feature PlaygroundExtendedCallbacks -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+var a = true
+if (a) {
+  5
+} else {
+  7
+}
+
+for i in 0..<3 {
+  i
+}
+// CHECK: [{{.*}}] __builtin_log_with_id_extended[a='true' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='5' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+
+var b = true
+for i in 0..<3 {
+  i
+  continue
+}
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[b='true' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+
+var c = true
+for i in 0..<3 {
+  i
+  break
+}
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[c='true' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main{{.*}}. file: {{.*/main[\d]?.swift}}]


### PR DESCRIPTION
### Summary

Adds the experimental feature `PlaygroundExtendedCallbacks` which (when `-playground` is also passed) causes the playground transform to use alternate forms of the result-value, scope-entry, and scope-exit callbacks that include the module name and file path of the source file.

### Rationale

The previous callbacks included integers for the module number and file number, but this was cumbersome to use because it required the caller to create source symbols with magical names formed from the module name and file path that the playground transform knew how to look up.

The extended callbacks in the experimental feature instead pass these strings as string literals. This is an experimental feature because of the need to measure the performance impact, and because of the need to provide an option to control which set of callbacks to use so that existing clients of the playground transform can opt into it when ready. It's also likely that we'll want to pass more information in the extended callbacks, such as an indication of the kind of result is being logged (e.g. a loop iteration variable vs a return statement vs a variable assignment). So this should be considered the first of a series of experimental improvements that will then be pitched as an actual, non-experimental v2.0 of the playground transform callback API. Because of the nature of how the playground transform is used, it's much easier to iterate on the functionality in the form of an experimental feature rather than using only desktop debug builds of the Swift compiler.

### Changes

- define a new experimental feature called `PlaygroundExtendedCallbacks`
- modify the playground transform step in sema to pass the module name and file name literals when the experimental feature is set
- add a unit test for the extended callbacks

There is no change in behaviour of the playground transform when `PlaygroundExtendedCallbacks` is not enabled.

rdar://109911742
