### PR TITLE
[cxx-interop] Mark C++ functions with unavailable return type as unav…

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -283,8 +283,9 @@ public:
 
   virtual bool isUnsafeCXXMethod(const FuncDecl *func) = 0;
 
-  virtual Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
-                                        DeclContext *dc) = 0;
+  virtual llvm::Optional<Type>
+  importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                           DeclContext *dc) = 0;
 
   virtual Type importVarDeclType(const clang::VarDecl *clangDecl,
                                  VarDecl *swiftDecl,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -531,8 +531,9 @@ public:
       const clang::NamedDecl *D,
       clang::DeclarationName givenName = clang::DeclarationName()) override;
 
-  Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
-                                 DeclContext *dc) override;
+  llvm::Optional<Type>
+  importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                           DeclContext *dc) override;
 
   Type importVarDeclType(const clang::VarDecl *clangDecl,
                          VarDecl *swiftDecl,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5707,8 +5707,9 @@ importName(const clang::NamedDecl *D,
     getDeclName();
 }
 
-Type ClangImporter::importFunctionReturnType(
-    const clang::FunctionDecl *clangDecl, DeclContext *dc) {
+llvm::Optional<Type>
+ClangImporter::importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                                        DeclContext *dc) {
   bool isInSystemModule =
       cast<ClangModuleUnit>(dc->getModuleScopeContext())->isSystemModule();
   bool allowNSUIntegerAsInt =
@@ -5717,7 +5718,7 @@ Type ClangImporter::importFunctionReturnType(
           Impl.importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt)
               .getType())
     return imported;
-  return dc->getASTContext().getNeverType();
+  return {};
 }
 
 Type ClangImporter::importVarDeclType(

--- a/test/Interop/Cxx/class/returns-unavailable-class.swift
+++ b/test/Interop/Cxx/class/returns-unavailable-class.swift
@@ -1,0 +1,76 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift
+
+//--- Inputs/module.modulemap
+module CxxTypes {
+    header "types.h"
+    requires cplusplus
+}
+
+module CxxModule {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/types.h
+
+template<class T>
+class TemplateInTypesModule {
+public:
+    T x, y;
+};
+
+//--- Inputs/header.h
+
+#pragma clang module import CxxTypes
+
+class Struct {
+public:
+    int x, y;
+
+    TemplateInTypesModule<int> returnsClassInTypesModules() const;
+
+    void takesClassInTypesModules(TemplateInTypesModule<int>) const;
+    void takesClassInTypesModulesRef(const TemplateInTypesModule<int> &) const;
+};
+
+// CHECK: struct Struct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   func returnsClassInTypesModules() -> Never
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT:   var y: Int32
+// CHECK-NEXT: }
+
+TemplateInTypesModule<int> funcWithClassInTypesModules();
+void funcWithClassInTypesModulesParam(TemplateInTypesModule<int>);
+void funcWithClassInTypesModulesParamRef(const TemplateInTypesModule<int> &);
+
+class StructPrivateDestructor {
+public:
+    StructPrivateDestructor();
+private:
+    ~StructPrivateDestructor();
+};
+
+StructPrivateDestructor returnsStructPrivateDestructor();
+
+//--- test.swift
+
+import CxxModule
+
+func test() {
+    funcWithClassInTypesModules() // expected-error {{'funcWithClassInTypesModules()' is unavailable: return type is unavailable in Swift}}
+    Struct().returnsClassInTypesModules() // expected-error {{'returnsClassInTypesModules()' is unavailable: return type is unavailable in Swift}}
+}
+
+func test2() {
+    funcWithClassInTypesModules() // expected-error {{'funcWithClassInTypesModules()' is unavailable: return type is unavailable in Swift}}
+}
+
+func testPrivateDesType() {
+    returnsStructPrivateDestructor() // expected-error {{'returnsStructPrivateDestructor()' is unavailable: return type is unavailable in Swift}}
+}


### PR DESCRIPTION
…ailable

This prevents users from calling functions with unsupported or unavailable return types. This ensures that users don't for example call a function that returns a non-copyable and non-movable type

Fixes https://github.com/apple/swift/issues/64401
