### PR TITLE
Stop treating macro declaring `init` identifier as producing initializers

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10764,15 +10764,6 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
     switch (expandedName.getKind()) {
     case MacroIntroducedDeclNameKind::Named: {
       names.push_back(DeclName(expandedName.getName()));
-
-      // Temporary hack: we previously allowed named(`init`) to mean the same
-      // thing as named(init), before the latter was supported. Smooth over the
-      // difference by treating the former as the latter, for a short time.
-      if (expandedName.getName().isSimpleName() &&
-          !expandedName.getName().getBaseName().isSpecial() &&
-          expandedName.getName().getBaseIdentifier().is("init"))
-        names.push_back(DeclName(DeclBaseName::createConstructor()));
-
       break;
     }
 

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -2,7 +2,7 @@
 //
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -verify-ignore-unknown
 // RUN: %target-build-swift -g -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
@@ -102,10 +102,12 @@ enum ElementType {
 
 print(ElementType.paper.unknown())
 
+#if TEST_DIAGNOSTICS
 @addMembersQuotedInit
-struct S2 {
+struct S2 { // expected-note{{in expansion of macro 'addMembersQuotedInit' here}}
   func useSynthesized() {
     S.method()
     print(type(of: getStorage()))
   }
 }
+#endif

--- a/test/Profiler/coverage_macros.swift
+++ b/test/Profiler/coverage_macros.swift
@@ -12,7 +12,7 @@ macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "Acce
 
 @attached(
   member,
-  names: named(`init`), named(Storage), named(storage), named(getStorage()), named(method)
+  names: named(init), named(Storage), named(storage), named(getStorage()), named(method)
 )
 macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
 


### PR DESCRIPTION
Unwind a temporary workaround we put into the compiler that treated the escaped identifier "init" as an initializer in the set of names introduced by a macro. We've addressed the underlying issues.

Fixes rdar://108589649.
