### PR TITLE
fix a linking problem in swift-frontend

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -48,6 +48,8 @@ class DominanceInfo : public DominatorTreeBase {
 public:
   DominanceInfo(SILFunction *F);
 
+  ~DominanceInfo();
+
   /// Does instruction A properly dominate instruction B?
   bool properlyDominates(SILInstruction *a, SILInstruction *b);
 

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -133,6 +133,8 @@ private:
 public:
   AliasAnalysis(SILPassManager *PM) : PM(PM) {}
 
+  ~AliasAnalysis();
+
   static SILAnalysisKind getAnalysisKind() { return SILAnalysisKind::Alias; }
 
   /// Perform an alias query to see if V1, V2 refer to the same values.

--- a/lib/SIL/Utils/Dominance.cpp
+++ b/lib/SIL/Utils/Dominance.cpp
@@ -37,6 +37,9 @@ DominanceInfo::DominanceInfo(SILFunction *F)
   recalculate(*F);
 }
 
+DominanceInfo::~DominanceInfo() {
+}
+
 bool DominanceInfo::properlyDominates(SILInstruction *a, SILInstruction *b) {
   auto aBlock = a->getParent(), bBlock = b->getParent();
 

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -526,6 +526,9 @@ static BridgedAliasAnalysis::Escaping2InstFn isObjReleasedFunction = nullptr;
 static BridgedAliasAnalysis::Escaping2ValIntFn isAddrVisibleFromObjFunction = nullptr;
 static BridgedAliasAnalysis::Escaping2ValFn canReferenceSameFieldFunction = nullptr;
 
+AliasAnalysis::~AliasAnalysis() {
+}
+
 /// The main AA entry point. Performs various analyses on V1, V2 in an attempt
 /// to disambiguate the two values.
 AliasResult AliasAnalysis::alias(SILValue V1, SILValue V2,


### PR DESCRIPTION
Sometimes when building the SwiftCompilerSources with a host compiler, linking fails with unresolved symbols for DenseMap and unique_ptr destroys. This looks like a problem with C++ interop: the compiler thinks that destructors for some Analysis classes are materialized in the SwiftCompilerSources, but they are not. Explicitly defining those destructors fixes the problem.
