### PR TITLE
[Test] Keep output of %validate-json in unicode_filename.swift

### DIFF
--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -scan-dependencies %/s %/S/Inputs/unicode_filёnamё.swift -o %t/deps.json
 
 // Check the contents of the JSON output
-// RUN: %validate-json %t/deps.json &>/dev/null
+// RUN: %validate-json %t/deps.json
 // RUN: %FileCheck %s < %t/deps.json
 
 public func bar() {


### PR DESCRIPTION
Preserve the output to understand failures on older Linux bots.