### PR TITLE
[5.9][Test] Force unicode_filename JSON verification to use UTF-8

### DIFF
--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -scan-dependencies %/s %/S/Inputs/unicode_filёnamё.swift -o %t/deps.json
 
 // Check the contents of the JSON output
-// RUN: %validate-json %t/deps.json &>/dev/null
+// RUN: env PYTHONIOENCODING=UTF-8 %validate-json < %t/deps.json
 // RUN: %FileCheck %s < %t/deps.json
 
 print(foo())


### PR DESCRIPTION
On older Linux CI machines the JSON file being validated was opened as ASCII, leading to encoding errors. Force the validation to use UTF-8 to fix this test.

Scope: Testing on Ubuntu 18.04 and CentOS 7.
Risk: Very low, it's a test change.
Reviewed by @artemcm and @drodriguez 
Cherry-pick of #67359