### PR TITLE
[5.9][move-only] Fix our handling of capturing self by local functions

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -125,7 +125,8 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
   if (!var->supportsMutation() && lowering.getLoweredType().isPureMoveOnly() &&
       !capture.isNoEscape()) {
       auto *param = dyn_cast<ParamDecl>(var);
-      if (!param || param->getValueOwnership() != ValueOwnership::Shared) {
+      if (!param || (param->getValueOwnership() != ValueOwnership::Shared &&
+                     !param->isSelfParameter())) {
         return CaptureKind::ImmutableBox;
       }
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1141,11 +1141,14 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     fArg->setClosureCapture(true);
     arg = SILValue(fArg);
 
-    // If our capture is no escape and we have a noncopyable value, insert a
-    // consumable and assignable. If we have an escaping closure, we are going
-    // to emit an error later in SIL since it is illegal to capture an inout
-    // value in an escaping closure.
-    if (isInOut && ty.isPureMoveOnly() && capture.isNoEscape()) {
+    // If we have an inout noncopyable paramter, insert a consumable and
+    // assignable.
+    //
+    // NOTE: If we have an escaping closure, we are going to emit an error later
+    // in SIL since it is illegal to capture an inout value in an escaping
+    // closure. The later code knows how to handle that we have the
+    // mark_must_check here.
+    if (isInOut && ty.isPureMoveOnly()) {
       arg = SGF.B.createMarkMustCheckInst(
           Loc, arg, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2323,6 +2323,18 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
       }
     }
 
+    // If our partial apply takes this parameter as an inout parameter and it
+    // has the no move only diagnostics marker on it, do not emit an error
+    // either.
+    if (auto *f = pas->getCalleeFunction()) {
+      if (f->hasSemanticsAttr(semantics::NO_MOVEONLY_DIAGNOSTICS)) {
+        if (ApplySite(pas).getArgumentOperandConvention(*op).isInoutConvention()) {
+          diagnosticEmitter.emitEarlierPassEmittedDiagnostic(markedValue);
+          return false;
+        }
+      }
+    }
+
     if (pas->isOnStack() ||
         ApplySite(pas).getArgumentConvention(*op).isInoutConvention()) {
       LLVM_DEBUG(llvm::dbgs() << "Found on stack partial apply or inout usage!\n");

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -611,7 +611,8 @@ func testConsumingEscapeClosureCaptureLet(_ f: consuming @escaping () -> ()) {
 // CHECK: } // end sil function '$s16moveonly_closure29testGlobalClosureCaptureInOutyyAA9SingleEltVzF'
 
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure29testGlobalClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -654,7 +655,8 @@ func testGlobalClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalLetClosureCaptureInOutyyAA9SingleEltVzF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure31testLocalLetClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -701,7 +703,8 @@ func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -749,7 +752,8 @@ func testLocalVarClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: } // end sil function '$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure026testInOutVarClosureCapturedE0yyyycz_AA9SingleEltVztFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]
@@ -804,7 +808,8 @@ func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) 
 // CHECK: } // end sil function '$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztF'
 //
 // CHECK-LABEL: sil private [ossa] @$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> () {
-// CHECK: bb0([[PROJECT:%.*]] : @closureCapture
+// CHECK: bb0([[ARG:%.*]] : @closureCapture
+// CHECK:   [[PROJECT:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK:   [[LOADED:%.*]] = load [copy] [[ACCESS]]

--- a/test/SILOptimizer/moveonly_self_captures.swift
+++ b/test/SILOptimizer/moveonly_self_captures.swift
@@ -10,6 +10,7 @@ struct E2 : ~Copyable {
     var k = Klass()
 }
 
+var g: () -> () = {}
 struct Test : ~Copyable {
     var e: E
     var e2: E2
@@ -28,10 +29,29 @@ struct Test : ~Copyable {
         e = E()
         e2 = E2()
         func capture() {
-            let _ = self // expected-error {{copy of noncopyable typed value}}
-            let _ = self.e2 // expected-error {{copy of noncopyable typed value}}
+            let _ = self
+            let _ = self.e2 // expected-error {{cannot partially consume 'self'}}
         }
         capture()
+    }
+
+    init(y: ()) { // expected-error {{missing reinitialization of closure capture 'self' after consume}}
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self // expected-note {{consumed here}}
+        }
+        capture()
+    }
+
+    init(z: ()) {
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self // expected-note {{captured here}}
+        }
+        capture()
+        g = capture // expected-error {{escaping local function captures mutating 'self' parameter}}
     }
 
     func captureByLocalFunction() {
@@ -85,5 +105,3 @@ struct Test : ~Copyable {
         }
     }
 }
-
-

--- a/test/SILOptimizer/moveonly_self_captures.swift
+++ b/test/SILOptimizer/moveonly_self_captures.swift
@@ -1,0 +1,89 @@
+// RUN: %target-swift-emit-sil -sil-verify-all -verify %s
+
+class Klass {}
+
+struct E {
+    var k = Klass()
+}
+
+struct E2 : ~Copyable {
+    var k = Klass()
+}
+
+struct Test : ~Copyable {
+    var e: E
+    var e2: E2
+
+    // Test that we capture inits by address.
+    init() {
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self.e
+        }
+        capture()
+    }
+
+    init(x: ()) {
+        e = E()
+        e2 = E2()
+        func capture() {
+            let _ = self // expected-error {{copy of noncopyable typed value}}
+            let _ = self.e2 // expected-error {{copy of noncopyable typed value}}
+        }
+        capture()
+    }
+
+    func captureByLocalFunction() {
+        func capture() {
+            let _ = self.e
+        }
+        capture()
+    }
+
+    func captureByLocalFunction2() { // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
+        func capture() {
+            let _ = self.e2 // expected-note {{consumed here}}
+        }
+        capture()
+    }
+
+    func captureByLocalFunction3() { // expected-error {{noncopyable 'self' cannot be consumed when captured by an escaping closure}}
+        func capture() {
+            let _ = self // expected-note {{consumed here}}
+        }
+        capture()
+    }
+
+    func captureByLocalLet() { // expected-error {{'self' cannot be captured by an escaping closure since it is a borrowed parameter}}
+        let f = { // expected-note {{capturing 'self' here}}
+            let _ = self.e
+        }
+        
+        f()
+    }
+
+    func captureByLocalVar() { // expected-error {{'self' cannot be captured by an escaping closure since it is a borrowed parameter}}
+        var f = {}
+        f = { // expected-note {{closure capturing 'self' here}}
+            let _ = self.e
+        }
+        f()
+    }
+
+    func captureByNonEscapingClosure() {
+        func useClosure(_ f: () -> ()) {}
+        useClosure {
+            let _ = self.e
+        }
+    }
+
+    func captureByNonEscapingClosure2() { // expected-error {{'self' cannot be consumed when captured by an escaping closure}}
+        func useClosure(_ f: () -> ()) {}
+        useClosure {
+            let _ = self // expected-note {{consumed here}}
+        }
+    }
+}
+
+


### PR DESCRIPTION
• Description: This patch fixes two different issues that cause us to crash when processing self being captured by a local function.

1. **The first issue is that we were attempting to access self (which is an object) as an address when self was captured by a local function parameter.** The reason for this is that when the capture code was brought up, we said that we would treat captured params that were marked with borrow as not being boxed. This is true for user written params, but compiler generated params like self need to have this property and are not marked as being boxed. I put in a special check for self here. Importantly, this does not apply to other parameters like setters since we immediately put the newValue into a box so we use different codegen.

4. **The second issue is that we were not performing move checking the noncopyable captured arguments of such local functions causing us to not reject invalid code.** The reason why we were doing this is that some time ago were emitting noncopyable errors even after we emitted an inout use by escaping capture error. As a first effort to stop that, we stopped inserting mark_must_check if the AST did not think that a captured argument was a non-escaping argument with the idea that we were for sure going to emit an escaping inout error. In this case, the AST information around what is no-escape is too conservative and we have a case where the capture info states that a parameter is escaping, but it is actually no-escaping. Rather than rely on imprecise AST information, I removed the no escape check here since subsequently to our initial effort to stop such extra diagnostics from being emitted we came up with a better method for not emitting such errors: marking the closure where the error occurs with a semantic tag that turns off the checker. So I was able to just insert the mark_must_check ensuring that we /do/ perform the checking, the escaping inout diagnostic works correctly and doesn't care about the mark_must_check being there/inserts the semantic tag, and everything is good in the world.

• Risk: Very low. Both of these fixes are small and only affect noncopyable types. Both only perturb code that only has to do with these specific capture code paths.
• Original PR: #67414
• Reviewed By: @jckarter 
• Testing: Added Swift tests
• Resolves: rdar://112547982 & rdar://112555589