### PR TITLE
[5.9] [Observation] Switch to peer instead of arbitrary macros

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -225,15 +225,6 @@ extension ObservableMacro: MemberMacro {
     declaration.addIfNeeded(ObservableMacro.accessFunction(observableType), to: &declarations)
     declaration.addIfNeeded(ObservableMacro.withMutationFunction(observableType), to: &declarations)
 
-#if !OBSERVATION_SUPPORTS_PEER_MACROS
-    let storedInstanceVariables = declaration.definedVariables.filter { $0.isValidForObservation }
-    for property in storedInstanceVariables {
-       if property.hasMacroApplication(ObservableMacro.ignoredMacroName) { continue }
-       let storage = DeclSyntax(property.privatePrefixed("_", addingAttribute: ObservableMacro.ignoredAttribute))
-       declaration.addIfNeeded(storage, to: &declarations)
-    }
-#endif
-
     return declarations
   }
 }

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -16,11 +16,7 @@ public protocol Observable { }
 #if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
-#if OBSERVATION_SUPPORTS_PEER_MACROS
 @attached(member, names: named(_$observationRegistrar), named(access), named(withMutation))
-#else
-@attached(member, names: named(_$observationRegistrar), named(access), named(withMutation), arbitrary)
-#endif
 @attached(memberAttribute)
 @attached(extension, conformances: Observable)
 public macro Observable() =
@@ -28,9 +24,7 @@ public macro Observable() =
 
 @available(SwiftStdlib 5.9, *)
 @attached(accessor, names: named(init), named(get), named(set))
-#if OBSERVATION_SUPPORTS_PEER_MACROS
 @attached(peer, names: prefixed(_))
-#endif
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")
 

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -207,6 +207,10 @@ struct Validator {
 
     
     let suite = TestSuite("Observable")
+
+    suite.test("only instantiate") {
+      let test = MiddleNamePerson()
+    }
     
     suite.test("unobserved value changes") {
       let test = MiddleNamePerson()


### PR DESCRIPTION
This is a cherry-pick of #67289 for the 5.9 branch.