### PR TITLE
Fix various places where we didn't handle "bound" pack references correctly

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -316,6 +316,14 @@ public:
       llvm::function_ref<llvm::Optional<Type>(TypeBase *, TypePosition)> fn)
       const;
 
+  /// Transform free pack element references, that is, those not captured by a
+  /// pack expansion.
+  ///
+  /// This is the 'map' counterpart to TypeBase::getTypeParameterPacks().
+  Type transformTypeParameterPacks(
+      llvm::function_ref<llvm::Optional<Type>(SubstitutableType *)> fn)
+      const;
+
   /// Look through the given type and its children and apply fn to them.
   void visit(llvm::function_ref<void (Type)> fn) const {
     findIf([&fn](Type t) -> bool {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5867,13 +5867,13 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig,
   }
 
   auto eraseParameterPackRec = [&](Type type) -> Type {
-    return type.transformRec([&](Type t) -> llvm::Optional<Type> {
-      if (auto *paramType = t->getAs<GenericTypeParamType>()) {
+    return type.transformTypeParameterPacks([&](SubstitutableType *t) -> llvm::Optional<Type> {
+      if (auto *paramType = dyn_cast<GenericTypeParamType>(t)) {
         if (packElementParams.find(paramType) != packElementParams.end()) {
           return Type(packElementParams[paramType]);
         }
 
-        return t;
+        return Type(t);
       }
       return llvm::None;
     });

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2247,7 +2247,6 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         if (arg.getKind() == clang::TemplateArgument::Type) {
           auto ty = arg.getAsType().getTypePtr();
           if (auto builtin = dyn_cast<clang::BuiltinType>(ty)) {
-            auto &ctx = swiftCtx;
             if (auto swiftTypeName = getSwiftBuiltinTypeName(builtin)) {
               buffer << *swiftTypeName;
               return;

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -330,8 +330,8 @@ static void bindElementSignatureRequirementsAtIndex(
               IGF.emitTypeMetadataRef(patternPackArchetype, request);
           auto elementArchetype =
               context.environment
-                  ->mapPackTypeIntoElementContext(
-                      patternPackArchetype->getInterfaceType())
+                  ->mapContextualPackTypeIntoElementContext(
+                      patternPackArchetype)
                   ->getCanonicalType();
           auto *patternPack = response.getMetadata();
           auto elementMetadata = bindMetadataAtIndex(
@@ -346,8 +346,8 @@ static void bindElementSignatureRequirementsAtIndex(
           auto patternPackArchetype = getMappedPackArchetypeType(context, ty);
           auto elementArchetype =
               context.environment
-                  ->mapPackTypeIntoElementContext(
-                      patternPackArchetype->getInterfaceType())
+                  ->mapContextualPackTypeIntoElementContext(
+                      patternPackArchetype)
                   ->getCanonicalType();
           llvm::Value *_metadata = nullptr;
           auto packConformance =

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9162,7 +9162,6 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
   if (!patternType->hasTypeVariable()) {
     auto *loc = getConstraintLocator(locator);
     auto shapeClass = patternType->getReducedShape();
-    patternType = patternType->mapTypeOutOfContext();
     auto *elementEnv = getPackElementEnvironment(loc, shapeClass);
 
     // Without an opened element environment, we cannot derive the
@@ -9185,7 +9184,7 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
     }
 
     auto expectedElementTy =
-        elementEnv->mapPackTypeIntoElementContext(patternType);
+        elementEnv->mapContextualPackTypeIntoElementContext(patternType);
     assert(!expectedElementTy->is<PackType>());
 
     addConstraint(ConstraintKind::Equal, elementType, expectedElementTy,

--- a/test/ModuleInterface/pack_expansion_type.swift
+++ b/test/ModuleInterface/pack_expansion_type.swift
@@ -2,6 +2,8 @@
 // RUN: %target-swift-emit-module-interface(%t/PackExpansionType.swiftinterface) %s -module-name PackExpansionType -disable-availability-checking
 // RUN: %FileCheck %s < %t/PackExpansionType.swiftinterface
 
+/// Requirements
+
 // CHECK: #if compiler(>=5.3) && $ParameterPacks
 // CHECK-NEXT: public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)) : Any
 public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {}
@@ -23,6 +25,13 @@ public struct VariadicType<each T> {
 }
 // CHECK: }
 // CHECK-NEXT: #endif
+
+// The second requirement should not be prefixed with 'repeat'
+// CHECK: public struct SameTypeReq<T, each U> where T : Swift.Sequence, T.Element == PackExpansionType.VariadicType<repeat each U> {
+public struct SameTypeReq<T: Sequence, each U> where T.Element == VariadicType<repeat each U> {}
+// CHECK: }
+
+/// Pack expansion types
 
 // CHECK: public func returnsVariadicType() -> PackExpansionType.VariadicType<>
 public func returnsVariadicType() -> VariadicType< > {}

--- a/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public protocol P {
+  associatedtype A
+}
+
+public struct G<each T> {}
+
+public struct S<T: P, each U: P> where repeat T.A == G<repeat each U> {
+    public init(predicate: repeat each U) {}
+}
+


### PR DESCRIPTION
We had three implementations of the mapping from type parameter packs to element generic parameters/archetypes:
- the requirement remapping in getOpenedElementSignature()
- mapPackTypeIntoElementContext()
- mapContextualPackTypeIntoElementContext()

All three were slightly wrong. The first one didn't attempt to handle nested PackExpansionTypes at all, the other two would skip nested PackExpansionTypes without visiting any PackElementTypes contained within. Unify them with a new Type::transformTypeParameterPacks() method.

This still duplicates TypeBase::getTypeParameterPacks(), but unfortunately there's no good way to share this sort of logic between the 'transform' and 'TypeWalker' implementation.

- rdar://112108253