### PR TITLE
[ConstraintSystem] Set up keypath expressions typechecking

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -254,7 +254,7 @@ public:
 
   /// Determine whether given locator points to the keypath value
   bool isKeyPathValue() const;
-  
+
   /// Determine whether given locator points to the choice picked as
   /// as result of the key path dynamic member lookup operation.
   bool isResultOfKeyPathDynamicMemberLookup() const;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -486,6 +486,10 @@ public:
   /// a type of a key path expression.
   bool isKeyPathType() const;
 
+  /// Determine whether this type variable represents a value type of a key path
+  /// expression.
+  bool isKeyPathValue() const;
+
   /// Determine whether this type variable represents a subscript result type.
   bool isSubscriptResultType() const;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3014,6 +3014,20 @@ public:
     return nullptr;
   }
 
+  TypeVariableType *getKeyPathValueType(const KeyPathExpr *keyPath) const {
+    auto result = getKeyPathValueTypeIfAvailable(keyPath);
+    assert(result);
+    return result;
+  }
+
+  TypeVariableType *
+  getKeyPathValueTypeIfAvailable(const KeyPathExpr *keyPath) const {
+    auto result = KeyPaths.find(keyPath);
+    if (result != KeyPaths.end())
+      return std::get<1>(result->second);
+    return nullptr;
+  }
+
   TypeBase* getFavoredType(Expr *E) {
     assert(E != nullptr);
     return this->FavoredTypes[E];

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3982,6 +3982,20 @@ public:
   bool resolveClosure(TypeVariableType *typeVar, Type contextualType,
                       ConstraintLocatorBuilder locator);
 
+  /// Given the fact a contextual type is now available for the type
+  /// variable representing one of the key path expressions, let's set a
+  /// pre-determined key path expression type.
+  ///
+  /// \param typeVar The type variable representing a key path expression.
+  /// \param contextualType The contextual type this key path would be
+  /// converted to.
+  /// \param locator The locator associated with contextual type.
+  ///
+  /// \returns `true` if it was possible to generate constraints for
+  /// the keyPath expression, `false` otherwise.
+  bool resolveKeyPath(TypeVariableType *typeVar, Type contextualType,
+                      ConstraintLocatorBuilder locator);
+
   /// Given the fact that contextual type is now available for the type
   /// variable representing a pack expansion type, let's resolve the expansion.
   ///

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11517,6 +11517,28 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   return !generateConstraints(AnyFunctionRef{closure}, closure->getBody());
 }
 
+bool ConstraintSystem::resolveKeyPath(TypeVariableType *typeVar,
+                                      Type contextualType,
+                                      ConstraintLocatorBuilder locator) {
+
+  if (auto *BGT = contextualType->getAs<BoundGenericType>()) {
+    auto args = BGT->getGenericArgs();
+    if (isKnownKeyPathType(contextualType) && args.size() >= 1) {
+      auto root = BGT->getGenericArgs()[0];
+
+      auto *keyPathLocator = typeVar->getImpl().getLocator();
+      auto *keyPath = castToExpr<KeyPathExpr>(keyPathLocator->getAnchor());
+      auto *keyPathValueTV = getKeyPathValueType(keyPath);
+      contextualType = BoundGenericType::get(
+          args.size() == 1 ? getASTContext().getKeyPathDecl() : BGT->getDecl(),
+          /*parent=*/Type(), {root, keyPathValueTV});
+    }
+  }
+
+  assignFixedType(typeVar, contextualType);
+  return true;
+}
+
 bool ConstraintSystem::resolvePackExpansion(TypeVariableType *typeVar,
                                             Type contextualType) {
   auto *locator = typeVar->getImpl().getLocator();

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -144,6 +144,10 @@ bool TypeVariableType::Implementation::isKeyPathType() const {
   return locator && locator->isKeyPathType();
 }
 
+bool TypeVariableType::Implementation::isKeyPathValue() const {
+  return locator && locator->isKeyPathValue();
+}
+
 bool TypeVariableType::Implementation::isSubscriptResultType() const {
   if (!(locator && locator->getAnchor()))
     return false;

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -136,8 +136,8 @@ func test_mismatch_with_contextual_optional_result() {
     var arr: [Int] = []
   }
 
-  let _ = A(B(), keyPath: \.arr)
-  // expected-error@-1 {{key path value type '[Int]' cannot be converted to contextual type '[Int]?'}}
+  let _ = A(B(), keyPath: \.arr) // expected-error {{cannot convert value of type 'KeyPath<B, [Int]>' to expected argument type 'KeyPath<B, [Int]?>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Value' ('[Int]' and '[Int]?') are expected to be equal}}
 }
 
 // https://github.com/apple/swift/issues/53581
@@ -178,6 +178,20 @@ func key_path_root_mismatch<T>(_ base: KeyPathBase?, subBase: KeyPathBaseSubtype
   // expected-note@-2 {{use '?' to access key path subscript only for non-'nil' base values}} {{22-22=?}}
   let _ : T = subBase[keyPath: kpa] // expected-error {{key path with root type 'AnotherBase' cannot be applied to a base of type 'KeyPathBaseSubtype?'}}
 
+}
+
+func key_path_value_mismatch() {
+  struct S {
+    var member: Int
+  }
+	
+  func test(_: KeyPath<S, String>) {}
+  // expected-note@-1 {{found candidate with type 'KeyPath<S, Int>'}}
+  func test(_: KeyPath<S, Float>) {}
+  // expected-note@-1 {{found candidate with type 'KeyPath<S, Int>'}}
+	
+  test(\.member)
+  // expected-error@-1 {{no exact matches in call to local function 'test'}}
 }
 
 // https://github.com/apple/swift/issues/55884

--- a/test/Sema/keypath_subscript_nolabel.swift
+++ b/test/Sema/keypath_subscript_nolabel.swift
@@ -28,4 +28,5 @@ struct S4 {
   subscript(v: KeyPath<S4, String>) -> Int { get { 0 } set(newValue) {} }
 }
 var s4 = S4()
-s4[\.x] = 10 // expected-error {{key path value type 'Int' cannot be converted to contextual type 'String'}}
+s4[\.x] = 10 // expected-error {{cannot convert value of type 'KeyPath<S4, Int>' to expected argument type 'KeyPath<S4, String>'}}
+// expected-note@-1 {{arguments to generic parameter 'Value' ('Int' and 'String') are expected to be equal}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -228,7 +228,7 @@ func testNoComponents() {
   let _: KeyPath<A, A> = \A // expected-error{{must have at least one component}}
   let _: KeyPath<C, A> = \C // expected-error{{must have at least one component}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
-  let _: KeyPath<A, C> = \A // expected-error{{must have at least one component}} 
+  let _: KeyPath<A, C> = \A // expected-error{{must have at least one component}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
   _ = \A // expected-error {{key path must have at least one component}}
 }


### PR DESCRIPTION
to use the contextual type determined by the solver along with the [key path root and value variables saved in `visitKeyPathExpr`](https://github.com/apple/swift/pull/67157) and delay key path value type checking until it is directly bound. This is an incremental step towards changing key path expression type checking to not prematurely generate constraints and type variables and instead wait until all other relevant parts of the source code have been resolved to determine a contextual type for the key path expression.

Resolves #65467