### PR TITLE
[cxx-interop] Import CF_OPTIONS types such as `Foundation.NSTextCheckingType` correctly

### DIFF
--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -53,6 +53,9 @@ CFPointeeInfo
 CFPointeeInfo::classifyTypedef(const clang::TypedefNameDecl *typedefDecl) {
   clang::QualType type = typedefDecl->getUnderlyingType();
 
+  if (auto elaborated = type->getAs<clang::ElaboratedType>())
+    type = elaborated->desugar();
+
   if (auto subTypedef = type->getAs<clang::TypedefType>()) {
     if (classifyTypedef(subTypedef->getDecl()))
       return forTypedef(subTypedef->getDecl());

--- a/test/Interop/Cxx/objc-correctness/Inputs/NSTextCheckingResult.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/NSTextCheckingResult.h
@@ -1,0 +1,12 @@
+#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#if (__cplusplus)
+#define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
+#else
+#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
+#endif
+
+typedef CF_OPTIONS(unsigned int, NSTextCheckingType) {
+  NSTextCheckingTypeOrthography           = 1ULL << 0,
+  NSTextCheckingTypeSpelling              = 1ULL << 1,
+  // ...
+};

--- a/test/Interop/Cxx/objc-correctness/Inputs/SwiftTextCheckingResult.swift
+++ b/test/Interop/Cxx/objc-correctness/Inputs/SwiftTextCheckingResult.swift
@@ -1,0 +1,5 @@
+import NSTextCheckingResult
+
+public func foo() -> NSTextCheckingType {
+  return .orthography
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -24,3 +24,8 @@ module OSObject {
   requires objc
   requires cplusplus
 }
+
+module NSTextCheckingResult {
+  header "NSTextCheckingResult.h"
+  requires objc
+}

--- a/test/Interop/Cxx/objc-correctness/foundation-string-extensions.swift
+++ b/test/Interop/Cxx/objc-correctness/foundation-string-extensions.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/SwiftTextCheckingResult.swift -I %S/Inputs -module-name SwiftTextCheckingResult -enable-objc-interop -emit-module -emit-module-path %t/SwiftTextCheckingResult.swiftmodule
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -enable-objc-interop -enable-experimental-cxx-interop
+
+// REQUIRES: objc_interop
+
+import SwiftTextCheckingResult
+
+let _ = foo()
+
+// CHECK: @"$sSy10FoundationE20replacingOccurrences2of4with7options5rangeSSqd___qd_0_So22NSStringCompareOptionsVSnySS5IndexVGSgtSyRd__SyRd_0_r0_lF"


### PR DESCRIPTION
This fixes linker errors which occurred when using Foundation extensions to `Swift.String`, such as `func replacingOccurrences`.

After the last rebranch, Clang started wrapping certain types in `clang::ElaboratedType`. This caused CF_OPTIONS types such as `Foundation.NSTextCheckingType` to be imported incorrectly in C++ language mode (`NSTextCheckingType` was imported as `uint64_t` without getting the special treatment of a CF type), which was causing deserialization errors when Swift tried reading `Foundation.swiftmodule`. Those deserialization errors were silenced by default. The IR for those functions was not emitted, which caused linker errors later.

rdar://109830032