### PR TITLE
[5.9][build] Make sure SPM is built with the forked clang, not the host clang

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -48,6 +48,7 @@ class SwiftPM(product.Product):
 
         toolchain_path = self.native_toolchain_path(host_target)
         swiftc = os.path.join(toolchain_path, "bin", "swiftc")
+        clang = os.path.join(toolchain_path, "bin", "clang")
 
         # FIXME: We require llbuild build directory in order to build. Is
         # there a better way to get this?
@@ -67,7 +68,7 @@ class SwiftPM(product.Product):
 
         helper_cmd += [
             "--swiftc-path", swiftc,
-            "--clang-path", self.toolchain.cc,
+            "--clang-path", clang,
             "--cmake-path", self.toolchain.cmake,
             "--ninja-path", self.toolchain.ninja,
             "--build-dir", self.build_dir,


### PR DESCRIPTION
Cherrypick of #64629

__Explanation:__ SPM was built with the freshly-built Swift toolchain, including the Swift-forked clang, for years, but a change in apple/swift-package-manager#5894 late last year inadvertently switched it to be built with the system clang used to natively build the Swift compiler, ie `self.toolchain.cc` in `build-script`. That passed the CI but caused problems when cross-compiling SPM on my daily Android CI, as the system clang is only meant for native compilation- for example, [we use the freshly-built Swift-forked clang for the native host by default when cross-compiling the Swift compiler itself](https://github.com/apple/swift/blob/80e4e0465c76749dfc4ec45405ce1588d739ec76/utils/build-script-impl#L1773)- so I've been using [this patch for the last seven months on my Android CI](https://github.com/finagolfin/swift-android-sdk/commit/8bb330b216c8af01e046bab35eb7f492d0842f98#diff-1d2c5fe1e8bb2625975dc65af9af541252788b229ecadc07ee12905499fcbc51R24).

__Scope:__ Only affects the C/C++/asm files built as part of SwiftPM, particularly when cross-compiled

__Issue:__ None

__Risk:__ low, as this only affects compilation of non-Swift portions of SPM itself

__Testing:__ Passed all CI on trunk and I've been using this on my Android CI since last year

__Reviewer:__ @etcwilde