### PR TITLE
[5.9][move-only] Ensure that copyable borrowing parameters of resilient type used by a function in the same module can be recognized by the checker

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -17,8 +17,15 @@ public class CopyableKlass {
     var letS = NonEmptyStruct()
 }
 
+public struct CopyableStruct {
+    var k = CopyableKlass()
+}
+
 public func borrowVal(_ x: borrowing NonEmptyStruct) {}
 public func borrowVal(_ x: borrowing EmptyStruct) {}
+public func borrowVal(_ x: borrowing CopyableKlass) {}
+public func borrowVal(_ x: borrowing CopyableStruct) {}
+public func consumeVal(_ x: consuming CopyableKlass) {}
 public func consumeVal(_ x: consuming NonEmptyStruct) {}
 public func consumeVal(_ x: consuming EmptyStruct) {}
 

--- a/test/SILOptimizer/noimplicitcopy.sil
+++ b/test/SILOptimizer/noimplicitcopy.sil
@@ -6,6 +6,10 @@
 
 class Klass {}
 
+struct CopyableStruct {
+  var k = Klass()
+}
+
 sil @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) -> ()
 
 ///////////
@@ -28,4 +32,17 @@ bb0(%0 : @noImplicitCopy @guaranteed $Klass):
   destroy_value %3 : $@moveOnly Klass
   %11 = tuple ()
   return %11 : $()
+}
+
+sil [ossa] @testSimpleBorrowParameter : $@convention(thin) (@in_guaranteed CopyableStruct) -> () {
+bb0(%0 : @noImplicitCopy $*CopyableStruct):
+  %1 = load_borrow %0 : $*CopyableStruct                       // users: %7, %2
+  %2 = copyable_to_moveonlywrapper [guaranteed] %1 : $CopyableStruct // user: %3
+  %3 = copy_value %2 : $@moveOnly CopyableStruct               // user: %4
+  %4 = mark_must_check [no_consume_or_assign] %3 : $@moveOnly CopyableStruct // users: %6, %5
+  debug_value %4 : $@moveOnly CopyableStruct, let, name "x", argno 1 // id: %5
+  destroy_value %4 : $@moveOnly CopyableStruct                 // id: %6
+  end_borrow %1 : $CopyableStruct                              // id: %7
+  %8 = tuple ()                                   // user: %9
+  return %8 : $()                                 // id: %9
 }


### PR DESCRIPTION
• Description: [5.9][move-only] Ensure that copyable borrowing parameters of resilient type used by a function in the same module can be recognized by the checker. This ensures that we can write code like:

```
public func borrowVal(_ x: borrowing CopyableStruct) { ... }
```
• Original PR: https://github.com/apple/swift/pull/67201
• Reviewed By: @jckarter
• Testing: Added Swift and SIL tests
• Resolves: rdar://112028837

----

I found this while looking at problems around library evolution for noncopyable types. Specifically:

```
+public func borrowVal(_ x: borrowing CopyableStruct) {}
```

causes an error since we do not recognize the load_borrow here:

```
+sil [ossa] @testSimpleBorrowParameter : $@convention(thin) (@in_guaranteed CopyableStruct) -> () {
+bb0(%0 : @noImplicitCopy $*CopyableStruct):
+  %1 = load_borrow %0 : $*CopyableStruct                       // users: %7, %2
+  %2 = copyable_to_moveonlywrapper [guaranteed] %1 : $CopyableStruct // user: %3
+  %3 = copy_value %2 : $@moveOnly CopyableStruct               // user: %4
+  %4 = mark_must_check [no_consume_or_assign] %3 : $@moveOnly CopyableStruct // users: %6, %5
+  debug_value %4 : $@moveOnly CopyableStruct, let, name "x", argno 1 // id: %5
+  destroy_value %4 : $@moveOnly CopyableStruct                 // id: %6
+  end_borrow %1 : $CopyableStruct                              // id: %7
+  %8 = tuple ()                                   // user: %9
+  return %8 : $()                                 // id: %9
+}
```

rdar://112028837
(cherry picked from commit 87713349d43e297df13b7e3859c4677248fb4fc4)
