### PR TITLE
5.9: [IRGen] Add metadata pack markers for more instructions.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -180,10 +180,13 @@ public:
     /// they have a type variable originator.
     SolverAllocated = 0x8000,
 
-    /// This type contains a concrete pack.
-    HasConcretePack = 0x10000,
+    /// Contains a PackType.
+    HasPack = 0x10000,
 
-    Last_Property = HasConcretePack
+    /// Contains a PackArchetypeType.
+    HasPackArchetype = 0x20000,
+
+    Last_Property = HasPackArchetype
   };
   enum { BitWidth = countBitsUsed(Property::Last_Property) };
 
@@ -259,7 +262,9 @@ public:
 
   bool hasParameterPack() const { return Bits & HasParameterPack; }
 
-  bool hasConcretePack() const { return Bits & HasConcretePack; }
+  bool hasPack() const { return Bits & HasPack; }
+
+  bool hasPackArchetype() const { return Bits & HasPackArchetype; }
 
   /// Does a type with these properties structurally contain a
   /// parameterized existential type?
@@ -419,12 +424,12 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+30,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+29,
     /// Type variable options.
     Options : 7,
     : NumPadBits,
     /// The unique number assigned to this type variable.
-    ID : 30
+    ID : 29
   );
 
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+4+1+2+1+1,
@@ -687,16 +692,26 @@ public:
     return getRecursiveProperties().hasLocalArchetype();
   }
 
+  /// Whether the type contains a generic parameter declared as a parameter
+  /// pack.
   bool hasParameterPack() const {
     return getRecursiveProperties().hasParameterPack();
   }
 
-  bool hasConcretePack() const {
-    return getRecursiveProperties().hasConcretePack();
+  /// Whether the type contains a PackType.
+  bool hasPack() const {
+    return getRecursiveProperties().hasPack();
   }
 
-  /// Whether the type has some flavor of pack.
-  bool hasPack() const { return hasParameterPack() || hasConcretePack(); }
+  /// Whether the type contains a PackArchetypeType.
+  bool hasPackArchetype() const {
+    return getRecursiveProperties().hasPackArchetype();
+  }
+
+  /// Whether the type has any flavor of pack.
+  bool hasAnyPack() const {
+    return hasParameterPack() || hasPack() || hasPackArchetype();
+  }
 
   /// Determine whether the type involves a parameterized existential type.
   bool hasParameterizedExistential() const {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -352,11 +352,14 @@ public:
   /// pack.
   bool hasParameterPack() const { return getASTType()->hasParameterPack(); }
 
-  /// Whether the type contains a concrete pack.
-  bool hasConcretePack() const { return getASTType()->hasConcretePack(); }
-
-  /// Whether the type contains some flavor of pack.
+  /// Whether the type contains a PackType.
   bool hasPack() const { return getASTType()->hasPack(); }
+
+  /// Whether the type contains a PackArchetypeType.
+  bool hasPackArchetype() const { return getASTType()->hasPackArchetype(); }
+
+  /// Whether the type contains any flavor of pack.
+  bool hasAnyPack() const { return getASTType()->hasAnyPack(); }
 
   /// True if the type is an empty tuple or an empty struct or a tuple or
   /// struct containing only empty types.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3404,7 +3404,7 @@ CanPackType CanPackType::get(const ASTContext &C,
 }
 
 PackType *PackType::get(const ASTContext &C, ArrayRef<Type> elements) {
-  RecursiveTypeProperties properties = RecursiveTypeProperties::HasConcretePack;
+  RecursiveTypeProperties properties = RecursiveTypeProperties::HasPack;
   bool isCanonical = true;
   for (Type eltTy : elements) {
     assert(!eltTy->is<PackType>() &&
@@ -3444,7 +3444,7 @@ void PackType::Profile(llvm::FoldingSetNodeID &ID, ArrayRef<Type> Elements) {
 
 CanSILPackType SILPackType::get(const ASTContext &C, ExtInfo info,
                                 ArrayRef<CanType> elements) {
-  RecursiveTypeProperties properties = RecursiveTypeProperties::HasConcretePack;
+  RecursiveTypeProperties properties;
   for (CanType eltTy : elements) {
     assert(!isa<SILPackType>(eltTy) &&
            "Cannot have pack directly inside another pack");
@@ -4036,7 +4036,7 @@ isAnyFunctionTypeCanonical(ArrayRef<AnyFunctionType::Param> params,
 static RecursiveTypeProperties
 getGenericFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
                                       Type result) {
-  static_assert(RecursiveTypeProperties::BitWidth == 17,
+  static_assert(RecursiveTypeProperties::BitWidth == 18,
                 "revisit this if you add new recursive type properties");
   RecursiveTypeProperties properties;
 
@@ -4677,7 +4677,7 @@ CanSILFunctionType SILFunctionType::get(
   void *mem = ctx.Allocate(bytes, alignof(SILFunctionType));
 
   RecursiveTypeProperties properties;
-  static_assert(RecursiveTypeProperties::BitWidth == 17,
+  static_assert(RecursiveTypeProperties::BitWidth == 18,
                 "revisit this if you add new recursive type properties");
   for (auto &param : params)
     properties |= param.getInterfaceType()->getRecursiveProperties();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3704,7 +3704,7 @@ PackArchetypeType::PackArchetypeType(
     LayoutConstraint Layout, PackShape Shape)
     : ArchetypeType(TypeKind::PackArchetype, Ctx,
                     RecursiveTypeProperties::HasArchetype |
-                        RecursiveTypeProperties::HasConcretePack,
+                        RecursiveTypeProperties::HasPackArchetype,
                     InterfaceType, ConformsTo, Superclass, Layout, GenericEnv) {
   assert(InterfaceType->isParameterPack());
   *getTrailingObjects<PackShape>() = Shape;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3703,8 +3703,9 @@ PackArchetypeType::PackArchetypeType(
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,
     LayoutConstraint Layout, PackShape Shape)
     : ArchetypeType(TypeKind::PackArchetype, Ctx,
-                    RecursiveTypeProperties::HasArchetype, InterfaceType,
-                    ConformsTo, Superclass, Layout, GenericEnv) {
+                    RecursiveTypeProperties::HasArchetype |
+                        RecursiveTypeProperties::HasConcretePack,
+                    InterfaceType, ConformsTo, Superclass, Layout, GenericEnv) {
   assert(InterfaceType->isParameterPack());
   *getTrailingObjects<PackShape>() = Shape;
 }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2645,6 +2645,10 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
         llvm::report_fatal_error(
             "Instruction resulted in on-stack pack metadata emission but no "
             "cleanup instructions were added");
+        // The markers which indicate where on-stack pack metadata should be
+        // deallocated were not inserted for I.  To fix this, add I's opcode to
+        // SILInstruction::mayRequirePackMetadata subject to the appropriate
+        // checks.
       }
     }
 #endif

--- a/lib/IRGen/PackMetadataMarkerInserter.cpp
+++ b/lib/IRGen/PackMetadataMarkerInserter.cpp
@@ -91,7 +91,7 @@ Inserter::shouldInsertMarkersForInstruction(SILInstruction *inst) {
             BuiltinValueKind::StartAsyncLetWithLocalBuffer ||
         bi->getBuiltinKind() == BuiltinValueKind::StartAsyncLet)
       return Inserter::FindResult::Unhandleable;
-    return Inserter::FindResult::None;
+    LLVM_FALLTHROUGH;
   }
   default:
     return inst->mayRequirePackMetadata() ? FindResult::Some : FindResult::None;

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1305,11 +1305,11 @@ bool SILInstruction::mayRequirePackMetadata() const {
   case SILInstructionKind::TryApplyInst: {
     // Check the function type for packs.
     auto apply = ApplySite::isa(const_cast<SILInstruction *>(this));
-    if (apply.getCallee()->getType().hasPack())
+    if (apply.getCallee()->getType().hasAnyPack())
       return true;
     // Check the substituted types for packs.
     for (auto ty : apply.getSubstitutionMap().getReplacementTypes()) {
-      if (ty->hasPack())
+      if (ty->hasAnyPack())
         return true;
     }
     return false;
@@ -1320,20 +1320,20 @@ bool SILInstruction::mayRequirePackMetadata() const {
   case SILInstructionKind::DestroyValueInst:
   // Unary instructions.
   {
-    return getOperand(0)->getType().hasPack();
+    return getOperand(0)->getType().hasAnyPack();
   }
   case SILInstructionKind::AllocStackInst: {
     auto *asi = cast<AllocStackInst>(this);
-    return asi->getType().hasPack();
+    return asi->getType().hasAnyPack();
   }
   case SILInstructionKind::MetatypeInst: {
     auto *mi = cast<MetatypeInst>(this);
-    return mi->getType().hasPack();
+    return mi->getType().hasAnyPack();
   }
   case SILInstructionKind::WitnessMethodInst: {
     auto *wmi = cast<WitnessMethodInst>(this);
     auto ty = wmi->getLookupType();
-    return ty->hasPack();
+    return ty->hasAnyPack();
   }
   default:
     return false;

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1314,17 +1314,15 @@ bool SILInstruction::mayRequirePackMetadata() const {
     }
     return false;
   }
-  case SILInstructionKind::DebugValueInst: {
-    auto *dvi = cast<DebugValueInst>(this);
-    return dvi->getOperand()->getType().hasPack();
+  case SILInstructionKind::ClassMethodInst:
+  case SILInstructionKind::DebugValueInst: 
+  // Unary instructions.
+  {
+    return getOperand(0)->getType().hasPack();
   }
   case SILInstructionKind::MetatypeInst: {
     auto *mi = cast<MetatypeInst>(this);
     return mi->getType().hasPack();
-  }
-  case SILInstructionKind::ClassMethodInst: {
-    auto *cmi = cast<ClassMethodInst>(this);
-    return cmi->getOperand()->getType().hasPack();
   }
   case SILInstructionKind::WitnessMethodInst: {
     auto *wmi = cast<WitnessMethodInst>(this);

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1316,6 +1316,8 @@ bool SILInstruction::mayRequirePackMetadata() const {
   }
   case SILInstructionKind::ClassMethodInst:
   case SILInstructionKind::DebugValueInst: 
+  case SILInstructionKind::DestroyAddrInst:
+  case SILInstructionKind::DestroyValueInst:
   // Unary instructions.
   {
     return getOperand(0)->getType().hasPack();

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1322,6 +1322,10 @@ bool SILInstruction::mayRequirePackMetadata() const {
   {
     return getOperand(0)->getType().hasPack();
   }
+  case SILInstructionKind::AllocStackInst: {
+    auto *asi = cast<AllocStackInst>(this);
+    return asi->getType().hasPack();
+  }
   case SILInstructionKind::MetatypeInst: {
     auto *mi = cast<MetatypeInst>(this);
     return mi->getType().hasPack();

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1336,6 +1336,27 @@ bool SILInstruction::mayRequirePackMetadata() const {
     return ty->hasAnyPack();
   }
   default:
+    // Instructions that deallocate stack must not result in pack metadata
+    // materialization.  If they did there would be no way to create the pack
+    // metadata on stack.
+    if (isDeallocatingStack())
+      return false;
+
+    // Check results and operands for packs.  If a pack appears, lowering the
+    // instruction might result in pack metadata emission.
+    for (auto result : getResults()) {
+      if (result->getType().hasAnyPack())
+        return true;
+    }
+    for (auto operandTy : getOperandTypes()) {
+      if (operandTy.hasAnyPack())
+        return true;
+    }
+    for (auto &tdo : getTypeDependentOperands()) {
+      if (tdo.get()->getType().hasAnyPack())
+        return true;
+    }
+
     return false;
   }
 }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1342,6 +1342,12 @@ bool SILInstruction::mayRequirePackMetadata() const {
     if (isDeallocatingStack())
       return false;
 
+    // Terminators that exit the function must not result in pack metadata
+    // materialization.
+    auto *ti = dyn_cast<TermInst>(this);
+    if (ti && ti->isFunctionExiting())
+      return false;
+
     // Check results and operands for packs.  If a pack appears, lowering the
     // instruction might result in pack metadata emission.
     for (auto result : getResults()) {

--- a/test/IRGen/pack_marker_insertion.swift
+++ b/test/IRGen/pack_marker_insertion.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+// Verify that we don't hit the `Instruction missing on-stack pack metadata cleanups!` assertion.
+
+// For alloc_stacks of tuples featuring a pack.
+public func tupleExpansionWithMemberType<each T: Sequence>(seqs: (repeat each T), elts: (repeat (each T).Element)) {}

--- a/test/IRGen/pack_metadata_marker_inserter.sil
+++ b/test/IRGen/pack_metadata_marker_inserter.sil
@@ -22,6 +22,9 @@ struct S1 {}
 struct S2 {}
 struct S3 {}
 
+struct GVT<each T> : Error {
+}
+
 struct GV<each T> {
   var tu: (repeat each T)
 }
@@ -143,6 +146,16 @@ entry:
   apply %take<Pack{G<T>}>() : $@convention(thin) <each T>() -> ()
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-SIL-LABEL: sil @return_variadic : {{.*}} {
+// CHECK-SIL:         [[RETVAL:%[^,]+]] = struct
+// CHECK-SIL:         return [[RETVAL]]
+// CHECK-SIL-LABEL: } // end sil function 'return_variadic'
+sil @return_variadic : $<each T>() -> GVT<repeat each T> {
+entry:
+  %retval = struct $GVT<repeat each T> () 
+  return %retval : $GVT<repeat each T>
 }
 
 // =============================================================================

--- a/test/IRGen/pack_metadata_marker_inserter_no_ir.sil
+++ b/test/IRGen/pack_metadata_marker_inserter_no_ir.sil
@@ -1,0 +1,23 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -pack-metadata-marker-inserter -enable-pack-metadata-stack-promotion=true | %FileCheck %s --check-prefixes CHECK-SIL
+
+// REQUIRES: asserts
+
+sil_stage lowered
+
+import Builtin
+
+protocol Error {}
+
+struct GVT<each T> {
+}
+
+// CHECK-SIL-LABEL: sil @throw_variadic : {{.*}} {
+// CHECK-SIL:         [[ERROR:%[^,]+]] = struct
+// CHECK-SIL:         throw [[ERROR]]
+// CHECK-SIL-LABEL: } // end sil function 'throw_variadic'
+sil @throw_variadic : $<each T>() -> ((), @error GVT<repeat each T>) {
+entry:
+  %retval = struct $GVT<repeat each T> () 
+  throw %retval : $GVT<repeat each T>
+}
+

--- a/test/IRGen/rdar112792831.swift
+++ b/test/IRGen/rdar112792831.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -emit-ir -O %s
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public struct Predicate<each Input> {
+    var x: Any? = nil
+    public func evaluate(_: repeat each Input) -> Bool { return false }
+}
+
+public struct PredicateBindings {
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public protocol PredicateExpression<Output> {
+    associatedtype Output
+
+    func evaluate(_ bindings: PredicateBindings) throws -> Output
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public struct PredicateEvaluate<
+    Condition : PredicateExpression,
+    each Input : PredicateExpression
+>
+where
+    Condition.Output == Predicate<repeat (each Input).Output>
+{   
+
+    public typealias Output = Bool
+    
+    public let predicate: Condition
+    public let input: (repeat each Input)
+        
+    public init(predicate: Condition, input: repeat each Input) {
+        self.predicate = predicate
+        self.input = (repeat each input)
+    }
+        
+    public func evaluate(_ bindings: PredicateBindings) throws -> Output {
+        try predicate.evaluate(bindings).evaluate(repeat (each input).evaluate(bindings))
+    }
+}


### PR DESCRIPTION
**Description:** Cleanup pack metadata when it's allocated for a destroy, alloc_stack, or other instruction when it involves a pack type.

SIL has no notion of metadata or witness tables.  SIL, however, is the right level at which to fixup stack nesting, ensuring that the various stack allocated things obey stack discipline.  When certain instructions are IRGen'd, packs of metadata and witness tables may be allocated on the stack.  Forcing these stack allocations to obey stack has two parts: (1) IRGen's SIL pass PackMetadataMarkerInserter and (2) IRGen itself.  In (1), a list (which this patch extends) of instructions which may result in pack metadata being allocated on the stack is consulted; each such instruction results in new marker instructions being inserted: a single `alloc_pack_metadata` instruction is inserted before it, and some number of `dealloc_pack_metadata` instructions are inserted on its boundary.  In (2), the on-stack metadata and witness tables emitted while IRGen'ing each such instruction are recorded.  Then when each `dealloc_pack_metadata` instruction is visited, those metadata and witness tables are cleaned up in reverse order.

The purpose of the list of instructions used by (1) is to limit the number of such marker instructions that are created.  Here, three new instructions are conditionally added to the list: `destroy_addr`, `destroy_value` and `alloc_stack`.  Such instructions only get markers if the type that they are destroying involves a pack.  

Finally, all (non-stack allocating, non-function exiting) other instructions are also given markers if any of their operands or results involve a pack type.  This will help to avoid similar problems in the future.
**Risk:** Low.  The change is just to expand the list of instructions that get these markers.
**Scope:** Narrow.  This only affects variadic generics code.
**Original PR:** https://github.com/apple/swift/pull/67493 , https://github.com/apple/swift/pull/67567 , https://github.com/apple/swift/pull/67569 , https://github.com/apple/swift/pull/67778
**Reviewed By:** @aschwaighofer
**Testing:** Added @slavapestov's source-level test cases that previously hit an assertion failure.
**Resolves:** rdar://112792831
