### PR TITLE
Sema: Allow default arguments to access `@usableFromInline` decls

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -217,11 +217,9 @@ struct FragileFunctionKind {
   };
 
   Kind kind = None;
-  bool allowUsableFromInline = false;
 
   friend bool operator==(FragileFunctionKind lhs, FragileFunctionKind rhs) {
-    return (lhs.kind == rhs.kind &&
-            lhs.allowUsableFromInline == rhs.allowUsableFromInline);
+    return lhs.kind == rhs.kind;
   }
 
   /// Casts to `unsigned` for diagnostic %selects.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6539,10 +6539,6 @@ ERROR(availability_macro_in_inlinable, none,
 
 #undef FRAGILE_FUNC_KIND
 
-NOTE(resilience_decl_declared_here_public,
-     none, DECL_OR_ACCESSOR "2 %1 is not public",
-     (DescriptiveDeclKind, DeclName, bool))
-
 NOTE(resilience_decl_declared_here,
      none, DECL_OR_ACCESSOR "2 %1 is not '@usableFromInline' or public",
      (DescriptiveDeclKind, DeclName, bool))

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -445,9 +445,10 @@ ResilienceExpansion DeclContext::getResilienceExpansion() const {
 
 FragileFunctionKind DeclContext::getFragileFunctionKind() const {
   auto &context = getASTContext();
-  return evaluateOrDefault(context.evaluator,
-                           FragileFunctionKindRequest { const_cast<DeclContext *>(this) },
-                           {FragileFunctionKind::None, false});
+  return evaluateOrDefault(
+      context.evaluator,
+      FragileFunctionKindRequest{const_cast<DeclContext *>(this)},
+      {FragileFunctionKind::None});
 }
 
 FragileFunctionKind
@@ -466,20 +467,17 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       if (VD->getDeclContext()->isLocalContext()) {
         auto kind = VD->getDeclContext()->getFragileFunctionKind();
         if (kind.kind != FragileFunctionKind::None)
-          return {FragileFunctionKind::DefaultArgument,
-                  kind.allowUsableFromInline};
+          return {FragileFunctionKind::DefaultArgument};
       }
 
       auto effectiveAccess =
           VD->getFormalAccessScope(/*useDC=*/nullptr,
                                    /*treatUsableFromInlineAsPublic=*/true);
       if (effectiveAccess.isPublic()) {
-        return {FragileFunctionKind::DefaultArgument,
-                /*allowUsableFromInline=*/true};
+        return {FragileFunctionKind::DefaultArgument};
       }
 
-      return {FragileFunctionKind::None,
-              /*allowUsableFromInline=*/false};
+      return {FragileFunctionKind::None};
     }
 
     // Stored property initializer contexts use minimal resilience expansion
@@ -488,13 +486,11 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       auto bindingIndex = init->getBindingIndex();
       if (auto *varDecl = init->getBinding()->getAnchoringVarDecl(bindingIndex)) {
         if (varDecl->isInitExposedToClients()) {
-          return {FragileFunctionKind::PropertyInitializer,
-                  /*allowUsableFromInline=*/true};
+          return {FragileFunctionKind::PropertyInitializer};
         }
       }
 
-      return {FragileFunctionKind::None,
-              /*allowUsableFromInline=*/false};
+      return {FragileFunctionKind::None};
     }
 
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(dc)) {
@@ -510,29 +506,24 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       // If the function is not externally visible, we will not be serializing
       // its body.
       if (!funcAccess.isPublic()) {
-        return {FragileFunctionKind::None,
-                /*allowUsableFromInline=*/false};
+        return {FragileFunctionKind::None};
       }
 
       // If the function is public, @_transparent implies @inlinable.
       if (AFD->isTransparent()) {
-        return {FragileFunctionKind::Transparent,
-                /*allowUsableFromInline=*/true};
+        return {FragileFunctionKind::Transparent};
       }
 
       if (AFD->getAttrs().hasAttribute<InlinableAttr>()) {
-        return {FragileFunctionKind::Inlinable,
-                /*allowUsableFromInline=*/true};
+        return {FragileFunctionKind::Inlinable};
       }
 
       if (AFD->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
-        return {FragileFunctionKind::AlwaysEmitIntoClient,
-                /*allowUsableFromInline=*/true};
+        return {FragileFunctionKind::AlwaysEmitIntoClient};
       }
 
       if (AFD->isBackDeployed(context->getASTContext())) {
-        return {FragileFunctionKind::BackDeploy,
-                /*allowUsableFromInline=*/true};
+        return {FragileFunctionKind::BackDeploy};
       }
 
       // Property and subscript accessors inherit @_alwaysEmitIntoClient,
@@ -540,23 +531,19 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       if (auto accessor = dyn_cast<AccessorDecl>(AFD)) {
         auto *storage = accessor->getStorage();
         if (storage->getAttrs().getAttribute<InlinableAttr>()) {
-          return {FragileFunctionKind::Inlinable,
-                  /*allowUsableFromInline=*/true};
+          return {FragileFunctionKind::Inlinable};
         }
         if (storage->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
-          return {FragileFunctionKind::AlwaysEmitIntoClient,
-                  /*allowUsableFromInline=*/true};
+          return {FragileFunctionKind::AlwaysEmitIntoClient};
         }
         if (storage->isBackDeployed(context->getASTContext())) {
-          return {FragileFunctionKind::BackDeploy,
-                  /*allowUsableFromInline=*/true};
+          return {FragileFunctionKind::BackDeploy};
         }
       }
     }
   }
 
-  return {FragileFunctionKind::None,
-          /*allowUsableFromInline=*/false};
+  return {FragileFunctionKind::None};
 }
 
 /// Determine whether the innermost context is generic.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -471,14 +471,11 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       }
 
       auto effectiveAccess =
-        VD->getFormalAccessScope(/*useDC=*/nullptr,
-                                 /*treatUsableFromInlineAsPublic=*/true);
-      auto formalAccess =
-        VD->getFormalAccessScope(/*useDC=*/nullptr,
-                                 /*treatUsableFromInlineAsPublic=*/false);
+          VD->getFormalAccessScope(/*useDC=*/nullptr,
+                                   /*treatUsableFromInlineAsPublic=*/true);
       if (effectiveAccess.isPublic()) {
         return {FragileFunctionKind::DefaultArgument,
-                !formalAccess.isPublic()};
+                /*allowUsableFromInline=*/true};
       }
 
       return {FragileFunctionKind::None,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -588,29 +588,28 @@ void swift::simple_display(llvm::raw_ostream &out,
   switch (value.kind) {
   case FragileFunctionKind::Transparent:
     out << "transparent";
-    break;
+    return;
   case FragileFunctionKind::Inlinable:
     out << "inlinable";
-    break;
+    return;
   case FragileFunctionKind::AlwaysEmitIntoClient:
     out << "alwaysEmitIntoClient";
-    break;
+    return;
   case FragileFunctionKind::DefaultArgument:
     out << "defaultArgument";
-    break;
+    return;
   case FragileFunctionKind::PropertyInitializer:
     out << "propertyInitializer";
-    break;
+    return;
   case FragileFunctionKind::BackDeploy:
     out << "backDeploy";
-    break;
+    return;
   case FragileFunctionKind::None:
     out << "none";
-    break;
+    return;
   }
 
-  out << ", allowUsableFromInline: "
-      << (value.allowUsableFromInline ? "true" : "false");
+  llvm_unreachable("Bad FragileFunctionKind");
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -61,8 +61,9 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
     return false;
 
   // General check on access-level of the decl.
-  auto declAccessScope = D->getFormalAccessScope(/*useDC=*/nullptr,
-                              fragileKind.allowUsableFromInline);
+  auto declAccessScope =
+      D->getFormalAccessScope(/*useDC=*/nullptr,
+                              /*allowUsableFromInline=*/true);
 
   // If the decl is imported, check if the import lowers it's access level.
   auto importAccessLevel = AccessLevel::Public;
@@ -134,13 +135,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
                          diagAccessLevel,
                          fragileKind.getSelector(), isAccessor);
 
-  if (fragileKind.allowUsableFromInline) {
-    Context.Diags.diagnose(D, diag::resilience_decl_declared_here,
-                           D->getDescriptiveKind(), diagName, isAccessor);
-  } else {
-    Context.Diags.diagnose(D, diag::resilience_decl_declared_here_public,
-                           D->getDescriptiveKind(), diagName, isAccessor);
-  }
+  Context.Diags.diagnose(D, diag::resilience_decl_declared_here,
+                         D->getDescriptiveKind(), diagName, isAccessor);
 
   if (problematicImport.has_value() &&
       diagAccessLevel == importAccessLevel) {

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -208,7 +208,7 @@ protocol StorageType {
   var identifier: String { get }
 }
 
-class Storage { // expected-note {{class 'Storage' is not public}}
+class Storage { // expected-note {{class 'Storage' is not '@usableFromInline' or public}}
 }
 
 extension Storage {
@@ -256,7 +256,7 @@ struct S61061_3<T> where T:Hashable {
 
 // https://github.com/apple/swift/issues/62025
 // Syntactic checks are not run on the default argument expressions
-public struct MyStruct {} // expected-note {{initializer 'init()' is not public}}
+public struct MyStruct {} // expected-note {{initializer 'init()' is not '@usableFromInline' or public}}
 public func issue62025_with_init<T>(_: T = MyStruct()) {}
 // expected-error@-1 {{initializer 'init()' is internal and cannot be referenced from a default argument value}}
 public func issue62025_with_type<T>(_: T = Storage.self) {}

--- a/test/decl/func/default-values-swift4.swift
+++ b/test/decl/func/default-values-swift4.swift
@@ -2,17 +2,16 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4 -enable-testing
 
 private func privateFunction() {}
-// expected-note@-1 2{{global function 'privateFunction()' is not public}}
+// expected-note@-1 2{{global function 'privateFunction()' is not '@usableFromInline' or public}}
 fileprivate func fileprivateFunction() {}
-// expected-note@-1 2{{global function 'fileprivateFunction()' is not public}}
+// expected-note@-1 2{{global function 'fileprivateFunction()' is not '@usableFromInline' or public}}
 func internalFunction() {}
-// expected-note@-1 2{{global function 'internalFunction()' is not public}}
-@usableFromInline func versionedFunction() {}
-// expected-note@-1 4{{global function 'versionedFunction()' is not public}}
+// expected-note@-1 2{{global function 'internalFunction()' is not '@usableFromInline' or public}}
+@usableFromInline func usableFromInlineFunction() {}
 public func publicFunction() {}
 
 func internalIntFunction() -> Int {}
-// expected-note@-1 {{global function 'internalIntFunction()' is not public}}
+// expected-note@-1 {{global function 'internalIntFunction()' is not '@usableFromInline' or public}}
 
 private func privateFunction2() {}
 // expected-note@-1 {{global function 'privateFunction2()' is not '@usableFromInline' or public}}
@@ -31,7 +30,7 @@ func internalFunctionWithDefaultValue(
 
       publicFunction()
       // OK
-      versionedFunction()
+      usableFromInlineFunction()
       // OK
       internalFunction()
       // OK
@@ -44,16 +43,14 @@ func internalFunctionWithDefaultValue(
     }(),
     y: Int = internalIntFunction()) {}
 
-@usableFromInline func versionedFunctionWithDefaultValue(
+@usableFromInline func usableFromInlineFunctionWithDefaultValue(
     x: Int = {
       struct Nested {}
       // expected-error@-1 {{type 'Nested' cannot be nested inside a default argument value}}
 
-      // FIXME: Some errors below are diagnosed twice
-
       publicFunction()
       // OK
-      versionedFunction()
+      usableFromInlineFunction()
       // OK
       internalFunction2()
       // expected-error@-1 {{global function 'internalFunction2()' is internal and cannot be referenced from a default argument value}}
@@ -76,8 +73,7 @@ public func publicFunctionWithDefaultValue(
 
       publicFunction()
 
-      versionedFunction()
-      // expected-error@-1 {{global function 'versionedFunction()' is internal and cannot be referenced from a default argument value}}
+      usableFromInlineFunction()
 
       internalFunction()
       // expected-error@-1 {{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}
@@ -101,18 +97,16 @@ public class MyClass {
 public func evilCode(
   x: Int = {
     let _ = publicFunction()
-    let _ = versionedFunction()
-    // expected-error@-1 {{global function 'versionedFunction()' is internal and cannot be referenced from a default argument value}}
+    let _ = usableFromInlineFunction()
 
     func localFunction() {
       publicFunction()
-      versionedFunction()
-      // expected-error@-1 {{global function 'versionedFunction()' is internal and cannot be referenced from a default argument value}}
+      usableFromInlineFunction()
     }
     return 0
   }()) {}
 
-private func privateIntFunction() -> Int {} // expected-note {{global function 'privateIntFunction()' is not public}}
+private func privateIntFunction() -> Int {} // expected-note {{global function 'privateIntFunction()' is not '@usableFromInline' or public}}
 
 public struct HasSubscript {
   public subscript(x: Int = {
@@ -121,8 +115,7 @@ public struct HasSubscript {
 
     publicFunction()
 
-    versionedFunction()
-    // expected-error@-1 {{global function 'versionedFunction()' is internal and cannot be referenced from a default argument value}}
+    usableFromInlineFunction()
 
     internalFunction()
     // expected-error@-1 {{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}


### PR DESCRIPTION
The restriction that default arguments be disallowed from accessing `@usableFromInline` decls is overbearing for library developers who need to write non-trivial code to compute a default value, since it forces them to either write a verbose closure inline in the function signature or expose a `public` helper function which unnecessarily expands API surface. A `@usableFromInline` function is a more reasonable way to encapsulate a verbose default value computation.

This reverses the semantic changes included in https://github.com/apple/swift/pull/15666.

Resolves rdar://112093794.