### PR TITLE
[5.9][Features] Allow ExtensionMacros to be enabled in noasserts builds.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -122,7 +122,7 @@ EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(InitAccessors, false)
 
-EXPERIMENTAL_FEATURE(ExtensionMacros, false)
+EXPERIMENTAL_FEATURE(ExtensionMacros, true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)", true)
 
 // FIXME: MoveOnlyClasses is not intended to be in production,


### PR DESCRIPTION
* **Explanation**: The `@Observable` macro has adopted `-enable-experimental-feature ExtensionMacros`. The Observation module is built in noasserts configurations in CI, but this flag is not available in noasserts builds, hence breaking CI. This change allows the flag to be enabled in noasserts builds.
* **Scope**: Only impacts the `enable-experimental-feature ExtensionMacros` feature flag.
* **Risk**: Extremely low due to tiny scope.
* **Testing**: noasserts CI configurations have successfully gotten past building the Observation module after the `main` PR was merged:
* **Main branch PR**: https://github.com/apple/swift/pull/67208