### PR TITLE
SILGen: Don't reuse the `Initialization` across branches of an `if` or `switch` expression.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2200,17 +2200,9 @@ RValue RValueEmitter::visitSingleValueStmtExpr(SingleValueStmtExpr *E,
   auto &lowering = SGF.getTypeLowering(E->getType());
   auto resultAddr = SGF.emitTemporaryAllocation(E, lowering.getLoweredType());
 
-  // This won't give us a useful diagnostic if the result doesn't end up
-  // initialized ("variable '<unknown>' used before being initialized"), but it
-  // will at least catch a potential miscompile when the SIL verifier is
-  // disabled.
-  resultAddr = SGF.B.createMarkUninitialized(
-      E, resultAddr, MarkUninitializedInst::Kind::Var);
-  KnownAddressInitialization init(resultAddr);
-
   // Collect the target exprs that will be used for initialization.
   SmallVector<Expr *, 4> scratch;
-  SILGenFunction::SingleValueStmtInitialization initInfo(&init);
+  SILGenFunction::SingleValueStmtInitialization initInfo(resultAddr);
   for (auto *E : E->getSingleExprBranches(scratch))
     initInfo.Exprs.insert(E);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1650,7 +1650,7 @@ void SILGenFunction::emitGeneratorFunction(
   mergeCleanupBlocks();
 }
 
-Initialization *SILGenFunction::getSingleValueStmtInit(Expr *E) {
+std::unique_ptr<Initialization> SILGenFunction::getSingleValueStmtInit(Expr *E) {
   if (SingleValueStmtInitStack.empty())
     return nullptr;
 
@@ -1659,7 +1659,15 @@ Initialization *SILGenFunction::getSingleValueStmtInit(Expr *E) {
   if (!SingleValueStmtInitStack.back().Exprs.contains(E))
     return nullptr;
 
-  return SingleValueStmtInitStack.back().Init;
+  // This won't give us a useful diagnostic if the result doesn't end up
+  // initialized ("variable '<unknown>' used before being initialized"), but it
+  // will at least catch a potential miscompile when the SIL verifier is
+  // disabled.
+  auto resultAddr = SingleValueStmtInitStack.back().InitializationBuffer;
+  resultAddr = B.createMarkUninitialized(
+      E, resultAddr, MarkUninitializedInst::Kind::Var);
+      
+  return std::make_unique<KnownAddressInitialization>(resultAddr);
 }
 
 void SILGenFunction::emitProfilerIncrement(ASTNode Node) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -353,9 +353,10 @@ public:
   struct SingleValueStmtInitialization {
     /// The target expressions to be used for initialization.
     SmallPtrSet<Expr *, 4> Exprs;
-    Initialization *Init;
+    SILValue InitializationBuffer;
 
-    SingleValueStmtInitialization(Initialization *init) : Init(init) {}
+    SingleValueStmtInitialization(SILValue buffer)
+      : InitializationBuffer(buffer) {}
   };
 
   /// A stack of active SingleValueStmtExpr initializations that may be
@@ -741,7 +742,7 @@ public:
   /// Check to see if an initalization for a SingleValueStmtExpr is active, and
   /// if the provided expression is for one of its branches. If so, returns the
   /// initialization to use for the expression. Otherwise returns \c nullptr.
-  Initialization *getSingleValueStmtInit(Expr *E);
+  std::unique_ptr<Initialization> getSingleValueStmtInit(Expr *E);
 
   //===--------------------------------------------------------------------===//
   // Entry points for codegen

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2981,6 +2981,7 @@ LValue SILGenLValue::visitRec(Expr *e, SGFAccessKind accessKind,
   // a `borrow x` operator, the operator is used on the base here), we want to
   // apply the lvalue within a formal access to the original value instead of
   // an actual loaded copy.
+  
   if (e->getType()->isPureMoveOnly()) {
     if (auto load = dyn_cast<LoadExpr>(e)) {
       LValue lv = visitRec(load->getSubExpr(), SGFAccessKind::BorrowedAddressRead,
@@ -2992,7 +2993,7 @@ LValue SILGenLValue::visitRec(Expr *e, SGFAccessKind accessKind,
       return lv;
     }
   }
-
+  
   // Otherwise we have a non-lvalue type (references, values, metatypes,
   // etc). These act as the root of a logical lvalue. Compute the root value,
   // wrap it in a ValueComponent, and return it for our caller.

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -423,9 +423,9 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
       // active, and if so, use it for this expression branch. If the expression
       // is uninhabited, we can skip this, and let unreachability checking
       // handle it.
-      auto *init = SGF.getSingleValueStmtInit(E);
+      auto init = SGF.getSingleValueStmtInit(E);
       if (init && !E->getType()->isStructurallyUninhabited()) {
-        SGF.emitExprInto(E, init);
+        SGF.emitExprInto(E, init.get());
       } else {
         SGF.emitIgnoredExpr(E);
       }

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -7,23 +7,24 @@ func foo() -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7if_expr3fooSiyF : $@convention(thin) () -> Int
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       cond_br {{%[0-9]+}}, [[TRUEBB:bb[0-9]+]], [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[TRUEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[ONE_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
 // CHECK:       [[ONE:%[0-9]+]] = apply {{%[0-9]+}}([[ONE_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[ONE]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[TWO_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 2
 // CHECK:       [[TWO:%[0-9]+]] = apply {{%[0-9]+}}([[TWO_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[TWO]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
@@ -36,22 +37,23 @@ func bar(_ x: C) -> C {
 // CHECK-LABEL: sil hidden [ossa] @$s7if_expr3baryAA1CCADF : $@convention(thin) (@guaranteed C) -> @owned C
 // CHECK:       bb0([[CPARAM:%[0-9]+]] : @guaranteed $C):
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $C
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*C
 // CHECK:       cond_br {{%[0-9]+}}, [[TRUEBB:bb[0-9]+]], [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[TRUEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*C
 // CHECK:       [[C:%[0-9]+]] = copy_value [[CPARAM]] : $C
 // CHECK:       store [[C]] to [init] [[RESULT]] : $*C
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*C
 // CHECK:       [[CTOR:%[0-9]+]] = function_ref @$s7if_expr1CCACycfC : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK:       [[C:%[0-9]+]] = apply [[CTOR]]({{%[0-9]+}}) : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK:       store [[C]] to [init] [[RESULT]] : $*C
 // CHECK:       br [[EXITBB]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [take] [[RESULT]] : $*C
+// CHECK:       [[VAL:%[0-9]+]] = load [take] [[RESULT_STORAGE]] : $*C
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*C
 // CHECK:       return [[VAL]] : $C
 
@@ -69,7 +71,6 @@ func baz() throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7if_expr3bazSiyKF : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       cond_br {{%[0-9]+}}, [[TRUEBB:bb[0-9]+]], [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
@@ -82,7 +83,7 @@ func baz() throws -> Int {
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
@@ -92,10 +93,10 @@ func qux() throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7if_expr3quxSiyKF : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       cond_br {{%[0-9]+}}, [[TRUEBB:bb[0-9]+]], [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       try_apply {{%[0-9]+}}() : $@convention(thin) () -> (Int, @error any Error), normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
 //
 // CHECK:       [[NORMALBB]]([[BAZVAL:%[0-9]+]] : $Int):
@@ -103,7 +104,7 @@ func qux() throws -> Int {
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 //
@@ -141,10 +142,10 @@ func testClosure() throws -> Int {
 
 // CHECK-LABEL: sil private [ossa] @$s7if_expr11testClosureSiyKFSiyKcfU_ : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       cond_br {{%[0-9]+}}, [[TRUEBB:bb[0-9]+]], [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       try_apply {{%[0-9]+}}() : $@convention(thin) () -> (Int, @error any Error), normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
 //
 // CHECK:       [[NORMALBB]]([[BAZVAL:%[0-9]+]] : $Int):
@@ -152,7 +153,7 @@ func testClosure() throws -> Int {
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 //
@@ -174,7 +175,6 @@ func testNested() throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7if_expr10testNestedSiyKF : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       cond_br {{%[0-9]+}}, [[TRUEBB:bb[0-9]+]], [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
@@ -187,7 +187,7 @@ func testNested() throws -> Int {
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -12,23 +12,24 @@ func foo() -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s11switch_expr3fooSiyF : $@convention(thin) () -> Int
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       switch_value {{%[0-9]+}} : $Builtin.Int1, case {{%[0-9]+}}: [[TRUEBB:bb[0-9]+]], case {{%[0-9]+}}: [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[TRUEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[ONE_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
 // CHECK:       [[ONE:%[0-9]+]] = apply {{%[0-9]+}}([[ONE_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[ONE]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[TWO_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 2
 // CHECK:       [[TWO:%[0-9]+]] = apply {{%[0-9]+}}([[TWO_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[TWO]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
@@ -46,22 +47,23 @@ func bar(_ x: C) -> C {
 // CHECK-LABEL: sil hidden [ossa] @$s11switch_expr3baryAA1CCADF : $@convention(thin) (@guaranteed C) -> @owned C
 // CHECK:       bb0([[CPARAM:%[0-9]+]] : @guaranteed $C):
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $C
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*C
 // CHECK:       switch_value {{%[0-9]+}} : $Builtin.Int1, case {{%[0-9]+}}: [[TRUEBB:bb[0-9]+]], case {{%[0-9]+}}: [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[TRUEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*C
 // CHECK:       [[C:%[0-9]+]] = copy_value [[CPARAM]] : $C
 // CHECK:       store [[C]] to [init] [[RESULT]] : $*C
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*C
 // CHECK:       [[CTOR:%[0-9]+]] = function_ref @$s11switch_expr1CCACycfC : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK:       [[C:%[0-9]+]] = apply [[CTOR]]({{%[0-9]+}}) : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK:       store [[C]] to [init] [[RESULT]] : $*C
 // CHECK:       br [[EXITBB]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [take] [[RESULT]] : $*C
+// CHECK:       [[VAL:%[0-9]+]] = load [take] [[RESULT_STORAGE]] : $*C
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*C
 // CHECK:       return [[VAL]] : $C
 
@@ -82,10 +84,10 @@ func baz(_ e: E) throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s11switch_expr3bazySiAA1EOKF : $@convention(thin) (E) -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       switch_enum %0 : $E, case #E.a!enumelt: [[ABB:bb[0-9]+]], case #E.b!enumelt: [[BBB:bb[0-9]+]], default [[DEFBB:bb[0-9]+]]
 //
 // CHECK:       [[ABB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[ONE_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
 // CHECK:       [[ONE:%[0-9]+]] = apply {{%[0-9]+}}([[ONE_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[ONE]] to [trivial] [[RESULT]] : $*Int
@@ -95,13 +97,14 @@ func baz(_ e: E) throws -> Int {
 // CHECK:       throw {{%[0-9]+}} : $any Error
 //
 // CHECK:       [[DEFBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[TWO_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 2
 // CHECK:       [[TWO:%[0-9]+]] = apply {{%[0-9]+}}([[TWO_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[TWO]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
@@ -116,10 +119,10 @@ func qux() throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s11switch_expr3quxSiyKF : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       switch_value {{%[0-9]+}} : $Builtin.Int1, case {{%[0-9]+}}: [[TRUEBB:bb[0-9]+]], case {{%[0-9]+}}: [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       try_apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(thin) (E) -> (Int, @error any Error), normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
 //
 // CHECK:       [[NORMALBB]]([[BAZVAL:%[0-9]+]] : $Int):
@@ -127,7 +130,7 @@ func qux() throws -> Int {
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 //
@@ -147,7 +150,6 @@ func testFallthrough() throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s11switch_expr15testFallthroughSiyKF : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       switch_value {{%[0-9]+}} : $Builtin.Int1, case {{%[0-9]+}}: [[TRUEBB:bb[0-9]+]], case {{%[0-9]+}}: [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[TRUEBB]]:
@@ -163,10 +165,11 @@ func testFallthrough() throws -> Int {
 // CHECK:       br [[ACTUALFALSEBB]]
 //
 // CHECK:       [[ACTUALFALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[ONE_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
 // CHECK:       [[ONE:%[0-9]+]] = apply {{%[0-9]+}}([[ONE_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[ONE]] to [trivial] [[RESULT]] : $*Int
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 
@@ -184,10 +187,10 @@ func testClosure() throws -> Int {
 
 // CHECK-LABEL: sil private [ossa] @$s11switch_expr11testClosureSiyKFSiyKcfU_ : $@convention(thin) () -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       switch_value {{%[0-9]+}} : $Builtin.Int1, case {{%[0-9]+}}: [[TRUEBB:bb[0-9]+]], case {{%[0-9]+}}: [[FALSEBB:bb[0-9]+]]
 //
 // CHECK:       [[FALSEBB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       try_apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(thin) (E) -> (Int, @error any Error), normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
 //
 // CHECK:       [[NORMALBB]]([[BAZVAL:%[0-9]+]] : $Int):
@@ -195,7 +198,7 @@ func testClosure() throws -> Int {
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 //
@@ -276,33 +279,34 @@ func testNested(_ e: E) throws -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s11switch_expr10testNestedySiAA1EOKF : $@convention(thin) (E) -> (Int, @error any Error)
 // CHECK:       [[RESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       switch_enum %0 : $E, case #E.a!enumelt: [[ABB:bb[0-9]+]], default [[DEFBB:bb[0-9]+]]
 //
 // CHECK:       [[ABB]]:
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[ONE_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
 // CHECK:       [[ONE:%[0-9]+]] = apply {{%[0-9]+}}([[ONE_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[ONE]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[DEFBB]]({{.*}}):
+// CHECK:       [[RESULT:%[0-9]+]] = mark_uninitialized [var] [[RESULT_STORAGE]] : $*Int
 // CHECK:       [[NESTEDRESULT_STORAGE:%[0-9]+]] = alloc_stack $Int
-// CHECK:       [[NESTEDRESULT:%[0-9]+]] = mark_uninitialized [var] [[NESTEDRESULT_STORAGE]] : $*Int
 // CHECK:       switch_enum %0 : $E, case #E.b!enumelt: [[BBB:bb[0-9]+]], default [[NESTEDDEFBB:bb[0-9]+]]
 
 // CHECK:       [[BBB]]:
 // CHECK:       throw {{%[0-9]+}} : $any Error
 //
 // CHECK:       [[NESTEDDEFBB]]({{.*}}):
+// CHECK:       [[NESTEDRESULT:%[0-9]+]] = mark_uninitialized [var] [[NESTEDRESULT_STORAGE]] : $*Int
 // CHECK:       [[TWO_BUILTIN:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 2
 // CHECK:       [[TWO:%[0-9]+]] = apply {{%[0-9]+}}([[TWO_BUILTIN]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       store [[TWO]] to [trivial] [[NESTEDRESULT]] : $*Int
-// CHECK:       [[TMP:%[0-9]+]] = load [trivial] [[NESTEDRESULT]] : $*Int
+// CHECK:       [[TMP:%[0-9]+]] = load [trivial] [[NESTEDRESULT_STORAGE]] : $*Int
 // CHECK:       store [[TMP]] to [trivial] [[RESULT]] : $*Int
 // CHECK:       br [[EXITBB:bb[0-9]+]]
 //
 // CHECK:       [[EXITBB]]:
-// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       [[VAL:%[0-9]+]] = load [trivial] [[RESULT_STORAGE]] : $*Int
 // CHECK:       dealloc_stack [[RESULT_STORAGE]] : $*Int
 // CHECK:       return [[VAL]] : $Int
 

--- a/test/SILGen/switch_expr_address_only_tuple_return_value_context.swift
+++ b/test/SILGen/switch_expr_address_only_tuple_return_value_context.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+// rdar://112213253
+
+struct BigNontrivialThing {
+    var x: Any
+    var y: Any
+}
+enum Foo {
+    case a(String)
+    case b(BigNontrivialThing, String)
+
+    var unpacked: (BigNontrivialThing?, String) {
+        switch self {
+        case .a(let s):
+            (nil, s)
+        case .b(let bnt, let s):
+            (bnt, s)
+        }
+    }
+}
+
+func throwBNT() throws -> BigNontrivialThing? { fatalError() }
+func nothrowBNT() -> BigNontrivialThing? { fatalError() }
+func throwStr() throws -> String { fatalError() }
+func nothrowStr() -> String { fatalError() }
+
+func maybeThrowDuringSingleExprSwitchResult(condition: Bool) throws
+    -> (BigNontrivialThing?, String) {
+    
+    switch (condition, condition) {
+    case (false, false):
+        (nothrowBNT(), nothrowStr())
+    case (false, true):
+        (nothrowBNT(), try throwStr())
+    case (true, false):
+        (try throwBNT(), nothrowStr())
+    case (true, true):
+        (try throwBNT(), try throwStr())
+    }
+}


### PR DESCRIPTION
`Initialization` is stateful and not meant to be emitted into multiple times across different contexts. If emitting into an initialization causes it to be split or aborted, that will carry over into further uses of the initialization. This was happening during `if` and `switch` expression emission, leading to miscompiles or compiler crashes. Fix this by saving only the buffer when we prepare emission for a statement expression, and creating the initialization in the scope where the expression for a branch actually gets emitted. Fixes rdar://112213253.