### PR TITLE
Skip running cmark tests in a few more macOS presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2167,6 +2167,7 @@ verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
 skip-build-benchmarks
+skip-test-cmark
 
 [preset: mixin_buildbot_incremental,test=macOS,type=device]
 


### PR DESCRIPTION
This expands on #35361

Addresses rdar://112604393