### PR TITLE
Ensure CMark is not tested by default

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1225,6 +1225,7 @@ def create_argument_parser():
     option('--skip-clean-swift-driver', toggle_false('clean_swift_driver'),
            help='skip cleaning up Swift driver')
     option('--skip-test-cmark', toggle_false('test_cmark'),
+           default=False,
            help='skip testing cmark')
     option('--skip-test-swiftpm', toggle_false('test_swiftpm'),
            help='skip testing swiftpm')


### PR DESCRIPTION
`test_cmark` is set by default to `True` because of the indirect  way we define it through `--skip-test-cmark` -- we want instead the user to opt in into this explicitly, as CMark tests on their own have little value when building as part of Swift.

Addresses rdar://112604393