### PR TITLE
test/CMakeLists.txt: add support for WASI SDK

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -111,7 +111,8 @@ function(get_test_dependencies SDK result_var_name)
      ("${SDK}" STREQUAL "OPENBSD") OR
      ("${SDK}" STREQUAL "ANDROID") OR
      ("${SDK}" STREQUAL "WINDOWS") OR
-     ("${SDK}" STREQUAL "HAIKU"))
+     ("${SDK}" STREQUAL "HAIKU") OR
+     ("${SDK}" STREQUAL "WASI"))
     # No extra dependencies.
   else()
     message(FATAL_ERROR "Unknown SDK: ${SDK}")


### PR DESCRIPTION
WASI SDK should be supported in `test/CMakeLists.txt` like the rest of the SDKs for us to be able to build tests for this platform.
