### PR TITLE
[5.9][CI] Disable early swift driver/syntax on Linux presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -876,6 +876,10 @@ installable-package=%(installable_package)s
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
+# Temporarily disable early swift driver/syntax builds so that linux images
+# can use the swift release images as a base.
+skip-early-swift-driver
+skip-early-swiftsyntax
 
 [preset: buildbot_linux_base]
 mixin-preset=


### PR DESCRIPTION
Allow Linux builds on a host with Swift installed. This will allow us to PR test enabling the early swift driver/syntax builds (once the Linux docker images are updated).

(cherry picked from commit e82d860af983a66fee61184b2eb92f02a5abf875)