### PR TITLE
[cxx-interop] Mark C++ functions with unavailable return type as unav…

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -283,8 +283,9 @@ public:
 
   virtual bool isUnsafeCXXMethod(const FuncDecl *func) = 0;
 
-  virtual Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
-                                        DeclContext *dc) = 0;
+  virtual llvm::Optional<Type>
+  importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                           DeclContext *dc) = 0;
 
   virtual Type importVarDeclType(const clang::VarDecl *clangDecl,
                                  VarDecl *swiftDecl,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -520,8 +520,9 @@ public:
       const clang::NamedDecl *D,
       clang::DeclarationName givenName = clang::DeclarationName()) override;
 
-  Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
-                                 DeclContext *dc) override;
+  llvm::Optional<Type>
+  importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                           DeclContext *dc) override;
 
   Type importVarDeclType(const clang::VarDecl *clangDecl,
                          VarDecl *swiftDecl,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5648,8 +5648,9 @@ importName(const clang::NamedDecl *D,
     getDeclName();
 }
 
-Type ClangImporter::importFunctionReturnType(
-    const clang::FunctionDecl *clangDecl, DeclContext *dc) {
+llvm::Optional<Type>
+ClangImporter::importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                                        DeclContext *dc) {
   bool isInSystemModule =
       cast<ClangModuleUnit>(dc->getModuleScopeContext())->isSystemModule();
   bool allowNSUIntegerAsInt =
@@ -5658,7 +5659,7 @@ Type ClangImporter::importFunctionReturnType(
           Impl.importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt)
               .getType())
     return imported;
-  return dc->getASTContext().getNeverType();
+  return {};
 }
 
 Type ClangImporter::importVarDeclType(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2129,8 +2129,21 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   if (!resultTyRepr && decl->getClangDecl() &&
       isa<clang::FunctionDecl>(decl->getClangDecl())) {
     auto clangFn = cast<clang::FunctionDecl>(decl->getClangDecl());
-    return ctx.getClangModuleLoader()->importFunctionReturnType(
+    auto returnType = ctx.getClangModuleLoader()->importFunctionReturnType(
         clangFn, decl->getDeclContext());
+    if (returnType)
+      return *returnType;
+    // Mark the imported Swift function as unavailable.
+    // That will ensure that the function will not be
+    // usable from Swift, even though it is imported.
+    if (!decl->getAttrs().isUnavailable(ctx)) {
+      StringRef unavailabilityMsgRef = "return type is unavailable in Swift";
+      auto ua =
+          AvailableAttr::createPlatformAgnostic(ctx, unavailabilityMsgRef);
+      decl->getAttrs().add(ua);
+    }
+
+    return ctx.getNeverType();
   }
 
   // Nothing to do if there's no result type.

--- a/test/Interop/Cxx/class/returns-unavailable-class.swift
+++ b/test/Interop/Cxx/class/returns-unavailable-class.swift
@@ -1,0 +1,76 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift
+
+//--- Inputs/module.modulemap
+module CxxTypes {
+    header "types.h"
+    requires cplusplus
+}
+
+module CxxModule {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/types.h
+
+template<class T>
+class TemplateInTypesModule {
+public:
+    T x, y;
+};
+
+//--- Inputs/header.h
+
+#pragma clang module import CxxTypes
+
+class Struct {
+public:
+    int x, y;
+
+    TemplateInTypesModule<int> returnsClassInTypesModules() const;
+
+    void takesClassInTypesModules(TemplateInTypesModule<int>) const;
+    void takesClassInTypesModulesRef(const TemplateInTypesModule<int> &) const;
+};
+
+// CHECK: struct Struct {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(x: Int32, y: Int32)
+// CHECK-NEXT:   func returnsClassInTypesModules() -> Never
+// CHECK-NEXT:   var x: Int32
+// CHECK-NEXT:   var y: Int32
+// CHECK-NEXT: }
+
+TemplateInTypesModule<int> funcWithClassInTypesModules();
+void funcWithClassInTypesModulesParam(TemplateInTypesModule<int>);
+void funcWithClassInTypesModulesParamRef(const TemplateInTypesModule<int> &);
+
+class StructPrivateDestructor {
+public:
+    StructPrivateDestructor();
+private:
+    ~StructPrivateDestructor();
+};
+
+StructPrivateDestructor returnsStructPrivateDestructor();
+
+//--- test.swift
+
+import CxxModule
+
+func test() {
+    funcWithClassInTypesModules() // expected-error {{'funcWithClassInTypesModules()' is unavailable: return type is unavailable in Swift}}
+    Struct().returnsClassInTypesModules() // expected-error {{'returnsClassInTypesModules()' is unavailable: return type is unavailable in Swift}}
+}
+
+func test2() {
+    funcWithClassInTypesModules() // expected-error {{'funcWithClassInTypesModules()' is unavailable: return type is unavailable in Swift}}
+}
+
+func testPrivateDesType() {
+    returnsStructPrivateDestructor() // expected-error {{'returnsStructPrivateDestructor()' is unavailable: return type is unavailable in Swift}}
+}


### PR DESCRIPTION
…ailable

This prevents users from calling functions with unsupported or unavailable return types. This ensures that users don't for example call a function that returns a non-copyable and non-movable type

Fixes https://github.com/apple/swift/issues/64401


- Explanation: Swift's clang importer imports functions without knowing their imported return type, sometimes. This is important as we must delay the evaluation of the C++ return type in some cases. When the imported return type is not known, it's imported and mapped into Swift later, during the evaluation of the function's return type request. However, not all C++ types can be imported, they're either unsupported (e.g. non-copyable) or unavailable (from an unexported module). In this case, clang importer sets the function's type to be `Never`. This works as a placeholder, but it doesn't produce errors to users in all cases. For instance, the user can still call a function and store its value into a `let` constant, even if it's `Never`. And then the underlying C++ type won't be correctly operated on, for instance, if it needs to be destroyed with a custom C++ destructor, causing potential leaks. This change plugs this hole by ensuring we at least mark such functions as unavailable when we know that their return type is unsupported. This specific fix is a compromise as it's not ideal to make such a change to the function when computing the return type, but the previous approach of determining this earlier (https://github.com/apple/swift/pull/65105) didn't work out as it caused semantics issues with some C++ member functions.
- Scope: C++ interop, function result type request. 
- Risk: Low, affects only the path of unsupported/unavailable C++ return type for an imported function.
- Testing: Unit tests, adopter testing.
- Original PR: https://github.com/apple/swift/pull/67234