### PR TITLE
[WIP] Raw storage and locks/atomics prototype

### DIFF
--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -49,6 +49,9 @@ ERROR(alignment_less_than_natural,none,
 ERROR(alignment_more_than_maximum,none,
       "@_alignment cannot increase alignment above maximum alignment of %0",
       (unsigned))
+      
+ERROR(raw_layout_dynamic_type_layout_unsupported,none,
+      "@_rawLayout is not yet supported for layouts dependent on generic types", ())
 
 ERROR(temporary_allocation_size_negative,none,
       "allocation capacity must be greater than or equal to zero", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1846,6 +1846,17 @@ ERROR(documentation_attr_metadata_expected_text,none,
 ERROR(documentation_attr_duplicate_metadata,none,
       "cannot give more than one metadata argument to the same item", ())
 
+ERROR(attr_rawlayout_expected_label,none,
+      "expected %0 argument to @_rawLayout attribute", (StringRef))
+ERROR(attr_rawlayout_expected_integer_size,none,
+      "expected integer literal size in @_rawLayout attribute", ())
+ERROR(attr_rawlayout_expected_integer_alignment,none,
+      "expected integer literal alignment in @_rawLayout attribute", ())
+ERROR(attr_rawlayout_expected_integer_count,none,
+      "expected integer literal count in @_rawLayout attribute", ())
+ERROR(attr_rawlayout_expected_params,none,
+      "expected %1 argument after %0 argument in @_rawLayout attribute", (StringRef, StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3811,6 +3811,15 @@ ERROR(attr_MainType_without_main,none,
 #undef SELECT_APPLICATION_MAIN
 #undef SELECT_APPLICATION_DELEGATE
 
+ERROR(attr_rawlayout_experimental,none,
+      "the @_rawLayout attribute is experimental", ())
+ERROR(attr_rawlayout_cannot_be_copyable,none,
+      "type with @_rawLayout cannot be copied and must be declared ~Copyable", ())
+ERROR(attr_rawlayout_cannot_have_stored_properties,none,
+      "type with @_rawLayout cannot have stored properties", ())
+ERROR(attr_rawlayout_cannot_have_alignment_attr,none,
+      "type with @_rawLayout cannot also have an @_alignment attribute", ())
+      
 // lazy
 ERROR(lazy_not_on_let,none,
       "'lazy' cannot be used on a let", ())
@@ -5342,6 +5351,8 @@ ERROR(concurrent_value_inherit,none,
       (bool, DeclName))
 ERROR(non_sendable_type,none,
       "type %0 does not conform to the 'Sendable' protocol", (Type))
+ERROR(sendable_raw_storage,none,
+      "struct %0 with @_rawLayout does not conform to the 'Sendable' protocol", (DeclName))
 
 WARNING(unchecked_conformance_not_special,none,
       "@unchecked conformance to %0 has no meaning", (Type))

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -224,6 +224,9 @@ EXPERIMENTAL_FEATURE(DeferredSendableChecking, false)
 /// "playground transform" is enabled.
 EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)
 
+/// Enable the `@_rawLayout` attribute.
+EXPERIMENTAL_FEATURE(RawLayout, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3439,6 +3439,10 @@ static bool usesFeatureBuiltinModule(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureRawLayout(Decl *decl) {
+  return decl->getAttrs().hasAttribute<RawLayoutAttr>();
+}
+
 static bool hasParameterPacks(Decl *decl) {
   if (auto genericContext = decl->getAsGenericContext()) {
     auto sig = genericContext->getGenericSignature();

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1462,6 +1462,28 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     Printer << ")";
     break;
   }
+  
+  case DAK_RawLayout: {
+    auto *attr = cast<RawLayoutAttr>(this);
+    Printer.printAttrName("@_rawLayout");
+    Printer << "(";
+    
+    if (auto sizeAndAlign = attr->getSizeAndAlignment()) {
+      Printer << "size: " << sizeAndAlign->first
+              << ", alignment: " << sizeAndAlign->second;
+    } else if (auto type = attr->getScalarLikeType()) {
+      Printer << "like: ";
+      type->print(Printer, Options);
+    } else if (auto array = attr->getArrayLikeTypeAndCount()) {
+      Printer << "likeArrayOf: ";
+      array->first->print(Printer, Options);
+      Printer << ", count: " << array->second;
+    } else {
+      llvm_unreachable("unhandled @_rawLayout form");
+    }
+    Printer << ")";
+    break;
+  }
 
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
@@ -1653,6 +1675,8 @@ StringRef DeclAttribute::getAttrName() const {
     case MacroSyntax::Attached:
       return "attached";
     }
+  case DAK_RawLayout:
+    return "_rawLayout";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -37,11 +37,12 @@ DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *FragmentStorageTy,
   assert(Align.getValue() != 0);
 }
 
-/// Determine whether this type has a custom @_alignment attribute.
+/// Determine whether this type has an attribute specifying a custom alignment.
 static bool hasDefaultAlignment(swift::Type Ty) {
   if (auto CanTy = Ty->getCanonicalType())
     if (auto *TyDecl = CanTy.getNominalOrBoundGenericNominal())
-      if (TyDecl->getAttrs().getAttribute<AlignmentAttr>())
+      if (TyDecl->getAttrs().getAttribute<AlignmentAttr>()
+          || TyDecl->getAttrs().getAttribute<RawLayoutAttr>())
         return false;
   return true;
 }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1674,13 +1674,15 @@ void IRGenModule::emitFieldDescriptor(const NominalTypeDecl *D) {
       needsFieldDescriptor = false;
   }
 
-  // If the type has custom @_alignment, emit a fixed record with the
-  // alignment since remote mirrors will need to treat the type as opaque.
+  // If the type has custom @_alignment, @_rawLayout, or other manual layout
+  // attributes, emit a fixed record with the size and alignment since the
+  // remote mirrors will need to treat the type as opaque.
   //
   // Note that we go on to also emit a field descriptor in this case,
   // since in-process reflection only cares about the types of the fields
   // and does not independently re-derive the layout.
-  if (D->getAttrs().hasAttribute<AlignmentAttr>()) {
+  if (D->getAttrs().hasAttribute<AlignmentAttr>()
+      || D->getAttrs().hasAttribute<RawLayoutAttr>()) {
     auto &TI = getTypeInfoForUnlowered(T);
     if (isa<FixedTypeInfo>(TI)) {
       needsOpaqueDescriptor = true;

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2831,9 +2831,10 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
         || structDecl->hasClangNode())
       return SILType();
 
-    // A single-field struct with custom alignment has different layout from its
+    // A single-field struct with custom layout has different layout from its
     // field.
-    if (structDecl->getAttrs().hasAttribute<AlignmentAttr>())
+    if (structDecl->getAttrs().hasAttribute<AlignmentAttr>()
+        || structDecl->getAttrs().hasAttribute<RawLayoutAttr>())
       return SILType();
 
     // If there's only one stored property, we have the layout of its field.

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2360,6 +2360,14 @@ namespace {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
       }
+      
+      // If the type has raw storage, it is move-only and address-only.
+      if (D->getAttrs().hasAttribute<RawLayoutAttr>()) {
+        properties.setAddressOnly();
+        properties.setNonTrivial();
+        properties.setLexical(IsLexical);
+        return handleMoveOnlyAddressOnly(structType, properties);
+      }
 
       auto subMap = structType->getContextSubstitutionMap(&TC.M, D);
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -722,8 +722,9 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
     // DISCUSSION: This only happens with noncopyable types since the memory
     // lifetime checker doesn't seem to process trivial locations. But empty
     // move only structs are non-trivial, so we need to handle this here.
-    if (isa<StructDecl>(nominal) && nominal->isMoveOnly() &&
-        nominal->getStoredProperties().empty()) {
+    if (isa<StructDecl>(nominal) && nominal->isMoveOnly()
+        && !nominal->getAttrs().hasAttribute<RawLayoutAttr>()
+        && nominal->getStoredProperties().empty()) {
       auto *si = B.createStruct(ctor, lowering.getLoweredType(), {});
       B.emitStoreValueOperation(ctor, si, selfLV.getLValueAddress(),
                                 StoreOwnershipQualifier::Init);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1932,14 +1932,16 @@ TypeVariableType *ConstraintSystem::openGenericParameter(
   // This lookup only can fail if the stdlib (i.e. the Swift module) has not
   // been loaded because you've passed `-parse-stdlib` and are not building the
   // stdlib itself (which would have `-module-name Swift` too).
-  if (auto *copyable = TypeChecker::getProtocol(getASTContext(), SourceLoc(),
-                                                KnownProtocolKind::Copyable)) {
-    addConstraint(
-        ConstraintKind::ConformsTo, typeVar,
-        copyable->getDeclaredInterfaceType(),
-        locator.withPathElement(LocatorPathElt::GenericParameter(parameter)));
+  if (!outerDC->getParentModule()->isBuiltinModule()) {
+    if (auto *copyable = TypeChecker::getProtocol(getASTContext(), SourceLoc(),
+                                                  KnownProtocolKind::Copyable)) {
+      addConstraint(
+          ConstraintKind::ConformsTo, typeVar,
+          copyable->getDeclaredInterfaceType(),
+          locator.withPathElement(LocatorPathElt::GenericParameter(parameter)));
+    }
   }
-
+  
   return typeVar;
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1534,6 +1534,7 @@ namespace  {
     UNINTERESTING_ATTR(Optional)
     UNINTERESTING_ATTR(Override)
     UNINTERESTING_ATTR(RawDocComment)
+    UNINTERESTING_ATTR(RawLayout)
     UNINTERESTING_ATTR(Required)
     UNINTERESTING_ATTR(Convenience)
     UNINTERESTING_ATTR(Semantics)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2061,6 +2061,14 @@ namespace decls_block {
     BCVBR<8>    // alignment
   >;
   
+  using RawLayoutDeclAttrLayout = BCRecordLayout<
+    RawLayout_DECL_ATTR,
+    BCFixed<1>, // implicit
+    TypeIDField, // like type
+    BCVBR<32>, // size
+    BCVBR<8> // alignment
+  >;
+  
   using SwiftNativeObjCRuntimeBaseDeclAttrLayout = BCRecordLayout<
     SwiftNativeObjCRuntimeBase_DECL_ATTR,
     BCFixed<1>, // implicit flag

--- a/test/DebugInfo/raw_layout.swift
+++ b/test/DebugInfo/raw_layout.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend %s -enable-experimental-feature RawLayout -emit-ir -g -o - | %FileCheck %s
+
+@_rawLayout(size: 12, alignment: 4)
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "S8_4"
+// CHECK-SAME:             size: 96,
+// CHECK-SAME:             align: 32,
+struct S8_4: ~Copyable {}
+
+var s = S8_4()

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -1,0 +1,94 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/chex.py < %s > %t/raw_layout.sil
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir %t/raw_layout.sil | %FileCheck %t/raw_layout.sil
+
+import Swift
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}4LockVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 4
+// stride
+// CHECK-SAME:  , {{i64|i32}} 4
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+
+@_rawLayout(size: 4, alignment: 4)
+struct Lock: ~Copyable { }
+
+struct PaddedStride {
+    var x: Int32
+    var y: Int8
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}16LikePaddedStrideVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 5
+// stride
+// CHECK-SAME:  , {{i64|i32}} 8
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+@_rawLayout(like: PaddedStride)
+struct LikePaddedStride: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}22LikePaddedStrideArray1VWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 8
+// stride
+// CHECK-SAME:  , {{i64|i32}} 8
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+@_rawLayout(likeArrayOf: PaddedStride, count: 1)
+struct LikePaddedStrideArray1: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}22LikePaddedStrideArray2VWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 16
+// stride
+// CHECK-SAME:  , {{i64|i32}} 16
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+@_rawLayout(likeArrayOf: PaddedStride, count: 2)
+struct LikePaddedStrideArray2: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}9KeymasterVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 12
+// stride
+// CHECK-SAME:  , {{i64|i32}} 12
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+struct Keymaster: ~Copyable {
+    let lock1: Lock
+    let lock2: Lock
+    let lock3: Lock
+}
+
+/*
+TODO: Dependent layout not yet implemented
+
+@_rawLayout(like: T)
+struct Cell<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 1)
+struct PaddedCell<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 8)
+struct SmallVectorBuf<T>: ~Copyable {}
+*/
+
+sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
+entry(%L: $*Lock):
+    return undef : $()
+}
+
+sil @use_keymaster_locks : $@convention(thin) (@in_guaranteed Keymaster) -> () {
+entry(%K: $*Keymaster):
+    %f = function_ref @use_lock : $@convention(thin) (@in_guaranteed Lock) -> ()
+    %a = struct_element_addr %K : $*Keymaster, #Keymaster.lock1
+    apply %f(%a) : $@convention(thin) (@in_guaranteed Lock) -> ()
+    %b = struct_element_addr %K : $*Keymaster, #Keymaster.lock2
+    apply %f(%b) : $@convention(thin) (@in_guaranteed Lock) -> ()
+    %c = struct_element_addr %K : $*Keymaster, #Keymaster.lock2
+    apply %f(%c) : $@convention(thin) (@in_guaranteed Lock) -> ()
+    return undef : $()
+}

--- a/test/Prototypes/UnfairLock.swift
+++ b/test/Prototypes/UnfairLock.swift
@@ -1,0 +1,120 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -enable-experimental-feature RawLayout -enable-experimental-feature BuiltinModule %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+
+import Builtin
+import Darwin
+
+@_rawLayout(like: os_unfair_lock_s)
+struct UnfairLock: ~Copyable, @unchecked Sendable {
+    // TODO: Clang importer can't handle the OS_UNFAIR_LOCK_INIT macro definition
+    private static let OS_UNFAIR_LOCK_INIT = os_unfair_lock_s()
+
+    // The lock is at a stable address as long as someone is borrowing it.
+    // If the address is gotten, it should only be used within the scope
+    // of a borrowing method.
+    @inline(__always)
+    private var _address: os_unfair_lock_t {
+        os_unfair_lock_t(Builtin.addressOfBorrow(self))
+    }
+
+    @inline(__always)
+    init() {
+        _address.initialize(to: UnfairLock.OS_UNFAIR_LOCK_INIT)
+    }
+
+    @inline(__always)
+    borrowing func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        let address = _address
+        os_unfair_lock_lock(address)
+        defer { os_unfair_lock_unlock(address) }
+
+        return try body()
+    }
+}
+
+final class Locked<T>: @unchecked Sendable {
+    private let lock = UnfairLock()
+
+    // Don't need exclusivity checking since accesses always go through the
+    // lock
+    @exclusivity(unchecked)
+    private var value: T
+
+    init(initialValue: T) {
+        self.value = consume initialValue
+    }
+
+    func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
+        return try lock.withLock { try body(&value) }
+    }
+}
+
+let myString = Locked(initialValue: "")
+
+@Sendable
+func thread1(_: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
+    usleep(1)
+    myString.withLock { $0 += "apple\n" }
+    usleep(1)
+    myString.withLock { $0 += "banana\n" }
+    usleep(1)
+    myString.withLock { $0 += "grapefruit\n" }
+    return nil
+}
+
+@Sendable
+func thread2(_: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
+    usleep(1)
+    myString.withLock { $0 += "BRUSSELS SPROUTS\n" }
+    usleep(1)
+    myString.withLock { $0 += "CAULIFLOWER\n" }
+    usleep(1)
+    myString.withLock { $0 += "BROCCOLI\n" }
+    return nil
+}
+
+@Sendable
+func thread3(_: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
+    usleep(1)
+    myString.withLock { $0 += "Croissant\n" }
+    usleep(1)
+    myString.withLock { $0 += "Boule\n" }
+    usleep(1)
+    myString.withLock { $0 += "Batard\n" }
+    return nil
+}
+
+func createPthread(
+    _ body: @Sendable @convention(c) (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer?
+) -> pthread_t? {
+    var thread: pthread_t? = nil
+    let r = pthread_create(&thread, nil, body, nil)
+    if r != 0 {
+        return nil
+    }
+    return thread
+}
+
+var t1 = createPthread(thread1)!
+var t2 = createPthread(thread2)!
+var t3 = createPthread(thread3)!
+
+pthread_join(t1, nil)
+pthread_join(t2, nil)
+pthread_join(t3, nil)
+
+// CHECK-DAG: apple
+// CHECK-DAG: banana
+// CHECK-DAG: grapefruit
+// CHECK-DAG: BRUSSELS SPROUTS
+// CHECK-DAG: CAULIFLOWER
+// CHECK-DAG: BROCCOLI
+// CHECK-DAG: Croissant
+// CHECK-DAG: Boule
+// CHECK-DAG: Batard
+myString.withLock { print($0) }

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout %s | %FileCheck %s
+
+// CHECK: @_rawLayout(size: 4, alignment: 4) @_moveOnly struct Lock
+// CHECK: @_rawLayout(like: T) @_moveOnly struct Cell<T>
+// CHECK: @_rawLayout(likeArrayOf: T, count: 8) @_moveOnly struct SmallVectorBuf<T>
+
+@_rawLayout(size: 4, alignment: 4)
+struct Lock: ~Copyable {
+    // Raw layout type should be lowered as address only
+    // CHECK-LABEL: sil {{.*}} @{{.*}}4Lock{{.*}}3foo{{.*}} : $@convention(method) (@in_guaranteed Lock) -> ()
+    borrowing func foo() {}
+
+    // CHECK-LABEL: sil {{.*}} @{{.*}}4Lock{{.*}}3bar{{.*}} : $@convention(method) (@inout Lock) -> ()
+    mutating func bar() {}
+
+    // CHECK-LABEL: sil {{.*}} @{{.*}}4Lock{{.*}}3bas{{.*}} : $@convention(method) (@in Lock) -> ()
+    consuming func bas() {}
+
+    deinit {}
+}
+
+@_rawLayout(like: T)
+struct Cell<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 8)
+struct SmallVectorBuf<T>: ~Copyable {}

--- a/test/Sema/raw_layout.swift
+++ b/test/Sema/raw_layout.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -typecheck -verify %s
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{type with @_rawLayout cannot be copied and must be declared ~Copyable}}
+struct ImproperlyCopyable {}
+
+@_rawLayout(size: 4, alignment: 3) // expected-error{{alignment value must be a power of two}}
+struct InvalidAlignment: ~Copyable {}
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{type with @_rawLayout cannot have stored properties}}
+struct HasStoredProperty: ~Copyable { var x: Int }
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{type with @_rawLayout cannot have stored properties}}
+struct HasLazyStoredProperty: ~Copyable { lazy var x: Int = 42 }
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{type with @_rawLayout cannot have stored properties}}
+struct HasObservedStoredProperty: ~Copyable { var x: Int { didSet { } } }
+
+@propertyWrapper
+struct Wrapper<T> {
+    var wrappedValue: T { fatalError() }
+}
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{type with @_rawLayout cannot have stored properties}}
+struct HasWrappedStoredProperty: ~Copyable { @Wrapper var x: Int }
+
+@_rawLayout(like: T) // expected-error{{cannot find type 'T' in scope}}
+struct TypeDoesntExist<A>: ~Copyable {}
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+enum EnumWithRawLayout: ~Copyable {}
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+class ClassWithRawLayout {}
+
+@_rawLayout(size: 4, alignment: 4)
+struct Lock: ~Copyable {}
+
+@_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+typealias TypealiasWithRawLayout = Lock
+
+struct Butt {
+    @_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+    var propertyWithStoredLayout: ()
+}
+
+@_rawLayout(size: 4, alignment: 4) @_alignment(16) // expected-error{{type with @_rawLayout cannot also have an @_alignment attribute}}
+struct RawLayoutAndAlignment: ~Copyable {}
+

--- a/test/Sema/raw_layout_correct.swift
+++ b/test/Sema/raw_layout_correct.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -typecheck -verify %s
+
+@_rawLayout(like: T)
+struct RawStorage<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 4)
+struct RawSmallArray<T>: ~Copyable {}
+
+@_rawLayout(size: 4, alignment: 4)
+struct Lock: ~Copyable {}

--- a/test/Sema/raw_layout_parse.swift
+++ b/test/Sema/raw_layout_parse.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -parse -verify %s
+
+@_rawLayout(size: 4, alignment: 4)
+struct Lock: ~Copyable {}
+
+@_rawLayout(like: Int)
+struct Lock2: ~Copyable {}
+
+@_rawLayout(like: Optional<Int>)
+struct Lock3: ~Copyable {}
+
+@_rawLayout(like: T)
+struct MyUnmanaged<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 8)
+struct SmallVectorBuf<T>: ~Copyable {}
+
+@_rawLayout // expected-error{{expected '('}}
+struct NoLayoutSpecified: ~Copyable {}
+
+@_rawLayout() // expected-error{{expected 'size', 'like', or 'likeArrayOf' argument to @_rawLayout attribute}}
+struct NoParamsSpecified: ~Copyable {}
+
+@_rawLayout(size: 4) // expected-error{{expected alignment argument after size argument in @_rawLayout attribute}}
+struct SizeWithoutAlignment: ~Copyable {}
+
+@_rawLayout(likeArrayOf: Optional<Int>) // expected-error{{expected count argument after likeArrayOf argument in @_rawLayout attribute}}
+struct ArrayWithoutSize: ~Copyable {}
+

--- a/test/Sema/raw_layout_sendable.swift
+++ b/test/Sema/raw_layout_sendable.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -enable-experimental-feature StrictConcurrency -enable-experimental-feature RawLayout -typecheck -verify %s
+
+func checkSendable(_: @Sendable () -> ()) {}
+
+@_rawLayout(size: 4, alignment: 4)
+struct NotAutomaticallySendableAndNotUsedAsSendable: ~Copyable {}
+
+@_rawLayout(size: 4, alignment: 4)
+struct NotAutomaticallySendable: ~Copyable {} // expected-note{{}}
+
+func testNotAutomaticallySendable() {
+    let s = NotAutomaticallySendable()
+
+    checkSendable { _ = s } // expected-warning{{capture of 's' with non-sendable type 'NotAutomaticallySendable'}}
+}
+
+@_rawLayout(size: 4, alignment: 4)
+struct UnuncheckedSendable: ~Copyable, Sendable {} // expected-warning{{@_rawLayout does not conform to the 'Sendable' protocol}}
+
+func testUnuncheckedSendable() {
+    let s = UnuncheckedSendable()
+
+    checkSendable { _ = s }
+}
+
+@_rawLayout(size: 4, alignment: 4)
+struct UncheckedSendable: ~Copyable, @unchecked Sendable {}
+
+func testUncheckedSendable() {
+    let s = UncheckedSendable()
+
+    checkSendable { _ = s }
+}
+

--- a/test/Serialization/attr-rawlayout.swift
+++ b/test/Serialization/attr-rawlayout.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
+// RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
+
+// BC-CHECK: <RawLayout_DECL_ATTR 
+
+// MODULE-CHECK: @_rawLayout(size: 5, alignment: 4) struct A_ExplicitSizeAlign
+@_rawLayout(size: 5, alignment: 4)
+struct A_ExplicitSizeAlign: ~Copyable {}
+
+// MODULE-CHECK: @_rawLayout(like: T) struct B_Cell
+@_rawLayout(like: T)
+struct B_Cell<T>: ~Copyable {}
+
+// MODULE-CHECK: @_rawLayout(likeArrayOf: T, count: 8) struct C_SmallVector
+@_rawLayout(likeArrayOf: T, count: 8)
+struct C_SmallVector<T>: ~Copyable {}

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -741,6 +741,12 @@ DECL_ATTR_KINDS = [
                   APIBreakingToAdd, APIBreakingToRemove,
                   code=144),
 
+    DeclAttribute('_rawLayout', 'RawLayout',
+                  OnStruct,
+                  UserInaccessible,
+                  ABIBreakingToAdd, ABIBreakingToRemove,
+                  APIStableToAdd, APIStableToRemove,
+                  code=146)
 ]
 
 # Schema for declaration modifiers:


### PR DESCRIPTION
Strawman implementation of a `@_rawLayout` attribute that gives a noncopyable struct a layout consisting of inline raw memory it can mostly do as it pleases with. As a proof of concept, show how this can be used to implement a safe wrapper over `os_unfair_lock` that can be stored inline within a class or other move-only type without an additional allocation.