### PR TITLE
[5.9][CodeComplete] Fix a crash when completing in the signature of a function annotated with result builder

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2560,22 +2560,25 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
   // Function builder function doesn't support partial type checking.
   if (auto *func = dyn_cast<FuncDecl>(DC)) {
     if (Type builderType = getResultBuilderType(func)) {
-      auto optBody = TypeChecker::applyResultBuilderBodyTransform(
-          func, builderType,
-          /*ClosuresInResultBuilderDontParticipateInInference=*/
-              ctx.CompletionCallback == nullptr && ctx.SolutionCallback == nullptr);
-      if (optBody && *optBody) {
-        // Wire up the function body now.
-        func->setBody(*optBody, AbstractFunctionDecl::BodyKind::TypeChecked);
-        return false;
+      if (func->getBody()) {
+        auto optBody = TypeChecker::applyResultBuilderBodyTransform(
+            func, builderType,
+            /*ClosuresInResultBuilderDontParticipateInInference=*/
+            ctx.CompletionCallback == nullptr &&
+                ctx.SolutionCallback == nullptr);
+        if (optBody && *optBody) {
+          // Wire up the function body now.
+          func->setBody(*optBody, AbstractFunctionDecl::BodyKind::TypeChecked);
+          return false;
+        }
+        // FIXME: We failed to apply the result builder transform. Fall back to
+        // just type checking the node that contains the code completion token.
+        // This may be missing some context from the result builder but in
+        // practice it often contains sufficient information to provide a decent
+        // level of code completion that's better than providing nothing at all.
+        // The proper solution would be to only partially type check the result
+        // builder so that this fall back would not be necessary.
       }
-      // FIXME: We failed to apply the result builder transform. Fall back to
-      // just type checking the node that contains the code completion token.
-      // This may be missing some context from the result builder but in
-      // practice it often contains sufficient information to provide a decent
-      // level of code completion that's better than providing nothing at all.
-      // The proper solution would be to only partially type check the result
-      // builder so that this fall back would not be necessary.
     } else if (func->hasSingleExpressionBody() &&
                 func->getResultInterfaceType()->isVoid()) {
        // The function returns void.  We don't need an explicit return, no matter

--- a/test/IDE/complete_result_builder_func_signature.swift
+++ b/test/IDE/complete_result_builder_func_signature.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+@resultBuilder struct MyBuilder {
+    static func buildBlock() -> Int
+    static func buildBlock<Content>(_ content: Content) -> Content
+}
+
+@MyBuilder func test(action: () -> #^COMPLETE^#Void) {}
+
+// COMPLETE: Decl[TypeAlias]/OtherModule[Swift]/IsSystem: Void[#Void#]; name=Void


### PR DESCRIPTION
* **Explanation**: When we are completing inside a function signature, the function doesn’t have a body. We were still running `PreCheckResultBuilderApplication`, which crashed if the body was `nullptr`. If there is no body in a function declaration just don’t try to apply a result builder transform to fix the issue
* **Scope**: Code completion in functions with a result builder annotation that don’t have a body
* **Risk**: Very low. AFAICT this always crashed in the case that the new `if` captures
* **Testing**: Added test case
* **Issue**: rdar://111489024
* **Reviewer**:  @xedin





