### PR TITLE
[Sema] Allow implicit dynamic @nonobjc.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4615,8 +4615,7 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D) {
 }
 
 static bool shouldBlockImplicitDynamic(Decl *D) {
-  if (D->getAttrs().hasAttribute<NonObjCAttr>() ||
-      D->getAttrs().hasAttribute<SILGenNameAttr>() ||
+  if (D->getAttrs().hasAttribute<SILGenNameAttr>() ||
       D->getAttrs().hasAttribute<TransparentAttr>() ||
       D->getAttrs().hasAttribute<InlinableAttr>())
     return true;

--- a/test/Interpreter/dynamic_replacement_implicit_dynamic_nonobjc.swift
+++ b/test/Interpreter/dynamic_replacement_implicit_dynamic_nonobjc.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-implicit-dynamic) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+class C : NSObject {
+  @nonobjc func foo() {
+    print("original")
+  }
+}
+
+extension C {
+  @_dynamicReplacement(for: foo()) @nonobjc private func replacement_for_foo() {
+    print("replacement")
+  }
+}
+
+func doit() {
+  let c = C()
+  c.foo()
+}
+
+// CHECK: replacement
+doit()


### PR DESCRIPTION
Back in https://github.com/apple/swift/pull/24959, marking a decl both dynamic and `@nonobjc` was allowed.  So implicitly mark decls that are `@nonobjc` dynamic when `-enable-implicit-dynamic` is specified.

rdar://112152116
