### PR TITLE
[DependencyScan] Prevent command-line flags added again on re-scan

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -110,13 +110,13 @@ public:
   ModuleDependencyInfoStorageBase(ModuleDependencyKind dependencyKind,
                                   StringRef moduleCacheKey = "")
       : dependencyKind(dependencyKind), moduleCacheKey(moduleCacheKey.str()),
-        resolved(false) { }
+        resolved(false), finalized(false) {}
 
   ModuleDependencyInfoStorageBase(ModuleDependencyKind dependencyKind,
                                   const std::vector<std::string> &moduleImports,
                                   StringRef moduleCacheKey = "")
       : dependencyKind(dependencyKind), moduleImports(moduleImports),
-        moduleCacheKey(moduleCacheKey.str()), resolved(false)  {}
+        moduleCacheKey(moduleCacheKey.str()), resolved(false), finalized(false)  {}
 
   virtual ModuleDependencyInfoStorageBase *clone() const = 0;
 
@@ -137,7 +137,11 @@ public:
   /// The cache key for the produced module.
   std::string moduleCacheKey;
 
+  /// The direct dependency of the module is resolved by scanner.
   bool resolved;
+  /// ModuleDependencyInfo is finalized (with all transitive dependencies
+  /// and inputs).
+  bool finalized;
 };
 
 struct CommonSwiftTextualModuleDependencyDetails {
@@ -602,6 +606,13 @@ public:
   }
   void setIsResolved(bool isResolved) {
     storage->resolved = isResolved;
+  }
+
+  bool isFinalized() const {
+    return storage->finalized;
+  }
+  void setIsFinalized(bool isFinalized) {
+    storage->finalized = isFinalized;
   }
 
   /// For a Source dependency, register a `Testable` import

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -302,6 +302,10 @@ static llvm::Error resolveExplicitModuleInputs(
   if (moduleID.second == ModuleDependencyKind::SwiftPlaceholder)
     return llvm::Error::success();
 
+  // If the dependency is already finalized, nothing needs to be done.
+  if (resolvingDepInfo.isFinalized())
+    return llvm::Error::success();
+
   std::vector<std::string> rootIDs;
   if (auto ID = resolvingDepInfo.getCASFSRootID())
     rootIDs.push_back(*ID);
@@ -505,6 +509,7 @@ static llvm::Error resolveExplicitModuleInputs(
         return E;
     }
   }
+  dependencyInfoCopy.setIsFinalized(true);
   cache.updateDependency(moduleID, dependencyInfoCopy);
 
   return llvm::Error::success();

--- a/test/Frontend/output_determinism_check.swift
+++ b/test/Frontend/output_determinism_check.swift
@@ -12,7 +12,7 @@
 /// FAIL:  %target-swift-frontend -module-name test -emit-reference-dependencies-path %t/test.swiftdeps -c -o %t/test.o -primary-file %s -enable-deterministic-check -always-compile-output-files
 
 /// Explicit module build. Check building swiftmodule from interface file.
-// RUN: %target-swift-frontend -scan-dependencies -module-name test -o %t/test.json %s -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=DEPSCAN_OUTPUT
+// RUN: %target-swift-frontend -scan-dependencies -module-name test -o %t/test.json %s -enable-deterministic-check  -load-dependency-scan-cache -dependency-scan-cache-path %t/deps-cache -serialize-dependency-scan-cache 2>&1 | %FileCheck %s --check-prefix=DEPSCAN_OUTPUT --check-prefix=DEPSCAN_CACHE_OUTPUT
 /// TODO: Implicit module build use a different compiler instance so it doesn't support checking yet.
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/test.swiftinterface %s -O -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=INTERFACE_OUTPUT
 /// Hit cache and not emit the second time.
@@ -20,8 +20,6 @@
 // RUN: not %target-swift-frontend -compile-module-from-interface %t/test.swiftinterface -explicit-interface-module-build -o %t/test.swiftmodule -enable-deterministic-check 2>&1 | %FileCheck --check-prefix=MODULE_MISMATCH %s
 /// Force swiftmodule generation.
 // RUN: %target-swift-frontend -compile-module-from-interface %t/test.swiftinterface -explicit-interface-module-build -o %t/test.swiftmodule -enable-deterministic-check -always-compile-output-files 2>&1 | %FileCheck --check-prefix=MODULE_OUTPUT %s
-
-// RUN: %target-swift-frontend -scan-dependencies -module-name test %s -o %t/test.deps.json -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=DEPS_JSON_OUTPUT
 
 // RUN: %target-swift-frontend -emit-pcm -module-name UserClangModule -o %t/test.pcm %S/Inputs/dependencies/module.modulemap -enable-deterministic-check 2>&1 | %FileCheck %s --check-prefix=PCM_OUTPUT
 
@@ -33,10 +31,10 @@
 // DEPS_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.d'
 // OBJECT_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.o'
 // OBJECT_MISMATCH: error: output file '{{.*}}{{/|\\}}test.o' is missing from second compilation for deterministic check
+// DEPSCAN_CACHE_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}deps-cache'
 // DEPSCAN_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.json'
 // INTERFACE_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.swiftinterface'
 // MODULE_MISMATCH: error: output file '{{.*}}{{/|\\}}test.swiftmodule' is missing from second compilation for deterministic check
-// DEPS_JSON_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.deps.json'
 // PCM_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.pcm'
 
 public var x = 1


### PR DESCRIPTION
Add a flag `finalized` to indicate that a module entry in the dependency cache is finalized and no longer needs to be updated. This prevents the command-line flags from dependency inputs get added multiple times on re-scan with the same service.

While during normal compilation, adding the same command-line flags multiple times are fine, it is bad for caching builds as a new compilation cache key needs to be computed every time.