### PR TITLE
[CSSimplify] Extend same-shape detection to account for pack archetypes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13479,6 +13479,17 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
                                     : SolutionKind::Solved;
     };
 
+    auto recordShapeMismatchFix = [&]() -> SolutionKind {
+      unsigned impact = 1;
+      if (locator.endsWith<LocatorPathElt::AnyRequirement>())
+        impact = assessRequirementFailureImpact(*this, shape1, locator);
+
+      return recordShapeFix(
+          SkipSameShapeRequirement::create(*this, type1, type2,
+                                           getConstraintLocator(locator)),
+          impact);
+    };
+
     // Let's check whether we can produce a tailored fix for argument/parameter
     // mismatches.
     if (locator.endsWith<LocatorPathElt::PackShape>()) {
@@ -13498,8 +13509,15 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
         auto argLoc =
             loc->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
 
-        auto argPack = type1->castTo<PackType>();
-        auto paramPack = type2->castTo<PackType>();
+        if (type1->getAs<PackArchetypeType>() &&
+            type2->getAs<PackArchetypeType>())
+          return recordShapeMismatchFix();
+
+        auto argPack = type1->getAs<PackType>();
+        auto paramPack = type2->getAs<PackType>();
+
+        if (!(argPack && paramPack))
+          return SolutionKind::Error;
 
         // Tailed diagnostic to explode tuples.
         // FIXME: This is very similar to
@@ -13558,14 +13576,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
       }
     }
 
-    unsigned impact = 1;
-    if (locator.endsWith<LocatorPathElt::AnyRequirement>())
-      impact = assessRequirementFailureImpact(*this, shape1, locator);
-
-    return recordShapeFix(
-        SkipSameShapeRequirement::create(*this, type1, type2,
-                                         getConstraintLocator(locator)),
-        impact);
+    return recordShapeMismatchFix();
   }
 
   return SolutionKind::Error;

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar112090069.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar112090069.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+func test<each Before,
+          each At,
+          each After,
+          each Return>(
+      _ fn: (repeat each Before, repeat each At, repeat each After) -> (repeat each Return),
+      at: repeat each At) -> (repeat each Before, repeat each After) -> (repeat each Return) {
+  return { (before: repeat each Before, after: repeat each After) in // expected-error {{no parameters may follow a variadic parameter in a closure}}
+    return fn(repeat each before, repeat each at, repeat each after)
+    // expected-error@-1 {{pack expansion requires that 'each At' and 'each Before' have the same shape}}
+    // expected-error@-2 {{cannot convert value of type 'each At' to expected argument type 'each Before'}}
+    // expected-error@-3 {{pack expansion requires that 'each After' and 'each Before' have the same shape}}
+    // expected-error@-4 {{cannot convert value of type 'each After' to expected argument type 'each Before'}}
+  }
+}


### PR DESCRIPTION
`same-shape` mismatch detection logic shouldn't expect that types are always 
packs because they could be either invalid (i.e. Void) or pack archetypes too.

Resolves: rdar://112090069

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
