### PR TITLE
Serialization: ensure that we deserialise IsStaticLibrary correctly

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -678,6 +678,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setIsAlwaysWeakImported(isWeakImported);
     fn->setClassSubclassScope(SubclassScope(subclassScope));
     fn->setHasCReferences(bool(hasCReferences));
+    fn->setIsStaticallyLinked(MF->getAssociatedModule()->isStaticLibrary());
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);

--- a/test/IRGen/static-serialization.swift
+++ b/test/IRGen/static-serialization.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift-target-frontend -static -emit-module -emit-module-path %t/StaticLibrary.swiftmodule/%host_triple.swiftmodule -module-name StaticLibrary -DSTATIC_LIBRARY %s
+// RUN: %swift-target-frontend -static -emit-module -emit-module-path %t/StaticLibrary.swiftmodule -module-name StaticLibrary -DSTATIC_LIBRARY %s
 // RUN: %swift-target-frontend -I%t -S %s -emit-ir -o - | %FileCheck %s
 
 #if STATIC_LIBRARY

--- a/test/IRGen/static-serialization.swift
+++ b/test/IRGen/static-serialization.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift-target-frontend -static -emit-module -emit-module-path %t/StaticLibrary.swiftmodule/%host_triple.swiftmodule -module-name StaticLibrary -DSTATIC_LIBRARY %s
+// RUN: %swift-target-frontend -I%t -S %s -emit-ir -o - | %FileCheck %s
+
+#if STATIC_LIBRARY
+public final class S {
+    public init() { }
+    deinit {}
+}
+
+@_transparent
+public func f() -> S { S() }
+#else
+import StaticLibrary
+internal let s = f()
+#endif
+
+// CHECK-NOT: declare dllimport swiftcc ptr @"$s13StaticLibrary1SCACycfC"(ptr swiftself)
+// CHECK: declare swiftcc ptr @"$s13StaticLibrary1SCACycfC"(ptr swiftself)


### PR DESCRIPTION
We would previously fail to deserialise the IsStaticLibrary bit on certain declarations when they were imported implicitly.  This would result in incorrect IRGen on Windows when building against a static swift module.