### PR TITLE
Enable test: discarding task group making sure we deinit confidently

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_discarding.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding.swift
@@ -34,7 +34,6 @@ actor SimpleCountDownLatch {
       fatalError("Counted down more times than expected! (From: \(from))")
     } else if count == 1 {
       print("hit resume")
-      print("resume")
       continuation?.resume()
     }
   }

--- a/test/Concurrency/Runtime/async_taskgroup_discarding.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 // TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
 
-// rdar://110025115 - Temporarily disable this test
-// REQUIRES: rdar110025115
-
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
@@ -19,28 +16,75 @@ import _Concurrency
 final class PayloadFirst {}
 final class PayloadSecond {}
 
+actor SimpleCountDownLatch {
+  let from: Int
+  var count: Int
+
+  var continuation: CheckedContinuation<Void, Never>?
+
+  init(from: Int) {
+    self.from = from
+    self.count = from
+  }
+
+  func hit() {
+    defer { count -= 1 }
+    print("hit @ \(count)")
+    if count == 0 {
+      fatalError("Counted down more times than expected! (From: \(from))")
+    } else if count == 1 {
+      print("hit resume")
+      print("resume")
+      continuation?.resume()
+    }
+  }
+
+  func wait() async {
+    guard self.count > 0 else {
+      return // we're done
+    }
+
+    return await withCheckedContinuation { cc in
+      self.continuation = cc
+    }
+  }
+}
+
 final class ErrorFirst: Error {
   let first: PayloadFirst
+  let id: String
+  let latch: SimpleCountDownLatch
 
-  init(file: String = #fileID, line: UInt = #line) {
+  init(latch: SimpleCountDownLatch, file: String = #fileID, line: UInt = #line) {
+    self.latch = latch
+    self.id = "\(file):\(line)"
     first = .init()
+    print("init \(self) id:\(id)")
   }
   deinit {
-    print("deinit \(self)")
+    print("deinit \(self) id:\(id)")
+    Task { [latch] in await latch.hit() }
   }
 }
 
+// Should not really matter that different types, but want to make really sure
 final class ErrorSecond: Error {
-  let second: PayloadSecond
+  let first: PayloadFirst
+  let id: String
+  let latch: SimpleCountDownLatch
 
-  init(file: String = #fileID, line: UInt = #line) {
-    second = .init()
+  init(latch: SimpleCountDownLatch, file: String = #fileID, line: UInt = #line) {
+    self.latch = latch
+    self.id = "\(file):\(line)"
+    first = .init()
+    print("init \(self) id:\(id)")
   }
-
   deinit {
-    print("deinit \(self)")
+    print("deinit \(self) id:\(id)")
+    Task { [latch] in await latch.hit() }
   }
 }
+
 
 func shouldStartWith(_ lhs: Any, _ rhs: Any) {
   let l = "\(lhs)"
@@ -50,20 +94,25 @@ func shouldStartWith(_ lhs: Any, _ rhs: Any) {
 
 // NOTE: Not as StdlibUnittest/TestSuite since these types of tests are unreasonably slow to load/debug.
 
+@discardableResult
+func one() -> Int {
+  1
+}
+
 @main struct Main {
   static func main() async {
+    let latch = SimpleCountDownLatch(from: 6)
     do {
-      let got = try await withThrowingDiscardingTaskGroup() { group in
-        group.addTask {
-          1
-        }
-        group.addTask {
-          throw ErrorFirst()
-        }
 
-        group.addTask {
-          throw ErrorSecond()
-        }
+      let got = try await withThrowingDiscardingTaskGroup() { group in
+        group.addTask { one() }
+        group.addTask { throw ErrorFirst(latch: latch) }
+        group.addTask { throw ErrorFirst(latch: latch) }
+        group.addTask { throw ErrorFirst(latch: latch) }
+
+        group.addTask { throw ErrorSecond(latch: latch) }
+        group.addTask { throw ErrorSecond(latch: latch) }
+        group.addTask { throw ErrorSecond(latch: latch) }
 
         return 12
       }
@@ -73,5 +122,12 @@ func shouldStartWith(_ lhs: Any, _ rhs: Any) {
     }
     // CHECK: deinit main.Error
     // CHECK: deinit main.Error
+    // CHECK: deinit main.Error
+
+    // CHECK: deinit main.Error
+    // CHECK: deinit main.Error
+    // CHECK: deinit main.Error
+    await latch.wait()
+    print("done") // CHECK: done
   }
 }


### PR DESCRIPTION
Similar to https://github.com/apple/swift/pull/67392 / rdar://110474311 we believe this type of failure: 

```
Input was:
<<<<<<
          1: deinit main.ErrorFirst 
check:72                      X~~~~~ error: no match found
>>>>>>
```

to be caused by the process exiting before the deinits complete running. We add a latch to make sure the deinits got to run before we exit the app

---

Resolves rdar://110025115 and re-enables `Concurrency/Runtime/async_taskgroup_discarding.swift`