### PR TITLE
[move-only] Fix two small errors around handling capturing of noncopyable self by local functions

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -126,7 +126,8 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
   if (!var->supportsMutation() && lowering.getLoweredType().isPureMoveOnly() &&
       !capture.isNoEscape()) {
       auto *param = dyn_cast<ParamDecl>(var);
-      if (!param || param->getValueOwnership() != ValueOwnership::Shared) {
+      if (!param || (param->getValueOwnership() != ValueOwnership::Shared &&
+                     !param->isSelfParameter())) {
         return CaptureKind::ImmutableBox;
       }
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1141,11 +1141,14 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     fArg->setClosureCapture(true);
     arg = SILValue(fArg);
 
-    // If our capture is no escape and we have a noncopyable value, insert a
-    // consumable and assignable. If we have an escaping closure, we are going
-    // to emit an error later in SIL since it is illegal to capture an inout
-    // value in an escaping closure.
-    if (isInOut && ty.isPureMoveOnly() && capture.isNoEscape()) {
+    // If we have an inout noncopyable paramter, insert a consumable and
+    // assignable.
+    //
+    // NOTE: If we have an escaping closure, we are going to emit an error later
+    // in SIL since it is illegal to capture an inout value in an escaping
+    // closure. The later code knows how to handle that we have the
+    // mark_must_check here.
+    if (isInOut && ty.isPureMoveOnly()) {
       arg = SGF.B.createMarkMustCheckInst(
           Loc, arg, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2314,6 +2314,18 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
       }
     }
 
+    // If our partial apply takes this parameter as an inout parameter and it
+    // has the no move only diagnostics marker on it, do not emit an error
+    // either.
+    if (auto *f = pas->getCalleeFunction()) {
+      if (f->hasSemanticsAttr(semantics::NO_MOVEONLY_DIAGNOSTICS)) {
+        if (ApplySite(pas).getArgumentOperandConvention(*op).isInoutConvention()) {
+          diagnosticEmitter.emitEarlierPassEmittedDiagnostic(markedValue);
+          return false;
+        }
+      }
+    }
+
     if (pas->isOnStack() ||
         ApplySite(pas).getArgumentConvention(*op).isInoutConvention()) {
       LLVM_DEBUG(llvm::dbgs() << "Found on stack partial apply or inout usage!\n");

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -614,7 +614,8 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
 // CHECK: } // end sil function '$s16moveonly_closure29testGlobalClosureCaptureInOutyyAA9SingleEltVzF'
 
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure29testGlobalClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -657,7 +658,8 @@ func testGlobalClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalLetClosureCaptureInOutyyAA9SingleEltVzF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure31testLocalLetClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -704,7 +706,8 @@ func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -752,7 +755,8 @@ func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -807,7 +811,8 @@ func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) 
 // CHECK: } // end sil function '$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]

--- a/test/SILOptimizer/moveonly_self_captures.swift
+++ b/test/SILOptimizer/moveonly_self_captures.swift
@@ -10,6 +10,7 @@ struct E2 : ~Copyable {
     var k = Klass()
 }
 
+var g: () -> () = {}
 struct Test : ~Copyable {
     var e: E
     var e2: E2
@@ -28,10 +29,29 @@ struct Test : ~Copyable {
         e = E()
         e2 = E2()
         func capture() {
-            let _ = self // expected-error {{copy of noncopyable typed value}}
-            let _ = self.e2 // expected-error {{copy of noncopyable typed value}}
+            let _ = self
+            let _ = self.e2 // expected-error {{cannot partially consume 'self'}}
         }
         capture()
+    }
+
+    init(y: ()) { // expected-error {{missing reinitialization of closure capture 'self' after consume}}
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self // expected-note {{consumed here}}
+        }
+        capture()
+    }
+
+    init(z: ()) {
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self // expected-note {{captured here}}
+        }
+        capture()
+        g = capture // expected-error {{escaping local function captures mutating 'self' parameter}}
     }
 
     func captureByLocalFunction() {
@@ -85,5 +105,3 @@ struct Test : ~Copyable {
         }
     }
 }
-
-

--- a/test/SILOptimizer/moveonly_self_captures.swift
+++ b/test/SILOptimizer/moveonly_self_captures.swift
@@ -1,0 +1,89 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+
+class Klass {}
+
+struct E {
+    var k = Klass()
+}
+
+struct E2 : ~Copyable {
+    var k = Klass()
+}
+
+struct Test : ~Copyable {
+    var e: E
+    var e2: E2
+
+    // Test that we capture inits by address.
+    init() {
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self.e
+        }
+        capture()
+    }
+
+    init(x: ()) {
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self // expected-error {{copy of noncopyable typed value}}
+            let _ = self.e2 // expected-error {{copy of noncopyable typed value}}
+        }
+        capture()
+    }
+
+    func captureByLocalFunction() {
+        func capture() {
+            let _ = self.e
+        }
+        capture()
+    }
+
+    func captureByLocalFunction2() { // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
+        func capture() {
+            let _ = self.e2 // expected-note {{consumed here}}
+        }
+        capture()
+    }
+
+    func captureByLocalFunction3() { // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
+        func capture() {
+            let _ = self // expected-note {{consumed here}}
+        }
+        capture()
+    }
+
+    func captureByLocalLet() { // expected-error {{'self' cannot be captured by an escaping closure since it is a borrowed parameter}}
+        let f = { // expected-note {{capturing 'self' here}}
+            let _ = self.e
+        }
+        
+        f()
+    }
+
+    func captureByLocalVar() { // expected-error {{'self' cannot be captured by an escaping closure since it is a borrowed parameter}}
+        var f = {}
+        f = { // expected-note {{closure capturing 'self' here}}
+            let _ = self.e
+        }
+        f()
+    }
+
+    func captureByNonEscapingClosure() {
+        func useClosure(_ f: () -> ()) {}
+        useClosure {
+            let _ = self.e
+        }
+    }
+
+    func captureByNonEscapingClosure2() { // expected-error {{'self' cannot be consumed when captured by an escaping closure}}
+        func useClosure(_ f: () -> ()) {}
+        useClosure {
+            let _ = self // expected-note {{consumed here}}
+        }
+    }
+}
+
+


### PR DESCRIPTION
Specifically:

----
```
[move-only] Do not try to capture self as an immutable box.

The problem here is that the logic was conditionalized on all noncopyable
parameters that are borrowed as having the ValueOwnership::Shared flag set. This
is only true for user written parameters. Implicit noncopyable parameters like
self do not have ValueOwnership::Shared set upon them. We could potentially do
that in Sema, but Sema does not know what the proper convention of self is since
that information is in TypeLowering today.

With that in mind, conditionalize the logic here so we do the right thing.

rdar://112547982
```
----
```
[move-only] Make sure we mark local function inout parameters with mark_must_check.

Originally, we were relying on capture info to determine if we needed to insert
this mark_must_check. This ignored that the way that we are handling
escaping/non-escaping is something that is approximated in the AST but actually
determined at SIL level. With that in mind, rather than relying on the capture
info here, just rely on us having an inout argument. The later SIL level
checking for inout escapes is able to handle mark_must_check and knows how to
turn off noncopyable errors in the closure where we detect the error to prevent
us from emitting further errors due to the mark_must_check here.

I discovered this while playing with the previous commit.

rdar://112555589
```

----