### PR TITLE
[5.9] Add source.request.index_to_store request to sourcekitd

### DIFF
--- a/test/SourceKit/Indexing/Inputs/indexstore_multifile_other.swift
+++ b/test/SourceKit/Indexing/Inputs/indexstore_multifile_other.swift
@@ -1,0 +1,4 @@
+struct OtherStruct {
+  let x: Int
+  let y: Int
+}

--- a/test/SourceKit/Indexing/indexstore_multifile.swift
+++ b/test/SourceKit/Indexing/indexstore_multifile.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %sourcekitd-test -req=index-to-store %s -index-store-path %t/idx -index-unit-output-path %t/indexstore_multifile.o -- -c -module-name indexstoremodule -o args_output_path.o %s %S/Inputs/indexstore_multifile_other.swift
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck  --dump-input=always --dump-input-filter=all %s
+
+struct Foo {
+  let bar: Int
+  let counter: Int
+  let other: OtherStruct
+
+  init(bar: Int, counter: Int = 0, other: OtherStruct) {
+    self.bar = bar
+    self.counter = counter
+    self.other = other
+  }
+}
+
+// CHECK: indexstore_multifile.o-{{.*}}
+// CHECK: module-name: indexstoremodule
+// CHECK: main-path: SOURCE_DIR{{/|\\}}test{{/|\\}}SourceKit{{/|\\}}Indexing{{/|\\}}indexstore_multifile.swift
+// CHECK: out-file: BUILD_DIR{{.*}}indexstore_multifile.o
+// CHECK: is-debug: 1
+// CHECK: Unit | system | Swift | {{.*}}{{/|\\}}Swift.swiftmodule
+// CHECK: Record | user | SOURCE_DIR{{/|\\}}test{{/|\\}}SourceKit{{/|\\}}Indexing{{/|\\}}indexstore_multifile.swift | indexstore_multifile.swift-{{.*}}

--- a/test/SourceKit/Indexing/indexstore_with_remappings.swift
+++ b/test/SourceKit/Indexing/indexstore_with_remappings.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %sourcekitd-test -req=index-to-store %s -index-store-path %t/idx -index-unit-output-path %t/indexstore_with_remappings.o -- -c -module-name indexstoremodule -file-prefix-map %S=REMAPPED_SRC_ROOT -file-prefix-map %t=REMAPPED_OUT_DIR %s
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+
+class Foo {
+  let member: Int
+  init(member: Int) {
+    self.member = member
+  }
+}
+
+// CHECK: indexstore_with_remappings.o-{{.*}}
+// CHECK: module-name: indexstoremodule
+// CHECK: main-path: REMAPPED_SRC_ROOT{{/|\\}}indexstore_with_remappings.swift
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}indexstore_with_remappings.o
+// CHECK: is-debug: 1
+// CHECK: Unit | system | Swift | {{.*}}{{/|\\}}Swift.swiftmodule

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -873,10 +873,18 @@ struct RenameLocations {
   std::vector<RenameLocation> LineColumnLocs;
 };
 
+struct IndexStoreOptions {
+  std::string IndexStorePath;
+  std::string IndexUnitOutputPath;
+};
+
+struct IndexStoreInfo{};
+
 typedef std::function<void(RequestResult<ArrayRef<CategorizedEdits>> Result)>
     CategorizedEditsReceiver;
 typedef std::function<void(RequestResult<ArrayRef<CategorizedRenameRanges>> Result)>
     CategorizedRenameRangesReceiver;
+typedef std::function<void(RequestResult<IndexStoreInfo> Result)> IndexToStoreReceiver;
 
 class DocInfoConsumer {
   virtual void anchor();
@@ -986,6 +994,12 @@ public:
   virtual void indexSource(StringRef Filename,
                            IndexingConsumer &Consumer,
                            ArrayRef<const char *> Args) = 0;
+
+  virtual void indexToStore(StringRef InputFile,
+                            ArrayRef<const char *> Args,
+                            IndexStoreOptions Opts,
+                            SourceKitCancellationToken CancellationToken,
+                            IndexToStoreReceiver Receiver) = 0;
 
   virtual void codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
                             OptionsDictionary *options,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -563,6 +563,12 @@ public:
   void indexSource(StringRef Filename, IndexingConsumer &Consumer,
                    ArrayRef<const char *> Args) override;
 
+  void indexToStore(StringRef InputFile,
+                    ArrayRef<const char *> Args,
+                    IndexStoreOptions Opts,
+                    SourceKitCancellationToken CancellationToken,
+                    IndexToStoreReceiver Receiver) override;
+
   void codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
                     OptionsDictionary *options,
                     SourceKit::CodeCompletionConsumer &Consumer,

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -166,6 +166,12 @@ def vfs_files : CommaJoined<["-"], "vfs-files=">,
 def vfs_name : Separate<["-"], "vfs-name">,
   HelpText<"Specify a virtual filesystem name">;
 
+def index_store_path : Separate<["-"], "index-store-path">,
+  HelpText<"Index Store path to use for indexing">;
+
+def index_unit_output_path : Separate<["-"], "index-unit-output-path">,
+  HelpText<"Index Store unit output path to use for indexing">;
+
 def suppress_config_request : Flag<["-"], "suppress-config-request">,
   HelpText<"Suppress the default global configuration request, that is otherwise sent before any other request (except for the global-config request itself)">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -154,6 +154,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("compile", SourceKitRequest::Compile)
         .Case("compile.close", SourceKitRequest::CompileClose)
         .Case("syntactic-expandmacro", SourceKitRequest::SyntacticMacroExpansion)
+        .Case("index-to-store", SourceKitRequest::IndexToStore)
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
 #include "swift/Refactoring/RefactoringKinds.def"
         .Default(SourceKitRequest::None);
@@ -205,6 +206,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                      << "- global-config\n"
                      << "- dependency-updated\n"
                      << "- syntactic-expandmacro\n"
+                     << "- index-to-store\n"
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) << "- refactoring." #ID "\n"
 #include "swift/Refactoring/RefactoringKinds.def"
                         "\n";
@@ -426,6 +428,14 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
 
     case OPT_vfs_name:
       VFSName = InputArg->getValue();
+      break;
+
+    case OPT_index_store_path:
+      IndexStorePath = InputArg->getValue();
+      break;
+
+    case OPT_index_unit_output_path:
+      IndexUnitOutputPath = InputArg->getValue();
       break;
 
     case OPT_module_cache_path:

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -71,6 +71,7 @@ enum class SourceKitRequest {
   Compile,
   CompileClose,
   SyntacticMacroExpansion,
+  IndexToStore,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/Refactoring/RefactoringKinds.def"
 };
@@ -148,6 +149,8 @@ struct TestOptions {
   llvm::Optional<std::string> VFSName;
   llvm::Optional<bool> CancelOnSubsequentRequest;
   bool ShellExecution = false;
+  std::string IndexStorePath;
+  std::string IndexUnitOutputPath;
   bool parseArgs(llvm::ArrayRef<const char *> Args);
   void printHelp(bool ShowHidden) const;
 };

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1153,6 +1153,13 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
                                           RequestSyntacticMacroExpansion);
     setSyntacticMacroExpansions(Req, Opts, SourceBuf.get());
     break;
+
+  case SourceKitRequest::IndexToStore:
+    sourcekitd_request_dictionary_set_string(Req, KeyName, SemaName.c_str());
+    sourcekitd_request_dictionary_set_string(Req, KeyIndexStorePath, Opts.IndexStorePath.c_str());
+    sourcekitd_request_dictionary_set_string(Req, KeyIndexUnitOutputPath, Opts.IndexUnitOutputPath.c_str());
+    sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestIndexToStore);
+    break;
   }
 
   if (!Opts.SourceFile.empty()) {
@@ -1584,6 +1591,9 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
         break;
       case SourceKitRequest::Statistics:
         printStatistics(Info, llvm::outs());
+        break;
+      case SourceKitRequest::IndexToStore:
+        printRawResponse(Resp);
         break;
     }
   }

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -212,6 +212,8 @@ UID_KEYS = [
     KEY('Expansions', 'key.expansions'),
     KEY('MacroRoles', 'key.macro_roles'),
     KEY('ExpandedMacroReplacements', 'key.expanded_macro_replacements'),
+    KEY('IndexStorePath', 'key.index_store_path'),
+    KEY('IndexUnitOutputPath', 'key.index_unit_output_path'),
 ]
 
 
@@ -279,6 +281,7 @@ UID_REQUESTS = [
     REQUEST('EnableRequestBarriers', 'source.request.enable_request_barriers'),
     REQUEST('SyntacticMacroExpansion',
             'source.request.syntactic_macro_expansion'),
+    REQUEST('IndexToStore', 'source.request.index_to_store'),
 ]
 
 


### PR DESCRIPTION
* Explanation: This request allows sourcekitd to perform indexing in process via a new request. This will allow IDEs to index files using already computed ASTs as opposed to needing a new AST. Required indexing related arguments such as index store path and index output path are provided in the request itself.
* Scope: sourcekitd
* Risk: Low, scoped entirely to a new request.
* Testing: Regression tests added
* Main branch PR: https://github.com/apple/swift/pull/66958