### PR TITLE
SIL: Fix substituted function type visitor for PackExpansionType with concrete pattern type

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1472,12 +1472,11 @@ public:
 
   /// Given that the value being abstracted is a pack expansion type,
   /// return the underlying pattern type.
-  ///
-  /// If you're looking for getPackExpansionCountType(), it deliberately
-  /// does not exist.  Count types are not lowered types, and the original
-  /// count types are not relevant to lowering.  Only the substituted
-  /// components and expansion counts are significant.
   AbstractionPattern getPackExpansionPatternType() const;
+
+  /// Given that the value being abstracted is a pack expansion type,
+  /// return the underlying count type.
+  AbstractionPattern getPackExpansionCountType() const;
 
   /// Given that the value being abstracted is a pack expansion type,
   /// return the appropriate pattern type for the given expansion

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -795,6 +795,49 @@ AbstractionPattern AbstractionPattern::getPackExpansionPatternType() const {
   llvm_unreachable("bad kind");
 }
 
+static CanType getPackExpansionCountType(CanType type) {
+  return cast<PackExpansionType>(type).getCountType();
+}
+
+AbstractionPattern AbstractionPattern::getPackExpansionCountType() const {
+  switch (getKind()) {
+  case Kind::Invalid:
+    llvm_unreachable("querying invalid abstraction pattern!");
+  case Kind::ObjCMethodType:
+  case Kind::CurriedObjCMethodType:
+  case Kind::PartialCurriedObjCMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CurriedCFunctionAsMethodType:
+  case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+  case Kind::Tuple:
+  case Kind::OpaqueFunction:
+  case Kind::OpaqueDerivativeFunction:
+  case Kind::ObjCCompletionHandlerArgumentsType:
+  case Kind::ClangType:
+    llvm_unreachable("pattern for function or tuple cannot be for "
+                     "pack expansion type");
+
+  case Kind::Opaque:
+    return *this;
+
+  case Kind::Type:
+    if (isTypeParameterOrOpaqueArchetype())
+      return AbstractionPattern::getOpaque();
+    return AbstractionPattern(getGenericSubstitutions(),
+                              getGenericSignature(),
+                              ::getPackExpansionCountType(getType()));
+
+  case Kind::Discard:
+    return AbstractionPattern::getDiscard(
+        getGenericSubstitutions(), getGenericSignature(),
+        ::getPackExpansionCountType(getType()));
+  }
+  llvm_unreachable("bad kind");
+}
+
 size_t AbstractionPattern::getNumPackExpandedComponents() const {
   assert(isPackExpansion());
   assert(getKind() == Kind::Type || getKind() == Kind::Discard);
@@ -2267,7 +2310,7 @@ public:
     // Recursively visit the pattern type.
     auto patternTy = visit(substPatternType, origPatternType);
 
-    // Find a pack parameter from the pattern to expand over.
+    // If the pattern contains a pack parameter, use that as the count type.
     CanType countParam;
     patternTy->walkPackReferences([&](Type t) {
       if (t->isTypeParameter()) {
@@ -2281,10 +2324,22 @@ public:
       return false;
     });
 
-    // If that didn't work, we should be able to find an expansion
-    // to use from either the substituted type or the subs.  At worst,
-    // we can make one.
-    assert(countParam && "implementable but lazy");
+    // If the pattern was fully substituted, substitute the original
+    // count type and use that instead.
+    if (!countParam) {
+      auto origCountType = origExpansion.getPackExpansionCountType();
+      CanType substCountType;
+      if (origExpansion.getGenericSubstitutions()) {
+        substCountType = cast<PackExpansionType>(origExpansion.getType())
+            .getCountType();
+      } else {
+        assert(candidateSubstType);
+        substCountType =
+          cast<PackExpansionType>(candidateSubstType).getCountType();
+      }
+
+      countParam = visit(substCountType, origCountType);
+    }
 
     return CanPackExpansionType::get(patternTy, countParam);
   }

--- a/validation-test/compiler_crashers_2_fixed/rdar112065340.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar112065340.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public func test<each T: BinaryInteger>(_ values: repeat each T) {
+    var values = (repeat UInt32(truncatingIfNeeded: each values))
+    withUnsafePointer(to: &values) { ptr in
+        _ = ptr[0]
+    }
+}


### PR DESCRIPTION
If the pattern doesn't have any pack parameters in it anymore, we need to recover the substituted count type from the original count type.

Fixes rdar://problem/112065340.