### PR TITLE
[NFC] Migrating LLVM API usage on main

### DIFF
--- a/include/swift/Basic/APIntMap.h
+++ b/include/swift/Basic/APIntMap.h
@@ -31,10 +31,10 @@ struct WidthPreservingAPIntDenseMapInfo {
   // for the value, then use a parser that always produces values with
   // minimal bit-widths so that we don't get a conflict.
   static inline APInt getEmptyKey() {
-    return APInt::getAllOnesValue(/*bitwidth*/2);
+    return APInt::getAllOnes(/*bitwidth*/2);
   }
   static inline APInt getTombstoneKey() {
-    return APInt::getAllOnesValue(/*bitwidth*/3);
+    return APInt::getAllOnes(/*bitwidth*/3);
   }
 
   static unsigned getHashValue(const APInt &Key) {

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -127,7 +127,7 @@ public:
       v = v.zext(v.getBitWidth() + numBits);
       return;
     }
-    Bits = APInt::getNullValue(numBits);
+    Bits = APInt::getZero(numBits);
   }
 
   /// Extend the vector out to the given length with clear bits.
@@ -148,7 +148,7 @@ public:
       v.setBitsFrom(w);
       return;
     }
-    Bits = APInt::getAllOnesValue(numBits);
+    Bits = APInt::getAllOnes(numBits);
     return;
   }
 
@@ -268,7 +268,7 @@ public:
     if (numBits == 0) {
       return ClusteredBitVector();
     }
-    auto vec = APInt::getNullValue(numBits);
+    auto vec = APInt::getZero(numBits);
     if (value) {
       vec.flipAllBits();
     }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1114,12 +1114,12 @@ APInt BuiltinIntegerWidth::parse(StringRef text, unsigned radix, bool negate,
     // Now we can safely negate.
     if (negate) {
       value = -value;
-      assert(value.isNegative() || value.isNullValue());
+      assert(value.isNegative() || value.isZero());
     }
 
     // Truncate down to the minimum number of bits required to express
     // this value exactly.
-    auto requiredBits = value.getMinSignedBits();
+    auto requiredBits = value.getSignificantBits();
     if (value.getBitWidth() > requiredBits)
       value = value.trunc(requiredBits);
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -576,10 +576,10 @@ void swift::ide::printModuleInterface(
 
         // If we're supposed to visit submodules, add them now.
         if (TraversalOptions & ModuleTraversal::VisitSubmodules) {
-          for (auto Sub = CM->submodule_begin(), SubEnd = CM->submodule_end();
-               Sub != SubEnd; ++Sub) {
-            if (Visited.insert(*Sub).second)
-              Worklist.push_back(*Sub);
+          for (clang::Module * submodule: CM->submodules()) {
+            if (Visited.insert(submodule).second) {
+                Worklist.push_back(submodule);
+            }
           }
         }
       }
@@ -593,9 +593,8 @@ void swift::ide::printModuleInterface(
   llvm::SmallPtrSet<const clang::Module *, 16> NoImportSubModules;
   if (TargetClangMod) {
     // Assume all submodules are missing.
-    for (auto It = TargetClangMod->submodule_begin();
-         It != TargetClangMod->submodule_end(); ++It) {
-      NoImportSubModules.insert(*It);
+    for (clang::Module *submodule: TargetClangMod->submodules()) {
+      NoImportSubModules.insert(submodule);
     }
   }
   llvm::StringMap<std::vector<Decl*>> FileRangedDecls;

--- a/lib/IRGen/BitPatternBuilder.h
+++ b/lib/IRGen/BitPatternBuilder.h
@@ -108,7 +108,7 @@ public:
     assert(numBits % 8 == 0);
     if (numBits) {
       Size += numBits;
-      Elements.push_back(APInt::getAllOnesValue(numBits));
+      Elements.push_back(APInt::getAllOnes(numBits));
     }
   }
 
@@ -119,7 +119,7 @@ public:
     assert(numBits % 8 == 0);
     if (numBits) {
       Size += numBits;
-      Elements.push_back(APInt::getNullValue(numBits));
+      Elements.push_back(APInt::getZero(numBits));
     }
   }
 
@@ -150,7 +150,7 @@ public:
     if (Size == 0) {
       return llvm::Optional<APInt>();
     }
-    auto result = APInt::getNullValue(Size);
+    auto result = APInt::getZero(Size);
     unsigned offset = 0;
     for (const auto &e : Elements) {
       unsigned index = offset;

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -111,7 +111,7 @@ static APInt createElementMask(const llvm::DataLayout &DL,
 
   // Pad the valueMask so that it can be applied to the entire
   // payload.
-  auto mask = APInt::getNullValue(payloadSizeInBits);
+  auto mask = APInt::getZero(payloadSizeInBits);
   auto offset = payloadOffset;
   if (DL.isBigEndian()) {
     offset = payloadSizeInBits - payloadOffset - elStoreSize;
@@ -348,7 +348,7 @@ EnumPayload::emitCompare(IRGenFunction &IGF,
       continue;
     
     // Apply the mask and test.
-    bool isMasked = !maskPiece.isAllOnesValue();
+    bool isMasked = !maskPiece.isAllOnes();
     auto intTy = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), size);
     // Need to bitcast to an integer in order to use 'icmp eq' if the piece
     // isn't already an int or pointer, or in order to apply a mask.
@@ -381,7 +381,7 @@ EnumPayload::emitCompare(IRGenFunction &IGF,
 void
 EnumPayload::emitApplyAndMask(IRGenFunction &IGF, const APInt &mask) {
   // Early exit if the mask has no effect.
-  if (mask.isAllOnesValue())
+  if (mask.isAllOnes())
     return;
 
   auto &DL = IGF.IGM.DataLayout;
@@ -395,7 +395,7 @@ EnumPayload::emitApplyAndMask(IRGenFunction &IGF, const APInt &mask) {
     auto maskPiece = maskReader.read(size);
     
     // If this piece is all ones, it has no effect.
-    if (maskPiece.isAllOnesValue())
+    if (maskPiece.isAllOnes())
       continue;
 
     // If the payload value is vacant, the mask can't change it.
@@ -446,7 +446,7 @@ EnumPayload::emitApplyOrMask(IRGenModule &IGM,
     
     // If the payload value is vacant, or the mask is all ones,
     // we can adopt the mask value directly.
-    if (pv.is<llvm::Type *>() || maskPiece.isAllOnesValue()) {
+    if (pv.is<llvm::Type *>() || maskPiece.isAllOnes()) {
       pv = builder.CreateBitOrPointerCast(maskConstant, payloadTy);
       continue;
     }

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -151,7 +151,7 @@ public:
 
   /// Get the bit mask that must be applied before testing an extra inhabitant.
   virtual APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const {
-    return APInt::getAllOnesValue(getFixedSize().getValueInBits());
+    return APInt::getAllOnes(getFixedSize().getValueInBits());
   }
 
   /// Create a constant of the given bit width holding one of the extra

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -218,7 +218,7 @@ static BuiltinInst *getOffsetSubtract(const TupleExtractInst *TE, SILModule &M) 
     return nullptr;
 
   auto *overflowFlag = dyn_cast<IntegerLiteralInst>(BI->getArguments()[2]);
-  if (!overflowFlag || !overflowFlag->getValue().isNullValue())
+  if (!overflowFlag || !overflowFlag->getValue().isZero())
     return nullptr;
 
   return BI;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -39,7 +39,7 @@ SILInstruction *SILCombiner::optimizeBuiltinCompareEq(BuiltinInst *BI,
       // cmp_eq %X, -1 -> xor (cmp_eq %X, 0), -1
       if (!NegateResult) {
         if (auto *ILOp = dyn_cast<IntegerLiteralInst>(BI->getArguments()[1]))
-          if (ILOp->getValue().isAllOnesValue()) {
+          if (ILOp->getValue().isAllOnes()) {
             auto X = BI->getArguments()[0];
             SILValue One(ILOp);
             SILValue Zero(
@@ -731,14 +731,14 @@ SILInstruction *SILCombiner::visitBuiltinInst(BuiltinInst *I) {
 
     return optimizeBitOp(I,
       [](APInt &left, const APInt &right) { left &= right; }    /* combine */,
-      [](const APInt &i) -> bool { return i.isAllOnesValue(); } /* isNeutral */,
+      [](const APInt &i) -> bool { return i.isAllOnes(); }      /* isNeutral */,
       [](const APInt &i) -> bool { return i.isMinValue(); }     /* isZero */,
       Builder, this);
   case BuiltinValueKind::Or:
     return optimizeBitOp(I,
       [](APInt &left, const APInt &right) { left |= right; }    /* combine */,
       [](const APInt &i) -> bool { return i.isMinValue(); }     /* isNeutral */,
-      [](const APInt &i) -> bool { return i.isAllOnesValue(); } /* isZero */,
+      [](const APInt &i) -> bool { return i.isAllOnes(); }      /* isZero */,
       Builder, this);
   case BuiltinValueKind::Xor:
     return optimizeBitOp(I,

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1377,13 +1377,13 @@ static SILValue skipInvert(SILValue Cond, bool &Inverted,
     if (BI->getBuiltinInfo().ID == BuiltinValueKind::Xor) {
       // Check if it's a boolean inversion of the condition.
       if (auto *IL = dyn_cast<IntegerLiteralInst>(Args[1])) {
-        if (IL->getValue().isAllOnesValue()) {
+        if (IL->getValue().isAllOnes()) {
           Cond = Args[0];
           Inverted = !Inverted;
           continue;
         }
       } else if (auto *IL = dyn_cast<IntegerLiteralInst>(Args[0])) {
-        if (IL->getValue().isAllOnesValue()) {
+        if (IL->getValue().isAllOnes()) {
           Cond = Args[1];
           Inverted = !Inverted;
           continue;
@@ -1513,7 +1513,7 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
       // Check if it's a boolean inversion of the condition.
       OperandValueArrayRef Args = Xor->getArguments();
       if (auto *IL = dyn_cast<IntegerLiteralInst>(Args[1])) {
-        if (IL->getValue().isAllOnesValue()) {
+        if (IL->getValue().isAllOnes()) {
           LLVM_DEBUG(llvm::dbgs() << "canonicalize cond_br: " << *BI);
           auto Cond = Args[0];
           SILBuilderWithScope Builder(BI);


### PR DESCRIPTION
This patch migrates the compiler off of the deprecated LLVM APIs on `main` where I can.
This is meant to help reduce the number of conflicts that appear while working on `next`.

 - `APInt::getAllOnesValue` -> `APInt::getAllOnes`
 - `APInt::getNullValue` -> `APInt::getZero`
 - `APInt::isNullValue` -> `APInt::isZero`
 - `APInt::getMinSignedBits` -> `APInt::getSignificantBits`
 - `clang::Module::submodule_`{`begin`,`end`} -> `clang::Module::submodules`
