### PR TITLE
[cxx-interop] Handle inherited templated operators during auto-conformance

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -568,6 +568,8 @@ public:
                                  clang::FunctionTemplateDecl *func,
                                  SubstitutionMap subst) override;
 
+  bool isSynthesizedAndVisibleFromAllModules(const clang::Decl *decl);
+
   bool isCXXMethodMutating(const clang::CXXMethodDecl *method) override;
 
   bool isUnsafeCXXMethod(const FuncDecl *func) override;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2842,6 +2842,12 @@ static bool isVisibleFromModule(const ClangModuleUnit *ModuleFilter,
   if (OwningClangModule == ModuleFilter->getClangModule())
     return true;
 
+  // If this decl was implicitly synthesized by the compiler, and is not
+  // supposed to be owned by any module, return true.
+  if (Importer->isSynthesizedAndVisibleFromAllModules(D)) {
+    return true;
+  }
+
   // Friends from class templates don't have an owning module. Just return true.
   if (isa<clang::FunctionDecl>(D) &&
       cast<clang::FunctionDecl>(D)->isThisDeclarationInstantiatedFromAFriendDefinition())
@@ -6300,6 +6306,11 @@ FuncDecl *ClangImporter::getCXXSynthesizedOperatorFunc(FuncDecl *decl) {
   assert(synthesizedOperator->isOperator() &&
          "expected the alternative to be a synthesized operator");
   return cast<FuncDecl>(synthesizedOperator);
+}
+
+bool ClangImporter::isSynthesizedAndVisibleFromAllModules(
+    const clang::Decl *decl) {
+  return Impl.synthesizedAndAlwaysVisibleDecls.contains(decl);
 }
 
 bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -642,6 +642,8 @@ public:
   llvm::MapVector<std::pair<NominalTypeDecl *, Type>,
                   std::pair<FuncDecl *, FuncDecl *>> cxxSubscripts;
 
+  llvm::SmallPtrSet<const clang::Decl *, 1> synthesizedAndAlwaysVisibleDecls;
+
 private:
   // Keep track of the decls that were already cloned for this specific class.
   llvm::DenseMap<std::pair<ValueDecl *, DeclContext *>, ValueDecl *>

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-collection.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-collection.h
@@ -28,4 +28,38 @@ public:
   const int& operator[](int index) const { return x[index]; }
 };
 
+template <typename T>
+struct HasInheritedTemplatedConstRACIterator {
+public:
+  typedef InheritedTemplatedConstRACIterator<int> iterator;
+
+private:
+  iterator b = iterator(1);
+  iterator e = iterator(6);
+
+public:
+  iterator begin() const { return b; }
+  iterator end() const { return e; }
+};
+
+typedef HasInheritedTemplatedConstRACIterator<int>
+    HasInheritedTemplatedConstRACIteratorInt;
+
+template <typename T>
+struct HasInheritedTemplatedConstRACIteratorOutOfLineOps {
+public:
+  typedef InheritedTemplatedConstRACIteratorOutOfLineOps<int> iterator;
+
+private:
+  iterator b = iterator(1);
+  iterator e = iterator(4);
+
+public:
+  iterator begin() const { return b; }
+  iterator end() const { return e; }
+};
+
+typedef HasInheritedTemplatedConstRACIteratorOutOfLineOps<int>
+    HasInheritedTemplatedConstRACIteratorOutOfLineOpsInt;
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_COLLECTION_H

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -593,4 +593,241 @@ operator-(const TemplatedRACIteratorOutOfLineEq<T> &lhs,
 
 using TemplatedRACIteratorOutOfLineEqInt = TemplatedRACIteratorOutOfLineEq<int>;
 
+// MARK: Iterator types that use inheritance
+
+struct BaseIntIterator {
+  using value_type = int;
+  using reference = const int &;
+
+  int value;
+
+  BaseIntIterator(int value) : value(value) {}
+
+  reference operator*() const { return value; }
+
+  bool operator==(const BaseIntIterator &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const BaseIntIterator &other) const {
+    return value != other.value;
+  }
+};
+
+struct InheritedConstIterator : BaseIntIterator {
+  using iterator_category = std::input_iterator_tag;
+  using pointer = int *;
+  using difference_type = int;
+
+  InheritedConstIterator(int value) : BaseIntIterator(value) {}
+  InheritedConstIterator(const InheritedConstIterator &other) = default;
+
+  InheritedConstIterator &operator++() {
+    value++;
+    return *this;
+  }
+  InheritedConstIterator operator++(int) {
+    auto tmp = InheritedConstIterator(value);
+    value++;
+    return tmp;
+  }
+};
+
+// MARK: Templated iterator types that use inheritance
+
+template <typename T>
+struct BaseTemplatedIterator {
+  using value_type = T;
+  using reference = const T &;
+
+  T value;
+
+  BaseTemplatedIterator(T value) : value(value) {}
+
+  reference operator*() const { return value; }
+
+  bool operator==(const BaseTemplatedIterator<T> &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const BaseTemplatedIterator<T> &other) const {
+    return value != other.value;
+  }
+};
+
+template <typename T>
+struct InheritedTemplatedConstIterator : BaseTemplatedIterator<T> {
+  using iterator_category = std::input_iterator_tag;
+  using pointer = int *;
+  using difference_type = int;
+
+  InheritedTemplatedConstIterator(T value) : BaseTemplatedIterator<T>(value) {}
+  InheritedTemplatedConstIterator(const InheritedTemplatedConstIterator<T> &other) = default;
+
+  InheritedTemplatedConstIterator<T> &operator++() {
+    BaseTemplatedIterator<T>::value++;
+    return *this;
+  }
+  InheritedTemplatedConstIterator<T> operator++(int) {
+    auto tmp = InheritedTemplatedConstIterator<T>(BaseTemplatedIterator<T>::value);
+    BaseTemplatedIterator<T>::value++;
+    return tmp;
+  }
+};
+
+typedef InheritedTemplatedConstIterator<int> InheritedTemplatedConstIteratorInt;
+
+template <typename T>
+struct BaseTemplatedRACIterator {
+  using value_type = T;
+  using reference = const T &;
+  using difference_type = int;
+
+  T value;
+
+  BaseTemplatedRACIterator(T value) : value(value) {}
+
+  reference operator*() const { return value; }
+
+  bool operator==(const BaseTemplatedRACIterator<T> &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const BaseTemplatedRACIterator<T> &other) const {
+    return value != other.value;
+  }
+};
+
+template <typename T>
+struct InheritedTemplatedConstRACIterator : BaseTemplatedRACIterator<T> {
+  using _super = BaseTemplatedRACIterator<T>;
+  using iterator_category = std::random_access_iterator_tag;
+  using pointer = int *;
+
+  InheritedTemplatedConstRACIterator(T value)
+      : BaseTemplatedRACIterator<T>(value) {}
+  InheritedTemplatedConstRACIterator(
+      const InheritedTemplatedConstRACIterator<T> &other) = default;
+
+  InheritedTemplatedConstRACIterator<T> &operator++() {
+    _super::value++;
+    return *this;
+  }
+  InheritedTemplatedConstRACIterator<T> operator++(int) {
+    auto tmp = InheritedTemplatedConstRACIterator<T>(_super::value);
+    _super::value++;
+    return tmp;
+  }
+
+  InheritedTemplatedConstRACIterator<T>
+  operator+(typename _super::difference_type v) const {
+    return {_super::value + v};
+  }
+  InheritedTemplatedConstRACIterator<T>
+  operator-(typename _super::difference_type v) const {
+    return {_super::value - v};
+  }
+  friend InheritedTemplatedConstRACIterator<T>
+  operator+(typename _super::difference_type v,
+            const InheritedTemplatedConstRACIterator<T> &it) {
+    return it + v;
+  }
+  int operator-(const InheritedTemplatedConstRACIterator<T> &other) const {
+    return _super::value - other.value;
+  }
+
+  void operator+=(typename _super::difference_type v) { _super::value += v; }
+  void operator-=(typename _super::difference_type v) { _super::value -= v; }
+
+  bool operator<(const InheritedTemplatedConstRACIterator<T> &other) const {
+    return _super::value < other.value;
+  }
+};
+
+typedef InheritedTemplatedConstRACIterator<int> InheritedTemplatedConstRACIteratorInt;
+
+template <typename T>
+struct BaseTemplatedRACIteratorOutOfLineOps {
+  using value_type = T;
+  using reference = const T &;
+  using difference_type = int;
+  
+  T value;
+
+  BaseTemplatedRACIteratorOutOfLineOps(T value) : value(value) {}
+
+  reference operator*() const { return value; }
+};
+
+template <typename T>
+bool operator==(const BaseTemplatedRACIteratorOutOfLineOps<T> &lhs,
+                const BaseTemplatedRACIteratorOutOfLineOps<T> &rhs) {
+  return lhs.value == rhs.value;
+}
+
+template <typename T>
+bool operator!=(const BaseTemplatedRACIteratorOutOfLineOps<T> &lhs,
+                const BaseTemplatedRACIteratorOutOfLineOps<T> &rhs) {
+  return lhs.value != rhs.value;
+}
+
+template <typename T>
+bool operator<(const BaseTemplatedRACIteratorOutOfLineOps<T> &lhs,
+               const BaseTemplatedRACIteratorOutOfLineOps<T> &rhs) {
+  return lhs.value < rhs.value;
+}
+
+template <typename T>
+typename BaseTemplatedRACIteratorOutOfLineOps<T>::difference_type
+operator-(const BaseTemplatedRACIteratorOutOfLineOps<T> &lhs,
+          const BaseTemplatedRACIteratorOutOfLineOps<T> &rhs) {
+  return lhs.value - rhs.value;
+}
+
+template <typename T>
+BaseTemplatedRACIteratorOutOfLineOps<T> operator+(
+    const BaseTemplatedRACIteratorOutOfLineOps<T> &lhs,
+    typename BaseTemplatedRACIteratorOutOfLineOps<T>::difference_type rhs) {
+  return {lhs.value + rhs};
+}
+
+template <typename T>
+BaseTemplatedRACIteratorOutOfLineOps<T> operator-(
+    const BaseTemplatedRACIteratorOutOfLineOps<T> &lhs,
+    typename BaseTemplatedRACIteratorOutOfLineOps<T>::difference_type rhs) {
+  return {lhs.value - rhs};
+}
+
+template <typename T>
+BaseTemplatedRACIteratorOutOfLineOps<T>
+operator+(typename BaseTemplatedRACIteratorOutOfLineOps<T>::difference_type lhs,
+          const BaseTemplatedRACIteratorOutOfLineOps<T> &rhs) {
+  return {rhs.value + lhs};
+}
+
+template <typename T>
+struct InheritedTemplatedConstRACIteratorOutOfLineOps
+    : BaseTemplatedRACIteratorOutOfLineOps<T> {
+  using _super = BaseTemplatedRACIteratorOutOfLineOps<T>;
+  using _self = InheritedTemplatedConstRACIteratorOutOfLineOps<T>;
+  using iterator_category = std::random_access_iterator_tag;
+  using pointer = int *;
+
+  InheritedTemplatedConstRACIteratorOutOfLineOps(T value) : _super(value) {}
+  InheritedTemplatedConstRACIteratorOutOfLineOps(const _self &other) = default;
+
+  _self &operator++() {
+    _super::value++;
+    return *this;
+  }
+  _self operator++(int) {
+    auto tmp = _self(_super::value);
+    _super::value++;
+    return tmp;
+  }
+
+  void operator+=(typename _super::difference_type v) { _super::value += v; }
+  void operator-=(typename _super::difference_type v) { _super::value -= v; }
+};
+
+typedef InheritedTemplatedConstRACIteratorOutOfLineOps<int>
+    InheritedTemplatedConstRACIteratorOutOfLineOpsInt;
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_ITERATOR_H

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -108,4 +108,31 @@ struct HasTemplatedIterator {
 
 typedef HasTemplatedIterator<int> HasUninstantiatableIterator;
 
+struct HasInheritedConstIterator {
+private:
+  InheritedConstIterator b = InheritedConstIterator(1);
+  InheritedConstIterator e = InheritedConstIterator(6);
+
+public:
+  InheritedConstIterator begin() const { return b; }
+  InheritedConstIterator end() const { return e; }
+};
+
+template <typename T>
+struct HasInheritedTemplatedConstIterator {
+public:
+  typedef InheritedTemplatedConstIterator<int> iterator;
+
+private:
+  iterator b = iterator(1);
+  iterator e = iterator(7);
+
+public:
+  iterator begin() const { return b; }
+  iterator end() const { return e; }
+};
+
+typedef HasInheritedTemplatedConstIterator<int>
+    HasInheritedTemplatedConstIteratorInt;
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_SEQUENCE_H

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
@@ -17,3 +17,15 @@
 // CHECK:   typealias Iterator = CxxIterator<SimpleCollectionReadOnly>
 // CHECK:   typealias RawIterator = SimpleCollectionReadOnly.iterator
 // CHECK: }
+
+// CHECK: struct HasInheritedTemplatedConstRACIterator<Int32> : CxxRandomAccessCollection {
+// CHECK:   typealias Element = InheritedTemplatedConstRACIterator<Int32>.Pointee
+// CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIterator<Int32>>
+// CHECK:   typealias RawIterator = InheritedTemplatedConstRACIterator<Int32>
+// CHECK: }
+
+// CHECK: struct HasInheritedTemplatedConstRACIteratorOutOfLineOps<Int32> : CxxRandomAccessCollection {
+// CHECK:   typealias Element = InheritedTemplatedConstRACIteratorOutOfLineOps<Int32>.Pointee
+// CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIteratorOutOfLineOps<Int32>>
+// CHECK:   typealias RawIterator = InheritedTemplatedConstRACIteratorOutOfLineOps<Int32>
+// CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -49,4 +49,22 @@ CxxCollectionTestSuite.test("SimpleArrayWrapper as Swift.Collection") {
   expectEqual(mapped.last, 51)
 }
 
+CxxCollectionTestSuite.test("HasInheritedTemplatedConstRACIterator as Swift.Collection") {
+  let c = HasInheritedTemplatedConstRACIteratorInt()
+  expectEqual(c.first, 1)
+  expectEqual(c.last, 5)
+
+  let reduced = c.reduce(0, +)
+  expectEqual(reduced, 15)
+}
+
+CxxCollectionTestSuite.test("HasInheritedTemplatedConstRACIteratorOutOfLineOps as Swift.Collection") {
+  let c = HasInheritedTemplatedConstRACIteratorOutOfLineOpsInt()
+  expectEqual(c.first, 1)
+  expectEqual(c.last, 3)
+
+  let reduced = c.reduce(0, +)
+  expectEqual(reduced, 6)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -59,4 +59,16 @@ CxxSequenceTestSuite.test("SimpleSequence.forEach") {
   expectEqual([1, 2, 3, 4] as [Int32], array)
 }
 
+CxxSequenceTestSuite.test("HasInheritedConstIterator to Swift.Array") {
+  let seq = HasInheritedConstIterator()
+  let array = Array(seq)
+  expectEqual([1, 2, 3, 4, 5] as [Int32], array)
+}
+
+CxxSequenceTestSuite.test("HasInheritedTemplatedConstIterator to Swift.Array") {
+  let seq = HasInheritedTemplatedConstIteratorInt()
+  let array = Array(seq)
+  expectEqual([1, 2, 3, 4, 5, 6] as [Int32], array)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -105,3 +105,23 @@
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = TemplatedRACIteratorOutOfLineEq<Int32>.difference_type
 // CHECK: }
+
+// CHECK: struct BaseIntIterator {
+// CHECK: }
+// CHECK: struct InheritedConstIterator : UnsafeCxxInputIterator {
+// CHECK: }
+
+// CHECK: struct InheritedTemplatedConstIterator<T> {
+// CHECK: }
+// CHECK: struct InheritedTemplatedConstIterator<Int32> : UnsafeCxxInputIterator {
+// CHECK: }
+
+// CHECK: struct InheritedTemplatedConstRACIterator<T> {
+// CHECK: }
+// CHECK: struct InheritedTemplatedConstRACIterator<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: }
+
+// CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<T> {
+// CHECK: }
+// CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: }

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -29,7 +29,6 @@ StdMapTestSuite.test("Map.subscript") {
   expectNil(m[5])
 }
 
-#if !os(Linux) // TODO: enable on Linux (rdar://105220600)
 StdMapTestSuite.test("UnorderedMap.subscript") {
   // This relies on the `std::unordered_map` conformance to `CxxDictionary` protocol.
   var m = initUnorderedMap()
@@ -39,6 +38,5 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
   expectNil(m[-1])
   expectNil(m[5])
 }
-#endif
 
 runAllTests()


### PR DESCRIPTION
This fixes the automatic `std::unordered_map` conformance to CxxDictionary on Linux. Previously `std::unordered_map::const_iterator` was not auto-conformed to UnsafeCxxInputIterator because its `operator==` is defined on a templated base class of `const_iterator`.

rdar://105220600
Resolves #66767