### PR TITLE
[SendNonSendable] Diagnose consumption sites not requirement sites

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -859,9 +859,13 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 // Warnings arising from the flow-sensitive checking of Sendability of
 // non-Sendable values
 WARNING(consumed_value_used, none,
-        "Non-Sendable value consumed, then used at this site; could yield race with another thread", ())
+        "non-Sendable value consumed, then used at this site; could yield race with another thread", ())
 WARNING(arg_region_consumed, none,
-        "This application could pass `self` or a Non-Sendable argument of this function to another thread, potentially yielding a race with the caller", ())
+        "this application could pass `self` or a Non-Sendable argument of this function to another thread, potentially yielding a race with the caller", ())
+WARNING(consumption_yields_race, none,
+        "non-Sendable value sent across isolation domains here, but could be accessed later in this function (%0 access site%select{|s}1 displayed%select{|, %3 more hidden}2)", (unsigned, bool, bool, unsigned))
+NOTE(possible_racy_access_site, none,
+    "access here could race with non-Sendable value send above", ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -79,14 +79,22 @@ private:
   // generated during compilation from a SILBasicBlock
   SILInstruction *sourceInst;
 
+  // Record an AST expression corresponding to this PartitionOp, currently
+  // populated only for Consume expressions to indicate the value being consumed
+  Expr *sourceExpr;
+
   // TODO: can the following declarations be merged?
   PartitionOp(PartitionOpKind OpKind, Element arg1,
-              SILInstruction *sourceInst = nullptr)
-      : OpKind(OpKind), OpArgs({arg1}), sourceInst(sourceInst) {}
+              SILInstruction *sourceInst = nullptr,
+              Expr* sourceExpr = nullptr)
+      : OpKind(OpKind), OpArgs({arg1}),
+        sourceInst(sourceInst), sourceExpr(sourceExpr) {}
 
   PartitionOp(PartitionOpKind OpKind, Element arg1, Element arg2,
-              SILInstruction *sourceInst = nullptr)
-      : OpKind(OpKind), OpArgs({arg1, arg2}), sourceInst(sourceInst) {}
+              SILInstruction *sourceInst = nullptr,
+              Expr* sourceExpr = nullptr)
+      : OpKind(OpKind), OpArgs({arg1, arg2}),
+        sourceInst(sourceInst), sourceExpr(sourceExpr) {}
 
   friend class Partition;
 
@@ -102,8 +110,10 @@ public:
   }
 
   static PartitionOp Consume(Element tgt,
-                             SILInstruction *sourceInst = nullptr) {
-    return PartitionOp(PartitionOpKind::Consume, tgt, sourceInst);
+                             SILInstruction *sourceInst = nullptr,
+                             Expr *sourceExpr = nullptr) {
+    return PartitionOp(PartitionOpKind::Consume, tgt,
+                       sourceInst, sourceExpr);
   }
 
   static PartitionOp Merge(Element tgt1, Element tgt2,
@@ -116,7 +126,9 @@ public:
     return PartitionOp(PartitionOpKind::Require, tgt, sourceInst);
   }
 
-  bool operator==(const PartitionOp &other) const = default;
+  bool operator==(const PartitionOp &other) const {
+      return OpKind == other.OpKind && sourceInst == other.sourceInst;
+  };
   // implemented for insertion into std::map
   bool operator<(const PartitionOp &other) const {
     if (OpKind != other.OpKind)

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -7,7 +7,42 @@
 #include "llvm/Support/Debug.h"
 #include <algorithm>
 
+#define DEBUG_TYPE "send-non-sendable"
+
 namespace swift {
+
+namespace PartitionPrimitives {
+
+struct Element {
+  unsigned num;
+
+  explicit Element(int num) : num(num) {}
+
+  bool operator==(const Element &other) const { return num == other.num; }
+  bool operator<(const Element &other) const { return num < other.num; }
+
+  operator unsigned() const { return num; }
+};
+
+struct Region {
+  signed num;
+
+  explicit Region(int num) : num(num) {
+    assert(num >= -1 && "-1 is the only valid negative Region label");
+  }
+
+  bool operator==(const Region &other) const { return num == other.num; }
+  bool operator<(const Region &other) const { return num < other.num; }
+
+  operator signed() const { return num; }
+
+  bool isConsumed() const { return num < 0; }
+
+  static Region consumed() { return Region(-1); }
+};
+}
+
+using namespace PartitionPrimitives;
 
 // PartitionOpKind represents the different kinds of PartitionOps that
 // SILInstructions can be translated to
@@ -38,65 +73,63 @@ enum class PartitionOpKind : uint8_t {
 class PartitionOp {
 private:
   PartitionOpKind OpKind;
-  llvm::SmallVector<unsigned, 2> OpArgs;
+  llvm::SmallVector<Element, 2> OpArgs;
 
   // Record the SILInstruction that this PartitionOp was generated from, if
   // generated during compilation from a SILBasicBlock
   SILInstruction *sourceInst;
 
   // TODO: can the following declarations be merged?
-  PartitionOp(PartitionOpKind OpKind, unsigned arg1,
+  PartitionOp(PartitionOpKind OpKind, Element arg1,
               SILInstruction *sourceInst = nullptr)
       : OpKind(OpKind), OpArgs({arg1}), sourceInst(sourceInst) {}
 
-  PartitionOp(PartitionOpKind OpKind, unsigned arg1, unsigned arg2,
+  PartitionOp(PartitionOpKind OpKind, Element arg1, Element arg2,
               SILInstruction *sourceInst = nullptr)
       : OpKind(OpKind), OpArgs({arg1, arg2}), sourceInst(sourceInst) {}
 
   friend class Partition;
 
 public:
-  static PartitionOp Assign(unsigned tgt, unsigned src,
+  static PartitionOp Assign(Element tgt, Element src,
                             SILInstruction *sourceInst = nullptr) {
     return PartitionOp(PartitionOpKind::Assign, tgt, src, sourceInst);
   }
 
-  static PartitionOp AssignFresh(unsigned tgt,
+  static PartitionOp AssignFresh(Element tgt,
                                  SILInstruction *sourceInst = nullptr) {
     return PartitionOp(PartitionOpKind::AssignFresh, tgt, sourceInst);
   }
 
-  static PartitionOp Consume(unsigned tgt,
+  static PartitionOp Consume(Element tgt,
                              SILInstruction *sourceInst = nullptr) {
     return PartitionOp(PartitionOpKind::Consume, tgt, sourceInst);
   }
 
-  static PartitionOp Merge(unsigned tgt1, unsigned tgt2,
+  static PartitionOp Merge(Element tgt1, Element tgt2,
                            SILInstruction *sourceInst = nullptr) {
     return PartitionOp(PartitionOpKind::Merge, tgt1, tgt2, sourceInst);
   }
 
-  static PartitionOp Require(unsigned tgt,
+  static PartitionOp Require(Element tgt,
                              SILInstruction *sourceInst = nullptr) {
     return PartitionOp(PartitionOpKind::Require, tgt, sourceInst);
   }
 
-  bool operator==(const PartitionOp& other) const = default;
+  bool operator==(const PartitionOp &other) const = default;
   // implemented for insertion into std::map
-  bool operator<(const PartitionOp& other) const {
+  bool operator<(const PartitionOp &other) const {
     if (OpKind != other.OpKind)
       return OpKind < other.OpKind;
     return sourceInst < other.sourceInst;
   }
 
-  PartitionOpKind getKind() const {
-    return OpKind;
-  }
+  PartitionOpKind getKind() const { return OpKind; }
 
   SILInstruction *getSourceInst(bool assertNonNull = false) const {
-    assert(!assertNonNull || sourceInst
-                             && "PartitionOps should be assigned SILInstruction"
-                                    " sources when used for the core analysis");
+    assert(!assertNonNull ||
+           sourceInst && "PartitionOps should be assigned SILInstruction"
+                         " sources when used for the core analysis");
     return sourceInst;
   }
 
@@ -143,19 +176,20 @@ public:
 // operation that's unfortunately used pervasively throughout PartitionOp
 // application. If this is a performance bottleneck, let's consider optimizing
 // it to a true union-find or other tree-based data structure.
-static void horizontalUpdate(std::map<unsigned, signed> &map, unsigned key,
-                             signed val) {
+static void horizontalUpdate(std::map<Element, Region> &map, Element key,
+                             Region val) {
   if (!map.count(key)) {
-    map[key] = val;
+    map.insert({key, val});
     return;
   }
 
-  signed oldVal = map[key];
-  if (val == oldVal) return;
+  Region oldVal = map.at(key);
+  if (val == oldVal)
+    return;
 
   for (auto [otherKey, otherVal] : map)
     if (otherVal == oldVal)
-      map[otherKey] = val;
+      map.insert_or_assign(otherKey, val);
 }
 
 class Partition {
@@ -163,11 +197,11 @@ private:
   // Label each index with a non-negative (unsigned) label if it is associated
   // with a valid region, and with -1 if it is associated with a consumed region
   // in-order traversal relied upon.
-  std::map<unsigned, signed> labels;
+  std::map<Element, Region> labels;
 
   // Track a label that is guaranteed to be strictly larger than all in use,
   // and therefore safe for use as a fresh label.
-  unsigned fresh_label = 0;
+  Region fresh_label = Region(0);
 
   // In a canonical partition, all regions are labelled with the smallest index
   // of any member. Certain operations like join and equals rely on canonicality
@@ -178,9 +212,10 @@ private:
   // Used only in assertions, check that Partitions promised to be canonical
   // are actually canonical
   bool is_canonical_correct() {
-    if (!canonical) return true; // vacuously correct
+    if (!canonical)
+      return true; // vacuously correct
 
-    auto fail = [&](unsigned i, int type) {
+    auto fail = [&](Element i, int type) {
       llvm::dbgs() << "FAIL(i=" << i << "; type=" << type << "): ";
       dump();
       return false;
@@ -188,16 +223,24 @@ private:
 
     for (auto &[i, label] : labels) {
       // correctness vacuous at consumed indices
-      if (label < 0) continue;
+      if (label.isConsumed())
+        continue;
 
       // this label should not exceed fresh_label
-      if ((unsigned) label >= fresh_label) return fail(i, 0);
+      if (label >= fresh_label)
+        return fail(i, 0);
 
       // the label of a region should be at most as large as each index in it
-      if ((unsigned) label > i) return fail(i, 1);
+      if ((unsigned)label > i)
+        return fail(i, 1);
 
-      // each region label should refer to an index in that region
-      if (labels[label] != label) return fail(i, 2);
+      // each region label should also be an element of the partition
+      if (!labels.count(Element(label)))
+        return fail(i, 2);
+
+      // each element that is also a region label should be mapped to itself
+      if (labels.at(Element(label)) != label)
+        return fail(i, 3);
     }
 
     return true;
@@ -211,46 +254,47 @@ private:
       return;
     canonical = true;
 
-    std::map<unsigned, unsigned> relabel;
+    std::map<Region, Region> relabel;
 
     // relies on in-order traversal of labels
     for (auto &[i, label] : labels) {
       // leave -1 (consumed region) as is
-      if (label < 0)
+      if (label.isConsumed())
         continue;
 
       if (!relabel.count(label)) {
         // if this is the first time encountering this region label,
         // then this region label should be relabelled to this index,
         // so enter that into the map
-        relabel[label] = i;
+        relabel.insert_or_assign(label, Region(i));
       }
 
       // update this label with either its own index, or a prior index that
       // shared a region with it
-      label = relabel[label];
+      label = relabel.at(label);
 
       // the maximum index iterated over will be used here to appropriately
       // set fresh_label
-      fresh_label = i + 1;
+      fresh_label = Region(i + 1);
     }
 
     assert(is_canonical_correct());
   }
 
   // linear time - merge the regions of two indices, maintaining canonicality
-  void merge(unsigned fst, unsigned snd) {
+  void merge(Element fst, Element snd) {
     assert(labels.count(fst) && labels.count(snd));
-    if (labels[fst] == labels[snd])
+    if (labels.at(fst) == labels.at(snd))
       return;
 
     // maintain canonicality by renaming the greater-numbered region
-    if (labels[fst] < labels[snd])
-      horizontalUpdate(labels, snd, labels[fst]);
+    if (labels.at(fst) < labels.at(snd))
+      horizontalUpdate(labels, snd, labels.at(fst));
     else
-      horizontalUpdate(labels, fst, labels[snd]);
+      horizontalUpdate(labels, fst, labels.at(snd));
 
     assert(is_canonical_correct());
+    assert(labels.at(fst) == labels.at(snd));
   }
 
 public:
@@ -260,13 +304,14 @@ public:
   // so set to false to begin with
   Partition(bool canonical) : labels({}), canonical(canonical) {}
 
-  static Partition singleRegion(std::vector<unsigned> indices) {
+  static Partition singleRegion(std::vector<Element> indices) {
     Partition p;
     if (!indices.empty()) {
-      unsigned min_index = *std::min_element(indices.begin(), indices.end());
-      p.fresh_label = min_index + 1;
-      for (unsigned index : indices) {
-        p.labels[index] = min_index;
+      Region min_index =
+          Region(*std::min_element(indices.begin(), indices.end()));
+      p.fresh_label = Region(min_index + 1);
+      for (Element index : indices) {
+        p.labels.insert_or_assign(index, min_index);
       }
     }
 
@@ -283,12 +328,10 @@ public:
     return fst.labels == snd.labels;
   }
 
-  bool isTracked(unsigned val) const {
-    return labels.count(val);
-  }
+  bool isTracked(Element val) const { return labels.count(val); }
 
-  bool isConsumed(unsigned val) const {
-    return isTracked(val) && labels.at(val) < 0;
+  bool isConsumed(Element val) const {
+    return isTracked(val) && labels.at(val).isConsumed();
   }
 
   // quadratic time - Construct the partition corresponding to the join of the
@@ -296,15 +339,15 @@ public:
   // and two indices are in the same region of the join iff they are in the same
   // region in either operand.
   static Partition join(Partition &fst, Partition &snd) {
-    //ensure copies are made
+    // ensure copies are made
     Partition fst_reduced = false;
     Partition snd_reduced = false;
 
     // make canonical copies of fst and snd, reduced to their intersected domain
     for (auto [i, _] : fst.labels)
       if (snd.labels.count(i)) {
-        fst_reduced.labels[i] = fst.labels[i];
-        snd_reduced.labels[i] = snd.labels[i];
+        fst_reduced.labels.insert_or_assign(i, fst.labels.at(i));
+        snd_reduced.labels.insert_or_assign(i, snd.labels.at(i));
       }
     fst_reduced.canonicalize();
     snd_reduced.canonicalize();
@@ -313,12 +356,21 @@ public:
     // of indices that are in the same region in snd are also in the same region
     // in fst - the desired property
     for (const auto [i, snd_label] : snd_reduced.labels) {
-      if (snd_label < 0)
+      if (snd_label.isConsumed())
         // if snd says that the region has been consumed, mark it consumed in fst
-        horizontalUpdate(fst_reduced.labels, i, -1);
+        horizontalUpdate(fst_reduced.labels, i, Region::consumed());
       else
-        fst_reduced.merge(i, snd_label);
+        fst_reduced.merge(i, Element(snd_label));
     }
+
+    LLVM_DEBUG(
+        llvm::dbgs() << "JOIN PEFORMED: \nFST: ";
+        fst.dump();
+        llvm::dbgs() << "SND: ";
+        snd.dump();
+        llvm::dbgs() << "RESULT: ";
+        fst_reduced.dump();
+    );
 
     assert(fst_reduced.is_canonical_correct());
 
@@ -336,15 +388,13 @@ public:
   // with the offending Consume.
   void apply(
       PartitionOp op,
-      llvm::function_ref<void(const PartitionOp&, unsigned)>
-      handleFailure = [](const PartitionOp&, unsigned) {},
+      llvm::function_ref<void(const PartitionOp &, Element)> handleFailure =
+          [](const PartitionOp &, Element) {},
 
-      std::vector<unsigned>
-          nonconsumables = {},
+      std::vector<Element> nonconsumables = {},
 
-      llvm::function_ref<void(const PartitionOp&, unsigned)>
-      handleConsumeNonConsumable = [](const PartitionOp&, unsigned) {}
-  ) {
+      llvm::function_ref<void(const PartitionOp &, Element)>
+          handleConsumeNonConsumable = [](const PartitionOp &, Element) {}) {
     switch (op.OpKind) {
     case PartitionOpKind::Assign:
       assert(op.OpArgs.size() == 2 &&
@@ -355,7 +405,7 @@ public:
       if (isConsumed(op.OpArgs[1]))
         handleFailure(op, op.OpArgs[1]);
 
-      labels[op.OpArgs[0]] = labels[op.OpArgs[1]];
+      labels.insert_or_assign(op.OpArgs[0], labels.at(op.OpArgs[1]));
 
       // assignment could have invalidated canonicality of either the old region
       // of op.OpArgs[0] or the region of op.OpArgs[1], or both
@@ -366,7 +416,10 @@ public:
              "AssignFresh PartitionOp should be passed 1 argument");
 
       // map index op.OpArgs[0] to a fresh label
-      labels[op.OpArgs[0]] = fresh_label++;
+      labels.insert_or_assign(op.OpArgs[0], fresh_label);
+
+      // increment the fresh label so it remains fresh
+      fresh_label = Region(fresh_label + 1);
       canonical = false;
       break;
     case PartitionOpKind::Consume:
@@ -380,15 +433,15 @@ public:
         handleFailure(op, op.OpArgs[0]);
 
       // mark region as consumed
-      horizontalUpdate(labels, op.OpArgs[0], -1);
+      horizontalUpdate(labels, op.OpArgs[0], Region::consumed());
 
       // check if any nonconsumables were consumed, and handle the failure if so
-      for (unsigned nonconsumable : nonconsumables) {
+      for (Element nonconsumable : nonconsumables) {
         assert(labels.count(nonconsumable) &&
                "nonconsumables should be function args and self, and therefore"
                "always present in the label map because of initialization at "
                "entry");
-        if (labels[nonconsumable] < 0) {
+        if (isConsumed(nonconsumable)) {
           handleConsumeNonConsumable(op, nonconsumable);
           break;
         }
@@ -422,9 +475,9 @@ public:
   }
 
   // return a vector of the consumed values in this partition
-  std::vector<unsigned> getConsumedVals() const {
+  std::vector<Element> getConsumedVals() const {
     // for effeciency, this could return an iterator not a vector
-    std::vector<unsigned> consumedVals;
+    std::vector<Element> consumedVals;
     for (auto [i, _] : labels)
       if (isConsumed(i))
         consumedVals.push_back(i);
@@ -433,14 +486,14 @@ public:
 
   // return a vector of the non-consumed regions in this partition, each
   // represented as a vector of values
-  std::vector<std::vector<unsigned>> getNonConsumedRegions() const {
+  std::vector<std::vector<Element>> getNonConsumedRegions() const {
     // for effeciency, this could return an iterator not a vector
-    std::map<signed, std::vector<unsigned>> buckets;
+    std::map<Region, std::vector<Element>> buckets;
 
     for (auto [i, label] : labels)
       buckets[label].push_back(i);
 
-    std::vector<std::vector<unsigned>> doubleVec;
+    std::vector<std::vector<Element>> doubleVec;
 
     for (auto [_, bucket] : buckets)
       doubleVec.push_back(bucket);
@@ -459,19 +512,19 @@ public:
   }
 
   void dump() LLVM_ATTRIBUTE_USED {
-    std::map<signed, std::vector<unsigned>> buckets;
+    std::map<Region, std::vector<Element>> buckets;
 
     for (auto [i, label] : labels)
       buckets[label].push_back(i);
 
     llvm::dbgs() << "[";
     for (auto [label, indices] : buckets) {
-      llvm::dbgs() << (label < 0 ? "{" : "(");
+      llvm::dbgs() << (label.isConsumed() ? "{" : "(");
       int j = 0;
-      for (unsigned i : indices) {
-        llvm::dbgs() << (j++? " " : "") << i;
+      for (Element i : indices) {
+        llvm::dbgs() << (j++ ? " " : "") << i;
       }
-      llvm::dbgs() << (label < 0 ? "}" : ")");
+      llvm::dbgs() << (label.isConsumed() ? "}" : ")");
     }
     llvm::dbgs() << "]\n";
   }

--- a/test/Concurrency/DeferredSendableChecking/region_based_sendability.swift
+++ b/test/Concurrency/DeferredSendableChecking/region_based_sendability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -emit-sil -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking
+// RUN: %target-typecheck-verify-swift -emit-sil -strict-concurrency=complete -enable-experimental-feature DeferredSendableChecking -disable-availability-checking
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
@@ -28,7 +28,6 @@ class NonSendable {
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 actor A {
     func run_closure(_ closure : () -> ()) async {
         closure();
@@ -39,7 +38,6 @@ actor A {
 
 func foo_noniso(_ ns : Any) {}
 
-@available(SwiftStdlib 5.1, *)
 func test_isolation_crossing_sensitivity(a : A) async {
     let ns0 = NonSendable();
     let ns1 = NonSendable();
@@ -48,13 +46,12 @@ func test_isolation_crossing_sensitivity(a : A) async {
     foo_noniso(ns0);
 
     //this call consumes ns1
-    await a.foo(ns1);
+    await a.foo(ns1); //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
     print(ns0);
-    print(ns1); //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    print(ns1); //expected-note{{access here could race with non-Sendable value send above}}
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
     let ns_let = NonSendable();
 
@@ -65,10 +62,9 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
     await a.foo(ns_let);
 
     // not safe to consume an arg
-    await a.foo(ns_arg); //expected-warning{{This application could pass `self` or a Non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await a.foo(ns_arg); //expected-warning{{this application could pass `self` or a Non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_closure_capture(a : A) async {
     let ns0 = NonSendable();
     let ns1 = NonSendable();
@@ -88,31 +84,30 @@ func test_closure_capture(a : A) async {
     print(ns3)
 
     // this should consume ns0
-    await a.run_closure(captures0)
+    await a.run_closure(captures0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-    print(ns0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    print(ns0) //expected-note{{access here could race with non-Sendable value send above}}
     print(ns1)
     print(ns2)
     print(ns3)
 
     // this should consume ns1 and ns2
-    await a.run_closure(captures12)
+    await a.run_closure(captures12) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-    print(ns0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-    print(ns1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-    print(ns2) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    print(ns0) //expected-note{{access here could race with non-Sendable value send above}}
+    print(ns1) //expected-note{{access here could race with non-Sendable value send above}}
+    print(ns2) //expected-note{{access here could race with non-Sendable value send above}}
     print(ns3)
 
     // this should consume ns3
-    await a.run_closure(captures3indirect)
+    await a.run_closure(captures3indirect) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-    print(ns0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-    print(ns1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-    print(ns2) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-    print(ns3) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    print(ns0) //expected-note{{access here could race with non-Sendable value send above}}
+    print(ns1) //expected-note{{access here could race with non-Sendable value send above}}
+    print(ns2) //expected-note{{access here could race with non-Sendable value send above}}
+    print(ns3) //expected-note{{access here could race with non-Sendable value send above}}
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_regions(a : A, b : Bool) async {
     // definitely aliases - should be in the same region
     let ns0_0 = NonSendable();
@@ -133,43 +128,42 @@ func test_regions(a : A, b : Bool) async {
     // check for each of the above pairs that consuming half of it consumes the other half
 
     if (b) {
-        await a.foo(ns0_0)
+        await a.foo(ns0_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns0_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns0_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns0_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns0_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns0_1)
+        await a.foo(ns0_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns0_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns0_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns0_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns0_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns1_0)
+        await a.foo(ns1_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns1_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns1_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns1_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns1_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns1_1)
+        await a.foo(ns1_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns1_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns1_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns1_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns1_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns2_0)
+        await a.foo(ns2_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns2_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns2_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns2_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns2_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns2_1)
+        await a.foo(ns2_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns2_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns2_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns2_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns2_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_indirect_regions(a : A, b : Bool) async {
     // in each of the following, nsX_0 and nsX_1 should be in the same region for various reasons
 
@@ -209,81 +203,80 @@ func test_indirect_regions(a : A, b : Bool) async {
     // now check for each pair that consuming half of it consumed the other half
 
     if (b) {
-        await a.foo(ns0_0)
+        await a.foo(ns0_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns0_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns0_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns0_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns0_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns0_1)
+        await a.foo(ns0_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns0_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns0_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns0_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns0_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns1_0)
+        await a.foo(ns1_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns1_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns1_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns1_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns1_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns1_1)
+        await a.foo(ns1_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns1_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns1_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns1_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns1_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns2_0)
+        await a.foo(ns2_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns2_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns2_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns2_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns2_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns2_1)
+        await a.foo(ns2_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns2_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns2_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns2_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns2_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns3_0)
+        await a.foo(ns3_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns3_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns3_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns3_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns3_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns3_1)
+        await a.foo(ns3_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns3_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns3_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns3_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns3_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns4_0)
+        await a.foo(ns4_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns4_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns4_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns4_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns4_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns4_1)
+        await a.foo(ns4_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns4_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns4_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns4_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns4_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 
     if (b) {
-        await a.foo(ns5_0)
+        await a.foo(ns5_0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns5_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns5_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns5_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns5_1) //expected-note{{access here could race with non-Sendable value send above}}
     } else {
-        await a.foo(ns5_1)
+        await a.foo(ns5_1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
 
-        print(ns5_0) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
-        print(ns5_1) //expected-warning{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        print(ns5_0) //expected-note{{access here could race with non-Sendable value send above}}
+        print(ns5_1) //expected-note{{access here could race with non-Sendable value send above}}
     }
 }
 
 // class methods in general cannot consume self, check that this is true except for Sendable classes (and actors)
 
-@available(SwiftStdlib 5.1, *)
 class C_NonSendable {
     func bar() {}
 
@@ -294,11 +287,10 @@ class C_NonSendable {
         foo_noniso(captures_self)
 
         // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-        await a.foo(captures_self) //expected-warning{{This application could pass `self` or a Non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
+        await a.foo(captures_self) //expected-warning{{this application could pass `self` or a Non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 final class C_Sendable : Sendable {
     func bar() {}
 
@@ -313,7 +305,6 @@ final class C_Sendable : Sendable {
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 actor A_Sendable {
     func bar() {}
 
@@ -328,17 +319,16 @@ actor A_Sendable {
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 func basic_loopiness(a : A, b : Bool) async {
     let ns = NonSendable()
 
     while (b) {
-        //TODO: remove duplicate warnings here and in following test cases
-        await a.foo(ns) //expected-warning 2{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+        await a.foo(ns)
+        //expected-warning@-1{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+        //expected-note@-2{{access here could race with non-Sendable value send above}}
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 func basic_loopiness_unsafe(a : A, b : Bool) async {
     var ns0 = NonSendable()
     var ns1 = NonSendable()
@@ -350,11 +340,10 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
         (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
     }
 
-    await a.foo(ns0)
-    await a.foo(ns3) //expected-warning 2{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    await a.foo(ns0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+    await a.foo(ns3) //expected-note{{access here could race with non-Sendable value send above}}
 }
 
-@available(SwiftStdlib 5.1, *)
 func basic_loopiness_safe(a : A, b : Bool) async {
     var ns0 = NonSendable()
     var ns1 = NonSendable()
@@ -378,7 +367,6 @@ struct StructBox {
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_struct_assign_doesnt_merge(a : A, b : Bool) async {
     let ns0 = NonSendable()
     let ns1 = NonSendable()
@@ -400,7 +388,6 @@ class ClassBox {
     }
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_class_assign_merges(a : A, b : Bool) async {
     let ns0 = NonSendable()
     let ns1 = NonSendable()
@@ -411,11 +398,10 @@ func test_class_assign_merges(a : A, b : Bool) async {
     box.contents = ns0
     box.contents = ns1
 
-    await a.foo(ns0)
-    await a.foo(ns1) //expected-warning 2{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    await a.foo(ns0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+    await a.foo(ns1) //expected-note{{access here could race with non-Sendable value send above}}
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_stack_assign_doesnt_merge(a : A, b : Bool) async {
     let ns0 = NonSendable()
     let ns1 = NonSendable()
@@ -431,7 +417,6 @@ func test_stack_assign_doesnt_merge(a : A, b : Bool) async {
     await a.foo(ns1)
 }
 
-@available(SwiftStdlib 5.1, *)
 func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
     let ns0 = NonSendable()
     let ns1 = NonSendable()
@@ -445,6 +430,6 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
     contents = ns0
     contents = ns1
 
-    await a.foo(ns0)
-    await a.foo(ns1) //expected-warning 2{{Non-Sendable value consumed, then used at this site; could yield race with another thread}}
+    await a.foo(ns0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+    await a.foo(ns1) //expected-note{{access here could race with non-Sendable value send above}}
 }

--- a/test/Concurrency/DeferredSendableChecking/region_based_sendability.swift
+++ b/test/Concurrency/DeferredSendableChecking/region_based_sendability.swift
@@ -433,3 +433,75 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
     await a.foo(ns0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
     await a.foo(ns1) //expected-note{{access here could race with non-Sendable value send above}}
 }
+
+func test_tuple_formation(a : A, i : Int) async {
+    let ns0 = NonSendable();
+    let ns1 = NonSendable();
+    let ns2 = NonSendable();
+    let ns3 = NonSendable();
+    let ns4 = NonSendable();
+    let ns012 = (ns0, ns1, ns2);
+    let ns13 = (ns1, ns3);
+
+    switch (i) {
+    case 0:
+        await a.foo(ns0) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+
+        foo_noniso(ns0); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns1); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns2); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns3); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns4);
+        foo_noniso(ns012); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns13); //expected-note{{access here could race with non-Sendable value send above}}
+    case 1:
+        await a.foo(ns1) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+
+        foo_noniso(ns0); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns1); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns2); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns3); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns4);
+        foo_noniso(ns012); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns13); //expected-note{{access here could race with non-Sendable value send above}}
+    case 2:
+        await a.foo(ns2) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+
+        foo_noniso(ns0); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns1); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns2); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns3); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns4);
+        foo_noniso(ns012); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns13); //expected-note{{access here could race with non-Sendable value send above}}
+    case 3:
+        await a.foo(ns4) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+
+        foo_noniso(ns0);
+        foo_noniso(ns1);
+        foo_noniso(ns2);
+        foo_noniso(ns4); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns012);
+        foo_noniso(ns13);
+    case 4:
+        await a.foo(ns012) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+
+        foo_noniso(ns0); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns1); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns2); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns3); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns4);
+        foo_noniso(ns012); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns13); //expected-note{{access here could race with non-Sendable value send above}}
+    default:
+        await a.foo(ns13) //expected-warning{{non-Sendable value sent across isolation domains here, but could be accessed later in this function}}
+
+        foo_noniso(ns0); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns1); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns2); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns3); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns4);
+        foo_noniso(ns012); //expected-note{{access here could race with non-Sendable value send above}}
+        foo_noniso(ns13); //expected-note{{access here could race with non-Sendable value send above}}
+    }
+}

--- a/unittests/SIL/PartitionUtilsTest.cpp
+++ b/unittests/SIL/PartitionUtilsTest.cpp
@@ -12,42 +12,42 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   Partition p2;
   Partition p3;
 
-  p1.apply(PartitionOp::AssignFresh(0));
-  p1.apply(PartitionOp::AssignFresh(1));
-  p1.apply(PartitionOp::AssignFresh(2));
-  p1.apply(PartitionOp::AssignFresh(3));
+  p1.apply(PartitionOp::AssignFresh(Element(0)));
+  p1.apply(PartitionOp::AssignFresh(Element(1)));
+  p1.apply(PartitionOp::AssignFresh(Element(2)));
+  p1.apply(PartitionOp::AssignFresh(Element(3)));
 
-  p2.apply(PartitionOp::AssignFresh(5));
-  p2.apply(PartitionOp::AssignFresh(6));
-  p2.apply(PartitionOp::AssignFresh(7));
-  p2.apply(PartitionOp::AssignFresh(0));
+  p2.apply(PartitionOp::AssignFresh(Element(5)));
+  p2.apply(PartitionOp::AssignFresh(Element(6)));
+  p2.apply(PartitionOp::AssignFresh(Element(7)));
+  p2.apply(PartitionOp::AssignFresh(Element(0)));
 
-  p3.apply(PartitionOp::AssignFresh(2));
-  p3.apply(PartitionOp::AssignFresh(3));
-  p3.apply(PartitionOp::AssignFresh(4));
-  p3.apply(PartitionOp::AssignFresh(5));
+  p3.apply(PartitionOp::AssignFresh(Element(2)));
+  p3.apply(PartitionOp::AssignFresh(Element(3)));
+  p3.apply(PartitionOp::AssignFresh(Element(4)));
+  p3.apply(PartitionOp::AssignFresh(Element(5)));
 
   EXPECT_FALSE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  p1.apply(PartitionOp::AssignFresh(4));
-  p1.apply(PartitionOp::AssignFresh(5));
-  p1.apply(PartitionOp::AssignFresh(6));
-  p1.apply(PartitionOp::AssignFresh(7));
-  p1.apply(PartitionOp::AssignFresh(8));
+  p1.apply(PartitionOp::AssignFresh(Element(4)));
+  p1.apply(PartitionOp::AssignFresh(Element(5)));
+  p1.apply(PartitionOp::AssignFresh(Element(6)));
+  p1.apply(PartitionOp::AssignFresh(Element(7)));
+  p1.apply(PartitionOp::AssignFresh(Element(8)));
 
-  p2.apply(PartitionOp::AssignFresh(1));
-  p2.apply(PartitionOp::AssignFresh(2));
-  p2.apply(PartitionOp::AssignFresh(3));
-  p2.apply(PartitionOp::AssignFresh(4));
-  p2.apply(PartitionOp::AssignFresh(8));
+  p2.apply(PartitionOp::AssignFresh(Element(1)));
+  p2.apply(PartitionOp::AssignFresh(Element(2)));
+  p2.apply(PartitionOp::AssignFresh(Element(3)));
+  p2.apply(PartitionOp::AssignFresh(Element(4)));
+  p2.apply(PartitionOp::AssignFresh(Element(8)));
 
-  p3.apply(PartitionOp::AssignFresh(6));
-  p3.apply(PartitionOp::AssignFresh(7));
-  p3.apply(PartitionOp::AssignFresh(0));
-  p3.apply(PartitionOp::AssignFresh(1));
-  p3.apply(PartitionOp::AssignFresh(8));
+  p3.apply(PartitionOp::AssignFresh(Element(6)));
+  p3.apply(PartitionOp::AssignFresh(Element(7)));
+  p3.apply(PartitionOp::AssignFresh(Element(0)));
+  p3.apply(PartitionOp::AssignFresh(Element(1)));
+  p3.apply(PartitionOp::AssignFresh(Element(8)));
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_TRUE(Partition::equals(p2, p3));
@@ -70,22 +70,22 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
     expect_join_eq();
   };
 
-  apply_to_p1_and_p3(PartitionOp::Merge(1, 2));
-  apply_to_p2_and_p3(PartitionOp::Merge(7, 8));
-  apply_to_p1_and_p3(PartitionOp::Merge(2, 7));
-  apply_to_p2_and_p3(PartitionOp::Merge(1, 3));
-  apply_to_p1_and_p3(PartitionOp::Merge(3, 4));
+  apply_to_p1_and_p3(PartitionOp::Merge(Element(1), Element(2)));
+  apply_to_p2_and_p3(PartitionOp::Merge(Element(7), Element(8)));
+  apply_to_p1_and_p3(PartitionOp::Merge(Element(2), Element(7)));
+  apply_to_p2_and_p3(PartitionOp::Merge(Element(1), Element(3)));
+  apply_to_p1_and_p3(PartitionOp::Merge(Element(3), Element(4)));
 
   EXPECT_FALSE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  apply_to_p2_and_p3(PartitionOp::Merge(2, 5));
-  apply_to_p1_and_p3(PartitionOp::Merge(5, 6));
-  apply_to_p2_and_p3(PartitionOp::Merge(1, 6));
-  apply_to_p1_and_p3(PartitionOp::Merge(2, 6));
-  apply_to_p2_and_p3(PartitionOp::Merge(3, 7));
-  apply_to_p1_and_p3(PartitionOp::Merge(7, 8));
+  apply_to_p2_and_p3(PartitionOp::Merge(Element(2), Element(5)));
+  apply_to_p1_and_p3(PartitionOp::Merge(Element(5), Element(6)));
+  apply_to_p2_and_p3(PartitionOp::Merge(Element(1), Element(6)));
+  apply_to_p1_and_p3(PartitionOp::Merge(Element(2), Element(6)));
+  apply_to_p2_and_p3(PartitionOp::Merge(Element(3), Element(7)));
+  apply_to_p1_and_p3(PartitionOp::Merge(Element(7), Element(8)));
 }
 
 // This test tests the semantics of assignment
@@ -94,50 +94,50 @@ TEST(PartitionUtilsTest, TestAssign) {
   Partition p2;
   Partition p3;
 
-  p1.apply(PartitionOp::AssignFresh(0));
-  p1.apply(PartitionOp::AssignFresh(1));
-  p1.apply(PartitionOp::AssignFresh(2));
-  p1.apply(PartitionOp::AssignFresh(3));
+  p1.apply(PartitionOp::AssignFresh(Element(0)));
+  p1.apply(PartitionOp::AssignFresh(Element(1)));
+  p1.apply(PartitionOp::AssignFresh(Element(2)));
+  p1.apply(PartitionOp::AssignFresh(Element(3)));
 
-  p2.apply(PartitionOp::AssignFresh(0));
-  p2.apply(PartitionOp::AssignFresh(1));
-  p2.apply(PartitionOp::AssignFresh(2));
-  p2.apply(PartitionOp::AssignFresh(3));
+  p2.apply(PartitionOp::AssignFresh(Element(0)));
+  p2.apply(PartitionOp::AssignFresh(Element(1)));
+  p2.apply(PartitionOp::AssignFresh(Element(2)));
+  p2.apply(PartitionOp::AssignFresh(Element(3)));
 
-  p3.apply(PartitionOp::AssignFresh(0));
-  p3.apply(PartitionOp::AssignFresh(1));
-  p3.apply(PartitionOp::AssignFresh(2));
-  p3.apply(PartitionOp::AssignFresh(3));
+  p3.apply(PartitionOp::AssignFresh(Element(0)));
+  p3.apply(PartitionOp::AssignFresh(Element(1)));
+  p3.apply(PartitionOp::AssignFresh(Element(2)));
+  p3.apply(PartitionOp::AssignFresh(Element(3)));
 
-  //expected: p1: ((0) (1) (2) (3)), p2: ((0) (1) (2) (3)), p3: ((0) (1) (2) (3))
+  //expected: p1: ((Element(0)) (Element(1)) (Element(2)) (Element(3))), p2: ((Element(0)) (Element(1)) (Element(2)) (Element(3))), p3: ((Element(0)) (Element(1)) (Element(2)) (Element(3)))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_TRUE(Partition::equals(p2, p3));
   EXPECT_TRUE(Partition::equals(p1, p3));
 
-  p1.apply(PartitionOp::Assign(0, 1));
-  p2.apply(PartitionOp::Assign(1, 0));
-  p3.apply(PartitionOp::Assign(2, 1));
+  p1.apply(PartitionOp::Assign(Element(0), Element(1)));
+  p2.apply(PartitionOp::Assign(Element(1), Element(0)));
+  p3.apply(PartitionOp::Assign(Element(2), Element(1)));
 
-  //expected: p1: ((0 1) (2) (3)), p2: ((0 1) (2) (3)), p3: ((0) (1 2) (3))
+  //expected: p1: ((0 1) (Element(2)) (Element(3))), p2: ((0 1) (Element(2)) (Element(3))), p3: ((Element(0)) (1 2) (Element(3)))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  p1.apply(PartitionOp::Assign(2, 0));
-  p2.apply(PartitionOp::Assign(2, 1));
-  p3.apply(PartitionOp::Assign(0, 2));
+  p1.apply(PartitionOp::Assign(Element(2), Element(0)));
+  p2.apply(PartitionOp::Assign(Element(2), Element(1)));
+  p3.apply(PartitionOp::Assign(Element(0), Element(2)));
 
-  //expected: p1: ((0 1 2) (3)), p2: ((0 1 2) (3)), p3: ((0 1 2) (3))
+  //expected: p1: ((0 1 2) (Element(3))), p2: ((0 1 2) (Element(3))), p3: ((0 1 2) (Element(3)))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_TRUE(Partition::equals(p2, p3));
   EXPECT_TRUE(Partition::equals(p1, p3));
 
-  p1.apply(PartitionOp::Assign(0, 3));
-  p2.apply(PartitionOp::Assign(1, 3));
-  p3.apply(PartitionOp::Assign(2, 3));
+  p1.apply(PartitionOp::Assign(Element(0), Element(3)));
+  p2.apply(PartitionOp::Assign(Element(1), Element(3)));
+  p3.apply(PartitionOp::Assign(Element(2), Element(3)));
 
   //expected: p1: ((1 2) (0 3)), p2: ((0 2) (1 3)), p3: ((0 1) (2 3))
 
@@ -145,19 +145,19 @@ TEST(PartitionUtilsTest, TestAssign) {
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  p1.apply(PartitionOp::Assign(1, 0));
-  p2.apply(PartitionOp::Assign(2, 1));
-  p3.apply(PartitionOp::Assign(0, 2));
+  p1.apply(PartitionOp::Assign(Element(1), Element(0)));
+  p2.apply(PartitionOp::Assign(Element(2), Element(1)));
+  p3.apply(PartitionOp::Assign(Element(0), Element(2)));
 
-  //expected: p1: ((2) (0 1 3)), p2: ((0) (1 2 3)), p3: ((1) (0 2 3))
+  //expected: p1: ((Element(2)) (0 1 3)), p2: ((Element(0)) (1 2 3)), p3: ((Element(1)) (0 2 3))
 
   EXPECT_FALSE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
   EXPECT_FALSE(Partition::equals(p1, p3));
 
-  p1.apply(PartitionOp::Assign(2, 3));
-  p2.apply(PartitionOp::Assign(0, 3));
-  p3.apply(PartitionOp::Assign(1, 3));
+  p1.apply(PartitionOp::Assign(Element(2), Element(3)));
+  p2.apply(PartitionOp::Assign(Element(0), Element(3)));
+  p3.apply(PartitionOp::Assign(Element(1), Element(3)));
 
   //expected: p1: ((0 1 2 3)), p2: ((0 1 2 3)), p3: ((0 1 2 3))
 
@@ -170,35 +170,35 @@ TEST(PartitionUtilsTest, TestAssign) {
 TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   Partition p;
 
-  p.apply(PartitionOp::AssignFresh(0));
-  p.apply(PartitionOp::AssignFresh(1));
-  p.apply(PartitionOp::AssignFresh(2));
-  p.apply(PartitionOp::AssignFresh(3));
-  p.apply(PartitionOp::AssignFresh(4));
-  p.apply(PartitionOp::AssignFresh(5));
-  p.apply(PartitionOp::AssignFresh(6));
-  p.apply(PartitionOp::AssignFresh(7));
-  p.apply(PartitionOp::AssignFresh(8));
-  p.apply(PartitionOp::AssignFresh(9));
-  p.apply(PartitionOp::AssignFresh(10));
-  p.apply(PartitionOp::AssignFresh(11));
+  p.apply(PartitionOp::AssignFresh(Element(0)));
+  p.apply(PartitionOp::AssignFresh(Element(1)));
+  p.apply(PartitionOp::AssignFresh(Element(2)));
+  p.apply(PartitionOp::AssignFresh(Element(3)));
+  p.apply(PartitionOp::AssignFresh(Element(4)));
+  p.apply(PartitionOp::AssignFresh(Element(5)));
+  p.apply(PartitionOp::AssignFresh(Element(6)));
+  p.apply(PartitionOp::AssignFresh(Element(7)));
+  p.apply(PartitionOp::AssignFresh(Element(8)));
+  p.apply(PartitionOp::AssignFresh(Element(9)));
+  p.apply(PartitionOp::AssignFresh(Element(10)));
+  p.apply(PartitionOp::AssignFresh(Element(11)));
 
-  p.apply(PartitionOp::Assign(1, 0));
-  p.apply(PartitionOp::Assign(2, 1));
+  p.apply(PartitionOp::Assign(Element(1), Element(0)));
+  p.apply(PartitionOp::Assign(Element(2), Element(1)));
 
-  p.apply(PartitionOp::Assign(4, 3));
-  p.apply(PartitionOp::Assign(5, 4));
+  p.apply(PartitionOp::Assign(Element(4), Element(3)));
+  p.apply(PartitionOp::Assign(Element(5), Element(4)));
 
-  p.apply(PartitionOp::Assign(7, 6));
-  p.apply(PartitionOp::Assign(9, 8));
+  p.apply(PartitionOp::Assign(Element(7), Element(6)));
+  p.apply(PartitionOp::Assign(Element(9), Element(8)));
 
-  //expected: p: ((0 1 2) (3 4 5) (6 7) (8 9) (10) (11))
+  //expected: p: ((0 1 2) (3 4 5) (6 7) (8 9) (Element(10)) (Element(11)))
 
-  p.apply(PartitionOp::Consume(2));
-  p.apply(PartitionOp::Consume(7));
-  p.apply(PartitionOp::Consume(10));
+  p.apply(PartitionOp::Consume(Element(2)));
+  p.apply(PartitionOp::Consume(Element(7)));
+  p.apply(PartitionOp::Consume(Element(10)));
 
-  // expected: p: ({0 1 2 6 7 10} (3 4 5) (8 9) (11))
+  // expected: p: ({0 1 2 6 7 10} (3 4 5) (8 9) (Element(11)))
 
   auto never_called = [](const PartitionOp &, unsigned) {
       EXPECT_TRUE(false);
@@ -214,18 +214,18 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
     return increment_times_called;
   };
 
-  p.apply(PartitionOp::Require(0), get_increment_times_called());
-  p.apply(PartitionOp::Require(1), get_increment_times_called());
-  p.apply(PartitionOp::Require(2), get_increment_times_called());
-  p.apply(PartitionOp::Require(3), never_called);
-  p.apply(PartitionOp::Require(4), never_called);
-  p.apply(PartitionOp::Require(5), never_called);
-  p.apply(PartitionOp::Require(6), get_increment_times_called());
-  p.apply(PartitionOp::Require(7), get_increment_times_called());
-  p.apply(PartitionOp::Require(8), never_called);
-  p.apply(PartitionOp::Require(9), never_called);
-  p.apply(PartitionOp::Require(10), get_increment_times_called());
-  p.apply(PartitionOp::Require(11), never_called);
+  p.apply(PartitionOp::Require(Element(0)), get_increment_times_called());
+  p.apply(PartitionOp::Require(Element(1)), get_increment_times_called());
+  p.apply(PartitionOp::Require(Element(2)), get_increment_times_called());
+  p.apply(PartitionOp::Require(Element(3)), never_called);
+  p.apply(PartitionOp::Require(Element(4)), never_called);
+  p.apply(PartitionOp::Require(Element(5)), never_called);
+  p.apply(PartitionOp::Require(Element(6)), get_increment_times_called());
+  p.apply(PartitionOp::Require(Element(7)), get_increment_times_called());
+  p.apply(PartitionOp::Require(Element(8)), never_called);
+  p.apply(PartitionOp::Require(Element(9)), never_called);
+  p.apply(PartitionOp::Require(Element(10)), get_increment_times_called());
+  p.apply(PartitionOp::Require(Element(11)), never_called);
 
   EXPECT_TRUE(times_called == expected_times_called);
 }
@@ -234,16 +234,16 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 // copies of partitions
 TEST(PartitionUtilsTest, TestCopyConstructor) {
   Partition p1;
-  p1.apply(PartitionOp::AssignFresh(0));
+  p1.apply(PartitionOp::AssignFresh(Element(0)));
   Partition p2 = p1;
-  p1.apply(PartitionOp::Consume(0));
+  p1.apply(PartitionOp::Consume(Element(0)));
   bool failure = false;
-  p1.apply(PartitionOp::Require(0), [&](const PartitionOp &, unsigned) {
+  p1.apply(PartitionOp::Require(Element(0)), [&](const PartitionOp &, unsigned) {
       failure = true;
     });
   EXPECT_TRUE(failure);
 
-  p2.apply(PartitionOp::Require(0), [](const PartitionOp &, unsigned) {
+  p2.apply(PartitionOp::Require(Element(0)), [](const PartitionOp &, unsigned) {
     EXPECT_TRUE(false);
   });
 }


### PR DESCRIPTION
In prior versions of the SendNonSendable pass, diagnostics were reported when it was discovered that a value in a consumed region was accessed. This is confusing as the site that performed the consumption is the site that actually invoked a cross-isolation call or other concurrency primitive. This PR changes the behavior to instead search for the site at which an original consumption took place, and diagnose that site along with notes of some potential accesses.