### PR TITLE
[Backtracing][Linux] Disable invoking process_vm_readv() for older Android APIs

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -660,9 +660,13 @@ memserver_fault(int sig) {
 ssize_t __attribute__((noinline))
 memserver_read(void *to, const void *from, size_t len) {
   if (memserver_has_ptrace) {
+// This won't run for older Android APIs anyway, but it can't be compiled
+// either, as process_vm_readv() isn't available.
+#if !(defined(__ANDROID_API__) && __ANDROID_API__ < 23)
     struct iovec local = { to, len };
     struct iovec remote = { const_cast<void *>(from), len };
     return process_vm_readv(memserver_pid, &local, 1, &remote, 1, 0);
+#endif
   } else {
     if (!sigsetjmp(memserver_fault_buf, 1)) {
       memcpy(to, from, len);
@@ -682,7 +686,12 @@ memserver_entry(void *dummy __attribute__((unused))) {
   prctl(PR_SET_NAME, "[backtrace]");
 #endif
 
+// process_vm_readv() is not available for older Android APIs.
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 23
+  memserver_has_ptrace = false;
+#else
   memserver_has_ptrace = !!prctl(PR_CAPBSET_READ, CAP_SYS_PTRACE);
+#endif
 
   if (!memserver_has_ptrace) {
     struct sigaction sa;


### PR DESCRIPTION
[The Android community CI has been broken](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/4740/console) ever since this was merged in #66334 last month, because that CI builds against Android API 21:
```
/home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android-arm64/swift/stdlib/public/runtime/CrashHandlerLinux.cpp:665:12: error: use of undeclared identifier 'process_vm_readv'
    return process_vm_readv(memserver_pid, &local, 1, &remote, 1, 0);
           ^
1 error generated.
```
Disable invoking this function before [API 23, where it was added](https://android.googlesource.com/platform/bionic/+/d633600d1c32eb00a51a521168eb336291847bb0/libc/include/sys/uio.h#145), which [I confirmed gets the stdlib building with API 21 again](https://github.com/finagolfin/swift-android-sdk/actions/runs/5636999782/job/15269631734#step:6:1329).

@al45tair, please review.