### PR TITLE
🍒[5.8/linux][Distributed] Fix handling indirect @in convention params in distributed funcs

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -472,6 +472,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
 
     // Remember to deallocate a copy.
     AllocatedArguments.push_back(stackAddr);
+    arguments.add(stackAddr.getAddressPointer());
     break;
   }
 

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -472,6 +472,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
 
     // Remember to deallocate a copy.
     AllocatedArguments.push_back(stackAddr);
+    // Don't forget to actually store the argument
     arguments.add(stackAddr.getAddressPointer());
     break;
   }

--- a/test/IRGen/distributed_func_indirect_in_parameter.swift
+++ b/test/IRGen/distributed_func_indirect_in_parameter.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-ir %s -Xllvm -sil-print-function=takeLarge -swift-version 5 -disable-availability-checking 2>&1 | %IRGenFileCheck %s --dump-input=always
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+// This struct must be "very large" in order to cause it to be passed as `indirect @in`.
+// Specifically, this needs to exercise the DistributedAccessor::decodeArgument paths for `Indirect_In` parameter convention.
+public struct LargeValue : Codable {
+  let field1 : Int64 = 1
+  let field2 : Int64 = 2
+  let field3 : Int64 = 3
+  let field4 : Int64 = 4
+  let field5 : Int64 = 5
+  let field6 : Int64 = 6
+  let field7 : Int64 = 7
+  let field8 : Int64 = 8
+}
+
+distributed actor D {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  // CHECK: sil hidden [distributed] @takeLarge : $@convention(method) (@in LargeValue, @guaranteed D) -> () {
+  @_silgen_name("takeLarge")
+  distributed func takeLarge(_ l: LargeValue) {}
+}


### PR DESCRIPTION
We're putting this PR up for consideration for a potential 5.8 non-apple platforms release (specifically, Linux), because it fixes a bug in distributed methods that manifests more commonly on Linux platforms. It would be nice to be able to run 5.8 in production systems hitting this issue today, even if developers would perhaps need to use 5.9 for development at desk.

This fix is already merged to main and 5.9, and _affects ONLY distributed funcs_ when the parameter passed to them is passed via `@in` convention (which seems to be pretty rarely, though e.g. triggers always for "very large structs")

---- 

**Description:** This resolves a crash in some projects where the parameter to a distributed func is passed indirect @in on Linux.

Specifically, the following assertion would trigger due to the argument count mismatch: ssert(NextValue + n <= Values.size()); // 3 + 1 <= 3 -> boom (Values expected to be 4 in this particular case)

Seems we never triggered this codepath before, even though many distributed functions with all kinds of parameters were written, they all ended up @in_guaranteed not triggering the bad codepath. Added test reproducing the issue and showcasing that it is fixed now.

**Risk:** Low, limited to @in passed parameters to distributed funcs which previously would crash
**Review by:** @xedin @jckarter
**Testing:** Added CI exercising this code-path, verified in real project with fixed compiler
**Original PR:** https://github.com/apple/swift/pull/67240
**Radar:** rdar://111887706
