### PR TITLE
[move-only] Fix lazily initialized global initializers.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1085,13 +1085,17 @@ namespace {
     ManagedValue Value;
     llvm::Optional<SILAccessEnforcement> Enforcement;
     bool IsRValue;
+    bool IsLazyInitializedGlobal;
+
   public:
     ValueComponent(ManagedValue value,
                    llvm::Optional<SILAccessEnforcement> enforcement,
                    LValueTypeData typeData, bool isRValue = false,
-                   llvm::Optional<ActorIsolation> actorIso = llvm::None)
+                   llvm::Optional<ActorIsolation> actorIso = llvm::None,
+                   bool isLazyInitializedGlobal = false)
         : PhysicalPathComponent(typeData, ValueKind, actorIso), Value(value),
-          Enforcement(enforcement), IsRValue(isRValue) {
+          Enforcement(enforcement), IsRValue(isRValue),
+          IsLazyInitializedGlobal(isLazyInitializedGlobal) {
       assert(IsRValue || value.getType().isAddress() ||
              value.getType().isBoxedNonCopyableType(value.getFunction()));
     }
@@ -1106,7 +1110,7 @@ namespace {
       if (Value.getType().isAddress() && Value.getType().isMoveOnly()) {
         SILValue addr = Value.getValue();
         auto box = dyn_cast<ProjectBoxInst>(addr);
-        if (box || isa<GlobalAddrInst>(addr)) {
+        if (box || isa<GlobalAddrInst>(addr) || IsLazyInitializedGlobal) {
           if (Enforcement)
             addr = enterAccessScope(SGF, loc, base, addr, getTypeData(),
                                     getAccessKind(), *Enforcement,
@@ -3228,9 +3232,12 @@ void LValue::addNonMemberVarComponent(
       auto astAccessKind = mapAccessKind(this->AccessKind);
       auto address = SGF.maybeEmitValueOfLocalVarDecl(Storage, astAccessKind);
 
+      bool isLazyInitializedGlobal = false;
+
       // The only other case that should get here is a global variable.
       if (!address) {
-          address = SGF.emitGlobalVariableRef(Loc, Storage, ActorIso);
+        address = SGF.emitGlobalVariableRef(Loc, Storage, ActorIso);
+        isLazyInitializedGlobal = Storage->isLazilyInitializedGlobal();
       } else {
         assert((!ActorIso || Storage->isTopLevelGlobal()) &&
                "local var should not be actor isolated!");
@@ -3256,7 +3263,8 @@ void LValue::addNonMemberVarComponent(
       }
 
       LV.add<ValueComponent>(address, enforcement, typeData,
-                             /*isRValue=*/false, ActorIso);
+                             /*isRValue=*/false, ActorIso,
+                             isLazyInitializedGlobal);
 
       if (address.getType().is<ReferenceStorageType>())
         LV.add<OwnershipComponent>(typeData);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1028,6 +1028,15 @@ void UseState::initializeLiveness(
     liveness.initializeDef(address, liveness.getTopLevelSpan());
   }
 
+  if (auto *ptai = dyn_cast<PointerToAddressInst>(
+          stripAccessMarkers(address->getOperand()))) {
+    assert(ptai->isStrict());
+    LLVM_DEBUG(llvm::dbgs() << "Found pointer to address use... "
+                               "adding mark_must_check as init!\n");
+    recordInitUse(address, address, liveness.getTopLevelSpan());
+    liveness.initializeDef(address, liveness.getTopLevelSpan());
+  }
+
   // Now that we have finished initialization of defs, change our multi-maps
   // from their array form to their map form.
   liveness.finishedInitializationOfDefs();

--- a/test/SILGen/moveonly_lazy_initialized_globals.swift
+++ b/test/SILGen/moveonly_lazy_initialized_globals.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-emit-silgen -sil-verify-all -parse-as-library %s | %FileCheck %s
+
+struct S: ~Copyable {
+  let s: String
+  init(_ s: String) { self.s = s }
+  deinit { print("deiniting \(s)") }
+}
+
+struct M4 : ~Copyable {
+  var s1: S
+  var s2: S
+  init(_ s: String) {
+      fatalError()
+  }
+}
+
+func rewriteTwo(_ one: inout S, _ two: inout S) {
+  one = S("new1")
+  two = S("new2")
+}
+
+var m = M4("1")
+var m2 = M4("1")
+
+struct Doit {
+  static var m3 = M4("1")
+  static var m4 = M4("1")
+
+  // CHECK-LABEL: sil hidden [ossa] @$s33moveonly_lazy_initialized_globals4DoitV3runyyFZ : $@convention(method) (@thin Doit.Type) -> () {
+  // CHECK: [[F1:%.*]] = function_ref @$s33moveonly_lazy_initialized_globals1mAA2M4Vvau : $@convention(thin) () -> Builtin.RawPointer
+  // CHECK: [[PTR1:%.*]] = apply [[F1]]()
+  // CHECK: [[ADDR1:%.*]] = pointer_to_address [[PTR1]]
+  // CHECK: [[F2:%.*]] = function_ref @$s33moveonly_lazy_initialized_globals2m2AA2M4Vvau : $@convention(thin) () -> Builtin.RawPointer
+  // CHECK: [[PTR2:%.*]] = apply [[F2]]()
+  // CHECK: [[ADDR2:%.*]] = pointer_to_address [[PTR2]]
+  // CHECK: [[ACCESS1:%.*]] = begin_access [modify] [dynamic] [[ADDR1]]
+  // CHECK: [[MARK1:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS1]]
+  // CHECK: [[GEP1:%.*]] = struct_element_addr [[MARK1]]
+  // CHECK: [[ACCESS2:%.*]] = begin_access [modify] [dynamic] [[ADDR2]]
+  // CHECK: [[MARK2:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS2]]
+  // CHECK: [[GEP2:%.*]] = struct_element_addr [[MARK2]]
+  // CHECK: apply {{%.*}}([[GEP1]], [[GEP2]])
+  //
+  // CHECK: [[F3:%.*]] = function_ref @$s33moveonly_lazy_initialized_globals4DoitV2m3AA2M4Vvau : $@convention(thin) () -> Builtin.RawPointer
+  // CHECK: [[PTR3:%.*]] = apply [[F3]]()
+  // CHECK: [[ADDR3:%.*]] = pointer_to_address [[PTR3]]
+  // CHECK: [[F4:%.*]] = function_ref @$s33moveonly_lazy_initialized_globals4DoitV2m4AA2M4Vvau : $@convention(thin) () -> Builtin.RawPointer
+  // CHECK: [[PTR4:%.*]] = apply [[F4]]()
+  // CHECK: [[ADDR4:%.*]] = pointer_to_address [[PTR4]]
+  // CHECK: [[ACCESS3:%.*]] = begin_access [modify] [dynamic] [[ADDR3]]
+  // CHECK: [[MARK3:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS3]]
+  // CHECK: [[GEP3:%.*]] = struct_element_addr [[MARK3]]
+  // CHECK: [[ACCESS4:%.*]] = begin_access [modify] [dynamic] [[ADDR4]]
+  // CHECK: [[MARK4:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS4]]
+  // CHECK: [[GEP4:%.*]] = struct_element_addr [[MARK4]]
+  // CHECK: apply {{%.*}}([[GEP3]], [[GEP4]])
+  // CHECK: } // end sil function '$s33moveonly_lazy_initialized_globals4DoitV3runyyFZ'
+  static func run() {
+      rewriteTwo(&m.s1, &m2.s2)
+      rewriteTwo(&m3.s1, &m4.s2)
+  }
+}

--- a/test/SILOptimizer/moveonly_lazy_initialized_globals.swift
+++ b/test/SILOptimizer/moveonly_lazy_initialized_globals.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -parse-as-library -verify %s
+
+struct S: ~Copyable {
+  let s: String
+  init(_ s: String) { self.s = s }
+  deinit { print("deiniting \(s)") }
+}
+
+struct M4 : ~Copyable {
+  var s1: S
+  var s2: S
+  init(_ s: String) {
+      fatalError()
+  }
+}
+
+func rewriteTwo(_ one: inout S, _ two: inout S) {
+  one = S("new1")
+  two = S("new2")
+}
+
+var m = M4("1")
+var m2 = M4("1")
+
+struct Doit {
+  static var m3 = M4("1")
+  static var m4 = M4("1")
+
+  // We should get no diagnostics.
+  static func run() {
+      rewriteTwo(&m.s1, &m2.s2)
+      rewriteTwo(&m3.s1, &m4.s2)
+  }
+}


### PR DESCRIPTION
Without this, we emit a copy of noncopyable type error since we do not insert a mark_must_check on lazily initialized global initializers.

rdar://111402912
