### PR TITLE
🍒[Observation] Tracking adjustments for stability and correctness

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -9,35 +9,161 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Provides storage for tracking and access to data changes.
+///
+/// You don't need to create an instance of `ObservationRegistrar` when using
+/// the ``Observation/Observable-swift.macro`` macro to indicate observability
+/// of a type.
 @available(SwiftStdlib 5.9, *)
 public struct ObservationRegistrar: Sendable {
-  struct State: @unchecked Sendable {
-    struct Observation {
-      var properties: Set<AnyKeyPath>
-      var observer: @Sendable () -> Void
+  internal class ValueObservationStorage {
+    func emit<Element>(_ element: Element) -> Bool { return false }
+    func cancel() { }
+  }
+  
+  private struct ValuesObserver {
+    private let storage: ValueObservationStorage
+    
+    internal init(storage: ValueObservationStorage) {
+      self.storage = storage
     }
     
-    var id = 0
-    var observations = [Int : Observation]()
-    var lookups = [AnyKeyPath : Set<Int>]()
+    internal func emit<Element>(_ element: Element) -> Bool {
+      storage.emit(element)
+    }
     
-    mutating func generateId() -> Int {
+    internal func cancel() {
+      storage.cancel()
+    }
+  }
+  
+  private struct State: @unchecked Sendable {
+    private enum ObservationKind {
+      case willSetTracking(@Sendable () -> Void)
+      case didSetTracking(@Sendable () -> Void)
+      case computed(@Sendable (Any) -> Void)
+      case values(ValuesObserver)
+    }
+    
+    private struct Observation {
+      private var kind: ObservationKind
+      internal var properties: Set<AnyKeyPath>
+      
+      internal init(kind: ObservationKind, properties: Set<AnyKeyPath>) {
+        self.kind = kind
+        self.properties = properties
+      }
+      
+      var willSetTracker: (@Sendable () -> Void)? {
+        switch kind {
+        case .willSetTracking(let tracker):
+          return tracker
+        default:
+          return nil
+        }
+      }
+
+      var didSetTracker: (@Sendable () -> Void)? {
+        switch kind {
+        case .didSetTracking(let tracker):
+          return tracker
+        default:
+          return nil
+        }
+      }
+      
+      var observer: (@Sendable (Any) -> Void)? {
+        switch kind {
+        case .computed(let observer):
+          return observer
+        default:
+          return nil
+        }
+      }
+      
+      var isValueObserver: Bool {
+        switch kind {
+        case .values:
+          return true
+        default:
+          return false
+        }
+      }
+      
+      func emit<Element>(_ value: Element) -> Bool {
+        switch kind {
+        case .values(let observer):
+          return observer.emit(value)
+        default:
+          return false
+        }
+      }
+      
+      func cancel() {
+        switch kind {
+        case .values(let observer):
+          observer.cancel()
+        default:
+          break
+        }
+      }
+    }
+    
+    private var id = 0
+    private var observations = [Int : Observation]()
+    private var lookups = [AnyKeyPath : Set<Int>]()
+    
+    internal mutating func generateId() -> Int {
       defer { id &+= 1 }
       return id
     }
     
-    mutating func registerTracking(for properties: Set<AnyKeyPath>, observer: @Sendable @escaping () -> Void) -> Int {
+    internal mutating func registerTracking(for properties: Set<AnyKeyPath>, willSet observer: @Sendable @escaping () -> Void) -> Int {
       let id = generateId()
-      observations[id] = Observation(properties: properties, observer: observer)
+      observations[id] = Observation(kind: .willSetTracking(observer), properties: properties)
+      for keyPath in properties {
+        lookups[keyPath, default: []].insert(id)
+      }
+      return id
+    }
+
+    internal mutating func registerTracking(for properties: Set<AnyKeyPath>, didSet observer: @Sendable @escaping () -> Void) -> Int {
+      let id = generateId()
+      observations[id] = Observation(kind: .didSetTracking(observer), properties: properties)
       for keyPath in properties {
         lookups[keyPath, default: []].insert(id)
       }
       return id
     }
     
-    mutating func cancel(_ id: Int) {
-      if let tracking = observations.removeValue(forKey: id) {
-        for keyPath in tracking.properties {
+    internal mutating func registerComputedValues(for properties: Set<AnyKeyPath>, observer: @Sendable @escaping (Any) -> Void) -> Int {
+      let id = generateId()
+      observations[id] = Observation(kind: .computed(observer), properties: properties)
+      for keyPath in properties {
+        lookups[keyPath, default: []].insert(id)
+      }
+      return id
+    }
+    
+    internal mutating func registerValues(for properties: Set<AnyKeyPath>, storage: ValueObservationStorage) -> Int {
+      let id = generateId()
+      observations[id] = Observation(kind: .values(ValuesObserver(storage: storage)), properties: properties)
+      for keyPath in properties {
+        lookups[keyPath, default: []].insert(id)
+      }
+      return id
+    }
+    
+    internal func valueObservers(for keyPath: AnyKeyPath) -> Set<Int> {
+      guard let ids = lookups[keyPath] else {
+        return []
+      }
+      return ids.filter { observations[$0]?.isValueObserver == true }
+    }
+    
+    internal mutating func cancel(_ id: Int) {
+      if let observation = observations.removeValue(forKey: id) {
+        for keyPath in observation.properties {
           if var ids = lookups[keyPath] {
             ids.remove(id)
             if ids.count == 0 {
@@ -47,52 +173,144 @@ public struct ObservationRegistrar: Sendable {
             }
           }
         }
+        observation.cancel()
       }
     }
+
+    internal mutating func cancelAll() {
+      for observation in observations.values {
+        observation.cancel()
+      }
+      observations.removeAll()
+      lookups.removeAll()
+    }
     
-    mutating func willSet(keyPath: AnyKeyPath) -> [@Sendable () -> Void] {
-      var observers = [@Sendable () -> Void]()
+    internal mutating func willSet(keyPath: AnyKeyPath) -> [@Sendable () -> Void] {
+      var trackers = [@Sendable () -> Void]()
       if let ids = lookups[keyPath] {
         for id in ids {
-          if let observation = observations[id] {
-            observers.append(observation.observer)
-            cancel(id)
+          if let tracker = observations[id]?.willSetTracker {
+            trackers.append(tracker)
           }
         }
       }
-      return observers
-    }
-  }
-  
-  struct Context: Sendable {
-    let state = _ManagedCriticalState(State())
-    
-    var id: ObjectIdentifier { state.id }
-    
-    func registerTracking(for properties: Set<AnyKeyPath>, observer: @Sendable @escaping () -> Void) -> Int {
-      state.withCriticalRegion { $0.registerTracking(for: properties, observer: observer) }
+      return trackers
     }
     
-    func cancel(_ id: Int) {
-      state.withCriticalRegion { $0.cancel(id) }
+    internal mutating func didSet<Subject: Observable, Member>(keyPath: KeyPath<Subject, Member>) -> ([@Sendable (Any) -> Void], [@Sendable () -> Void]) {
+      var observers = [@Sendable (Any) -> Void]()
+      var trackers = [@Sendable () -> Void]()
+      if let ids = lookups[keyPath] {
+        for id in ids {
+          if let observer = observations[id]?.observer {
+            observers.append(observer)
+            cancel(id)
+          }
+          if let tracker = observations[id]?.didSetTracker {
+            trackers.append(tracker)
+          }
+        }
+      }
+      return (observers, trackers)
     }
     
-    func willSet<Subject, Member>(
-       _ subject: Subject,
-       keyPath: KeyPath<Subject, Member>
-    ) {
-      let actions = state.withCriticalRegion { $0.willSet(keyPath: keyPath) }
-      for action in actions {
-        action()
+    internal mutating func emit<Element>(_ value: Element, ids: Set<Int>) {
+      for id in ids {
+        if observations[id]?.emit(value) == true {
+          cancel(id)
+        }
       }
     }
   }
   
-  let context = Context()
+  internal struct Context: Sendable {
+    private let state = _ManagedCriticalState(State())
+    
+    internal var id: ObjectIdentifier { state.id }
+    
+    internal func registerTracking(for properties: Set<AnyKeyPath>, willSet observer: @Sendable @escaping () -> Void) -> Int {
+      state.withCriticalRegion { $0.registerTracking(for: properties, willSet: observer) }
+    }
+
+    internal func registerTracking(for properties: Set<AnyKeyPath>, didSet observer: @Sendable @escaping () -> Void) -> Int {
+      state.withCriticalRegion { $0.registerTracking(for: properties, didSet: observer) }
+    }
+    
+    internal func registerComputedValues(for properties: Set<AnyKeyPath>, observer: @Sendable @escaping (Any) -> Void) -> Int {
+      state.withCriticalRegion { $0.registerComputedValues(for: properties, observer: observer) }
+    }
+    
+    internal func registerValues(for properties: Set<AnyKeyPath>, storage: ValueObservationStorage) -> Int {
+      state.withCriticalRegion { $0.registerValues(for: properties, storage: storage) }
+    }
+    
+    internal func cancel(_ id: Int) {
+      state.withCriticalRegion { $0.cancel(id) }
+    }
+
+    internal func cancelAll() {
+      state.withCriticalRegion { $0.cancelAll() }
+    }
+    
+    internal func willSet<Subject: Observable, Member>(
+       _ subject: Subject,
+       keyPath: KeyPath<Subject, Member>
+    ) {
+      let tracking = state.withCriticalRegion { $0.willSet(keyPath: keyPath) }
+      for action in tracking {
+        action()
+      }
+    }
+    
+    internal func didSet<Subject: Observable, Member>(
+      _ subject: Subject,
+      keyPath: KeyPath<Subject, Member>
+    ) {
+      let (ids, (actions, tracking)) = state.withCriticalRegion { ($0.valueObservers(for: keyPath), $0.didSet(keyPath: keyPath)) }
+      if !ids.isEmpty {
+        let value = subject[keyPath: keyPath]
+        state.withCriticalRegion { $0.emit(value, ids: ids) }
+      }
+      for action in tracking {
+        action()
+      }
+      for action in actions {
+        action(subject)
+      }
+    }
+  }
+
+  private final class Extent: @unchecked Sendable {
+    let context = Context()
+
+    init() {
+    }
+
+    deinit {
+      context.cancelAll()
+    }
+  }
   
+  internal var context: Context {
+    return extent.context
+  }
+  
+  private var extent = Extent()
+
+  /// Creates an instance of the observation registrar.
+  ///
+  /// You don't need to create an instance of
+  /// ``Observation/ObservationRegistrar`` when using the
+  /// ``Observation/Observable-swift.macro`` macro to indicate observably
+  /// of a type.
   public init() {
   }
 
+  /// Registers access to a specific property for observation.
+  ///
+  /// - Parameters:
+  ///   - subject: An instance of an observable type.
+  ///   - keyPath: The key path of an observed property.
   public func access<Subject: Observable, Member>(
       _ subject: Subject,
       keyPath: KeyPath<Subject, Member>
@@ -106,20 +324,37 @@ public struct ObservationRegistrar: Sendable {
     }
   }
   
+  /// A property observation called before setting the value of the subject.
+  ///
+  /// - Parameters:
+  ///     - subject: An instance of an observable type.
+  ///     - keyPath: The key path of an observed property.
   public func willSet<Subject: Observable, Member>(
       _ subject: Subject,
       keyPath: KeyPath<Subject, Member>
   ) {
     context.willSet(subject, keyPath: keyPath)
   }
-  
+
+  /// A property observation called after setting the value of the subject.
+  ///
+  /// - Parameters:
+  ///   - subject: An instance of an observable type.
+  ///   - keyPath: The key path of an observed property.
   public func didSet<Subject: Observable, Member>(
       _ subject: Subject,
       keyPath: KeyPath<Subject, Member>
   ) {
-    
+    context.didSet(subject, keyPath: keyPath)
   }
   
+  /// Identifies mutations to the transactions registered for observers.
+  ///
+  /// This method calls ``willset(_:keypath:)`` before the mutation. Then it
+  /// calls ``didset(_:keypath:)`` after the mutation.
+  /// - Parameters:
+  ///   - of: An instance of an observable type.
+  ///   - keyPath: The key path of an observed property.
   public func withMutation<Subject: Observable, Member, T>(
     of subject: Subject,
     keyPath: KeyPath<Subject, Member>,

--- a/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationTracking.swift
@@ -11,35 +11,41 @@
 
 @available(SwiftStdlib 5.9, *)
 @_spi(SwiftUI)
-public struct ObservationTracking {
+public struct ObservationTracking: Sendable {
+  enum Id {
+    case willSet(Int)
+    case didSet(Int)
+    case full(Int, Int)
+  }
+
   struct Entry: @unchecked Sendable {
-    let registerTracking: @Sendable (Set<AnyKeyPath>, @Sendable @escaping () -> Void) -> Int
-    let cancel: @Sendable (Int) -> Void
-    var properties = Set<AnyKeyPath>()
+    let context: ObservationRegistrar.Context
     
-    init(_ context: ObservationRegistrar.Context) {
-      registerTracking = { properties, observer in
-        context.registerTracking(for: properties, observer: observer)
-      }
-      cancel = { id in
-        context.cancel(id)
-      }
+    var properties: Set<AnyKeyPath>
+    
+    init(_ context: ObservationRegistrar.Context, properties: Set<AnyKeyPath> = []) {
+      self.context = context
+      self.properties = properties
     }
     
-    func addObserver(_ changed: @Sendable @escaping () -> Void) -> Int {
-      return registerTracking(properties, changed)
+    func addWillSetObserver(_ changed: @Sendable @escaping () -> Void) -> Int {
+      return context.registerTracking(for: properties, willSet: changed)
+    }
+
+    func addDidSetObserver(_ changed: @Sendable @escaping () -> Void) -> Int {
+      return context.registerTracking(for: properties, didSet: changed)
     }
     
     func removeObserver(_ token: Int) {
-      cancel(token)
+      context.cancel(token)
     }
     
     mutating func insert(_ keyPath: AnyKeyPath) {
       properties.insert(keyPath)
     }
     
-    mutating func formUnion(_ properties: Set<AnyKeyPath>) {
-      self.properties.formUnion(properties)
+    func union(_ entry: Entry) -> Entry {
+      Entry(context, properties: properties.union(entry.properties))
     }
   }
   
@@ -57,10 +63,40 @@ public struct ObservationTracking {
     }
     
     internal mutating func merge(_ other: _AccessList) {
-      for (identifier, entry) in other.entries {
-        entries[identifier, default: entry].formUnion(entry.properties)
+      entries.merge(other.entries) { existing, entry in
+        existing.union(entry)
       }
     }
+  }
+
+  @_spi(SwiftUI)
+  public static func _installTracking(
+    _ tracking: ObservationTracking,
+    willSet: (@Sendable (ObservationTracking) -> Void)? = nil,
+    didSet: (@Sendable (ObservationTracking) -> Void)? = nil
+  ) {
+    let values = tracking.list.entries.mapValues { 
+      switch (willSet, didSet) {
+      case (.some(let willSetObserver), .some(let didSetObserver)):
+        return Id.full($0.addWillSetObserver {
+          willSetObserver(tracking)
+        }, $0.addDidSetObserver {
+          didSetObserver(tracking)
+        })
+      case (.some(let willSetObserver), .none):
+        return Id.willSet($0.addWillSetObserver {
+          willSetObserver(tracking)
+        })
+      case (.none, .some(let didSetObserver)):
+        return Id.didSet($0.addDidSetObserver {
+          didSetObserver(tracking)
+        })
+      case (.none, .none):
+        fatalError()
+      }  
+    }
+    
+    tracking.install(values)
   }
 
   @_spi(SwiftUI)
@@ -68,23 +104,57 @@ public struct ObservationTracking {
     _ list: _AccessList,
     onChange: @escaping @Sendable () -> Void
   ) {
-    let state = _ManagedCriticalState([ObjectIdentifier: Int]())
-    let values = list.entries.mapValues { $0.addObserver {
+    let tracking = ObservationTracking(list)
+    _installTracking(tracking, willSet: { _ in
       onChange()
-      let values = state.withCriticalRegion { $0 }
-      for (id, token) in values {
-        list.entries[id]?.removeObserver(token)
+      tracking.cancel()
+    })
+  }
+
+  struct State {
+    var values = [ObjectIdentifier: ObservationTracking.Id]()
+    var cancelled = false
+  }
+  
+  private let state = _ManagedCriticalState(State())
+  private let list: _AccessList
+  
+  @_spi(SwiftUI)
+  public init(_ list: _AccessList?) {
+    self.list = list ?? _AccessList()
+  }
+
+  internal func install(_ values:  [ObjectIdentifier : ObservationTracking.Id]) {
+    state.withCriticalRegion {
+      if !$0.cancelled {
+        $0.values = values
       }
-    }}
-    state.withCriticalRegion { $0 = values }
+    }
+  }
+
+  public func cancel() {
+    let values = state.withCriticalRegion {
+      $0.cancelled = true
+      let values = $0.values
+      $0.values = [:]
+      return values
+    }
+    for (id, observationId) in values {
+        switch observationId {
+        case .willSet(let token):
+          list.entries[id]?.removeObserver(token)
+        case .didSet(let token):
+          list.entries[id]?.removeObserver(token)
+        case .full(let willSetToken, let didSetToken):
+          list.entries[id]?.removeObserver(willSetToken)
+          list.entries[id]?.removeObserver(didSetToken)
+        }
+      }
   }
 }
 
 @available(SwiftStdlib 5.9, *)
-public func withObservationTracking<T>(
-  _ apply: () -> T,
-  onChange: @autoclosure () -> @Sendable () -> Void
-) -> T {
+fileprivate func generateAccessList<T>(_ apply: () -> T) -> (T, ObservationTracking._AccessList?) {
   var accessList: ObservationTracking._AccessList?
   let result = withUnsafeMutablePointer(to: &accessList) { ptr in
     let previous = _ThreadLocal.value
@@ -102,17 +172,51 @@ public func withObservationTracking<T>(
     }
     return apply()
   }
-  if let list = accessList {
-    let state = _ManagedCriticalState([ObjectIdentifier: Int]())
-    let onChange = onChange()
-    let values = list.entries.mapValues { $0.addObserver {
-      onChange()
-      let values = state.withCriticalRegion { $0 }
-      for (id, token) in values {
-        list.entries[id]?.removeObserver(token)
-      }
-    }}
-    state.withCriticalRegion { $0 = values }
+  return (result, accessList)
+}
+
+@available(SwiftStdlib 5.9, *)
+public func withObservationTracking<T>(
+  _ apply: () -> T,
+  onChange: @autoclosure () -> @Sendable () -> Void
+) -> T {
+  let (result, accessList) = generateAccessList(apply)
+  if let accessList {
+    ObservationTracking._installTracking(accessList, onChange: onChange())
   }
+  return result
+}
+
+@available(SwiftStdlib 5.9, *)
+@_spi(SwiftUI)
+public func withObservationTracking<T>(
+  _ apply: () -> T,
+  willSet: @escaping @Sendable (ObservationTracking) -> Void,
+  didSet: @escaping @Sendable (ObservationTracking) -> Void
+) -> T {
+  let (result, accessList) = generateAccessList(apply)
+  ObservationTracking._installTracking(ObservationTracking(accessList), willSet: willSet, didSet: didSet)
+  return result
+}
+
+@available(SwiftStdlib 5.9, *)
+@_spi(SwiftUI)
+public func withObservationTracking<T>(
+  _ apply: () -> T,
+  willSet: @escaping @Sendable (ObservationTracking) -> Void
+) -> T {
+  let (result, accessList) = generateAccessList(apply)
+  ObservationTracking._installTracking(ObservationTracking(accessList), willSet: willSet, didSet: nil)
+  return result
+}
+
+@available(SwiftStdlib 5.9, *)
+@_spi(SwiftUI)
+public func withObservationTracking<T>(
+  _ apply: () -> T,
+  didSet: @escaping @Sendable (ObservationTracking) -> Void
+) -> T {
+  let (result, accessList) = generateAccessList(apply)
+  ObservationTracking._installTracking(ObservationTracking(accessList), willSet: nil, didSet: didSet)
   return result
 }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -174,6 +174,32 @@ class CapturedState<State>: @unchecked Sendable {
   }
 }
 
+@Observable
+class RecursiveInner {
+  var value = "prefix"
+}
+
+@Observable
+class RecursiveOuter {
+  var inner = RecursiveInner()
+  var value = "prefix"
+  @ObservationIgnored var innerEventCount = 0
+  @ObservationIgnored var outerEventCount = 0
+
+  func recursiveTrackingCalls() {
+    withObservationTracking({
+      let _ = value
+      _ = withObservationTracking({
+        inner.value
+      }, onChange: {
+        self.innerEventCount += 1
+      })
+    }, onChange: {
+      self.outerEventCount += 1
+    })
+  }
+}
+
 @main
 struct Validator {
   @MainActor
@@ -361,7 +387,31 @@ struct Validator {
       test.test = "c"
       expectEqual(changed.state, false)
     }
-    
+
+    suite.test("recursive tracking inner then outer") {
+      let obj = RecursiveOuter()
+      obj.recursiveTrackingCalls()
+      obj.inner.value = "test"
+      expectEqual(obj.innerEventCount, 1)
+      expectEqual(obj.outerEventCount, 1)
+      obj.recursiveTrackingCalls()
+      obj.value = "test"
+      expectEqual(obj.innerEventCount, 1)
+      expectEqual(obj.outerEventCount, 2)
+    }
+
+    suite.test("recursive tracking outer then inner") {
+      let obj = RecursiveOuter()
+      obj.recursiveTrackingCalls()
+      obj.value = "test"
+      expectEqual(obj.innerEventCount, 0)
+      expectEqual(obj.outerEventCount, 1)
+      obj.recursiveTrackingCalls()
+      obj.inner.value = "test"
+      expectEqual(obj.innerEventCount, 2)
+      expectEqual(obj.outerEventCount, 2)
+    }
+
     runAllTests()
   }
 }


### PR DESCRIPTION
* [Observation] Correct tracking such that recursive but disperate changes can be tracked without crashing

* [Observation] Adjust the SPI interface for tracking to support deferred cancellation of events and handle both willSet and didSet events

Explanation:
Using recursive withObservationTracking was found to potentially crash when merging access lists - this corrects the tracking to no longer crash when doing so.
Furthermore there was a request for addressing leading/trailing edge notifications of changes for the tracking. This adds SPI for the use by SwiftUI to allow for that affordance.

Scope:
Observation; no code-gen, macros, or other APIs will be touched

Risk:
Low

Reviewed By: @natecook1000 

Testing: Added testing to validate both the recursive case and general ordering of observation.

Resolves:
rdar://111915203
rdar://111212956
