### PR TITLE
[Variadic Generics] abstract tuple of Sendable elements does not conform to Sendable

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1922,7 +1922,7 @@ LookupConformanceInModuleRequest::evaluate(
     Evaluator &evaluator, LookupConformanceDescriptor desc) const {
   auto *mod = desc.Mod;
   auto type = desc.Ty;
-  auto protocol = desc.PD;
+  auto *protocol = desc.PD;
   ASTContext &ctx = mod->getASTContext();
 
   // A dynamic Self type conforms to whatever its underlying type
@@ -2009,9 +2009,10 @@ LookupConformanceInModuleRequest::evaluate(
     return getBuiltinBuiltinTypeConformance(type, builtinType, protocol);
   }
 
-  // Specific handling of Copyable for pack expansions.
+  // Specific handling of Copyable and Sendable for pack expansions.
   if (auto packExpansion = type->getAs<PackExpansionType>()) {
-    if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
+    if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable) ||
+        protocol->isSpecificProtocol(KnownProtocolKind::Sendable)) {
       auto patternType = packExpansion->getPatternType();
       return (patternType->isTypeParameter()
                ? ProtocolConformanceRef(protocol)

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -362,10 +362,6 @@ void LookupInModuleRequest::writeDependencySink(
   }
 }
 
-//----------------------------------------------------------------------------//
-// LookupConformanceInModuleRequest computation.
-//----------------------------------------------------------------------------//
-
 void swift::simple_display(llvm::raw_ostream &out,
                            const LookupConformanceDescriptor &desc) {
   out << "looking up conformance to ";
@@ -375,6 +371,10 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << " in ";
   simple_display(out, desc.Mod);
 }
+
+//----------------------------------------------------------------------------//
+// AnyObjectLookupRequest computation.
+//----------------------------------------------------------------------------//
 
 void AnyObjectLookupRequest::writeDependencySink(
     evaluator::DependencyCollector &reqTracker,

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -56,3 +56,12 @@ do {
     return Test<String, Int, repeat each T>("a", 42, repeat each v) // Ok
   }
 }
+// rdar://107479662 - variadic tuple of Sendable elements does not conform to Sendable
+do {
+  struct Test<each T> : Sendable {
+    let prop: (repeat TestProperty<each T>)
+  }
+
+  struct TestProperty<T> : Sendable {
+  }
+}


### PR DESCRIPTION
* **Explanation**: Solves the failure to type check that a stored property of a Sendable struct which is an abstract tuple of Sendable pack elements itself conforms to Sendable.
* **Scope**: Only impacts variadic generics.
* **Issue**: rdar://107479662
* **Risk**: Low.
* **Testing**: Added a new test case with code that previously emitted an error when type checking Sendable conformance.
* **Reviewer**: @kavon @slavapestov
* **Main branch PR**: https://github.com/apple/swift/pull/67407