### PR TITLE
[CodeComplete] Fix a crash when completing in the signature of a function annotated with result builder

### DIFF
--- a/test/IDE/complete_result_builder_func_signature.swift
+++ b/test/IDE/complete_result_builder_func_signature.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+@resultBuilder struct MyBuilder {
+    static func buildBlock() -> Int
+    static func buildBlock<Content>(_ content: Content) -> Content
+}
+
+@MyBuilder func test(action: () -> #^COMPLETE^#Void) {}
+
+// COMPLETE: Decl[TypeAlias]/OtherModule[Swift]/IsSystem: Void[#Void#]; name=Void


### PR DESCRIPTION
When we are completing inside a function signature, the function doesn’t have a body. We were still running `PreCheckResultBuilderApplication`, which crashed if the body was `nullptr`.

rdar://111489024