### PR TITLE
[swift-demangle] Warn when passed an empty argument.

### DIFF
--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -403,6 +403,12 @@ int main(int argc, char **argv) {
                         "is quoted or escaped.\n";
         continue;
       }
+      if (name == "") {
+        llvm::errs() << "warning: empty input symbol is likely the result of "
+                        "variable expansion by the shell. Ensure the argument "
+                        "is quoted or escaped.\n";
+        continue;
+      }
       if (name.startswith("S") || name.startswith("s") ) {
         std::string correctedName = std::string("$") + name.str();
         demangle(llvm::outs(), correctedName, DCtx, options);


### PR DESCRIPTION
We already have a warning when a single _ is passed, which catches the case where someone passes _$someMangledName and the shell expands it as a variable. But sometimes people do this without the leading underscore. Detect and warn about that case too.