### PR TITLE
Skip new parser validation when skipping function bodies

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1538,10 +1538,22 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
     opts |= ParsingFlags::SuppressWarnings;
   }
 
-  // Turn off round-trip checking for secondary files, and for dependency
-  // scanning and IDE inspection.
+  // Turn off new parser round-trip and diagnostics checking for
+  //   - secondary files
+  //     - Only want to verify on primary files, no point checking more than
+  //       once
+  //   - IDE inspection
+  //     - We don't want to pay the cost of verification for simple IDE
+  //       functionality (eg. completion and cursor info)
+  //   - dependency scanning
+  //     - Same as IDE inspection, this is meant to be a very fast operation.
+  //       Don't slow it down
+  //   - skipped function bodies
+  //     - Swift parser doesn't support function body skipping yet, so this
+  //       would result in verification failures when bodies have errors
   if (!isEffectivelyPrimary || SourceMgr.hasIDEInspectionTargetBuffer() ||
-      frontendOpts.RequestedAction == ActionType::ScanDependencies) {
+      frontendOpts.RequestedAction == ActionType::ScanDependencies ||
+      typeOpts.SkipFunctionBodies != FunctionBodySkipping::None) {
     opts -= ParsingFlags::RoundTrip;
     opts -= ParsingFlags::ValidateNewParserDiagnostics;
   }

--- a/test/Parse/new_parser_diagnostics.swift
+++ b/test/Parse/new_parser_diagnostics.swift
@@ -1,8 +1,7 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserDiagnostics
-
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
+// REQUIRES: swift_swift_parser
 // REQUIRES: asserts
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserDiagnostics
 
 _ = [(Int) -> async throws Int]()
 // expected-error@-1{{'async throws' must precede '->'}}

--- a/test/Parse/validate_new_parser_diagnostics.swift
+++ b/test/Parse/validate_new_parser_diagnostics.swift
@@ -1,0 +1,17 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: asserts
+
+// Checks that skipping function bodies doesn't cause the new parser validation
+// to fail. This can currently be the case because the new parser doesn't
+// support skipping, causing validation fail as it generates diagnostics when
+// the C++ parser would not.
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserValidation
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature ParserValidation -experimental-skip-all-function-bodies
+
+func bad() {
+  _ = [(Int) -> async throws Int]()
+  // expected-error@-1{{'throws' may only occur before '->'}}
+  // expected-error@-2{{'async' may only occur before '->'}}
+}
+


### PR DESCRIPTION
This would otherwise result in false positives, since if the old parser skipping a body with errors would cause a verification failure.

Don't perform round trip validation either, since we'll presumbly still hit parsing the full file when not skipping bodies - there's no point running it twice.

Resolves rdar://111032175.