### PR TITLE
[IRGen] Visit members generated by peer macros in ClassDataBuilder.

### DIFF
--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -71,7 +71,7 @@ public:
   ///
   /// \seealso IterableDeclContext::getImplementationContext()
   void visitImplementationMembers(NominalTypeDecl *D) {
-    for (Decl *member : D->getImplementationContext()->getMembers()) {
+    for (Decl *member : D->getImplementationContext()->getAllMembers()) {
       asImpl().visit(member);
     }
     

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2842,7 +2842,14 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     if (auto *vd = dyn_cast<ValueDecl>(member)) {
       // Add synthesized members to a side table and sort them by their mangled
       // name, since they could have been added to the class in any order.
-      if (vd->isSynthesized()) {
+      if (vd->isSynthesized() &&
+          // FIXME: IRGen requires the distributed actor synthesized
+          // properties to be in a specific order that is different
+          // from ordering by their mangled name, so preserve the order
+          // they were added in.
+          !(nominal &&
+            (vd == nominal->getDistributedActorIDProperty() ||
+             vd == nominal->getDistributedActorSystemProperty()))) {
         synthesizedMembers.add(vd);
         return;
       }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -681,6 +681,7 @@ void swift::checkDistributedActorProperties(const NominalTypeDecl *decl) {
       if (id == C.Id_actorSystem || id == C.Id_id) {
         prop->diagnose(diag::distributed_actor_user_defined_special_property,
                       id);
+        prop->setInvalid();
       }
     }
   }

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -38,14 +38,12 @@ distributed actor D2 {
   // expected-error@-1{{actor 'D2' has no initializers}}
   let actorSystem: String
   // expected-error@-1{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'actorSystem'}}
-  // expected-note@-3{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
+  // expected-note@-2{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
 }
 
 distributed actor D3 {
   var id: Int { 0 }
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'id'}}
 }
 
 struct OtherActorIdentity: Sendable, Hashable, Codable {}
@@ -55,12 +53,10 @@ distributed actor D4 {
 
   let actorSystem: String
   // expected-error@-1{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'actorSystem'}}
-  // expected-note@-3{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
+  // expected-note@-2{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
   let id: OtherActorIdentity
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'id'}}
-  // expected-note@-3{{stored property 'id' without initial value prevents synthesized initializers}}
+  // expected-note@-2{{stored property 'id' without initial value prevents synthesized initializers}}
 }
 
 protocol P1: DistributedActor {


### PR DESCRIPTION
`ClassDataBuilder` was skipping members generated by peer macros because `TypeMemberVisitor::visitImplementationMembers` called `getMembers()` instead of `getAllMembers()`.

Resolves rdar://112217268 and the runtime crash that was hit in https://github.com/apple/swift/pull/67289
