### PR TITLE
[5.9] [CS] Walk UnresolvedDeclRefExprs in UnresolvedVarCollector

### DIFF
--- a/test/Constraints/rdar112264204.swift
+++ b/test/Constraints/rdar112264204.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://112264204: Make sure we can type-check this.
+func foo(_ fn: (Int) -> Void) {}
+
+func bar(_ x: Int) {
+  foo { [x] y in
+    switch y {
+    case x:
+      ()
+    default:
+      ()
+    }
+  }
+}


### PR DESCRIPTION
*5.9 cherry-pick of https://github.com/apple/swift/pull/67332*

- Explanation: Fixes a bogus error message that could appear when attempting to use a switch expression in a single-expression closure with a capture list that is referenced by one of the switch patterns.
- Scope: Affects switch expressions
- Issue: rdar://112264204
- Risk: Low, expands an existing bit of logic to cover more cases
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich