### PR TITLE
[SE-0401] Rename DisableActorInferenceFromPropertyWrapperUsage to DisableOutwardActorInference

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -114,7 +114,7 @@ UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
 UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(ExistentialAny, 335, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
-UPCOMING_FEATURE(DisableActorInferenceFromPropertyWrapperUsage, 401, 6)
+UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3387,7 +3387,7 @@ static bool usesFeatureBuiltinMacros(Decl *decl) {
 }
 
 
-static bool usesFeatureDisableActorInferenceFromPropertyWrapperUsage(Decl *decl) {
+static bool usesFeatureDisableOutwardActorInference(Decl *decl) {
   return false;
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3701,7 +3701,7 @@ getIsolationFromWrappers(NominalTypeDecl *nominal) {
     return llvm::None;
 
   ASTContext &ctx = nominal->getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::DisableActorInferenceFromPropertyWrapperUsage)) {
+  if (ctx.LangOpts.hasFeature(Feature::DisableOutwardActorInference)) {
     // In Swift 6, we no longer infer isolation of a nominal type
     // based on the property wrappers used in its stored properties
     return llvm::None;


### PR DESCRIPTION
Per the decision of the Language Steering Group, this feature is being renamed