### PR TITLE
[Observation] Forward availability and defines to extensions

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/Availability.swift
+++ b/lib/Macros/Sources/ObservationMacros/Availability.swift
@@ -44,34 +44,14 @@ extension IfConfigClauseSyntax.Elements {
 extension IfConfigClauseSyntax {
   var availability: IfConfigClauseSyntax? {
     if let availability = elements?.availability {
-      return IfConfigClauseSyntax(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforePoundKeyword,
-        poundKeyword: poundKeyword,
-        unexpectedBetweenPoundKeywordAndCondition,
-        condition: condition,
-        unexpectedBetweenConditionAndElements,
-        elements: availability,
-        unexpectedAfterElements,
-        trailingTrivia: trailingTrivia
-      )
+      return with(\.elements, availability)
     } else {
       return nil
     }
   }
   
   var clonedAsIf: IfConfigClauseSyntax {
-    IfConfigClauseSyntax(
-      leadingTrivia: leadingTrivia,
-      unexpectedBeforePoundKeyword,
-      poundKeyword: .poundIfKeyword(),
-      unexpectedBetweenPoundKeywordAndCondition,
-      condition: condition,
-      unexpectedBetweenConditionAndElements,
-      elements: elements,
-      unexpectedAfterElements,
-      trailingTrivia: trailingTrivia
-    )
+    detached.with(\.poundKeyword, .poundIfKeyword())
   }
 }
 
@@ -90,15 +70,7 @@ extension IfConfigDeclSyntax {
     if elements.isEmpty {
       return nil
     } else {
-      return IfConfigDeclSyntax(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeClauses,
-        clauses: IfConfigClauseListSyntax(elements),
-        unexpectedBetweenClausesAndPoundEndif,
-        poundEndif: poundEndif,
-        unexpectedAfterPoundEndif,
-        trailingTrivia: trailingTrivia
-      )
+      return with(\.clauses, IfConfigClauseListSyntax(elements))
     }
     
   }

--- a/lib/Macros/Sources/ObservationMacros/Availability.swift
+++ b/lib/Macros/Sources/ObservationMacros/Availability.swift
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntaxBuilder
+
+
+extension AttributeSyntax {
+  var availability: AttributeSyntax? {
+    if attributeName.identifier == "available" {
+      return self
+    } else {
+      return nil
+    }
+  }
+}
+
+extension IfConfigClauseSyntax.Elements {
+  var availability: IfConfigClauseSyntax.Elements? {
+    switch self {
+    case .attributes(let attributes):
+      if let availability = attributes.availability {
+        return .attributes(availability)
+      } else {
+        return nil
+      }
+    default:
+      return nil
+    }
+  }
+}
+
+extension IfConfigClauseSyntax {
+  var availability: IfConfigClauseSyntax? {
+    if let availability = elements?.availability {
+      return IfConfigClauseSyntax(
+        leadingTrivia: leadingTrivia,
+        unexpectedBeforePoundKeyword,
+        poundKeyword: poundKeyword,
+        unexpectedBetweenPoundKeywordAndCondition,
+        condition: condition,
+        unexpectedBetweenConditionAndElements,
+        elements: availability,
+        unexpectedAfterElements,
+        trailingTrivia: trailingTrivia
+      )
+    } else {
+      return nil
+    }
+  }
+  
+  var clonedAsIf: IfConfigClauseSyntax {
+    IfConfigClauseSyntax(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforePoundKeyword,
+      poundKeyword: .poundIfKeyword(),
+      unexpectedBetweenPoundKeywordAndCondition,
+      condition: condition,
+      unexpectedBetweenConditionAndElements,
+      elements: elements,
+      unexpectedAfterElements,
+      trailingTrivia: trailingTrivia
+    )
+  }
+}
+
+extension IfConfigDeclSyntax {
+  var availability: IfConfigDeclSyntax? {
+    var elements = [IfConfigClauseListSyntax.Element]()
+    for clause in clauses {
+      if let availability = clause.availability {
+        if elements.isEmpty {
+          elements.append(availability.clonedAsIf)
+        } else {
+          elements.append(availability)
+        }
+      }
+    }
+    if elements.isEmpty {
+      return nil
+    } else {
+      return IfConfigDeclSyntax(
+        leadingTrivia: leadingTrivia,
+        unexpectedBeforeClauses,
+        clauses: IfConfigClauseListSyntax(elements),
+        unexpectedBetweenClausesAndPoundEndif,
+        poundEndif: poundEndif,
+        unexpectedAfterPoundEndif,
+        trailingTrivia: trailingTrivia
+      )
+    }
+    
+  }
+}
+
+extension AttributeListSyntax.Element {
+  var availability: AttributeListSyntax.Element? {
+    switch self {
+    case .attribute(let attribute):
+      if let availability = attribute.availability {
+        return .attribute(availability)
+      }
+    case .ifConfigDecl(let ifConfig):
+      if let availability = ifConfig.availability {
+        return .ifConfigDecl(availability)
+      }
+    default:
+      break
+    }
+    return nil
+  }
+}
+
+extension AttributeListSyntax {
+  var availability: AttributeListSyntax? {
+    var elements = [AttributeListSyntax.Element]()
+    for element in self {
+      if let availability = element.availability {
+        elements.append(availability)
+      }
+    }
+    if elements.isEmpty {
+      return nil
+    }
+    return AttributeListSyntax(elements)
+  }
+}
+
+extension DeclGroupSyntax {
+  var availability: AttributeListSyntax? {
+    if let attributes {
+      return attributes.availability
+    } else {
+      return nil
+    }
+  }
+}

--- a/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
@@ -11,8 +11,9 @@
 #===----------------------------------------------------------------------===#
 
 add_swift_macro_library(ObservationMacros
-  ObservableMacro.swift
+  Availability.swift
   Extensions.swift
+  ObservableMacro.swift
   SWIFT_DEPENDENCIES
     SwiftSyntax::SwiftDiagnostics
     SwiftSyntax::SwiftOperators

--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -11,10 +11,9 @@
 
 import SwiftSyntax
 import SwiftSyntaxMacros
-
-@_implementationOnly import SwiftDiagnostics
-@_implementationOnly import SwiftOperators
-@_implementationOnly import SwiftSyntaxBuilder
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntaxBuilder
 
 extension VariableDeclSyntax {
   var identifierPattern: IdentifierPatternSyntax? {

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -280,28 +280,15 @@ extension ObservableMacro: ExtensionMacro {
       return []
     }
 
-    if let availability = declaration.availability {
-      let emptyBlock: MemberDeclBlockSyntax = "{ }"
-
-      return [
-        ExtensionDeclSyntax(
-          leadingTrivia: .newline,
-          attributes: availability,
-          extensionKeyword: .keyword(.extension),
-          extendedType: type,
-          inheritanceClause: TypeInheritanceClauseSyntax(inheritedTypeCollection: InheritedTypeListSyntax([InheritedTypeSyntax(typeName: observableConformanceType)])),
-          memberBlock: emptyBlock,
-          trailingTrivia: .newline
-        )
-      ]
-    } else {
-      let decl: DeclSyntax = """
+    let decl: DeclSyntax = """
         extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
         """
+    let ext = decl.cast(ExtensionDeclSyntax.self)
 
-      return [
-        decl.cast(ExtensionDeclSyntax.self)
-      ]
+    if let availability = declaration.availability {
+      return [ext.with(\.attributes, availability)]
+    } else {
+      return [ext]
     }
   }
 }

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -11,10 +11,9 @@
 
 import SwiftSyntax
 import SwiftSyntaxMacros
-
-@_implementationOnly import SwiftDiagnostics
-@_implementationOnly import SwiftOperators
-@_implementationOnly import SwiftSyntaxBuilder
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntaxBuilder
 
 public struct ObservableMacro {
   static let moduleName = "Observation"
@@ -281,13 +280,29 @@ extension ObservableMacro: ExtensionMacro {
       return []
     }
 
-    let decl: DeclSyntax = """
-      extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
-      """
+    if let availability = declaration.availability {
+      let emptyBlock: MemberDeclBlockSyntax = "{ }"
 
-    return [
-      decl.cast(ExtensionDeclSyntax.self)
-    ]
+      return [
+        ExtensionDeclSyntax(
+          leadingTrivia: .newline,
+          attributes: availability,
+          extensionKeyword: .keyword(.extension),
+          extendedType: type,
+          inheritanceClause: TypeInheritanceClauseSyntax(inheritedTypeCollection: InheritedTypeListSyntax([InheritedTypeSyntax(typeName: observableConformanceType)])),
+          memberBlock: emptyBlock,
+          trailingTrivia: .newline
+        )
+      ]
+    } else {
+      let decl: DeclSyntax = """
+        extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
+        """
+
+      return [
+        decl.cast(ExtensionDeclSyntax.self)
+      ]
+    }
   }
 }
 

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -202,6 +202,16 @@ class RecursiveOuter {
   }
 }
 
+@Observable
+#if FOO
+@available(SwiftStdlib 5.9, *)
+#elseif BAR
+@available(SwiftStdlib 5.9, *)
+#else
+#endif
+class GuardedAvailability {
+}
+
 @main
 struct Validator {
   @MainActor


### PR DESCRIPTION
Using availability markers and `#if` guards for observable types incorrectly emit extensions that are inherently incompatible with extensions.

This forwards the relevant availability to the extensions.

Resolves:
rdar://112413879