### PR TITLE
[5.9][SILGen] Expand magic literals like `#file` and `#line` to values in the outermost source file.

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1838,3 +1838,36 @@ public struct PeerValueWithSuffixNameMacro: PeerMacro {
     return ["var \(raw: identified.identifier.text)_peer: Int { 1 }"]
   }
 }
+
+public struct MagicFileMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return "#file"
+  }
+}
+
+public struct MagicLineMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return "(#line)"
+  }
+}
+
+public struct NestedMagicLiteralMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return
+      """
+      {
+        print(#MagicFile)
+        print(#MagicLine)
+      }()
+      """
+  }
+}

--- a/test/Macros/magic_literal_expansion.swift
+++ b/test/Macros/magic_literal_expansion.swift
@@ -1,0 +1,28 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-build-swift -enable-experimental-feature ExtensionMacros -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5 -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+
+@freestanding(expression)
+macro MagicFile() -> String = #externalMacro(module: "MacroDefinition", type: "MagicFileMacro")
+
+@freestanding(expression)
+macro MagicLine() -> Int = #externalMacro(module: "MacroDefinition", type: "MagicLineMacro")
+
+// CHECK: magic_literal_expansion.swift
+print(#MagicFile)
+
+// CHECK: 21
+print(#MagicLine)
+
+@freestanding(expression)
+macro Nested() -> Void = #externalMacro(module: "MacroDefinition", type: "NestedMagicLiteralMacro")
+
+// CHECK: magic_literal_expansion.swift
+// CHECK: 28
+#Nested


### PR DESCRIPTION
* **Explanation**: Currently, uses of magic literals like `#file` and `#line` inside macro expansions will use the source location inside the macro expansion buffer, which is unexpected and not useful. This change makes magic literal expansion walk to the location of the attached or freestanding macro in the outermost source file to use that source location instead.
* **Scope**: Only impacts magic literals in macro expansion buffers.
* **Risk**: Very low.
* **Testing**: Added new tests
* **Issue**: rdar://107060087
* **Reviewer**: @DougGregor 
* **Main branch PR**: https://github.com/apple/swift/pull/67447