### PR TITLE
[IRGen] Add metadata pack markers for destroys.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2653,6 +2653,10 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
         llvm::report_fatal_error(
             "Instruction resulted in on-stack pack metadata emission but no "
             "cleanup instructions were added");
+        // The markers which indicate where on-stack pack metadata should be
+        // deallocated were not inserted for I.  To fix this, add I's opcode to
+        // SILInstruction::mayRequirePackMetadata subject to the appropriate
+        // checks.
       }
     }
 #endif

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1298,6 +1298,8 @@ bool SILInstruction::mayRequirePackMetadata() const {
   }
   case SILInstructionKind::ClassMethodInst:
   case SILInstructionKind::DebugValueInst: 
+  case SILInstructionKind::DestroyAddrInst:
+  case SILInstructionKind::DestroyValueInst:
   // Unary instructions.
   {
     return getOperand(0)->getType().hasPack();

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1296,17 +1296,15 @@ bool SILInstruction::mayRequirePackMetadata() const {
     }
     return false;
   }
-  case SILInstructionKind::DebugValueInst: {
-    auto *dvi = cast<DebugValueInst>(this);
-    return dvi->getOperand()->getType().hasPack();
+  case SILInstructionKind::ClassMethodInst:
+  case SILInstructionKind::DebugValueInst: 
+  // Unary instructions.
+  {
+    return getOperand(0)->getType().hasPack();
   }
   case SILInstructionKind::MetatypeInst: {
     auto *mi = cast<MetatypeInst>(this);
     return mi->getType().hasPack();
-  }
-  case SILInstructionKind::ClassMethodInst: {
-    auto *cmi = cast<ClassMethodInst>(this);
-    return cmi->getOperand()->getType().hasPack();
   }
   case SILInstructionKind::WitnessMethodInst: {
     auto *wmi = cast<WitnessMethodInst>(this);

--- a/test/IRGen/rdar112792831.swift
+++ b/test/IRGen/rdar112792831.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -emit-ir -O %s
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public struct Predicate<each Input> {
+    var x: Any? = nil
+    public func evaluate(_: repeat each Input) -> Bool { return false }
+}
+
+public struct PredicateBindings {
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public protocol PredicateExpression<Output> {
+    associatedtype Output
+
+    func evaluate(_ bindings: PredicateBindings) throws -> Output
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public struct PredicateEvaluate<
+    Condition : PredicateExpression,
+    each Input : PredicateExpression
+>
+where
+    Condition.Output == Predicate<repeat (each Input).Output>
+{   
+
+    public typealias Output = Bool
+    
+    public let predicate: Condition
+    public let input: (repeat each Input)
+        
+    public init(predicate: Condition, input: repeat each Input) {
+        self.predicate = predicate
+        self.input = (repeat each input)
+    }
+        
+    public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+        try predicate.evaluate(bindings).evaluate(repeat (each input).evaluate(bindings))
+    }
+}


### PR DESCRIPTION
Destroys of values whose types feature a pack may require allocating the pack on-stack.

Thanks to @slavapestov for the test case.

rdar://112792831
