### PR TITLE
[cxx-interop] Do not add base class members that cause lookup ambigui…

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5114,6 +5114,15 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
   // If this is a C++ record, look through any base classes.
   if (auto cxxRecord =
           dyn_cast<clang::CXXRecordDecl>(recordDecl->getClangDecl())) {
+    // Capture the arity of already found members in the
+    // current record, to avoid adding ambiguous members
+    // from base classes.
+    const auto getArity =
+        ClangImporter::Implementation::getImportedBaseMemberDeclArity;
+    llvm::SmallSet<size_t, 4> foundNameArities;
+    for (const auto *valueDecl : result)
+      foundNameArities.insert(getArity(valueDecl));
+
     for (auto base : cxxRecord->bases()) {
       if (base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
         continue;
@@ -5149,6 +5158,10 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
           }
         }
         for (auto foundInBase : baseResults) {
+          // Do not add duplicate entry with the same arity,
+          // as that would cause an ambiguous lookup.
+          if (foundNameArities.count(getArity(foundInBase)))
+            continue;
           if (auto newDecl = clangModuleLoader->importBaseMemberDecl(
                   foundInBase, recordDecl)) {
             result.push_back(newDecl);
@@ -6320,6 +6333,16 @@ ValueDecl *ClangImporter::Implementation::importBaseMemberDecl(
   }
 
   return known->second;
+}
+
+size_t ClangImporter::Implementation::getImportedBaseMemberDeclArity(
+    const ValueDecl *valueDecl) {
+  if (auto *func = dyn_cast<FuncDecl>(valueDecl)) {
+    if (auto *params = func->getParameters()) {
+      return params->size();
+    }
+  }
+  return 0;
 }
 
 ValueDecl *ClangImporter::importBaseMemberDecl(ValueDecl *decl,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8894,6 +8894,23 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
   for (auto member: members) {
     // This means we found a member in a C++ record's base class.
     if (swiftDecl->getClangDecl() != clangRecord) {
+      // Do not clone the base member into the derived class
+      // when the derived class already has a member of such
+      // name and arity.
+      auto memberArity =
+          getImportedBaseMemberDeclArity(cast<ValueDecl>(member));
+      bool shouldAddBaseMember = true;
+      for (const auto *currentMember : swiftDecl->getMembers()) {
+        auto vd = dyn_cast<ValueDecl>(currentMember);
+        if (vd->getName() == cast<ValueDecl>(member)->getName()) {
+          if (memberArity == getImportedBaseMemberDeclArity(vd)) {
+            shouldAddBaseMember = false;
+            break;
+          }
+        }
+      }
+      if (!shouldAddBaseMember)
+        continue;
       // So we need to clone the member into the derived class.
       if (auto newDecl = importBaseMemberDecl(cast<ValueDecl>(member), swiftDecl)) {
         swiftDecl->addMember(newDecl);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -650,6 +650,8 @@ private:
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext);
 
 public:
+  static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
+
   // Cache for already-specialized function templates and any thunks they may
   // have.
   llvm::DenseMap<clang::FunctionDecl *, ValueDecl *>

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -4,6 +4,10 @@ struct HasThreeFields {
   int c = 3;
 };
 
+struct DerivedWithSameField : HasThreeFields {
+  int a = 2;
+};
+
 struct DerivedWithOneField : HasThreeFields {
   int d = 4;
 };

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -50,6 +50,14 @@ struct Base {
   }
 
   void pure() const __attribute__((pure)) {}
+
+  inline int sameMethodNameSameSignature() const {
+    return 42;
+  }
+
+  inline int sameMethodDifferentSignature() const {
+    return 18;
+  }
 };
 
 struct OtherBase {
@@ -64,6 +72,14 @@ struct Derived : Base, OtherBase {
   inline const char *inDerived() const
       __attribute__((swift_attr("import_unsafe"))) {
     return "Derived::inDerived";
+  }
+
+  inline int sameMethodNameSameSignature() const {
+    return 21;
+  }
+
+  inline int sameMethodDifferentSignature(int x) const {
+    return x + 1;
   }
 };
 

--- a/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
@@ -8,6 +8,13 @@
 // CHECK-NEXT:   var c: Int32
 // CHECK-NEXT: }
 
+// CHECK-NEXT: struct DerivedWithSameField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }
+
 // CHECK-NEXT: struct DerivedWithOneField {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   var d: Int32

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -79,4 +79,10 @@ FieldsTestSuite.test("Derived from class template") {
   expectEqual(derived.value, 42)
 }
 
+FieldsTestSuite.test("Same field from derived") {
+  var derived = DerivedWithSameField()
+  derived.a = 42
+  expectEqual(derived.a, 42)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -29,6 +29,10 @@
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct OtherBase {
@@ -42,6 +46,10 @@
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodDifferentSignature(_ x: Int32) -> Int32
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
@@ -56,6 +64,8 @@
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
@@ -67,6 +77,10 @@
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodNameSameSignature() -> Int32
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodDifferentSignature(_ x: Int32) -> Int32
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
@@ -81,6 +95,8 @@
 // CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
 // CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func sameMethodDifferentSignature() -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
@@ -11,3 +11,9 @@ extension Base {
 }
 
 Derived().swiftFunc() // expected-error {{value of type 'Derived' has no member 'swiftFunc'}}
+
+// ok, this calls the derived method.
+Derived().sameMethodNameSameSignature()
+Derived().sameMethodDifferentSignature(1)
+// ok, this is the base class method.
+Derived().sameMethodDifferentSignature()

--- a/test/Interop/Cxx/class/inheritance/functions.swift
+++ b/test/Interop/Cxx/class/inheritance/functions.swift
@@ -38,6 +38,13 @@ FunctionsTestSuite.test("Other base member from derived") {
   expectEqual(String(cString: derived.inOtherBase()!), "OtherBase::inOtherBase")
 }
 
+FunctionsTestSuite.test("Unambiguous members from derived") {
+  let derived = Derived()
+  expectEqual(derived.sameMethodNameSameSignature(), 21)
+  expectEqual(derived.sameMethodDifferentSignature(1), 2)
+  expectEqual(derived.sameMethodDifferentSignature(), 18)
+}
+
 FunctionsTestSuite.test("Basic methods from derived * 2") {
   let dd = DerivedFromDerived()
   expectEqual(String(cString: dd.constInBase()!), "Base::constInBase")


### PR DESCRIPTION
…ties with a derived class member of the same name

Fixes https://github.com/apple/swift/issues/66323

(cherry picked from commit 11d7d589425c231df2484e7f83c49cd744349fcf)

- Explanation: Swift's clang importer adds base class members into a derived class when such a derived C++ class is imported into Swift. However, the importer did not check if the added member could cause an ambiguity between another member in the derived class and the added base member. This caused ambiguity errors when trying to call shadowed or reimplemented base class members from derived class in Swift. This change resolves this by detecting ambiguous base members using their arity and not adding them into the derived class when they conflict with another derived member.
- Scope: C++ interop, clang importer, base class member import.
- Risk: Medium, affects how base class members are imported. Tested on some adopters without issues.
- Testing: Unit tests, adopter testing.
- Original PR: https://github.com/apple/swift/pull/67178