### PR TITLE
Fix RawSILInstLowering for InitAccessors

### DIFF
--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -289,6 +289,7 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
 
       SILValue selfRef;
       if (isRefSelf) {
+        // create a begin_borrow if selfValue is not guaranteed
         selfRef = b.emitBeginBorrowOperation(loc, selfValue);
       } else {
         selfRef = b.createBeginAccess(loc, selfValue, SILAccessKind::Modify,
@@ -337,7 +338,9 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
       b.createApply(loc, initFn, SubstitutionMap(), arguments);
 
       if (isRefSelf) {
-        b.emitEndBorrowOperation(loc, selfRef);
+        if (selfRef != selfValue) {
+          b.emitEndBorrowOperation(loc, selfRef);
+        }
       } else {
         b.createEndAccess(loc, selfRef, /*aborted=*/false);
       }


### PR DESCRIPTION
If 'self' is already borrowed, then avoid creating a redundant end_borrow.

Fixes rdar://112417250 (Crash with macro expansion on generic NSObject subclass)
