### PR TITLE
[Macros] Diagnose undocumented conformances in extension macro expansions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7246,6 +7246,9 @@ ERROR(literal_type_in_macro_expansion,none,
 ERROR(invalid_macro_introduced_name,none,
       "declaration name %0 is not covered by macro %1",
       (DeclName, DeclName))
+ERROR(undocumented_conformance_in_expansion,none,
+      "conformance to %0 is not covered by macro %1",
+      (Type, DeclName))
 ERROR(invalid_macro_role_for_macro_syntax,none,
       "invalid macro role for %{a freestanding|an attached}0 macro",
       (unsigned))

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1437,6 +1437,52 @@ public struct DelegatedConformanceViaExtensionMacro: ExtensionMacro {
   }
 }
 
+public struct AlwaysAddConformance: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let decl: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription): P where Element: P {
+        static func requirement() {
+          Element.requirement()
+        }
+      }
+
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
+public struct AlwaysAddCodable: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let decl: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription): Codable {
+      }
+
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
+
 public struct ExtendableEnum: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -127,4 +127,32 @@ struct S<Element> {}
 // expected-note@-1 {{in expansion of macro 'UndocumentedNamesInExtension' here}}
 
 // CHECK-DIAGS: error: declaration name 'requirement()' is not covered by macro 'UndocumentedNamesInExtension'
+
+@attached(extension, names: named(requirement))
+macro UndocumentedConformanceInExtension() = #externalMacro(module: "MacroDefinition", type: "AlwaysAddConformance")
+
+@UndocumentedConformanceInExtension
+struct InvalidConformance<Element> {}
+// expected-note@-1 {{in expansion of macro 'UndocumentedConformanceInExtension' here}}
+
+// CHECK-DIAGS: error: conformance to 'P' is not covered by macro 'UndocumentedConformanceInExtension'
+
+@attached(extension)
+macro UndocumentedCodable() = #externalMacro(module: "MacroDefinition", type: "AlwaysAddCodable")
+
+@UndocumentedCodable
+struct TestUndocumentedCodable {}
+// expected-note@-1 {{in expansion of macro 'UndocumentedCodable' here}}
+
+// CHECK-DIAGS: error: conformance to 'Codable' (aka 'Decodable & Encodable') is not covered by macro 'UndocumentedCodable'
+
+@attached(extension, conformances: Decodable)
+macro UndocumentedEncodable() = #externalMacro(module: "MacroDefinition", type: "AlwaysAddCodable")
+
+@UndocumentedEncodable
+struct TestUndocumentedEncodable {}
+// expected-note@-1 {{in expansion of macro 'UndocumentedEncodable' here}}
+
+// CHECK-DIAGS: error: conformance to 'Codable' (aka 'Decodable & Encodable') is not covered by macro 'UndocumentedEncodable'
+
 #endif


### PR DESCRIPTION
Extension macros can only add conformances that are documented in the `conformances:` list of the `@attached(extension)` attribute. Diagnose an error if the macro adds any conformances that are not documented.

Resolves rdar://112163965