### PR TITLE
Platform: add URL Monikers to the WinSDK overlay

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -449,6 +449,12 @@ module WinSDK [system] {
     }
   }
 
+  module URLMonikers {
+    header "urlmon.h"
+    export *
+    link "Urlmon.Lib"
+  }
+
   module User {
     header "WinUser.h"
     export *


### PR DESCRIPTION
Add a module definition for importing the URL Monikers interfaces.  This is in service of DocC.