### PR TITLE
tests: configure Wasm runtime selection in `lit.cfg`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1733,7 +1733,7 @@ elif run_os == 'wasi':
         config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = os.path.join(config.swift_utils, 'webassembly', 'wasm-run.py')
+    config.target_run = os.path.join(config.swift_utils, 'wasm-run.py')
     config.target_env_prefix = 'WASM_RUN_CHILD_'
 
     if 'interpret' in lit_config.params:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -342,7 +342,6 @@ config.swift_demangle_yamldump = inferSwiftBinary('swift-demangle-yamldump')
 config.swift_demangle = inferSwiftBinary('swift-demangle')
 config.benchmark_o = inferSwiftBinary('Benchmark_O')
 config.benchmark_driver = inferSwiftBinary('Benchmark_Driver')
-config.wasmer = inferSwiftBinary('wasmer')
 config.wasm_ld = inferSwiftBinary('wasm-ld')
 
 config.swift_utils = make_path(config.swift_src_root, 'utils')
@@ -1734,7 +1733,9 @@ elif run_os == 'wasi':
         config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = '%s run --backend cranelift --' % config.wasmer
+    config.target_run = os.path.join(config.swift_utils, 'webassembly', 'wasm-run.py')
+    config.target_env_prefix = 'WASM_RUN_CHILD_'
+
     if 'interpret' in lit_config.params:
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (

--- a/utils/wasm-run.py
+++ b/utils/wasm-run.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def collect_wasm_env(local_env=os.environ, prefix='WASM_RUN_CHILD_'):
+    return dict((key[len(prefix):], value)
+                for key, value in local_env.items() if key.startswith(prefix))
+
+
+class WasmtimeRunner(object):
+    def __init__(self):
+        pass
+
+    def run(self, args):
+        command = self.invocation(args)
+        if args.verbose:
+            print(' '.join(command), file=sys.stderr)
+
+        if not args.dry_run:
+            subprocess.check_call(command)
+
+    def invocation(self, args):
+        command = ["wasmtime", "run"]
+        envs = collect_wasm_env()
+        for key in envs:
+            command.append("--env")
+            command.append(f"{key}={envs[key]}")
+        command.append("--")
+        command.extend(args.command)
+        return command
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-v', '--verbose', action='store_true', dest='verbose',
+                        help='print commands as they are run')
+    parser.add_argument('-n', '--dry-run', action='store_true', dest='dry_run',
+                        help="print the commands that would have been run, but"
+                             " don't actually run them")
+    parser.add_argument('command', nargs=argparse.REMAINDER,
+                        help='the command to run', metavar='command...')
+
+    args = parser.parse_args()
+    runner = WasmtimeRunner()
+    runner.run(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently `wasmer` is hardcoded as a Wasm runtime for running tests. We should make this configurable to be able to select an arbitrary runtime.