### PR TITLE
Introduce `then` statements 

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1244,8 +1244,9 @@ ERROR(case_stmt_without_body,none,
 // 'try' on statements
 ERROR(try_on_stmt,none,
       "'try' cannot be used with '%0'", (StringRef))
-ERROR(try_on_return_throw_yield,none,
-      "'try' must be placed on the %select{returned|thrown|yielded}0 expression",
+ERROR(try_must_come_after_stmt,none,
+      "'try' must be placed on the %select{returned|thrown|yielded|produced}0 "
+      "expression",
       (unsigned))
 ERROR(try_on_var_let,none,
       "'try' must be placed on the initial value expression", ())
@@ -1399,6 +1400,12 @@ ERROR(expected_expr_after_each, none,
       "expected expression after 'each'", ())
 ERROR(expected_expr_after_repeat, none,
       "expected expression after 'repeat'", ())
+ERROR(expected_expr_after_then,none,
+      "expected expression after 'then'", ())
+
+WARNING(unindented_code_after_then,none,
+        "expression following 'then' is treated as an argument of "
+        "the 'then'", ())
 
 WARNING(move_consume_final_spelling, none,
         "'_move' has been renamed to 'consume', and the '_move' spelling will be removed shortly", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1231,14 +1231,18 @@ ERROR(if_expr_must_be_syntactically_exhaustive,none,
 ERROR(single_value_stmt_branch_empty,none,
       "expected expression in branch of '%0' expression",
       (StmtKind))
-ERROR(single_value_stmt_branch_must_end_in_throw,none,
-      "non-expression branch of '%0' expression may only end with a 'throw'",
+ERROR(single_value_stmt_branch_must_end_in_result,none,
+      "non-expression branch of '%0' expression may only end with a 'throw' "
+      "or 'then'",
       (StmtKind))
 ERROR(cannot_jump_in_single_value_stmt,none,
       "cannot '%0' in '%1' when used as expression",
       (StmtKind, StmtKind))
 ERROR(effect_marker_on_single_value_stmt,none,
       "'%0' may not be used on '%1' expression", (StringRef, StmtKind))
+ERROR(out_of_place_then_stmt,none,
+      "'then' may only appear as the last statement in an 'if' or 'switch' "
+      "expression", ())
 
 ERROR(did_not_call_function_value,none,
       "function value was used as a property; add () to call it",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -70,6 +70,7 @@ namespace swift {
   class CallExpr;
   class KeyPathExpr;
   class CaptureListExpr;
+  class ThenStmt;
 
 enum class ExprKind : uint8_t {
 #define EXPR(Id, Parent) Id,
@@ -6125,10 +6126,10 @@ private:
   SingleValueStmtExpr(Stmt *S, DeclContext *DC)
       : Expr(ExprKind::SingleValueStmt, /*isImplicit*/ true), S(S), DC(DC) {}
 
-public:
   /// Creates a new SingleValueStmtExpr wrapping a statement.
   static SingleValueStmtExpr *create(ASTContext &ctx, Stmt *S, DeclContext *DC);
 
+public:
   /// Creates a new SingleValueStmtExpr wrapping a statement, and recursively
   /// attempts to wrap any branches of that statement that can become single
   /// value statement expressions.
@@ -6144,6 +6145,16 @@ public:
   /// SingleValueStmtExpr.
   static SingleValueStmtExpr *tryDigOutSingleValueStmtExpr(Expr *E);
 
+  /// Retrieves a resulting ThenStmt from the given BraceStmt, or \c nullptr if
+  /// the brace does not have a resulting ThenStmt.
+  static ThenStmt *getThenStmtFrom(BraceStmt *BS);
+
+  /// Whether the given BraceStmt has a result to be produced from a parent
+  /// SingleValueStmtExpr.
+  static bool hasResult(BraceStmt *BS) {
+    return getThenStmtFrom(BS);
+  }
+
   /// Retrieve the wrapped statement.
   Stmt *getStmt() const { return S; }
   void setStmt(Stmt *newS) { S = newS; }
@@ -6154,10 +6165,15 @@ public:
   /// Retrieve the complete set of branches for the underlying statement.
   ArrayRef<Stmt *> getBranches(SmallVectorImpl<Stmt *> &scratch) const;
 
-  /// Retrieve the single expression branches of the statement, excluding
-  /// branches that either have multiple expressions, or have statements.
+  /// Retrieve the resulting ThenStmts from each branch of the
+  /// SingleValueStmtExpr.
+  ArrayRef<ThenStmt *>
+  getThenStmts(SmallVectorImpl<ThenStmt *> &scratch) const;
+
+  /// Retrieve the result expressions from each branch of the
+  /// SingleValueStmtExpr.
   ArrayRef<Expr *>
-  getSingleExprBranches(SmallVectorImpl<Expr *> &scratch) const;
+  getResultExprs(SmallVectorImpl<Expr *> &scratch) const;
 
   DeclContext *getDeclContext() const { return DC; }
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -667,6 +667,7 @@ private:
   void visitFailStmt(FailStmt *) {}
   void visitReturnStmt(ReturnStmt *) {}
   void visitYieldStmt(YieldStmt *) {}
+  void visitThenStmt(ThenStmt *) {}
   void visitThrowStmt(ThrowStmt *) {}
   void visitDiscardStmt(DiscardStmt *) {}
   void visitPoundAssertStmt(PoundAssertStmt *) {}

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -304,6 +304,38 @@ public:
   static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Yield; }
 };
 
+/// The statement `then <expr>`. This is used within if/switch expressions to
+/// indicate the value being produced by a given branch.
+class ThenStmt : public Stmt {
+  SourceLoc ThenLoc;
+  Expr *Result;
+
+  ThenStmt(SourceLoc thenLoc, Expr *result, bool isImplicit)
+      : Stmt(StmtKind::Then, isImplicit), ThenLoc(thenLoc), Result(result) {
+    assert(Result && "Must have non-null result");
+  }
+
+public:
+  /// Create a new parsed ThenStmt.
+  static ThenStmt *createParsed(ASTContext &ctx, SourceLoc thenLoc,
+                                Expr *result);
+
+  /// Create an implicit ThenStmt.
+  ///
+  /// Note that such statements will be elided during the result builder
+  /// transform.
+  static ThenStmt *createImplicit(ASTContext &ctx, Expr *result);
+
+  SourceLoc getThenLoc() const { return ThenLoc; }
+
+  SourceRange getSourceRange() const;
+
+  Expr *getResult() const { return Result; }
+  void setResult(Expr *e) { Result = e; }
+
+  static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Then; }
+};
+
 /// DeferStmt - A 'defer' statement.  This runs the substatement it contains
 /// when the enclosing scope is exited.
 ///

--- a/include/swift/AST/StmtNodes.def
+++ b/include/swift/AST/StmtNodes.def
@@ -46,6 +46,7 @@
 
 STMT(Brace, Stmt)
 STMT(Return, Stmt)
+STMT(Then, Stmt)
 STMT(Yield, Stmt)
 STMT(Defer, Stmt)
 ABSTRACT_STMT(Labeled, Stmt)

--- a/include/swift/AST/TokenKinds.def
+++ b/include/swift/AST/TokenKinds.def
@@ -258,6 +258,7 @@ MISC(string_segment)
 MISC(string_interpolation_anchor)
 MISC(kw_yield)
 MISC(kw_discard)
+MISC(kw_then)
 
 // The following tokens are irrelevant for swiftSyntax and thus only declared 
 // in this .def file

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3901,8 +3901,8 @@ public:
     /// The statement is an 'if' statement without an unconditional 'else'.
     NonExhaustiveIf,
 
-    /// There are no single-expression branches.
-    NoExpressionBranches,
+    /// There is no branch that produces a resulting value.
+    NoResult,
 
     /// There is an unhandled statement branch. This should only be the case
     /// for invalid AST.
@@ -3957,8 +3957,8 @@ public:
   static IsSingleValueStmtResult nonExhaustiveIf() {
     return IsSingleValueStmtResult(Kind::NonExhaustiveIf);
   }
-  static IsSingleValueStmtResult noExpressionBranches() {
-    return IsSingleValueStmtResult(Kind::NoExpressionBranches);
+  static IsSingleValueStmtResult noResult() {
+    return IsSingleValueStmtResult(Kind::NoResult);
   }
   static IsSingleValueStmtResult unhandledStmt() {
     return IsSingleValueStmtResult(Kind::UnhandledStmt);

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -226,6 +226,9 @@ EXPERIMENTAL_FEATURE(GlobalConcurrency, false)
 /// "playground transform" is enabled.
 EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)
 
+/// Enable 'then' statements.
+EXPERIMENTAL_FEATURE(ThenStatements, false)
+
 /// Enable the `@_rawLayout` attribute.
 EXPERIMENTAL_FEATURE(RawLayout, true)
 

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -213,6 +213,7 @@ enum class CompletionKind : uint8_t {
   CallArg,
   LabeledTrailingClosure,
   ReturnStmtExpr,
+  ThenStmtExpr,
   YieldStmtExpr,
   ForEachSequence,
 

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -235,6 +235,8 @@ public:
 
   virtual void completeReturnStmt(CodeCompletionExpr *E) {};
 
+  virtual void completeThenStmt(CodeCompletionExpr *E) {};
+
   /// Complete a yield statement.  A missing yield index means that the
   /// completion immediately follows the 'yield' keyword; it may be either
   /// an expression or a parenthesized expression list.  A present yield

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -602,6 +602,10 @@ public:
             cast<AccessorDecl>(CurDeclContext)->isCoroutine());
   }
 
+  /// Whether the current token is the contextual keyword for a \c then
+  /// statement.
+  bool isContextualThenKeyword(bool preferExpr);
+
   /// `discard self` is the only valid phrase, but we peek ahead for just any
   /// identifier after `discard` to determine if it's the statement. This helps
   /// us avoid interpreting `discard(self)` as the statement and not a call.
@@ -641,7 +645,7 @@ public:
     while (Tok.isNot(K..., tok::eof, tok::r_brace, tok::pound_endif,
                      tok::pound_else, tok::pound_elseif,
                      tok::code_complete) &&
-           !isStartOfStmt() &&
+           !isStartOfStmt(/*preferExpr*/ false) &&
            !isStartOfSwiftDecl(/*allowPoundIfAttributes=*/true)) {
       skipSingle();
     }
@@ -1919,7 +1923,13 @@ public:
   //===--------------------------------------------------------------------===//
   // Statement Parsing
 
-  bool isStartOfStmt();
+  /// Whether we are at the start of a statement.
+  ///
+  /// \param preferExpr If either an expression or statement could be parsed and
+  /// this parameter is \c true, the function returns \c false such that an
+  /// expression can be parsed.
+  bool isStartOfStmt(bool preferExpr);
+
   bool isTerminatorForBraceItemListKind(BraceItemListKind Kind,
                                         ArrayRef<ASTNode> ParsedDecls);
   ParserResult<Stmt> parseStmt();
@@ -1928,6 +1938,7 @@ public:
   ParserResult<Stmt> parseStmtContinue();
   ParserResult<Stmt> parseStmtReturn(SourceLoc tryLoc);
   ParserResult<Stmt> parseStmtYield(SourceLoc tryLoc);
+  ParserResult<Stmt> parseStmtThen(SourceLoc tryLoc);
   ParserResult<Stmt> parseStmtThrow(SourceLoc tryLoc);
   ParserResult<Stmt> parseStmtDiscard();
   ParserResult<Stmt> parseStmtDefer();

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -108,7 +108,38 @@ public:
   bool isBinaryOperator() const {
     return Kind == tok::oper_binary_spaced || Kind == tok::oper_binary_unspaced;
   }
-  
+
+  /// Checks whether the token is either a binary operator, or is a token that
+  /// acts like a binary operator (e.g infix '=', '?', '->').
+  bool isBinaryOperatorLike() const {
+    if (isBinaryOperator())
+      return true;
+
+    switch (Kind) {
+    case tok::equal:
+    case tok::arrow:
+    case tok::question_infix:
+      return true;
+    default:
+      return false;
+    }
+    llvm_unreachable("Unhandled case in switch!");
+  }
+
+  /// Checks whether the token is either a postfix operator, or is a token that
+  /// acts like a postfix operator (e.g postfix '!' and '?').
+  bool isPostfixOperatorLike() const {
+    switch (Kind) {
+    case tok::oper_postfix:
+    case tok::exclaim_postfix:
+    case tok::question_postfix:
+      return true;
+    default:
+      return false;
+    }
+    llvm_unreachable("Unhandled case in switch!");
+  }
+
   bool isAnyOperator() const {
     return isBinaryOperator() || Kind == tok::oper_postfix ||
            Kind == tok::oper_prefix;

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -458,6 +458,9 @@ enum class FixKind : uint8_t {
   /// Ignore an attempt to specialize non-generic type.
   AllowConcreteTypeSpecialization,
 
+  /// Ignore an out-of-place \c then statement.
+  IgnoreOutOfPlaceThenStmt,
+
   /// Ignore situations when provided number of generic arguments didn't match
   /// expected number of parameters.
   IgnoreGenericSpecializationArityMismatch,
@@ -3681,6 +3684,29 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowConcreteTypeSpecialization;
+  }
+};
+
+class IgnoreOutOfPlaceThenStmt final : public ConstraintFix {
+  IgnoreOutOfPlaceThenStmt(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::IgnoreOutOfPlaceThenStmt, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore out-of-place ThenStmt";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreOutOfPlaceThenStmt *create(ConstraintSystem &cs,
+                                          ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreOutOfPlaceThenStmt;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -103,8 +103,14 @@ enum class ConversionRestrictionKind;
 
 /// The kind of SingleValueStmtExpr branch the locator identifies.
 enum class SingleValueStmtBranchKind {
-  Regular,
-  InSingleExprClosure
+  /// Explicitly written 'then <expr>'.
+  Explicit,
+
+  /// Implicitly written '<expr>'.
+  Implicit,
+
+  /// Implicitly written '<expr>' in a single expr closure body.
+  ImplicitInSingleExprClosure
 };
 
 /// Locates a given constraint within the expression being
@@ -938,19 +944,19 @@ public:
   }
 };
 
-/// The branch of a SingleValueStmtExpr. Note the stored index corresponds to
-/// the expression branches, i.e it skips statement branch indices.
-class LocatorPathElt::SingleValueStmtBranch final
+/// A particular result of a ThenStmt at a given index in a SingleValueStmtExpr.
+/// The stored index corresponds to the \c getResultExprs array.
+class LocatorPathElt::SingleValueStmtResult final
     : public StoredIntegerElement<1> {
 public:
-  SingleValueStmtBranch(unsigned exprIdx)
-      : StoredIntegerElement(ConstraintLocator::SingleValueStmtBranch,
+  SingleValueStmtResult(unsigned exprIdx)
+      : StoredIntegerElement(ConstraintLocator::SingleValueStmtResult,
                              exprIdx) {}
 
-  unsigned getExprBranchIndex() const { return getValue(); }
+  unsigned getIndex() const { return getValue(); }
 
   static bool classof(const LocatorPathElt *elt) {
-    return elt->getKind() == ConstraintLocator::SingleValueStmtBranch;
+    return elt->getKind() == ConstraintLocator::SingleValueStmtResult;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -259,8 +259,8 @@ CUSTOM_LOCATOR_PATH_ELT(SyntacticElement)
 /// The element of the pattern binding declaration.
 CUSTOM_LOCATOR_PATH_ELT(PatternBindingElement)
 
-/// A branch of a SingleValueStmtExpr.
-CUSTOM_LOCATOR_PATH_ELT(SingleValueStmtBranch)
+/// A particular result of a ThenStmt at a given index in a SingleValueStmtExpr.
+CUSTOM_LOCATOR_PATH_ELT(SingleValueStmtResult)
 
 /// A declaration introduced by a pattern: name (i.e. `x`) or `_`
 ABSTRACT_LOCATOR_PATH_ELT(PatternDecl)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1624,6 +1624,13 @@ public:
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
+  void visitThenStmt(ThenStmt *S) {
+    printCommon(S, "then_stmt");
+    OS << '\n';
+    printRec(S->getResult());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+  }
+
   void visitDeferStmt(DeferStmt *S) {
     printCommon(S, "defer_stmt") << '\n';
     printRec(S->getTempDecl());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3502,6 +3502,10 @@ static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureThenStatements(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureNewCxxMethodSafetyHeuristics(Decl *decl) {
   return decl->hasClangNode();
 }
@@ -5512,6 +5516,16 @@ void PrintAST::visitYieldStmt(YieldStmt *stmt) {
     (void) yield;
   }
   if (parens) Printer << ")";
+}
+
+void PrintAST::visitThenStmt(ThenStmt *stmt) {
+  // For now, don't print implicit 'then' statements, since they can be
+  // present when the feature is disabled.
+  // TODO: Once we enable the feature, we can remove this.
+  if (!stmt->isImplicit())
+    Printer.printKeyword("then", Options, " ");
+
+  visit(stmt->getResult());
 }
 
 void PrintAST::visitThrowStmt(ThrowStmt *stmt) {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -437,6 +437,12 @@ public:
     return p;
   }
 
+  ASTScopeImpl *visitThenStmt(ThenStmt *ts, ASTScopeImpl *p,
+                              ScopeCreator &scopeCreator) {
+    visitExpr(ts->getResult(), p, scopeCreator);
+    return p;
+  }
+
   ASTScopeImpl *visitDeferStmt(DeferStmt *ds, ASTScopeImpl *p,
                                ScopeCreator &scopeCreator) {
     visitFuncDecl(ds->getTempDecl(), p, scopeCreator);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1214,7 +1214,7 @@ public:
     void verifyChecked(SingleValueStmtExpr *E) {
       using Kind = IsSingleValueStmtResult::Kind;
       switch (E->getStmt()->mayProduceSingleValue(Ctx).getKind()) {
-      case Kind::NoExpressionBranches:
+      case Kind::NoResult:
         // These are allowed as long as the type is Void.
         checkSameType(
             E->getType(), Ctx.getVoidType(),

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1772,6 +1772,15 @@ Stmt *Traversal::visitYieldStmt(YieldStmt *YS) {
   return YS;
 }
 
+Stmt *Traversal::visitThenStmt(ThenStmt *TS) {
+  auto *E = doIt(TS->getResult());
+  if (!E)
+    return nullptr;
+
+  TS->setResult(E);
+  return TS;
+}
+
 Stmt *Traversal::visitDeferStmt(DeferStmt *DS) {
   if (doIt(DS->getTempDecl()))
     return nullptr;

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -51,6 +51,8 @@ StringRef Stmt::getDescriptiveKindName(StmtKind K) {
     return "return";
   case StmtKind::Yield:
     return "yield";
+  case StmtKind::Then:
+    return "then";
   case StmtKind::Defer:
     return "defer";
   case StmtKind::If:
@@ -361,6 +363,26 @@ YieldStmt *YieldStmt::create(const ASTContext &ctx, SourceLoc yieldLoc,
 
 SourceLoc YieldStmt::getEndLoc() const {
   return RPLoc.isInvalid() ? getYields()[0]->getEndLoc() : RPLoc;
+}
+
+ThenStmt *ThenStmt::createParsed(ASTContext &ctx, SourceLoc thenLoc,
+                                 Expr *result) {
+  return new (ctx) ThenStmt(thenLoc, result, /*isImplicit*/ false);
+}
+
+ThenStmt *ThenStmt::createImplicit(ASTContext &ctx, Expr *result) {
+  return new (ctx) ThenStmt(SourceLoc(), result, /*isImplicit*/ true);
+}
+
+SourceRange ThenStmt::getSourceRange() const {
+  auto range = getResult()->getSourceRange();
+  if (!range)
+    return ThenLoc;
+
+  if (ThenLoc)
+    range.widen(ThenLoc);
+
+  return range;
 }
 
 SourceLoc ThrowStmt::getEndLoc() const { return SubExpr->getEndLoc(); }

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -35,6 +35,7 @@ extension Parser.ExperimentalFeatures {
         insert(feature)
       }
     }
+    mapFeature(.ThenStatements, to: .thenStatements)
   }
 }
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -45,6 +45,7 @@ public:
 
   void completeCallArg(CodeCompletionExpr *E, bool isFirst) override;
   void completeReturnStmt(CodeCompletionExpr *E) override;
+  void completeThenStmt(CodeCompletionExpr *E) override;
   void completeYieldStmt(CodeCompletionExpr *E,
                          llvm::Optional<unsigned> yieldIndex) override;
 
@@ -70,6 +71,10 @@ void ContextInfoCallbacks::completeCallArg(CodeCompletionExpr *E,
   ParsedExpr = E;
 }
 void ContextInfoCallbacks::completeReturnStmt(CodeCompletionExpr *E) {
+  CurDeclContext = P.CurDeclContext;
+  ParsedExpr = E;
+}
+void ContextInfoCallbacks::completeThenStmt(CodeCompletionExpr *E) {
   CurDeclContext = P.CurDeclContext;
   ParsedExpr = E;
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3578,10 +3578,11 @@ ParserResult<Expr> Parser::parseExprCollection() {
 
       // If The next token is at the beginning of a new line and can never start
       // an element, break.
-      if (Tok.isAtStartOfLine() && (Tok.isAny(tok::r_brace, tok::pound_endif) ||
-                                    isStartOfSwiftDecl() || isStartOfStmt()))
+      if (Tok.isAtStartOfLine() &&
+          (Tok.isAny(tok::r_brace, tok::pound_endif) || isStartOfSwiftDecl() ||
+           isStartOfStmt(/*preferExpr*/ false))) {
         break;
-
+      }
       diagnose(Tok, diag::expected_separator, ",")
           .fixItInsertAfter(PreviousLoc, ",");
       Status.setIsParseError();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -707,8 +707,10 @@ SourceLoc Parser::skipUntilGreaterInTypeList(bool protocolComposition) {
     // 'Self' can appear in types, skip it.
     if (Tok.is(tok::kw_Self))
       break;
-    if (isStartOfStmt() || isStartOfSwiftDecl() || Tok.is(tok::pound_endif))
+    if (isStartOfStmt(/*preferExpr*/ false) || isStartOfSwiftDecl() ||
+        Tok.is(tok::pound_endif)) {
       return lastLoc;
+    }
     break;
 
     case tok::l_paren:
@@ -1019,8 +1021,8 @@ Parser::parseListItem(ParserStatus &Status, tok RightK, SourceLoc LeftLoc,
   }
   // If we're in a comma-separated list, the next token is at the
   // beginning of a new line and can never start an element, break.
-  if (Tok.isAtStartOfLine() &&
-      (Tok.is(tok::r_brace) || isStartOfSwiftDecl() || isStartOfStmt())) {
+  if (Tok.isAtStartOfLine() && (Tok.is(tok::r_brace) || isStartOfSwiftDecl() ||
+                                isStartOfStmt(/*preferExpr*/ false))) {
     return ParseListItemResult::Finished;
   }
   // If we found EOF or such, bailout.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2235,7 +2235,7 @@ RValue RValueEmitter::visitSingleValueStmtExpr(SingleValueStmtExpr *E,
   // Collect the target exprs that will be used for initialization.
   SmallVector<Expr *, 4> scratch;
   SILGenFunction::SingleValueStmtInitialization initInfo(resultAddr);
-  for (auto *E : E->getSingleExprBranches(scratch))
+  for (auto *E : E->getResultExprs(scratch))
     initInfo.Exprs.insert(E);
 
   // Push the initialization for branches of the statement to initialize into.

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -246,6 +246,7 @@ void DiagnosticEmitter::emitMissingConsumeInDiscardingContext(
       case StmtKind::Return:
       case StmtKind::Yield:
       case StmtKind::Break:
+      case StmtKind::Then:
       case StmtKind::Fail:
       case StmtKind::PoundAssert:
         return true;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -163,6 +163,11 @@ protected:
       assert(returnStmt->isImplicit());
       element = returnStmt->getResult();
     }
+    // Unwrap an implicit ThenStmt.
+    if (auto *thenStmt = getAsStmt<ThenStmt>(element)) {
+      if (thenStmt->isImplicit())
+        element = thenStmt->getResult();
+    }
 
     if (auto *decl = element.dyn_cast<Decl *>()) {
       switch (decl->getKind()) {
@@ -756,6 +761,7 @@ protected:
   UNSUPPORTED_STMT(Throw)
   UNSUPPORTED_STMT(Return)
   UNSUPPORTED_STMT(Yield)
+  UNSUPPORTED_STMT(Then)
   UNSUPPORTED_STMT(Discard)
   UNSUPPORTED_STMT(Defer)
   UNSUPPORTED_STMT(Guard)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8764,20 +8764,8 @@ namespace {
       auto resultTy = solution.getResolvedType(SVE);
       Rewriter.cs.setType(SVE, resultTy);
 
-      SmallVector<Expr *, 4> scratch;
-      SmallPtrSet<Expr *, 4> exprBranches;
-      for (auto *branch : SVE->getSingleExprBranches(scratch))
-        exprBranches.insert(branch);
-
       return Rewriter.cs.applySolutionToSingleValueStmt(
           solution, SVE, solution.getDC(), [&](SyntacticElementTarget target) {
-            // We need to fixup the conversion type to the full result type,
-            // not the branch result type. This is necessary as there may be
-            // an additional conversion required for the branch.
-            if (auto *E = target.getAsExpr()) {
-              if (exprBranches.contains(E))
-                target.setExprConversionType(resultTy);
-            }
             auto resultTarget = rewriteTarget(target);
             if (!resultTarget)
               return resultTarget;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2575,7 +2575,7 @@ bool ContextualFailure::diagnoseAsError() {
     diagnostic = diag::ternary_expr_cases_mismatch;
     break;
   }
-  case ConstraintLocator::SingleValueStmtBranch: {
+  case ConstraintLocator::SingleValueStmtResult: {
     diagnostic = diag::single_value_stmt_branches_mismatch;
     break;
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9158,6 +9158,11 @@ bool ConcreteTypeSpecialization::diagnoseAsError() {
   return true;
 }
 
+bool OutOfPlaceThenStmtFailure::diagnoseAsError() {
+  emitDiagnostic(diag::out_of_place_then_stmt);
+  return true;
+}
+
 bool InvalidTypeSpecializationArity::diagnoseAsError() {
   emitDiagnostic(diag::type_parameter_count_mismatch, D->getBaseIdentifier(),
                  NumParams, NumArgs, NumArgs < NumParams, HasParameterPack);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -3073,6 +3073,16 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose an out-of-place ThenStmt.
+class OutOfPlaceThenStmtFailure final : public FailureDiagnostic {
+public:
+  OutOfPlaceThenStmtFailure(const Solution &solution,
+                            ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose attempts to specialize with invalid number of generic arguments:
 ///
 /// \code

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2843,6 +2843,18 @@ AllowConcreteTypeSpecialization::create(ConstraintSystem &cs, Type concreteTy,
       AllowConcreteTypeSpecialization(cs, concreteTy, locator);
 }
 
+bool IgnoreOutOfPlaceThenStmt::diagnose(const Solution &solution,
+                                        bool asNote) const {
+  OutOfPlaceThenStmtFailure failure(solution, getLocator());
+  return failure.diagnose(asNote);
+}
+
+IgnoreOutOfPlaceThenStmt *
+IgnoreOutOfPlaceThenStmt::create(ConstraintSystem &cs,
+                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator()) IgnoreOutOfPlaceThenStmt(cs, locator);
+}
+
 bool IgnoreGenericSpecializationArityMismatch::diagnose(
     const Solution &solution, bool asNote) const {
   InvalidTypeSpecializationArity failure(solution, D, NumParams, NumArgs,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3872,10 +3872,10 @@ namespace {
       if (auto *SVE = expr->getSingleValueStmtExpr()) {
         // If we have a SingleValueStmtExpr, form a join of the branch types.
         SmallVector<Expr *, 4> scratch;
-        auto branches = SVE->getSingleExprBranches(scratch);
+        auto branches = SVE->getResultExprs(scratch);
         for (auto idx : indices(branches)) {
           auto *eltLoc = CS.getConstraintLocator(
-              SVE, {LocatorPathElt::SingleValueStmtBranch(idx)});
+              SVE, {LocatorPathElt::SingleValueStmtResult(idx)});
           elements.emplace_back(CS.getType(branches[idx]), eltLoc);
         }
       } else {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15291,6 +15291,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::DestructureTupleToMatchPackExpansionParameter:
   case FixKind::AllowValueExpansionWithoutPackReferences:
   case FixKind::IgnoreInvalidPatternInExpr:
+  case FixKind::IgnoreOutOfPlaceThenStmt:
   case FixKind::IgnoreMissingEachKeyword:
     llvm_unreachable("handled elsewhere");
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5859,12 +5859,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
       continue;
     }
 
-    case ConstraintLocator::SingleValueStmtBranch: {
-      auto branchElt = path[0].castTo<LocatorPathElt::SingleValueStmtBranch>();
-      auto exprIdx = branchElt.getExprBranchIndex();
+    case ConstraintLocator::SingleValueStmtResult: {
+      auto branchElt = path[0].castTo<LocatorPathElt::SingleValueStmtResult>();
+      auto exprIdx = branchElt.getIndex();
       auto *SVE = castToExpr<SingleValueStmtExpr>(anchor);
       SmallVector<Expr *, 4> scratch;
-      anchor = SVE->getSingleExprBranches(scratch)[exprIdx];
+      anchor = SVE->getResultExprs(scratch)[exprIdx];
       path = path.slice(1);
       continue;
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3846,7 +3846,6 @@ class SingleValueStmtUsageChecker final : public ASTWalker {
   ASTContext &Ctx;
   DiagnosticEngine &Diags;
   llvm::DenseSet<SingleValueStmtExpr *> ValidSingleValueStmtExprs;
-  llvm::DenseSet<ThenStmt *> ValidThenStmts;
 
 public:
   SingleValueStmtUsageChecker(
@@ -3918,11 +3917,6 @@ private:
         Diags.diagnose(SVE->getLoc(), diag::single_value_stmt_out_of_place,
                        SVE->getStmt()->getKind());
       }
-
-      // Mark the valid 'then' statements.
-      SmallVector<ThenStmt *, 4> scratch;
-      for (auto *thenStmt : SVE->getThenStmts(scratch))
-        ValidThenStmts.insert(thenStmt);
 
       // Diagnose invalid SingleValueStmtExprs. This should only happen for
       // expressions in positions that we didn't support before
@@ -4008,11 +4002,8 @@ private:
     if (auto *TS = dyn_cast<ThrowStmt>(S))
       markValidSingleValueStmt(TS->getSubExpr());
 
-    if (auto *TS = dyn_cast<ThenStmt>(S)) {
+    if (auto *TS = dyn_cast<ThenStmt>(S))
       markValidSingleValueStmt(TS->getResult());
-      if (!ValidThenStmts.contains(TS))
-        Diags.diagnose(TS->getThenLoc(), diag::out_of_place_then_stmt);
-    }
 
     return Action::Continue(S);
   }

--- a/test/Constraints/then_stmt.swift
+++ b/test/Constraints/then_stmt.swift
@@ -1,0 +1,109 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ThenStatements
+
+// Required for experimental features
+// REQUIRES: asserts
+
+enum E {
+  case e
+  case f
+  case g(Int)
+}
+
+func testVoidNeverConversion() {
+  // Explicit 'then' statements don't participate in implicit Void/Never conversions.
+  let _: () -> Void = {
+    if .random() {
+      then 0 // expected-error {{cannot convert value of type 'Int' to specified type 'Void'}}
+    } else {
+      0
+    }
+  }
+  let _: () -> Void = {
+    if .random() {
+      then fatalError() // expected-error {{cannot convert value of type 'Never' to specified type 'Void'}}
+    } else {
+      0
+    }
+  }
+  let _ = {
+    if .random() {
+      then "" // expected-error {{branches have mismatching types 'String' and 'Int'}}
+    } else {
+      then 0
+    }
+  }
+  let _ = {
+    if .random() {
+      then ()
+    } else {
+      0 // expected-warning {{integer literal is unused}}
+    }
+  }
+  let _ = {
+    if .random() {
+      then ""
+    } else {
+      fatalError()
+    }
+  }
+  func foo() -> Int {
+    switch Bool.random() {
+    case true:
+      fatalError()
+    case false:
+      then fatalError() // expected-error {{cannot convert value of type 'Never' to specified type 'Int'}}
+    }
+  }
+}
+
+enum Either<T, U> {
+  case first(T), second(U)
+}
+
+@resultBuilder
+struct Builder { // expected-note 2{{struct 'Builder' declared here}}
+  static func buildBlock<T>(_ x: T) -> T { x }
+  static func buildBlock<T, U>(_ x: T, _ y: U) -> (T, U) { (x, y) }
+
+  static func buildEither<T, U>(first x: T) -> Either<T, U> { .first(x) }
+  static func buildEither<T, U>(second x: U) -> Either<T, U> { .second(x) }
+
+  static func buildExpression(_ x: Double) -> Double { x }
+  static func buildExpression<T>(_ x: T) -> T { x }
+}
+
+@Builder
+func testThenStmtBuilder1() -> Either<Int, Int> {
+  // We don't allow explicit 'then' to be part of the transform.
+  if .random() {
+    then 0 // expected-error {{closure containing control flow statement cannot be used with result builder 'Builder'}}
+  } else {
+    1
+  }
+}
+
+@Builder
+func testThenStmtBuilder2() -> Either<Int, Int> {
+  // We don't allow explicit 'then' to be part of the transform.
+  if .random() {
+    then 0 // expected-error {{closure containing control flow statement cannot be used with result builder 'Builder'}}
+  } else {
+    1
+  }
+  ()
+}
+
+@Builder
+func testThenStmtBuilder3() -> Either<Int, String> {
+  // But it's fine as part of e.g a binding.
+  let x = if .random() {
+    then 0
+  } else {
+    1
+  }
+  if .random() {
+    x
+  } else {
+    ""
+  }
+}

--- a/test/IDE/complete_then_stmt.swift
+++ b/test/IDE/complete_then_stmt.swift
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -enable-experimental-feature ThenStatements -debug-forbid-typecheck-prefix FORBIDDEN -filecheck %raw-FileCheck -completion-output-dir %t
+
+// Experimental feature requires asserts
+// REQUIRES: asserts
+
+enum E {
+  case e
+  case f(Int)
+}
+
+struct NO {
+  // Triggering interface type computation of this will cause an assert to fire,
+  // ensuring we don't attempt to type-check any references to it.
+  static var TYPECHECK = FORBIDDEN
+}
+
+func testThenStmt1() -> E {
+  if .random() {
+    ()
+    then .#^DOT1?check=DOT^#
+  } else {
+    .e
+  }
+}
+
+func testThenStmt2() -> E {
+  switch Bool.random() {
+  case true:
+    .e
+  case false:
+    ()
+    then .#^DOT2?check=DOT^#
+  }
+}
+
+func testThenStmt3() throws -> E {
+  switch Bool.random() {
+  case true:
+    NO.TYPECHECK
+    throw NO.TYPECHECK
+  case false:
+    ()
+    then .#^DOT3?check=DOT^#
+  }
+}
+
+func testThenStmt4() throws -> E {
+  switch Bool.random() {
+  case true:
+    NO.TYPECHECK
+    throw NO.TYPECHECK
+  case false:
+    then #^NODOT1?check=NODOT^#
+  }
+}
+
+// NODOT:     Begin completions
+// NODOT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .e[#E#]; name=e
+// NODOT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .f({#Int#})[#E#]; name=f()
+
+struct S {
+  var e: E
+}
+
+func testThenStmt5() throws -> E {
+  let x = switch Bool.random() {
+  case true:
+    NO.TYPECHECK
+    throw NO.TYPECHECK
+  case false:
+    let s = S(e: .e)
+    then s.#^SDOT1?check=SDOT^#
+  }
+  return x
+}
+
+// SDOT:     Begin completions, 2 items
+// SDOT-DAG: Keyword[self]/CurrNominal:          self[#S#]; name=self
+// SDOT-DAG: Decl[InstanceVar]/CurrNominal:      e[#E#]; name=e
+
+// DOT:     Begin completions, 2 items
+// DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: e[#E#]; name=e
+// DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: f({#Int#})[#E#]; name=f()

--- a/test/stmt/print/then_stmt.swift
+++ b/test/stmt/print/then_stmt.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -print-ast -enable-experimental-feature ThenStatements %s 2>&1 | %FileCheck %s
+
+// Required for experimental features
+// REQUIRES: asserts
+
+func foo() -> Int {
+  if .random() {
+    then 0
+  } else {
+    0
+  }
+  // Make sure we don't print implicit 'then' statements.
+  // CHECK:      return if Bool.random() {
+  // CHECK-NEXT: {{^}}  then 0
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: {{^}}  0
+  // CHECK-NEXT: }
+}

--- a/test/stmt/then_stmt.swift
+++ b/test/stmt/then_stmt.swift
@@ -1,0 +1,220 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -enable-experimental-feature ThenStatements
+
+// Required for experimental features
+// REQUIRES: asserts
+
+// Required for regex
+// REQUIRES: swift_in_compiler
+
+func then(_: Int = 0, x: Int = 0, fn: () -> Void = {}) {}
+
+func testThenStmt(_ x: Int) {
+  // These are statements
+  then x // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then ()  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then (1)  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then (1, 2)  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then ""  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then []
+  // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  // expected-error@-2 {{empty collection literal requires an explicit type}}
+  then [0]  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+
+  then if .random() { 0 } else { 1 }
+  // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  // expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+  then -1 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then ~1 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then /abc/ // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+
+  let x: Int = if .random() {
+    then .zero
+  } else {
+    then 0
+  }
+  let y = if .random() { then x } else { then 1 }
+  let _ = if .random() { (); then y } else { then 1 }
+
+  // We don't allow labels on 'then' statements.
+  let _ = switch Bool.random() {
+  case true:
+    a: then 0 // expected-error {{labels are only valid on loops, if, and switch statements}}
+  case false:
+    then 1
+  }
+}
+
+func testThenFunctionCalls() {
+  // These should all be treated as function calls.
+  then()
+  then(0)
+  then(x: 0)
+  then{}
+  then {}
+}
+
+func testThenLabel() {
+  then: for then in [0] { // expected-warning {{immutable value 'then' was never used; consider replacing with '_' or removing it}}
+    break then
+    continue then
+  }
+}
+
+struct S {
+  var then: Int
+  func then(_ x: Int) {}
+
+  subscript(x: Int) -> Void { () }
+
+  mutating func testThenAsMember() -> Int {
+    do {
+      then  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    } // expected-error {{expected expression after 'then'}}
+    then // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    0 // expected-warning {{expression following 'then' is treated as an argument of the 'then'}}
+    // expected-note@-1 {{indent the expression to silence this warning}}
+
+    // Indented is okay.
+    then // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+      0
+
+    then;
+    // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    // expected-error@-2 {{expected expression after 'then'}}
+
+    then . foo
+    // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    // expected-error@-2 {{reference to member 'foo' cannot be resolved without a contextual type}}
+
+    // These are expressions.
+    let _ = then
+    let _ = self.then
+    then + 1 // expected-warning {{result of operator '+' is unused}}
+    then = 2
+
+    (then) // expected-warning {{property is accessed but result is unused}}
+
+    then is Int 
+    // expected-warning@-1 {{'is' test is always true}}
+    // expected-warning@-2 {{expression of type 'Bool' is unused}}
+    then as Int 
+    // expected-warning@-1 {{expression of type 'Int' is unused}}
+    then as? Int
+    // expected-warning@-1 {{conditional cast from 'Int' to 'Int' always succeeds}}
+    // expected-warning@-2 {{expression of type 'Int?' is unused}}
+    then as! Int
+    // expected-warning@-1 {{forced cast of 'Int' to same type has no effect}}
+    // expected-warning@-2 {{expression of type 'Int' is unused}}
+
+    then ? 0 : 1 // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    then! // expected-error {{cannot force unwrap value of non-optional type 'Int'}}
+    then? // expected-error {{cannot use optional chaining on non-optional value of type 'Int'}}
+    then.bitWidth // expected-warning {{expression of type 'Int' is unused}}
+    then?.bitWidth // expected-error {{cannot use optional chaining on non-optional value of type 'Int'}}
+    then!.bitWidth // expected-error {{cannot force unwrap value of non-optional type 'Int'}}
+
+    // This is tricky because the lexer considers '/^' to be an infix operator.
+    then /^ then/
+    // expected-error@-1 {{cannot find operator '/^' in scope}}
+    // expected-error@-2 {{'/' is not a postfix unary operator}}
+
+    self.then(0)
+    return then
+  }
+  func testThenSubscript() {
+    let then = self
+    then[0]
+  }
+}
+
+func testOutOfPlace() -> Int {
+  if .random() {
+    guard .random() else {
+      then 0 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    }
+    if .random() {
+      then 0 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    } else {
+      then 1 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    }
+    then 0 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    then 0
+  } else {
+    then 1
+  }
+}
+
+func testNested1() -> Int {
+  if .random() {
+    if .random() {
+      then 1
+    } else {
+      then 2
+    }
+  } else {
+    switch Bool.random() {
+    case true:
+      then 0
+    case false:
+      then 1
+    }
+  }
+}
+
+func testNested2() -> Int {
+  if .random() {
+    then if .random() {
+      then 1
+    } else {
+      then 2
+    }
+  } else {
+    then switch Bool.random() {
+    case true:
+      then 0
+    case false:
+      then 1
+    }
+  }
+}
+
+func testNested3() -> Int {
+  if .random() {
+    print("hello")
+    then if .random() {
+      then 1
+    } else {
+      then 2
+    }
+  } else {
+    ()
+    ()
+    then switch Bool.random() {
+    case true:
+      then 0
+    case false:
+      then 1
+    }
+  }
+}
+
+func throwingFn() throws -> Int { 0 }
+
+func testTryOnThen() throws -> Int {
+  switch 0 {
+  case 1:
+    then try throwingFn() // okay
+  default:
+    try then() // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+    try then{} // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+    try then {} // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+
+    try then throwingFn()
+    // expected-error@-1 {{'try' must be placed on the produced expression}} {{5-9=}} {{14-14=try }}
+  }
+}
+
+func testReturnTryThen(_ then: Int) -> Int {
+  return try then // expected-warning {{no calls to throwing functions occur within 'try' expression}}
+}

--- a/test/stmt/then_stmt_disabled.swift
+++ b/test/stmt/then_stmt_disabled.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+// Then statements are disabled by default
+let x = if .random() {
+  print("hello")
+  then 0
+  // expected-error@-1 {{cannot find 'then' in scope}}
+  // expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
+} else {
+  1
+}

--- a/test/stmt/then_stmt_exec.swift
+++ b/test/stmt/then_stmt_exec.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -Xfrontend -enable-experimental-feature -Xfrontend ThenStatements -o %t/a.out %s
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Required for experimental features
+// REQUIRES: asserts
+
+func testDefer(_ x: Bool) -> Int {
+  defer {
+    print("defer fn")
+  }
+  let x = if x {
+    defer {
+      print("defer if")
+    }
+    print("enter if")
+    then 0
+  } else {
+    1
+  }
+  print("after if")
+  return x
+}
+_ = testDefer(true)
+
+// CHECK:      enter if
+// CHECK-NEXT: defer if
+// CHECK-NEXT: after if
+// CHECK-NEXT: defer fn


### PR DESCRIPTION
These allow multi-statement `if`/`switch` expression branches that can produce a value at the end by saying `then <expr>`. This is gated behind `-enable-experimental-feature ThenStatements` pending evolution discussion.