### PR TITLE
NFC: Add hidden option to bypass resilience checks.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -576,6 +576,10 @@ namespace swift {
     /// All block list configuration files to be honored in this compilation.
     std::vector<std::string> BlocklistConfigFilePaths;
 
+    /// Whether to ignore checks that a module is resilient during
+    /// type-checking, SIL verification, and IR emission,
+    bool BypassResilienceChecks = false;
+
     bool isConcurrencyModelTaskToThread() const {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;
     }

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -638,6 +638,10 @@ def disable_swift3_objc_inference :
 def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Add 'dynamic' to all declarations">;
+
+def bypass_resilience : Flag<["-"], "bypass-resilience-checks">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Ignore all checks for module resilience.">;
   
 def enable_experimental_opaque_type_erasure : Flag<["-"], "enable-experimental-opaque-type-erasure">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -491,6 +491,10 @@ struct SILOptOptions {
         "enable-copy-propagation",
         llvm::cl::desc("Whether to run the copy propagation pass: "
                        "'true', 'false', or 'requested-passes-only'."));
+
+  llvm::cl::opt<bool> BypassResilienceChecks = llvm::cl::opt<bool>(
+      "bypass-resilience-checks",
+      llvm::cl::desc("Ignore all checks for module resilience."));
 };
 
 /// Regular expression corresponding to the value given in one of the
@@ -603,6 +607,8 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
     Invocation.getLangOptions().Features.insert(
         Feature::OldOwnershipOperatorSpellings);
   }
+  Invocation.getLangOptions().BypassResilienceChecks =
+      options.BypassResilienceChecks;
   for (auto &featureName : options.ExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureName)) {
       Invocation.getLangOptions().Features.insert(*feature);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1302,6 +1302,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
             .Case("task-to-thread", ConcurrencyModel::TaskToThread)
             .Default(ConcurrencyModel::Standard);
   }
+  Opts.BypassResilienceChecks |= Args.hasArg(OPT_bypass_resilience);
 
   return HadError || UnsupportedOS || UnsupportedArch;
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1290,6 +1290,8 @@ ModuleDecl *CompilerInstance::getMainModule() const {
       MainModule->setPrivateImportsEnabled();
     if (Invocation.getFrontendOptions().EnableImplicitDynamic)
       MainModule->setImplicitDynamicEnabled();
+    if (Invocation.getLangOptions().BypassResilienceChecks)
+      MainModule->setBypassResilience();
     if (!Invocation.getFrontendOptions().ModuleABIName.empty()) {
       MainModule->setABIName(getASTContext().getIdentifier(
           Invocation.getFrontendOptions().ModuleABIName));

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -849,6 +849,8 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
     for (auto name: loadedModuleFile->getAllowableClientNames()) {
       M.addAllowableClientName(Ctx.getIdentifier(name));
     }
+    if (Ctx.LangOpts.BypassResilienceChecks)
+      M.setBypassResilience();
     auto diagLocOrInvalid = diagLoc.value_or(SourceLoc());
     loadInfo.status = loadedModuleFile->associateWithFileContext(
         fileUnit, diagLocOrInvalid, Ctx.LangOpts.AllowModuleWithCompilerErrors);


### PR DESCRIPTION
This functionality was added awhile back to support the debugger.  Here a flag for use by other cliients is provided.

The immediate motivation for this is enabling rerunning sil-opt against SIL from a module built with resilience, allowing the function to be processed by sil-opt without failing because it's not built in the same module.  This is useful when reducing test cases: given SIL that a pass isn't handling correctly, the pass can be run on just that SIL even if the module was built with resilience and would normally fail to build.
