### PR TITLE
[cxx-interop] Make CxxPair's fields mutable

### DIFF
--- a/stdlib/public/Cxx/CxxPair.swift
+++ b/stdlib/public/Cxx/CxxPair.swift
@@ -17,6 +17,6 @@ public protocol CxxPair<First, Second> {
   associatedtype First
   associatedtype Second
 
-  var first: First { get }
-  var second: Second { get }
+  var first: First { get set }
+  var second: Second { get set }
 }

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -33,4 +33,14 @@ StdPairTestSuite.test("PairStructInt.elements") {
   expectEqual(pair.second, 11)
 }
 
+StdPairTestSuite.test("StdPair as CxxPair") {
+  func changeFirst(_ p: inout any CxxPair<CInt, CInt>) {
+    p.first = 123
+  }
+
+  var pair: any CxxPair<CInt, CInt> = getIntPair()
+  changeFirst(&pair)
+  expectEqual(pair.first, 123)
+}
+
 runAllTests()


### PR DESCRIPTION
This will be needed to support mutable C++ iterators, e.g. `std::map::iterator`.