### PR TITLE
test: Add missing target-specific lit properties for WASI

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1855,10 +1855,16 @@ elif run_os == 'wasi':
     config.target_sil_opt = (
         '%s -target %s %s %s %s' %
         (config.sil_opt, config.variant_triple, config.resource_dir_opt, mcp_opt, config.sil_test_options))
+    subst_target_sil_opt_mock_sdk = config.target_sil_opt
+    subst_target_sil_opt_mock_sdk_after = ""
     config.target_swift_symbolgraph_extract = ' '.join([
         config.swift_symbolgraph_extract,
         '-target', config.variant_triple,
         mcp_opt])
+    config.target_swift_api_extract = ' '.join([
+        config.swift_api_extract,
+        '-target', config.variant_triple,
+        '-sdk', shell_quote(config.variant_sdk)])
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,


### PR DESCRIPTION
Lack of these properties prevents the WASI test suite from running successfully.
