### PR TITLE
[TypeCheckPattern] Attempt ExprPattern conversion before failing pattern coercion to optional

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -412,6 +412,22 @@ do {
   enum E {
    case baz
    case bar
+
+      static var member: Self {
+          .baz
+      }
+
+      static func method() -> Self {
+          .bar
+      }
+
+      static func methodArg(_: Void) -> Self {
+          .baz
+      }
+
+      static var none: Self {
+          .baz
+      }
   }
 
   let oe: E? = .bar
@@ -419,6 +435,11 @@ do {
   switch oe {
    case .bar?: break // Ok
    case .baz: break // Ok
+   case .member: break // Ok
+   case .missingMember: break // expected-error {{type 'E?' has no member 'missingMember'}}
+   case .method(): break // Ok
+   case .methodArg(()): break // Ok
+   case .none: break // expected-warning {{assuming you mean 'Optional<E>.none'; did you mean 'E.none' instead?}} expected-note {{use 'nil' to silence this warning}} expected-note {{use 'none?' instead}}
    default: break
   }
 
@@ -427,11 +448,31 @@ do {
   switch ooe {
    case .bar?: break // Ok
    case .baz: break // Ok
+   case .member: break // Ok
+   case .missingMember: break // expected-error {{type 'E??' has no member 'missingMember'}}
+   case .method(): break // Ok
+   case .methodArg(()): break // Ok
    default: break
   }
 
   if case .baz = ooe {} // Ok
   if case .bar? = ooe {} // Ok
+  if case .member = ooe {} // Ok
+  if case .missingMember = ooe {} // expected-error {{type 'E??' has no member 'missingMember'}}
+  if case .method() = ooe {} // Ok
+  if case .methodArg(()) = ooe {} // Ok
+
+  enum M {
+    case m
+    static func `none`(_: Void) -> Self { .m }
+  }
+
+  let om: M? = .m
+
+  switch om {
+  case .none: break // Ok
+  default: break
+  }
 }
 
 // rdar://problem/60048356 - `if case` fails when `_` pattern doesn't have a label

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -222,6 +222,30 @@ func matchOptionalEnum2(bar: OneOrTwo??) {
   }
 }
 
+enum OneTwoOrNone {
+    case one
+    case two
+
+    var none: Self {
+        .one
+    }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4enum18matchOptionalEnum33baryAA12OneTwoOrNoneOSg_tF : $@convention(thin) (Optional<OneTwoOrNone>) -> () {
+// CHECK: bb0(%0 : $Optional<OneTwoOrNone>):
+// CHECK-NEXT:  debug_value %0 : $Optional<OneTwoOrNone>, let, name "bar", argno 1
+// CHECK-NEXT:  switch_enum %0 : $Optional<OneTwoOrNone>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb4
+// CHECK: bb1([[PHI_ARG:%.*]] : $OneTwoOrNone):
+// CHECK-NEXT:  switch_enum [[PHI_ARG]] : $OneTwoOrNone, case #OneTwoOrNone.one!enumelt: bb2, case #OneTwoOrNone.two!enumelt: bb3
+func matchOptionalEnum3(bar: OneTwoOrNone?) {
+  switch bar {
+  case .one: print("one")
+  case .two?: print("two")
+  case .none: print("none")
+  default: print("default")
+  }
+}
+
 // Make sure that we handle enum, tuple initialization composed
 // correctly. Previously, we leaked down a failure path due to us misusing
 // scopes.


### PR DESCRIPTION
See previous PR\[1\] and previous forum threads\[2\]\[3\] regarding similar behavior and the intended semantics of expression pattern matching.

Expected behavior is for structural pattern matching and expression pattern matching to be transparent for the user. Currently, when matching an `EnumElementPattern` (of the form `.foo`) against an expression of type `T`, if we fail to find an enum element `T.foo` then we will attempt to fall back to matching `.foo` as an expression, which can find static members `.foo`.

However, if `T` is an optional type `U?`, then if lookup of `Optional.foo` fails to find a matching enum element member, we will look into the wrapped type for an enum element `U.foo`. If this fails, we (presently) do not take the fallback path and instead immediately fail with the error "enum case 'foo' not found in type 'U?'" even though lookup for `UnresolvedMemberExpr`s would _also_ look through optional types when attempting expression matching.

This PR allows us to match against `U.foo` expressions by delaying the failure diagnostic in the optional case until _after_ we've attempted the expression fallback. This will have the effect of allowing us to match the pattern `.foo` against values of type `U?` when `U` has a static member `foo: Self`. It will also potentially change the diagnostic in failure cases from "enum case 'foo' not found in type 'U?'" to "type 'U?' has no member 'foo'," which is IMO more accurate since 'foo' is indeed permitted to be any (static) member, not just an enum case.

\[1]: https://github.com/apple/swift/pull/22486
\[2]: https://forums.swift.org/t/matching-optionals-in-a-switch-statement/12905
\[3]: https://forums.swift.org/t/allow-enum-case-matching-without/20544
