### PR TITLE
[CSSimplify] Fix invalid diagnostics emitted for a pack reference outside of pack expansion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5350,6 +5350,11 @@ bool ConstraintSystem::repairFailures(
       if (repairByUsingRawValueOfRawRepresentableType(lhs, rhs))
         return true;
 
+      // If either side is a placeholder then let's consider this
+      // assignment correctly typed.
+      if (lhs->isPlaceholder() || rhs->isPlaceholder())
+        return true;
+
       // Let's try to match source and destination types one more
       // time to see whether they line up, if they do - the problem is
       // related to immutability, otherwise it's a type mismatch.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5093,7 +5093,7 @@ bool ConstraintSystem::repairFailures(
     if (auto objType = valueType->getOptionalObjectType())
       valueType = objType;
 
-    if (rawReprType->isTypeVariableOrMember())
+    if (rawReprType->isTypeVariableOrMember() || rawReprType->isPlaceholder())
       return false;
 
     auto rawValue = isRawRepresentable(*this, rawReprType);

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -722,3 +722,15 @@ do {
     _ = value.data.key // Ok
   }
 }
+
+// rdar://110847476 - unrelated assignment and raw representable diagnostics
+do {
+  struct Test<each Base: AsyncSequence> {
+    let base: (repeat each Base)
+
+    init(base: repeat each Base) {
+      self.base = base
+      // expected-error@-1 {{pack reference 'each Base' can only appear in pack expansion}}
+    }
+  }
+}


### PR DESCRIPTION
`.rawValue` and assignment diagnostics didn't handle holes properly which led to
the solver recording incorrect fixes.

Resolves: rdar://110847476

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
