### PR TITLE
[Availability] Update SwiftStdlib 5.9 availability to macOS 14/iOS 17-era

### DIFF
--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -33,8 +33,9 @@ SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
 SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
-SwiftStdlib 5.9:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
-# TODO: Also update ASTContext::getSwift59Availability when 5.9 is released
+SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
+SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+# TODO: Also update ASTContext::getSwift510Availability when needed
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
We have version numbers that corresponding to the Swift 5.9 runtime for Apple platforms, so enable them for the availability macros.