### PR TITLE
[CSSimplify] Deplay member lookup until single-element tuple with pac…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9378,6 +9378,17 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     return result;
   }
 
+  // Delay member lookup until single-element tuple with pack expansion
+  // is sufficiently resolved.
+  if (isSingleUnlabeledPackExpansionTuple(instanceTy)) {
+    auto elementTy = instanceTy->castTo<TupleType>()->getElementType(0);
+    if (elementTy->is<TypeVariableType>()) {
+      MemberLookupResult result;
+      result.OverallResult = MemberLookupResult::Unsolved;
+      return result;
+    }
+  }
+
   // Okay, start building up the result list.
   MemberLookupResult result;
   result.OverallResult = MemberLookupResult::HasResults;

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -707,3 +707,18 @@ do {
     test3(str: "", a, a)  // expected-error {{ambiguous use of 'test3'}}
   }
 }
+
+// rdar://112095973 - single-element tuples are not unwrapped in member references
+do {
+  struct V<Value> {
+    let key: Int
+  }
+
+  struct S<each T> {
+    let data: (repeat V<each T>)
+  }
+
+  func test<U>(_ value: S<U>) {
+    _ = value.data.key // Ok
+  }
+}


### PR DESCRIPTION
…k expansion is sufficiently resolved

Such tuples should be treated specially because once pack 
expansion is sufficiently resolved they'd get exploded and 
the resulting type is what member lookup should use as a base.

Resolves: rdar://110721928

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
