### PR TITLE
No more `pipes`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1214,7 +1214,7 @@ endif()
 # Find required dependencies.
 #
 
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 3.6 COMPONENTS Interpreter REQUIRED)
 
 #
 # Find optional dependencies.

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -191,7 +191,7 @@ toolchain as a one-off, there are a couple of differences:
 ### Spot check dependencies
 
 * Run `cmake --version`; this should be at least 3.19.6 (3.24.2 if you want to use Xcode for editing on macOS).
-* Run `python3 --version`; check that this succeeds.
+* Run `python3 --version`; this should be at least 3.6.
 * Run `ninja --version`; check that this succeeds.
 * If you installed and want to use Sccache: Run `sccache --version`; check
   that this succeeds.

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -1,5 +1,5 @@
 import os
-import pipes
+import shlex
 
 
 if 'sourcekit' not in config.available_features:
@@ -18,5 +18,4 @@ else:
     config.substitutions.append( ('%sourcekitd-test', '%s -module-cache-path %r' % (config.sourcekitd_test, config.clang_module_cache_path)) )
     config.substitutions.append( ('%complete-test', '%s -module-cache-path=%r' % (config.complete_test, config.clang_module_cache_path)) )
     config.substitutions.append( ('%swiftlib_dir', config.swiftlib_dir) )
-    config.substitutions.append( ('%sed_clean', '%s %s' % (pipes.quote(sys.executable), sk_path_sanitize) ) )
-
+    config.substitutions.append( ('%sed_clean', '%s %s' % (shlex.quote(sys.executable), sk_path_sanitize) ) )

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -27,7 +27,6 @@ import subprocess
 import sys
 import socket
 import glob
-import pipes
 from distutils.sysconfig import get_python_lib
 
 import lit
@@ -129,11 +128,7 @@ def get_lldb_python_interpreter(lldb_build_root):
     return python_path
 
 if not platform.system() == 'Windows':
-    # Python 3.3 has shlex.quote, while previous Python have pipes.quote
-    if sys.version_info[0:2] >= (3, 2):
-        shell_quote = shlex.quote
-    else:
-        shell_quote = pipes.quote
+    shell_quote = shlex.quote
 else:
     # In Windows neither pipe.quote nor shlex.quote works.
     def shell_quote(s):

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -344,7 +344,7 @@ function with_pushd() {
 }
 
 function quoted_print() {
-    python3 -c 'import pipes; import sys; print(" ".join(pipes.quote(arg) for arg in sys.argv[1:]))' "$@"
+    python3 -c 'import shlex; import sys; print(" ".join(shlex.quote(arg) for arg in sys.argv[1:]))' "$@"
 }
 
 function toupper() {

--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 from copy import copy as _copy
 from pathlib import Path
-from pipes import quote as _quote
+from shlex import quote as _quote
 from shlex import split
 from subprocess import CalledProcessError
 

--- a/utils/coverage/coverage-generate-data
+++ b/utils/coverage/coverage-generate-data
@@ -13,8 +13,8 @@ import argparse
 import logging
 import multiprocessing
 import os
-import pipes
 import platform
+import shlex
 import subprocess
 import sys
 import timeit
@@ -38,7 +38,7 @@ global_build_subdir = ''
 
 def quote_shell_cmd(cmd):
     """Return `cmd` as a properly quoted shell string"""
-    return ' '.join([pipes.quote(a) for a in cmd])
+    return ' '.join([shlex.quote(a) for a in cmd])
 
 
 def call(cmd, verbose=True, show_cmd=True):

--- a/utils/rth
+++ b/utils/rth
@@ -12,7 +12,6 @@
 import argparse
 import glob
 import os
-import pipes
 import platform
 import shlex
 import shutil
@@ -27,7 +26,7 @@ def verbose_print_command(command):
         if platform.system() == 'Windows':
             print(subprocess.list2cmdline(command))
         else:
-            print(" ".join(pipes.quote(c) for c in command))
+            print(" ".join(shlex.quote(c) for c in command))
         sys.stdout.flush()
 
 

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -13,7 +13,7 @@ import argparse
 import glob
 import multiprocessing
 import os
-import pipes
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -91,7 +91,7 @@ def get_verify_resource_dir_modules_commands(
 
 
 def quote_shell_command(args):
-    return " ".join([pipes.quote(a) for a in args])
+    return " ".join([shlex.quote(a) for a in args])
 
 
 def run_commands_in_parallel(commands):

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -11,8 +11,8 @@
 # ===---------------------------------------------------------------------===#
 
 import os
-import pipes
 import platform
+import shlex
 
 from build_swift.build_swift import argparse
 from build_swift.build_swift.constants import BUILD_SCRIPT_IMPL_PATH
@@ -128,9 +128,9 @@ class BuildScriptInvocation(object):
             "--build-jobs", str(args.build_jobs),
             "--lit-jobs", str(args.lit_jobs),
             "--common-cmake-options=%s" % ' '.join(
-                pipes.quote(opt) for opt in cmake.common_options()),
+                shlex.quote(opt) for opt in cmake.common_options()),
             "--build-args=%s" % ' '.join(
-                pipes.quote(arg) for arg in cmake.build_args()),
+                shlex.quote(arg) for arg in cmake.build_args()),
             "--dsymutil-jobs", str(args.dsymutil_jobs),
             '--build-swift-libexec', str(args.build_swift_libexec).lower(),
             '--swift-enable-backtracing', str(args.swift_enable_backtracing).lower(),
@@ -167,7 +167,7 @@ class BuildScriptInvocation(object):
                     args.host_target, product_name))
             cmake_opts = product.cmake_options
 
-            # FIXME: We should be using pipes.quote here but we run into issues
+            # FIXME: We should be using shlex.quote here but we run into issues
             # with build-script-impl/cmake not being happy with all of the
             # extra "'" in the strings. To fix this easily, we really need to
             # just invoke cmake from build-script directly rather than futzing
@@ -398,7 +398,7 @@ class BuildScriptInvocation(object):
         if args.extra_cmake_options:
             impl_args += [
                 "--extra-cmake-options=%s" % ' '.join(
-                    pipes.quote(opt) for opt in args.extra_cmake_options)
+                    shlex.quote(opt) for opt in args.extra_cmake_options)
             ]
 
         if args.lto_type is not None:

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -14,8 +14,8 @@ Centralized command line and file system interface for the build script.
 # ----------------------------------------------------------------------------
 
 import os
-import pipes
 import platform
+import shlex
 import shutil
 import subprocess
 import sys
@@ -35,7 +35,7 @@ def _fatal_error(message):
 
 
 def _quote(arg):
-    return pipes.quote(str(arg))
+    return shlex.quote(str(arg))
 
 
 def quote_command(args):


### PR DESCRIPTION
eliminates `pipes` in favor of `shlex` in our python utilites.

This solves deprecation warnings in build-script:

```
DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
```

This change assumes that the minimum version
of Python3 is 3.3, which has `shlex.quote`.

Since our build bots currently use 3.6 as their
Python version, we can't yet use `shlex.join`
to further simplify some of the code using
quote.