### PR TITLE
[Requirement Machine] Implement same-element requirements.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -123,6 +123,7 @@ EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
+EXPERIMENTAL_FEATURE(SameElementRequirements, false)
 
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)", true)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3259,6 +3259,10 @@ static bool usesFeatureTupleConformances(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureSameElementRequirements(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureSymbolLinkageMarkers(Decl *decl) {
   auto &attrs = decl->getAttrs();
   return std::any_of(attrs.begin(), attrs.end(), [](auto *attr) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1854,6 +1854,9 @@ void PrintAST::printRequirement(const Requirement &req) {
   SmallVector<Type, 2> rootParameterPacks;
   getTransformedType(req.getFirstType())
       ->getTypeParameterPacks(rootParameterPacks);
+  if (req.getKind() != RequirementKind::Layout)
+    getTransformedType(req.getSecondType())
+        ->getTypeParameterPacks(rootParameterPacks);
   bool isPackRequirement = !rootParameterPacks.empty();
 
   switch (req.getKind()) {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -180,16 +180,16 @@ struct FindElementArchetypeForOpenedPackParam {
     : findElementParam(env, openedPacks), getElementArchetype(env) {}
 
 
-  ElementArchetypeType *operator()(Type interfaceType) {
+  Type operator()(Type interfaceType) {
     assert(interfaceType->isTypeParameter());
     if (auto member = interfaceType->getAs<DependentMemberType>()) {
-      auto baseArchetype = (*this)(member->getBase());
+      auto baseArchetype = (*this)(member->getBase())
+             ->castTo<ElementArchetypeType>();
       return baseArchetype->getNestedType(member->getAssocType())
                ->castTo<ElementArchetypeType>();
     }
     assert(interfaceType->is<GenericTypeParamType>());
-    return getElementArchetype(findElementParam(interfaceType))
-             ->castTo<ElementArchetypeType>();
+    return getElementArchetype(findElementParam(interfaceType));
   }
 };
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -794,6 +794,10 @@ int swift::compareDependentTypes(Type type1, Type type2) {
   // Fast-path check for equality.
   if (type1->isEqual(type2)) return 0;
 
+  // Packs are always ordered after scalar type parameters.
+  if (type1->isParameterPack() != type2->isParameterPack())
+    return type2->isParameterPack() ? -1 : +1;
+
   // Ordering is as follows:
   // - Generic params
   auto gp1 = type1->getAs<GenericTypeParamType>();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -105,8 +105,16 @@ void GenericSignatureImpl::forEachParam(
 
   for (auto req : getRequirements()) {
     GenericTypeParamType *gp;
+    bool isCanonical = false;
     switch (req.getKind()) {
     case RequirementKind::SameType: {
+      if (req.getSecondType()->isParameterPack() != 
+          req.getFirstType()->isParameterPack()) {
+        // This is a same-element requirement, which does not make
+        // type parameters non-canonical.
+        isCanonical = true;
+      }
+
       if (auto secondGP = req.getSecondType()->getAs<GenericTypeParamType>()) {
         // If two generic parameters are same-typed, then the right-hand one
         // is non-canonical.
@@ -136,7 +144,7 @@ void GenericSignatureImpl::forEachParam(
     }
 
     unsigned index = GenericParamKey(gp).findIndexIn(genericParams);
-    genericParamsAreCanonical[index] = false;
+    genericParamsAreCanonical[index] = isCanonical;
   }
 
   // Call the callback with each parameter and the result of the above analysis.

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -308,20 +308,6 @@ bool RequirementMachine::isReducedType(Type type) const {
       if (!component->hasTypeParameter())
         return Action::SkipChildren;
 
-      if (auto *expansion = component->getAs<PackExpansionType>()) {
-        auto pattern = expansion->getPatternType();
-        auto shape = expansion->getCountType();
-        if (!Self.isReducedType(pattern))
-          return Action::Stop;
-
-        auto reducedShape =
-            Self.getReducedShape(shape, Self.getGenericParams());
-        if (reducedShape->getCanonicalType() != CanType(shape))
-          return Action::Stop;
-
-        return Action::SkipChildren;
-      }
-
       if (!component->isTypeParameter())
         return Action::Continue;
 

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -743,7 +743,8 @@ RewriteSystem::getMinimizedGenericSignatureRules() const {
       continue;
     }
 
-    if (rule.getLHS()[0].getKind() != Symbol::Kind::GenericParam)
+    if (rule.getLHS()[0].getKind() != Symbol::Kind::PackElement &&
+        rule.getLHS()[0].getKind() != Symbol::Kind::GenericParam)
       continue;
 
     rules.push_back(ruleID);

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -298,6 +298,9 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
         // member type rooted at Self; handle the associated type below.
         break;
 
+      case Symbol::Kind::PackElement:
+        continue;
+
       case Symbol::Kind::Name:
       case Symbol::Kind::Layout:
       case Symbol::Kind::Superclass:

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -286,6 +286,7 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
   case Symbol::Kind::ConcreteType:
   case Symbol::Kind::ConcreteConformance:
   case Symbol::Kind::Shape:
+  case Symbol::Kind::PackElement:
     break;
   }
 
@@ -552,6 +553,7 @@ void RewriteSystem::computeCandidateConformancePaths(
         //
         // where Y is the simplified form of X.W.
         } else if (rhs.isAnyConformanceRule() &&
+                   !lhs.isSameElementRule() &&
                    (unsigned)(lhs.getLHS().end() - from) < rhs.getLHS().size()) {
           if (Debug.contains(DebugFlags::MinimalConformancesDetail)) {
             llvm::dbgs() << "Case 2: same-type suffix\n";

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -646,6 +646,7 @@ void PropertyMap::addProperty(
   case Symbol::Kind::GenericParam:
   case Symbol::Kind::AssociatedType:
   case Symbol::Kind::Shape:
+  case Symbol::Kind::PackElement:
     break;
   }
 

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -248,6 +248,7 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
       case Symbol::Kind::AssociatedType:
       case Symbol::Kind::GenericParam:
       case Symbol::Kind::Shape:
+      case Symbol::Kind::PackElement:
         break;
       }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -218,15 +218,6 @@ static void desugarSameTypeRequirement(Requirement req, SourceLoc loc,
         break;
       }
 
-      // If one side is a parameter pack, this is a same-element requirement, which
-      // is not yet supported.
-      if (firstType->isParameterPack() != secondType->isParameterPack()) {
-        errors.push_back(RequirementError::forSameElement(
-            {kind, sugaredFirstType, secondType}, loc));
-        recordedErrors = true;
-        return true;
-      }
-
       if (firstType->isTypeParameter() && secondType->isTypeParameter()) {
         result.emplace_back(kind, sugaredFirstType, secondType);
         return true;

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -218,6 +218,18 @@ static void desugarSameTypeRequirement(Requirement req, SourceLoc loc,
         break;
       }
 
+      auto &ctx = firstType->getASTContext();
+      if (!ctx.LangOpts.hasFeature(Feature::SameElementRequirements)) {
+        // If one side is a parameter pack, this is a same-element requirement, which
+        // is not yet supported.
+        if (firstType->isParameterPack() != secondType->isParameterPack()) {
+          errors.push_back(RequirementError::forSameElement(
+              {kind, sugaredFirstType, secondType}, loc));
+          recordedErrors = true;
+          return true;
+        }
+      }
+
       if (firstType->isTypeParameter() && secondType->isTypeParameter()) {
         result.emplace_back(kind, sugaredFirstType, secondType);
         return true;

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -560,7 +560,7 @@ void RequirementMachine::dump(llvm::raw_ostream &out) const {
     for (auto paramTy : Params) {
       out << " " << Type(paramTy);
       if (paramTy->isParameterPack())
-        out << "…";
+        out << " " << paramTy;
     }
     out << " >";
   }

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -963,13 +963,13 @@ InferredGenericSignatureRequest::evaluate(
         if (reduced->hasError() || reduced->isEqual(genericParam))
           continue;
 
-        if (reduced->isTypeParameter()) {
-          // If one side is a parameter pack and the other is not, this is a
-          // same-element requirement that cannot be expressed with only one
-          // type parameter.
-          if (genericParam->isParameterPack() != reduced->isParameterPack())
-            continue;
+        // If one side is a parameter pack and the other is not, this is a
+        // same-element requirement that cannot be expressed with only one
+        // type parameter.
+        if (genericParam->isParameterPack() != reduced->isParameterPack())
+          continue;
 
+        if (reduced->isTypeParameter()) {
           ctx.Diags.diagnose(loc, diag::requires_generic_params_made_equal,
                              genericParam, result->getSugaredType(reduced))
             .warnUntilSwiftVersion(6);

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -48,6 +48,9 @@ class RewriteContext final {
   /// The singleton storage for shape symbols.
   Symbol::Storage *TheShapeSymbol;
 
+  /// The singleton storage for pack element symbols.
+  Symbol::Storage *ThePackElementSymbol;
+
   /// Folding set for uniquing terms.
   llvm::FoldingSet<Term::Storage> Terms;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -570,7 +570,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
 
       if (index != 0) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam ||
-                    lhs[index - 1].getKind() == Symbol::Kind::PackElement);
+                    (index == 1 &&
+                     lhs[index - 1].getKind() == Symbol::Kind::PackElement));
       }
 
       if (!rule.isLHSSimplified() &&
@@ -626,7 +627,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
 
       if (index != 0) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam ||
-                    lhs[index - 1].getKind() == Symbol::Kind::PackElement);
+                    (index == 1 &&
+                     lhs[index - 1].getKind() == Symbol::Kind::PackElement));
       }
 
       if (!rule.isRHSSimplified() &&

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -569,7 +569,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
       }
 
       if (index != 0) {
-        ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam);
+        ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam ||
+                    lhs[index - 1].getKind() == Symbol::Kind::PackElement);
       }
 
       if (!rule.isLHSSimplified() &&

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -625,7 +625,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
       }
 
       if (index != 0) {
-        ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam);
+        ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam ||
+                    lhs[index - 1].getKind() == Symbol::Kind::PackElement);
       }
 
       if (!rule.isRHSSimplified() &&

--- a/lib/AST/RequirementMachine/Rule.cpp
+++ b/lib/AST/RequirementMachine/Rule.cpp
@@ -73,6 +73,7 @@ const ProtocolDecl *Rule::isAnyConformanceRule() const {
     case Symbol::Kind::AssociatedType:
     case Symbol::Kind::GenericParam:
     case Symbol::Kind::Shape:
+    case Symbol::Kind::PackElement:
       break;
     }
 
@@ -144,6 +145,11 @@ bool Rule::isCircularConformanceRule() const {
     return false;
 
   return true;
+}
+
+/// Returns \c true if this rule is prefixed with the \c [element] symbol.
+bool Rule::isSameElementRule() const {
+  return LHS[0].getKind() == Symbol::Kind::PackElement;
 }
 
 /// A protocol typealias rule takes one of the following two forms,

--- a/lib/AST/RequirementMachine/Rule.h
+++ b/lib/AST/RequirementMachine/Rule.h
@@ -137,6 +137,8 @@ public:
 
   bool isCircularConformanceRule() const;
 
+  bool isSameElementRule() const;
+
   /// See above for an explanation of these predicates.
   bool isPermanent() const {
     return Permanent;

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -367,6 +367,7 @@ void RuleBuilder::addRequirement(const Requirement &req,
 
   case RequirementKind::SameType: {
     auto otherType = CanType(req.getSecondType());
+    auto elementSymbol = Symbol::forPackElement(Context);
 
     if (!otherType->isTypeParameter()) {
       // A concrete same-type requirement T == C<X, Y> becomes a
@@ -379,6 +380,16 @@ void RuleBuilder::addRequirement(const Requirement &req,
                         otherType, *substitutions, result)
                    : Context.getSubstitutionSchemaFromType(
                         otherType, proto, result));
+
+      // If 'T' is a parameter pack, this is a same-element
+      // requirement that becomes the following rewrite rule:
+      //
+      //   [element].T.[concrete: C<X, Y>] => [element].T
+      if (subjectType->isParameterPack()) {
+        llvm::SmallVector<Symbol, 3> subjectSymbols{elementSymbol};
+        subjectSymbols.append(subjectTerm.begin(), subjectTerm.end());
+        subjectTerm = MutableTerm(std::move(subjectSymbols));
+      }
 
       constraintTerm = subjectTerm;
       constraintTerm.add(Symbol::forConcreteType(otherType, result, Context));
@@ -393,7 +404,6 @@ void RuleBuilder::addRequirement(const Requirement &req,
 
     if (subjectType->isParameterPack() != otherType->isParameterPack()) {
       // This is a same-element requirement.
-      auto elementSymbol = Symbol::forPackElement(Context);
       llvm::SmallVector<Symbol, 3> symbols{elementSymbol};
 
       if (subjectType->isParameterPack()) {

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -390,6 +390,21 @@ void RuleBuilder::addRequirement(const Requirement &req,
                             otherType, *substitutions)
                       : Context.getMutableTermForType(
                             otherType, proto));
+
+    if (subjectType->isParameterPack() != otherType->isParameterPack()) {
+      // This is a same-element requirement.
+      auto elementSymbol = Symbol::forPackElement(Context);
+      llvm::SmallVector<Symbol, 3> symbols{elementSymbol};
+
+      if (subjectType->isParameterPack()) {
+        symbols.append(subjectTerm.begin(), subjectTerm.end());
+        subjectTerm = MutableTerm(std::move(symbols));
+      } else {
+        symbols.append(constraintTerm.begin(), constraintTerm.end());
+        constraintTerm = MutableTerm(std::move(symbols));
+      }
+    }
+
     break;
   }
   }

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -117,6 +117,10 @@ public:
     /// generic parameter.
     Shape,
 
+    /// A pack element [element].(each T) where 'each T' is a type
+    /// parameter pack.
+    PackElement,
+
     //////
     ////// "Property-like" symbol kinds:
     //////
@@ -205,6 +209,8 @@ public:
                                 RewriteContext &ctx);
 
   static Symbol forShape(RewriteContext &ctx);
+
+  static Symbol forPackElement(RewriteContext &Ctx);
 
   static Symbol forLayout(LayoutConstraint layout,
                           RewriteContext &ctx);

--- a/lib/AST/RequirementMachine/Term.cpp
+++ b/lib/AST/RequirementMachine/Term.cpp
@@ -135,29 +135,16 @@ static llvm::Optional<int> shortlexCompare(const Symbol *lhsBegin,
                                            RewriteContext &ctx) {
   // First, compare the number of name and pack element symbols.
   unsigned lhsNameCount = 0;
-  unsigned lhsPackElementCount = 0;
   for (auto *iter = lhsBegin; iter != lhsEnd; ++iter) {
     if (iter->getKind() == Symbol::Kind::Name)
       ++lhsNameCount;
-
-    if (iter->getKind() == Symbol::Kind::PackElement)
-      ++lhsPackElementCount;
   }
 
   unsigned rhsNameCount = 0;
-  unsigned rhsPackElementCount = 0;
   for (auto *iter = rhsBegin; iter != rhsEnd; ++iter) {
     if (iter->getKind() == Symbol::Kind::Name)
       ++rhsNameCount;
-
-    if (iter->getKind() == Symbol::Kind::PackElement)
-      ++rhsPackElementCount;
   }
-
-  // A term with more pack element symbols orders after a term with
-  // fewer pack element symbols.
-  if (lhsPackElementCount != rhsPackElementCount)
-    return lhsPackElementCount > rhsPackElementCount ? 1 : -1;
 
   // A term with more name symbols orders after a term with fewer name symbols.
   if (lhsNameCount != rhsNameCount)

--- a/lib/AST/RequirementMachine/Term.cpp
+++ b/lib/AST/RequirementMachine/Term.cpp
@@ -133,18 +133,31 @@ static llvm::Optional<int> shortlexCompare(const Symbol *lhsBegin,
                                            const Symbol *rhsBegin,
                                            const Symbol *rhsEnd,
                                            RewriteContext &ctx) {
-  // First, compare the number of name symbols.
+  // First, compare the number of name and pack element symbols.
   unsigned lhsNameCount = 0;
+  unsigned lhsPackElementCount = 0;
   for (auto *iter = lhsBegin; iter != lhsEnd; ++iter) {
     if (iter->getKind() == Symbol::Kind::Name)
       ++lhsNameCount;
+
+    if (iter->getKind() == Symbol::Kind::PackElement)
+      ++lhsPackElementCount;
   }
 
   unsigned rhsNameCount = 0;
+  unsigned rhsPackElementCount = 0;
   for (auto *iter = rhsBegin; iter != rhsEnd; ++iter) {
     if (iter->getKind() == Symbol::Kind::Name)
       ++rhsNameCount;
+
+    if (iter->getKind() == Symbol::Kind::PackElement)
+      ++rhsPackElementCount;
   }
+
+  // A term with more pack element symbols orders after a term with
+  // fewer pack element symbols.
+  if (lhsPackElementCount != rhsPackElementCount)
+    return lhsPackElementCount > rhsPackElementCount ? 1 : -1;
 
   // A term with more name symbols orders after a term with fewer name symbols.
   if (lhsNameCount != rhsNameCount)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3843,6 +3843,11 @@ namespace {
       auto *locator = cs.getConstraintLocator(expr);
       auto *environment = cs.getPackElementEnvironment(locator,
           expansionTy->getCountType()->getCanonicalType());
+
+      // Assert that we have an opened element environment, otherwise we'll get
+      // an ASTVerifier crash when pack archetypes or element archetypes appear
+      // inside the pack expansion expression.
+      assert(environment);
       expr->setGenericEnvironment(environment);
 
       return expr;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3125,18 +3125,9 @@ namespace {
         auto expansionType =
             CS.getType(packEnvironment)->castTo<PackExpansionType>();
         CS.addConstraint(ConstraintKind::ShapeOf, expansionType->getCountType(),
-                         elementType,
+                         packType,
                          CS.getConstraintLocator(packEnvironment,
                                                  ConstraintLocator::PackShape));
-        auto *elementShape = CS.createTypeVariable(
-            CS.getConstraintLocator(expr, ConstraintLocator::PackShape),
-            TVO_CanBindToPack);
-        CS.addConstraint(
-            ConstraintKind::ShapeOf, elementShape, elementType,
-            CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
-        CS.addConstraint(
-            ConstraintKind::Equal, elementShape, expansionType->getCountType(),
-            CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
       } else {
         CS.recordFix(AllowInvalidPackReference::create(
             CS, packType, CS.getConstraintLocator(expr->getPackRefExpr())));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13584,6 +13584,16 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
     return SolutionKind::Solved;
   }
 
+  if (isSingleUnlabeledPackExpansionTuple(packTy)) {
+    auto *packVar =
+        createTypeVariable(getConstraintLocator(locator), TVO_CanBindToPack);
+    addConstraint(ConstraintKind::MaterializePackExpansion, packTy,
+                  packVar,
+                  getConstraintLocator(locator, {ConstraintLocator::Member}));
+    addConstraint(ConstraintKind::ShapeOf, shapeTy, packVar, locator);
+    return SolutionKind::Solved;
+  }
+
   // Map element archetypes to the pack context to check for equality.
   if (packTy->hasElementArchetype()) {
     auto *packEnv = DC->getGenericEnvironmentOfContext();

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -63,8 +63,7 @@ func outerArchetype<each T, U>(t: repeat each T, u: U) where repeat each T: P {
 }
 
 func sameElement<each T, U>(t: repeat each T, u: U) where repeat each T: P, repeat each T == U {
-  // FIXME
-//  let _: (repeat each T) = (repeat (each t).f(u))
+  let _ = (repeat (each t).f(u))
 }
 
 func forEachEach<each C, U>(c: repeat each C, function: (U) -> Void)

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -63,18 +63,13 @@ func outerArchetype<each T, U>(t: repeat each T, u: U) where repeat each T: P {
 }
 
 func sameElement<each T, U>(t: repeat each T, u: U) where repeat each T: P, repeat each T == U {
-// expected-error@-1{{same-element requirements are not yet supported}}
-
-  let _: (repeat each T) = (repeat (each t).f(u))
-  // expected-error@-1 {{cannot convert value of type 'U' to expected argument type 'each T'}}
+  // FIXME
+//  let _: (repeat each T) = (repeat (each t).f(u))
 }
 
 func forEachEach<each C, U>(c: repeat each C, function: (U) -> Void)
     where repeat each C: Collection, repeat (each C).Element == U {
-    // expected-error@-1{{same-element requirements are not yet supported}}
-
-  _ = (repeat (each c).forEach(function))
-  // expected-error@-1 {{cannot convert value of type '(U) -> Void' to expected argument type '(each C.Element) throws -> Void'}}
+  repeat (each c).forEach(function)
 }
 
 func typeReprPacks<each T: ExpressibleByIntegerLiteral>(_ t: repeat each T) {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -63,12 +63,16 @@ func outerArchetype<each T, U>(t: repeat each T, u: U) where repeat each T: P {
 }
 
 func sameElement<each T, U>(t: repeat each T, u: U) where repeat each T: P, repeat each T == U {
-  let _ = (repeat (each t).f(u))
+  // expected-error@-1{{same-element requirements are not yet supported}}
+  let _: (repeat each T) = (repeat (each t).f(u))
+  // expected-error@-1 {{cannot convert value of type 'U' to expected argument type 'each T'}}
 }
 
 func forEachEach<each C, U>(c: repeat each C, function: (U) -> Void)
     where repeat each C: Collection, repeat (each C).Element == U {
-  repeat (each c).forEach(function)
+  // expected-error@-1{{same-element requirements are not yet supported}}
+  _ = (repeat (each c).forEach(function))
+  // expected-error@-1 {{cannot convert value of type '(U) -> Void' to expected argument type '(each C.Element) throws -> Void'}}
 }
 
 func typeReprPacks<each T: ExpressibleByIntegerLiteral>(_ t: repeat each T) {

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -1,8 +1,12 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-availability-checking 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-availability-checking -enable-experimental-feature SameElementRequirements 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
 
 protocol P {
   associatedtype A: P
   associatedtype B
+
+  func f(_ self: Self) -> Self
 }
 
 // CHECK-LABEL: inferSameShape(ts:us:)
@@ -158,3 +162,24 @@ func dependentSameElementConcrete<each C: Collection>(
 func dependentSameElementGeneric<each C: Collection, Element>(
   _: repeat each C
 ) where repeat (each C).Element == Element {}
+
+// FIXME: Either 'repeat each T: P' or 'U: P' should be redundant.
+// CHECK-LABEL: sameElementRedundantConformance
+// CHECK-NEXT: Generic signature: <each T, U where repeat each T : P, U : P, repeat U == each T>
+func sameElementRedundantConformance<each T, U>(
+  t: repeat each T,
+  u: U
+) where repeat each T: P,
+        repeat each T == U {
+  let _ = (repeat (each t).f(u))
+}
+
+// CHECK-LABEL: forEachEach
+// CHECK-NEXT: Generic signature: <each C, U where repeat each C : Collection, repeat U == (each C).[Sequence]Element>
+func forEachEach<each C, U>(
+  c: repeat each C,
+  function: (U) -> Void
+) where repeat each C: Collection,
+        repeat (each C).Element == U {
+  repeat (each c).forEach(function)
+}

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-availability-checking -enable-experimental-feature SameElementRequirements 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-availability-checking -enable-experimental-feature SameElementRequirements 2>&1 | %FileCheck %s -dump-input=fail
 
 // REQUIRES: asserts
 

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -154,7 +154,7 @@ func dependentSameElementConcrete<each C: Collection>(
 ) where repeat (each C).Element == Int {}
 
 // CHECK-LABEL: dependentSameElementGeneric
-// CHECK-NEXT: Generic signature: <each C, Element where repeat Element == (each C).[Sequence]Element, repeat each C : Collection>
+// CHECK-NEXT: Generic signature: <each C, Element where repeat each C : Collection, repeat Element == (each C).[Sequence]Element>
 func dependentSameElementGeneric<each C: Collection, Element>(
   _: repeat each C
 ) where repeat (each C).Element == Element {}

--- a/test/Generics/parameter-pack-requirements.swift
+++ b/test/Generics/parameter-pack-requirements.swift
@@ -2,6 +2,7 @@
 
 protocol P {
   associatedtype A: P
+  associatedtype B
 }
 
 // CHECK-LABEL: inferSameShape(ts:us:)
@@ -126,3 +127,34 @@ func sameTypeMatch1<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: re
 // CHECK-NEXT: <T, each U, each V where T : PP, repeat each U : PP, (repeat (each U, each V)) : Any, repeat each V : PP, T.[PP]A == (/* shape: each U */ repeat ())>
 func sameTypeMatch2<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: repeat each V)
   where T.A == Shape<repeat each U>, T.A == Shape<repeat each V> {}
+
+
+//////
+///
+/// Same-element requirements.
+///
+//////
+
+// CHECK-LABEL: sameElementConcrete
+// CHECK-NEXT: Generic signature: <each T where repeat each T == Int>
+func sameElementConcrete<each T>(
+  _: repeat each T
+) where repeat each T == Int {}
+
+// CHECK-LABEL: sameElementGeneric
+// CHECK-NEXT: Generic signature: <each T, U where repeat U == each T>
+func sameElementGeneric<each T, U>(
+  _: repeat each T
+) where repeat each T == U {}
+
+// CHECK-LABEL: dependentSameElementConcrete
+// CHECK-NEXT: Generic signature: <each C where repeat each C : Collection, repeat (each C).[Sequence]Element == Int>
+func dependentSameElementConcrete<each C: Collection>(
+  _: repeat each C
+) where repeat (each C).Element == Int {}
+
+// CHECK-LABEL: dependentSameElementGeneric
+// CHECK-NEXT: Generic signature: <each C, Element where repeat Element == (each C).[Sequence]Element, repeat each C : Collection>
+func dependentSameElementGeneric<each C: Collection, Element>(
+  _: repeat each C
+) where repeat (each C).Element == Element {}


### PR DESCRIPTION
SE-0393 supports _same-element requirements_. From the proposal:

> A same-type requirement where one side is a type parameter pack and the other type is a scalar type that does not capture any type parameter packs is interpreted as constraining each element of the replacement type pack to the same scalar type:
> ```swift
> func variadic<each S: Sequence, T>(_: repeat each S) where repeat (each S).Element == T {}
> ```
> This is called a _same-element requirement._

We represent pack elements in the requirement machine through a new singleton `PackElement` symbol, written `[element]`. Same-element requirements are mapped to re-write rules that prefix type parameter pack terms with the `[element]` symbol.

For example, given a protocol `P` with an associated type `A`, the generic signature `<each T, U> where repeat each T: P, repeat (each T).A == U` maps to the following re-write system:

```
Rewrite system: {
- [P].[P] => [P]
- [P].A => [P:A]
- [P].[P:A] => [P:A]
- [P:A].[shape] => [shape]
- τ_0_1.[shape] => [shape]
- each τ_0_0.[P] => each τ_0_0
- [element].each τ_0_0.A => τ_0_1
- each τ_0_0.A => each τ_0_0.[P:A]
- [element].each τ_0_0.[P:A] => τ_0_1
- [element].each τ_0_0.[shape] => [shape]
}
```

The implementation is gated behind `-enable-experimental-feature SameElementRequirements` because the minimal conformance computation doesn't yet support same-element requirements. The current rewrite rules also do not support deriving pack element conformance from a scalar type parameter conformance through same-element requirements. For example, the generic signature `<each T, U> where U: P, repeat each T == U` maps to the following rewrite system:

```
Rewrite system: {
- [P].[P] => [P]
- [P].A => [P:A]
- [P].[P:A] => [P:A]
- [P:A].[shape] => [shape]
- τ_0_1.[shape] => [shape]
- τ_0_1.[P] => τ_0_1
- [element].each τ_0_0 => τ_0_1
- τ_0_1.A => τ_0_1.[P:A]
}
```

The conformance rule `τ_0_1.[P] => τ_0_1` and the same-element rule `[element].each τ_0_0 => τ_0_1 ` do not provide a rewrite path to the pack conformance rule `each τ_0_0.[P] => each τ_0_0`. One possible solution is to use element symbols for all property rules, which would also allow the minimal conformance support to fallout naturally. However, this approach poses a problem for same-type-pack requirements. If we use `[element]` symbols for same-type-pack requirements, e.g. `[element].each τ_0_0 => [element].each τ_0_1`, then this rule no longer implies a same-shape rule `each τ_0_0.[shape] => each τ_0_1.[shape]`. Stripping the `[element]` symbols from same-type-pack rewrite rules creates a different set of problems for conformances, because the pack conformance rules contain `[element]` symbols, which would prohibit applying associated type rewrite rules to non-element pack terms. I'm still exploring strategies for resolving these issues, hence the experimental flag!