### PR TITLE
[ConstraintSystem] implement implicit pack materialization for abstract tuples instead of explicit '.element'

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -325,7 +325,6 @@ IDENTIFIER(size)
 IDENTIFIER(speed)
 IDENTIFIER(unchecked)
 IDENTIFIER(unsafe)
-IDENTIFIER(element)
 
 // The singleton instance of TupleTypeDecl in the Builtin module
 IDENTIFIER(TheTupleType)

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -234,6 +234,9 @@ enum class ConstraintKind : char {
   ExplicitGenericArguments,
   /// Both (first and second) pack types should have the same reduced shape.
   SameShape,
+  /// The first type is a tuple containing a single unlabeled element that is a
+  /// pack expansion. The second type is that pack expansion.
+  MaterializePackExpansion,
 };
 
 /// Classification of the different kinds of constraints.
@@ -703,6 +706,7 @@ public:
     case ConstraintKind::UnresolvedMemberChainBase:
     case ConstraintKind::PackElementOf:
     case ConstraintKind::SameShape:
+    case ConstraintKind::MaterializePackExpansion:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1475,6 +1475,10 @@ public:
   llvm::DenseMap<ConstraintLocator *, std::pair<UUID, Type>>
       PackExpansionEnvironments;
 
+  /// The pack expansion environment that can open a given pack element.
+  llvm::SmallMapVector<PackElementExpr *, PackExpansionExpr *, 2>
+      PackEnvironments;
+
   /// The locators of \c Defaultable constraints whose defaults were used.
   llvm::SmallPtrSet<ConstraintLocator *, 2> DefaultedConstraints;
 
@@ -2251,6 +2255,9 @@ private:
   llvm::SmallMapVector<ConstraintLocator *, std::pair<UUID, Type>, 4>
       PackExpansionEnvironments;
 
+  llvm::SmallMapVector<PackElementExpr *, PackExpansionExpr *, 2>
+      PackEnvironments;
+
   /// The set of functions that have been transformed by a result builder.
   llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>
       resultBuilderTransformed;
@@ -2736,6 +2743,9 @@ public:
 
     /// The length of \c PackExpansionEnvironments.
     unsigned numPackExpansionEnvironments;
+
+    /// The length of \c PackEnvironments.
+    unsigned numPackEnvironments;
 
     /// The length of \c DefaultedConstraints.
     unsigned numDefaultedConstraints;
@@ -3231,6 +3241,13 @@ public:
   /// Get the opened element generic environment for the given locator.
   GenericEnvironment *getPackElementEnvironment(ConstraintLocator *locator,
                                                 CanType shapeClass);
+
+  /// Get the opened element generic environment for the given pack element.
+  PackExpansionExpr *getPackEnvironment(PackElementExpr *packElement) const;
+
+  /// Associate an opened element generic environment to a pack element.
+  void addPackEnvironment(PackElementExpr *packElement,
+                          PackExpansionExpr *packExpansion);
 
   /// Retrieve the constraint locator for the given anchor and
   /// path, uniqued and automatically infer the summary flags

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4938,6 +4938,13 @@ private:
                                            TypeMatchOptions flags,
                                            ConstraintLocatorBuilder locator);
 
+  /// Remove the tuple wrapping of left-hand type if it contains only a single
+  /// unlabeled element that is a pack expansion.
+  SolutionKind
+  simplifyMaterializePackExpansionConstraint(Type type1, Type type2,
+                                             TypeMatchOptions flags,
+                                             ConstraintLocatorBuilder locator);
+
 public: // FIXME: Public for use by static functions.
   /// Simplify a conversion constraint with a fix applied to it.
   SolutionKind simplifyFixConstraint(ConstraintFix *fix, Type type1, Type type2,
@@ -5480,7 +5487,8 @@ public:
     }
 
     cs.addConstraint(ConstraintKind::PackElementOf, elementType,
-                     packType, cs.getConstraintLocator(elementEnv));
+                     packType->getRValueType(),
+                     cs.getConstraintLocator(elementEnv));
     return elementType;
   }
 };
@@ -6162,6 +6170,9 @@ Type isPlaceholderVar(PatternBindingDecl *PB);
 void dumpAnchor(ASTNode anchor, SourceManager *SM, raw_ostream &out);
 
 bool isSingleUnlabeledPackExpansionTuple(Type type);
+
+/// \returns null if \c type is not a single unlabeled pack expansion tuple.
+Type getPatternTypeOfSingleUnlabeledPackExpansionTuple(Type type);
 
 } // end namespace constraints
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3852,9 +3852,8 @@ namespace {
         auto packRefType = cs.getType(packRefExpr);
         if (auto *tuple = packRefType->getRValueType()->getAs<TupleType>();
             tuple && tuple->isSingleUnlabeledPackExpansion()) {
-          auto *expansion =
-              tuple->getElementType(0)->castTo<PackExpansionType>();
-          auto patternType = expansion->getPatternType();
+          auto patternType =
+              getPatternTypeOfSingleUnlabeledPackExpansionTuple(tuple);
           auto *materializedPackExpr = MaterializePackExpr::create(
               cs.getASTContext(), packRefExpr, packRefExpr->getLoc(),
               patternType, /*implicit*/ true);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1483,6 +1483,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::PackElementOf:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6170,8 +6170,10 @@ bool InvalidPackElement::diagnoseAsError() {
 }
 
 bool InvalidPackReference::diagnoseAsError() {
-  emitDiagnostic(diag::pack_reference_outside_expansion,
-                 packType);
+  auto patternType =
+      getPatternTypeOfSingleUnlabeledPackExpansionTuple(packType);
+  auto diagnosisType = patternType ? patternType : packType;
+  emitDiagnostic(diag::pack_reference_outside_expansion, diagnosisType);
   return true;
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1091,10 +1091,6 @@ namespace {
 
     Type openPackElement(Type packType, ConstraintLocator *locator,
                          PackExpansionExpr *packElementEnvironment) {
-      // If 'each t' is written outside of a pack expansion expression, allow the
-      // type to bind to a hole. The invalid pack reference will be diagnosed when
-      // attempting to bind the type variable for the underlying pack reference to
-      // a pack type without TVO_CanBindToPack.
       if (!packElementEnvironment) {
         return CS.createTypeVariable(locator,
                                      TVO_CanBindToHole | TVO_CanBindToNoEscape);
@@ -3103,8 +3099,14 @@ namespace {
           llvm_unreachable("unsupported pack reference ASTNode");
         }
 
+        auto *elementShape = CS.createTypeVariable(
+            CS.getConstraintLocator(pack, ConstraintLocator::PackShape),
+            TVO_CanBindToPack);
         CS.addConstraint(
-            ConstraintKind::ShapeOf, expansionType->getCountType(), packType,
+            ConstraintKind::ShapeOf, elementShape, packType,
+            CS.getConstraintLocator(pack, ConstraintLocator::PackShape));
+        CS.addConstraint(
+            ConstraintKind::Equal, elementShape, expansionType->getCountType(),
             CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
       }
 
@@ -3113,27 +3115,31 @@ namespace {
 
     Type visitPackElementExpr(PackElementExpr *expr) {
       auto packType = CS.getType(expr->getPackRefExpr());
-
-      if (isSingleUnlabeledPackExpansionTuple(packType)) {
-        packType =
-            addMemberRefConstraints(expr, expr->getPackRefExpr(),
-                                    DeclNameRef(CS.getASTContext().Id_element),
-                                    FunctionRefKind::Unapplied, {});
-        CS.setType(expr->getPackRefExpr(), packType);
-      }
-
       auto *packEnvironment = CS.getPackEnvironment(expr);
+      auto elementType = openPackElement(
+          packType, CS.getConstraintLocator(expr), packEnvironment);
       if (packEnvironment) {
         auto expansionType =
             CS.getType(packEnvironment)->castTo<PackExpansionType>();
         CS.addConstraint(ConstraintKind::ShapeOf, expansionType->getCountType(),
-                         packType,
+                         elementType,
                          CS.getConstraintLocator(packEnvironment,
                                                  ConstraintLocator::PackShape));
+        auto *elementShape = CS.createTypeVariable(
+            CS.getConstraintLocator(expr, ConstraintLocator::PackShape),
+            TVO_CanBindToPack);
+        CS.addConstraint(
+            ConstraintKind::ShapeOf, elementShape, elementType,
+            CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
+        CS.addConstraint(
+            ConstraintKind::Equal, elementShape, expansionType->getCountType(),
+            CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
+      } else {
+        CS.recordFix(AllowInvalidPackReference::create(
+            CS, packType, CS.getConstraintLocator(expr->getPackRefExpr())));
       }
 
-      return openPackElement(packType, CS.getConstraintLocator(expr),
-                             packEnvironment);
+      return elementType;
     }
 
     Type visitMaterializePackExpr(MaterializePackExpr *expr) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -129,10 +129,18 @@ static bool isPackExpansionType(Type type) {
 
 bool constraints::isSingleUnlabeledPackExpansionTuple(Type type) {
   auto *tuple = type->getRValueType()->getAs<TupleType>();
-  // TODO: drop no name requirement
   return tuple && (tuple->getNumElements() == 1) &&
          isPackExpansionType(tuple->getElementType(0)) &&
          !tuple->getElement(0).hasName();
+}
+
+Type constraints::getPatternTypeOfSingleUnlabeledPackExpansionTuple(Type type) {
+  if (!isSingleUnlabeledPackExpansionTuple(type)) {
+    return {};
+  }
+  auto tuple = type->getRValueType()->castTo<TupleType>();
+  auto *expansion = tuple->getElementType(0)->castTo<PackExpansionType>();
+  return expansion->getPatternType();
 }
 
 static bool containsPackExpansionType(ArrayRef<AnyFunctionType::Param> params) {
@@ -2283,6 +2291,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     llvm_unreachable("Bad constraint kind in matchTupleTypes()");
   }
 
@@ -2643,6 +2652,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     return true;
   }
 
@@ -3161,6 +3171,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     llvm_unreachable("Not a relational constraint");
   }
 
@@ -6817,6 +6828,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::ShapeOf:
     case ConstraintKind::ExplicitGenericArguments:
     case ConstraintKind::SameShape:
+    case ConstraintKind::MaterializePackExpansion:
       llvm_unreachable("Not a relational constraint");
     }
   }
@@ -9121,13 +9133,13 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
   }
 
   if (isSingleUnlabeledPackExpansionTuple(patternType)) {
-    auto *elementVar =
-        createTypeVariable(getConstraintLocator(locator), /*options=*/0);
-    addValueMemberConstraint(
-        patternType, DeclNameRef(getASTContext().Id_element), elementVar, DC,
-        FunctionRefKind::Unapplied, {},
-        getConstraintLocator(locator, {ConstraintLocator::Member}));
-    patternType = elementVar;
+    auto *packVar =
+        createTypeVariable(getConstraintLocator(locator), TVO_CanBindToPack);
+    addConstraint(ConstraintKind::MaterializePackExpansion, patternType,
+                  packVar,
+                  getConstraintLocator(locator, {ConstraintLocator::Member}));
+    addConstraint(ConstraintKind::PackElementOf, elementType, packVar, locator);
+    return SolutionKind::Solved;
   }
 
   // Let's try to resolve element type based on the pattern type.
@@ -9147,10 +9159,18 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
       if (!shapeClass->is<PackArchetypeType>()) {
         if (recordFix(AllowInvalidPackElement::create(*this, patternType, loc)))
           return SolutionKind::Error;
+      } else {
+        auto envShape = PackExpansionEnvironments.find(loc);
+        if (envShape == PackExpansionEnvironments.end()) {
+          return SolutionKind::Error;
+        }
+        auto *fix = SkipSameShapeRequirement::create(
+            *this, envShape->second.second, shapeClass,
+            getConstraintLocator(loc, ConstraintLocator::PackShape));
+        if (recordFix(fix)) {
+          return SolutionKind::Error;
+        }
       }
-
-      // Only other posibility is that there is a shape mismatch between
-      // elements of the pack expansion pattern which is detected separately.
 
       recordAnyTypeVarAsPotentialHole(elementType);
       return SolutionKind::Solved;
@@ -13505,6 +13525,37 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
 }
 
 ConstraintSystem::SolutionKind
+ConstraintSystem::simplifyMaterializePackExpansionConstraint(
+    Type type1, Type type2, TypeMatchOptions flags,
+    ConstraintLocatorBuilder locator) {
+  auto formUnsolved = [&]() {
+    // If we're supposed to generate constraints, do so.
+    if (flags.contains(TMF_GenerateConstraints)) {
+      auto *explictGenericArgs =
+          Constraint::create(*this, ConstraintKind::MaterializePackExpansion,
+                             type1, type2, getConstraintLocator(locator));
+
+      addUnsolvedConstraint(explictGenericArgs);
+      return SolutionKind::Solved;
+    }
+
+    return SolutionKind::Unsolved;
+  };
+
+  type1 = simplifyType(type1);
+  if (type1->hasTypeVariable()) {
+    return formUnsolved();
+  }
+  if (auto patternType =
+          getPatternTypeOfSingleUnlabeledPackExpansionTuple(type1)) {
+    addConstraint(ConstraintKind::Equal, patternType, type2, locator);
+    return SolutionKind::Solved;
+  }
+
+  return SolutionKind::Error;
+}
+
+ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
     Type type1, Type type2, TypeMatchOptions flags,
     ConstraintLocatorBuilder locator) {
@@ -15115,6 +15166,10 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
     return simplifyExplicitGenericArgumentsConstraint(
         first, second, subflags, locator);
 
+  case ConstraintKind::MaterializePackExpansion:
+    return simplifyMaterializePackExpansionConstraint(first, second, subflags,
+                                                      locator);
+
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueWitness:
@@ -15692,6 +15747,11 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
 
   case ConstraintKind::ExplicitGenericArguments:
     return simplifyExplicitGenericArgumentsConstraint(
+        constraint.getFirstType(), constraint.getSecondType(),
+        /*flags*/ llvm::None, constraint.getLocator());
+
+  case ConstraintKind::MaterializePackExpansion:
+    return simplifyMaterializePackExpansionConstraint(
         constraint.getFirstType(), constraint.getSecondType(),
         /*flags*/ llvm::None, constraint.getLocator());
   }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -226,6 +226,8 @@ Solution ConstraintSystem::finalize() {
     solution.PackExpansionEnvironments.insert(env);
   }
 
+  solution.PackEnvironments = PackEnvironments;
+
   return solution;
 }
 
@@ -288,6 +290,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the solutions's pack expansion environments.
   for (const auto &expansion : solution.PackExpansionEnvironments) {
     PackExpansionEnvironments.insert(expansion);
+  }
+
+  // Register the solutions's pack environments.
+  for (auto &packEnvironment : solution.PackEnvironments) {
+    PackEnvironments.insert(packEnvironment);
   }
 
   // Register the defaulted type variables.
@@ -613,6 +620,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numOpenedPackExpansionTypes = cs.OpenedPackExpansionTypes.size();
   numPackExpansionEnvironments = cs.PackExpansionEnvironments.size();
+  numPackEnvironments = cs.PackEnvironments.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
   numAddedKeyPathComponentTypes = cs.addedKeyPathComponentTypes.size();
@@ -696,6 +704,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any pack expansion environments.
   truncate(cs.PackExpansionEnvironments, numPackExpansionEnvironments);
+
+  // Remove any pack environments.
+  truncate(cs.PackEnvironments, numPackEnvironments);
 
   // Remove any defaulted type variables.
   truncate(cs.DefaultedConstraints, numDefaultedConstraints);

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -83,6 +83,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -173,6 +174,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -322,6 +324,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -580,6 +583,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
     Out << " explicit generic argument binding ";
     break;
 
+  case ConstraintKind::MaterializePackExpansion:
+    Out << " materialize pack expansion ";
+    break;
+
   case ConstraintKind::Disjunction:
     llvm_unreachable("disjunction handled above");
   case ConstraintKind::Conjunction:
@@ -750,6 +757,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::ShapeOf:
   case ConstraintKind::ExplicitGenericArguments:
   case ConstraintKind::SameShape:
+  case ConstraintKind::MaterializePackExpansion:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -683,6 +683,21 @@ ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator,
                                               shapeParam, contextSubs);
 }
 
+PackExpansionExpr *
+ConstraintSystem::getPackEnvironment(PackElementExpr *packElement) const {
+  const auto match = PackEnvironments.find(packElement);
+  return (match == PackEnvironments.end()) ? nullptr : match->second;
+}
+
+void ConstraintSystem::addPackEnvironment(PackElementExpr *packElement,
+                                          PackExpansionExpr *packExpansion) {
+  assert(packElement);
+  assert(packExpansion);
+  [[maybe_unused]] const auto inserted =
+      PackEnvironments.insert({packElement, packExpansion}).second;
+  assert(inserted && "Mapping already defined?");
+}
+
 /// Extend the given depth map by adding depths for all of the subexpressions
 /// of the given expression.
 static void extendDepthMap(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3608,9 +3608,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // In the future, _if_ the syntax allows for multiple expansions
     // this code would have to be adjusted to project l-value from the
     // base type just like TupleIndex does.
-    auto tuple = choice.getBaseType()->getRValueType()->castTo<TupleType>();
-    auto *expansion = tuple->getElementType(0)->castTo<PackExpansionType>();
-    adjustedRefType = expansion->getPatternType();
+    adjustedRefType =
+        getPatternTypeOfSingleUnlabeledPackExpansionTuple(choice.getBaseType());
     refType = adjustedRefType;
     break;
   }
@@ -3866,7 +3865,8 @@ struct TypeSimplifier {
             if (typeVar->getImpl().isPackExpansion() &&
                 !resolvedType->isEqual(typeVar) &&
                 !resolvedType->is<PackExpansionType>() &&
-                !resolvedType->is<PackType>()) {
+                !resolvedType->is<PackType>() &&
+                !resolvedType->is<PackArchetypeType>()) {
               return resolvedType;
             }
           }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -88,7 +88,7 @@ func typeReprPacks<each T: ExpressibleByIntegerLiteral>(_ t: repeat each T) {
 func sameShapeDiagnostics<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = (repeat (each t, each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
   _ = (repeat Array<(each T, each U)>()) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
-  _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
+  _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each U' and 'each T' have the same shape}}
 }
 
 func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
@@ -600,5 +600,18 @@ func test_that_expansions_are_bound_early() {
     let _: Value<Data> = Value({
         equal($0.prop, i) // Ok
       })
+  }
+}
+
+do {
+  func test<T>(x: T) {}
+
+  // rdar://110711746 to make this valid
+  func caller1<each T>(x: repeat each T) {
+    _ = (repeat { test(x: each x) }()) // expected-error {{pack reference 'each T' can only appear in pack expansion}}
+  }
+
+  func caller2<each T>(x: repeat each T) {
+    _ = { (repeat test(x: each x)) }()
   }
 }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -88,7 +88,7 @@ func typeReprPacks<each T: ExpressibleByIntegerLiteral>(_ t: repeat each T) {
 func sameShapeDiagnostics<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = (repeat (each t, each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
   _ = (repeat Array<(each T, each U)>()) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
-  _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each U' and 'each T' have the same shape}}
+  _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
 }
 
 func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
@@ -613,5 +613,24 @@ do {
 
   func caller2<each T>(x: repeat each T) {
     _ = { (repeat test(x: each x)) }()
+  }
+}
+
+// rdar://110401127 - name lookup bug when abstract tuple stored property shadows a global
+do {
+  let c = [false, true]
+  _ = c
+
+  struct ZipCollection<each C> {
+    public let c: (repeat each C)
+
+    func makeTuple() -> (repeat each C) {
+      fatalError()
+    }
+
+    public func f() -> (repeat Optional<each C>) {
+      _ = (repeat each makeTuple())
+      _ = (repeat (each makeTuple()))
+    }
   }
 }


### PR DESCRIPTION
* **Explanation**: Solves the failure to type check the expansion of an abstract tuple shadowed by a global variable name by adding tracking of pack environments for pack elements to Constraint System and implementing implicit pack materialization for abstract tuples instead of explicit '.element'.
* **Scope**: Only impacts variadic generics.
* **Issue**: rdar://110401127
* **Risk**: Low.
* **Testing**: Added a new test case with code that previously emitted an error when type checking the expansion of an abstract tuple shadowed by a global variable name.
* **Reviewer**: @xedin @hborla
* **Main branch PR**: https://github.com/apple/swift/pull/67164 https://github.com/apple/swift/pull/67292