### PR TITLE
[🍒][cxx-interop] Break when we find a linkage specification when traversing all decls in IRGen.

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -188,6 +188,9 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
       if (isa<clang::TagDecl>(DC)) {
         break;
       }
+      if (isa<clang::LinkageSpecDecl>(DC)) {
+        break;
+      }
       D = cast<const clang::Decl>(DC);
     }
     if (!GlobalClangDecls.insert(D->getCanonicalDecl()).second) {

--- a/test/Interop/Cxx/extern-c/Inputs/inline-func.h
+++ b/test/Interop/Cxx/extern-c/Inputs/inline-func.h
@@ -1,0 +1,18 @@
+extern "C" {
+
+inline void inlineFn();
+
+void cacheMis() { }
+void incorrectCacheHit() {
+  inlineFn();
+}
+
+static void caller() {
+  cacheMis();
+  incorrectCacheHit();
+}
+
+inline void inlineFn() { }
+
+}
+

--- a/test/Interop/Cxx/extern-c/Inputs/module.modulemap
+++ b/test/Interop/Cxx/extern-c/Inputs/module.modulemap
@@ -2,3 +2,8 @@ module ExternC {
   header "extern-c.h"
   requires cplusplus
 }
+
+module InlineFunc {
+  header "inline-func.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/extern-c/inline-func.swift
+++ b/test/Interop/Cxx/extern-c/inline-func.swift
@@ -1,0 +1,8 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+// REQUIRES: executable_test
+
+import InlineFunc
+
+public func test() {
+  caller()
+}


### PR DESCRIPTION
Description: Fixes a bug where we'd find the linkage specification decl as the canonical parent decl of multiple functions. This linkage specification decl was the same for multiple functions and we'd cache it. So when we hit the cache, we wouldn't visit the other (sibling) functions, resulting in linker errors. 
Scope: C++ interop
Risk: Low, trivial change, only effects C++ interop.
Testing: Unit testing (CI)
Original PR: https://github.com/apple/swift/pull/67211
Radar: rdar://110439422