### PR TITLE
🍒[Observation] Avoid using T since it is a common generic name, instead use a very specific generic return value name 

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -59,10 +59,10 @@ public struct ObservableMacro {
   static func withMutationFunction(_ observableType: TokenSyntax) -> DeclSyntax {
     return 
       """
-      internal nonisolated func withMutation<Member, T>(
+      internal nonisolated func withMutation<Member, MutationResult>(
         keyPath: KeyPath<\(observableType), Member>,
-        _ mutation: () throws -> T
-      ) rethrows -> T {
+        _ mutation: () throws -> MutationResult
+      ) rethrows -> MutationResult {
         try \(raw: registrarVariableName).withMutation(of: self, keyPath: keyPath, mutation)
       }
       """


### PR DESCRIPTION
This renames the generic signature generated by the macro for observation. It removes a common generic name `T` and replaces it with a much more specific name that won't likely cause conflicts with user code.

Risk level: low
Risk details: isolated to macro application, isolated to just users of `@Observable`, and only impacts adopters which have generic types.
Reward: no warnings emitted into client code from macro usage.
Addresses: rdar://111224006