### PR TITLE
[Macros on Darwin] Use device platform paths when building for the simulator

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -660,6 +660,15 @@ void toolchains::Darwin::addPlatformSpecificPluginFrontendArgs(
     llvm::sys::path::remove_filename(platformPath); // specific SDK
     llvm::sys::path::remove_filename(platformPath); // SDKs
     llvm::sys::path::remove_filename(platformPath); // Developer
+
+    StringRef platformName = llvm::sys::path::filename(platformPath);
+    if (platformName.endswith("Simulator.platform")){
+      StringRef devicePlatformName =
+          platformName.drop_back(strlen("Simulator.platform"));
+      llvm::sys::path::remove_filename(platformPath); // Platform
+      llvm::sys::path::append(platformPath, devicePlatformName + "OS.platform");
+    }
+
     llvm::sys::path::append(platformPath, "Developer");
     addExternalPluginFrontendArgs(platformPath, inputArgs, arguments);
   }

--- a/test/Driver/compiler_plugin_path_iphonesimulator.swift
+++ b/test/Driver/compiler_plugin_path_iphonesimulator.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swiftc_driver -driver-print-jobs -target x86_64-apple-ios15.0-simulator %s 2>&1 | %FileCheck %s
+// REQUIRES: OS=ios
+
+// CHECK: -external-plugin-path
+// CHECK-SAME: .sdk/usr/lib/swift/host/plugins#
+// CHECK-SAME: .sdk/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -external-plugin-path
+// CHECK-SAME: .sdk/usr/local/lib/swift/host/plugins#
+// CHECK-SAME: .sdk/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -external-plugin-path
+// CHECK-SAME: iPhoneOS.platform/Developer/usr/lib/swift/host/plugins#
+// CHECK-SAME: iPhoneOS.platform/Developer/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -external-plugin-path
+// CHECK-SAME: iPhoneOS.platform/Developer/usr/local/lib/swift/host/plugins#
+// CHECK-SAME: iPhoneOS.platform/Developer/usr/bin/swift-plugin-server
+
+// CHECK-SAME: -plugin-path
+// CHECK-SAME: {{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
+
+// CHECK-SAME: -plugin-path
+// CHECK-SAME: {{(/|\\\\)}}local{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins


### PR DESCRIPTION
To avoid having duplicated macro implementations in both the device and simulator platforms, when building for a simulator platform, pass `-external-plugin-path` that points into the *device* platform. There is no need to have macro implementations in the simulator platforms.

Implements rdar://112563655.
