### PR TITLE
test/AutolinkExtract/empty.swift: add support for Wasm binary format

### DIFF
--- a/test/AutolinkExtract/empty.swift
+++ b/test/AutolinkExtract/empty.swift
@@ -5,3 +5,4 @@
 
 // CHECK-elf: -lswiftCore
 // CHECK-coff: -lswiftCore
+// CHECK-wasm: -lswiftCore

--- a/test/AutolinkExtract/empty_archive.swift
+++ b/test/AutolinkExtract/empty_archive.swift
@@ -7,3 +7,4 @@
 
 // CHECK-elf: -lswiftCore
 // CHECK-coff: -lswiftCore
+// CHECK-wasm: -lswiftCore

--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -18,4 +18,7 @@
 // CHECK-coff-DAG: -lswiftCore
 // CHECK-coff-DAG: -lempty
 
+// CHECK-wasm-DAG: -lswiftCore
+// CHECK-wasm-DAG: -lempty
+
 import empty

--- a/test/AutolinkExtract/import_archive.swift
+++ b/test/AutolinkExtract/import_archive.swift
@@ -12,4 +12,7 @@
 // CHECK-coff-DAG: -lswiftCore
 // CHECK-coff-DAG: -lempty
 
+// CHECK-wasm-DAG: -lswiftCore
+// CHECK-wasm-DAG: -lempty
+
 import empty


### PR DESCRIPTION
Let's check in tests all supported object formats that need autolinking to work, including Wasm.
