### PR TITLE
Sema: Fix ASTPrinter and opened element environments to handle nested pack expansion types [5.9]

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -316,6 +316,14 @@ public:
       llvm::function_ref<llvm::Optional<Type>(TypeBase *, TypePosition)> fn)
       const;
 
+  /// Transform free pack element references, that is, those not captured by a
+  /// pack expansion.
+  ///
+  /// This is the 'map' counterpart to TypeBase::getTypeParameterPacks().
+  Type transformTypeParameterPacks(
+      llvm::function_ref<llvm::Optional<Type>(SubstitutableType *)> fn)
+      const;
+
   /// Look through the given type and its children and apply fn to them.
   void visit(llvm::function_ref<void (Type)> fn) const {
     findIf([&fn](Type t) -> bool {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5856,13 +5856,13 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig,
   }
 
   auto eraseParameterPackRec = [&](Type type) -> Type {
-    return type.transformRec([&](Type t) -> llvm::Optional<Type> {
-      if (auto *paramType = t->getAs<GenericTypeParamType>()) {
+    return type.transformTypeParameterPacks([&](SubstitutableType *t) -> llvm::Optional<Type> {
+      if (auto *paramType = dyn_cast<GenericTypeParamType>(t)) {
         if (packElementParams.find(paramType) != packElementParams.end()) {
           return Type(packElementParams[paramType]);
         }
 
-        return t;
+        return Type(t);
       }
       return llvm::None;
     });

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -804,7 +804,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
 
   void printType(Type T) { printTypeWithOptions(T, Options); }
 
-  void printTransformedTypeWithOptions(Type T, PrintOptions options) {
+  Type getTransformedType(Type T) {
     if (CurrentType && Current && CurrentType->mayHaveMembers()) {
       auto *M = Current->getDeclContext()->getParentModule();
       SubstitutionMap subMap;
@@ -825,9 +825,16 @@ class PrintAST : public ASTVisitor<PrintAST> {
       }
 
       T = T.subst(subMap, SubstFlags::DesugarMemberTypes);
-
-      options.TransformContext = TypeTransformContext(CurrentType);
     }
+
+    return T;
+  }
+
+  void printTransformedTypeWithOptions(Type T, PrintOptions options) {
+    T = getTransformedType(T);
+
+    if (CurrentType && Current && CurrentType->mayHaveMembers())
+      options.TransformContext = TypeTransformContext(CurrentType);
 
     printTypeWithOptions(T, options);
   }
@@ -1833,6 +1840,11 @@ void PrintAST::printSingleDepthOfGenericSignature(
 }
 
 void PrintAST::printRequirement(const Requirement &req) {
+  SmallVector<Type, 2> rootParameterPacks;
+  getTransformedType(req.getFirstType())
+      ->getTypeParameterPacks(rootParameterPacks);
+  bool isPackRequirement = !rootParameterPacks.empty();
+
   switch (req.getKind()) {
   case RequirementKind::SameShape:
     Printer << "(repeat (";
@@ -1842,7 +1854,7 @@ void PrintAST::printRequirement(const Requirement &req) {
     Printer << ")) : Any";
     return;
   case RequirementKind::Layout:
-    if (req.getFirstType()->hasParameterPack())
+    if (isPackRequirement)
       Printer << "repeat ";
     printTransformedType(req.getFirstType());
     Printer << " : ";
@@ -1850,14 +1862,13 @@ void PrintAST::printRequirement(const Requirement &req) {
     return;
   case RequirementKind::Conformance:
   case RequirementKind::Superclass:
-    if (req.getFirstType()->hasParameterPack())
+    if (isPackRequirement)
       Printer << "repeat ";
     printTransformedType(req.getFirstType());
     Printer << " : ";
     break;
   case RequirementKind::SameType:
-    if (req.getFirstType()->hasParameterPack() ||
-        req.getSecondType()->hasParameterPack())
+    if (isPackRequirement)
       Printer << "repeat ";
     printTransformedType(req.getFirstType());
     Printer << " == ";

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1009,8 +1009,11 @@ Type ConstraintSystem::openType(Type type, OpenedTypeMap &replacements,
       // that gets introduced by the interface type, see
       // \c openUnboundGenericType for more details.
       if (auto *packTy = type->getAs<PackType>()) {
-        if (auto expansion = packTy->unwrapSingletonPackExpansion())
-          type = expansion->getPatternType();
+        if (auto expansionTy = packTy->unwrapSingletonPackExpansion()) {
+          auto patternTy = expansionTy->getPatternType();
+          if (patternTy->isTypeParameter())
+            return openType(patternTy, replacements, locator);
+        }
       }
 
       if (auto *expansion = type->getAs<PackExpansionType>()) {

--- a/test/ModuleInterface/pack_expansion_type.swift
+++ b/test/ModuleInterface/pack_expansion_type.swift
@@ -2,6 +2,8 @@
 // RUN: %target-swift-emit-module-interface(%t/PackExpansionType.swiftinterface) %s -module-name PackExpansionType -disable-availability-checking
 // RUN: %FileCheck %s < %t/PackExpansionType.swiftinterface
 
+/// Requirements
+
 // CHECK: #if compiler(>=5.3) && $ParameterPacks
 // CHECK-NEXT: public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)) : Any
 public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {}
@@ -23,6 +25,13 @@ public struct VariadicType<each T> {
 }
 // CHECK: }
 // CHECK-NEXT: #endif
+
+// The second requirement should not be prefixed with 'repeat'
+// CHECK: public struct SameTypeReq<T, each U> where T : Swift.Sequence, T.Element == PackExpansionType.VariadicType<repeat each U> {
+public struct SameTypeReq<T: Sequence, each U> where T.Element == VariadicType<repeat each U> {}
+// CHECK: }
+
+/// Pack expansion types
 
 // CHECK: public func returnsVariadicType() -> PackExpansionType.VariadicType<>
 public func returnsVariadicType() -> VariadicType< > {}

--- a/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public protocol P {
+  associatedtype A
+}
+
+public struct G<each T> {}
+
+public struct S<T: P, each U: P> where repeat T.A == G<repeat each U> {
+    public init(predicate: repeat each U) {}
+}
+

--- a/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
@@ -6,7 +6,12 @@ public protocol P {
 
 public struct G<each T> {}
 
-public struct S<T: P, each U: P> where repeat T.A == G<repeat each U> {
-    public init(predicate: repeat each U) {}
+public protocol Q {
+  init()
+}
+
+public struct S<T: P, each U: P>: Q where repeat T.A == G<repeat each U.A> {
+  public init() {}
+  public init(predicate: repeat each U) {}
 }
 


### PR DESCRIPTION
* Description: In a couple of places we incorrectly decided that a same-type requirement `T.A == G<repeat each U>` (where T.A is a scalar type) was a pack requirement, as if we were expanding the entire requirement across the `each U`. The ASTPrinter would prefix the requirement with `repeat`, and creating element archetypes would do the wrong thing and crash. Fix these places to correctly handle nested pack expansion types so that pack references bound by those expansions are not considered.

* Radar: rdar://112108253

* Reviewed by: @hborla 