### PR TITLE
[5.9][AST/Sema/SIL] Init accessor improvements

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1623,6 +1623,9 @@ public:
     return {getTrailingObjects<Identifier>() + NumInitializes, NumAccesses};
   }
 
+  ArrayRef<VarDecl *> getInitializesProperties(AccessorDecl *attachedTo) const;
+  ArrayRef<VarDecl *> getAccessesProperties(AccessorDecl *attachedTo) const;
+
   static StorageRestrictionsAttr *create(ASTContext &ctx, SourceLoc atLoc,
                                          SourceRange range,
                                          ArrayRef<Identifier> initializes,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1594,6 +1594,45 @@ public:
   }
 };
 
+class StorageRestrictionsAttr final
+    : public DeclAttribute,
+      private llvm::TrailingObjects<StorageRestrictionsAttr, Identifier> {
+  friend TrailingObjects;
+
+  size_t NumInitializes;
+  size_t NumAccesses;
+
+  size_t numTrailingObjects(OverloadToken<Identifier>) const {
+    return NumInitializes + NumAccesses;
+  }
+
+public:
+  StorageRestrictionsAttr(SourceLoc AtLoc, SourceRange Range,
+                          ArrayRef<Identifier> initializes,
+                          ArrayRef<Identifier> accesses, bool Implicit);
+
+  unsigned getNumInitializesProperties() const { return NumInitializes; }
+
+  unsigned getNumAccessesProperties() const { return NumAccesses; }
+
+  ArrayRef<Identifier> getInitializesNames() const {
+    return {getTrailingObjects<Identifier>(), NumInitializes};
+  }
+
+  ArrayRef<Identifier> getAccessesNames() const {
+    return {getTrailingObjects<Identifier>() + NumInitializes, NumAccesses};
+  }
+
+  static StorageRestrictionsAttr *create(ASTContext &ctx, SourceLoc atLoc,
+                                         SourceRange range,
+                                         ArrayRef<Identifier> initializes,
+                                         ArrayRef<Identifier> accesses);
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_StorageRestrictions;
+  }
+};
+
 /// The @_implements attribute, which treats a decl as the implementation for
 /// some named protocol requirement (but otherwise not-visible by that name).
 class ImplementsAttr : public DeclAttribute {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7652,6 +7652,13 @@ public:
   /// for anything other than a getter or setter.
   void printUserFacingName(llvm::raw_ostream &out) const;
 
+  /// If this is an init accessor, retrieve a list of instance properties
+  /// initialized by it.
+  ArrayRef<VarDecl *> getInitializedProperties() const;
+  /// If this is an init accessor, retrieve a list of instance properties
+  /// accessed by it.
+  ArrayRef<VarDecl *> getAccessedProperties() const;
+
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Accessor;
   }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2127,5 +2127,17 @@ ERROR(init_accessor_is_not_on_property,none,
       "init accessors could only be associated with properties",
       ())
 
+ERROR(missing_storage_restrictions_attr_label,none,
+      "missing label in @storageRestrictions attribute", ())
+
+ERROR(invalid_storage_restrictions_attr_label,none,
+      "unexpected label %0 in @storageRestrictions attribute", (Identifier))
+
+ERROR(duplicate_storage_restrictions_attr_label,none,
+      "duplicate label %0 in @storageRestrictions attribute", (Identifier))
+
+ERROR(storage_restrictions_attr_expected_name,none,
+      "expected property name in @storageRestrictions list", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7384,6 +7384,9 @@ ERROR(init_accessor_initializes_attribute_on_other_declaration,none,
 ERROR(init_accessor_accesses_attribute_on_other_declaration,none,
       "accesses(...) attribute could only be used with init accessors",
       ())
+ERROR(storage_restrictions_attribute_not_on_init_accessor,none,
+      "@storageRestrictions attribute could only be used with init accessors",
+      ())
 ERROR(init_accessor_property_both_init_and_accessed,none,
       "property %0 cannot be both initialized and accessed",
       (DeclName))

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1072,6 +1072,11 @@ public:
       llvm::function_ref<bool(Parser &)> parseSILTargetName,
       llvm::function_ref<bool(Parser &)> parseSILSIPModule);
 
+  /// Parse the @storageRestrictions(initializes:accesses:) attribute.
+  /// \p Attr is where to store the parsed attribute
+  ParserResult<StorageRestrictionsAttr>
+  parseStorageRestrictionsAttribute(SourceLoc AtLoc, SourceLoc Loc);
+
   /// Parse the @_implements attribute.
   /// \p Attr is where to store the parsed attribute
   ParserResult<ImplementsAttr> parseImplementsAttribute(SourceLoc AtLoc,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -958,12 +958,14 @@ public:
         getSILDebugLocation(Loc), Src, Dest, Initializer, Setter, mode));
   }
 
-  AssignOrInitInst *createAssignOrInit(SILLocation Loc, SILValue Src,
+  AssignOrInitInst *createAssignOrInit(SILLocation Loc,
+                                       SILValue Self,
+                                       SILValue Src,
                                        SILValue Initializer,
                                        SILValue Setter,
                                        AssignOrInitInst::Mode Mode) {
     return insert(new (getModule()) AssignOrInitInst(
-        getSILDebugLocation(Loc), Src, Initializer, Setter, Mode));
+        getSILDebugLocation(Loc), Self, Src, Initializer, Setter, Mode));
   }
 
   StoreBorrowInst *createStoreBorrow(SILLocation Loc, SILValue Src,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1360,6 +1360,7 @@ void SILCloner<ImplClass>::visitAssignOrInitInst(AssignOrInitInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createAssignOrInit(
                 getOpLocation(Inst->getLoc()),
+                getOpValue(Inst->getSelf()),
                 getOpValue(Inst->getSrc()),
                 getOpValue(Inst->getInitializer()),
                 getOpValue(Inst->getSetter()), Inst->getMode()));

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4988,6 +4988,7 @@ public:
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 
+  StringRef getPropertyName() const;
   AccessorDecl *getReferencedInitAccessor() const;
 };
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4933,7 +4933,7 @@ class AssignOrInitInst
   friend SILBuilder;
   USE_SHARED_UINT8;
 
-  FixedOperandList<3> Operands;
+  FixedOperandList<4> Operands;
 
   /// Marks all of the properties in `initializes(...)` list that
   /// have been initialized before this intruction to help Raw SIL
@@ -4953,14 +4953,14 @@ public:
   };
 
 private:
-  AssignOrInitInst(SILDebugLocation DebugLoc,
-                   SILValue Src, SILValue Initializer,
-                   SILValue Setter, Mode mode);
+  AssignOrInitInst(SILDebugLocation DebugLoc, SILValue Self, SILValue Src,
+                   SILValue Initializer, SILValue Setter, Mode mode);
 
 public:
-  SILValue getSrc() const { return Operands[0].get(); }
-  SILValue getInitializer() const { return Operands[1].get(); }
-  SILValue getSetter() { return  Operands[2].get(); }
+  SILValue getSelf() const { return Operands[0].get(); }
+  SILValue getSrc() const { return Operands[1].get(); }
+  SILValue getInitializer() const { return Operands[2].get(); }
+  SILValue getSetter() { return  Operands[3].get(); }
 
   Mode getMode() const {
     return Mode(sharedUInt8().AssignOrInitInst.mode);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1594,6 +1594,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "initializes";
   case DAK_Accesses:
     return "accesses";
+  case DAK_StorageRestrictions:
+    return "storageRestrictions";
   case DAK_Implements:
     return "_implements";
   case DAK_ClangImporterSynthesizedType:
@@ -2395,6 +2397,29 @@ AccessesAttr::create(ASTContext &ctx, SourceLoc atLoc, SourceRange range,
   unsigned size = totalSizeToAlloc<Identifier>(properties.size());
   void *mem = ctx.Allocate(size, alignof(AccessesAttr));
   return new (mem) AccessesAttr(atLoc, range, properties);
+}
+
+StorageRestrictionsAttr::StorageRestrictionsAttr(
+    SourceLoc AtLoc, SourceRange Range, ArrayRef<Identifier> initializes,
+    ArrayRef<Identifier> accesses, bool Implicit)
+    : DeclAttribute(DAK_StorageRestrictions, AtLoc, Range, Implicit),
+      NumInitializes(initializes.size()),
+      NumAccesses(accesses.size()) {
+  std::uninitialized_copy(initializes.begin(), initializes.end(),
+                          getTrailingObjects<Identifier>());
+  std::uninitialized_copy(accesses.begin(), accesses.end(),
+                          getTrailingObjects<Identifier>() + NumInitializes);
+}
+
+StorageRestrictionsAttr *
+StorageRestrictionsAttr::create(
+    ASTContext &ctx, SourceLoc atLoc, SourceRange range,
+    ArrayRef<Identifier> initializes, ArrayRef<Identifier> accesses) {
+  unsigned size =
+      totalSizeToAlloc<Identifier>(initializes.size() + accesses.size());
+  void *mem = ctx.Allocate(size, alignof(StorageRestrictionsAttr));
+  return new (mem) StorageRestrictionsAttr(atLoc, range, initializes, accesses,
+                                           /*implicit=*/false);
 }
 
 ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2596,6 +2596,26 @@ AccessesAttr::getPropertyDecls(AccessorDecl *attachedTo) const {
       {});
 }
 
+ArrayRef<VarDecl *> StorageRestrictionsAttr::getInitializesProperties(
+    AccessorDecl *attachedTo) const {
+  auto &ctx = attachedTo->getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           InitAccessorReferencedVariablesRequest{
+                               const_cast<StorageRestrictionsAttr *>(this),
+                               attachedTo, getInitializesNames()},
+                           {});
+}
+
+ArrayRef<VarDecl *>
+StorageRestrictionsAttr::getAccessesProperties(AccessorDecl *attachedTo) const {
+  auto &ctx = attachedTo->getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           InitAccessorReferencedVariablesRequest{
+                               const_cast<StorageRestrictionsAttr *>(this),
+                               attachedTo, getAccessesNames()},
+                           {});
+}
+
 void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {
   if (attr)
     attr->print(out);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6818,8 +6818,17 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
 
   // If this is a 'var' decl, then we're settable if we have storage or a
   // setter.
-  if (!isLet())
+  if (!isLet()) {
+    if (hasInitAccessor()) {
+      if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(UseDC)) {
+        if (base && ctor->getImplicitSelfDecl() != base->getDecl())
+          return supportsMutation();
+        return true;
+      }
+    }
+
     return supportsMutation();
+  }
 
   // Static 'let's are always immutable.
   if (isStatic()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9529,15 +9529,15 @@ void AccessorDecl::printUserFacingName(raw_ostream &out) const {
 
 ArrayRef<VarDecl *> AccessorDecl::getInitializedProperties() const {
   assert(isInitAccessor());
-  if (auto *initAttr = getAttrs().getAttribute<InitializesAttr>())
-    return initAttr->getPropertyDecls(const_cast<AccessorDecl *>(this));
+  if (auto *SR = getAttrs().getAttribute<StorageRestrictionsAttr>())
+    return SR->getInitializesProperties(const_cast<AccessorDecl *>(this));
   return {};
 }
 
 ArrayRef<VarDecl *> AccessorDecl::getAccessedProperties() const {
   assert(isInitAccessor());
-  if (auto *accessAttr = getAttrs().getAttribute<AccessesAttr>())
-    return accessAttr->getPropertyDecls(const_cast<AccessorDecl *>(this));
+  if (auto *SR = getAttrs().getAttribute<StorageRestrictionsAttr>())
+    return SR->getAccessesProperties(const_cast<AccessorDecl *>(this));
   return {};
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9529,15 +9529,27 @@ void AccessorDecl::printUserFacingName(raw_ostream &out) const {
 
 ArrayRef<VarDecl *> AccessorDecl::getInitializedProperties() const {
   assert(isInitAccessor());
+
   if (auto *SR = getAttrs().getAttribute<StorageRestrictionsAttr>())
     return SR->getInitializesProperties(const_cast<AccessorDecl *>(this));
+
+  // Fallback to old effect style declaration.
+  if (auto *initAttr = getAttrs().getAttribute<InitializesAttr>())
+    return initAttr->getPropertyDecls(const_cast<AccessorDecl *>(this));
+
   return {};
 }
 
 ArrayRef<VarDecl *> AccessorDecl::getAccessedProperties() const {
   assert(isInitAccessor());
+
   if (auto *SR = getAttrs().getAttribute<StorageRestrictionsAttr>())
     return SR->getAccessesProperties(const_cast<AccessorDecl *>(this));
+
+  // Fallback to old effect style declaration.
+  if (auto *accessAttr = getAttrs().getAttribute<AccessesAttr>())
+    return accessAttr->getPropertyDecls(const_cast<AccessorDecl *>(this));
+
   return {};
 }
 

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -312,7 +312,8 @@ public struct ObservationTrackedMacro: AccessorMacro {
 
     let initAccessor: AccessorDeclSyntax =
       """
-      init(initialValue) initializes(_\(identifier)) {
+      @storageRestrictions(initializes: _\(identifier))
+      init(initialValue) {
         _\(identifier) = initialValue
       }
       """

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3371,6 +3371,10 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     llvm_unreachable("AccessesAttr not yet implemented");
   }
 
+  case DAK_StorageRestrictions: {
+    llvm_unreachable("StorageRestrictionsAttr not yet implemented");
+  }
+
   case DAK_Implements: {
     ParserResult<ImplementsAttr> Attr = parseImplementsAttribute(AtLoc, Loc);
     if (Attr.isNonNull()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1165,6 +1165,111 @@ bool Parser::parseSpecializeAttribute(
   return true;
 }
 
+ParserResult<StorageRestrictionsAttr>
+Parser::parseStorageRestrictionsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
+  StringRef AttrName = "storageRestrictions";
+  ParserStatus Status;
+
+  if (Tok.isNot(tok::l_paren)) {
+    diagnose(Loc, diag::attr_expected_lparen, AttrName,
+             /*DeclModifier=*/false);
+    Status.setIsParseError();
+    return Status;
+  }
+
+  // Consume '('
+  SourceLoc lParenLoc = consumeToken();
+
+  SmallVector<Identifier> initializesProperties;
+  SmallVector<Identifier> accessesProperties;
+
+  auto parseProperties = [&](SourceLoc loc, Identifier label,
+                             SmallVectorImpl<Identifier> &properties) {
+    if (!properties.empty()) {
+      diagnose(loc, diag::duplicate_storage_restrictions_attr_label, label);
+      return true;
+    }
+
+    bool hasNextProperty = false;
+    do {
+      // Next is not a property name but a label followed by ':'
+      if (peekToken().is(tok::colon))
+        break;
+
+      Identifier propertyName;
+      SourceLoc propertyNameLoc;
+      if (parseIdentifier(propertyName, propertyNameLoc,
+                          diag::storage_restrictions_attr_expected_name,
+                          /*diagnoseDollarPrefix=*/true)) {
+        return true;
+      }
+
+      properties.push_back(propertyName);
+
+      // Parse the comma, if the list continues.
+      hasNextProperty = consumeIf(tok::comma);
+    } while (hasNextProperty);
+
+    return false;
+  };
+
+  auto parseArgument = [&](bool isOptional = false) -> bool {
+    if (Tok.is(tok::r_paren) && isOptional)
+      return false;
+
+    Identifier accessLabel;
+    SourceLoc loc;
+    parseOptionalArgumentLabel(accessLabel, loc);
+
+    if (accessLabel.empty()) {
+      diagnose(Loc, diag::missing_storage_restrictions_attr_label);
+      return true;
+    }
+
+    enum class AccessKind { Initialization, Access, Invalid };
+
+    auto access = llvm::StringSwitch<AccessKind>(accessLabel.str())
+                      .Case("initializes", AccessKind::Initialization)
+                      .Case("accesses", AccessKind::Access)
+                      .Default(AccessKind::Invalid);
+
+    switch (access) {
+    case AccessKind::Initialization:
+      return parseProperties(loc, accessLabel, initializesProperties);
+
+    case AccessKind::Access:
+      return parseProperties(loc, accessLabel, accessesProperties);
+
+    case AccessKind::Invalid:
+      diagnose(loc, diag::invalid_storage_restrictions_attr_label, accessLabel);
+      return true;
+    }
+  };
+
+  // Attribute should have at least one argument.
+  if (parseArgument() || parseArgument(/*isOptional=*/true)) {
+    Status.setIsParseError();
+    // Let's skip ahead to `)` to recover.
+    skipUntil(tok::r_paren);
+  }
+
+  // Consume ')'
+  SourceLoc rParenLoc;
+  if (!consumeIf(tok::r_paren, rParenLoc)) {
+    diagnose(lParenLoc, diag::attr_expected_rparen, AttrName,
+             /*DeclModifier=*/false);
+    Status.setIsParseError();
+  }
+
+  if (Status.isErrorOrHasCompletion()) {
+    return Status;
+  }
+
+  return ParserResult<StorageRestrictionsAttr>(StorageRestrictionsAttr::create(
+      Context, AtLoc, SourceRange(Loc, rParenLoc), initializesProperties,
+      accessesProperties));
+}
+
 ParserResult<ImplementsAttr>
 Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
   StringRef AttrName = "_implements";
@@ -3372,7 +3477,12 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   }
 
   case DAK_StorageRestrictions: {
-    llvm_unreachable("StorageRestrictionsAttr not yet implemented");
+    ParserResult<StorageRestrictionsAttr> Attr =
+        parseStorageRestrictionsAttribute(AtLoc, Loc);
+    if (Attr.isNonNull()) {
+      Attributes.add(Attr.get());
+    }
+    break;
   }
 
   case DAK_Implements: {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2381,26 +2381,22 @@ static CanSILFunctionType getSILFunctionTypeForInitAccessor(
   // Drop `self` parameter.
   inputs.pop_back();
 
-  // `accesses(...)` appear as `inout` parameters because they could be
+  // accessed properties appear as `inout` parameters because they could be
   // read from and modified.
-  if (auto *attr = accessor->getAttrs().getAttribute<AccessesAttr>()) {
-    for (auto *property : attr->getPropertyDecls(accessor)) {
-      inputs.push_back(
-          SILParameterInfo(property->getInterfaceType()->getCanonicalType(),
-                           ParameterConvention::Indirect_Inout));
-    }
+  for (auto *property : accessor->getAccessedProperties()) {
+    inputs.push_back(
+        SILParameterInfo(property->getInterfaceType()->getCanonicalType(),
+                         ParameterConvention::Indirect_Inout));
   }
 
   SmallVector<SILResultInfo, 8> results;
 
-  // `initializes(...)` appear as `@out` result because they are initialized
-  // by the accessor.
-  if (auto *attr = accessor->getAttrs().getAttribute<InitializesAttr>()) {
-    for (auto *property : attr->getPropertyDecls(accessor)) {
-      results.push_back(
-          SILResultInfo(property->getInterfaceType()->getCanonicalType(),
-                        ResultConvention::Indirect));
-    }
+  // initialized properties appear as `@out` results because they are
+  // initialized by the accessor.
+  for (auto *property : accessor->getInitializedProperties()) {
+    results.push_back(
+        SILResultInfo(property->getInterfaceType()->getCanonicalType(),
+                      ResultConvention::Indirect));
   }
 
   auto calleeConvention = ParameterConvention::Direct_Unowned;

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1304,26 +1304,18 @@ AccessorDecl *AssignOrInitInst::getReferencedInitAccessor() const {
 }
 
 unsigned AssignOrInitInst::getNumInitializedProperties() const {
-  if (auto *accessor = getReferencedInitAccessor()) {
-    auto *initAttr = accessor->getAttrs().getAttribute<InitializesAttr>();
-    return initAttr ? initAttr->getNumProperties() : 0;
-  }
-  return 0;
+  return getInitializedProperties().size();
 }
 
 ArrayRef<VarDecl *> AssignOrInitInst::getInitializedProperties() const {
-  if (auto *accessor = getReferencedInitAccessor()) {
-    if (auto *initAttr = accessor->getAttrs().getAttribute<InitializesAttr>())
-      return initAttr->getPropertyDecls(accessor);
-  }
+  if (auto *accessor = getReferencedInitAccessor())
+    return accessor->getInitializedProperties();
   return {};
 }
 
 ArrayRef<VarDecl *> AssignOrInitInst::getAccessedProperties() const {
-  if (auto *accessor = getReferencedInitAccessor()) {
-    if (auto *accessAttr = accessor->getAttrs().getAttribute<AccessesAttr>())
-      return accessAttr->getPropertyDecls(accessor);
-  }
+  if (auto *accessor = getReferencedInitAccessor())
+    return accessor->getAccessedProperties();
   return {};
 }
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1283,6 +1283,12 @@ bool AssignOrInitInst::isPropertyAlreadyInitialized(unsigned propertyIdx) {
   return Assignments.test(propertyIdx);
 }
 
+StringRef AssignOrInitInst::getPropertyName() const {
+  auto *accessor = getReferencedInitAccessor();
+  assert(accessor);
+  return cast<VarDecl>(accessor->getStorage())->getNameStr();
+}
+
 AccessorDecl *AssignOrInitInst::getReferencedInitAccessor() const {
   SILValue initRef = getInitializer();
   SILFunction *accessorFn = nullptr;

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1284,10 +1284,17 @@ bool AssignOrInitInst::isPropertyAlreadyInitialized(unsigned propertyIdx) {
 }
 
 AccessorDecl *AssignOrInitInst::getReferencedInitAccessor() const {
-  auto *initRef = cast<FunctionRefInst>(getInitializer());
-  auto *accessorRef = initRef->getReferencedFunctionOrNull();
-  assert(accessorRef);
-  return dyn_cast_or_null<AccessorDecl>(accessorRef->getDeclContext());
+  SILValue initRef = getInitializer();
+  SILFunction *accessorFn = nullptr;
+
+  if (auto *PAI = dyn_cast<PartialApplyInst>(initRef)) {
+    accessorFn = PAI->getReferencedFunctionOrNull();
+  } else {
+    accessorFn = cast<FunctionRefInst>(initRef)->getReferencedFunctionOrNull();
+  }
+
+  assert(accessorFn);
+  return dyn_cast_or_null<AccessorDecl>(accessorFn->getDeclContext());
 }
 
 unsigned AssignOrInitInst::getNumInitializedProperties() const {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1252,11 +1252,12 @@ AssignByWrapperInst::AssignByWrapperInst(SILDebugLocation Loc,
   sharedUInt8().AssignByWrapperInst.mode = uint8_t(mode);
 }
 
-AssignOrInitInst::AssignOrInitInst(SILDebugLocation Loc, SILValue Src,
-                                   SILValue Initializer, SILValue Setter,
-                                   AssignOrInitInst::Mode Mode)
-    : InstructionBase<SILInstructionKind::AssignOrInitInst, NonValueInstruction>(Loc),
-      Operands(this, Src, Initializer, Setter) {
+AssignOrInitInst::AssignOrInitInst(SILDebugLocation Loc, SILValue Self,
+                                   SILValue Src, SILValue Initializer,
+                                   SILValue Setter, AssignOrInitInst::Mode Mode)
+    : InstructionBase<SILInstructionKind::AssignOrInitInst,
+                      NonValueInstruction>(Loc),
+      Operands(this, Self, Src, Initializer, Setter) {
   assert(Initializer->getType().is<SILFunctionType>());
   sharedUInt8().AssignOrInitInst.mode = uint8_t(Mode);
   Assignments.resize(getNumInitializedProperties());

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1773,7 +1773,8 @@ public:
       }
     }
 
-    *this << getIDAndType(AI->getSrc());
+    *this << "self " << getIDAndType(AI->getSelf());
+    *this << ", value " << getIDAndType(AI->getSrc());
     *this << ", init " << getIDAndType(AI->getInitializer())
           << ", set " << getIDAndType(AI->getSetter());
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -4684,13 +4684,15 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   }
 
   case SILInstructionKind::AssignOrInitInst: {
-    SILValue Src, InitFn, SetFn;
+    SILValue Self, Src, InitFn, SetFn;
     AssignOrInitInst::Mode Mode;
     llvm::SmallVector<unsigned, 2> assignments;
 
     if (parseAssignOrInitMode(Mode, *this) ||
         parseAssignOrInitAssignments(assignments, *this) ||
-        parseTypedValueRef(Src, B) ||
+        parseVerbatim("self") || parseTypedValueRef(Self, B) ||
+        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
+        parseVerbatim("value") || parseTypedValueRef(Src, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
         parseVerbatim("init") || parseTypedValueRef(InitFn, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
@@ -4698,7 +4700,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         parseSILDebugLocation(InstLoc, B))
       return true;
 
-    auto *AI = B.createAssignOrInit(InstLoc, Src, InitFn, SetFn, Mode);
+    auto *AI = B.createAssignOrInit(InstLoc, Self, Src, InitFn, SetFn, Mode);
 
     for (unsigned index : assignments)
       AI->markAsInitialized(index);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2727,17 +2727,12 @@ public:
     SILValue initFn = AI->getInitializer();
     SILValue setterFn = AI->getSetter();
 
-    CanSILFunctionType initTy = initFn->getType().castTo<SILFunctionType>();
     // Check init - it's an unapplied reference that takes property addresses
     // and `initialValue`.
     {
-      // We need to map un-applied function reference into context before
-      // check `initialValue` argument.
-      auto subs = cast<PartialApplyInst>(setterFn)->getSubstitutionMap();
-      initTy = initTy->substGenericArgs(F.getModule(), subs,
-                                        F.getTypeExpansionContext());
-
+      CanSILFunctionType initTy = initFn->getType().castTo<SILFunctionType>();
       SILFunctionConventions initConv(initTy, AI->getModule());
+
       require(initConv.getNumIndirectSILResults() ==
                   AI->getInitializedProperties().size(),
               "init function has invalid number of indirect results");

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2739,6 +2739,9 @@ public:
       checkAssigOrInitInstAccessorArgs(Src->getType(), initConv);
     }
 
+    if (isa<SILUndef>(setterFn))
+      return;
+
     // Check setter - it's a partially applied reference which takes
     // `initialValue`.
     CanSILFunctionType setterTy = setterFn->getType().castTo<SILFunctionType>();

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -115,6 +115,7 @@ public:
     WritebackPseudoKind,        // a fake component to customize writeback
     OpenNonOpaqueExistentialKind,  // opened class or metatype existential
     LogicalKeyPathApplicationKind, // applying a key path
+    InitAccessorKind,           // init accessor
     
     // Translation LValue kinds (a subtype of logical)
     OrigToSubstKind,            // generic type substitution

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1618,6 +1618,25 @@ namespace {
                                           SGF.getTypeExpansionContext());
       };
 
+      auto emitPartialInitAccessorApply =
+          [&](AccessorDecl *initAccessor) -> SILValue {
+        assert(initAccessor->isInitAccessor());
+        auto initConstant = SGF.getAccessorDeclRef(initAccessor);
+        SILValue initFRef = SGF.emitGlobalFunctionRef(loc, initConstant);
+
+        // If there are no substitutions there is no need to emit partial
+        // apply.
+        if (Substitutions.empty())
+          return initFRef;
+
+        // Emit partial apply without argument to produce a substituted
+        // init accessor reference.
+        PartialApplyInst *initPAI = SGF.B.createPartialApply(
+            loc, initFRef, Substitutions, ArrayRef<SILValue>(),
+            ParameterConvention::Direct_Guaranteed);
+        return SGF.emitManagedRValueWithCleanup(initPAI).getValue();
+      };
+
       auto emitPartialSetterApply =
           [&](SILValue setterFRef,
               const SILFunctionConventions &setterConv) -> ManagedValue {
@@ -1707,9 +1726,8 @@ namespace {
         }
 
         // Emit the init accessor function partially applied to the base.
-        auto *initAccessor = field->getOpaqueAccessor(AccessorKind::Init);
-        auto initConstant = SGF.getAccessorDeclRef(initAccessor);
-        SILValue initFRef = SGF.emitGlobalFunctionRef(loc, initConstant);
+        auto initFn = emitPartialInitAccessorApply(
+            field->getOpaqueAccessor(AccessorKind::Init));
 
         // Emit the set accessor function partially applied to the base.
         auto setterFRef = getSetterFRef();
@@ -1720,7 +1738,7 @@ namespace {
         // Create the assign_or_init with the initializer and setter.
         auto value = emitValue(field, FieldType, setterTy, setterConv);
         SGF.B.createAssignOrInit(loc, base.getValue(), value.forward(SGF),
-                                 initFRef, setterFn.getValue(),
+                                 initFn, setterFn.getValue(),
                                  AssignOrInitInst::Unknown);
         return;
       }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1719,8 +1719,8 @@ namespace {
 
         // Create the assign_or_init with the initializer and setter.
         auto value = emitValue(field, FieldType, setterTy, setterConv);
-        SGF.B.createAssignOrInit(loc, value.forward(SGF), initFRef,
-                                 setterFn.getValue(),
+        SGF.B.createAssignOrInit(loc, base.getValue(), value.forward(SGF),
+                                 initFRef, setterFn.getValue(),
                                  AssignOrInitInst::Unknown);
         return;
       }

--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -314,7 +314,7 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
 
       SmallVector<SILValue> arguments;
 
-      // First, emit all of the properties listed in `initializes(...)`. They
+      // First, emit all of the properties listed in `initializes`. They
       // are passed as indirect results.
       {
         auto toInitialize = inst->getInitializedProperties();
@@ -330,7 +330,7 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
       emitInitAccessorInitialValueArgument(arguments, src, convention, b,
                                            forCleanup);
 
-      // And finally, emit all of the `accesses(...)` properties.
+      // And finally, emit all of the `accesses` properties.
       for (auto *property : inst->getAccessedProperties())
         arguments.push_back(emitFieldReference(property));
 

--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -284,9 +284,6 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
       CanSILFunctionType fTy = initFn->getType().castTo<SILFunctionType>();
       SILFunctionConventions convention(fTy, inst->getModule());
 
-      auto *setterPA = dyn_cast<PartialApplyInst>(inst->getSetter());
-      assert(setterPA);
-
       auto selfValue = inst->getSelf();
       auto isRefSelf = selfValue->getType().getASTType()->mayHaveSuperclass();
 
@@ -337,7 +334,7 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
       for (auto *property : inst->getAccessedProperties())
         arguments.push_back(emitFieldReference(property));
 
-      b.createApply(loc, initFn, setterPA->getSubstitutionMap(), arguments);
+      b.createApply(loc, initFn, SubstitutionMap(), arguments);
 
       if (isRefSelf) {
         b.emitEndBorrowOperation(loc, selfRef);
@@ -345,10 +342,13 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
         b.createEndAccess(loc, selfRef, /*aborted=*/false);
       }
 
+      auto *setterPA = dyn_cast<PartialApplyInst>(inst->getSetter());
+      assert(setterPA);
+
       // The unused partial_apply violates memory lifetime rules in case "self"
       // is an inout. Therefore we cannot keep it as a dead closure to be
       // cleaned up later. We have to delete it in this pass.
-      toDelete.insert(inst->getSetter());
+      toDelete.insert(setterPA);
 
       // Also the argument of the closure (which usually is a "load") has to be
       // deleted to avoid memory lifetime violations.

--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -287,7 +287,7 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
       auto *setterPA = dyn_cast<PartialApplyInst>(inst->getSetter());
       assert(setterPA);
 
-      auto selfValue = setterPA->getOperand(1);
+      auto selfValue = inst->getSelf();
       auto isRefSelf = selfValue->getType().getASTType()->mayHaveSuperclass();
 
       SILValue selfRef;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9648,21 +9648,15 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
             // If name doesn't appear in either `initializes` or `accesses`
             // then it's invalid instance member.
 
-            if (auto *initializesAttr =
-                    accessor->getAttrs().getAttribute<InitializesAttr>()) {
-              isValidReference |= llvm::any_of(
-                  initializesAttr->getProperties(), [&](Identifier name) {
-                    return DeclNameRef(name) == memberName;
-                  });
-            }
+            isValidReference |= llvm::any_of(
+                accessor->getInitializedProperties(), [&](VarDecl *prop) {
+                  return prop->createNameRef() == memberName;
+                });
 
-            if (auto *accessesAttr =
-                    accessor->getAttrs().getAttribute<AccessesAttr>()) {
-              isValidReference |= llvm::any_of(
-                  accessesAttr->getProperties(), [&](Identifier name) {
-                    return DeclNameRef(name) == memberName;
-                  });
-            }
+            isValidReference |= llvm::any_of(
+                accessor->getAccessedProperties(), [&](VarDecl *prop) {
+                  return prop->createNameRef() == memberName;
+                });
 
             if (!isValidReference) {
               result.addUnviable(

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1311,6 +1311,7 @@ HasMemberwiseInitRequest::evaluate(Evaluator &evaluator,
 
         // Record all of the properties initialized by calling init accessor.
         auto properties = initAccessor->getInitializedProperties();
+        initializedProperties.insert(var);
         initializedProperties.insert(properties.begin(), properties.end());
         continue;
       }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1304,22 +1304,14 @@ HasMemberwiseInitRequest::evaluate(Evaluator &evaluator,
       if (auto *initAccessor = var->getAccessor(AccessorKind::Init)) {
         // Make sure that all properties accessed by init accessor
         // are previously initialized.
-        if (auto accessAttr =
-            initAccessor->getAttrs().getAttribute<AccessesAttr>()) {
-          for (auto *property : accessAttr->getPropertyDecls(initAccessor)) {
-            if (!initializedProperties.count(property))
-              invalidOrderings.push_back(
-                {var, property->getName()});
-          }
+        for (auto *property : initAccessor->getAccessedProperties()) {
+          if (!initializedProperties.count(property))
+            invalidOrderings.push_back({var, property->getName()});
         }
 
         // Record all of the properties initialized by calling init accessor.
-        if (auto initAttr =
-            initAccessor->getAttrs().getAttribute<InitializesAttr>()) {
-          auto properties = initAttr->getPropertyDecls(initAccessor);
-          initializedProperties.insert(properties.begin(), properties.end());
-        }
-
+        auto properties = initAccessor->getInitializedProperties();
+        initializedProperties.insert(properties.begin(), properties.end());
         continue;
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -294,6 +294,7 @@ public:
   void visitTypeEraserAttr(TypeEraserAttr *attr);
   void visitInitializesAttr(InitializesAttr *attr);
   void visitAccessesAttr(AccessesAttr *attr);
+  void visitStorageRestrictionsAttr(StorageRestrictionsAttr *attr);
   void visitImplementsAttr(ImplementsAttr *attr);
   void visitNoMetadataAttr(NoMetadataAttr *attr);
 
@@ -3549,6 +3550,9 @@ void AttributeChecker::visitAccessesAttr(AccessesAttr *attr) {
       }
     }
   }
+}
+
+void AttributeChecker::visitStorageRestrictionsAttr(StorageRestrictionsAttr *attr) {
 }
 
 void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3553,6 +3553,21 @@ void AttributeChecker::visitAccessesAttr(AccessesAttr *attr) {
 }
 
 void AttributeChecker::visitStorageRestrictionsAttr(StorageRestrictionsAttr *attr) {
+  auto *accessor = dyn_cast<AccessorDecl>(D);
+  if (!accessor || accessor->getAccessorKind() != AccessorKind::Init) {
+    diagnose(attr->getLocation(),
+             diag::storage_restrictions_attribute_not_on_init_accessor);
+    return;
+  }
+
+  auto initializesProperties = attr->getInitializesProperties(accessor);
+  for (auto *property : attr->getAccessesProperties(accessor)) {
+    if (llvm::is_contained(initializesProperties, property)) {
+      diagnose(attr->getLocation(),
+               diag::init_accessor_property_both_init_and_accessed,
+               property->getName());
+    }
+  }
 }
 
 void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1581,6 +1581,7 @@ namespace  {
     UNINTERESTING_ATTR(RestatedObjCConformance)
     UNINTERESTING_ATTR(Initializes)
     UNINTERESTING_ATTR(Accesses)
+    UNINTERESTING_ATTR(StorageRestrictions)
     UNINTERESTING_ATTR(Implements)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
     UNINTERESTING_ATTR(ClangImporterSynthesizedType)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -368,9 +368,8 @@ MemberwiseInitPropertiesRequest::evaluate(Evaluator &evaluator,
     // that the accessor initializes. Mark those stored properties as being subsumed; we'll
     // get back to them later.
     if (auto initAccessor = var->getAccessor(AccessorKind::Init)) {
-      if (auto initAttr = initAccessor->getAttrs().getAttribute<InitializesAttr>()) {
-        for (auto subsumed : initAttr->getPropertyDecls(initAccessor))
-          subsumedViaInitAccessor.insert(subsumed);
+      for (auto subsumed : initAccessor->getInitializedProperties()) {
+        subsumedViaInitAccessor.insert(subsumed);
       }
     }
   };

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5399,6 +5399,30 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::StorageRestrictions_DECL_ATTR: {
+        unsigned numInitializesProperties;
+        ArrayRef<uint64_t> rawPropertyIDs;
+        serialization::decls_block::StorageRestrictionsDeclAttrLayout::
+            readRecord(scratch, numInitializesProperties, rawPropertyIDs);
+
+        SmallVector<Identifier> initializes;
+        SmallVector<Identifier> accesses;
+
+        for (unsigned i = 0, n = rawPropertyIDs.size(); i != n; ++i) {
+          auto propertyName = MF.getIdentifier(rawPropertyIDs[i]);
+
+          if (i < numInitializesProperties) {
+            initializes.push_back(propertyName);
+          } else {
+            accesses.push_back(propertyName);
+          }
+        }
+
+        Attr = StorageRestrictionsAttr::create(ctx, SourceLoc(), SourceRange(),
+                                               initializes, accesses);
+        break;
+      }
+
       case decls_block::DynamicReplacement_DECL_ATTR: {
         bool isImplicit;
         uint64_t numArgs;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 789; // extension macros
+const uint16_t SWIFTMODULE_VERSION_MINOR = 795; // @storageRestrictions attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2228,6 +2228,12 @@ namespace decls_block {
   using AccessesDeclAttrLayout = BCRecordLayout<
       Accesses_DECL_ATTR,
       BCArray<IdentifierIDField> // initialized properties
+  >;
+
+  using StorageRestrictionsDeclAttrLayout = BCRecordLayout<
+      StorageRestrictions_DECL_ATTR,
+      BCVBR<16>, // num "initializes" properties
+      BCArray<IdentifierIDField> // properties
   >;
 
   using DifferentiableDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2953,6 +2953,30 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_StorageRestrictions: {
+      auto abbrCode = S.DeclTypeAbbrCodes[AccessesDeclAttrLayout::Code];
+      auto attr = cast<StorageRestrictionsAttr>(DA);
+
+      SmallVector<IdentifierID, 4> properties;
+
+      llvm::transform(attr->getInitializesNames(),
+                      std::back_inserter(properties),
+                      [&](Identifier propertyName) {
+                        return S.addDeclBaseNameRef(propertyName);
+                      });
+
+      llvm::transform(attr->getAccessesNames(),
+                      std::back_inserter(properties),
+                      [&](Identifier propertyName) {
+                        return S.addDeclBaseNameRef(propertyName);
+                      });
+
+      StorageRestrictionsDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode, attr->getNumInitializesProperties(),
+          properties);
+      return;
+    }
+
     case DAK_DynamicReplacement: {
       auto abbrCode =
           S.DeclTypeAbbrCodes[DynamicReplacementDeclAttrLayout::Code];

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -324,6 +324,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // ON_MEMBER_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // ON_MEMBER_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding
+// ON_MEMBER_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -395,6 +396,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // KEYWORD_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
+// KEYWORD_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyGenericPropertyWrapper[#MyGenericPropertyWrapper#]; name=MyGenericPropertyWrapper

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -462,3 +462,57 @@ test_memberwise_with_default_args()
 // CHECK-NEXT: test-defaulted-1: TestDefaulted(_a: 0, _b: 0)
 // CHECK-NEXT: test-defaulted-2: TestDefaulted(_a: 3, _b: 4)
 // CHECK-NEXT: test-defaulted-class: ("<<default>>", 1)
+
+func test_init_accessors_without_setters() {
+  struct TestStruct<T> {
+    var _x: T
+
+    var x: T {
+      init(initialValue) initializes(_x) {
+        _x = initialValue
+      }
+
+      get { _x }
+    }
+
+    init(value: T) {
+      x = value
+    }
+  }
+
+  let test1 = TestStruct(value: 42)
+  print("test-without-setter1: \(test1.x)")
+
+  class Base<T: Collection> {
+    private var _v: T
+
+    var data: T {
+      init(initialValue) initializes(_v) {
+        _v = initialValue
+      }
+
+      get { _v }
+    }
+
+    init(data: T) {
+      self.data = data
+    }
+  }
+
+  let test2 = Base(data: [1, 2, 3])
+  print("test-without-setter2: \(test2.data)")
+
+  class Sub<U> : Base<U> where U: Collection, U.Element == String {
+    init(other: U) {
+      super.init(data: other)
+    }
+  }
+
+  let test3 = Sub(other: ["a", "b", "c"])
+  print("test-without-setter3: \(test3.data)")
+}
+
+test_init_accessors_without_setters()
+// CHECK: test-without-setter1: 42
+// CHECK-NEXT: test-without-setter2: [1, 2, 3]
+// CHECK-NEXT: test-without-setter3: ["a", "b", "c"]

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -10,7 +10,8 @@ struct TestInit {
   var full: (Int, Int)
 
   var point: (Int, Int) {
-    init(initialValue) initializes(y, full) accesses(x) {
+    @storageRestrictions(initializes: y, full, accesses: x)
+    init(initialValue) {
       self.y = initialValue.1
       self.full = (self.x, self.y)
     }
@@ -36,7 +37,8 @@ struct TestSetter {
   var y: Int
 
   var point: (Int, Int) {
-    init(initialValue) accesses(x, y) {
+    @storageRestrictions(accesses: x, y)
+    init(initialValue) {
     }
 
     get { (x, y) }
@@ -61,7 +63,8 @@ struct TestInitThenSetter {
   var y: Int
 
   var point: (Int, Int) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       self.x = initialValue.0
       self.y = initialValue.1
     }
@@ -94,7 +97,8 @@ struct TestPartialInt {
   var y: Int
 
   var pointX: Int {
-    init(newValue) initializes(x) {
+    @storageRestrictions(initializes: x)
+    init(newValue) {
       self.x = newValue
     }
 
@@ -103,7 +107,8 @@ struct TestPartialInt {
   }
 
   var pointY: Int {
-    init(newValue) initializes(y) {
+    @storageRestrictions(initializes: y)
+    init(newValue) {
       self.y = newValue
     }
 
@@ -135,7 +140,8 @@ struct TestNoInitAndInit {
   var y: Int
 
   var pointX: Int {
-    init(initalValue) accesses(x) {
+    @storageRestrictions(accesses: x)
+    init(initalValue) {
     }
 
     get { x }
@@ -143,7 +149,8 @@ struct TestNoInitAndInit {
   }
 
   var pointY: Int {
-    init(initialValue) initializes(y) {
+    @storageRestrictions(initializes: y)
+    init(initialValue) {
       self.y = initialValue
     }
 
@@ -169,7 +176,8 @@ class TestClass {
   var y: (Int, [String])
 
   var data: (Int, (Int, [String])) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       x = initialValue.0
       y = initialValue.1
     }
@@ -198,7 +206,8 @@ struct TestGeneric<T, U> {
   var c: U
 
   var data: (T, T) {
-    init(initialValue) initializes(a, b) accesses(c) {
+    @storageRestrictions(initializes: a, b, accesses: c)
+    init(initialValue) {
       a = initialValue.0
       b = initialValue.1
       print("TestGeneric(c: \(c))")
@@ -230,7 +239,8 @@ func test_local_with_memberwise() {
     var b: String
 
     var pair: (Int, String) {
-      init(initialValue) initializes(a, b) {
+      @storageRestrictions(initializes: a, b)
+      init(initialValue) {
         a = initialValue.0
         b = initialValue.1
       }
@@ -251,7 +261,8 @@ func test_local_with_memberwise() {
     var _c: C
 
     var a: T {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -260,7 +271,8 @@ func test_local_with_memberwise() {
     }
 
     var pair: (String, C) {
-      init(initialValue) initializes(_b, _c) accesses(_a) {
+      @storageRestrictions(initializes: _b, _c, accesses: _a)
+      init(initialValue) {
         _b = initialValue.0
         _c = initialValue.1
         _c.append(_a)
@@ -285,7 +297,8 @@ func test_assignments() {
     var _b: Int
 
     var a: Int {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         self._a = initialValue
         print("a-init-accessor: \(self._a)")
       }
@@ -294,7 +307,8 @@ func test_assignments() {
     }
 
     var pair: (Int, Int) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }
@@ -339,7 +353,8 @@ func test_memberwise_ordering() {
     var _b: Int
 
     var a: Int {
-      init(initialValue) initializes(_a) accesses(_b) {
+      @storageRestrictions(initializes: _a, accesses: _b)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -355,7 +370,8 @@ func test_memberwise_ordering() {
     var _a: Int
 
     var pair: (Int, Int) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }
@@ -375,7 +391,8 @@ func test_memberwise_ordering() {
     var _b: Int
 
     var pair: (Int, Int) {
-      init(initialValue) accesses(_a, _b) {
+      @storageRestrictions(accesses: _a, _b)
+      init(initialValue) {
       }
 
       get { (_a, _b) }
@@ -400,7 +417,8 @@ func test_memberwise_with_default_args() {
     var _b: Int
 
     var pair: (Int, Int) = (-1, 42) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }
@@ -421,7 +439,8 @@ func test_memberwise_with_default_args() {
     var _b: Int = 0
 
     var pair: (Int, Int) = (1, 2) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }
@@ -442,7 +461,8 @@ func test_memberwise_with_default_args() {
     var _a: Int = 1
 
     var pair: (String, Int) = ("", 42) {
-      init(initialValue) initializes(_q, _a) {
+      @storageRestrictions(initializes: _q, _a)
+      init(initialValue) {
         _q = initialValue.0
         _a = initialValue.1
       }
@@ -468,7 +488,8 @@ func test_init_accessors_without_setters() {
     var _x: T
 
     var x: T {
-      init(initialValue) initializes(_x) {
+      @storageRestrictions(initializes: _x)
+      init(initialValue) {
         _x = initialValue
       }
 
@@ -487,7 +508,8 @@ func test_init_accessors_without_setters() {
     private var _v: T
 
     var data: T {
-      init(initialValue) initializes(_v) {
+      @storageRestrictions(initializes: _v)
+      init(initialValue) {
         _v = initialValue
       }
 

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -538,3 +538,25 @@ test_init_accessors_without_setters()
 // CHECK: test-without-setter1: 42
 // CHECK-NEXT: test-without-setter2: [1, 2, 3]
 // CHECK-NEXT: test-without-setter3: ["a", "b", "c"]
+
+func test_effects_are_still_supported() {
+  struct Test {
+    var _a: Int
+    var _b: Int
+
+    var a: Int {
+      init(initialValue) initializes(_a) accesses(_b) {
+        _a = initialValue
+        _b = 0
+      }
+
+      get { _a }
+    }
+  }
+
+  let test = Test(_b: 1, a: 42)
+  print("effects-support-test: \(test)")
+}
+
+test_effects_are_still_supported()
+// CHEKC: effects-support-test: Test(_a: 42, b: 0)

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -560,3 +560,29 @@ func test_effects_are_still_supported() {
 
 test_effects_are_still_supported()
 // CHEKC: effects-support-test: Test(_a: 42, b: 0)
+
+func test_memberwise_without_stored_properties() {
+  struct Test {
+    var a: Int {
+      init {
+        print("no-stored: a = \(newValue)")
+      }
+
+      get { 0 }
+    }
+
+    var b: Int {
+      init {
+        print("no-stored: b = \(newValue)")
+      }
+
+      get { 1 }
+    }
+  }
+
+  _ = Test(a: 1, b: 2)
+}
+
+test_memberwise_without_stored_properties()
+// CHECK: no-stored: a = 1
+// CHECK-NEXT: no-stored: b = 2

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -8,7 +8,8 @@ struct Test1 {
   var full: (Int, Int)
 
   var test1: (Int, Int) {
-    init(initialValue) initializes(y, full) accesses(x) {
+    @storageRestrictions(initializes: y, full, accesses: x)
+    init(initialValue) {
       self.full = (self.x, self.y) // expected-error {{variable 'y' used before being initialized}}
     }
 
@@ -17,7 +18,8 @@ struct Test1 {
   }
 
   var pointY: Int {
-    init(initialValue) initializes(y) {
+    @storageRestrictions(initializes: y)
+    init(initialValue) {
       self.y = initialValue // Ok
     }
 
@@ -26,7 +28,8 @@ struct Test1 {
   }
 
   var errorPoint1: (Int, Int) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       // expected-error@-1 {{property 'x' not initialized by init accessor}}
       // expected-error@-2 {{property 'y' not initialized by init accessor}}
     }
@@ -36,7 +39,8 @@ struct Test1 {
   }
 
   var errorPoint2: (Int, Int) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       // expected-error@-1 {{property 'y' not initialized by init accessor}}
       self.x = initialValue.0
     }
@@ -46,7 +50,8 @@ struct Test1 {
   }
 
   var errorPoint3: (Int, Int) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       self.y = initialValue.1
       print(y) // Ok
       print(x) // expected-error {{variable 'x' used before being initialized}}
@@ -68,7 +73,8 @@ struct TestPartial {
   var y: Int
 
   var point: (Int, Int) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       self.x = initialValue.0
       self.y = initialValue.1
     }
@@ -93,7 +99,8 @@ struct TestDoubleInit1 {
   let x: Int // expected-note {{change 'let' to 'var' to make it mutable}}
 
   var invalidPointX: Int {
-    init(initialValue) initializes(x) {
+    @storageRestrictions(initializes: x)
+    init(initialValue) {
       self.x = initialValue
       self.x = 42 // expected-error {{immutable value 'x' may only be initialized once}}
     }
@@ -107,7 +114,8 @@ struct TestDoubleInit2 {
   let x: Int // expected-note {{change 'let' to 'var' to make it mutable}}
 
   var pointX: Int {
-    init(initialValue) initializes(x) {
+    @storageRestrictions(initializes: x)
+    init(initialValue) {
       self.x = initialValue
     }
 
@@ -124,7 +132,8 @@ struct TestDoubleInit2 {
 struct TestAccessBeforeInit {
   var _x: Int
   var x: Int {
-    init(initialValue) initializes(_x) accesses(y) {
+    @storageRestrictions(initializes: _x, accesses: y)
+    init(initialValue) {
       _x = initialValue
     }
 
@@ -145,7 +154,8 @@ class TestInitWithGuard {
   var _b: Int
 
   var pair1: (Int, Int) {
-    init(initialValue) initializes(_a, _b) { // expected-error {{property '_b' not initialized by init accessor}}
+    @storageRestrictions(initializes: _a, _b)
+    init(initialValue) { // expected-error {{property '_b' not initialized by init accessor}}
       _a = initialValue.0
 
       if _a > 0 {
@@ -160,7 +170,8 @@ class TestInitWithGuard {
   }
 
   var pair2: (Int, Int) {
-    init(initialValue) initializes(_a, _b) { // Ok
+    @storageRestrictions(initializes: _a, _b)
+    init(initialValue) { // Ok
       _a = initialValue.0
 
       if _a > 0 {
@@ -185,7 +196,8 @@ do {
     private var _v: T
 
     var data: T {
-      init(initialValue) initializes(_v) {
+      @storageRestrictions(initializes: _v)
+      init(initialValue) {
         _v = initialValue
       }
 
@@ -218,7 +230,8 @@ do {
     var _a: Int
 
     var a: Int {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         self._a = initialValue
       }
 

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -179,3 +179,58 @@ class TestInitWithGuard {
     self.pair2 = (a, b)
   }
 }
+
+do {
+  class Base<T: Collection> {
+    private var _v: T
+
+    var data: T {
+      init(initialValue) initializes(_v) {
+        _v = initialValue
+      }
+
+      get { _v }
+    }
+
+    init(data: T) {
+      self.data = data
+    }
+
+    init(reinit: T) {
+      self.data = reinit
+      self.data = reinit // expected-error {{immutable value 'data' may only be initialized once}}
+    }
+  }
+
+  class Sub<U> : Base<U> where U: Collection, U.Element == String {
+    init(other: U) {
+      super.init(data: other)
+    }
+
+    init(error: U) {
+      super.init(data: error)
+      data = error // expected-error {{immutable value 'data' may only be initialized once}}
+    }
+  }
+
+  // Make sure that re-initialization is not allowed when there is no setter.
+  struct TestPartialWithoutSetter {
+    var _a: Int
+
+    var a: Int {
+      init(initialValue) initializes(_a) {
+        self._a = initialValue
+      }
+
+      get { _a }
+    }
+
+    var b: Int
+
+    init(v: Int) {
+      self.a = v
+      self.a = v // expected-error {{immutable value 'a' may only be initialized once}}
+      self.b = v
+    }
+  }
+}

--- a/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
+++ b/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
@@ -7,7 +7,8 @@ struct Test1 {
   var _b: String
 
   var a: Int {
-    init(initialValue) initializes(_a) {
+    @storageRestrictions(initializes: _a)
+    init(initialValue) {
       _a = initialValue
     }
 
@@ -16,7 +17,8 @@ struct Test1 {
   }
 
   var b: String {
-    init(initialValue) initializes(_a, _b) {
+    @storageRestrictions(initializes: _a, _b)
+    init(initialValue) {
       _a = 0
       _b = initialValue
     }
@@ -46,7 +48,8 @@ struct Test2<T> {
   var _c: String
 
   var pair: (Int, T) {
-    init(initialValue) initializes(_a, _b) {
+    @storageRestrictions(initializes: _a, _b)
+    init(initialValue) {
       _a = initialValue.0
       _b = initialValue.1
     }

--- a/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
+++ b/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
@@ -27,12 +27,15 @@ struct Test1 {
 
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering5Test1V1aACSi_tcfC : $@convention(method) (Int, @thin Test1.Type) -> @owned Test1
   init(a: Int) {
-    // CHECK: assign_or_init [init] self {{.*}}, value [[VALUE:%.*]] : $Int, init {{.*}} : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering5Test1V1aSivi : $@convention(thin) (Int) -> @out Int
+    // CHECK: assign_or_init [init] self {{.*}}, value [[VALUE:%.*]] : $Int, init [[INIT_REF]] : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.a = a
-    // CHECK: assign_or_init [init] [assign=0] self {{.*}}, value [[VALUE:%.*]] : $String, init {{.*}} : $@convention(thin) (@owned String) -> (@out Int, @out String), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering5Test1V1bSSvi : $@convention(thin) (@owned String) -> (@out Int, @out String)
+    // CHECK: assign_or_init [init] [assign=0] self {{.*}}, value [[VALUE:%.*]] : $String, init [[INIT_REF]] : $@convention(thin) (@owned String) -> (@out Int, @out String), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
     self.a = -1
     self.b = ""
-    // CHECK: assign_or_init [set] self {{.*}}, value [[VALUE:%.*]] : $Int, init {{.*}} : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering5Test1V1aSivi : $@convention(thin) (Int) -> @out Int
+    // CHECK: assign_or_init [set] self {{.*}}, value [[VALUE:%.*]] : $Int, init [[INIT_REF]] : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.a = a
   }
 }
@@ -54,12 +57,18 @@ struct Test2<T> {
 
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering5Test2V1a1bACyxGSi_xtcfC : $@convention(method) <T> (Int, @in T, @thin Test2<T>.Type) -> @out Test2<T>
   init(a: Int, b: T) {
-    // CHECK: assign_or_init [init] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering5Test2V4pairSi_xtvi : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0)
+    // CHECK-NEXT: [[SUBST_INIT_REF:%.*]] = partial_apply [callee_guaranteed] [[INIT_REF]]<T>() : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0)
+    // CHECK: assign_or_init [init] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init [[SUBST_INIT_REF]] : $@callee_guaranteed (Int, @in T) -> (@out Int, @out T), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
     self.pair = (a, b)
-    // CHECK: assign_or_init [init] [assign=0] [assign=1] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering5Test2V4pairSi_xtvi : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0)
+    // CHECK-NEXT: [[SUBST_INIT_REF:%.*]] = partial_apply [callee_guaranteed] [[INIT_REF]]<T>() : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0)
+    // CHECK: assign_or_init [init] [assign=0] [assign=1] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init [[SUBST_INIT_REF]] : $@callee_guaranteed (Int, @in T) -> (@out Int, @out T), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
     self.pair = (0, b)
     self._c = ""
-    // CHECK: assign_or_init [set] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering5Test2V4pairSi_xtvi : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0)
+    // CHECK-NEXT: [[SUBST_INIT_REF:%.*]] = partial_apply [callee_guaranteed] [[INIT_REF]]<T>() : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0)
+    // CHECK: assign_or_init [set] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init [[SUBST_INIT_REF]] : $@callee_guaranteed (Int, @in T) -> (@out Int, @out T), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
     self.pair = (1, b)
   }
 }
@@ -75,7 +84,8 @@ struct Test {
 
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering4TestV1vACSi_tcfC : $@convention(method) (Int, @thin Test.Type) -> Test
   init(v: Int) {
-    // CHECK: assign_or_init [set] self {{.*}}, value %0 : $Int, init {{.*}} : $@convention(thin) (Int) -> (), set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering4TestV4testSivi : $@convention(thin) (Int) -> ()
+    // CHECK: assign_or_init [set] self {{.*}}, value %0 : $Int, init [[INIT_REF]] : $@convention(thin) (Int) -> (), set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.test = v
   }
 }

--- a/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
+++ b/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
@@ -27,12 +27,12 @@ struct Test1 {
 
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering5Test1V1aACSi_tcfC : $@convention(method) (Int, @thin Test1.Type) -> @owned Test1
   init(a: Int) {
-    // CHECK: assign_or_init [init] [[VALUE:%.*]] : $Int, init {{.*}} : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: assign_or_init [init] self {{.*}}, value [[VALUE:%.*]] : $Int, init {{.*}} : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.a = a
-    // CHECK: assign_or_init [init] [assign=0] [[VALUE:%.*]] : $String, init {{.*}} : $@convention(thin) (@owned String) -> (@out Int, @out String), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
+    // CHECK: assign_or_init [init] [assign=0] self {{.*}}, value [[VALUE:%.*]] : $String, init {{.*}} : $@convention(thin) (@owned String) -> (@out Int, @out String), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
     self.a = -1
     self.b = ""
-    // CHECK: assign_or_init [set] [[VALUE:%.*]] : $Int, init {{.*}} : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: assign_or_init [set] self {{.*}}, value [[VALUE:%.*]] : $Int, init {{.*}} : $@convention(thin) (Int) -> @out Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.a = a
   }
 }
@@ -54,12 +54,12 @@ struct Test2<T> {
 
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering5Test2V1a1bACyxGSi_xtcfC : $@convention(method) <T> (Int, @in T, @thin Test2<T>.Type) -> @out Test2<T>
   init(a: Int, b: T) {
-    // CHECK: assign_or_init [init] [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
+    // CHECK: assign_or_init [init] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
     self.pair = (a, b)
-    // CHECK: assign_or_init [init] [assign=0] [assign=1] [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
+    // CHECK: assign_or_init [init] [assign=0] [assign=1] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
     self.pair = (0, b)
     self._c = ""
-    // CHECK: assign_or_init [set] [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
+    // CHECK: assign_or_init [set] self {{.*}}, value [[VALUE:%.*]] : $*(Int, T), init {{.*}} : $@convention(thin) <τ_0_0> (Int, @in τ_0_0) -> (@out Int, @out τ_0_0), set {{.*}} : $@callee_guaranteed (Int, @in T) -> ()
     self.pair = (1, b)
   }
 }
@@ -75,7 +75,7 @@ struct Test {
 
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering4TestV1vACSi_tcfC : $@convention(method) (Int, @thin Test.Type) -> Test
   init(v: Int) {
-    // CHECK: assign_or_init [set] %0 : $Int, init {{.*}} : $@convention(thin) (Int) -> (), set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: assign_or_init [set] self {{.*}}, value %0 : $Int, init {{.*}} : $@convention(thin) (Int) -> (), set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.test = v
   }
 }

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -33,7 +33,8 @@ struct TestInit {
     // CHECK-NEXT: [[FULL_ELT_1:%.*]] = tuple_element_addr [[FULL_ACCESS]] : $*(Int, Int), 1
     // CHECK-NEXT: store [[Y_VAL]] to [trivial] [[FULL_ELT_1]] : $*Int
     // CHECK-NEXT: end_access [[FULL_ACCESS]] : $*(Int, Int)
-    init(initialValue) initializes(y, full) accesses(x) {
+    @storageRestrictions(initializes: y, full, accesses: x)
+    init(initialValue) {
       self.y = initialValue.1
       self.full = (self.x, self.y)
     }
@@ -63,7 +64,8 @@ struct TestSetter {
   var y: Int
 
   var point: (Int, Int) {
-    init(initialValue) accesses(x, y) {
+    @storageRestrictions(accesses: x, y)
+    init(initialValue) {
     }
 
     get { (x, y) }
@@ -86,7 +88,8 @@ struct TestInitThenSetter {
   var y: Int
 
   var point: (Int, Int) {
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       self.x = initialValue.0
       self.y = initialValue.1
     }
@@ -119,7 +122,8 @@ struct TestPartialInt {
   var y: Int
 
   var pointX: Int {
-    init(newValue) initializes(x) {
+    @storageRestrictions(initializes: x)
+    init(newValue) {
       self.x = newValue
     }
 
@@ -128,7 +132,8 @@ struct TestPartialInt {
   }
 
   var pointY: Int {
-    init(newValue) initializes(y) {
+    @storageRestrictions(initializes: y)
+    init(newValue) {
       self.y = newValue
     }
 
@@ -174,7 +179,8 @@ struct TestNoInitAndInit {
   var y: Int
 
   var pointX: Int {
-    init(initalValue) accesses(x) {
+    @storageRestrictions(accesses: x)
+    init(initalValue) {
     }
 
     get { x }
@@ -182,7 +188,8 @@ struct TestNoInitAndInit {
   }
 
   var pointY: Int {
-    init(initialValue) initializes(y) {
+    @storageRestrictions(initializes: y)
+    init(initialValue) {
       self.y = initialValue
     }
 
@@ -232,7 +239,8 @@ class TestClass {
     // CHECK-NEXT: [[Y_ELT_1:%.*]] = tuple_element_addr [[Y_ACCESS]] : $*(Int, Array<String>), 1
     // CHECK-NEXT: store [[Y_VAL_1]] to [init] [[Y_ELT_1]] : $*Array<String>
     // CHECK-NEXT: end_access [[Y_ACCESS]] : $*(Int, Array<String>)
-    init(initialValue) initializes(x, y) {
+    @storageRestrictions(initializes: x, y)
+    init(initialValue) {
       x = initialValue.0
       y = initialValue.1
     }
@@ -280,7 +288,8 @@ struct TestGeneric<T, U> {
   // CHECK-NEXT: copy_addr [[C_ACCESS]] to [init] [[C_AS_ANY]] : $*U
   // CHECK-NEXT: end_access [[C_ACCESS]] : $*U
   var data: (T, T) {
-    init(initialValue) initializes(a, b) accesses(c) {
+    @storageRestrictions(initializes: a, b, accesses: c)
+    init(initialValue) {
       a = initialValue.0
       b = initialValue.1
       print(c)
@@ -315,7 +324,8 @@ func test_local_with_memberwise() {
     var b: String
 
     var pair: (Int, String) {
-      init(initialValue) initializes(a, b) {
+      @storageRestrictions(initializes: a, b)
+      init(initialValue) {
         a = initialValue.0
         b = initialValue.1
       }
@@ -347,7 +357,8 @@ func test_local_with_memberwise() {
     var _c: C
 
     var a: T {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -356,7 +367,8 @@ func test_local_with_memberwise() {
     }
 
     var pair: (String, C) {
-      init(initialValue) initializes(_b, _c) accesses(_a) {
+      @storageRestrictions(initializes: _b, _c, accesses: _a)
+      init(initialValue) {
         _b = initialValue.0
         _c = initialValue.1
         _c.append(_a)
@@ -389,7 +401,8 @@ func test_assignments() {
     var _b: Int
 
     var a: Int {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         self._a = initialValue
       }
       get { _a }
@@ -397,7 +410,8 @@ func test_assignments() {
     }
 
     var pair: (Int, Int) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -293,11 +293,12 @@ struct TestGeneric<T, U> {
   // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors11TestGenericV1a1b1cACyxq_Gx_xq_tcfC : $@convention(method) <T, U> (@in T, @in T, @in U, @thin TestGeneric<T, U>.Type) -> @out TestGeneric<T, U>
   //
   // CHECK: [[INIT_ACCESSOR:%.*]] = function_ref @$s14init_accessors11TestGenericV4datax_xtvi : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_0, @inout τ_0_1) -> (@out τ_0_0, @out τ_0_0)
-  // CHECK: {{.*}} = apply [[INIT_ACCESSOR]]<T, U>({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_0, @inout τ_0_1) -> (@out τ_0_0, @out τ_0_0)
+  // CHECK-NEXT: [[SUBST_INIT_ACCESSOR:%.*]] = partial_apply [callee_guaranteed] [[INIT_ACCESSOR]]<T, U>() : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_0, @inout τ_0_1) -> (@out τ_0_0, @out τ_0_0)
+  // CHECK: {{.*}} = apply [[SUBST_INIT_ACCESSOR]]({{.*}}) : $@callee_guaranteed (@in T, @in T, @inout U) -> (@out T, @out T)
   //
   // CHECK: [[SETTER:%.*]] = function_ref @$s14init_accessors11TestGenericV4datax_xtvs : $@convention(method) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_0, @inout TestGeneric<τ_0_0, τ_0_1>) -> ()
   // CHECK-NEXT: [[SETTER_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[SETTER]]<T, U>([[SELF_VALUE:%.*]]) : $@convention(method) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_0, @inout TestGeneric<τ_0_0, τ_0_1>) -> ()
-  // CHECK: %55 = apply [[SETTER_CLOSURE]]({{.*}}) : $@callee_guaranteed (@in T, @in T) -> ()
+  // CHECK: {{.*}} = apply [[SETTER_CLOSURE]]({{.*}}) : $@callee_guaranteed (@in T, @in T) -> ()
   // CHECK-NEXT: end_access [[SELF_VALUE]] : $*TestGeneric<T, U>
   init(a: T, b: T, c: U) {
     self.c = c

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -246,8 +246,7 @@ class TestClass {
 
   // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors9TestClassC1x1yACSi_Si_SaySSGttcfc : $@convention(method) (Int, Int, @owned Array<String>, @owned TestClass) -> @owned TestClass
   // CHECK: [[INIT_ACCESSOR:%.*]] = function_ref @$s14init_accessors9TestClassC4dataSi_Si_SaySSGttvi : $@convention(thin) (Int, Int, @owned Array<String>) -> (@out Int, @out (Int, Array<String>))
-  // CHECK: [[SELF_VALUE:%.*]] = copy_value %3 : $TestClass
-  // CHECK: [[SELF_REF:%.*]] = begin_borrow [[SELF_VALUE]] : $TestClass
+  // CHECK: [[SELF_REF:%.*]] = begin_borrow [[SELF_VALUE:%.*]] : $TestClass
   // CHECK: [[X_REF:%.*]] = ref_element_addr [[SELF_REF]] : $TestClass, #TestClass.x
   // CHECK-NEXT: [[Y_REF:%.*]] = ref_element_addr [[SELF_REF]] : $TestClass, #TestClass.y
   //

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -465,3 +465,59 @@ func test_default_arguments_are_analyzed() {
     }
   }
 }
+
+struct TestStructPropWithoutSetter {
+  var _x: Int
+
+  var x: Int {
+    init(initialValue) initializes(_x) {
+      self._x = initialValue
+    }
+
+    get { _x }
+  }
+
+  init(v: Int) {
+    x = v // Ok
+  }
+}
+
+extension TestStructPropWithoutSetter {
+  init(other: Int) {
+    x = other // Ok
+  }
+
+  init(other: inout TestStructPropWithoutSetter, v: Int) {
+    other.x = v // expected-error {{cannot assign to property: 'x' is immutable}}
+  }
+}
+
+do {
+  class TestClassPropWithoutSetter {
+    var x: Int {
+      init {
+      }
+
+      get { 0 }
+    }
+  }
+
+  class SubTestPropWithoutSetter : TestClassPropWithoutSetter {
+    init(otherV: Int) {
+      x = otherV // Ok
+    }
+  }
+
+  class OtherWithoutSetter<U> {
+    var data: U {
+      init {
+      }
+
+      get { fatalError() }
+    }
+
+    init(data: U) {
+      self.data = data // Ok
+    }
+  }
+}

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -521,3 +521,37 @@ do {
     }
   }
 }
+
+func test_invalid_storage_restrictions() {
+  struct Test {
+    var a: Int {
+      @storageRestrictions()
+      // expected-error@-1 {{missing label in @storageRestrictions attribute}}
+      init {}
+    }
+
+    var b: Int {
+      @storageRestrictions(initializes:)
+      // expected-error@-1 {{expected property name in @storageRestrictions list}}
+      init {}
+    }
+
+    var c: Int {
+      @storageRestrictions(initializes: a, initializes: b)
+      // expected-error@-1 {{duplicate label 'initializes' in @storageRestrictions attribute}}
+      init {}
+    }
+
+    var d: Int {
+      @storageRestrictions(accesses: a, accesses: c)
+      // expected-error@-1 {{duplicate label 'accesses' in @storageRestrictions attribute}}
+      init {}
+    }
+
+    var e: Int {
+      @storageRestrictions(initialize: a, b, accesses: c, d)
+      // expected-error@-1 {{unexpected label 'initialize' in @storageRestrictions attribute}}
+      init {}
+    }
+  }
+}

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -524,6 +524,9 @@ do {
 
 func test_invalid_storage_restrictions() {
   struct Test {
+    var _a: Int
+    var _b: Int
+
     var a: Int {
       @storageRestrictions()
       // expected-error@-1 {{missing label in @storageRestrictions attribute}}
@@ -552,6 +555,18 @@ func test_invalid_storage_restrictions() {
       @storageRestrictions(initialize: a, b, accesses: c, d)
       // expected-error@-1 {{unexpected label 'initialize' in @storageRestrictions attribute}}
       init {}
+    }
+
+    var f: Int {
+      @storageRestrictions(initializes: _a, accesses: _b, _a)
+      // expected-error@-1 {{property '_a' cannot be both initialized and accessed}}
+      init {}
+    }
+
+    var g: Int {
+      @storageRestrictions(initializes: _a)
+      // expected-error@-1 {{@storageRestrictions attribute could only be used with init accessors}}
+      get { 0 }
     }
   }
 }

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -25,7 +25,8 @@ func test_empty_init_accessor() {
 func test_invalid_init_accessor_use() {
   var other: String = "" // expected-warning {{}}
   var x: Int {
-    init(initialValue) initializes(other) {}
+    @storageRestrictions(initializes: other)
+    init(initialValue) {}
     // expected-error@-1 {{init accessors could only be associated with properties}}
 
     get { 42 }
@@ -46,7 +47,8 @@ func test_use_of_initializes_accesses_on_non_inits() {
     var y: String
 
     var _x: Int {
-      init(initialValue) initializes(x) accesses(y) { // Ok
+      @storageRestrictions(initializes: x, accesses: y)
+      init(initialValue) { // Ok
       }
 
       get { x }
@@ -55,14 +57,17 @@ func test_use_of_initializes_accesses_on_non_inits() {
 
     var _y: String {
       get { y }
-      set(initialValue) initializes(y) {}
-      // expected-error@-1 {{initalizes(...) attribute could only be used with init accessors}}
+
+      @storageRestrictions(initializes: y)
+      // expected-error@-1 {{@storageRestrictions attribute could only be used with init accessors}}
+      set(initialValue) {}
     }
 
     var _q: String {
       get { y }
-      set(initialValue) accesses(x) {}
-      // expected-error@-1 {{accesses(...) attribute could only be used with init accessors}}
+      @storageRestrictions(accesses: x)
+      // expected-error@-1 {{@storageRestrictions attribute could only be used with init accessors}}
+      set(initialValue) {}
     }
 
     init(x: Int, y: String) {
@@ -76,15 +81,17 @@ func test_invalid_refs_in_init_attrs() {
   struct Test {
     var c: Int { get { 42 } }
     var x: Int {
-      init(initialValue) initializes(a) accesses(b, c) {}
+      @storageRestrictions(initializes: a, accesses: b, c)
       // expected-error@-1 {{find type 'a' in scope}}
       // expected-error@-2 {{find type 'b' in scope}}
       // expected-error@-3 {{init accessor cannot refer to property 'c'; init accessors can refer only to stored properties}}
+      init(initialValue) {}
     }
 
     var y: String {
-      init(initialValue) initializes(test) {}
+      @storageRestrictions(initializes: test)
       // expected-error@-1 {{ambiguous reference to member 'test'}}
+      init(initialValue) {}
     }
 
     func test(_: Int) {} // expected-note {{'test' declared here}}
@@ -98,14 +105,16 @@ func test_assignment_to_let_properties() {
     let y: Int // expected-note {{change 'let' to 'var' to make it mutable}}
 
     var pointX: Int {
-      init(initialValue) initializes(x) accesses(y) {
+      @storageRestrictions(initializes: x, accesses: y)
+      init(initialValue) {
         self.x = initialValue // Ok
         self.y = 42 // expected-error {{cannot assign to property: 'y' is a 'let' constant}}
       }
     }
 
     var point: (Int, Int) {
-      init(initialValue) initializes(x, y) {
+      @storageRestrictions(initializes: x, y)
+      init(initialValue) {
         self.x = initialValue.0 // Ok
         self.y = initialValue.1 // Ok
       }
@@ -126,8 +135,9 @@ func test_duplicate_and_computed_lazy_properties() {
     var _b: Int
 
     var a: Int {
-      init(initialValue) initializes(_b, _a) accesses(_a) {
-        // expected-error@-1 {{property '_a' cannot be both initialized and accessed}}
+      @storageRestrictions(initializes: _b, _a, accesses: _a)
+      // expected-error@-1 {{property '_a' cannot be both initialized and accessed}}
+      init(initialValue) {
       }
 
       get { _a }
@@ -142,10 +152,11 @@ func test_duplicate_and_computed_lazy_properties() {
     var _a: Int
 
     var a: Int {
-      init(initialValue) initializes(a, c) accesses(_a, b) {}
+      @storageRestrictions(initializes: a, c, accesses: _a, b)
       // expected-error@-1 {{init accessor cannot refer to property 'a'; init accessors can refer only to stored properties}}
       // expected-error@-2 {{init accessor cannot refer to property 'b'; init accessors can refer only to stored properties}}
       // expected-error@-3 {{init accessor cannot refer to property 'c'; init accessors can refer only to stored properties}}
+      init(initialValue) {}
     }
 
     var b: Int {
@@ -204,7 +215,8 @@ func test_invalid_references() {
     var _d: String
 
     var data: Int {
-      init(initialValue) initializes(_a) accesses(_d) {
+      @storageRestrictions(initializes: _a, accesses: _d)
+      init(initialValue) {
         _a = initialValue // Ok
 
         print(_d) // Ok
@@ -249,7 +261,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     var _b: Int
 
     var a: T {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -258,7 +271,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     }
 
     var pair: (T, Int) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }
@@ -278,7 +292,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     var _b: Int
 
     var a: T {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -287,7 +302,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     }
 
     var b: Int {
-      init(initialValue) initializes(_b) {
+      @storageRestrictions(initializes: _b)
+      init(initialValue) {
         _b = initialValue
       }
 
@@ -298,7 +314,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     var _c: U
 
     var pair: (T, U) {
-      init(initialValue) initializes(_a, _c) {
+      @storageRestrictions(initializes: _a, _c)
+      init(initialValue) {
         _a = initialValue.0
         _c = initialValue.1
       }
@@ -316,7 +333,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     var _b: Int
 
     var a: T {
-      init(initialValue) initializes(_a) {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -325,7 +343,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     }
 
     var b: Int {
-      init(initialValue) initializes(_b) {
+      @storageRestrictions(initializes: _b)
+      init(initialValue) {
         _b = initialValue
       }
 
@@ -336,7 +355,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     var _c: U
 
     var c: U {
-      init(initialValue) initializes(_c) {
+      @storageRestrictions(initializes: _c)
+      init(initialValue) {
         _c = initialValue
       }
 
@@ -345,7 +365,8 @@ func test_memberwise_with_overlaps_dont_synthesize_inits() {
     }
 
     var triple: (T, Int, U) {
-      init(initialValue) initializes(_a, _b, _c) {
+      @storageRestrictions(initializes: _a, _b, _c)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
         _c = initialValue.2
@@ -366,7 +387,8 @@ func test_memberwise_ordering() {
     var _b: Int
 
     var a: Int {
-      init(initialValue) initializes(_a) accesses(_b) {
+      @storageRestrictions(initializes: _a, accesses: _b)
+      init(initialValue) {
         _a = initialValue
       }
 
@@ -381,7 +403,8 @@ func test_memberwise_ordering() {
     var _a: Int
 
     var a: Int {
-      init(initialValue) initializes(_a) accesses(_b) {
+      @storageRestrictions(initializes: _a, accesses: _b)
+      init(initialValue) {
         // expected-note@-1 {{init accessor for 'a' cannot access stored property '_b' because it is called before '_b' is initialized}}
         _a = initialValue
       }
@@ -396,7 +419,8 @@ func test_memberwise_ordering() {
     var _a: Int
 
     var pair: (Int, Int) {
-      init(initialValue) initializes(_a, _b) {
+      @storageRestrictions(initializes: _a, _b)
+      init(initialValue) {
         _a = initialValue.0
         _b = initialValue.1
       }
@@ -415,7 +439,8 @@ func test_memberwise_ordering() {
     var _b: Int
 
     var pair: (Int, Int) {
-      init(initalValue) accesses(_a, _b) {
+      @storageRestrictions(accesses: _a, _b)
+      init(initalValue) {
       }
 
       get { (_a, _b) }
@@ -432,7 +457,8 @@ func test_memberwise_ordering() {
     var _b: Int
 
     var c: Int {
-      init(initalValue) initializes(_c) accesses(_a, _b) {
+      @storageRestrictions(initializes: _c, accesses: _a, _b)
+      init(initalValue) {
       }
 
       get { _c }
@@ -470,7 +496,8 @@ struct TestStructPropWithoutSetter {
   var _x: Int
 
   var x: Int {
-    init(initialValue) initializes(_x) {
+    @storageRestrictions(initializes: _x)
+    init(initialValue) {
       self._x = initialValue
     }
 
@@ -524,8 +551,8 @@ do {
 
 func test_invalid_storage_restrictions() {
   struct Test {
-    var _a: Int
-    var _b: Int
+    var _a: Int = 0
+    var _b: Int = 0
 
     var a: Int {
       @storageRestrictions()
@@ -568,5 +595,7 @@ func test_invalid_storage_restrictions() {
       // expected-error@-1 {{@storageRestrictions attribute could only be used with init accessors}}
       get { 0 }
     }
+
+    init() {}
   }
 }

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -930,6 +930,11 @@ DECL_MODIFIER_KINDS = [
                   ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=142),
     DeclAttributeAlias('freestanding', 'MacroRole'),
+    DeclAttribute('storageRestrictions', 'StorageRestrictions',
+                  OnAccessor,
+                  ABIStableToAdd, ABIStableToRemove,
+                  APIBreakingToAdd, APIBreakingToRemove,
+                  code=145),
 ]
 
 DEPRECATED_MODIFIER_KINDS = [


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/66987, https://github.com/apple/swift/pull/67107, https://github.com/apple/swift/pull/67183

---

- Explanation:

  This changes address 1/3 of the feedback from the proposal review and implement init accessor properties without setters.

  - Extends `assign_or_init` instruction to carry a reference to "self" (this is preliminary change to unlock init accessors without setters).
  - Allows use of properties with init accessors without setters, such properties behave as `let` properties do.
  - Introduces new `@storageRestrictions(initializes:accesses:)` attribute which is used instead of `initializes/accesses` effects associated with init accessors.

- Scope: Init accessors

- Main Branch PRs: https://github.com/apple/swift/pull/66987, https://github.com/apple/swift/pull/67107, https://github.com/apple/swift/pull/67183

- Risk: Low

- Reviewed By: @hborla @jckarter 

- Testing: Added test-cases to the suite.

Resolves:  rdar://112077182

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
