### PR TITLE
[interop][SwiftToCxx] ensure swift::Int and swift::UInt are usable in…

### DIFF
--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Core -clang-header-expose-decls=all-public -emit-clang-header-path %t/core.h
+// RUN: %FileCheck %s < %t/core.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/core.h)
+
+// REQUIRES: PTRSIZE=64
+// REQUIRES: OS=macosx
+
+// CHECK: // type metadata address for Bool.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSbN;
+// CHECK-NEXT: // type metadata address for Int8.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss4Int8VN;
+// CHECK-NEXT: // type metadata address for UInt8.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss5UInt8VN;
+// CHECK-NEXT: // type metadata address for Int16.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss5Int16VN;
+// CHECK-NEXT: // type metadata address for UInt16.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss6UInt16VN;
+// CHECK-NEXT: // type metadata address for Int32.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss5Int32VN;
+// CHECK-NEXT: // type metadata address for UInt32.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss6UInt32VN;
+// CHECK-NEXT: // type metadata address for Int64.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss5Int64VN;
+// CHECK-NEXT: // type metadata address for UInt64.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss6UInt64VN;
+// CHECK-NEXT: // type metadata address for Float.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSfN;
+// CHECK-NEXT: // type metadata address for Double.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSdN;
+// CHECK-NEXT: // type metadata address for OpaquePointer.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss13OpaquePointerVN;
+// CHECK-NEXT: // type metadata address for Int.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSiN;
+// CHECK-NEXT: // type metadata address for UInt.
+// CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSuN;
+// CHECK-EMPTY:
+// CHECK-NEXT: #ifdef __cplusplus
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK: static inline const constexpr bool isUsableInGenericContext<void *> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<void *> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss13OpaquePointerVN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<swift::Int> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<swift::Int> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$sSiN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<swift::UInt> = true;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<>
+// CHECK-NEXT: struct TypeMetadataTrait<swift::UInt> {
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$sSuN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: #pragma clang diagnostic pop
+// CHECK-EMPTY:
+// CHECK-NEXT: } // namespace swift
+

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -93,8 +93,7 @@
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $sSdN;
 // CHECK-NEXT: // type metadata address for OpaquePointer.
 // CHECK-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss13OpaquePointerVN;
-// CHECK-EMPTY:
-// CHECK-NEXT: #ifdef __cplusplus
+// CHECK: #ifdef __cplusplus
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 // CHECK-EMPTY:
@@ -224,7 +223,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-EMPTY:
-// CHECK-NEXT: #pragma clang diagnostic pop
+// CHECK: #pragma clang diagnostic pop
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
@@ -17,5 +17,10 @@ public func test() -> String {
     return ""
 }
 
+@_expose(Cxx)
+public func testIntArray() -> [Int] {
+    return []
+}
+
 // CHECK: namespace swift SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("swift") {
 // CHECK: class SWIFT_SYMBOL("{{.*}}") String final {


### PR DESCRIPTION
… generic context

Fixes https://github.com/apple/swift/issues/63452

(cherry picked from commit 85a431eedf65b69c131f06c3213c9d61050275c7)


- Explanation: The generated header contains a set of C++ type traits that allow some fundamental builtin types like int and int64_t to be used in Swift's generics from C++. However, the `swift::Int` and `swift::UInt` type is not guaranteed to be covered by existing set of templates on all platforms. More specifically, on Darwin, `swift::Int -> ptrdiff_t -> long` does not have a corresponding type trait, as `long` is not used for `int64_t`. In this case, we should add an explicit type trait for `swift::Int` and `swift::UInt`, to ensure that these types can be used in a generic context from C++ on Darwin.
- Scope: C++ interop, generated header generator, generated C++ type traits for Swift's builtin types.
- Risk: Low, adds new type traits only with minimal risk of template conflict.
- Testing: Unit tests.
- Original PR: https://github.com/apple/swift/pull/67241