### PR TITLE
Serialization: allow `IS_STATIC_LIBRARY` to be deserialised properly

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -837,6 +837,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, SDK_PATH);
   BLOCK_RECORD(options_block, XCC);
   BLOCK_RECORD(options_block, IS_SIB);
+  BLOCK_RECORD(options_block, IS_STATIC_LIBRARY);
   BLOCK_RECORD(options_block, IS_TESTABLE);
   BLOCK_RECORD(options_block, ARE_PRIVATE_IMPORTS_ENABLED);
   BLOCK_RECORD(options_block, RESILIENCE_STRATEGY);

--- a/test/Serialization/static.swift
+++ b/test/Serialization/static.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t %s
+// RUN: llvm-bcanalyzer -dump %t/static.swiftmodule | %FileCheck %s -check-prefix CHECK -check-prefix DYNAMIC
+
+// RUN: %target-swift-frontend -static -emit-module -o %t %s
+// RUN: llvm-bcanalyzer -dump %t/static.swiftmodule | %FileCheck %s -check-prefix CHECK -check-prefix STATIC
+
+// CHECK: <MODULE_BLOCK {{.*}}>
+// CHECK-STATIC: <IS_STATIC abbrevid={{[0-9]+}}/>
+// CHECK-DYNAMIC-NOT: <IS_STATIC abbrevid={{[0-9]+}}/>
+// CHECK: </MODULE_BLOCK>


### PR DESCRIPTION
Properly encode the field metadata to permit the deserialization by `llvm-bcanalyzer` for aiding debugging.