### PR TITLE
[Linux][Backtracing] Fix a couple of backtracer issues.

### DIFF
--- a/stdlib/public/Backtracing/Elf.swift
+++ b/stdlib/public/Backtracing/Elf.swift
@@ -1680,7 +1680,11 @@ class ElfImage<SomeImageSource: ImageSource,
           done = true
         }
 
-        prevState = state
+        if state.endSequence {
+          prevState = nil
+        } else {
+          prevState = state
+        }
       }
     }
 


### PR DESCRIPTION
Fix the `FramePointerUnwinder` so it always returns `nil` after the it first stops iteration.

Fix line number processing so that we don't erroneously match regions between the end of one sequence and the start of the next.

rdar://112534548, rdar://112595022