### PR TITLE
test/lit.cfg: force static linking for WASI as dynamic is unsupported

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1838,7 +1838,7 @@ elif run_os == 'wasi':
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
     config.target_build_swift_dylib = (
-        "%s -parse-as-library -emit-library -o '\\1'"
+        "%s -parse-as-library -emit-library -static -o '\\1'"
         % (config.target_build_swift))
     config.target_add_rpath = ''
     config.target_swift_frontend = ' '.join([


### PR DESCRIPTION
wasm32-unknown-wasi target doesn't support dynamic linking.