### PR TITLE
github: add CODEOWNERS entry for `swift-inspect`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -182,6 +182,7 @@
 /tools/SourceKit                                    @ahoppen @bnbarham @rintaro @hamishknight
 /tools/lldb-moduleimport-test/                      @adrian-prantl
 /tools/swift-ide-test                               @ahoppen @bnbarham @rintaro @hamishknight
+/tools/swift-inspect                                @mikeash @al45tair @compnerd
 /tools/swift-refactor                               @ahoppen @bnbarham
 
 # unittests


### PR DESCRIPTION
Add some implicit reviewers for `swift-inspect`.  @mikeash and @al45tair are obvious candidates, and I've done a small amount of contribution to the tool as well.