### PR TITLE
docs: fix old spelling of assert/assume APIs in docs

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -89,8 +89,8 @@ public protocol SerialExecutor: Executor {
   ///
   /// This check is not used when performing executor switching.
   ///
-  /// This check is used when performing `preconditionTaskOnActorExecutor`, `preconditionTaskOnActorExecutor`,
-  /// `assumeOnActorExecutor` and similar APIs which assert about the same "exclusive serial execution context".
+  /// This check is used when performing ``Actor/assertIsolated()``, ``Actor/preconditionIsolated()``,
+  /// ``Actor/assumeIsolated()`` and similar APIs which assert about the same "exclusive serial execution context".
   ///
   /// - Parameter other: the executor to compare with.
   /// - Returns: true, if `self` and the `other` executor actually are mutually exclusive

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -74,7 +74,7 @@ actor Someone {
 
       // FIXME: calling without await from main() should also succeed, we must set the executor while we're kicking off main
 
-      tests.test("preconditionTaskOnActorExecutor(main): from Main friend") {
+      tests.test("MainActor.preconditionIsolated(): from Main friend") {
         await MainFriend().callCheckMainActor()
       }
 


### PR DESCRIPTION
**Description:** Serial executor used old names of assert/assume methods in the documentation of `isSameExclusiveExecutionContext`. This changes them to the correct ones, and makes them docc links.
**Risk:** Low, docs only
**Review by:** @DougGregor
**Testing:** CI testing
**Radar:** rdar://112689338