### PR TITLE
SwiftCompilerSources: fix a compiler error when building with hosttools

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -78,7 +78,7 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
     let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.bytes_begin(),
                                             count: count)
 #else
-    let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.bytes_begin(),
+    let buffer = UnsafeBufferPointer<UInt8>(start: _bridged.__bytes_beginUnsafe(),
                                             count: count)
 #endif
     return buffer[index]


### PR DESCRIPTION
Fixes a simple copy-paste error, introduced in https://github.com/apple/swift/pull/67296
