### PR TITLE
[cxx-interop] Import mutating dereference operators

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2186,17 +2186,6 @@ namespace {
       // The name of every member.
       llvm::DenseSet<StringRef> allMemberNames;
 
-      bool hasConstOperatorStar = false;
-      for (auto member : decl->decls()) {
-        if (auto method = dyn_cast<clang::CXXMethodDecl>(member)) {
-          if (method->getOverloadedOperator() ==
-                  clang::OverloadedOperatorKind::OO_Star &&
-              method->param_empty() && method->isConst())
-            hasConstOperatorStar = true;
-        }
-      }
-      bool hasSynthesizedPointeeProperty = false;
-
       // FIXME: Import anonymous union fields and support field access when
       // it is nested in a struct.
       for (auto m : decl->decls()) {
@@ -2275,26 +2264,11 @@ namespace {
 
         if (auto MD = dyn_cast<FuncDecl>(member)) {
           if (auto cxxMethod = dyn_cast<clang::CXXMethodDecl>(m)) {
+            ImportedName methodImportedName =
+                Impl.importFullName(cxxMethod, getActiveSwiftVersion());
             auto cxxOperatorKind = cxxMethod->getOverloadedOperator();
 
-            if (cxxOperatorKind == clang::OO_Star && cxxMethod->param_empty()) {
-              // This is a dereference operator. We synthesize a computed
-              // property called `pointee` for it.
-
-              // If this record has multiple overloads of `operator*`, prefer
-              // the const overload if it exists.
-              if ((cxxMethod->isConst() || !hasConstOperatorStar) &&
-                  !hasSynthesizedPointeeProperty) {
-                VarDecl *pointeeProperty =
-                    synthesizer.makeDereferencedPointeeProperty(MD);
-                result->addMember(pointeeProperty);
-                hasSynthesizedPointeeProperty = true;
-              }
-
-              Impl.markUnavailable(MD, "use .pointee property");
-              MD->overwriteAccess(AccessLevel::Private);
-            } else if (cxxOperatorKind ==
-                       clang::OverloadedOperatorKind::OO_PlusPlus) {
+            if (cxxOperatorKind == clang::OverloadedOperatorKind::OO_PlusPlus) {
               // Make sure the type is not a foreign reference type.
               // We cannot handle `operator++` for those types, since the
               // current implementation creates a new instance of the type.
@@ -2319,8 +2293,8 @@ namespace {
                          clang::OverloadedOperatorKind::OO_PlusPlus &&
                      cxxOperatorKind !=
                          clang::OverloadedOperatorKind::OO_Call &&
-                     cxxOperatorKind !=
-                         clang::OverloadedOperatorKind::OO_Subscript) {
+                     !methodImportedName.isSubscriptAccessor() &&
+                     !methodImportedName.isDereferenceAccessor()) {
 
               auto opFuncDecl = synthesizer.makeOperator(MD, cxxMethod);
 
@@ -2550,6 +2524,18 @@ namespace {
           // carried into derived classes.
           auto *subscriptImpl = getterAndSetter.first ? getterAndSetter.first : getterAndSetter.second;
           Impl.addAlternateDecl(subscriptImpl, subscript);
+        }
+
+        if (Impl.cxxDereferenceOperators.find(result) !=
+            Impl.cxxDereferenceOperators.end()) {
+          // If this type has a dereference operator, synthesize a computed
+          // property called `pointee` for it.
+          auto getterAndSetter = Impl.cxxDereferenceOperators[result];
+
+          VarDecl *pointeeProperty =
+              synthesizer.makeDereferencedPointeeProperty(
+                  getterAndSetter.first, getterAndSetter.second);
+          result->addMember(pointeeProperty);
         }
       }
 
@@ -3191,6 +3177,8 @@ namespace {
       case ImportedAccessorKind::None:
       case ImportedAccessorKind::SubscriptGetter:
       case ImportedAccessorKind::SubscriptSetter:
+      case ImportedAccessorKind::DereferenceGetter:
+      case ImportedAccessorKind::DereferenceSetter:
         break;
 
       case ImportedAccessorKind::PropertyGetter: {
@@ -3531,6 +3519,8 @@ namespace {
           }
         }
 
+        bool makePrivate = false;
+
         if (importedName.isSubscriptAccessor() && !importFuncWithoutSignature) {
           assert(func->getParameters()->size() == 1);
           auto typeDecl = dc->getSelfNominalTypeDecl();
@@ -3558,8 +3548,32 @@ namespace {
 
           Impl.markUnavailable(func, "use subscript");
         }
-        // Someday, maybe this will need to be 'open' for C++ virtual methods.
-        func->setAccess(AccessLevel::Public);
+
+        if (importedName.isDereferenceAccessor() &&
+            !importFuncWithoutSignature) {
+          auto typeDecl = dc->getSelfNominalTypeDecl();
+          auto &getterAndSetter = Impl.cxxDereferenceOperators[typeDecl];
+
+          switch (importedName.getAccessorKind()) {
+          case ImportedAccessorKind::DereferenceGetter:
+            getterAndSetter.first = func;
+            break;
+          case ImportedAccessorKind::DereferenceSetter:
+            getterAndSetter.second = func;
+            break;
+          default:
+            llvm_unreachable("invalid dereference operator kind");
+          }
+
+          Impl.markUnavailable(func, "use .pointee property");
+          makePrivate = true;
+        }
+
+        if (makePrivate)
+          func->setAccess(AccessLevel::Private);
+        else
+          // Someday, maybe this will need to be 'open' for C++ virtual methods.
+          func->setAccess(AccessLevel::Public);
       }
 
       result->setIsObjC(false);
@@ -3983,6 +3997,10 @@ namespace {
       case ImportedAccessorKind::SubscriptSetter:
       case ImportedAccessorKind::None:
         return importObjCMethodDecl(decl, dc, llvm::None);
+
+      case ImportedAccessorKind::DereferenceGetter:
+      case ImportedAccessorKind::DereferenceSetter:
+        llvm_unreachable("dereference operators only exist in C++");
       }
     }
 
@@ -6045,6 +6063,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   case ImportedAccessorKind::None:
   case ImportedAccessorKind::SubscriptGetter:
   case ImportedAccessorKind::SubscriptSetter:
+  case ImportedAccessorKind::DereferenceGetter:
+  case ImportedAccessorKind::DereferenceSetter:
     llvm_unreachable("Not a property accessor");
 
   case ImportedAccessorKind::PropertyGetter:

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -38,6 +38,8 @@ enum class ImportedAccessorKind : unsigned {
   PropertySetter,
   SubscriptGetter,
   SubscriptSetter,
+  DereferenceGetter,
+  DereferenceSetter,
 };
 enum { NumImportedAccessorKindBits = 3 };
 
@@ -324,6 +326,8 @@ public:
     case ImportedAccessorKind::None:
     case ImportedAccessorKind::SubscriptGetter:
     case ImportedAccessorKind::SubscriptSetter:
+    case ImportedAccessorKind::DereferenceGetter:
+    case ImportedAccessorKind::DereferenceSetter:
       return false;
 
     case ImportedAccessorKind::PropertyGetter:
@@ -338,10 +342,29 @@ public:
     case ImportedAccessorKind::None:
     case ImportedAccessorKind::PropertyGetter:
     case ImportedAccessorKind::PropertySetter:
+    case ImportedAccessorKind::DereferenceGetter:
+    case ImportedAccessorKind::DereferenceSetter:
       return false;
 
     case ImportedAccessorKind::SubscriptGetter:
     case ImportedAccessorKind::SubscriptSetter:
+      return true;
+    }
+
+    llvm_unreachable("Invalid ImportedAccessorKind.");
+  }
+
+  bool isDereferenceAccessor() const {
+    switch (getAccessorKind()) {
+    case ImportedAccessorKind::None:
+    case ImportedAccessorKind::PropertyGetter:
+    case ImportedAccessorKind::PropertySetter:
+    case ImportedAccessorKind::SubscriptGetter:
+    case ImportedAccessorKind::SubscriptSetter:
+      return false;
+
+    case ImportedAccessorKind::DereferenceGetter:
+    case ImportedAccessorKind::DereferenceSetter:
       return true;
     }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -642,6 +642,9 @@ public:
   llvm::MapVector<std::pair<NominalTypeDecl *, Type>,
                   std::pair<FuncDecl *, FuncDecl *>> cxxSubscripts;
 
+  llvm::MapVector<NominalTypeDecl *, std::pair<FuncDecl *, FuncDecl *>>
+      cxxDereferenceOperators;
+
   llvm::SmallPtrSet<const clang::Decl *, 1> synthesizedAndAlwaysVisibleDecls;
 
 private:

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -275,9 +275,10 @@ public:
   /// Given an imported C++ dereference operator (`operator*()`), create a
   /// `pointee` computed property.
   ///
-  /// \param dereferenceFunc function returning `Unsafe(Mutable)?Pointer<T>`
+  /// \param getter function returning `UnsafePointer<T>`
+  /// \param setter function returning `UnsafeMutablePointer<T>`
   /// \return computed property declaration
-  VarDecl *makeDereferencedPointeeProperty(FuncDecl *dereferenceFunc);
+  VarDecl *makeDereferencedPointeeProperty(FuncDecl *getter, FuncDecl *setter);
 
   /// Given a C++ pre-increment operator (`operator++()`). create a non-mutating
   /// function `successor() -> Self`.

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -206,7 +206,7 @@
 // CHECK: }
 
 // CHECK: struct Iterator {
-// CHECK:   var pointee: Int32 { mutating get }
+// CHECK:   var pointee: Int32 { mutating get set }
 // CHECK:   @available(*, unavailable, message: "use .pointee property")
 // CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
 // CHECK: }
@@ -224,8 +224,8 @@
 // CHECK: }
 
 // CHECK: struct AmbiguousOperatorStar {
-// CHECK-NEXT:   var pointee: Int32 { get }
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var pointee: Int32
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
@@ -233,8 +233,8 @@
 // CHECK-NEXT: }
 
 // CHECK: struct AmbiguousOperatorStar2 {
-// CHECK-NEXT:   var pointee: Int32 { get }
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var pointee: Int32
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -51,6 +51,12 @@ var diffTypesArrayByVal = DifferentTypesArrayByVal()
 let diffTypesResultIntByVal: Int32 = diffTypesArrayByVal[0]
 let diffTypesResultDoubleByVal: Double = diffTypesArrayByVal[0.5]
 
+var iter = Iterator()
+iter.pointee = 123
+
+var constIter = ConstIterator()
+constIter.pointee = 123 // expected-error {{cannot assign to property: 'pointee' is a get-only property}}
+
 let postIncrement = HasPostIncrementOperator()
 postIncrement.successor() // expected-error {{value of type 'HasPostIncrementOperator' has no member 'successor'}}
 

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -349,6 +349,9 @@ OperatorsTestSuite.test("Iterator.pointee") {
   var iter = Iterator()
   let res = iter.pointee
   expectEqual(123, res)
+
+  iter.pointee = 456
+  expectEqual(456, iter.pointee)
 }
 
 OperatorsTestSuite.test("ConstIterator.pointee") {

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -830,4 +830,40 @@ struct InheritedTemplatedConstRACIteratorOutOfLineOps
 typedef InheritedTemplatedConstRACIteratorOutOfLineOps<int>
     InheritedTemplatedConstRACIteratorOutOfLineOpsInt;
 
+struct InputOutputIterator {
+private:
+  int value;
+
+public:
+  struct iterator_category : std::input_iterator_tag,
+                             std::output_iterator_tag {};
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  InputOutputIterator(int value) : value(value) {}
+  InputOutputIterator(const InputOutputIterator &other) = default;
+
+  const int &operator*() const { return value; }
+  int &operator*() { return value; }
+
+  InputOutputIterator &operator++() {
+    value++;
+    return *this;
+  }
+  InputOutputIterator operator++(int) {
+    auto tmp = InputOutputIterator(value);
+    value++;
+    return tmp;
+  }
+
+  bool operator==(const InputOutputIterator &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const InputOutputIterator &other) const {
+    return value != other.value;
+  }
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_ITERATOR_H

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,15 +1,15 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIterator
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
 // CHECK: }
 
 // CHECK: struct ConstRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstRACIterator
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout ConstRACIterator, v: ConstRACIterator.difference_type)
@@ -18,8 +18,8 @@
 // CHECK: }
 
 // CHECK: struct ConstRACIteratorRefPlusEq : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstRACIterator
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout ConstRACIteratorRefPlusEq, v: ConstRACIteratorRefPlusEq.difference_type)
@@ -28,35 +28,35 @@
 // CHECK: }
 
 // CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIteratorOutOfLineEq
+// CHECK:   var pointee: Int32 { get }
 // CHECK: }
 // CHECK: func == (lhs: ConstIteratorOutOfLineEq, rhs: ConstIteratorOutOfLineEq) -> Bool
 
 // CHECK: struct MinimalIterator : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> MinimalIterator
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: MinimalIterator, other: MinimalIterator) -> Bool
 // CHECK: }
 
 // CHECK: struct ForwardIterator : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ForwardIterator
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ForwardIterator, other: ForwardIterator) -> Bool
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTag : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTag
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
 // CHECK: }
 
 // CHECK: struct HasCustomRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomRACIteratorTag
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout HasCustomRACIteratorTag, x: Int32)
@@ -65,15 +65,15 @@
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTagInline
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTagInline, other: HasCustomIteratorTagInline) -> Bool
 // CHECK: }
 
 // CHECK: struct HasTypedefIteratorTag : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasTypedefIteratorTag
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasTypedefIteratorTag, other: HasTypedefIteratorTag) -> Bool
 // CHECK: }
@@ -87,21 +87,21 @@
 // CHECK-NOT: struct HasNoDereferenceOperator : UnsafeCxxInputIterator
 
 // CHECK: struct TemplatedIterator<Int32> : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> TemplatedIterator<Int32>
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: TemplatedIterator<Int32>, other: TemplatedIterator<Int32>) -> Bool
 // CHECK: }
 
 // CHECK: struct TemplatedIteratorOutOfLineEq<Int32> : UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> TemplatedIteratorOutOfLineEq<Int32>
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK: struct TemplatedRACIteratorOutOfLineEq<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> TemplatedRACIteratorOutOfLineEq<Int32>
+// CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = TemplatedRACIteratorOutOfLineEq<Int32>.difference_type
 // CHECK: }
@@ -124,4 +124,9 @@
 // CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<T> {
 // CHECK: }
 // CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: }
+
+// CHECK: struct InputOutputIterator : UnsafeCxxInputIterator {
+// CHECK:   func successor() -> InputOutputIterator
+// CHECK:   var pointee: Int32
 // CHECK: }


### PR DESCRIPTION
C++ `T& operator*()` is mapped to a Swift computed property `var pointee: T`.

Previously `var pointee` only had a getter, after this change it will also have a setter if the C++ type declares an overload of `operator*` that returns a mutable reference.

rdar://112471779