### PR TITLE
[Macros] Remove the `ExtensionMacros` experimental feature flag.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7277,6 +7277,9 @@ ERROR(extension_macro_invalid_conformance,none,
 ERROR(macro_attached_to_invalid_decl,none,
       "'%0' macro cannot be attached to %1",
       (StringRef, DescriptiveDeclKind))
+ERROR(conformance_macro,none,
+      "conformance macros are replaced by extension macros",
+      ())
 
 ERROR(macro_resolve_circular_reference, none,
       "circular reference resolving %select{freestanding|attached}0 macro %1",

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -123,7 +123,6 @@ EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 EXPERIMENTAL_FEATURE(InitAccessors, false)
 
-EXPERIMENTAL_FEATURE(ExtensionMacros, true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)", true)
 
 // Whether to enable @_used and @_section attributes

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10586,11 +10586,10 @@ bool swift::isMacroSupported(MacroRole role, ASTContext &ctx) {
   case MacroRole::Member:
   case MacroRole::Peer:
   case MacroRole::Conformance:
+  case MacroRole::Extension:
     return true;
   case MacroRole::CodeItem:
     return ctx.LangOpts.hasFeature(Feature::CodeItemMacros);
-  case MacroRole::Extension:
-    return ctx.LangOpts.hasFeature(Feature::ExtensionMacros);
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7152,9 +7152,9 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
     case MacroRole::Peer:
       break;
     case MacroRole::Conformance:
-      if (!attr->getNames().empty())
-        diagnoseAndRemoveAttr(attr, diag::macro_cannot_introduce_names,
-                              getMacroRoleString(attr->getMacroRole()));
+      diagnoseAndRemoveAttr(attr, diag::conformance_macro)
+          .fixItReplace(attr->getRange(),
+                        "@attached(extension, conformances: <#Protocol#>)");
       break;
     case MacroRole::Extension:
       break;

--- a/test/IDE/complete_macro_attribute.swift
+++ b/test/IDE/complete_macro_attribute.swift
@@ -12,12 +12,13 @@ macro FreestandingMacro
 @attached(#^ATTACHED_ROLE^#)
 macro AttachedMacro
 
-// ATTACHED_ROLE: Begin completions, 5 items
+// ATTACHED_ROLE: Begin completions, 6 items
 // ATTACHED_ROLE-DAG: Keyword/None:                       accessor; name=accessor
 // ATTACHED_ROLE-DAG: Keyword/None:                       memberAttribute; name=memberAttribute
 // ATTACHED_ROLE-DAG: Keyword/None:                       member; name=member
 // ATTACHED_ROLE-DAG: Keyword/None:                       peer; name=peer
 // ATTACHED_ROLE-DAG: Keyword/None:                       conformance; name=conformance
+// ATTACHED_ROLE-DAG: Keyword/None:                       extension; name=extension
 
 @freestanding(declaration, #^NAMES_POSITION^#)
 macro FreestandingDeclarationMacro

--- a/test/IDE/complete_macros.swift
+++ b/test/IDE/complete_macros.swift
@@ -52,7 +52,7 @@ public macro AttachedMemberAttributeMacro()
 @attached(peer)
 public macro AttachedPeerMacro()
 
-@attached(conformance)
+@attached(extension)
 public macro AttachedConformanceMacro()
 
 @freestanding(expression)
@@ -61,7 +61,7 @@ public macro AttachedConformanceMacro()
 @attached(member)
 @attached(memberAttribute)
 @attached(peer)
-@attached(conformance)
+@attached(extension)
 public macro EverythingMacro()
 
 //--- MacroUses.swift

--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -17,7 +17,7 @@ func foo() {
 }
 
 @attached(member, names: named(RawValue), named(rawValue), named(`init`), arbitrary)
-@attached(conformance)
+@attached(extension, conformances: OptionSet)
 public macro OptionSet<RawType>() =
   #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
 

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -26,7 +26,7 @@ macro freestandingDecl<T>(arg: T) = #externalMacro(module: "IndexMacros", type: 
 macro Accessor() = #externalMacro(module: "IndexMacros", type: "SomeAccessorMacro")
 // CHECK: [[@LINE-1]]:7 | macro/Swift | Accessor() |  [[ACCESSOR_USR:.*]] | Def
 
-@attached(conformance)
+@attached(extension, conformances: TestProto)
 macro Conformance() = #externalMacro(module: "IndexMacros", type: "SomeConformanceMacro")
 // CHECK: [[@LINE-1]]:7 | macro/Swift | Conformance() |  [[CONFORMANCE_USR:.*]] | Def
 

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -14,10 +14,15 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
-@attached(conformance)
+#if TEST_DIAGNOSTICS
+@attached(conformance) // expected-error{{conformance macros are replaced by extension macros}}
+macro InvalidEquatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
+#endif
+
+@attached(extension, conformances: Equatable)
 macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
 
-@attached(conformance)
+@attached(extension, conformances: Hashable)
 macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
 
 #if MODULE_EXPORTING_TYPE
@@ -52,7 +57,7 @@ enum E {
   @Equatable struct Nested {}
 }
 
-// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances1S9EquatablefMc_.swift
+// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances1S9EquatablefMe_.swift
 // CHECK-DUMP: extension S: Equatable  {
 // CHECK-DUMP: }
 
@@ -77,7 +82,7 @@ requireHashable(PublicEquatable())
 //expected-error@-1{{global function 'requireHashable' requires that 'PublicEquatable' conform to 'Hashable'}}
 #endif
 
-@attached(conformance)
+@attached(extension, conformances: P)
 @attached(member, names: named(requirement))
 macro DelegatedConformance() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceMacro")
 
@@ -94,7 +99,7 @@ struct Wrapped: P {
 @DelegatedConformance
 struct Generic<Element> {}
 
-// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances7Generic20DelegatedConformancefMc_.swift
+// CHECK-DUMP: @__swiftmacro_25macro_expand_conformances7Generic20DelegatedConformancefMe_.swift
 // CHECK-DUMP: extension Generic: P where Element: P {
 // CHECK-DUMP: }
 

--- a/test/Macros/option_set.swift
+++ b/test/Macros/option_set.swift
@@ -5,7 +5,7 @@
 import Swift
 
 @attached(member, names: named(RawValue), named(rawValue), named(`init`), arbitrary)
-@attached(conformance)
+@attached(extension, conformances: OptionSet)
 public macro OptionSet<RawType>() =
   #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
 

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -117,7 +117,7 @@ macro Empty<T>(_ closure: () -> T) = #externalMacro(module: "MacroDefinition", t
   S(a: 10, b: 10)
 }
 
-@attached(conformance)
+@attached(extension, conformances: Initializable)
 @attached(member, names: named(init))
 macro Initializable() = #externalMacro(module: "MacroDefinition", type: "InitializableMacro")
 

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -50,11 +50,11 @@
 @attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "SomeModule", type: "AccessorInitFuncMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(extension, conformances: Swift.Sendable) @attached(conformance) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
+// CHECK: @attached(extension, conformances: Swift.Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
 // CHECK-NEXT: #else
-// CHECK: @attached(conformance) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
+// CHECK: @attached(member) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
 // CHECK-NEXT: #endif
-@attached(extension, conformances: Sendable) @attached(conformance) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
+@attached(extension, conformances: Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
 
 // CHECK-NOT: internalStringify
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -45,7 +45,7 @@ struct S3 {
   }
 }
 
-@attached(conformance)
+@attached(extension, conformances: Hashable)
 macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
 
 @Hashable
@@ -263,7 +263,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on a conformance macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=51:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CONFORMANCE_EXPAND %s
 // CONFORMANCE_EXPAND: source.edit.kind.active:
-// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S48HashablefMc_.swift) "extension S4: Hashable {
+// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S48HashablefMe_.swift) "extension S4: Hashable {
 // CONFORMANCE_EXPAND-NEXT: }"
 // CONFORMANCE_EXPAND-NEXT: source.edit.kind.active:
 // CONFORMANCE_EXPAND-NEXT: 51:1-51:10 ""

--- a/test/SourceKit/Macros/macro_option_set.swift
+++ b/test/SourceKit/Macros/macro_option_set.swift
@@ -17,7 +17,7 @@ func test(opts: ShippingOptions) {
 }
 
 @attached(member, names: named(RawValue), named(rawValue), named(`init`), arbitrary)
-@attached(conformance)
+@attached(extension, conformances: OptionSet)
 public macro OptionSet<RawType>() =
   #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
 


### PR DESCRIPTION
This change removes the `ExtensionMacros` experimental feature identifier and diagnoses `@attached(conformance)` attributes as being replaced by `@attached(extension, conformances: <#Protocol#>)`.

Resolves rdar://112548321