### PR TITLE
Option: add `-libc` as an option for Swift tools

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -834,7 +834,9 @@ def enable_app_extension : Flag<["-"], "application-extension">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Restrict code to those available for App Extensions">;
 
-def libc : Separate<["-"], "libc">, HelpText<"libc runtime library to use">;
+def libc : Separate<["-"], "libc">,
+           Flags<[SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
+           HelpText<"libc runtime library to use">;
 
 // Linker options
 


### PR DESCRIPTION
Ensure that we process `-libc` in `swift-symbolgraph-extract` and `swift-api-extract`.  This option is used by Windows to determine the C ABI to use and thus impacts the ABI exposed by the ClangImporter to the Swift interface.  This partially enables the use of `swift package dump-symbol-graph` on Windows.