### PR TITLE
[AddressLowering] Handle move_value.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3050,6 +3050,9 @@ protected:
     }
   }
 
+  template <typename Introducer>
+  void visitLifetimeIntroducer(Introducer *introducer);
+
   void visitBeginBorrowInst(BeginBorrowInst *borrow);
 
   void visitEndBorrowInst(EndBorrowInst *end) {}
@@ -3263,15 +3266,16 @@ void UseRewriter::rewriteDestructure(SILInstruction *destructure) {
   }
 }
 
-void UseRewriter::visitBeginBorrowInst(BeginBorrowInst *borrow) {
-  assert(use == getProjectedDefOperand(borrow));
+template <typename Introducer>
+void UseRewriter::visitLifetimeIntroducer(Introducer *introducer) {
+  assert(use == getProjectedDefOperand(introducer));
 
   // Mark the value as rewritten and use the operand's storage.
   auto address = pass.valueStorageMap.getStorage(use->get()).storageAddress;
-  markRewritten(borrow, address);
+  markRewritten(introducer, address);
 
-  // Borrows are irrelevant unless they are marked lexical.
-  if (borrow->isLexical()) {
+  // Lifetime introducers are irrelevant unless they are marked lexical.
+  if (introducer->isLexical()) {
     if (auto base = getAccessBase(address)) {
       if (auto *allocStack = dyn_cast<AllocStackInst>(base)) {
         allocStack->setIsLexical();
@@ -3285,6 +3289,10 @@ void UseRewriter::visitBeginBorrowInst(BeginBorrowInst *borrow) {
     SWIFT_ASSERT_ONLY(address->dump());
     llvm_unreachable("^^^ unknown lexical address producer");
   }
+}
+
+void UseRewriter::visitBeginBorrowInst(BeginBorrowInst *borrow) {
+  visitLifetimeIntroducer(borrow);
 }
 
 // Opening an opaque existential. Rewrite the opened existentials here on

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -872,6 +872,9 @@ static Operand *getProjectedDefOperand(SILValue value) {
 
     return nullptr;
 
+  case ValueKind::MoveValueInst:
+    return &cast<MoveValueInst>(value)->getOperandRef();
+
   case ValueKind::MultipleValueInstructionResult: {
     SILInstruction *destructure =
         cast<MultipleValueInstructionResult>(value)->getParent();
@@ -3128,6 +3131,8 @@ protected:
   // types.
   void visitOpenExistentialValueInst(OpenExistentialValueInst *openExistential);
 
+  void visitMoveValueInst(MoveValueInst *mvi);
+
   void visitReturnInst(ReturnInst *returnInst) {
     // Returns are rewritten for any function with indirect results after
     // opaque value rewriting.
@@ -3293,6 +3298,10 @@ void UseRewriter::visitLifetimeIntroducer(Introducer *introducer) {
 
 void UseRewriter::visitBeginBorrowInst(BeginBorrowInst *borrow) {
   visitLifetimeIntroducer(borrow);
+}
+
+void UseRewriter::visitMoveValueInst(MoveValueInst *mvi) {
+  visitLifetimeIntroducer(mvi);
 }
 
 // Opening an opaque existential. Rewrite the opened existentials here on

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1924,6 +1924,60 @@ entry(%addr : $*T):
     return %retval : $()
 }
 
+// The move_value is lexical so the corresponding alloc_stack must be marked
+// lexical too.
+// CHECK-LABEL: sil [ossa] @testMoveValueLexical : {{.*}} {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'testMoveValueLexical'
+sil [ossa] @testMoveValueLexical : $@convention(thin) <T> () -> () {
+  %getT = function_ref @getT : $@convention(thin) <T> () -> @out T
+  %instance = apply %getT<T>() : $@convention(thin) <T> () -> @out T
+  %moved = move_value [lexical] %instance : $T
+  destroy_value %moved : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify that the temporary storage is lexical and moved out of 
+// (copy_addr [take]).
+// CHECK-LABEL: sil [ossa] @testMoveValueLexicalAndReturn : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[RETVAL:%[^,]+]] :
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack [lexical]
+// CHECK:         copy_addr [take] [[STACK]] to [init] [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'testMoveValueLexicalAndReturn'
+sil [ossa] @testMoveValueLexicalAndReturn : $@convention(thin) <T> () -> @out T {
+  %getT = function_ref @getT : $@convention(thin) <T> () -> @out T
+  %instance = apply %getT<T>() : $@convention(thin) <T> () -> @out T
+  %moved = move_value [lexical] %instance : $T
+  return %moved : $T
+}
+
+// Verify that a move_value gets no stack storage if it's from an argument.
+// CHECK-LABEL: sil [ossa] @testMoveValueLexicalArgument : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         destroy_addr [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'testMoveValueLexicalArgument'
+sil [ossa] @testMoveValueLexicalArgument : $@convention(thin) <T> (@in T) -> () {
+entry(%instance : @owned $T):
+  %moved = move_value [lexical] %instance : $T
+  destroy_value %moved : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Only lexical move_values should mark the alloc_stack lexical.
+// CHECK-LABEL: sil [ossa] @testMoveValueNonlexical : {{.*}} {
+// CHECK-NOT:     alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'testMoveValueNonlexical'
+sil [ossa] @testMoveValueNonlexical : $@convention(thin) <T> () -> () {
+  %getT = function_ref @getT : $@convention(thin) <T> () -> @out T
+  %instance = apply %getT<T>() : $@convention(thin) <T> () -> @out T
+  %moved = move_value %instance : $T
+  destroy_value %moved : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil hidden [ossa] @testOpaqueYield :
 // CHECK: bb0(%0 : @guaranteed $TestGeneric<T>):
 // CHECK:   [[REF:%.*]] = ref_element_addr %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric


### PR DESCRIPTION
It's handled just like `begin_borrow`: ignored unless lexical, in which case the storage is marked lexical.
