### PR TITLE
[Test] Reenable disabled test in associated_type_demangle_private.swift.

### DIFF
--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -104,8 +104,7 @@ AssociatedTypeDemangleTests.test("nested private generic types in associated typ
   if #available(SwiftStdlib 5.1, *) {}
   // Bug is still present in Swift 5.0 runtime.
   else {
-    // FIXME: rdar://problem/51959305
-    // expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
     return
   }
 


### PR DESCRIPTION
This was disabled due to a weird failure on iOS 10, which is no longer a supported target.

rdar://97996884