### PR TITLE
[cxx-interop] Import iterator types that are not typedef-ed

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2788,6 +2788,15 @@ getClangOwningModule(ClangNode Node, const clang::ASTContext &ClangCtx) {
         originalDecl = pattern;
       }
     }
+    if (!originalDecl->hasOwningModule()) {
+      if (auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(D)) {
+        if (auto pattern = cxxRecordDecl->getTemplateInstantiationPattern()) {
+          // Class template instantiations sometimes don't have an owning Clang
+          // module, if the instantiation is not typedef-ed.
+          originalDecl = pattern;
+        }
+      }
+    }
 
     return ExtSource->getModule(originalDecl->getOwningModuleID());
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2799,7 +2799,7 @@ namespace {
 
       // If this module is declared as a C++ module, try to synthesize
       // conformances to Swift protocols from the Cxx module.
-      auto clangModule = decl->getOwningModule();
+      auto clangModule = Impl.getClangOwningModule(result->getClangNode());
       if (clangModule && requiresCPlusPlus(clangModule)) {
         auto nominalDecl = cast<NominalTypeDecl>(result);
         conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -2,8 +2,10 @@
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H
 
 #include <vector>
+#include <string>
 
 using Vector = std::vector<int>;
+using VectorOfString = std::vector<std::string>;
 
 inline Vector initVector() { return {}; }
 

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -13,13 +13,13 @@ import CxxStdlib
 
 var StdVectorTestSuite = TestSuite("StdVector")
 
-StdVectorTestSuite.test("init") {
+StdVectorTestSuite.test("VectorOfInt.init") {
     let v = Vector()
     expectEqual(v.size(), 0)
     expectTrue(v.empty())
 }
 
-StdVectorTestSuite.test("push back") {
+StdVectorTestSuite.test("VectorOfInt.push_back") {
     var v = Vector()
     let _42: CInt = 42
     v.push_back(_42)
@@ -34,7 +34,7 @@ func fill(vector v: inout Vector) {
     v.push_back(CInt(3))
 }
 
-StdVectorTestSuite.test("for loop") {
+StdVectorTestSuite.test("VectorOfInt for loop") {
     var v = Vector()
     fill(vector: &v)
 
@@ -46,12 +46,38 @@ StdVectorTestSuite.test("for loop") {
     expectEqual(count, 4)
 }
 
-StdVectorTestSuite.test("map") {
+StdVectorTestSuite.test("VectorOfString for loop") {
+    var v = VectorOfString()
+    var count = 0
+    for _ in v {
+        count += 1
+    }
+    expectEqual(count, 0)
+
+    v.push_back(std.string("abc"))
+    v.push_back(std.string("ab"))
+    for it in v {
+        count += it.length()
+    }
+    expectEqual(count, 5)
+}
+
+StdVectorTestSuite.test("VectorOfInt.map") {
     var v = Vector()
     fill(vector: &v)
 
     let a = v.map { $0 + 5 }
     expectEqual(a, [6, 7, 8])
+}
+
+StdVectorTestSuite.test("VectorOfString.map") {
+    var v = VectorOfString()
+    v.push_back(std.string("abc"))
+    v.push_back(std.string("a"))
+    v.push_back(std.string("ab"))
+
+    let a = v.map { $0.length() }
+    expectEqual(a, [3, 1, 2])
 }
 
 runAllTests()


### PR DESCRIPTION
This prevented `std::vector<std::string>` from being auto-conformed to `CxxRandomAccessCollection`.

If an iterator type is templated, and does not have an explicit instantiation via a typedef or a using-decl, its specialization will not have an owning Clang module. Make sure we treat it as a part of the Clang module that owns the template decl.

rdar://112762768 / resolves https://github.com/apple/swift/issues/67410