### PR TITLE
[AutoDiff] Generalize handling of semantic result parameters

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -246,16 +246,17 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
   return s;
 }
 
-/// A semantic function result type: either a formal function result type or
-/// an `inout` parameter type. Used in derivative function type calculation.
+/// A semantic function result type: either a formal function result type or a
+/// semantic resul (an `inout`) parameter type. Used in derivative function type
+/// calculation.
 struct AutoDiffSemanticFunctionResultType {
   Type type;
   unsigned index : 30;
-  bool isInout : 1;
+  bool isSemanticResultParameter : 1;
   bool isWrtParam : 1;
 
-  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, bool inout, bool wrt)
-    : type(t), index(idx), isInout(inout), isWrtParam(wrt) { }
+  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, bool param, bool wrt)
+    : type(t), index(idx), isSemanticResultParameter(param), isWrtParam(wrt) { }
 };
 
 /// Key for caching SIL derivative function types.

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -253,10 +253,9 @@ struct AutoDiffSemanticFunctionResultType {
   Type type;
   unsigned index : 30;
   bool isSemanticResultParameter : 1;
-  bool isWrtParam : 1;
 
-  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, bool param, bool wrt)
-    : type(t), index(idx), isSemanticResultParameter(param), isWrtParam(wrt) { }
+  AutoDiffSemanticFunctionResultType(Type t, unsigned idx, bool param)
+    : type(t), index(idx), isSemanticResultParameter(param) { }
 };
 
 /// Key for caching SIL derivative function types.

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -247,7 +247,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
 }
 
 /// A semantic function result type: either a formal function result type or a
-/// semantic resul (an `inout`) parameter type. Used in derivative function type
+/// semantic result (an `inout`) parameter type. Used in derivative function type
 /// calculation.
 struct AutoDiffSemanticFunctionResultType {
   Type type;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3515,8 +3515,8 @@ public:
   /// Preconditions:
   /// - Parameters corresponding to parameter indices must conform to
   ///   `Differentiable`.
-  /// - There is one semantic function result type: either the formal original
-  ///   result or an `inout` parameter. It must conform to `Differentiable`.
+  /// - There are semantic function result type: either the formal original
+  ///   result or a "wrt" semantic result parameter.
   ///
   /// Differential typing rules: takes "wrt" parameter derivatives and returns a
   /// "wrt" result derivative.
@@ -3524,10 +3524,7 @@ public:
   /// - Case 1: original function has no `inout` parameters.
   ///   - Original:     `(T0, T1, ...) -> R`
   ///   - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
-  /// - Case 2: original function has a non-wrt `inout` parameter.
-  ///   - Original:     `(T0, inout T1, ...) -> Void`
-  ///   - Differential: `(T0.Tan, ...) -> T1.Tan`
-  /// - Case 3: original function has a wrt `inout` parameter.
+  /// - Case 2: original function has a wrt `inout` parameter.
   ///   - Original:     `(T0, inout T1, ...) -> Void`
   ///   - Differential: `(T0.Tan, inout T1.Tan, ...) -> Void`
   ///
@@ -3537,10 +3534,7 @@ public:
   /// - Case 1: original function has no `inout` parameters.
   ///   - Original: `(T0, T1, ...) -> R`
   ///   - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
-  /// - Case 2: original function has a non-wrt `inout` parameter.
-  ///   - Original: `(T0, inout T1, ...) -> Void`
-  ///   - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
-  /// - Case 3: original function has a wrt `inout` parameter.
+  /// - Case 2: original function has a wrt `inout` parameter.
   ///   - Original: `(T0, inout T1, ...) -> Void`
   ///   - Pullback: `(inout T1.Tan) -> (T0.Tan, ...)`
   ///

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -681,6 +681,18 @@ public:
     llvm_unreachable("invalid apply kind");
   }
 
+  AutoDiffSemanticResultArgumentRange getAutoDiffSemanticResultArguments() const {
+    switch (getKind()) {
+    case FullApplySiteKind::ApplyInst:
+      return cast<ApplyInst>(getInstruction())->getAutoDiffSemanticResultArguments();
+    case FullApplySiteKind::TryApplyInst:
+      return cast<TryApplyInst>(getInstruction())->getAutoDiffSemanticResultArguments();
+    case FullApplySiteKind::BeginApplyInst:
+      return cast<BeginApplyInst>(getInstruction())->getAutoDiffSemanticResultArguments();
+    }
+    llvm_unreachable("invalid apply kind");
+  }
+
   /// Returns true if \p op is the callee operand of this apply site
   /// and not an argument operand.
   bool isCalleeOperand(const Operand &op) const {

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -209,13 +209,13 @@ void autodiff::getFunctionSemanticResults(
 
   bool addNonWrts = resultTypes.empty();
 
-  // Collect wrt `inout` parameters as semantic results
-  // As an extention, collect all (including non-wrt) inouts as results for
-  // functions returning void.
+  // Collect wrt semantic result (`inout`) parameters as
+  // semantic results As an extention, collect all (including non-wrt) inouts as
+  // results for functions returning void.
   auto collectSemanticResults = [&](const AnyFunctionType *functionType,
                                     unsigned curryOffset = 0) {
     for (auto paramAndIndex : enumerate(functionType->getParams())) {
-      if (!paramAndIndex.value().isInOut())
+      if (!paramAndIndex.value().isAutoDiffSemanticResult())
         continue;
 
       unsigned idx = paramAndIndex.index() + curryOffset;

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -199,19 +199,16 @@ void autodiff::getFunctionSemanticResults(
     if (formalResultType->is<TupleType>()) {
       for (auto elt : formalResultType->castTo<TupleType>()->getElements()) {
         resultTypes.emplace_back(elt.getType(), resultIdx++,
-                                 /*isInout*/ false, /*isWrt*/ false);
+                                 /*isParameter*/ false);
       }
     } else {
       resultTypes.emplace_back(formalResultType, resultIdx++,
-                               /*isInout*/ false, /*isWrt*/ false);
+                               /*isParameter*/ false);
     }
   }
 
-  bool addNonWrts = resultTypes.empty();
-
   // Collect wrt semantic result (`inout`) parameters as
-  // semantic results As an extention, collect all (including non-wrt) inouts as
-  // results for functions returning void.
+  // semantic results
   auto collectSemanticResults = [&](const AnyFunctionType *functionType,
                                     unsigned curryOffset = 0) {
     for (auto paramAndIndex : enumerate(functionType->getParams())) {
@@ -221,10 +218,9 @@ void autodiff::getFunctionSemanticResults(
       unsigned idx = paramAndIndex.index() + curryOffset;
       assert(idx < parameterIndices->getCapacity() &&
              "invalid parameter index");
-      bool isWrt = parameterIndices->contains(idx);
-      if (addNonWrts || isWrt)
+      if (parameterIndices->contains(idx))
         resultTypes.emplace_back(paramAndIndex.value().getPlainType(),
-                                 resultIdx, /*isInout*/ true, isWrt);
+                                 resultIdx, /*isParameter*/ true);
       resultIdx += 1;
     }
   };

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5558,7 +5558,7 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     return llvm::make_error<DerivativeFunctionTypeError>(
         this, DerivativeFunctionTypeError::Kind::NoSemanticResults);
 
-  // Accumulate non-inout result tangent spaces.
+  // Accumulate non-semantic result tangent spaces.
   SmallVector<Type, 1> resultTanTypes, inoutTanTypes;
   for (auto i : range(originalResults.size())) {
     auto originalResult = originalResults[i];
@@ -5579,14 +5579,8 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
 
     if (!originalResult.isSemanticResultParameter)
       resultTanTypes.push_back(resultTan->getType());
-    else if (originalResult.isSemanticResultParameter && !originalResult.isWrtParam)
-      inoutTanTypes.push_back(resultTan->getType());
   }
 
-  // Treat non-wrt inouts as semantic results for functions returning Void
-  if (resultTanTypes.empty())
-    resultTanTypes = inoutTanTypes;
-  
   // Compute the result linear map function type.
   FunctionType *linearMapType;
   switch (kind) {
@@ -5597,11 +5591,7 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // - Original:     `(T0, T1, ...) -> R`
     // - Differential: `(T0.Tan, T1.Tan, ...) -> R.Tan`
     //
-    // Case 2: original function has a non-wrt `inout` parameter.
-    // - Original:      `(T0, inout T1, ...) -> Void`
-    // - Differential:  `(T0.Tan, ...) -> T1.Tan`
-    //
-    // Case 3: original function has a wrt `inout` parameter.
+    // Case 2: original function has a wrt `inout` parameter.
     // - Original:      `(T0, inout T1, ...) -> Void`
     // - Differential:  `(T0.Tan, inout T1.Tan, ...) -> Void`
     SmallVector<AnyFunctionType::Param, 4> differentialParams;
@@ -5648,11 +5638,7 @@ AnyFunctionType::getAutoDiffDerivativeFunctionLinearMapType(
     // - Original: `(T0, T1, ...) -> R`
     // - Pullback: `R.Tan -> (T0.Tan, T1.Tan, ...)`
     //
-    // Case 2: original function has a non-wrt `inout` parameter.
-    // - Original: `(T0, inout T1, ...) -> Void`
-    // - Pullback: `(T1.Tan) -> (T0.Tan, ...)`
-    //
-    // Case 3: original function has wrt `inout` parameters.
+    // Case 2: original function has wrt `inout` parameters.
     // - Original: `(T0, inout T1, ...) -> R`
     // - Pullback: `(R.Tan, inout T1.Tan) -> (T0.Tan, ...)`
     SmallVector<TupleTypeElt, 4> pullbackResults;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -253,11 +253,8 @@ IndexSubset *SILFunctionType::getDifferentiabilityResultIndices() {
     //    cases, so supporting it is a non-goal.
     //
     // See TF-1305 for solution ideas. For now, `@noDerivative` `inout`
-    // parameters are not treated as differentiability results, unless the
-    // original function has no formal results, in which case all `inout`
-    // parameters are treated as differentiability results.
-    if (resultIndices.empty() ||
-        resultParamAndIndex.value().getDifferentiability() !=
+    // parameters are not treated as differentiability results.
+    if (resultParamAndIndex.value().getDifferentiability() !=
         SILParameterDifferentiability::NotDifferentiable)
       resultIndices.push_back(getNumResults() + resultParamAndIndex.index());
 

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -138,8 +138,8 @@ void DifferentiableActivityInfo::propagateVaried(
     if (isVaried(operand->get(), i)) {
       for (auto indRes : applySite.getIndirectSILResults())
         propagateVariedInwardsThroughProjections(indRes, i);
-      for (auto inoutArg : applySite.getInoutArguments())
-        propagateVariedInwardsThroughProjections(inoutArg, i);
+      for (auto semresArg : applySite.getAutoDiffSemanticResultArguments())
+        propagateVariedInwardsThroughProjections(semresArg, i);
       // Propagate variedness to apply site direct results.
       forEachApplyDirectResult(applySite, [&](SILValue directResult) {
         setVariedAndPropagateToUsers(directResult, i);

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -147,11 +147,11 @@ void collectAllFormalResultsInTypeOrder(SILFunction &function,
   for (auto &resInfo : convs.getResults())
     results.push_back(resInfo.isFormalDirect() ? dirResults[dirResIdx++]
                                                : indResults[indResIdx++]);
-  // Treat `inout` parameters as semantic results.
-  // Append `inout` parameters after formal results.
+  // Treat semantic result parameters as semantic results.
+  // Append them` parameters after formal results.
   for (auto i : range(convs.getNumParameters())) {
     auto paramInfo = convs.getParameters()[i];
-    if (!paramInfo.isIndirectMutating())
+    if (!paramInfo.isAutoDiffSemanticResult())
       continue;
     auto *argument = function.getArgumentsWithoutIndirectResults()[i];
     results.push_back(argument);
@@ -190,6 +190,7 @@ void collectMinimalIndicesForFunctionCall(
     SmallVectorImpl<unsigned> &resultIndices) {
   auto calleeFnTy = ai->getSubstCalleeType();
   auto calleeConvs = ai->getSubstCalleeConv();
+
   // Parameter indices are indices (in the callee type signature) of parameter
   // arguments that are varied or are arguments.
   // Record all parameter indices in type order.
@@ -199,6 +200,7 @@ void collectMinimalIndicesForFunctionCall(
       paramIndices.push_back(currentParamIdx);
     ++currentParamIdx;
   }
+
   // Result indices are indices (in the callee type signature) of results that
   // are useful.
   SmallVector<SILValue, 8> directResults;
@@ -226,22 +228,21 @@ void collectMinimalIndicesForFunctionCall(
       ++indResIdx;
     }
   }
-  // Record all `inout` parameters as results.
-  auto inoutParamResultIndex = calleeFnTy->getNumResults();
+  
+  // Record all semantic result parameters as results.
+  auto semanticResultParamResultIndex = calleeFnTy->getNumResults();
   for (auto &paramAndIdx : enumerate(calleeConvs.getParameters())) {
     auto &param = paramAndIdx.value();
-    if (!param.isIndirectMutating())
+    if (!param.isAutoDiffSemanticResult())
       continue;
     unsigned idx = paramAndIdx.index() + calleeFnTy->getNumIndirectFormalResults();
-    auto inoutArg = ai->getArgument(idx);
-    results.push_back(inoutArg);
-    resultIndices.push_back(inoutParamResultIndex++);
+    results.push_back(ai->getArgument(idx));
+    resultIndices.push_back(semanticResultParamResultIndex++);
   }
+
   // Make sure the function call has active results.
 #ifndef NDEBUG
-  auto numResults = calleeFnTy->getNumResults() +
-                    calleeFnTy->getNumIndirectMutatingParameters();
-  assert(results.size() == numResults);
+  assert(results.size() == calleeFnTy->getNumAutoDiffSemanticResults());
   assert(llvm::any_of(results, [&](SILValue result) {
     return activityInfo.isActive(result, parentConfig);
   }));

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -177,7 +177,7 @@ Type LinearMapInfo::getLinearMapType(ADContext &context, ApplyInst *ai) {
   auto hasActiveResults = llvm::any_of(allResults, [&](SILValue res) {
     return activityInfo.isActive(res, config);
   });
-  bool hasActiveInoutArgument = false;
+  bool hasActiveSemanticResultArgument = false;
   bool hasActiveArguments = false;
   auto numIndirectResults = ai->getNumIndirectResults();
   for (auto argIdx : range(ai->getSubstCalleeConv().getNumParameters())) {
@@ -186,13 +186,13 @@ Type LinearMapInfo::getLinearMapType(ADContext &context, ApplyInst *ai) {
       hasActiveArguments = true;
       auto paramInfo = ai->getSubstCalleeConv().getParamInfoForSILArg(
           numIndirectResults + argIdx);
-      if (paramInfo.isIndirectMutating())
-        hasActiveInoutArgument = true;
+      if (paramInfo.isAutoDiffSemanticResult())
+        hasActiveSemanticResultArgument = true;
     }
   }
   if (!hasActiveArguments)
     return {};
-  if (!hasActiveResults && !hasActiveInoutArgument)
+  if (!hasActiveResults && !hasActiveSemanticResultArgument)
     return {};
 
   // Compute differentiability parameters.
@@ -213,9 +213,8 @@ Type LinearMapInfo::getLinearMapType(ADContext &context, ApplyInst *ai) {
         ai->getArgumentsWithoutIndirectResults().size(), activeParamIndices);
   }
   // Compute differentiability results.
-  auto numResults = remappedOrigFnSubstTy->getNumResults() +
-                    remappedOrigFnSubstTy->getNumIndirectMutatingParameters();
-  auto *results = IndexSubset::get(original->getASTContext(), numResults,
+  auto *results = IndexSubset::get(original->getASTContext(),
+                                   remappedOrigFnSubstTy->getNumAutoDiffSemanticResults(),
                                    activeResultIndices);
   // Create autodiff indices for the `apply` instruction.
   AutoDiffConfig applyConfig(parameters, results);
@@ -234,10 +233,11 @@ Type LinearMapInfo::getLinearMapType(ADContext &context, ApplyInst *ai) {
     for (auto resultIndex : applyConfig.resultIndices->getIndices()) {
       SILType remappedResultType;
       if (resultIndex >= origFnTy->getNumResults()) {
-        auto inoutArgIdx = resultIndex - origFnTy->getNumResults();
-        auto inoutArg =
-            *std::next(ai->getInoutArguments().begin(), inoutArgIdx);
-        remappedResultType = inoutArg->getType();
+        auto semanticResultArgIdx = resultIndex - origFnTy->getNumResults();
+        auto semanticResultArg =
+            *std::next(ai->getAutoDiffSemanticResultArguments().begin(),
+                       semanticResultArgIdx);
+        remappedResultType = semanticResultArg->getType();
       } else {
         remappedResultType =
             origFnTy->getResults()[resultIndex].getSILStorageInterfaceType();
@@ -277,8 +277,9 @@ Type LinearMapInfo::getLinearMapType(ADContext &context, ApplyInst *ai) {
   SmallVector<AnyFunctionType::Param, 8> params;
   for (auto &param : silFnTy->getParameters()) {
     ParameterTypeFlags flags;
-    if (param.isIndirectMutating())
+    if (param.isAutoDiffSemanticResult())
       flags = flags.withInOut(true);
+
     params.push_back(
         AnyFunctionType::Param(param.getInterfaceType(), Identifier(), flags));
   }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -544,11 +544,11 @@ emitDerivativeFunctionReference(
       for (auto resultIndex : desiredResultIndices->getIndices()) {
         SILType resultType;
         if (resultIndex >= originalFnTy->getNumResults()) {
-          auto inoutParamIdx = resultIndex - originalFnTy->getNumResults();
-          auto inoutParam =
-              *std::next(originalFnTy->getIndirectMutatingParameters().begin(),
-                         inoutParamIdx);
-          resultType = inoutParam.getSILStorageInterfaceType();
+          auto semanticResultParamIdx = resultIndex - originalFnTy->getNumResults();
+          auto semanticResultParam =
+              *std::next(originalFnTy->getAutoDiffSemanticResultsParameters().begin(),
+                         semanticResultParamIdx);
+          resultType = semanticResultParam.getSILStorageInterfaceType();
         } else {
           resultType = originalFnTy->getResults()[resultIndex]
                            .getSILStorageInterfaceType();

--- a/test/AutoDiff/SILGen/inout_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/inout_differentiability_witness.swift
@@ -17,7 +17,7 @@ func test3(x: Int, y: inout DiffableStruct, z: Float) -> (Float, Float) { return
 @differentiable(reverse, wrt: y)
 func test4(x: Int, y: inout DiffableStruct, z: Float) -> Void { }
 
-@differentiable(reverse, wrt: z)
+@differentiable(reverse, wrt: (y, z))
 func test5(x: Int, y: inout DiffableStruct, z: Float) -> Void { }
 
 @differentiable(reverse, wrt: (y, z))
@@ -48,9 +48,9 @@ func test6(x: Int, y: inout DiffableStruct, z: Float) -> (Float, Float) { return
 // CHECK: }
 
 // CHECK-LABEL: differentiability witness for test5(x:y:z:)
-// CHECK: sil_differentiability_witness hidden [reverse] [parameters 2] [results 0] @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> () {
-// CHECK:   jvp: @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftFTJfUUSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (Float) -> @out DiffableStruct.TangentVector
-// CHECK:   vjp: @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftFTJrUUSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@in_guaranteed DiffableStruct.TangentVector) -> Float
+// CHECK: sil_differentiability_witness hidden [reverse] [parameters 1 2] [results 0] @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftF : $@convention(thin) (Int, @inout DiffableStruct, Float) -> () {
+// CHECK:   jvp: @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftFTJfUSSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@inout DiffableStruct.TangentVector, Float) -> ()
+// CHECK:   vjp: @$s31inout_differentiability_witness5test51x1y1zySi_AA14DiffableStructVzSftFTJrUSSpSr : $@convention(thin) (Int, @inout DiffableStruct, Float) -> @owned @callee_guaranteed (@inout DiffableStruct.TangentVector) -> Float
 // CHECK: }
 
 // CHECK-LABEL: differentiability witness for test6(x:y:z:)

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -12,7 +12,7 @@ protocol Protocol: Differentiable {
   @differentiable(reverse)
   var property: Float { get set }
 
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (self, x))
   subscript(_ x: Float, _ y: Float) -> Float { get set }
 }
 
@@ -82,22 +82,22 @@ struct Struct: Protocol {
   // CHECK: apply [[VJP_FN]]
   // CHECK: }
 
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (self, x))
   subscript(_ x: Float, _ y: Float) -> Float {
     get { x }
     set {}
   }
 
-  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SUU : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SUS : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, @in_guaranteed τ_0_0) -> Float for <DummyTangentVector>)
   // CHECK: [[ORIG_FN:%.*]] = function_ref @$s13witness_table6StructVyS2f_Sftcig : $@convention(method) (Float, Float, Struct) -> Float
-  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [results 0] [[ORIG_FN]]
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0 2] [results 0] [[ORIG_FN]]
   // CHECK: [[JVP_FN:%.*]] = differentiable_function_extract [jvp] [[DIFF_FN]]
   // CHECK: apply [[JVP_FN]]
   // CHECK: }
 
-  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUU : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUS : $@convention(witness_method: Protocol) (Float, Float, @in_guaranteed Struct) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, @out τ_0_0) for <DummyTangentVector>)
   // CHECK: [[ORIG_FN:%.*]] = function_ref @$s13witness_table6StructVyS2f_Sftcig : $@convention(method) (Float, Float, Struct) -> Float
-  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [results 0] [[ORIG_FN]]
+  // CHECK: [[DIFF_FN:%.*]] = differentiable_function [parameters 0 2] [results 0] [[ORIG_FN]]
   // CHECK: [[VJP_FN:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]]
   // CHECK: apply [[VJP_FN]]
   // CHECK: }
@@ -118,10 +118,10 @@ struct Struct: Protocol {
 // CHECK-NEXT:   method #Protocol.property!setter.vjp.SS.<Self where Self : Protocol>: <Self where Self : Protocol> (inout Self) -> (Float) -> () : @AD__$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvsTW_vjp_SS
 // CHECK-NEXT:   method #Protocol.property!modify: <Self where Self : Protocol> (inout Self) -> () -> () : @$s13witness_table6StructVAA8ProtocolA2aDP8propertySfvMTW
 // CHECK-NEXT:   method #Protocol.subscript!getter: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW
-// CHECK-NEXT:   method #Protocol.subscript!getter.jvp.SUU.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SU
-// CHECK-NEXT:   method #Protocol.subscript!getter.vjp.SUU.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUU
+// CHECK-NEXT:   method #Protocol.subscript!getter.jvp.SUS.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_jvp_SUS
+// CHECK-NEXT:   method #Protocol.subscript!getter.vjp.SUS.<Self where Self : Protocol>: <Self where Self : Protocol> (Self) -> (Float, Float) -> Float : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcigTW_vjp_SUS
 // CHECK-NEXT:   method #Protocol.subscript!setter: <Self where Self : Protocol> (inout Self) -> (Float, Float, Float) -> () : @$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcisTW
-// CHECK-NEXT:   method #Protocol.subscript!setter.jvp.USUU.<Self where Self : Protocol>: <Self where Self : Protocol> (inout Self) -> (Float, Float, Float) -> () : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcisTW_jvp_USUU
-// CHECK-NEXT:   method #Protocol.subscript!setter.vjp.USUU.<Self where Self : Protocol>: <Self where Self : Protocol> (inout Self) -> (Float, Float, Float) -> () : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcisTW_vjp_USUU
+// CHECK-NEXT:   method #Protocol.subscript!setter.jvp.USUS.<Self where Self : Protocol>: <Self where Self : Protocol> (inout Self) -> (Float, Float, Float) -> () : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcisTW_jvp_USUS
+// CHECK-NEXT:   method #Protocol.subscript!setter.vjp.USUS.<Self where Self : Protocol>: <Self where Self : Protocol> (inout Self) -> (Float, Float, Float) -> () : @AD__$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftcisTW_vjp_USUS
 // CHECK-NEXT:   method #Protocol.subscript!modify: <Self where Self : Protocol> (inout Self) -> (Float, Float) -> () : @$s13witness_table6StructVAA8ProtocolA2aDPyS2f_SftciMTW
 // CHECK: }

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -400,11 +400,11 @@ func activeInoutParamControlFlowComplex(_ array: [Float], _ bool: Bool) -> Float
 
 struct Mut: Differentiable {}
 extension Mut {
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (self, x))
   mutating func mutatingMethod(_ x: Mut) {}
 }
 
-@differentiable(reverse, wrt: x)
+@differentiable(reverse, wrt: (nonactive, x))
 func nonActiveInoutParam(_ nonactive: inout Mut, _ x: Mut) {
   nonactive.mutatingMethod(x)
 }
@@ -416,14 +416,14 @@ func activeInoutParamMutatingMethod(_ x: Mut) -> Mut {
   return result
 }
 
-@differentiable(reverse, wrt: x)
+@differentiable(reverse, wrt: (nonactive, x))
 func activeInoutParamMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) {
   var result = nonactive
   result.mutatingMethod(x)
   nonactive = result
 }
 
-@differentiable(reverse, wrt: x)
+@differentiable(reverse, wrt: (nonactive, x))
 func activeInoutParamMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) {
   var result = (nonactive, x)
   result.0.mutatingMethod(result.0)

--- a/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
@@ -89,7 +89,7 @@ func activeInoutParamControlFlow(_ array: [Float]) -> Float {
 struct X: Differentiable {
   var x: Float
 
-  @differentiable(reverse, wrt: y)
+  @differentiable(reverse, wrt: (self, y))
   mutating func mutate(_ y: X) { self.x = y.x }
 }
 
@@ -104,7 +104,7 @@ func activeMutatingMethod(_ x: Float) -> Float {
 
 struct Mut: Differentiable {}
 extension Mut {
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (self, x))
   mutating func mutatingMethod(_ x: Mut) {}
 }
 

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -769,7 +769,8 @@ struct InoutParameters: Differentiable {
 }
 
 extension InoutParameters {
-  // expected-note @+1 4 {{'staticMethod(_:rhs:)' defined here}}
+  // expected-note @+2 {{'staticMethod(_:rhs:)' defined here}}
+  // expected-note @+1 {{'staticMethod(_:rhs:)' defined here}}
   static func staticMethod(_ lhs: inout Self, rhs: Self) {}
 
   // Test wrt `inout` parameter.
@@ -800,33 +801,34 @@ extension InoutParameters {
 
   // Test non-wrt `inout` parameter.
 
+  // expected-error @+1 {{cannot differentiate void function 'staticMethod(_:rhs:)'}}
   @derivative(of: staticMethod, wrt: rhs)
   static func vjpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
     value: Void, pullback: (TangentVector) -> TangentVector
   ) { fatalError() }
 
-  // expected-error @+1 {{function result's 'pullback' type does not match 'staticMethod(_:rhs:)'}}
+  // expected-error @+1 {{cannot differentiate void function 'staticMethod(_:rhs:)'}}
   @derivative(of: staticMethod, wrt: rhs)
   static func vjpNotWrtInoutMismatch(_ lhs: inout Self, _ rhs: Self) -> (
-    // expected-note @+1 {{'pullback' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
     value: Void, pullback: (inout TangentVector) -> TangentVector
   ) { fatalError() }
 
+  // expected-error @+1 {{cannot differentiate void function 'staticMethod(_:rhs:)'}}
   @derivative(of: staticMethod, wrt: rhs)
   static func jvpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
     value: Void, differential: (TangentVector) -> TangentVector
   ) { fatalError() }
 
-  // expected-error @+1 {{function result's 'differential' type does not match 'staticMethod(_:rhs:)'}}
+  // expected-error @+1 {{cannot differentiate void function 'staticMethod(_:rhs:)'}}
   @derivative(of: staticMethod, wrt: rhs)
   static func jvpNotWrtInout(_ lhs: inout Self, _ rhs: Self) -> (
-    // expected-note @+1 {{'differential' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
     value: Void, differential: (inout TangentVector) -> TangentVector
   ) { fatalError() }
 }
 
 extension InoutParameters {
-  // expected-note @+1 4 {{'mutatingMethod' defined here}}
+  // expected-note @+2 {{'mutatingMethod' defined here}}
+  // expected-note @+1 {{'mutatingMethod' defined here}}  
   mutating func mutatingMethod(_ other: Self) {}
 
   // Test wrt `inout` `self` parameter.
@@ -857,27 +859,27 @@ extension InoutParameters {
 
   // Test non-wrt `inout` `self` parameter.
 
+  // expected-error @+1 {{cannot differentiate void function 'mutatingMethod'}}
   @derivative(of: mutatingMethod, wrt: other)
   mutating func vjpNotWrtInout(_ other: Self) -> (
     value: Void, pullback: (TangentVector) -> TangentVector
   ) { fatalError() }
 
-  // expected-error @+1 {{function result's 'pullback' type does not match 'mutatingMethod'}}
+  // expected-error @+1 {{cannot differentiate void function 'mutatingMethod'}}
   @derivative(of: mutatingMethod, wrt: other)
   mutating func vjpNotWrtInoutMismatch(_ other: Self) -> (
-    // expected-note @+1 {{'pullback' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
     value: Void, pullback: (inout TangentVector) -> TangentVector
   ) { fatalError() }
 
+  // expected-error @+1 {{cannot differentiate void function 'mutatingMethod'}}
   @derivative(of: mutatingMethod, wrt: other)
   mutating func jvpNotWrtInout(_ other: Self) -> (
     value: Void, differential: (TangentVector) -> TangentVector
   ) { fatalError() }
 
-  // expected-error @+1 {{function result's 'differential' type does not match 'mutatingMethod'}}
+  // expected-error @+1 {{cannot differentiate void function 'mutatingMethod'}}
   @derivative(of: mutatingMethod, wrt: other)
   mutating func jvpNotWrtInoutMismatch(_ other: Self) -> (
-    // expected-note @+1 {{'differential' does not have expected type '(InoutParameters.TangentVector) -> InoutParameters.TangentVector' (aka '(DummyTangentVector) -> DummyTangentVector')}}
     value: Void, differential: (TangentVector, TangentVector) -> Void
   ) { fatalError() }
 }

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -681,7 +681,7 @@ struct InoutParameters: Differentiable {
 }
 
 extension NonDiffableStruct {
-  // expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'NonDiffableStruct' does not conform to 'Differentiable'}}
+  // expected-error @+1 {{cannot differentiate void function 'nondiffResult(x:y:z:)'}}
   @differentiable(reverse)
   static func nondiffResult(x: Int, y: inout NonDiffableStruct, z: Float) {}
 

--- a/test/AutoDiff/compiler_crashers_fixed/issue-55745-noderivative-inout-parameter.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-55745-noderivative-inout-parameter.swift
@@ -4,15 +4,16 @@ import _Differentiation
 
 // https://github.com/apple/swift/issues/55745
 // Test protocol witness thunk for `@differentiable` protocol requirement, where
-// the required method has a non-wrt `inout` parameter that should be treated as
-// a differentiability result.
+// the required method has a non-wrt `inout` parameter.
 
 protocol Proto {
+  // expected-error @+1 {{cannot differentiate void function 'method(x:y:)'}}
   @differentiable(reverse, wrt: x)
   func method(x: Float, y: inout Float)
 }
 
 struct Struct: Proto {
+  // expected-error @+1 {{cannot differentiate void function 'method(x:y:)'}}  
   @differentiable(reverse, wrt: x)
   func method(x: Float, y: inout Float) {
     y = y * x

--- a/test/AutoDiff/validation-test/forward_mode_simple.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simple.swift
@@ -1320,28 +1320,13 @@ ForwardModeTests.test("ForceUnwrapping") {
 }
 
 ForwardModeTests.test("NonVariedResult") {
-  @differentiable(reverse, wrt: x)
-  func nonWrtInoutParam<T: Differentiable>(_ x: T, _ y: inout T) {
-    y = x
-  }
-
   @differentiable(reverse)
   func wrtInoutParam<T: Differentiable>(_ x: T, _ y: inout T) {
     y = x
   }
 
-  @differentiable(reverse, wrt: x)
-  func nonWrtInoutParamNonVaried<T: Differentiable>(_ x: T, _ y: inout T) {}
-
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (x, y))
   func wrtInoutParamNonVaried<T: Differentiable>(_ x: T, _ y: inout T) {}
-
-  @differentiable(reverse)
-  func variedResultTracked(_ x: Tracked<Float>) -> Tracked<Float> {
-    var result: Tracked<Float> = 0
-    nonWrtInoutParam(x, &result)
-    return result
-  }
 
   @differentiable(reverse)
   func variedResultTracked2(_ x: Tracked<Float>) -> Tracked<Float> {
@@ -1352,13 +1337,6 @@ ForwardModeTests.test("NonVariedResult") {
 
   @differentiable(reverse)
   func nonVariedResultTracked(_ x: Tracked<Float>) -> Tracked<Float> {
-    var result: Tracked<Float> = 0
-    nonWrtInoutParamNonVaried(x, &result)
-    return result
-  }
-
-  @differentiable(reverse)
-  func nonVariedResultTracked2(_ x: Tracked<Float>) -> Tracked<Float> {
     // expected-warning @+1 {{variable 'result' was never mutated}}
     var result: Tracked<Float> = 0
     return result

--- a/test/AutoDiff/validation-test/inout_parameters.swift
+++ b/test/AutoDiff/validation-test/inout_parameters.swift
@@ -191,26 +191,27 @@ InoutParameterAutoDiffTests.test("InoutClassParameter") {
   }
 }
 
-// https://github.com/apple/swift/issues/55745
-// Test function with non-wrt `inout` parameter, which should be
-// treated as a differentiability result.
+// Test function with wrt `inout` parameter, which should be treated as a differentiability result.
+// Original issue https://github.com/apple/swift/issues/55745 deals with non-wrt `inout` which
+// we explicitly disallow now
+
 
 protocol P_55745 {
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (x, y))
   func method(_ x: Float, _ y: inout Float)
 
-  @differentiable(reverse, wrt: x)
+  @differentiable(reverse, wrt: (x, y))
   func genericMethod<T: Differentiable>(_ x: T, _ y: inout T)
 }
 
 InoutParameterAutoDiffTests.test("non-wrt inout parameter") {
   struct Struct: P_55745 {
-    @differentiable(reverse, wrt: x)
+    @differentiable(reverse, wrt: (x, y))
     func method(_ x: Float, _ y: inout Float) {
       y = y * x
     }
 
-    @differentiable(reverse, wrt: x)
+    @differentiable(reverse, wrt: (x, y))
     func genericMethod<T: Differentiable>(_ x: T, _ y: inout T) {
       y = x
     }


### PR DESCRIPTION
Introduce "semantic result parameters" abstraction and treat inouts via this abstraction only.
Do not consider non-wrt semantic result parameters as semantic results

Fixes https://github.com/apple/swift/issues/67174