### PR TITLE
[cxx-interop] Only mark projections of self-contained types as unsafe.

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
+++ b/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
@@ -27,7 +27,11 @@ public struct SourceLoc {
     guard bridged.isValid() else {
       return nil
     }
+#if hasFeature(NewCxxMethodSafetyHeuristics)
+    self.locationInFile = bridged.getOpaquePointerValue().assumingMemoryBound(to: UInt8.self)
+#else
     self.locationInFile = bridged.__getOpaquePointerValueUnsafe().assumingMemoryBound(to: UInt8.self)
+#endif
   }
 
   public var bridged: swift.SourceLoc {
@@ -57,9 +61,15 @@ public struct CharSourceRange {
   }
 
   public init?(bridged: swift.CharSourceRange) {
+#if hasFeature(NewCxxMethodSafetyHeuristics)
+    guard let start = SourceLoc(bridged: bridged.getStart()) else {
+      return nil
+    }
+#else
     guard let start = SourceLoc(bridged: bridged.__getStartUnsafe()) else {
       return nil
     }
+#endif
     self.init(start: start, byteLength: bridged.getByteLength())
   }
 

--- a/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
+++ b/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
@@ -27,7 +27,7 @@ public struct SourceLoc {
     guard bridged.isValid() else {
       return nil
     }
-#if hasFeature(NewCxxMethodSafetyHeuristics)
+#if $NewCxxMethodSafetyHeuristics
     self.locationInFile = bridged.getOpaquePointerValue().assumingMemoryBound(to: UInt8.self)
 #else
     self.locationInFile = bridged.__getOpaquePointerValueUnsafe().assumingMemoryBound(to: UInt8.self)
@@ -61,7 +61,7 @@ public struct CharSourceRange {
   }
 
   public init?(bridged: swift.CharSourceRange) {
-#if hasFeature(NewCxxMethodSafetyHeuristics)
+#if $NewCxxMethodSafetyHeuristics
     guard let start = SourceLoc(bridged: bridged.getStart()) else {
       return nil
     }

--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -66,19 +66,34 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
   public var description: String { string }
 
   public var count: Int {
+#if hasFeature(NewCxxMethodSafetyHeuristics)
+    Int(_bridged.bytes_end() - _bridged.bytes_begin())
+#else
     Int(_bridged.__bytes_endUnsafe() - _bridged.__bytes_beginUnsafe())
+#endif
   }
 
   public subscript(index: Int) -> UInt8 {
-    let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.__bytes_beginUnsafe(),
+#if hasFeature(NewCxxMethodSafetyHeuristics)
+    let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.bytes_begin(),
                                             count: count)
+#else
+    let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.bytes_begin(),
+                                            count: count)
+#endif
     return buffer[index]
   }
 
   public static func ==(lhs: StringRef, rhs: StaticString) -> Bool {
+#if hasFeature(NewCxxMethodSafetyHeuristics)
+    let lhsBuffer = UnsafeBufferPointer<UInt8>(
+      start: lhs._bridged.bytes_begin(),
+      count: lhs.count)
+#else
     let lhsBuffer = UnsafeBufferPointer<UInt8>(
       start: lhs._bridged.__bytes_beginUnsafe(),
       count: lhs.count)
+#endif
     return rhs.withUTF8Buffer { (rhsBuffer: UnsafeBufferPointer<UInt8>) in
       if lhsBuffer.count != rhsBuffer.count { return false }
       return lhsBuffer.elementsEqual(rhsBuffer, by: ==)

--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -66,7 +66,7 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
   public var description: String { string }
 
   public var count: Int {
-#if hasFeature(NewCxxMethodSafetyHeuristics)
+#if $NewCxxMethodSafetyHeuristics
     Int(_bridged.bytes_end() - _bridged.bytes_begin())
 #else
     Int(_bridged.__bytes_endUnsafe() - _bridged.__bytes_beginUnsafe())
@@ -74,7 +74,7 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
   }
 
   public subscript(index: Int) -> UInt8 {
-#if hasFeature(NewCxxMethodSafetyHeuristics)
+#if $NewCxxMethodSafetyHeuristics
     let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.bytes_begin(),
                                             count: count)
 #else
@@ -85,7 +85,7 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
   }
 
   public static func ==(lhs: StringRef, rhs: StaticString) -> Bool {
-#if hasFeature(NewCxxMethodSafetyHeuristics)
+#if $NewCxxMethodSafetyHeuristics
     let lhsBuffer = UnsafeBufferPointer<UInt8>(
       start: lhs._bridged.bytes_begin(),
       count: lhs.count)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -91,6 +91,7 @@ LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc", true)
 LANGUAGE_FEATURE(BuiltinUnprotectedStackAlloc, 0, "Builtin.unprotectedStackAlloc", true)
 LANGUAGE_FEATURE(BuiltinTaskRunInline, 0, "Builtin.taskRunInline", true)
 LANGUAGE_FEATURE(BuiltinUnprotectedAddressOf, 0, "Builtin.unprotectedAddressOf", true)
+LANGUAGE_FEATURE(NewCxxMethodSafetyHeuristics, 0, "Only import C++ methods that return pointers (projections) on owned types as unsafe", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
 LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
 LANGUAGE_FEATURE(BuiltinCreateTaskGroupWithFlags, 0, "Builtin.createTaskGroupWithFlags", true)
@@ -204,10 +205,6 @@ EXPERIMENTAL_FEATURE(RuntimeDiscoverableAttrs, false)
 /// Swift types and C++ methods as symbolic functions with blank
 /// signatures.
 EXPERIMENTAL_FEATURE(ImportSymbolicCXXDecls, false)
-
-// Only import C++ methods that return pointers (projections) on owned types as
-// unsafe.
-EXPERIMENTAL_FEATURE(NewCxxMethodSafetyHeuristics, true)
 
 /// Generate bindings for functions that 'throw' in the C++ section of the generated Clang header.
 EXPERIMENTAL_FEATURE(GenerateBindingsForThrowingFunctionsInCXX, false)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -205,6 +205,10 @@ EXPERIMENTAL_FEATURE(RuntimeDiscoverableAttrs, false)
 /// signatures.
 EXPERIMENTAL_FEATURE(ImportSymbolicCXXDecls, false)
 
+// Only import C++ methods that return pointers (projections) on owned types as
+// unsafe.
+EXPERIMENTAL_FEATURE(NewCxxMethodSafetyHeuristics, true)
+
 /// Generate bindings for functions that 'throw' in the C++ section of the generated Clang header.
 EXPERIMENTAL_FEATURE(GenerateBindingsForThrowingFunctionsInCXX, false)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3484,6 +3484,10 @@ static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureNewCxxMethodSafetyHeuristics(Decl *decl) {
+  return decl->hasClangNode();
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6789,6 +6789,37 @@ CxxRecordAsSwiftType::evaluate(Evaluator &evaluator,
   return nullptr;
 }
 
+bool anySubobjectsSelfContained(const clang::CXXRecordDecl *decl) {
+  if (!decl->getDefinition())
+    return false;
+
+  if (hasCustomCopyOrMoveConstructor(decl))
+    return true;
+  
+  auto checkType = [](clang::QualType t) {
+    if (auto recordType = dyn_cast<clang::RecordType>(t.getCanonicalType())) {
+      if (auto cxxRecord =
+              dyn_cast<clang::CXXRecordDecl>(recordType->getDecl())) {
+        return hasCustomCopyOrMoveConstructor(cxxRecord);
+      }
+    }
+
+    return false;
+  };
+
+  for (auto field : decl->fields()) {
+    if (checkType(field->getType()))
+      return true;
+  }
+
+  for (auto base : decl->bases()) {
+    if (checkType(base.getType()))
+      return true;
+  }
+  
+  return false;
+}
+
 bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
                                   SafeUseOfCxxDeclDescriptor desc) const {
   const clang::Decl *decl = desc.decl;
@@ -6806,10 +6837,19 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
     if (isForeignReferenceType(method->getReturnType()))
       return true;
 
-    // If it returns a pointer or reference, that's a projection.
+    auto parentQualType = method
+      ->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
+
+    bool parentIsSelfContained =
+      hasOwnedValueAttr(method->getParent()) ||
+      (!isForeignReferenceType(parentQualType) &&
+       anySubobjectsSelfContained(method->getParent()));
+
+    // If it returns a pointer or reference from an owned parent, that's a
+    // projection (unsafe).
     if (method->getReturnType()->isPointerType() ||
         method->getReturnType()->isReferenceType())
-      return false;
+      return !parentIsSelfContained;
 
     // Check if it's one of the known unsafe methods we currently
     // mark as safe by default.
@@ -6824,9 +6864,10 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
               dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
         if (isSwiftClassType(cxxRecordReturnType))
           return true;
+
         if (hasIteratorAPIAttr(cxxRecordReturnType) ||
             isIterator(cxxRecordReturnType)) {
-          return false;
+          return !parentIsSelfContained;
         }
 
         // Mark this as safe to help our diganostics down the road.
@@ -6834,10 +6875,12 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return true;
         }
 
-        if (!hasCustomCopyOrMoveConstructor(cxxRecordReturnType) &&
+        // A projection of a view type (such as a string_view) from a self
+        // contained parent is a proejction (unsafe).
+        if (!anySubobjectsSelfContained(cxxRecordReturnType) &&
             !hasOwnedValueAttr(cxxRecordReturnType) &&
             hasPointerInSubobjects(cxxRecordReturnType)) {
-          return false;
+          return !parentIsSelfContained;
         }
       }
     }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6865,9 +6865,8 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
           return true;
 
         if (hasIteratorAPIAttr(cxxRecordReturnType) ||
-            isIterator(cxxRecordReturnType)) {
-          return !parentIsSelfContained;
-        }
+            isIterator(cxxRecordReturnType))
+          return false;
 
         // Mark this as safe to help our diganostics down the road.
         if (!cxxRecordReturnType->getDefinition()) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6820,11 +6820,66 @@ bool anySubobjectsSelfContained(const clang::CXXRecordDecl *decl) {
   return false;
 }
 
+static bool legacyIsSafeUseOfCxxMethod(clang::CXXMethodDecl *method) {
+  // The user explicitly asked us to import this method.
+  if (hasUnsafeAPIAttr(method))
+    return true;
+
+  // If it's a static method, it cannot project anything. It's fine.
+  if (method->isOverloadedOperator() || method->isStatic() ||
+      isa<clang::CXXConstructorDecl>(decl))
+    return true;
+
+  if (isForeignReferenceType(method->getReturnType()))
+    return true;
+
+  // If it returns a pointer or reference, that's a projection.
+  if (method->getReturnType()->isPointerType() ||
+      method->getReturnType()->isReferenceType())
+    return false;
+
+  // Check if it's one of the known unsafe methods we currently
+  // mark as safe by default.
+  if (isUnsafeStdMethod(method))
+    return false;
+
+  // Try to figure out the semantics of the return type. If it's a
+  // pointer/iterator, it's unsafe.
+  if (auto returnType = dyn_cast<clang::RecordType>(
+          method->getReturnType().getCanonicalType())) {
+    if (auto cxxRecordReturnType =
+            dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
+      if (isSwiftClassType(cxxRecordReturnType))
+        return true;
+      if (hasIteratorAPIAttr(cxxRecordReturnType) ||
+          isIterator(cxxRecordReturnType)) {
+        return false;
+      }
+
+      // Mark this as safe to help our diganostics down the road.
+      if (!cxxRecordReturnType->getDefinition()) {
+        return true;
+      }
+
+      if (!hasCustomCopyOrMoveConstructor(cxxRecordReturnType) &&
+          !hasOwnedValueAttr(cxxRecordReturnType) &&
+          hasPointerInSubobjects(cxxRecordReturnType)) {
+        return false;
+      }
+    }
+  }
+  
+  return true;
+}
+
 bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
                                   SafeUseOfCxxDeclDescriptor desc) const {
   const clang::Decl *decl = desc.decl;
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(decl)) {
+    if (!desc.ctx.LangOpts.hasFeature(Feature::NewCxxMethodSafetyHeuristics))
+      return legacyIsSafeUseOfCxxMethod(method);
+    
     // The user explicitly asked us to import this method.
     if (hasUnsafeAPIAttr(method))
       return true;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6837,6 +6837,12 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
     if (isForeignReferenceType(method->getReturnType()))
       return true;
 
+    // begin and end methods likely return an interator, so they're unsafe. This
+    // is required so that automatic the conformance to RAC works properly.
+    if (method->getNameAsString() == "begin" ||
+        method->getNameAsString() == "end")
+      return false;
+
     auto parentQualType = method
       ->getParent()->getTypeForDecl()->getCanonicalTypeUnqualified();
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6820,66 +6820,11 @@ bool anySubobjectsSelfContained(const clang::CXXRecordDecl *decl) {
   return false;
 }
 
-static bool legacyIsSafeUseOfCxxMethod(clang::CXXMethodDecl *method) {
-  // The user explicitly asked us to import this method.
-  if (hasUnsafeAPIAttr(method))
-    return true;
-
-  // If it's a static method, it cannot project anything. It's fine.
-  if (method->isOverloadedOperator() || method->isStatic() ||
-      isa<clang::CXXConstructorDecl>(decl))
-    return true;
-
-  if (isForeignReferenceType(method->getReturnType()))
-    return true;
-
-  // If it returns a pointer or reference, that's a projection.
-  if (method->getReturnType()->isPointerType() ||
-      method->getReturnType()->isReferenceType())
-    return false;
-
-  // Check if it's one of the known unsafe methods we currently
-  // mark as safe by default.
-  if (isUnsafeStdMethod(method))
-    return false;
-
-  // Try to figure out the semantics of the return type. If it's a
-  // pointer/iterator, it's unsafe.
-  if (auto returnType = dyn_cast<clang::RecordType>(
-          method->getReturnType().getCanonicalType())) {
-    if (auto cxxRecordReturnType =
-            dyn_cast<clang::CXXRecordDecl>(returnType->getDecl())) {
-      if (isSwiftClassType(cxxRecordReturnType))
-        return true;
-      if (hasIteratorAPIAttr(cxxRecordReturnType) ||
-          isIterator(cxxRecordReturnType)) {
-        return false;
-      }
-
-      // Mark this as safe to help our diganostics down the road.
-      if (!cxxRecordReturnType->getDefinition()) {
-        return true;
-      }
-
-      if (!hasCustomCopyOrMoveConstructor(cxxRecordReturnType) &&
-          !hasOwnedValueAttr(cxxRecordReturnType) &&
-          hasPointerInSubobjects(cxxRecordReturnType)) {
-        return false;
-      }
-    }
-  }
-  
-  return true;
-}
-
 bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
                                   SafeUseOfCxxDeclDescriptor desc) const {
   const clang::Decl *decl = desc.decl;
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(decl)) {
-    if (!desc.ctx.LangOpts.hasFeature(Feature::NewCxxMethodSafetyHeuristics))
-      return legacyIsSafeUseOfCxxMethod(method);
-    
     // The user explicitly asked us to import this method.
     if (hasUnsafeAPIAttr(method))
       return true;

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -232,6 +232,7 @@ struct __attribute__((swift_attr("import_iterator"))) Iterator {
 };
 
 struct HasMethodThatReturnsIterator {
+  HasMethodThatReturnsIterator(const HasMethodThatReturnsIterator&);
   Iterator getIterator() const;
 };
 
@@ -240,6 +241,7 @@ struct IteratorBox {
 };
 
 struct HasMethodThatReturnsIteratorBox {
+  HasMethodThatReturnsIteratorBox(const HasMethodThatReturnsIteratorBox&);
   IteratorBox getIteratorBox() const;
 };
 

--- a/test/Interop/Cxx/class/fixit-add-safe-to-import-self-contained.swift
+++ b/test/Interop/Cxx/class/fixit-add-safe-to-import-self-contained.swift
@@ -12,6 +12,8 @@ module Test {
 struct Ptr { int *p; };
 
 struct X {
+  X(const X&);
+  
   int *test() { }
   Ptr other() { }
 };

--- a/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
+++ b/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
@@ -13,13 +13,14 @@ struct Ptr { int *p; };
 struct __attribute__((swift_attr("import_owned"))) StirngLiteral { const char *name; };
 
 struct M {
-        int *_Nonnull test1() const;
-        int &test2() const;
-        Ptr test3() const;
+  M(const M&);
+  int *_Nonnull test1() const;
+  int &test2() const;
+  Ptr test3() const;
 
-        int *begin() const;
+  int *begin() const;
 
-        StirngLiteral stringLiteral() const { return StirngLiteral{"M"}; }
+  StirngLiteral stringLiteral() const { return StirngLiteral{"M"}; }
 };
 
 //--- test.swift

--- a/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
@@ -52,6 +52,7 @@ struct Unsafe {
 };
 
 struct HasAmbiguousUnsafeMethods {
+  HasAmbiguousUnsafeMethods(const HasAmbiguousUnsafeMethods&);
   Unsafe getUnsafe() const { return Unsafe(); }
   Unsafe getUnsafe() { return Unsafe(); }
 };

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -7,3 +7,10 @@ module AmbiguousMethods {
   header "ambiguous_methods.h"
   requires cplusplus
 }
+
+module UnsafeProjections {
+  header "unsafe-projections.h"
+  requires cplusplus
+  
+  export *
+}

--- a/test/Interop/Cxx/class/method/Inputs/unsafe-projections.h
+++ b/test/Interop/Cxx/class/method/Inputs/unsafe-projections.h
@@ -1,0 +1,75 @@
+#ifndef TEST_INTEROP_CXX_CLASS_METHOD_UNSAFE_PROJECTIONS_H
+#define TEST_INTEROP_CXX_CLASS_METHOD_UNSAFE_PROJECTIONS_H
+
+#include <string>
+
+struct NestedSelfContained;
+struct Empty;
+struct SelfContained;
+
+struct View {
+  void *ptr;
+  
+  void *data() const;
+  void *empty() const;
+  std::string name() const;
+  NestedSelfContained nested() const;
+};
+
+struct SelfContained {
+  void *ptr;
+  SelfContained(const SelfContained&);
+  
+  std::string name() const;
+  SelfContained selfContained() const;
+  NestedSelfContained nested() const;
+  Empty empty() const;
+  int value() const;
+  View view() const;
+  int *pointer() const;
+};
+
+struct NestedSelfContained {
+  SelfContained member;
+  
+  std::string name() const;
+  SelfContained selfContained() const;
+  NestedSelfContained nested() const;
+  Empty empty() const;
+  int value() const;
+  View view() const;
+  int *pointer() const;
+};
+
+struct InheritSelfContained: SelfContained {
+  std::string name() const;
+  SelfContained selfContained() const;
+  NestedSelfContained nested() const;
+  Empty empty() const;
+  int value() const;
+  View view() const;
+  int *pointer() const;
+};
+
+struct __attribute__((swift_attr("import_owned"))) ExplicitSelfContained {
+  void *ptr;
+  
+  void *pointer() const;
+  View view() const;
+};
+
+struct Empty {
+  Empty empty() const;
+  void *pointer() const;
+  SelfContained selfContained() const;
+};
+
+struct IntPair {
+  int a; int b;
+
+  int first() const;
+  void *pointer() const;
+  SelfContained selfContained() const;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_METHOD_UNSAFE_PROJECTIONS_H

--- a/test/Interop/Cxx/class/method/Inputs/unsafe-projections.h
+++ b/test/Interop/Cxx/class/method/Inputs/unsafe-projections.h
@@ -6,6 +6,8 @@
 struct NestedSelfContained;
 struct Empty;
 struct SelfContained;
+struct ExplicitSelfContained;
+struct NestedExplicitSelfContained;
 
 struct View {
   void *ptr;
@@ -14,6 +16,8 @@ struct View {
   void *empty() const;
   std::string name() const;
   NestedSelfContained nested() const;
+  ExplicitSelfContained explicitSelfContained() const;
+  NestedExplicitSelfContained explicitNested() const;
 };
 
 struct SelfContained {
@@ -27,6 +31,8 @@ struct SelfContained {
   int value() const;
   View view() const;
   int *pointer() const;
+  ExplicitSelfContained explicitSelfContained() const;
+  NestedExplicitSelfContained explicitNested() const;
 };
 
 struct NestedSelfContained {
@@ -39,6 +45,8 @@ struct NestedSelfContained {
   int value() const;
   View view() const;
   int *pointer() const;
+  ExplicitSelfContained explicitSelfContained() const;
+  NestedExplicitSelfContained explicitNested() const;
 };
 
 struct InheritSelfContained: SelfContained {
@@ -56,6 +64,17 @@ struct __attribute__((swift_attr("import_owned"))) ExplicitSelfContained {
   
   void *pointer() const;
   View view() const;
+  NestedSelfContained nested() const;
+};
+
+struct NestedExplicitSelfContained {
+  ExplicitSelfContained m;
+
+  SelfContained selfContained() const;
+  NestedSelfContained nested() const;
+  int value() const;
+  View view() const;
+  int *pointer() const;
 };
 
 struct Empty {

--- a/test/Interop/Cxx/class/method/unsafe-projections.swift
+++ b/test/Interop/Cxx/class/method/unsafe-projections.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=UnsafeProjections -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK: struct View {
+// CHECK:   func data() -> UnsafeMutableRawPointer!
+// CHECK:   func empty() -> UnsafeMutableRawPointer!
+// CHECK:   func name() -> std{{.*}}string
+// CHECK:   func nested() -> NestedSelfContained
+// CHECK: }
+
+// CHECK: struct SelfContained {
+// CHECK:   func name() -> std{{.*}}string
+// CHECK:   func selfContained() -> SelfContained
+// CHECK:   func nested() -> NestedSelfContained
+// CHECK:   func empty() -> Empty
+// CHECK:   func value() -> Int32
+// CHECK:   func __viewUnsafe() -> View
+// CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
+// CHECK: }
+
+// CHECK: struct NestedSelfContained {
+// CHECK:   func name() -> std{{.*}}string
+// CHECK:   func selfContained() -> SelfContained
+// CHECK:   func nested() -> NestedSelfContained
+// CHECK:   func empty() -> Empty
+// CHECK:   func value() -> Int32
+// CHECK:   func __viewUnsafe() -> View
+// CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
+// CHECK: }
+
+// CHECK: struct InheritSelfContained {
+// CHECK:   func name() -> std{{.*}}string
+// CHECK:   func selfContained() -> SelfContained
+// CHECK:   func nested() -> NestedSelfContained
+// CHECK:   func empty() -> Empty
+// CHECK:   func value() -> Int32
+// CHECK:   func __viewUnsafe() -> View
+// CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
+// CHECK: }
+
+// CHECK: struct ExplicitSelfContained {
+// CHECK:   func __pointerUnsafe() -> UnsafeMutableRawPointer!
+// CHECK:   func __viewUnsafe() -> View
+// CHECK: }
+
+// CHECK: struct Empty {
+// CHECK:   func empty() -> Empty
+// CHECK:   func pointer() -> UnsafeMutableRawPointer!
+// CHECK:   func selfContained() -> SelfContained
+// CHECK: }
+
+// CHECK: struct IntPair {
+// CHECK:   func first() -> Int32
+// CHECK:   func pointer() -> UnsafeMutableRawPointer!
+// CHECK:   func selfContained() -> SelfContained
+// CHECK: }

--- a/test/Interop/Cxx/class/method/unsafe-projections.swift
+++ b/test/Interop/Cxx/class/method/unsafe-projections.swift
@@ -5,6 +5,8 @@
 // CHECK:   func empty() -> UnsafeMutableRawPointer!
 // CHECK:   func name() -> std{{.*}}string
 // CHECK:   func nested() -> NestedSelfContained
+// CHECK:   func explicitSelfContained() -> ExplicitSelfContained
+// CHECK:   func explicitNested() -> NestedExplicitSelfContained
 // CHECK: }
 
 // CHECK: struct SelfContained {
@@ -15,6 +17,8 @@
 // CHECK:   func value() -> Int32
 // CHECK:   func __viewUnsafe() -> View
 // CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
+// CHECK:   func explicitSelfContained() -> ExplicitSelfContained
+// CHECK:   func explicitNested() -> NestedExplicitSelfContained
 // CHECK: }
 
 // CHECK: struct NestedSelfContained {
@@ -25,6 +29,8 @@
 // CHECK:   func value() -> Int32
 // CHECK:   func __viewUnsafe() -> View
 // CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
+// CHECK:   func explicitSelfContained() -> ExplicitSelfContained
+// CHECK:   func explicitNested() -> NestedExplicitSelfContained
 // CHECK: }
 
 // CHECK: struct InheritSelfContained {
@@ -35,11 +41,22 @@
 // CHECK:   func value() -> Int32
 // CHECK:   func __viewUnsafe() -> View
 // CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
+// CHECK:   func explicitSelfContained() -> ExplicitSelfContained
+// CHECK:   func explicitNested() -> NestedExplicitSelfContained
 // CHECK: }
 
 // CHECK: struct ExplicitSelfContained {
 // CHECK:   func __pointerUnsafe() -> UnsafeMutableRawPointer!
 // CHECK:   func __viewUnsafe() -> View
+// CHECK:   func nested() -> NestedSelfContained
+// CHECK: }
+
+// CHECK: struct NestedExplicitSelfContained {
+// CHECK:   func selfContained() -> SelfContained
+// CHECK:   func nested() -> NestedSelfContained
+// CHECK:   func value() -> Int32
+// CHECK:   func __viewUnsafe() -> View
+// CHECK:   func __pointerUnsafe() -> UnsafeMutablePointer<Int32>!
 // CHECK: }
 
 // CHECK: struct Empty {

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -24,7 +24,9 @@ struct SimpleCopyAwareSequence {
   SimpleCopyAwareSequence(const SimpleCopyAwareSequence &other) { copiesCount++; }
 };
 
-struct SimpleArrayWrapper {
+struct
+  __attribute__((swift_attr("import_owned")))
+SimpleArrayWrapper {
 private:
   int a[5] = {10, 20, 30, 40, 50};
 
@@ -33,7 +35,9 @@ public:
   const int *end() const __attribute__((returns_nonnull)) { return &a[5]; }
 };
 
-struct SimpleArrayWrapperNullableIterators {
+struct
+  __attribute__((swift_attr("import_owned")))
+SimpleArrayWrapperNullableIterators {
 private:
   int a[5] = {10, 20, 30, 40, 50};
 
@@ -42,7 +46,9 @@ public:
   const int *end() const { return &a[5]; }
 };
 
-struct SimpleEmptySequence {
+struct
+  __attribute__((swift_attr("import_owned")))
+SimpleEmptySequence {
   const int *begin() const { return nullptr; }
   const int *end() const { return nullptr; }
 };

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -24,9 +24,7 @@ struct SimpleCopyAwareSequence {
   SimpleCopyAwareSequence(const SimpleCopyAwareSequence &other) { copiesCount++; }
 };
 
-struct
-  __attribute__((swift_attr("import_owned")))
-SimpleArrayWrapper {
+struct SimpleArrayWrapper {
 private:
   int a[5] = {10, 20, 30, 40, 50};
 
@@ -35,9 +33,7 @@ public:
   const int *end() const __attribute__((returns_nonnull)) { return &a[5]; }
 };
 
-struct
-  __attribute__((swift_attr("import_owned")))
-SimpleArrayWrapperNullableIterators {
+struct SimpleArrayWrapperNullableIterators {
 private:
   int a[5] = {10, 20, 30, 40, 50};
 
@@ -46,9 +42,7 @@ public:
   const int *end() const { return &a[5]; }
 };
 
-struct
-  __attribute__((swift_attr("import_owned")))
-SimpleEmptySequence {
+struct SimpleEmptySequence {
   const int *begin() const { return nullptr; }
   const int *end() const { return nullptr; }
 };

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -108,6 +108,7 @@ struct HasTemplatedIterator {
 
 typedef HasTemplatedIterator<int> HasUninstantiatableIterator;
 
+<<<<<<< HEAD
 struct HasInheritedConstIterator {
 private:
   InheritedConstIterator b = InheritedConstIterator(1);

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -108,7 +108,6 @@ struct HasTemplatedIterator {
 
 typedef HasTemplatedIterator<int> HasUninstantiatableIterator;
 
-<<<<<<< HEAD
 struct HasInheritedConstIterator {
 private:
   InheritedConstIterator b = InheritedConstIterator(1);


### PR DESCRIPTION
Projections of trivial types and view types aren't unsafe. This matches what was described in the vision document.

To elaborate: a view type like `StringRef` is already referencing memory it does not own, so if it projects its data again (via the data method for example), there's no additional unsafety. The really unsafe thing is when a self contained (owned) type projects its owned memory because there are subtle difference in C++ and Swift lifetime models (along with different safety expectations). 

This is a relatively breaking change. Expect turbulence. 