### PR TITLE
[reference-bindings] Compile in ReferenceBindings in non-asserts builds.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -209,7 +209,7 @@ EXPERIMENTAL_FEATURE(ImportSymbolicCXXDecls, false)
 EXPERIMENTAL_FEATURE(GenerateBindingsForThrowingFunctionsInCXX, false)
 
 /// Enable reference bindings.
-EXPERIMENTAL_FEATURE(ReferenceBindings, false)
+EXPERIMENTAL_FEATURE(ReferenceBindings, true)
 
 /// Enable the explicit 'import Builtin' and allow Builtin usage.
 EXPERIMENTAL_FEATURE(BuiltinModule, true)


### PR DESCRIPTION
Just to fix the bots.

rdar://112230433
