### PR TITLE
[Serialization] InitAccessors: Use correct code for `@storageRestrict…

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2957,7 +2957,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     }
 
     case DAK_StorageRestrictions: {
-      auto abbrCode = S.DeclTypeAbbrCodes[AccessesDeclAttrLayout::Code];
+      auto abbrCode = S.DeclTypeAbbrCodes[StorageRestrictionsDeclAttrLayout::Code];
       auto attr = cast<StorageRestrictionsAttr>(DA);
 
       SmallVector<IdentifierID, 4> properties;

--- a/test/Serialization/init_accessors.swift
+++ b/test/Serialization/init_accessors.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// REQUIRES: asserts
+
+// RUN: %target-swift-frontend -emit-module %t/src/PublicModule.swift \
+// RUN:   -module-name PublicModule -swift-version 5 \
+// RUN:   -emit-module-path %t/sdk/PublicModule.swiftmodule \
+// RUN:   -enable-experimental-feature InitAccessors
+
+// RUN: %target-swift-frontend -typecheck %t/src/Client.swift \
+// RUN:   -enable-experimental-feature InitAccessors \
+// RUN:   -module-name Client -I %t/sdk
+
+//--- PublicModule.swift
+public struct Test<T> {
+  private var _x: T
+
+  public var x: T {
+    @storageRestrictions(initializes: _x)
+    init {
+      _x = newValue
+    }
+
+    get { _x }
+    set { _x = newValue }
+  }
+
+  public init(data: T) {
+    self.x = data
+  }
+}
+
+public struct TestMulti<T, U> {
+  private var _a: T
+  private var _c: U
+
+  public var b: Int
+
+  public var data: (T, U) {
+    @storageRestrictions(initializes: _a, _c, accesses: b)
+    init {
+      _a = newValue.0
+      _c = newValue.1
+      b = 0
+    }
+
+    get { (_a, _c) }
+  }
+
+  public init(data: (T, U), b: Int) {
+    self.b = b
+    self.data = data
+  }
+}
+
+//--- Client.swift
+import PublicModule
+
+let test1 = Test<[Int]>(data: [1, 2, 3])
+_ = test1.x
+
+let test2 = TestMulti(data: ("Question", 42), b: -1)
+_ = print("\(test2.data), \(test2.b)")


### PR DESCRIPTION
…ions` serialization

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
