### PR TITLE
[IRGen] Fix enum metadata instantiation for resilient payload

### DIFF
--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -222,6 +222,8 @@ XIElement findXIElement(const Metadata *type) {
 void swift::swift_initEnumMetadataSinglePayloadWithLayoutString(
     EnumMetadata *self, EnumLayoutFlags layoutFlags,
     const Metadata *payloadType, unsigned emptyCases) {
+  assert(self->hasLayoutString());
+
   auto *payloadLayout = payloadType->getTypeLayout();
   size_t payloadSize = payloadLayout->size;
   unsigned payloadNumExtraInhabitants = payloadLayout->getNumExtraInhabitants();

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -78,3 +78,9 @@ public func getResilientSinglePayloadEnumSimpleEmpty0() -> ResilientSinglePayloa
 public func getResilientSingletonEnumNonEmpty(_ x: AnyObject) -> ResilientSingletonEnum {
     return .nonEmpty(x)
 }
+
+public enum ResilientSinglePayloadEnum {
+    case empty0
+    case empty1
+    case nonEmpty(AnyObject, Int)
+}

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -686,6 +686,22 @@ func testResilientSingletonEnumGenericInjectTag() {
 
 testResilientSingletonEnumGenericInjectTag()
 
+enum ResilientPayloadSinglePayloadEnum {
+    case empty0
+    case empty1
+    case empty2
+    case nonEmpty(ResilientSinglePayloadEnum, Int)
+}
+
+func testResilientPayloadSinglePayloadEnum() {
+    let xxx = ResilientPayloadSinglePayloadEnum.nonEmpty(.empty0, 1)
+
+    // CHECK: nonEmpty(layout_string_witnesses_types_resilient.ResilientSinglePayloadEnum.empty0, 1)
+    print(xxx)
+}
+
+testResilientPayloadSinglePayloadEnum()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
The metadata can't be constant when we generate a layout string at runtime.