### PR TITLE
[5.9][ScanDependencies] Fix JSON generation under certain circunstances.

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -852,8 +852,11 @@ static void writeJSON(llvm::raw_ostream &out,
       bool hasOverlayDependencies =
           swiftTextualDeps->swift_overlay_module_dependencies &&
           swiftTextualDeps->swift_overlay_module_dependencies->count > 0;
+      bool commaAfterBridgingHeaderPath = hasOverlayDependencies;
+      bool commaAfterExtraPcmArgs =
+          hasBridgingHeaderPath || commaAfterBridgingHeaderPath;
       bool commaAfterFramework =
-          swiftTextualDeps->extra_pcm_args->count != 0 || hasBridgingHeaderPath;
+          swiftTextualDeps->extra_pcm_args->count != 0 || commaAfterExtraPcmArgs;
 
       writeJSONSingleField(out, "isFramework", swiftTextualDeps->is_framework,
                            5, commaAfterFramework);
@@ -871,7 +874,7 @@ static void writeJSON(llvm::raw_ostream &out,
           out << "\n";
         }
         out.indent(5 * 2);
-        out << (hasBridgingHeaderPath ? "],\n" : "]\n");
+        out << (commaAfterExtraPcmArgs ? "],\n" : "]\n");
       }
       /// Bridging header and its source file dependencies, if any.
       if (hasBridgingHeaderPath) {
@@ -887,12 +890,12 @@ static void writeJSON(llvm::raw_ostream &out,
                              swiftTextualDeps->bridging_module_dependencies, 6,
                              /*trailingComma=*/false);
         out.indent(5 * 2);
-        out << (hasOverlayDependencies ? "},\n" : "}\n");
+        out << (commaAfterBridgingHeaderPath ? "},\n" : "}\n");
       }
       if (hasOverlayDependencies) {
         writeDependencies(out, swiftTextualDeps->swift_overlay_module_dependencies,
                           "swiftOverlayDependencies", 5,
-                          /*trailingComma=*/true);
+                          /*trailingComma=*/false);
       }
     } else if (swiftPlaceholderDeps) {
       out << "\"swiftPlaceholder\": {\n";

--- a/test/Frontend/module-alias-scan-deps.swift
+++ b/test/Frontend/module-alias-scan-deps.swift
@@ -12,7 +12,7 @@
 
 /// Scanned dependencies should contain real name AppleLogging
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandump.output
-// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME -input-file  %t/scandump.output
+// RUN: %validate-json %t/scandump.output | %FileCheck %s -check-prefix=CHECK-REAL-NAME
 // CHECK-REAL-NAME-NOT: "swiftPrebuiltExternal": "XLogging"
 // CHECK-REAL-NAME-NOT: "compiledModulePath":{{.*}}XLogging.swiftmodule",
 // CHECK-REAL-NAME: "swiftPrebuiltExternal": "AppleLogging"
@@ -25,7 +25,7 @@
 
 /// Scanned dependencies should contain real name AppleLoggingIF
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
-// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF -input-file  %t/scandumpIF.output
+// RUN: %validate-json %t/scandumpIF.output | %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF
 // CHECK-REAL-NAME-IF-NOT: "swift": "XLogging"
 // CHECK-REAL-NAME-IF-NOT: "moduleInterfacePath":{{.*}}XLogging.swiftinterface
 // CHECK-REAL-NAME-IF: "swift": "AppleLoggingIF"

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -6,6 +6,7 @@
 // RUN: %target-swift-frontend -typecheck -strict-implicit-module-context %s -I %S/Inputs/macro-only-module -Xcc -DTANGERINE=1 -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
 
 // RUN: %target-swift-frontend -scan-dependencies -strict-implicit-module-context %s -o %t/deps.json -I %S/Inputs/macro-only-module -Xcc -DTANGERINE=1 -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
 import ImportsMacroSpecificClangModule

--- a/test/ModuleInterface/clang-session-transitive.swift
+++ b/test/ModuleInterface/clang-session-transitive.swift
@@ -5,6 +5,7 @@
 // RUN: %target-build-swift -module-name TestModule -module-link-name TestModule %S/Inputs/TestModule.swift -enable-library-evolution -emit-module-interface -o %t/TestModule.swiftmodule -swift-version 5 -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import
 
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I%t -validate-clang-modules-once -clang-build-session-file %t/Build.session -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
 import TestModule

--- a/test/ModuleInterface/extension-transitive-availability.swift
+++ b/test/ModuleInterface/extension-transitive-availability.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-emit-module-interface(%t/ExtensionAvailable.swiftinterface) %S/Inputs/extension-available.swift -module-name ExtensionAvailable -I%t -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
 
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I%t -application-extension -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
 import ExtensionAvailable

--- a/test/ModuleInterface/infer-arch-from-file.swift
+++ b/test/ModuleInterface/infer-arch-from-file.swift
@@ -6,6 +6,6 @@
 import arm64
 
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -target arm64-apple-macos11.0
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // CHECK-NOT: arm64e-apple-macos11.0

--- a/test/ScanDependencies/batch_module_scan.swift
+++ b/test/ScanDependencies/batch_module_scan.swift
@@ -17,8 +17,8 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s -check-prefix=CHECK-PCM < %t/outputs/F.pcm.json
-// RUN: %FileCheck %s -check-prefix=CHECK-SWIFT < %t/outputs/F.swiftmodule.json
+// RUN: %validate-json %t/outputs/F.pcm.json | %FileCheck %s -check-prefix=CHECK-PCM
+// RUN: %validate-json %t/outputs/F.swiftmodule.json | %FileCheck %s -check-prefix=CHECK-SWIFT
 
 // CHECK-PCM: 		{
 // CHECK-PCM-NEXT:  "mainModuleName": "F",

--- a/test/ScanDependencies/batch_module_scan_arguments.swift
+++ b/test/ScanDependencies/batch_module_scan_arguments.swift
@@ -17,8 +17,8 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s -check-prefix=CHECK-TEN < %t/outputs/H.10.9.pcm.json
-// RUN: %FileCheck %s -check-prefix=CHECK-ELEVEN < %t/outputs/H.11.0.pcm.json
+// RUN: %validate-json %t/outputs/H.10.9.pcm.json | %FileCheck %s -check-prefix=CHECK-TEN
+// RUN: %validate-json %t/outputs/H.11.0.pcm.json | %FileCheck %s -check-prefix=CHECK-ELEVEN
 
 // CHECK-TEN: "clang": "I"
 // CHECK-ELEVEN-NOT: "clang": "I"

--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -17,7 +17,8 @@
 // RUN: %target-swift-frontend -scan-dependencies -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -target %target-cpu-apple-macosx11.0 -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s -check-prefix=CHECK-PCM109 < %t/outputs/G_109.pcm.json
+// RUN: %validate-json %t/outputs/G_109.pcm.json | %FileCheck %s -check-prefix=CHECK-PCM109
+// RUN: %validate-json %t/outputs/G_110.pcm.json &>/dev/null
 // RUN: %FileCheck %s -check-prefix=CHECK-PCM110 < %t/outputs/G_110.pcm.json
 
 // CHECK-PCM109: 		{

--- a/test/ScanDependencies/batch_prescan.swift
+++ b/test/ScanDependencies/batch_prescan.swift
@@ -12,7 +12,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -import-prescan -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s -check-prefix=CHECK-SWIFT < %t/outputs/F.swiftmodule.json
+// RUN: %validate-json %t/outputs/F.swiftmodule.json | %FileCheck %s -check-prefix=CHECK-SWIFT
 
 // CHECK-SWIFT: {
 // CHECK-SWIFT-NEXT:"imports": [

--- a/test/ScanDependencies/bin_mod_import.swift
+++ b/test/ScanDependencies/bin_mod_import.swift
@@ -8,11 +8,11 @@ import EWrapper
 // RUN: %target-swift-frontend -compile-module-from-interface %S/Inputs/Swift/EWrapper.swiftinterface -o %t/EWrapper.swiftmodule -I %t
 // Step 3: scan dependency should give us the binary module and a textual swift dependency from it
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Step 4: Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization %s -o %t/deps.json -I %t
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // CHECK: "modulePath": "{{.*}}EWrapper.swiftmodule"
 // CHECK-NEXT: "directDependencies": [

--- a/test/ScanDependencies/binary_framework_dependency.swift
+++ b/test/ScanDependencies/binary_framework_dependency.swift
@@ -11,7 +11,7 @@
 
 // Run the scan
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -F %t/Frameworks/ -sdk %t
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import Foo
 

--- a/test/ScanDependencies/binary_module_only.swift
+++ b/test/ScanDependencies/binary_module_only.swift
@@ -22,8 +22,8 @@ import Foo
 
 // Step 3: scan dependencies, pointed only at the binary module file should detect it as a swiftBinaryModule kind of dependency
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t/binaryModuleOnly -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
-// RUN: %FileCheck %s -check-prefix=BINARY_MODULE_ONLY < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=BINARY_MODULE_ONLY
 
 // Step 4: Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization %s -o %t/deps.json -I %t/binaryModuleOnly -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
-// RUN: %FileCheck %s -check-prefix=BINARY_MODULE_ONLY < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=BINARY_MODULE_ONLY

--- a/test/ScanDependencies/blocklist-path-pass-down.swift
+++ b/test/ScanDependencies/blocklist-path-pass-down.swift
@@ -15,7 +15,7 @@
 
 // Run the scan
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -F %t/Frameworks/ -sdk %t -blocklist-file %t/blocklist.yml
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import E
 

--- a/test/ScanDependencies/can_import_placeholder.swift
+++ b/test/ScanDependencies/can_import_placeholder.swift
@@ -11,11 +11,11 @@
 // RUN: echo "}]" >> %/t/inputs/map.json
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/clang-target.swift
+++ b/test/ScanDependencies/clang-target.swift
@@ -14,7 +14,7 @@
 // RUN: find %t.module-cache -name "X-*.pcm" | count 1
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache %s -o %t.deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target %target-cpu-apple-macosx10.14 -clang-target %target-cpu-apple-macosx10.14
 
-// RUN: %FileCheck %s < %t.deps.json
+// RUN: %validate-json %t.deps.json | %FileCheck %s
 
 // CHECK: "-clang-target"
 // CHECK-NEXT: "{{.*}}-apple-macosx10.14"

--- a/test/ScanDependencies/compiled_swift_modules.swift
+++ b/test/ScanDependencies/compiled_swift_modules.swift
@@ -15,25 +15,25 @@ import Foo
 
 // Step 2: scan dependency should give us the binary module adjacent to the interface file.
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d
-// RUN: %FileCheck %s -check-prefix=HAS_COMPILED < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=HAS_COMPILED
 
 // Step 3: remove the adjacent module.
 // RUN: rm %t/Foo.swiftmodule/%target-swiftmodule-name
 
 // Step 4: scan dependency should give us the interface file.
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d
-// RUN: %FileCheck %s -check-prefix=HAS_NO_COMPILED < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=HAS_NO_COMPILED
 
 // Step 4: build prebuilt module cache using the interface.
 // RUN: %target-swift-frontend -compile-module-from-interface -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -disable-interface-lock %t/Foo.swiftmodule/%target-swiftinterface-name
 
 // Step 5: scan dependency now should give us the prebuilt module cache
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
-// RUN: %FileCheck %s -check-prefix=HAS_COMPILED < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=HAS_COMPILED
 
 // Step 6: update the interface file from where the prebuilt module cache was built.
 // RUN: touch %t/Foo.swiftmodule/%target-swiftinterface-name
 
 // Step 7: scan dependency should give us the prebuilt module file even though it's out-of-date.
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -emit-dependencies -emit-dependencies-path %t/deps.d -sdk %t -prebuilt-module-cache-path %t/ResourceDir/%target-sdk-name/prebuilt-modules
-// RUN: %FileCheck %s -check-prefix=HAS_COMPILED < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=HAS_COMPILED

--- a/test/ScanDependencies/embed_tbd_module_dependency.swift
+++ b/test/ScanDependencies/embed_tbd_module_dependency.swift
@@ -2,7 +2,7 @@
 // RUN: mkdir -p %t/clang-module-cache
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -swift-version 4 -embed-tbd-for-module E
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // CHECK: "mainModuleName": "deps"
 // CHECK-NEXT:  "modules": [

--- a/test/ScanDependencies/escaped.swift
+++ b/test/ScanDependencies/escaped.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -scan-dependencies %s -I %S\\Inputs -o - | %FileCheck %s
+// RUN: %target-swift-frontend -scan-dependencies %s -I %S\\Inputs -o - | %validate-json | %FileCheck %s
 
 // We want to explicitly use the Windows path separator
 // REQUIRES: OS=windows-msvc

--- a/test/ScanDependencies/explicit-swift-dependencies.swift
+++ b/test/ScanDependencies/explicit-swift-dependencies.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/include-sdk-in-command.swift
+++ b/test/ScanDependencies/include-sdk-in-command.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -sdk %t/mysecretsdk.sdk
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 func foo() { print(1) }
 

--- a/test/ScanDependencies/local_cache_consistency.swift
+++ b/test/ScanDependencies/local_cache_consistency.swift
@@ -7,7 +7,7 @@
 
 // Run the scanner once, ensuring CoreFoundation dependencies are as expected
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import CoreFoundation
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -3,10 +3,10 @@
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 // Check the contents of the JSON output
-// RUN: %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s -check-prefix CHECK-NO-SEARCH-PATHS < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix CHECK-NO-SEARCH-PATHS
 
 // Check the make-style dependencies file
 // RUN: %FileCheck %s -check-prefix CHECK-MAKE-DEPS < %t/deps.d
@@ -22,12 +22,12 @@
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s
 
 // Ensure that scanning with `-clang-target` makes sure that Swift modules' respective PCM-dependency-build-argument sets do not contain target triples.
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps_clang_target.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -clang-target %target-cpu-apple-macosx10.14
 // Check the contents of the JSON output
-// RUN: %FileCheck -check-prefix CHECK_CLANG_TARGET %s < %t/deps_clang_target.json
+// RUN: %validate-json %t/deps_clang_target.json | %FileCheck -check-prefix CHECK_CLANG_TARGET %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -8,6 +8,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s -check-prefix CHECK-REMARK-LOAD
 
 // Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
 // REQUIRES: executable_test

--- a/test/ScanDependencies/module_deps_clang_private_submodule.swift
+++ b/test/ScanDependencies/module_deps_clang_private_submodule.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache %s -o %t.deps.json -I %S/Inputs/CHeaders
 
-// RUN: %FileCheck %s < %t.deps.json
+// RUN: %validate-json %t.deps.json | %FileCheck %s
 // CHECK: "clang": "X_Private"
 import X.Private
 

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -2,11 +2,11 @@
 // RUN: mkdir -p %t/clang-module-cache
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
+++ b/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
@@ -5,10 +5,12 @@
 
 // Run the scanner once, emitting the serialized scanner cache, with one set of search paths
 // RUN: %target-swift-frontend -scan-dependencies -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps_initial.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+// RUN: %validate-json %t/deps_initial.json &>/dev/null
 // RUN: %FileCheck -input-file %t/deps_initial.json %s -check-prefix CHECK-INITIAL-SCAN
 
 // Run the scanner again, but now re-using previously-serialized cache and using a different search path for Swift modules
 // RUN: %target-swift-frontend -scan-dependencies -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/SwiftDifferent -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck -input-file %t/deps.json %s -check-prefix CHECK-DIFFERENT
 
 // REQUIRES: executable_test

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -13,7 +13,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Check the make-style dependencies file
 // RUN: %FileCheck %s -check-prefix CHECK-MAKE-DEPS < %t/deps.d
@@ -29,7 +29,7 @@
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/module_deps_private_interface.swift
+++ b/test/ScanDependencies/module_deps_private_interface.swift
@@ -9,7 +9,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import Foo
 

--- a/test/ScanDependencies/module_deps_swift_overlay.swift
+++ b/test/ScanDependencies/module_deps_swift_overlay.swift
@@ -2,11 +2,11 @@
 // RUN: mkdir -p %t/clang-module-cache
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/module_framework.swift
+++ b/test/ScanDependencies/module_framework.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -Xcc -Xclang
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -Xcc -Xclang
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/ScanDependencies/no_main_module_cross_import.swift
+++ b/test/ScanDependencies/no_main_module_cross_import.swift
@@ -2,7 +2,7 @@
 // RUN: mkdir -p %t/clang-module-cache
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/CHeaders/ExtraCModules -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -module-name SubE
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/no_trasitive_implementation-only_deps.swift
+++ b/test/ScanDependencies/no_trasitive_implementation-only_deps.swift
@@ -11,7 +11,7 @@
 
 // Run the scan
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -F %t/Frameworks/ -sdk %t
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import Foo
 

--- a/test/ScanDependencies/placholder_overlay_deps.swift
+++ b/test/ScanDependencies/placholder_overlay_deps.swift
@@ -14,6 +14,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json
 
 // Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
 // REQUIRES: executable_test

--- a/test/ScanDependencies/prescan_deps.swift
+++ b/test/ScanDependencies/prescan_deps.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -import-prescan -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/ScanDependencies/private_interface_candidate_module.swift
+++ b/test/ScanDependencies/private_interface_candidate_module.swift
@@ -16,7 +16,7 @@
 
 // Run the scan
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -F %t/Frameworks/ -sdk %t
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import E
 

--- a/test/ScanDependencies/required_deps_of_testable_imports.swift
+++ b/test/ScanDependencies/required_deps_of_testable_imports.swift
@@ -12,6 +12,7 @@
 
 // Step 3: scan dependencies
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache -I %S/Inputs/CHeaders -I %S/Inputs/Swift
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // The dependency of `Foo` on `A` will not be visible if the scanner simply scans the textual interface
 // of `Foo`. So we verify that for a `@testable` import, the scanner also opens up the adjacent binary module and

--- a/test/ScanDependencies/separate_bridging_header_deps.swift
+++ b/test/ScanDependencies/separate_bridging_header_deps.swift
@@ -2,7 +2,7 @@
 // RUN: mkdir -p %t/clang-module-cache
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import E
 

--- a/test/ScanDependencies/test_clang_gmodules.swift
+++ b/test/ScanDependencies/test_clang_gmodules.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/module-cache)
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target %target-cpu-apple-macosx10.14
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
 
 import X
 

--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -scan-dependencies %/s %/S/Inputs/unicode_filёnamё.swift -o %t/deps.json
 
 // Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
 print(foo())

--- a/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s %S/Inputs/EmitWhileBuilding/Extra.swift -emit-symbol-graph -emit-symbol-graph-dir %t
-// RUN: %{python} -m json.tool %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
+// RUN: %validate-json %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix HEADER
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix LOCATION

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Macros.swift
@@ -4,7 +4,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/stringify_macro.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 // RUN: %target-swift-frontend -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name Macros -emit-module -emit-module-path %t/Macros.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
-// RUN: %{python} -m json.tool %t/Macros.symbols.json %t/Macros.formatted.symbols.json
+// RUN: %validate-json %t/Macros.symbols.json %t/Macros.formatted.symbols.json
 
 // Make sure that the `= #externalMacro(...)` doesn't show up in declaration fragments and in names
 // fragments, and also that macros with no parameters get the `()` in their name.

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
@@ -6,7 +6,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name SomeProtocol -emit-module -emit-module-path %t/SomeProtocol.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
-// RUN: %{python} -m json.tool %t/SomeProtocol.symbols.json %t/SomeProtocol.formatted.symbols.json
+// RUN: %validate-json %t/SomeProtocol.symbols.json %t/SomeProtocol.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/SomeProtocol.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/SomeProtocol.formatted.symbols.json --check-prefix MULTI
 

--- a/test/SymbolGraph/Symbols/OpaqueParams.swift
+++ b/test/SymbolGraph/Symbols/OpaqueParams.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -swift-version 5 %s -emit-module -emit-module-path %t/OpaqueParams.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
-// RUN: %{python} -m json.tool %t/OpaqueParams.symbols.json %t/OpaqueParams.formatted.symbols.json
+// RUN: %validate-json %t/OpaqueParams.symbols.json %t/OpaqueParams.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/OpaqueParams.formatted.symbols.json
 
 // CHECK: "precise": "s:12OpaqueParams7MyClassC6myFunc5param10otherParamyq__xtAA0C8ProtocolRzAaGR_r0_lF"

--- a/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
+++ b/test/SymbolGraph/Symbols/SkipProtocolImplementations.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -module-name SkipProtocolImplementations -emit-module -emit-module-path %t/SkipProtocolImplementations.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/ -skip-protocol-implementations
-// RUN: %{python} -m json.tool %t/SkipProtocolImplementations.symbols.json %t/SkipProtocolImplementations.formatted.symbols.json
+// RUN: %validate-json %t/SkipProtocolImplementations.symbols.json %t/SkipProtocolImplementations.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/SkipProtocolImplementations.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/SkipProtocolImplementations.formatted.symbols.json --check-prefix COUNT
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -594,6 +594,7 @@ config.substitutions.append( ('%llvm-strings', config.llvm_strings) )
 config.substitutions.append( ('%target-ptrauth', run_ptrauth ) )
 config.substitutions.append( ('%swift-path', config.swift) )
 config.substitutions.append( ('%swift-plugin-server', config.swift_plugin_server) )
+config.substitutions.append( ('%validate-json', f"{config.python} -m json.tool") )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(


### PR DESCRIPTION
## Cherry-pick of #67246

- Release: Swift 5.9
- Explanation: Cherry-picks a bug fix for the dependency scanner JSON output,  which might be invalid in some cases.
- Scope of Issue: The problem affects users that parse the JSON output generated by the `--scan-dependencies`. It happens a couple of times in the test suite, and it happens organically when trying to `--scan-dependencies` of all frameworks and modules in Xcode 15 betas SDKs.
- Risk: The changes in the test files should be zero risk and should make release/5.9 less prone of introducing JSON formatting bugs by mistake. The change in the code is low risk and its impact should only be limited to the output of `--scan-dependencies`.
- Reviewed By: @artemcm 

### Original commit message:
The code of `ScanDependencies.cpp` was creating invalid JSON since #66031 because in the case of having `extraPcmArgs` and `swiftOverlayDependencies`, but not `bridgingHeader`, a comma will not be added at the end of `extraPcmArgs`, creating an invalid JSON file. Additionally that same PR added a trailing comma at the end of the `swiftOverlayDependencies`, which valid JSON does not allow, but that bug was removed in #66366.

Both problems are, however, present in the 5.9 branch, because #66936 included #66031, but not #66366.

Besides fixing the problem in `ScanDependencies.cpp` I modified every test that uses `--scan-dependencies` to pass the produced JSON through Python's `json.tool` in order to validate proper JSON is produced. In most cases I was able to pipe the output of the tool into `FileCheck`, but in some cases the validation is done by itself because the checks depend on the exact format generated by `--scan-dependencies`. In a couple of tests I added a call to `FileCheck` that seemed to be missing.

Without these changes, two tests seems to be generating invalid JSON in my machine:

- `ScanDependencies/local_cache_consistency.swift` (which outputs `Expecting ',' delimiter: line 525 column 11 (char 22799)`)
- `ScanDependencies/placholder_overlay_deps.swift`

### Additional changes for the cherry-pick:

- Removed some changes in some CAS tests that are not present in release/5.9.
- Switch `trailingComma` from `true` to `false` for `swiftOverlayDependencies` similar to what #66366 did in `main`.
- Remove the new `RUN` line in `optional_deps_of_testable_imports.swift` because it fails in 5.9 if the `CHECK` is performed.
