### PR TITLE
[OptimizeHopToExecutor] Don't hop for begin_borrow/end_borrow.

### DIFF
--- a/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
+++ b/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
@@ -331,6 +331,14 @@ bool OptimizeHopToExecutor::needsExecutor(SILInstruction *inst) {
   if (auto *copy = dyn_cast<CopyAddrInst>(inst)) {
     return isGlobalMemory(copy->getSrc()) || isGlobalMemory(copy->getDest());
   }
+  // BeginBorrowInst and EndBorrowInst currently have
+  // MemoryBehavior::MayHaveSideEffects.  Fixing that is tracked by
+  // rdar://111875527.  These instructions only have effects in the sense of
+  // memory dependencies, which aren't relevant for hop_to_executor
+  // elimination.
+  if (isa<BeginBorrowInst>(inst) || isa<EndBorrowInst>(inst)) {
+    return false;
+  }
   return inst->mayReadOrWriteMemory();
 }
 

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -278,3 +278,27 @@ bb0(%0 : @guaranteed $MyActor):
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil [ossa] @handleBeginBorrow : {{.*}} {
+// CHECK-NOT:     hop_to_executor
+// CHECK-LABEL: } // end sil function 'handleBeginBorrow'
+sil [ossa] @handleBeginBorrow : $@convention(method) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  hop_to_executor %0 : $MyActor
+  %b = begin_borrow %0 : $MyActor
+  end_borrow %b : $MyActor
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @handleEndBorrow : {{.*}} {
+// CHECK-NOT:     hop_to_executor
+// CHECK-LABEL: } // end sil function 'handleEndBorrow'
+sil [ossa] @handleEndBorrow : $@convention(method) @async (@guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %b = begin_borrow %0 : $MyActor
+  hop_to_executor %0 : $MyActor
+  end_borrow %b : $MyActor
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
Although they currently have `MemoryBehavior::MayHaveSideEffects`, the `begin_borrow` and `end_borrow` instructions do not have side-effects of interest to this pass.
