### PR TITLE
Update OptTable in swift_cache_tool to use new LLVM OptTable APIs

### DIFF
--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -63,7 +63,10 @@ enum ID {
 #undef OPTION
 };
 
-#define PREFIX(NAME, VALUE) static const char *const NAME[] = VALUE;
+#define PREFIX(NAME, VALUE)                                                    \
+  constexpr llvm::StringLiteral NAME##_init[] = VALUE;                         \
+  constexpr llvm::ArrayRef<llvm::StringLiteral> NAME(                          \
+      NAME##_init, std::size(NAME##_init) - 1);
 #include "SwiftCacheToolOptions.inc"
 #undef PREFIX
 
@@ -76,9 +79,9 @@ static const OptTable::Info InfoTable[] = {
 #undef OPTION
 };
 
-class CacheToolOptTable : public llvm::opt::OptTable {
+class CacheToolOptTable : public llvm::opt::GenericOptTable {
 public:
-  CacheToolOptTable() : OptTable(InfoTable) {}
+  CacheToolOptTable() : GenericOptTable(InfoTable) {}
 };
 
 class SwiftCacheToolInvocation {
@@ -98,18 +101,14 @@ public:
     Instance.addDiagnosticConsumer(&PDC);
   }
 
-  std::unique_ptr<llvm::opt::OptTable> createOptTable() {
-    return std::unique_ptr<OptTable>(new CacheToolOptTable());
-  }
-
   int parseArgs(ArrayRef<const char *> Args) {
     auto &Diags = Instance.getDiags();
 
-    std::unique_ptr<llvm::opt::OptTable> Table = createOptTable();
+    CacheToolOptTable Table;
     unsigned MissingIndex;
     unsigned MissingCount;
     llvm::opt::InputArgList ParsedArgs =
-        Table->ParseArgs(Args, MissingIndex, MissingCount);
+        Table.ParseArgs(Args, MissingIndex, MissingCount);
     if (MissingCount) {
       Diags.diagnose(SourceLoc(), diag::error_missing_arg_value,
                      ParsedArgs.getArgString(MissingIndex), MissingCount);
@@ -119,8 +118,8 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->printHelp(llvm::outs(), ExecutableName.c_str(), "Swift Cache Tool",
-                       0, 0, /*ShowAllAliases*/ false);
+      Table.printHelp(llvm::outs(), ExecutableName.c_str(), "Swift Cache Tool",
+                      0, 0, /*ShowAllAliases*/ false);
       return 0;
     }
 


### PR DESCRIPTION
Fix OptTable for upstream llvm/main.

rdar://112418691
