### PR TITLE
[Test] Force unicode_filename JSON validation to use UTF-8

### DIFF
--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -scan-dependencies %/s %/S/Inputs/unicode_filёnamё.swift -o %t/deps.json
 
 // Check the contents of the JSON output
-// RUN: %validate-json %t/deps.json
+// RUN: env PYTHONIOENCODING=UTF-8 %validate-json < %t/deps.json
 // RUN: %FileCheck %s < %t/deps.json
 
 public func bar() {


### PR DESCRIPTION
On older CI machines the JSON file being verified was opened as ascii, leading to encoding errors. Force the validation to use UTF-8. There is likely a bigger configuration issue on these bots but this is a start.