### PR TITLE
[interop][SwiftToCxx] ensure swift::Int and swift::UInt are usable in…

### DIFF
--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -93,8 +93,7 @@
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSdN;
 // CHECK-NEXT: // type metadata address for OpaquePointer.
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss13OpaquePointerVN;
-// CHECK-EMPTY:
-// CHECK-NEXT: #ifdef __cplusplus
+// CHECK: #ifdef __cplusplus
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 // CHECK-EMPTY:
@@ -224,7 +223,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-EMPTY:
-// CHECK-NEXT: #pragma clang diagnostic pop
+// CHECK: #pragma clang diagnostic pop
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
@@ -17,5 +17,10 @@ public func test() -> String {
     return ""
 }
 
+@_expose(Cxx)
+public func testIntArray() -> [Int] {
+    return []
+}
+
 // CHECK: namespace swift SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("swift") {
 // CHECK: class SWIFT_SYMBOL("{{.*}}") String final {


### PR DESCRIPTION
… generic context
