### PR TITLE
[CSBindings] Prefer conjunctions over closure variables without bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1094,6 +1094,13 @@ bool BindingSet::favoredOverConjunction(Constraint *conjunction) const {
   if (locator->directlyAt<ClosureExpr>()) {
     auto *closure = castToExpr<ClosureExpr>(locator->getAnchor());
 
+    // If there are no bindings for the closure yet we cannot prioritize
+    // it because that runs into risk of missing a result builder transform.
+    if (TypeVar->getImpl().isClosureType()) {
+      if (Bindings.empty())
+        return false;
+    }
+
     if (auto transform = CS.getAppliedResultBuilderTransform(closure)) {
       // Conjunctions that represent closures with result builder transformed
       // bodies could be attempted right after their resolution if they meet

--- a/test/Constraints/issue67363.swift
+++ b/test/Constraints/issue67363.swift
@@ -1,0 +1,85 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+// https://github.com/apple/swift/issues/67363
+
+protocol UIView {
+  init()
+}
+
+class UILabel : UIView {
+  required init() {}
+}
+
+class UIStackView : UIView {
+  required init() {}
+}
+
+protocol ViewRepresentable {
+  associatedtype View: UIView
+  func configure(view: View)
+}
+
+struct StyledString: ViewRepresentable {
+  let content: String
+  func configure(view: UILabel) {}
+}
+
+class StackViewOne<First: UIView>: UIStackView {
+  var first = First()
+}
+
+struct Stack {
+  struct One<First: ViewRepresentable>: ViewRepresentable {
+    let first: First
+    func configure(view: StackViewOne<First.View>) {
+      first.configure(view: view.first)
+    }
+  }
+
+  @resultBuilder
+  enum Builder {
+    static func buildBlock<First: ViewRepresentable>(_ first: First) -> Stack.One<First> {
+      Stack.One(first: first)
+    }
+  }
+
+  static func vertical<StackType: ViewRepresentable>(@Builder build builder: () -> StackType) -> StackType {
+    builder()
+  }
+}
+
+struct ListItem {
+  let body: any ViewRepresentable
+}
+
+@resultBuilder
+enum ListBuilder {
+  static func buildExpression<View: ViewRepresentable>(_ expression: View?) -> [ListItem?] {
+    [expression.map { .init(body: $0) }]
+  }
+
+  static func buildBlock(_ components: [ListItem?]...) -> [ListItem] {
+    components.flatMap { $0.compactMap { $0 } }
+  }
+}
+
+struct WithFooter<T: ViewRepresentable>: ViewRepresentable {
+  let body: T
+  let footer: () -> [ListItem]
+  func configure(view: T.View) {}
+}
+
+extension ViewRepresentable {
+  func withFooter(@ListBuilder build: @escaping () -> [ListItem]) -> WithFooter<Self> {
+    .init(body: self, footer: build)
+  }
+}
+
+func testThatResultBuilderIsAppliedToWithFooterArgument() -> some ViewRepresentable {
+  Stack.vertical() {
+    StyledString(content: "vertical")
+  }
+  .withFooter {
+    StyledString(content: "footer")
+  }
+}

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -694,3 +694,27 @@ func test_recursive_var_reference_in_multistatement_closure() {
     }
   }
 }
+
+// https://github.com/apple/swift/issues/67363
+func test_result_builder_in_member_chaining() {
+  @resultBuilder
+  struct Builder {
+    static func buildBlock<T>(_: T) -> Int { 42 }
+  }
+
+  struct Test {
+    static func test<T>(fn: () -> T) -> T {
+      fn()
+    }
+
+    func builder(@Builder _: () -> Int) {}
+  }
+
+  Test.test {
+    let test = Test()
+    return test
+  }.builder { // Ok
+    let result = ""
+    result
+  }
+}


### PR DESCRIPTION
If a closure doesn't have a contextual type inferred yet it should be delayed in favor of 
already resolved closure conjunction because "resolving" such a closure early could 
miss result builder attribute attached to a parameter the closure is passed to.

Partially resolves https://github.com/apple/swift/issues/67363

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
