### PR TITLE
test: Disable `test/stdlib/Duration.swift` on 32-bit platforms

### DIFF
--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -1,6 +1,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Int128 operations are not supported on 32bit platforms, 128-bit types are not
+// provided by the 32-bit LLVM. See `dividingFullWidth` in IntegerTypes.swift.gyb
+// UNSUPPORTED: PTRSIZE=32
+
 import StdlibUnittest
 
 var suite = TestSuite("StringIndexTests")


### PR DESCRIPTION
128-bit types are not provided by LLVM for 32-bit targets.