### PR TITLE
[next] Remove ptrelt intrinsics

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2130,7 +2130,6 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Subdivide2Argument:
   case IITDescriptor::Subdivide4Argument:
   case IITDescriptor::PPCQuad:
-  case IITDescriptor::AnyPtrToElt:
   case IITDescriptor::AArch64Svcount:
     // These types cannot be expressed in swift yet.
     return Type();
@@ -2176,14 +2175,6 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Argument:
     return getTypeArgument(D.getArgumentNumber());
 
-  // A pointer to a type argument.
-  case IITDescriptor::PtrToArgument: {
-    Type argType = getTypeArgument(D.getArgumentNumber());
-    if (!argType) return Type();
-    unsigned addrspace = 0; // An apparent limitation of LLVM.
-    return makePointer(argType, addrspace);
-  }
-
   // A vector of the same width as a type argument.
   case IITDescriptor::SameVecWidthArgument: {
     Type maybeVectorType = getTypeArgument(D.getArgumentNumber());
@@ -2193,15 +2184,6 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
     return maybeMakeVectorized(eltType, maybeVectorType);
   }
 
-  // A pointer to the element type of a type argument, which must be a vector.
-  case IITDescriptor::PtrToElt: {
-    Type argType = getTypeArgument(D.getArgumentNumber());
-    if (!argType) return Type();
-    auto vecType = argType->getAs<BuiltinVectorType>();
-    if (!vecType) return Type();
-    unsigned addrspace = 0; // An apparent limitation of LLVM.
-    return makePointer(vecType->getElementType(), addrspace);
-  }
 
   // A struct, which we translate as a tuple.
   case IITDescriptor::Struct: {


### PR DESCRIPTION
LLVM upstream removed the PtrToElt and AnyPtrToElt intrinsics in commit 4136e08f14ae9043b46bbe0a101e8609164d1be5.

LLVM upstream removed the PtrToArgument intrinsic in commit 253a52988fe37887ba1f7741271d602083fe7dd7.

rdar://112418066
