### PR TITLE
[5.9] ModuleLoader: emit a note when encountering a blocklisted module interface

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -881,6 +881,10 @@ ERROR(need_cxx_interop_to_import_module,none,
 NOTE(enable_cxx_interop_docs,none,
      "visit https://www.swift.org/documentation/cxx-interop/project-build-setup to learn how to enable C++ interoperability", ())
 
+NOTE(interface_block_listed_broken,none,
+     "textual interface for %0 is blocklisted as broken; "
+     "interface verification errors are downgraded to warnings", (StringRef))
+
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"
       " 'foo.%1' expression", (DeclName, StringRef))

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -183,10 +183,14 @@ bool ExplicitModuleInterfaceBuilder::collectDepsForSerialization(
 
 static bool shouldDowngradeInterfaceVerificationError(const FrontendOptions &opts,
                                                       ASTContext &ctx) {
-  return opts.DowngradeInterfaceVerificationError ||
-    ctx.blockListConfig.hasBlockListAction(opts.ModuleName,
-                                           BlockListKeyKind::ModuleName,
-                        BlockListAction::DowngradeInterfaceVerificationFailure);
+  if (ctx.blockListConfig.hasBlockListAction(opts.ModuleName,
+                                             BlockListKeyKind::ModuleName,
+                        BlockListAction::DowngradeInterfaceVerificationFailure)) {
+    ctx.Diags.diagnose(SourceLoc(), diag::interface_block_listed_broken,
+                       opts.ModuleName);
+    return true;
+  }
+  return opts.DowngradeInterfaceVerificationError;
 }
 
 std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(

--- a/test/ModuleInterface/blocklist_action.swift
+++ b/test/ModuleInterface/blocklist_action.swift
@@ -18,4 +18,8 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -downgrade-typecheck-interface-error
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml
 
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml &> %t/notes.txt
+// RUN: %FileCheck -check-prefix CHECK-NOTES --input-file %t/notes.txt %s
+// CHECK-NOTES: note: textual interface for Test is blocklisted as broken; interface verification errors are downgraded to warnings
+
 public func foo() {}


### PR DESCRIPTION
- Explanation: separately installed blocklist can inform the compiler about downgrading the module interface verification errors to warnings to unblock the build. When this happens, a note should be emitted in the build log so engineers can be better informed of that such behavior is intentional.
- Scope: module interface verification
- Risk: Extremely low
- Testing: Regression test added
- Main branch PR: https://github.com/apple/swift/pull/67269