### PR TITLE
[5.9] SILGen: Provide a reabstracted writeback for inout parameters emitted in a more abstract closure literal context.

### DIFF
--- a/test/SILGen/inout_reabstracted_closure_literal.swift
+++ b/test/SILGen/inout_reabstracted_closure_literal.swift
@@ -1,0 +1,66 @@
+// RUN: %target-swift-emit-silgen %s
+
+func bar<T>(f: (inout T) throws -> Void) {}
+
+func condition() -> Bool { fatalError() }
+func error() -> Error { fatalError() }
+
+func foo(x: @escaping () -> Void) {
+    // CHECK-LABEL: sil private [ossa] @${{.*}}3foo{{.*}}U_ :
+    // CHECK:       bb0(
+    // CHECK-SAME:    [[ARG:%.*]] = $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>,
+    // CHECK-SAME:    [[CAPTURE:%.*]] = @closureCapture @guaranteed $@callee_guaranteed () -> ()
+
+    // Reabstract the initial value of the inout parameter
+    // CHECK:         [[INITIAL:%.*]] = load [take] [[ARG]]
+    // CHECK:         [[INITIAL_CONV:%.*]] = convert_function [[INITIAL]]
+    // CHECK:         [[THUNK:%.*]] = function_ref @{{.*}}_TR
+    // CHECK:         [[INITIAL_REAB:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[INITIAL_CONV]])
+    // CHECK:         [[REAB_ARG:%.*]] = alloc_stack
+    // CHECK:         store [[INITIAL_REAB]] to [[REAB_ARG]]
+    bar {
+        // Read from the reabstracted buffer
+        //  CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[REAB_ARG]]
+        //  CHECK: [[COPY]] = load [copy] [[ACCESS]]
+        _ = $0 as () -> Void
+
+        // Assign to the reabstracted buffer
+        $0 = x
+
+        // Writeback occurs no matter how we exit the function
+        // CHECK:   cond_br {{%.*}}, [[THEN1:bb[0-9]+]], [[ELSE1:bb[0-9]+]]
+        if condition() {
+            // Throwing:
+            // CHECK: [[THEN1]]:
+            // Take final reabstracted value from the reabstracted buffer
+            // CHECK:   [[FINAL_REAB:%.*]] = load [take] [[REAB_ARG]]
+            // Reabstract back to original representation and store back to
+            // original buffer
+            // CHECK:   [[THUNK_ORIG:%.*]] = function_ref @{{.*}}_TR
+            // CHECK:   [[FINAL_CONV:%.*]] = partial_apply [callee_guaranteed] [[THUNK_ORIG]]([[FINAL_REAB]])
+            // CHECK:   [[FINAL:%.*]] = convert_function [[FINAL_CONV]]
+            // CHECK:   store [[FINAL]] to [[ARG]]
+            // CHECK:   throw
+            throw error()
+        // CHECK: [[ELSE1]]:
+        // CHECK:   cond_br {{%.*}}, [[THEN2:bb[0-9]+]], [[ELSE2:bb[0-9]+]]
+        } else if condition() {
+            // Explicit return
+            // CHECK: [[THEN1]]:
+            // CHECK:   br [[EPILOG:bb[0-9]+]]
+            return
+        } else {
+            // Fall through
+        }
+        // CHECK: [[EPILOG]]:
+        // Take final reabstracted value from the reabstracted buffer
+        // CHECK:   [[FINAL_REAB:%.*]] = load [take] [[REAB_ARG]]
+        // Reabstract back to original representation and store back to
+        // original buffer
+        // CHECK:   [[THUNK_ORIG:%.*]] = function_ref @{{.*}}_TR
+        // CHECK:   [[FINAL_CONV:%.*]] = partial_apply [callee_guaranteed] [[THUNK_ORIG]]([[FINAL_REAB]])
+        // CHECK:   [[FINAL:%.*]] = convert_function [[FINAL_CONV]]
+        // CHECK:   store [[FINAL]] to [[ARG]]
+        // CHECK:   return
+    }
+}


### PR DESCRIPTION
Issue: rdar://111563642
Explanation: When a literal closure is passed into a generic context that takes an `(inout T) -> ()` function argument, we emit the closure literal with the abstraction pattern expected by the callee, but when `T` was itself a function type, we failed to handle the abstraction difference of the `inout` parameter locally, leading to compiler crashes. This patch fixes that by having the closure perform reabstraction on the initial value going in, storing it to a local buffer to represent the inout parameter locally, then reabstracting back to the expected representation and writing back to the original inout parameter.
Scope of Issue: Fixes a regression.
Origination: Last year's thunk elimination optimizations.
Risk: Low. The fix is targeted to a relatively rare situation, which currently crashes the compiler, and should have minimal effect on other code.
Reviewed by: @atrick
Cherry picked from: https://github.com/apple/swift/pull/67239