### PR TITLE
[ExplicitModule] Allow typecheck-module-from-interface using explicit module

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -105,7 +105,7 @@ WARNING(warning_cannot_find_locale_file,none,
 WARNING(warning_cannot_multithread_batch_mode,none,
       "ignoring -num-threads argument; cannot multithread batch mode", ())
 ERROR(error_cannot_explicit_interface_build_in_mode,none,
-      "'-explicit-interface-module-build' only supported when building a module from interface ('-compile-module-from-interface')'", ())
+      "'-explicit-interface-module-build' only supported when building a module from interface ('-compile-module-from-interface' or '-typecheck-module-from-interface')'", ())
 ERROR(error_cannot_direct_cc1_pcm_build_in_mode,none,
       "'-direct-clang-cc1-module-build' only supported when building a PCM ('-emit-pcm')'", ())
 ERROR(error_unsupported_option_argument,none,

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -141,6 +141,9 @@ public:
   /// Clang Include Trees.
   std::vector<std::string> ClangIncludeTrees;
 
+  /// CacheKey for input file.
+  std::string InputFileKey;
+
   /// Number of retry opening an input file if the previous opening returns
   /// bad file descriptor error.
   unsigned BadFileDescriptorRetryCount = 0;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1225,6 +1225,8 @@ def always_compile_output_files :
 def allow_unstable_cache_key_for_testing: Flag<["-"], "allow-unstable-cache-key-for-testing">,
   HelpText<"Allow compilation caching with unstable inputs for testing purpose">;
 
+def input_file_key : Separate<["-"], "input-file-key">,
+  HelpText<"Cache Key for input file">;
 def bridging_header_pch_key : Separate<["-"], "bridging-header-pch-key">,
   HelpText<"Cache Key for bridging header pch">;
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -229,7 +229,6 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::DumpInterfaceHash:
   case ActionType::EmitImportedModules:
   case ActionType::ScanDependencies:
-  case ActionType::TypecheckModuleFromInterface:
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpAST:
@@ -241,6 +240,7 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::Immediate:
   case ActionType::DumpTypeInfo:
     return false;
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::CompileModuleFromInterface:
   case ActionType::EmitPCH:
   case ActionType::EmitPCM:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -769,7 +769,6 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::MergeModules:
   case ActionType::CompileModuleFromInterface:
-  case ActionType::TypecheckModuleFromInterface:
   case ActionType::DumpTypeInfo:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
@@ -777,6 +776,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::PrintFeature:
     return true;
 
+  case ActionType::TypecheckModuleFromInterface:
   case ActionType::NoneAction:
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -800,12 +800,12 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitPCM:
+  case ActionType::TypecheckModuleFromInterface:
     return false;
 
   case ActionType::Parse:
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
-  case ActionType::TypecheckModuleFromInterface:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:

--- a/lib/Frontend/Serialization.cpp
+++ b/lib/Frontend/Serialization.cpp
@@ -65,8 +65,10 @@ void swift::serializeToBuffers(
     std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
     const SILModule *M) {
+  // Serialization output is disabled.
+  if (options.OutputPath.empty())
+    return;
 
-  assert(!options.OutputPath.empty());
   {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftmodule, to buffer");

--- a/test/CAS/Inputs/ExtractOutputKey.py
+++ b/test/CAS/Inputs/ExtractOutputKey.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+#
+# Usage: ExtractOutputKey.py file.json OutputPath
+
+import json
+import sys
+
+input_json = sys.argv[1]
+output_path = sys.argv[2]
+
+
+with open(input_json, 'r') as file:
+    outputs = json.load(file)
+    for output in outputs:
+        if output['OutputPath'] != output_path:
+            continue
+        print(output['CacheKey'])

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -120,11 +120,11 @@
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
 // RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution \
-// RUN:   -explicit-interface-module-build -o /dev/null -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-MISS
+// RUN:   -explicit-interface-module-build -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-MISS
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
 // RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution \
-// RUN:   -explicit-interface-module-build -o %t/check.swiftmodule -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-HIT
+// RUN:   -explicit-interface-module-build -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-HIT
 
 // CHECK-DAG: loaded module 'A'
 // CHECK-DAG: loaded module 'B'

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -110,12 +110,32 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid -Rmodule-loading -Xcc -Rmodule-import %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck %s
 
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job \
+// RUN:   -cas-path %t/cas -allow-unstable-cache-key-for-testing  -swift-version 5 -enable-library-evolution > %t/keys.json
+
+// RUN: %S/Inputs/ExtractOutputKey.py %t/keys.json %t/Foo.swiftinterface > %t/interface.casid
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
+// RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution \
+// RUN:   -explicit-interface-module-build -o /dev/null -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-MISS
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
+// RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution \
+// RUN:   -explicit-interface-module-build -o %t/check.swiftmodule -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-HIT
+
 // CHECK-DAG: loaded module 'A'
 // CHECK-DAG: loaded module 'B'
 // CHECK-DAG: loaded module 'Swift'
 // CHECK-DAG: loaded module '_StringProcessing'
 // CHECK-DAG: loaded module '_Concurrency'
 // CHECK-DAG: loaded module 'SwiftOnoneSupport'
+
+// CACHE-MISS: remark: cache miss output file
+// VERIFY-OUTPUT: warning: module 'A' was not compiled with library evolution support
+// CACHE-HIT: remark: replay output file
 
 //--- A.swift
 func test() {}

--- a/test/ScanDependencies/explicit-module-map-typecheck-module-from-interface.swift
+++ b/test/ScanDependencies/explicit-module-map-typecheck-module-from-interface.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: echo "/// Some cool comments" > %t/foo.swift
+// RUN: echo "public func foo() {}" >> %t/foo.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface \
+// RUN:   -swift-version 5 -enable-library-evolution -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_Concurrency\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/concurrency_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_StringProcessing\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/string_processing_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -module-cache-path %t.module-cache \
+// RUN:   -o /dev/null -explicit-interface-module-build -explicit-swift-module-map-file %t/inputs/map.json -Rmodule-loading -Xcc -Rmodule-import 2>&1 | %FileCheck %s
+
+// CHECK-DAG: loaded module 'Swift'
+// CHECK-DAG: loaded module '_StringProcessing'
+// CHECK-DAG: loaded module '_Concurrency'

--- a/test/ScanDependencies/explicit-module-map-typecheck-module-from-interface.swift
+++ b/test/ScanDependencies/explicit-module-map-typecheck-module-from-interface.swift
@@ -35,7 +35,7 @@
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -module-cache-path %t.module-cache \
-// RUN:   -o /dev/null -explicit-interface-module-build -explicit-swift-module-map-file %t/inputs/map.json -Rmodule-loading -Xcc -Rmodule-import 2>&1 | %FileCheck %s
+// RUN:   -explicit-interface-module-build -explicit-swift-module-map-file %t/inputs/map.json -Rmodule-loading -Xcc -Rmodule-import 2>&1 | %FileCheck %s
 
 // CHECK-DAG: loaded module 'Swift'
 // CHECK-DAG: loaded module '_StringProcessing'


### PR DESCRIPTION
Allow `-typecheck-module-from-interface` using explicit module instead of building implicit module.

This setups swift-frontend to accept explicit module build arguments and loading explicit module during verifying. SwiftDriver needs to setup correct arguments including the output path for swift module to fully enable explicit module interface check.