### PR TITLE
[5.9][Type Resolution] Only allow `each` applied directly to a type parameter pack.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -767,6 +767,10 @@ public:
   /// include type parameters in nested positions e.g. \c X<T...>.
   bool isParameterPack();
 
+  /// Determine whether this type is directly a type parameter pack, which
+  /// can only be a GenericTypeParamType.
+  bool isRootParameterPack();
+
   /// Determine whether this type can dynamically be an optional type.
   ///
   /// \param includeExistential Whether an existential type should be considered

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -191,6 +191,12 @@ bool TypeBase::isParameterPack() {
   while (auto *memberTy = t->getAs<DependentMemberType>())
     t = memberTy->getBase();
 
+  return t->isRootParameterPack();
+}
+
+bool TypeBase::isRootParameterPack() {
+  Type t(this);
+
   return t->is<GenericTypeParamType>() &&
          t->castTo<GenericTypeParamType>()->isParameterPack();
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4672,7 +4672,7 @@ NeverNullType TypeResolver::resolvePackElement(PackElementTypeRepr *repr,
   if (packReference->hasError())
     return ErrorType::get(ctx);
 
-  if (!packReference->isParameterPack()) {
+  if (!packReference->isRootParameterPack()) {
     auto diag =
         ctx.Diags.diagnose(repr->getLoc(), diag::each_non_pack, packReference);
     if (auto *packIdent = dyn_cast<IdentTypeRepr>(repr->getPackType())) {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -58,7 +58,7 @@ extension P {
 
 
 func outerArchetype<each T, U>(t: repeat each T, u: U) where repeat each T: P {
-  let _: (repeat (each T.A, U)) = (repeat ((each t).value, u))
+  let _: (repeat ((each T).A, U)) = (repeat ((each t).value, u))
 }
 
 func sameElement<each T, U>(t: repeat each T, u: U) where repeat each T: P, repeat each T == U {
@@ -476,11 +476,11 @@ do {
 
 // rdar://107675464 - misplaced `each` results in `type of expression is ambiguous without a type annotation`
 do {
-  func test_correct_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
+  func test_correct_each<each T: P>(_ value: repeat each T) -> (repeat (each T).A) {
     return (repeat (each value).makeA()) // Ok
   }
 
-  func test_misplaced_each<each T: P>(_ value: repeat each T) -> (repeat each T.A) {
+  func test_misplaced_each<each T: P>(_ value: repeat each T) -> (repeat (each T).A) {
     return (repeat each value.makeA())
     // expected-error@-1 {{value pack 'each T' must be referenced with 'each'}} {{25-25=(each }} {{30-30=)}}
   }

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -12,7 +12,7 @@ func inferSameShape<each T, each U>(ts t: repeat each T, us u: repeat each U) wh
 // CHECK-LABEL: desugarSameShape(ts:us:)
 // CHECK-NEXT: Generic signature: <each T, each U where repeat each T : P, (repeat (each T, each U)) : Any, repeat each U : P>
 func desugarSameShape<each T, each U>(ts t: repeat each T, us u: repeat each U)
-  where repeat each T: P, repeat each U: P, (repeat (each T.A, each U.A)): Any {}
+  where repeat each T: P, repeat each U: P, (repeat ((each T).A, (each U).A)): Any {}
 
 // CHECK-LABEL: multipleSameShape1(ts:us:vs:)
 // CHECK-NEXT: Generic signature: <each T, each U, each V where (repeat (each T, each U)) : Any, (repeat (each U, each V)) : Any>
@@ -75,11 +75,11 @@ func expandedParameters<each T, each Result>(_ t: repeat each T, transform: repe
 
 // CHECK-LABEL: sameType1
 // CHECK-NEXT: Generic signature: <each T, each U where repeat each T : P, repeat each U : P, repeat (each T).[P]A == (each U).[P]A>
-func sameType1<each T, each U>(_: repeat (each T, each U)) where repeat each T: P, repeat each U: P, repeat each T.A == each U.A {}
+func sameType1<each T, each U>(_: repeat (each T, each U)) where repeat each T: P, repeat each U: P, repeat (each T).A == (each U).A {}
 
 // Make sure inherited associated types are handled
 protocol Q: P where A: Q {}
 
 // CHECK-LABEL: sameType2
 // CHECK-NEXT: Generic signature: <each T, each U where repeat each T : Q, repeat each U : Q, repeat (each T).[P]A.[P]A == (each U).[P]A.[P]A>
-func sameType2<each T, each U>(_: repeat (each T, each U)) where repeat each T: Q, repeat each U: Q, repeat each T.A.A == each U.A.A {}
+func sameType2<each T, each U>(_: repeat (each T, each U)) where repeat each T: Q, repeat each U: Q, repeat (each T).A.A == (each U).A.A {}

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -12,7 +12,7 @@ protocol P {
 }
 
 extension Builtin.TheTupleType: P where repeat each Elements: P {
-  typealias A = (repeat each Elements.A)
+  typealias A = (repeat (each Elements).A)
   typealias B = Float
   func f() {}
 }

--- a/test/Generics/variadic_generic_requirements.swift
+++ b/test/Generics/variadic_generic_requirements.swift
@@ -20,7 +20,7 @@ _ = Layout<Class, Subclass>.self  // ok
 _ = Layout<Int, String>.self  // expected-error {{'Layout' requires that 'Int' be a class type}}
 
 struct Outer<each T: Sequence> {
-  struct Inner<each U: Sequence> where repeat each T.Element == each U.Element {}
+  struct Inner<each U: Sequence> where repeat (each T).Element == (each U).Element {}
   // expected-note@-1 {{requirement specified as '(each T).Element' == '(each U).Element' [with each T = Array<Int>, Array<String>; each U = Set<String>, Set<Int>]}}
   // expected-note@-2 {{requirement specified as '(each T).Element' == '(each U).Element' [with each T = Array<Int>; each U = Set<Int>, Set<String>]}}
 

--- a/test/IRGen/bind_element_archetype.swift
+++ b/test/IRGen/bind_element_archetype.swift
@@ -8,7 +8,7 @@ public protocol Q {
 
 public func f<T: P>(_: T) {}
 
-public func foo1<each T: Q>(t: repeat each T, u: repeat each T.A) {
+public func foo1<each T: Q>(t: repeat each T, u: repeat (each T).A) {
   repeat f(each u)
 }
 

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -626,10 +626,10 @@ entry(%intIndex : $Builtin.Word):
   return %t : $()
 }
 
-sil @unwrap_from_PA : $<each T_1 : PA where repeat each T_1.A : P> (Builtin.Word) -> () {
+sil @unwrap_from_PA : $<each T_1 : PA where repeat (each T_1).A : P> (Builtin.Word) -> () {
 entry(%intIndex : $Builtin.Word):
   %direct_access_from_parameter_with_conformance = function_ref @direct_access_from_parameter_with_conformance : $@convention(thin) <each T_1: P> (Builtin.Word) -> ()
-  apply %direct_access_from_parameter_with_conformance<Pack{repeat GenFwdP<each T_1.A>}>(%intIndex) : $@convention(thin) <each T_1: P> (Builtin.Word) -> ()
+  apply %direct_access_from_parameter_with_conformance<Pack{repeat GenFwdP<(each T_1).A>}>(%intIndex) : $@convention(thin) <each T_1: P> (Builtin.Word) -> ()
   %t = tuple ()
   return %t : $()
 }
@@ -637,7 +637,7 @@ entry(%intIndex : $Builtin.Word):
 sil @extract_associatedtype_with_conformance : $<each T_1 : P> (Builtin.Word) -> () {
 entry(%intIndex : $Builtin.Word):
   %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat each T_1}
-  %token = open_pack_element %innerIndex of <each U_1 : PA where repeat each U_1.A : P> at <Pack{repeat GenAssocPA<GenFwdP<each T_1>>}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000005"
+  %token = open_pack_element %innerIndex of <each U_1 : PA where repeat (each U_1).A : P> at <Pack{repeat GenAssocPA<GenFwdP<each T_1>>}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000005"
   %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000005") U_1).Type
   %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
   apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000005") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
@@ -653,7 +653,7 @@ sil @extract_associatedtype_with_conformance2 : $<each T_1 : P, Tee : P, each T_
 entry(%intIndex : $Builtin.Word):
   %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>, repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>}
   %token = open_pack_element %innerIndex 
-    of <each U_1 : PA, Ewe : PA, each U_2 : PA where repeat each U_1.A : PA, repeat each U_1.A.A : PA, repeat each U_1.A.A.A : P, Ewe.A : PA, Ewe.A.A : PA, Ewe.A.A.A : P, repeat each U_2.A : PA, repeat each U_2.A.A : PA, repeat each U_2.A.A.A : P, (repeat (each U_1, each U_2)): Any> 
+    of <each U_1 : PA, Ewe : PA, each U_2 : PA where repeat (each U_1).A : PA, repeat (each U_1).A.A : PA, repeat (each U_1).A.A.A : P, Ewe.A : PA, Ewe.A.A : PA, Ewe.A.A.A : P, repeat (each U_2).A : PA, repeat (each U_2).A.A : PA, repeat (each U_2).A.A.A : P, (repeat (each U_1, each U_2)): Any> 
     at <
         Pack{repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>, repeat GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<each T_1>>>>}, 
         GenAssocPA<GenAssocPA<GenAssocPA<GenFwdP<Tee>>>>, 

--- a/test/IRGen/variadic_generic_captures.swift
+++ b/test/IRGen/variadic_generic_captures.swift
@@ -80,6 +80,6 @@ public func has_witness_table_pack<each T: Sequence>(t: repeat each T) -> () -> 
 }
 
 public func has_witness_table_pack2<each T: Sequence>(t: repeat each T) -> () -> ()
-    where repeat each T.Element: Sequence {
+    where repeat (each T).Element: Sequence {
   return { _ = (repeat (each T).Element.Element).self }
 }

--- a/test/IRGen/variadic_generic_functions.sil
+++ b/test/IRGen/variadic_generic_functions.sil
@@ -73,14 +73,14 @@ sil @fc : $<each T : P> () -> () {}
 // CHECK-SAME:        i8*** %"each T.PA",
 // CHECK-SAME:        i8*** %"each T.A.P")
 // CHECK:         call swiftcc void @f1c([[INT]] %0, %swift.type** %"each T", i8*** %"each T.PA", i8*** %"each T.A.P")
-sil @f1 : $<each T : PA where repeat each T.A : P> () -> () {
-    %f1c = function_ref @f1c : $@convention(thin) <each T : PA where repeat each T.A : P> () -> ()
-    apply %f1c<Pack{repeat each T}>() : $@convention(thin) <each T : PA where repeat each T.A : P> () -> ()
+sil @f1 : $<each T : PA where repeat (each T).A : P> () -> () {
+    %f1c = function_ref @f1c : $@convention(thin) <each T : PA where repeat (each T).A : P> () -> ()
+    apply %f1c<Pack{repeat each T}>() : $@convention(thin) <each T : PA where repeat (each T).A : P> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
 
-sil @f1c : $<each T : PA where repeat each T.A : P> () -> () {}
+sil @f1c : $<each T : PA where repeat (each T).A : P> () -> () {}
 
 // Construct associatedtype metadata pack, forward root wtable pack.
 // CHECK-LABEL: define {{.*}}@associatedtype_with_added_conformance(
@@ -93,9 +93,9 @@ sil @f1c : $<each T : PA where repeat each T.A : P> () -> () {}
 // CHECK-SAME:        [[INT]] [[SHAPE]],
 // CHECK-SAME:        %swift.type** [[ASSOCIATEDTYPES]],
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q]])
-sil @associatedtype_with_added_conformance : $<each T : PA where repeat each T.A : Q> () -> () {
+sil @associatedtype_with_added_conformance : $<each T : PA where repeat (each T).A : Q> () -> () {
     %callee = function_ref @associatedtype_with_added_conformance_callee : $@convention(thin) <each T : Q> () -> ()
-    apply %callee<Pack{repeat each T.A}>() : $@convention(thin) <each T : Q> () -> ()
+    apply %callee<Pack{repeat (each T).A}>() : $@convention(thin) <each T : Q> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
@@ -113,9 +113,9 @@ sil @associatedtype_with_added_conformance_callee : $<each T : Q> () -> () {}
 // CHECK-SAME:        [[INT]] [[SHAPE]],
 // CHECK-SAME:        %swift.type** [[ASSOCIATEDTYPES]],
 // CHECK-SAME:        i8*** [[ASSOCIATEDTYPES_CONFORMANCES_TO_Q]])
-sil @associatedtype_with_added_conformance_2 : $<each T : PA where repeat each T.A : QA, repeat each T.A.A : R> () -> () {
+sil @associatedtype_with_added_conformance_2 : $<each T : PA where repeat (each T).A : QA, repeat (each T).A.A : R> () -> () {
     %j = function_ref @associatedtype_with_added_conformance_2_callee : $@convention(thin) <each T : R> () -> ()
-    apply %j<Pack{repeat each T.A.A}>() : $@convention(thin) <each T : R> () -> ()
+    apply %j<Pack{repeat (each T).A.A}>() : $@convention(thin) <each T : R> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
@@ -158,13 +158,13 @@ sil @associatedtype_with_forwarded_conformance_1_callee : $<each T : Q> () -> ()
 // CHECK-SAME:        i8*** [[GEN1_CONFORMANCES_TO_PA]],
 // CHECK-SAME:        i8*** %"each T.A.Q")
 // CHECK:         call void @llvm.stackrestore(i8* [[STORED_STACK_LOC]])
-sil @generictype_with_forwarded_conformance_2 : $<each T : PA where repeat each T.A : Q>() -> () {
-    %callee = function_ref @generictype_with_forwarded_conformance_2_callee : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
-    apply %callee<Pack{repeat Gen1<each T>}>() : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
+sil @generictype_with_forwarded_conformance_2 : $<each T : PA where repeat (each T).A : Q>() -> () {
+    %callee = function_ref @generictype_with_forwarded_conformance_2_callee : $@convention(thin) <each T : PA where repeat (each T).A : Q> () -> ()
+    apply %callee<Pack{repeat Gen1<each T>}>() : $@convention(thin) <each T : PA where repeat (each T).A : Q> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
-sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where repeat each T.A : Q> () -> () {}
+sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where repeat (each T).A : Q> () -> () {}
 
 // Construct a pack of generic types of generic types which "forward" conformance to a protocol with an associatedtype which itself conforms to a protocol.
 // CHECK-LABEL: define {{.*}}@generic_with_forwarded_conformance_3(
@@ -181,12 +181,12 @@ sil @generictype_with_forwarded_conformance_2_callee : $<each T : PA where repea
 // CHECK-SAME:        i8*** [[GEN1_GEN1_CONFORMANCES_TO_PA]],
 // CHECK-SAME:        i8*** %"each T.A.Q")
 // CHECK:         call void @llvm.stackrestore(i8* [[STORED_STACK_LOC]])
-sil @generic_with_forwarded_conformance_3 : $<each T : PA where repeat each T.A : Q> () -> () {
-    %callee = function_ref @generic_with_forwarded_conformance_3_callee : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
-    apply %callee<Pack{repeat Gen1<Gen1<each T>>}>() : $@convention(thin) <each T : PA where repeat each T.A : Q> () -> ()
+sil @generic_with_forwarded_conformance_3 : $<each T : PA where repeat (each T).A : Q> () -> () {
+    %callee = function_ref @generic_with_forwarded_conformance_3_callee : $@convention(thin) <each T : PA where repeat (each T).A : Q> () -> ()
+    apply %callee<Pack{repeat Gen1<Gen1<each T>>}>() : $@convention(thin) <each T : PA where repeat (each T).A : Q> () -> ()
     %ret = tuple ()
     return %ret : $()
 }
-sil @generic_with_forwarded_conformance_3_callee : $<each T : PA where repeat each T.A : Q> () -> () {
+sil @generic_with_forwarded_conformance_3_callee : $<each T : PA where repeat (each T).A : Q> () -> () {
 }
 

--- a/test/Interpreter/variadic_generic_conformances.swift
+++ b/test/Interpreter/variadic_generic_conformances.swift
@@ -56,29 +56,29 @@ extension Int: Q {}
 extension Bool: Q {}
 
 protocol HasPackRequirements {
-  func doStuff1<each T: Q>(_ value: repeat each T) -> (repeat each T.A)
-  func doStuff2<each T: Q>(_ value: repeat each T) -> (repeat each T.A)
+  func doStuff1<each T: Q>(_ value: repeat each T) -> (repeat (each T).A)
+  func doStuff2<each T: Q>(_ value: repeat each T) -> (repeat (each T).A)
 }
 
 extension HasPackRequirements {
-  func doStuff1<each T: Q>(_ value: repeat each T) -> (repeat each T.A) {
+  func doStuff1<each T: Q>(_ value: repeat each T) -> (repeat (each T).A) {
     return (repeat (each value).makeA())
   }
 }
 
 struct ConformsPackRequirements: HasPackRequirements {
-  func doStuff2<each T: Q>(_ value: repeat each T) -> (repeat each T.A) {
+  func doStuff2<each T: Q>(_ value: repeat each T) -> (repeat (each T).A) {
     return (repeat (each value).makeA())
   }
 }
 
 func testPackRequirements1<T: HasPackRequirements, each U: Q>(_ t: T, _ u: repeat each U)
-    -> (repeat each U.A) {
+    -> (repeat (each U).A) {
   return t.doStuff1(repeat each u)
 }
 
 func testPackRequirements2<T: HasPackRequirements, each U: Q>(_ t: T, _ u: repeat each U)
-    -> (repeat each U.A) {
+    -> (repeat (each U).A) {
   return t.doStuff2(repeat each u)
 }
 

--- a/test/Interpreter/variadic_generic_type_witnesses.swift
+++ b/test/Interpreter/variadic_generic_type_witnesses.swift
@@ -20,8 +20,8 @@ struct G<each T> {}
 
 struct TupleWitnesses<each T: Sequence>: P {
   typealias A = (Bool, repeat each T)
-  typealias B = (repeat each T.Element, x: Bool)
-  typealias C = (x: Bool, repeat H<each T.Element>)
+  typealias B = (repeat (each T).Element, x: Bool)
+  typealias C = (x: Bool, repeat H<(each T).Element>)
 }
 
 struct SingletonTupleWitnesses<each T>: P {
@@ -32,14 +32,14 @@ struct SingletonTupleWitnesses<each T>: P {
 
 struct FunctionWitnesses<each T: Sequence>: P {
   typealias A = (Bool, repeat each T) -> ()
-  typealias B = (repeat each T.Element, Bool) -> ()
-  typealias C = (Bool, repeat H<each T.Element>) -> ()
+  typealias B = (repeat (each T).Element, Bool) -> ()
+  typealias C = (Bool, repeat H<(each T).Element>) -> ()
 }
 
 struct NominalWitnesses<each T: Sequence>: P {
   typealias A = G<Bool, repeat each T>
-  typealias B = G<repeat each T.Element, Bool>
-  typealias C = G<Bool, repeat H<each T.Element>>
+  typealias B = G<repeat (each T).Element, Bool>
+  typealias C = G<Bool, repeat H<(each T).Element>>
 }
 
 func getA<T: P>(_: T.Type) -> Any.Type {

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -101,7 +101,7 @@ types.test("LayoutReq") {
 }
 
 public struct OuterSeq<each T: Sequence> {
-  public struct InnerSeq<each U: Sequence> where repeat each T.Element == each U.Element {}
+  public struct InnerSeq<each U: Sequence> where repeat (each T).Element == (each U).Element {}
 }
 
 types.test("SameTypeReq") {

--- a/test/SILGen/variadic_generic_conformances.swift
+++ b/test/SILGen/variadic_generic_conformances.swift
@@ -8,6 +8,6 @@ struct S: P {
   typealias A = S
 }
 
-func f<each T: P>(_: repeat each T) -> (repeat each T.A.A.A.A) {}
+func f<each T: P>(_: repeat each T) -> (repeat (each T).A.A.A.A) {}
 
 f(S(), S(), S())

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -64,7 +64,7 @@ struct Outer<each T> {
 
 func packRef<each T>(_: repeat each T) where repeat each T: P {}
 
-func packMemberRef<each T>(_: repeat each T.T) where repeat each T: P {}
+func packMemberRef<each T>(_: repeat (each T).T) where repeat each T: P {}
 
 // expected-error@+1 {{'each' cannot be applied to non-pack type 'Int'}}
 func invalidPackRefEachInt(_: each Int) {}

--- a/validation-test/compiler_crashers_2_fixed/rdar108319167.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar108319167.swift
@@ -13,6 +13,6 @@ public func foo1<each T: Q, each U>(t: repeat each T, u: repeat each U)
   repeat f(each u)
 }
 
-public func foo2<each T: Q>(t: repeat each T, u: repeat each T.A) {
+public func foo2<each T: Q>(t: repeat each T, u: repeat (each T).A) {
   repeat f(each u)
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar110363503.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar110363503.swift
@@ -6,11 +6,11 @@ struct ZipCollection<each C: Collection> {
 
 extension ZipCollection: Collection {
   struct Element {
-    var elt: (repeat each C.Element)
+    var elt: (repeat (each C).Element)
   }
 
   struct Index {
-    let i: (repeat each C.Index)
+    let i: (repeat (each C).Index)
   }
 
   var startIndex: Index {

--- a/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar112108253.swift
@@ -10,7 +10,7 @@ public protocol Q {
   init()
 }
 
-public struct S<T: P, each U: P>: Q where repeat T.A == G<repeat each U.A> {
+public struct S<T: P, each U: P>: Q where repeat T.A == G<repeat (each U).A> {
   public init() {}
   public init(predicate: repeat each U) {}
 }


### PR DESCRIPTION
* **Explanation**: The current implementation allows `each T.Element` in type position, but SE-0393 states that you can only write `(each T).Element`, because the parenthesis are always required in expression position and in the future, `each T.Element` could mean that `Element` is an associated type pack. This change requires that `each` be applied directly to a parameter pack in type resolution.
* **Scope**: Only impacts the syntax of parameter packs in type position.
* **Risk**: Low.
* **Testing**: Updated existing tests.
* **Reviewer**: @slavapestov 
* **Main branch PR**: https://github.com/apple/swift/pull/67428. The second commit is deliberately not cherry-picked because it's just a small refactoring, it's NFC, and there are conflicts.