### PR TITLE
[Diagnostics] Improve diagnostics involving macros

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -221,7 +221,7 @@ ERROR(unknown_attribute,none,
 // MARK: macro diagnostics
 //------------------------------------------------------------------------------
 NOTE(in_macro_expansion,none,
-     "in expansion of macro %0 here", (DeclName))
+     "in expansion of macro %0%select{| on %kind1}1 here", (DeclName, const Decl *))
 ERROR(macro_experimental,none,
       "%0 macros are an experimental feature that is not enabled %select{|(%1)}1",
       (StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7232,8 +7232,8 @@ ERROR(extension_macro_invalid_conformance,none,
       "invalid protocol conformance %0 in extension macro",
       (Type))
 ERROR(macro_attached_to_invalid_decl,none,
-      "'%0' macro cannot be attached to %1",
-      (StringRef, DescriptiveDeclKind))
+      "'%0' macro cannot be attached to %1 (%base2)",
+      (StringRef, DescriptiveDeclKind, const Decl *))
 ERROR(conformance_macro,none,
       "conformance macros are replaced by extension macros",
       ())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3688,10 +3688,9 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       for (auto *roleAttr : macro->getAttrs().getAttributes<MacroRoleAttr>()) {
         auto role = roleAttr->getMacroRole();
         if (isInvalidAttachedMacro(role, D)) {
-          diagnoseAndRemoveAttr(attr,
-                                diag::macro_attached_to_invalid_decl,
+          diagnoseAndRemoveAttr(attr, diag::macro_attached_to_invalid_decl,
                                 getMacroRoleString(role),
-                                D->getDescriptiveKind());
+                                D->getDescriptiveKind(), D);
         }
       }
 

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -114,5 +114,5 @@ struct MyBrokenStruct {
 
 @myPropertyWrapper
 struct CannotHaveAccessors {}
-// CHECK-DIAGS: 'accessor' macro cannot be attached to struct
+// CHECK-DIAGS: 'accessor' macro cannot be attached to struct ('CannotHaveAccessors')
 #endif

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -76,7 +76,7 @@ macro Invalid() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro"
 
 @Invalid
 struct Bad {}
-// expected-note@-1 18 {{in expansion of macro 'Invalid' here}}
+// expected-note@-2 18 {{in expansion of macro 'Invalid' on struct 'Bad' here}}
 
 // CHECK-DIAGS: error: macro expansion cannot introduce import
 // CHECK-DIAGS: error: macro expansion cannot introduce precedence group

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -144,9 +144,9 @@ expansionOrder.originalMember = 28
 #if TEST_DIAGNOSTICS
 @wrapAllProperties
 typealias A = Int
-// expected-error@-2{{'memberAttribute' macro cannot be attached to type alias}}
+// expected-error@-2{{'memberAttribute' macro cannot be attached to type alias ('A')}}
 
 @wrapAllProperties
 func noMembers() {}
-// expected-error@-2{{'memberAttribute' macro cannot be attached to global function}}
+// expected-error@-2{{'memberAttribute' macro cannot be attached to global function ('noMembers')}}
 #endif

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -124,7 +124,7 @@ macro UndocumentedNamesInExtension() = #externalMacro(module: "MacroDefinition",
 
 @UndocumentedNamesInExtension
 struct S<Element> {}
-// expected-note@-1 {{in expansion of macro 'UndocumentedNamesInExtension' here}}
+// expected-note@-2 {{in expansion of macro 'UndocumentedNamesInExtension' on generic struct 'S' here}}
 
 // CHECK-DIAGS: error: declaration name 'requirement()' is not covered by macro 'UndocumentedNamesInExtension'
 
@@ -133,7 +133,7 @@ macro UndocumentedConformanceInExtension() = #externalMacro(module: "MacroDefini
 
 @UndocumentedConformanceInExtension
 struct InvalidConformance<Element> {}
-// expected-note@-1 {{in expansion of macro 'UndocumentedConformanceInExtension' here}}
+// expected-note@-2 {{in expansion of macro 'UndocumentedConformanceInExtension' on generic struct 'InvalidConformance' here}}
 
 // CHECK-DIAGS: error: conformance to 'P' is not covered by macro 'UndocumentedConformanceInExtension'
 
@@ -142,7 +142,7 @@ macro UndocumentedCodable() = #externalMacro(module: "MacroDefinition", type: "A
 
 @UndocumentedCodable
 struct TestUndocumentedCodable {}
-// expected-note@-1 {{in expansion of macro 'UndocumentedCodable' here}}
+// expected-note@-2 {{in expansion of macro 'UndocumentedCodable' on struct 'TestUndocumentedCodable' here}}
 
 // CHECK-DIAGS: error: conformance to 'Codable' (aka 'Decodable & Encodable') is not covered by macro 'UndocumentedCodable'
 
@@ -151,7 +151,7 @@ macro UndocumentedEncodable() = #externalMacro(module: "MacroDefinition", type: 
 
 @UndocumentedEncodable
 struct TestUndocumentedEncodable {}
-// expected-note@-1 {{in expansion of macro 'UndocumentedEncodable' here}}
+// expected-note@-2 {{in expansion of macro 'UndocumentedEncodable' on struct 'TestUndocumentedEncodable' here}}
 
 // CHECK-DIAGS: error: conformance to 'Codable' (aka 'Decodable & Encodable') is not covered by macro 'UndocumentedEncodable'
 

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -113,11 +113,11 @@ func testLocal() {
 
 @DelegatedConformance
 typealias A = Int
-// expected-error@-2 {{'extension' macro cannot be attached to type alias}}
+// expected-error@-2 {{'extension' macro cannot be attached to type alias ('A')}}
 
 @DelegatedConformance
 extension Int {}
-// expected-error@-2 {{'extension' macro cannot be attached to extension}}
+// expected-error@-2 {{'extension' macro cannot be attached to extension (extension of 'Int')}}
 
 @attached(extension, conformances: P)
 macro UndocumentedNamesInExtension() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceViaExtensionMacro")

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -217,7 +217,7 @@ func testVarPeer() {
 #if TEST_DIAGNOSTICS
 // Macros cannot be attached to function parameters
 
-// expected-error@+1{{'peer' macro cannot be attached to parameter}}
+// expected-error@+1{{'peer' macro cannot be attached to parameter ('x')}}
 func test(@declareVarValuePeer x: Int) {}
 #endif
 

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -104,7 +104,8 @@ print(ElementType.paper.unknown())
 
 #if TEST_DIAGNOSTICS
 @addMembersQuotedInit
-struct S2 { // expected-note{{in expansion of macro 'addMembersQuotedInit' here}}
+struct S2 {
+// expected-note@-2 {{in expansion of macro 'addMembersQuotedInit' on struct 'S2' here}}
   func useSynthesized() {
     S.method()
     print(type(of: getStorage()))

--- a/test/SourceKit/Macros/diags.swift.response
+++ b/test/SourceKit/Macros/diags.swift.response
@@ -169,16 +169,16 @@
       key.description: "macro expansion cannot introduce import",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -193,16 +193,16 @@
       key.description: "variable 'x' was never mutated; consider changing to 'let' constant",
       key.diagnostics: [
         {
-          key.line: 24,
+          key.line: 23,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'addMemberWithFixIt' here",
+          key.description: "in expansion of macro 'addMemberWithFixIt' on struct 'S' here",
           key.ranges: [
             {
-              key.offset: 738,
-              key.length: 11
+              key.offset: 718,
+              key.length: 31
             }
           ]
         }
@@ -217,16 +217,16 @@
       key.description: "macro expansion cannot introduce precedence group",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -241,16 +241,16 @@
       key.description: "macro 'myMacro()' requires a definition",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -265,16 +265,16 @@
       key.description: "macro expansion cannot introduce macro",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -289,16 +289,16 @@
       key.description: "macro expansion cannot introduce extension",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -313,16 +313,16 @@
       key.description: "macro expansion cannot introduce '@main' type",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -337,16 +337,16 @@
       key.description: "declaration name 'MyMain' is not covered by macro 'Invalid'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -361,16 +361,16 @@
       key.description: "declaration name 'Array' is not covered by macro 'Invalid'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -385,16 +385,16 @@
       key.description: "declaration name 'Dictionary' is not covered by macro 'Invalid'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -409,16 +409,16 @@
       key.description: "macro expansion cannot introduce default literal type 'BooleanLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -433,16 +433,16 @@
       key.description: "macro expansion cannot introduce default literal type 'ExtendedGraphemeClusterType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -457,16 +457,16 @@
       key.description: "macro expansion cannot introduce default literal type 'FloatLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -481,16 +481,16 @@
       key.description: "macro expansion cannot introduce default literal type 'IntegerLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -505,16 +505,16 @@
       key.description: "macro expansion cannot introduce default literal type 'StringLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -529,16 +529,16 @@
       key.description: "macro expansion cannot introduce default literal type 'UnicodeScalarType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -553,16 +553,16 @@
       key.description: "macro expansion cannot introduce default literal type '_ColorLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -577,16 +577,16 @@
       key.description: "macro expansion cannot introduce default literal type '_ImageLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }
@@ -601,16 +601,16 @@
       key.description: "macro expansion cannot introduce default literal type '_FileReferenceLiteralType'",
       key.diagnostics: [
         {
-          key.line: 17,
+          key.line: 16,
           key.column: 1,
           key.filepath: diags.swift,
           key.severity: source.diagnostic.severity.note,
           key.id: "in_macro_expansion",
-          key.description: "in expansion of macro 'Invalid' here",
+          key.description: "in expansion of macro 'Invalid' on struct 'Bad' here",
           key.ranges: [
             {
-              key.offset: 486,
-              key.length: 13
+              key.offset: 477,
+              key.length: 22
             }
           ]
         }


### PR DESCRIPTION
The main change here is to update the `in expansion of macro` note location for attached macros to that of the attribute instead of the declaration. But as that then makes the declaration it's on less obvious, I've added its name to the message as well. Since we just changed the location of `macro_attached_to_invalid_decl` I also added the declaration name there as well.