### PR TITLE
[AddressLowering] End borrow scopes for begin_apply at coro endpoints.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -580,7 +580,7 @@ struct BorrowedValue {
   /// instructions and pass them individually to visitor. Asserts if this is
   /// called with a scope that is not local.
   ///
-  /// Returns false and early exist if \p visitor returns false.
+  /// Returns false and exits early if \p visitor returns false.
   ///
   /// The intention is that this method can be used instead of
   /// BorrowScopeIntroducingValue::getLocalScopeEndingUses() to avoid

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2255,7 +2255,7 @@ void ApplyRewriter::rewriteApply(ArrayRef<SILValue> newCallArgs) {
   // will be deleted with its destructure_tuple.
 }
 
-/// Emit end_borrows for a an incomplete BorrowedValue with only nonlifetime
+/// Emit end_borrows for an incomplete BorrowedValue with only nonlifetime
 /// ending uses.
 static void emitEndBorrows(SILValue value, AddressLoweringState &pass);
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2332,7 +2332,10 @@ void ApplyRewriter::convertBeginApplyWithOpaqueYield() {
       SILValue load =
           resultBuilder.emitLoadBorrowOperation(callLoc, &newResult);
       oldResult.replaceAllUsesWith(load);
-      emitEndBorrows(load, pass);
+      for (auto *user : origCall->getTokenResult()->getUsers()) {
+        pass.getBuilder(user->getIterator())
+            .createEndBorrow(pass.genLoc(), load);
+      }
     } else {
       auto *load = resultBuilder.createTrivialLoadOr(
           callLoc, &newResult, LoadOwnershipQualifier::Take);

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1590,8 +1590,8 @@ entry:
 // CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
 // CHECK:         [[BORROW_1:%[^,]+]] = load_borrow [[ADDR_1]] : $*LoadableNontrivial
 // CHECK:         struct_extract [[BORROW_1]] : $LoadableNontrivial, #LoadableNontrivial.x
-// CHECK:         end_borrow [[BORROW_1]] : $LoadableNontrivial
 // CHECK:         copy_addr [[ADDR_2]] to [init] [[OPAQUE_OUT]] : $*T
+// CHECK:         end_borrow [[BORROW_1]] : $LoadableNontrivial
 // CHECK-LABEL: } // end sil function 'testBeginApply9Yield1LoadableNontrivialGuaranteed1OpaqueGuaranteed'
 sil [ossa] @testBeginApply9Yield1LoadableNontrivialGuaranteed1OpaqueGuaranteed : $@convention(thin) <T> () -> (@out Klass, @out T) {
 entry:


### PR DESCRIPTION
When a `load_borrow` is created on behalf of a `begin_apply`, it's possible that it may have escaping users.  When it does, `findInnerTransitiveGuaranteedUses` returns `false` and the uses it finds are incomplete.  As a result the boundary computed in `emitEndBorrows` will be incomplete.

In fact, this is generally true, so the `emitEndBorrows` function needs to be eliminated.  This is the second step in that process.
