### PR TITLE
test: disable crashing tests on WASI

### DIFF
--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -78,10 +78,12 @@ actor Someone {
         await MainFriend().callCheckMainActor()
       }
 
+      #if !os(WASI)
       tests.test("precondition on actor (main): wrongly assume the main executor, from actor on other executor") {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor()
       }
+      #endif
 
       // === Global actor -----------------------------------------------------
 

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -115,14 +115,17 @@ final class MainActorEcho {
         await MainFriend().callCheck(echo: echo)
       }
 
+      #if !os(WASI)
       tests.test("MainActor.assumeIsolated: wrongly assume the main executor, from actor on other executor") {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor(echo: echo)
       }
+      #endif
 
       // === some Actor -------------------------------------------------------
 
       let someone = Someone()
+      #if !os(WASI)
       tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from 'main() async'") {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.Someone.")
         checkAssumeSomeone(someone: someone)
@@ -132,6 +135,7 @@ final class MainActorEcho {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.Someone.")
         checkAssumeSomeone(someone: someone)
       }
+      #endif
 
       tests.test("assumeOnActorExecutor: assume someone's executor, from Someone") {
         await someone.callCheckSomeone()
@@ -141,11 +145,12 @@ final class MainActorEcho {
         await SomeonesFriend(someone: someone).callCheckSomeone()
       }
 
+      #if !os(WASI)
       tests.test("assumeOnActorExecutor: wrongly assume the main executor, from actor on other executor") {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.Someone.")
         await CompleteStranger(someone: someone).callCheckSomeone()
       }
-
+      #endif
 
     }
 

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -16,6 +16,7 @@ struct TestError: Error {}
     var tests = TestSuite("CheckedContinuation")
 
     if #available(SwiftStdlib 5.1, *) {
+      #if !os(WASI)
       tests.test("trap on double resume non-throwing continuation") {
         expectCrashLater()
 
@@ -42,6 +43,7 @@ struct TestError: Error {}
         }
         await task.get()
       }
+      #endif
 
       tests.test("test withCheckedThrowingContinuation") {
         let task2 = detach {

--- a/test/Concurrency/Runtime/continuation_validation.swift
+++ b/test/Concurrency/Runtime/continuation_validation.swift
@@ -12,6 +12,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -207,6 +207,7 @@ ErrorTests.test("test dealloc empty error box") {
   }
 }
 
+#if !os(WASI)
 var errors: [Error] = []
 
 @inline(never)
@@ -249,6 +250,7 @@ ErrorTests.test("willThrow") {
   expectEqual(2, errors.count)
   expectEqual(SillyError.self, type(of: errors.last!))
 }
+#endif
 
 runAllTests()
 

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -342,6 +342,7 @@ StringTests.test("SameTypeComparisons") {
   expectFalse(xs != xs)
 }
 
+#if !os(WASI)
 StringTests.test("CompareStringsWithUnpairedSurrogates")
   .xfail(
     .always("<rdar://problem/18029104> Strings referring to underlying " +
@@ -357,6 +358,7 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
     ]
   )
 }
+#endif
 
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -7,6 +7,12 @@
 
 import StdlibUnittest
 
+#if os(WASI)
+let enableCrashTests = false
+#else
+let enableCrashTests = true
+#endif
+
 var CStringTests = TestSuite("CStringTests")
 
 func getNullUTF8() -> UnsafeMutablePointer<UInt8>? {
@@ -239,6 +245,7 @@ CStringTests.test("String.cString.with.Array.UInt8.input") {
       }
     }
   }
+  guard enableCrashTests else { return }
   // no need to test every case; that is covered in other tests
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
@@ -263,6 +270,7 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
       }
     }
   }
+  guard enableCrashTests else { return }
   // no need to test every case; that is covered in other tests
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
@@ -292,6 +300,7 @@ CStringTests.test("String.cString.with.inout.UInt8.conversion") {
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
   c = 100
+  guard enableCrashTests else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(cString:) must be null-terminated"
@@ -306,6 +315,7 @@ CStringTests.test("String.cString.with.inout.CChar.conversion") {
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
   c = 100
+  guard enableCrashTests else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(cString:) must be null-terminated"
@@ -330,6 +340,7 @@ CStringTests.test("String.validatingUTF8.with.Array.input") {
       }
     }
   }
+  guard enableCrashTests else { return }
   // no need to test every case; that is covered in other tests
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
@@ -362,6 +373,7 @@ CStringTests.test("String.validatingUTF8.with.inout.conversion") {
   expectNotNil(str)
   expectEqual(str?.isEmpty, true)
   c = 100
+  guard enableCrashTests else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
@@ -387,6 +399,7 @@ CStringTests.test("String.decodeCString.with.Array.input") {
       }
     }
   }
+  guard enableCrashTests else { return }
   // no need to test every case; that is covered in other tests
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
@@ -426,6 +439,7 @@ CStringTests.test("String.decodeCString.with.inout.conversion") {
   expectEqual(result?.result.isEmpty, true)
   expectEqual(result?.repairsMade, false)
   c = 100
+  guard enableCrashTests else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
@@ -449,6 +463,7 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
       }
     }
   }
+  guard enableCrashTests else { return }
   // no need to test every case; that is covered in other tests
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
@@ -478,6 +493,7 @@ CStringTests.test("String.init.decodingCString.with.inout.conversion") {
   var str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectEqual(str.isEmpty, true)
   c = 100
+  guard enableCrashTests else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(decodingCString:as:) must be null-terminated"

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -70,6 +70,7 @@ TemporaryAllocationTestSuite.test("untypedEmptyAllocationIsStackAllocated") {
   }
 }
 
+#if !os(WASI)
 TemporaryAllocationTestSuite.test("crashOnNegativeByteCount") {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
@@ -83,6 +84,7 @@ TemporaryAllocationTestSuite.test("crashOnNegativeAlignment") {
     withUnsafeTemporaryAllocation(byteCount: 16, alignment: alignment) { _ in }
   }
 }
+#endif
 
 TemporaryAllocationTestSuite.test("untypedAllocationIsAligned") {
   withUnsafeTemporaryAllocation(byteCount: 1, alignment: 8) { buffer in
@@ -136,12 +138,14 @@ TemporaryAllocationTestSuite.test("voidAllocationIsStackAllocated") {
   }
 }
 
+#if !os(WASI)
 TemporaryAllocationTestSuite.test("crashOnNegativeValueCount") {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(of: Int.self, capacity: capacity) { _ in }
   }
 }
+#endif
 
 TemporaryAllocationTestSuite.test("typedAllocationIsAligned") {
   withUnsafeTemporaryAllocation(of: Int.self, capacity: 1) { buffer in

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -131,6 +131,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
   expectEqual(result, 0xffff_0000)
 }
 
+#if !os(WASI)
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
@@ -154,6 +155,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.invalid.mutable")
   }
   expectUnreachable()
 }
+#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
 .skip(.custom({
@@ -184,6 +186,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
               0)
 }
 
+#if !os(WASI)
 UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
@@ -203,6 +206,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
   p1.storeBytes(of: m, as: Missile.self)
   expectUnreachable()
 }
+#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("copyMemory") {
   let sizeInBytes = 4 * MemoryLayout<Int>.stride


### PR DESCRIPTION
WASI doesn't support spawning a subprocess, so crash tests crashes the test harness itself. Those should be skipped until proper subprocess support is available.
