### PR TITLE
[cxx-interop][5.9] windows ABI fixes

### DIFF
--- a/test/Interop/Cxx/class/Inputs/destructors.h
+++ b/test/Interop/Cxx/class/Inputs/destructors.h
@@ -6,11 +6,21 @@ struct DummyStruct {};
 struct __attribute__((swift_attr("import_unsafe")))
 HasUserProvidedDestructorAndDummy {
   DummyStruct dummy;
+  HasUserProvidedDestructorAndDummy(DummyStruct dummy) : dummy(dummy) {}
+#if __is_target_os(windows)
+  // On windows, force this type to be address-only.
+  HasUserProvidedDestructorAndDummy(const HasUserProvidedDestructorAndDummy &) {}
+#endif
   ~HasUserProvidedDestructorAndDummy() {}
 };
 
 struct __attribute__((swift_attr("import_unsafe"))) HasUserProvidedDestructor {
   int *value;
+#if __is_target_os(windows)
+  // On windows, force this type to be address-only.
+  HasUserProvidedDestructor() {}
+  HasUserProvidedDestructor(const HasUserProvidedDestructor &other) {}
+#endif
   ~HasUserProvidedDestructor() { *value = 42; }
 };
 

--- a/test/Interop/Cxx/class/Inputs/nodiscard.h
+++ b/test/Interop/Cxx/class/Inputs/nodiscard.h
@@ -6,6 +6,7 @@
 class NoDiscardMultiply {
  public:
   NoDiscardMultiply() {}
+  NoDiscardMultiply(const NoDiscardMultiply &) { }
   ~NoDiscardMultiply() {}
 
   [[nodiscard]] int Multiply(int x, int y) { return x * y; }

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -12,6 +12,7 @@ struct DoesNotConformToProtocol {
 struct DummyStruct {};
 
 struct __attribute__((swift_attr("import_unsafe"))) NonTrivial {
+  NonTrivial(const NonTrivial &other) {}
   ~NonTrivial() {}
   NonTrivial(DummyStruct) {}
   NonTrivial() {}

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -80,6 +80,12 @@ struct StructWithSubobjectMoveAssignment {
 };
 
 struct __attribute__((swift_attr("import_unsafe"))) StructWithDestructor {
+#if __is_target_os(windows)
+  // On windows, force this type to be address-only.
+  StructWithDestructor() {}
+  StructWithDestructor(const StructWithDestructor &other) {}
+#endif
+
   ~StructWithDestructor() {}
 };
 

--- a/test/Interop/Cxx/class/delete-operator-destructor-ref-irgen.swift
+++ b/test/Interop/Cxx/class/delete-operator-destructor-ref-irgen.swift
@@ -24,6 +24,7 @@ public:
 class Container {
 public:
     Container() : pointer(new BaseClass) {}
+    Container(const Container &other) : pointer(new BaseClass) {}
     ~Container() { delete pointer; }
 
     inline int method() const {

--- a/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
@@ -4,6 +4,7 @@ import Destructors
 
 // CHECK-LABEL: define {{.*}}void @"$s4main4testyyF"
 // CHECK: [[H:%.*]] = alloca %TSo33HasUserProvidedDestructorAndDummyV
+// CHECK: [[CXX_THIS_PRE:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[H]] to %struct.HasUserProvidedDestructorAndDummy*
 // CHECK: [[CXX_THIS:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[H]] to %struct.HasUserProvidedDestructorAndDummy*
 // CHECK: call {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}(%struct.HasUserProvidedDestructorAndDummy* [[CXX_THIS]])
 

--- a/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
@@ -6,8 +6,9 @@ import Destructors
 // CHECK: [[H:%.*]] = alloca %TSo33HasUserProvidedDestructorAndDummyV
 // CHECK: [[CXX_THIS:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[H]] to %struct.HasUserProvidedDestructorAndDummy*
 // CHECK: call {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}(%struct.HasUserProvidedDestructorAndDummy* [[CXX_THIS]])
+
 // CHECK: ret void
 public func test() {
   let d = DummyStruct()
-  let h = HasUserProvidedDestructorAndDummy(dummy: d)
+  let h = HasUserProvidedDestructorAndDummy(d)
 }

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -30,6 +30,7 @@ struct DerivedFromOneField : OneField {};
 
 struct __attribute__((swift_attr("import_unsafe"))) NonTrivial {
   NonTrivial() {}
+  NonTrivial(const NonTrivial &) {}
   ~NonTrivial() {}
 };
 
@@ -45,6 +46,7 @@ struct NonTrivialDerivedWithOneField : NonTrivialHasThreeFields {
 
 struct __attribute__((swift_attr("import_unsafe"))) NonTrivialHasOneField {
   NonTrivialHasOneField() {}
+  NonTrivialHasOneField(const NonTrivialHasOneField &other) : e(other.e) {}
   ~NonTrivialHasOneField() {}
 
   int e = 5;

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -1,5 +1,6 @@
 struct __attribute__((swift_attr("import_unsafe"))) NonTrivial {
   NonTrivial() {}
+  NonTrivial(const NonTrivial &) {}
   ~NonTrivial() {}
 
   inline const char *inNonTrivial() const

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -4,6 +4,11 @@
 struct __attribute__((swift_attr("import_unsafe"))) NonTrivialInWrapper {
   int value;
 
+  NonTrivialInWrapper(int value) : value(value) {}
+
+  // explicit copy constructor is needed, as on Windows a destructor
+  // still makes this a type that's passed in registers.
+  NonTrivialInWrapper(const NonTrivialInWrapper &other) : value(other.value) {}
   ~NonTrivialInWrapper() { }
 };
 

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -enable-experimental-cxx-interop %s -Xcc -fignore-exceptions | %FileCheck %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+import Methods
+
+public func use() -> CInt {
+    var instance = HasMethods()
+    let result = instance.nonConstPassThroughAsWrapper(42)
+    return result.value
+}
+
+// CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
+// CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
+// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr sret(%struct.NonTrivialInWrapper) %[[result]], ptr %[[instance]], i32 42)
+
+// CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, ptr {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
@@ -12,6 +12,8 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr sret(%struct.NonTrivialInWrapper) %[[result]], ptr %[[instance]], i32 42)
+// CHECK: %[[CXX_THIS_PRE:.*]] = bitcast %TSo10HasMethodsV* %[[instance]] to %struct.HasMethods*
+// CHECK: %[[CXX_THIS:.*]] = bitcast %TSo10HasMethodsV* %[[instance]] to %struct.HasMethods*
+// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(%struct.NonTrivialInWrapper* sret(%struct.NonTrivialInWrapper) %{{.*}}, %struct.HasMethods* %[[CXX_THIS]], i32 42)
 
-// CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, ptr {{.*}} %{{.*}}, i32 noundef %{{.*}})
+// CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(%struct.NonTrivialInWrapper* noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, %struct.HasMethods* {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+
+// REQUIRES: OS=windows-msvc
+
+import Methods
+
+public func use() -> CInt {
+    var instance = HasMethods()
+    let result = instance.nonConstPassThroughAsWrapper(42)
+    return result.value
+}
+
+// CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
+// CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
+// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr sret(%struct.NonTrivialInWrapper) %[[result]], i32 42)
+
+// CHECK: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
@@ -12,6 +12,8 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr sret(%struct.NonTrivialInWrapper) %[[result]], i32 42)
+// CHECK: %[[CXX_THIS_PRE:.*]] = bitcast %TSo10HasMethodsV* %[[instance]] to %struct.HasMethods*
+// CHECK: %[[CXX_THIS:.*]] = bitcast %TSo10HasMethodsV* %[[instance]] to %struct.HasMethods*
+// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(%struct.HasMethods* %[[CXX_THIS]], %struct.NonTrivialInWrapper* sret(%struct.NonTrivialInWrapper) %{{.*}}, i32 42)
 
-// CHECK: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})
+// CHECK: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(%struct.HasMethods* {{.*}} %{{.*}}, %struct.NonTrivialInWrapper* noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods.swift
+++ b/test/Interop/Cxx/class/method/methods.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-//
-// Crash when running on windows: rdar://88391102
-// XFAIL: OS=windows-msvc
 
 import StdlibUnittest
 import Methods
@@ -34,15 +31,15 @@ CxxMethodTestSuite.test("(Int, Int) -> Int") {
 CxxMethodTestSuite.test("(NonTrivialInWrapper, NonTrivialInWrapper) -> Int") {
   var instance = HasMethods()
 
-  expectEqual(42, instance.nonConstSum(NonTrivialInWrapper(value: 40), NonTrivialInWrapper(value: 2)))
-  expectEqual(42, instance.constSum(NonTrivialInWrapper(value: 40), NonTrivialInWrapper(value: 2)))
+  expectEqual(42, instance.nonConstSum(NonTrivialInWrapper(40), NonTrivialInWrapper(2)))
+  expectEqual(42, instance.constSum(NonTrivialInWrapper(40), NonTrivialInWrapper(2)))
 }
 
 CxxMethodTestSuite.test("(NonTrivialInWrapper, NonTrivialInWrapper) -> NonTrivialInWrapper") {
   var instance = HasMethods()
 
-  expectEqual(42, instance.nonConstSumAsWrapper(NonTrivialInWrapper(value: 40), NonTrivialInWrapper(value: 2)).value)
-  expectEqual(42, instance.constSumAsWrapper(NonTrivialInWrapper(value: 40), NonTrivialInWrapper(value: 2)).value)
+  expectEqual(42, instance.nonConstSumAsWrapper(NonTrivialInWrapper(40), NonTrivialInWrapper(2)).value)
+  expectEqual(42, instance.constSumAsWrapper(NonTrivialInWrapper(40), NonTrivialInWrapper(2)).value)
 }
 
 CxxMethodTestSuite.test("(Int) -> NonTrivialInWrapper") {

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -92,6 +92,11 @@ public:
 class ClassWithDestructor {
   int m = 0;
 public:
+#if __is_target_os(windows)
+  // On windows, force this type to be address-only.
+  inline ClassWithDestructor() noexcept {}
+  inline ClassWithDestructor(const ClassWithDestructor &other) noexcept : m(other.m)  {}
+#endif
   inline ~ClassWithDestructor() {
     (void)freeFunctionNoThrow(0);
   }
@@ -100,6 +105,11 @@ public:
 class ClassWithThrowingDestructor {
   int m = 0;
 public:
+#if __is_target_os(windows)
+  // On windows, force this type to be address-only.
+  inline ClassWithThrowingDestructor() noexcept {}
+  inline ClassWithThrowingDestructor(const ClassWithThrowingDestructor &other) noexcept : m(other.m) {}
+#endif
   inline ~ClassWithThrowingDestructor() noexcept(false) {
     throw 2;
   }
@@ -139,6 +149,8 @@ struct StructWithDefaultConstructor {
 
 
 struct NonTrivial {
+  NonTrivial() noexcept;
+  NonTrivial(const NonTrivial &other) noexcept;
   ~NonTrivial() {}
 };
 

--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -1,23 +1,19 @@
 // RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
-// We can't yet call member functions correctly on Windows
-// (https://github.com/apple/swift/issues/55575).
-// XFAIL: OS=windows-msvc
-
 import MemberTemplates
 
 // CHECK-LABEL: sil hidden @$s4main9basicTestyyF : $@convention(thin) () -> ()
 
-// CHECK: [[ADD:%.*]] = function_ref @_ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_ : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK: [[ADD:%.*]] = function_ref @{{_ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_|\?\?\$addSameTypeParams@H@HasMemberTemplates@@QEAAHHH@Z}} : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 // CHECK: apply [[ADD]]({{.*}}) : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK: [[ADD_TWO_TEMPLATES:%.*]] = function_ref @_ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_ : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK: [[ADD_TWO_TEMPLATES:%.*]] = function_ref @{{_ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_|\?\?\$addMixedTypeParams@HH@HasMemberTemplates@@QEAAHHH@Z}} : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 // CHECK: apply [[ADD_TWO_TEMPLATES]]({{.*}}) : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK: [[ADD_ALL:%.*]] = function_ref @_ZN18HasMemberTemplates6addAllIiiEEiiT_T0_ : $@convention(cxx_method) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK: [[ADD_ALL:%.*]] = function_ref @{{_ZN18HasMemberTemplates6addAllIiiEEiiT_T0_|\?\?\$addAll@HH@HasMemberTemplates@@QEAAHHHH@Z}} : $@convention(cxx_method) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32
 // CHECK: apply [[ADD_ALL]]({{.*}}) : $@convention(cxx_method) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK: [[DO_NOTHING:%.*]] = function_ref @_ZN18HasMemberTemplates17doNothingConstRefIiEEvRKT_ : $@convention(cxx_method) (@in_guaranteed Int32, @inout HasMemberTemplates) -> ()
+// CHECK: [[DO_NOTHING:%.*]] = function_ref @{{_ZN18HasMemberTemplates17doNothingConstRefIiEEvRKT_|\?\?\$doNothingConstRef@H@HasMemberTemplates@@QEAAXAEBH@Z}} : $@convention(cxx_method) (@in_guaranteed Int32, @inout HasMemberTemplates) -> ()
 // CHECK: apply [[DO_NOTHING]]({{.*}}) : $@convention(cxx_method) (@in_guaranteed Int32, @inout HasMemberTemplates) -> ()
 
 // CHECK-LABEL: end sil function '$s4main9basicTestyyF'
@@ -30,17 +26,17 @@ func basicTest() {
   obj.doNothingConstRef(i)
 }
 
-// CHECK-LABEL: sil [clang HasMemberTemplates.addSameTypeParams] @_ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_ : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK-LABEL: sil [clang HasMemberTemplates.addSameTypeParams] @{{_ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_|\?\?\$addSameTypeParams@H@HasMemberTemplates@@QEAAHHH@Z}} : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK-LABEL: sil [clang HasMemberTemplates.addMixedTypeParams] @_ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_ : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK-LABEL: sil [clang HasMemberTemplates.addMixedTypeParams] @{{_ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_|\?\?\$addMixedTypeParams@HH@HasMemberTemplates@@QEAAHHH@Z}} : $@convention(cxx_method) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK-LABEL: sil [clang HasMemberTemplates.addAll] @_ZN18HasMemberTemplates6addAllIiiEEiiT_T0_ : $@convention(cxx_method) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK-LABEL: sil [clang HasMemberTemplates.addAll] @{{_ZN18HasMemberTemplates6addAllIiiEEiiT_T0_|\?\?\$addAll@HH@HasMemberTemplates@@QEAAHHHH@Z}} : $@convention(cxx_method) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK-LABEL: sil [clang HasMemberTemplates.doNothingConstRef] @_ZN18HasMemberTemplates17doNothingConstRefIiEEvRKT_ : $@convention(cxx_method) (@in_guaranteed Int32, @inout HasMemberTemplates) -> ()
+// CHECK-LABEL: sil [clang HasMemberTemplates.doNothingConstRef] @{{_ZN18HasMemberTemplates17doNothingConstRefIiEEvRKT_|\?\?\$doNothingConstRef@H@HasMemberTemplates@@QEAAXAEBH@Z}} : $@convention(cxx_method) (@in_guaranteed Int32, @inout HasMemberTemplates) -> ()
 
 // CHECK-LABEL: sil hidden @$s4main12testSetValueyyF : $@convention(thin) () -> ()
 
-// CHECK: [[SET_VALUE:%.*]] = function_ref @_ZN32TemplateClassWithMemberTemplatesIiE8setValueIlEEvT_ : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
+// CHECK: [[SET_VALUE:%.*]] = function_ref @{{_ZN32TemplateClassWithMemberTemplatesIiE8setValueIlEEvT_|\?\?\$setValue@_J@\?\$TemplateClassWithMemberTemplates@H@@QEAAX_J@Z}} : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
 // CHECK: apply [[SET_VALUE]]({{.*}}) : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
 
 // CHECK-LABEL: end sil function '$s4main12testSetValueyyF'
@@ -51,13 +47,13 @@ func testSetValue() {
 
 // CHECK-LABEL: sil hidden @$s4main17testStaticMembersyyF : $@convention(thin) () -> ()
 
-// CHECK: [[ADD_FN:%.*]] = function_ref @_ZN24HasStaticMemberTemplates3addIlEET_S1_S1_ : $@convention(c) (Int, Int) -> Int
+// CHECK: [[ADD_FN:%.*]] = function_ref @{{_ZN24HasStaticMemberTemplates3addIlEET_S1_S1_|\?\?\$add@_J@HasStaticMemberTemplates@@SA_J_J0@Z}} : $@convention(c) (Int, Int) -> Int
 // CHECK: apply [[ADD_FN]]({{.*}}) : $@convention(c) (Int, Int) -> Int
 
-// CHECK: [[ADD_TWO_TEMPLATES_FN:%.*]] = function_ref @_ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_ : $@convention(c) (Int, Int8) -> Int
+// CHECK: [[ADD_TWO_TEMPLATES_FN:%.*]] = function_ref @{{_ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_|\?\?\$addTwoTemplates@_JD@HasStaticMemberTemplates@@SA_J_JD@Z}} : $@convention(c) (Int, Int8) -> Int
 // CHECK: apply [[ADD_TWO_TEMPLATES_FN]]({{.*}}) : $@convention(c) (Int, Int8) -> Int
 
-// CHECK: [[REMOVE_REFERENCE_FN:%.*]] = function_ref @_ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_ : $@convention(c) (@inout Int) -> Int
+// CHECK: [[REMOVE_REFERENCE_FN:%.*]] = function_ref @{{_ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_|\?\?\$removeReference@_J@HasStaticMemberTemplates@@SA_JAEA_J@Z}} : $@convention(c) (@inout Int) -> Int
 // CHECK: apply [[REMOVE_REFERENCE_FN]]({{.*}}) : $@convention(c) (@inout Int) -> Int
 
 // CHECK-LABEL: end sil function '$s4main17testStaticMembersyyF'
@@ -69,8 +65,8 @@ func testStaticMembers() {
   HasStaticMemberTemplates.removeReference(&x)
 }
 
-// CHECK: sil hidden_external [clang HasStaticMemberTemplates.add] @_ZN24HasStaticMemberTemplates3addIlEET_S1_S1_ : $@convention(c) (Int, Int) -> Int
+// CHECK: sil hidden_external [clang HasStaticMemberTemplates.add] @{{_ZN24HasStaticMemberTemplates3addIlEET_S1_S1_|\?\?\$add@_J@HasStaticMemberTemplates@@SA_J_J0@Z}} : $@convention(c) (Int, Int) -> Int
 
-// CHECK: sil hidden_external [clang HasStaticMemberTemplates.addTwoTemplates] @_ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_ : $@convention(c) (Int, Int8) -> Int
+// CHECK: sil hidden_external [clang HasStaticMemberTemplates.addTwoTemplates] @{{_ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_|\?\?\$addTwoTemplates@_JD@HasStaticMemberTemplates@@SA_J_JD@Z}} : $@convention(c) (Int, Int8) -> Int
 
-// CHECK: sil hidden_external [clang HasStaticMemberTemplates.removeReference] @_ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_ : $@convention(c) (@inout Int) -> Int
+// CHECK: sil hidden_external [clang HasStaticMemberTemplates.removeReference] @{{_ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_|\?\?\$removeReference@_J@HasStaticMemberTemplates@@SA_JAEA_J@Z}} : $@convention(c) (@inout Int) -> Int

--- a/test/Interop/Cxx/value-witness-table/Inputs/custom-destructors.h
+++ b/test/Interop/Cxx/value-witness-table/Inputs/custom-destructors.h
@@ -3,6 +3,12 @@
 
 struct __attribute__((swift_attr("import_unsafe"))) HasUserProvidedDestructor {
   int *value;
+  HasUserProvidedDestructor() {}
+  HasUserProvidedDestructor(int *value) : value(value) {}
+#if __is_target_os(windows) && !defined(WIN_TRIVIAL)
+  // On windows, force this type to be address-only.
+  HasUserProvidedDestructor(const HasUserProvidedDestructor &other) : value(other.value) {}
+#endif
   ~HasUserProvidedDestructor() { *value = 42; }
 };
 
@@ -71,6 +77,11 @@ struct DummyStruct {};
 struct __attribute__((swift_attr("import_unsafe")))
 HasUserProvidedDestructorAndDummy {
   DummyStruct dummy;
+  HasUserProvidedDestructorAndDummy(DummyStruct dummy) : dummy(dummy) {}
+#if __is_target_os(windows) && !defined(WIN_TRIVIAL)
+  // On windows, force this type to be address-only.
+  HasUserProvidedDestructorAndDummy(const HasUserProvidedDestructorAndDummy &other) : dummy(other.dummy) {}
+#endif
   ~HasUserProvidedDestructorAndDummy() {}
 };
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
@@ -17,6 +17,7 @@ extension HasUserProvidedDestructorAndDummy : InitWithDummy { }
 
 // CHECK-LABEL: define {{.*}}void @"$s4main37testHasUserProvidedDestructorAndDummyyyF"
 // CHECK: [[OBJ:%.*]] = alloca %TSo33HasUserProvidedDestructorAndDummyV
+// CHECK: [[CXX_OBJ_PRE:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[OBJ]] to %struct.HasUserProvidedDestructorAndDummy*
 // CHECK: [[CXX_OBJ:%.*]] = bitcast %TSo33HasUserProvidedDestructorAndDummyV* [[OBJ]] to %struct.HasUserProvidedDestructorAndDummy*
 // CHECK: call {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}(%struct.HasUserProvidedDestructorAndDummy* [[CXX_OBJ]])
 // CHECK: ret void

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
@@ -6,7 +6,7 @@
 import CustomDestructor
 
 protocol InitWithDummy {
-  init(dummy: DummyStruct)
+  init(_: DummyStruct)
 }
 
 extension HasUserProvidedDestructorAndDummy : InitWithDummy { }
@@ -25,7 +25,7 @@ extension HasUserProvidedDestructorAndDummy : InitWithDummy { }
 // CHECK-LABEL: define {{.*}}@{{_ZN33HasUserProvidedDestructorAndDummyD(1|2)Ev|"\?\?1HasUserProvidedDestructorAndDummy@@QEAA@XZ"}}
 // CHECK: ret
 public func testHasUserProvidedDestructorAndDummy() {
-  _ = HasUserProvidedDestructorAndDummy(dummy: DummyStruct())
+  _ = HasUserProvidedDestructorAndDummy(DummyStruct())
 }
 
 // CHECK-LABEL: define {{.*}}void @"$s4main26testHasDefaultedDestructoryyF"

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual.swift
@@ -9,7 +9,7 @@ import StdlibUnittest
 var CXXDestructorTestSuite = TestSuite("CXXDestructor")
 
 protocol InitWithPtr {
-  init(value: UnsafeMutablePointer<Int32>!)
+  init(_: UnsafeMutablePointer<Int32>!)
 }
 
 extension HasUserProvidedDestructor : InitWithPtr { }
@@ -26,14 +26,14 @@ extension HasEmptyDestructorAndMemberWithUserDefinedConstructor
 func withCxxDestructorSideEffects<T>(_ _: inout T) { }
 
 func createTypeWithUserProvidedDestructor(_ ptr: UnsafeMutablePointer<Int32>) {
-  var obj = HasUserProvidedDestructor(value: ptr)
+  var obj = HasUserProvidedDestructor(ptr)
   withCxxDestructorSideEffects(&obj)
 }
 
 func createTypeWithEmptyDestructorAndMemberWithUserDefinedConstructor(
   _ ptr: UnsafeMutablePointer<Int32>
 ) {
-  let member = HasUserProvidedDestructor(value: ptr)
+  let member = HasUserProvidedDestructor(ptr)
   var obj = HasEmptyDestructorAndMemberWithUserDefinedConstructor(member: member)
   withCxxDestructorSideEffects(&obj)
 }
@@ -41,7 +41,7 @@ func createTypeWithEmptyDestructorAndMemberWithUserDefinedConstructor(
 func createTypeWithNonTrivialImplicitDestructor(
   _ ptr: UnsafeMutablePointer<Int32>
 ) {
-  let member = HasUserProvidedDestructor(value: ptr)
+  let member = HasUserProvidedDestructor(ptr)
   var obj = HasNonTrivialImplicitDestructor(member: member)
   withCxxDestructorSideEffects(&obj)
 }
@@ -49,7 +49,7 @@ func createTypeWithNonTrivialImplicitDestructor(
 func createTypeWithNonTrivialDefaultDestructor(
   _ ptr: UnsafeMutablePointer<Int32>
 ) {
-  let member = HasUserProvidedDestructor(value: ptr)
+  let member = HasUserProvidedDestructor(ptr)
   var obj = HasNonTrivialDefaultedDestructor(member: member)
   withCxxDestructorSideEffects(&obj)
 }
@@ -58,7 +58,7 @@ func createTypeWithGeneric<T : InitWithPtr>(
   _ ptr: UnsafeMutablePointer<Int32>,
   type: T.Type
 ) {
-  var obj = T(value: ptr)
+  var obj = T(ptr)
   withCxxDestructorSideEffects(&obj)
 }
 
@@ -66,7 +66,7 @@ func createTypeWithProtocol(
   _ ptr: UnsafeMutablePointer<Int32>,
   type: InitWithPtr.Type
 ) {
-  var obj = type.self.init(value: ptr)
+  var obj = type.self.init(ptr)
   withCxxDestructorSideEffects(&obj)
 }
 
@@ -75,7 +75,7 @@ func createTypeWithProtocol(
   type: InitWithPtr.Type,
   holder: InitWithMember.Type
 ) {
-  let member = type.self.init(value: ptr)
+  let member = type.self.init(ptr)
   var obj = holder.self.init(member: member as! HasUserProvidedDestructor)
   withCxxDestructorSideEffects(&obj)
 }

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-typechecker-trivial-windows-abi.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-typechecker-trivial-windows-abi.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -DWIN_TRIVIAL
+
+// REQUIRES: OS=windows-msvc
+
+import CustomDestructor
+
+_ = HasUserProvidedDestructor() // expected-error {{non-trivial C++ class with trivial ABI is not yet available in Swift}}
+_ = HasEmptyDestructorAndMemberWithUserDefinedConstructor() // expected-error {{non-trivial C++ class with trivial ABI is not yet available in Swift}}
+_ = HasNonTrivialImplicitDestructor() // expected-error {{non-trivial C++ class with trivial ABI is not yet available in Swift}}
+_ = HasNonTrivialDefaultedDestructor() // expected-error {{non-trivial C++ class with trivial ABI is not yet available in Swift}}

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -37,7 +37,7 @@ namespace ns {
         T x;
 
         NonTrivialTemplate();
-        NonTrivialTemplate(const NonTrivialTemplate<T> &) = default;
+        NonTrivialTemplate(const NonTrivialTemplate<T> &other) : x(other.x) {}
         NonTrivialTemplate(NonTrivialTemplate<T> &&) = default;
         ~NonTrivialTemplate() {}
     };
@@ -46,6 +46,8 @@ namespace ns {
 
     struct NonTrivialImplicitMove {
         NonTrivialTemplate<int> member;
+
+        NonTrivialImplicitMove(const NonTrivialImplicitMove &other) : member(other.member) {}
     };
 
     #define IMMORTAL_REF                                \

--- a/test/SILOptimizer/Inputs/CXXTypesWithUserProvidedDestructor.h
+++ b/test/SILOptimizer/Inputs/CXXTypesWithUserProvidedDestructor.h
@@ -2,16 +2,20 @@
 #define TEST_SIL_OPTIMIZER_CXX_WITH_CUSTOM_DESTRUCTOR_H
 
 struct HasUserProvidedDestructor {
-  int x;
+  int x = 0;
+
+  HasUserProvidedDestructor(const HasUserProvidedDestructor &other) : x(other.x) {}
   ~HasUserProvidedDestructor() {}
 };
 
 struct Loadable {
-  int x;
+  int x = 0;
 };
 
 struct HasMemberWithUserProvidedDestructor {
   Loadable y;
+
+  HasMemberWithUserProvidedDestructor(const HasMemberWithUserProvidedDestructor &other) : y(other.y) {}
   ~HasMemberWithUserProvidedDestructor() {}
 };
 


### PR DESCRIPTION
[cxx-interop] Fix the windows ABI for returning indirect values out of methods
    
    Fixes https://github.com/apple/swift/issues/66326
    
    This allows us to reneable Windows method tests. Note that Windows still has
    a broken convention for non-trivial record with non-trivial destructor but
    trivial copy-constructor, so classes in the methods.swift test need an explicit
    copy constructor.
    
    Fixes rdar://88391102

[cxx-interop] Windows: unify address-only logic and mark non-trivial loadable C++ types as unavailable
    
    Windows logic for determining address-only type layout for a C++ type is now unified with other platforms.
    However, this means that on Windows, a C++ type with a custom destructor, but a default copy constructor
    is now loadable, even though it's non-trivial. Since Swift does not support such type operations at the
    moment (it can't be yet destroyed), mark such type as unavailable in Swift instead, when building for
    the Windows target.
    
    This fixes the Windows miscompilation related to such types when they were passed indirectly to C++
    functions even though they're actually passed directly.

- Explanation: 
Windows MSVC ABI  had two problems with IRGen for calls to C++:
1) Methods returning values indirectly had incorrect order between `this` and the returned value. This is now fixed, and we get the ordering right for the MSVC ABI.
2) Non-trivial but passed in registers types (MSVC ABI example - C++ class with destructor but default copy constructor) were incorrectly passed indirectly as we marked them as address-only. This patch now marks them loadable, which fixes that issue. However, we cannot yet support such types correctly semantically, as they can't be yet destroyed from Swift. Therefore, mark such types as unavailable on Windows to avoid missing C++ destructor calls from Swift.

- Scope: C++ interop, Clang importer, IRGen.
- Risk: Low, the affected code changes only affect the MSVC windows target, and only affect C++ imported types, not C.
- Testing: Unit tests.
- Original PR: https://github.com/apple/swift/pull/67268