### PR TITLE
Add filter method for ordered and unordered map

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -29,7 +29,6 @@ public protocol CxxDictionary<Key, Value> {
 
   /// Do not implement this function manually in Swift.
   func __findUnsafe(_ key: Key) -> RawIterator
-  
   /// Do not implement this function manually in Swift.
   mutating func __findMutatingUnsafe(_ key: Key) -> RawMutableIterator
 
@@ -77,7 +76,6 @@ extension CxxDictionary {
       }
     }
   }
-  
 public func filter(_ isIncluded: (_ key: Key, _ value: Value) throws -> Bool) rethrows -> Self {
     var filteredDictionary = Self.init()
     var iterator = __beginUnsafe()

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -42,8 +42,26 @@ public protocol CxxDictionary<Key, Value> {
   /// Do not implement this function manually in Swift.
   func __endUnsafe() -> RawIterator
 
+<<<<<<< HEAD
   /// Do not implement this function manually in Swift.
   mutating func __endMutatingUnsafe() -> RawMutableIterator
+=======
+  func filter(
+    _ isIncluded: (Key, Value) throws -> Bool
+  ) rethrows -> [Key: Value] {
+    var filteredDictionary: [Key: Value] = [:]
+    let iterator = __findUnsafe(Key)
+    let endIterator = __endUnsafe()
+
+    while iterator != endIterator {
+      let pair = iterator.pointee
+      if try isIncluded(pair.first, pair.second) {
+        filteredDictionary[pair.first] = pair.second
+      }
+      iterator.successor()
+    }
+  }
+>>>>>>> 2dccec95be3 (Add filter method for ordered and unordered map)
 }
 
 extension CxxDictionary {

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -76,7 +76,8 @@ extension CxxDictionary {
       }
     }
   }
-public func filter(_ isIncluded: (_ key: Key, _ value: Value) throws -> Bool) rethrows -> Self {
+  
+  public func filter(_ isIncluded: (_ key: Key, _ value: Value) throws -> Bool) rethrows -> Self {
     var filteredDictionary = Self.init()
     var iterator = __beginUnsafe()
     let endIterator = __endUnsafe()

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -29,10 +29,7 @@ public protocol CxxDictionary<Key, Value> {
 
   /// Do not implement this function manually in Swift.
   func __findUnsafe(_ key: Key) -> RawIterator
-
-  /// Do not implement this function manually in Swift.
-  func __beginUnsafe() -> RawIterator
-
+  
   /// Do not implement this function manually in Swift.
   mutating func __findMutatingUnsafe(_ key: Key) -> RawMutableIterator
 
@@ -43,26 +40,15 @@ public protocol CxxDictionary<Key, Value> {
   /// Do not implement this function manually in Swift.
   @discardableResult
   mutating func erase(_ key: Key) -> Size
+
+  /// Do not implement this function manually in Swift.
   func __beginUnsafe() -> RawIterator
 
   /// Do not implement this function manually in Swift.
   func __endUnsafe() -> RawIterator
-}
 
   /// Do not implement this function manually in Swift.
   mutating func __endMutatingUnsafe() -> RawMutableIterator
-
-extension CxxDictionary {
-  @inlinable
-  public subscript(key: Key) -> Value? {
-    get {
-      let iter = __findUnsafe(key)
-      guard iter != __endUnsafe() else {
-        return nil
-      }
-      return iter.pointee.second
-    }
-  }
 }
 
 extension CxxDictionary {
@@ -92,21 +78,21 @@ extension CxxDictionary {
     }
   }
   
-  public func filter(
-    _ isIncluded: (_ key: Key, _ value: Value) throws -> Bool
-) rethrows -> Self {
-    var filteredDictionary: Self.init()
-    var iterator = __beginUnsafe() 
+public func filter(_ isIncluded: (_ key: Key, _ value: Value) throws -> Bool) rethrows -> Self {
+    var filteredDictionary = Self.init()
+    var iterator = __beginUnsafe()
     let endIterator = __endUnsafe()
 
     while iterator != endIterator {
-        let pair = iterator.pointee
-        if try isIncluded(pair.first, pair.second) {
-            filteredDictionary[pair.first] = pair.second
-        }
-        iterator = iterator.successor() 
+      let pair = iterator.pointee
+
+      if try isIncluded(pair.first, pair.second) {
+        filteredDictionary.__insertUnsafe(pair)
+      }
+
+      iterator = iterator.successor()
     }
 
     return filteredDictionary
-}
+  }
 }

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -14,7 +14,7 @@
 ///
 /// C++ standard library types such as `std::map` and `std::unordered_map`
 /// conform to this protocol.
-public protocol CxxDictionary<Key, Value> {
+public protocol CxxDictionary where Key: Hashable {
   associatedtype Key
   associatedtype Value
   associatedtype Element: CxxPair<Key, Value>
@@ -59,20 +59,22 @@ extension CxxDictionary {
   }
   
   func filter(
-    _ isIncluded: (Key, Value) throws -> Bool
-  ) rethrows -> [Key: Value] {
+    _ isIncluded: (_ key: Key, _ value: Value) throws -> Bool
+) rethrows -> [Key: Value] {
     var filteredDictionary: [Key: Value] = [:]
-    let iterator = __findUnsafe(Key)
+    var iterator = __findUnsafe(Key) 
     let endIterator = __endUnsafe()
 
     while iterator != endIterator {
-      let pair = iterator.pointee
-      if try isIncluded(pair.first, pair.second) {
-        filteredDictionary[pair.first] = pair.second
-      }
-      iterator.successor()
+        let pair = iterator.pointee
+        if try isIncluded(pair.first, pair.second) {
+            filteredDictionary[pair.first] = pair.second
+        }
+        iterator = iterator.successor() 
     }
-  }
+
+    return filteredDictionary
+}
 }
 
 extension CxxDictionary {

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -38,6 +38,7 @@ public protocol CxxDictionary where Key: Hashable {
   /// Do not implement this function manually in Swift.
   @discardableResult
   mutating func erase(_ key: Key) -> Size
+  func __beginUnsafe() -> RawIterator
 
   /// Do not implement this function manually in Swift.
   func __endUnsafe() -> RawIterator
@@ -62,7 +63,7 @@ extension CxxDictionary {
     _ isIncluded: (_ key: Key, _ value: Value) throws -> Bool
 ) rethrows -> [Key: Value] {
     var filteredDictionary: [Key: Value] = [:]
-    var iterator = __findUnsafe(Key) 
+    var iterator = __beginUnsafe(Key) 
     let endIterator = __endUnsafe()
 
     while iterator != endIterator {

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -25,6 +25,8 @@ public protocol CxxDictionary<Key, Value> {
   associatedtype Size: BinaryInteger
   associatedtype InsertionResult
 
+  init()
+
   /// Do not implement this function manually in Swift.
   func __findUnsafe(_ key: Key) -> RawIterator
 
@@ -61,24 +63,6 @@ extension CxxDictionary {
       return iter.pointee.second
     }
   }
-  
-  func filter(
-    _ isIncluded: (_ key: Key, _ value: Value) throws -> Bool
-) rethrows -> [Key: Value] {
-    var filteredDictionary: [Key: Value] = [:]
-    var iterator = __beginUnsafe(Key) 
-    let endIterator = __endUnsafe()
-
-    while iterator != endIterator {
-        let pair = iterator.pointee
-        if try isIncluded(pair.first, pair.second) {
-            filteredDictionary[pair.first] = pair.second
-        }
-        iterator = iterator.successor() 
-    }
-
-    return filteredDictionary
-}
 }
 
 extension CxxDictionary {
@@ -107,4 +91,22 @@ extension CxxDictionary {
       }
     }
   }
+  
+  public func filter(
+    _ isIncluded: (_ key: Key, _ value: Value) throws -> Bool
+) rethrows -> Self {
+    var filteredDictionary: Self.init()
+    var iterator = __beginUnsafe() 
+    let endIterator = __endUnsafe()
+
+    while iterator != endIterator {
+        let pair = iterator.pointee
+        if try isIncluded(pair.first, pair.second) {
+            filteredDictionary[pair.first] = pair.second
+        }
+        iterator = iterator.successor() 
+    }
+
+    return filteredDictionary
+}
 }

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -29,6 +29,9 @@ public protocol CxxDictionary<Key, Value> {
   func __findUnsafe(_ key: Key) -> RawIterator
 
   /// Do not implement this function manually in Swift.
+  func __beginUnsafe() -> RawIterator
+  
+  /// Do not implement this function manually in Swift.
   mutating func __findMutatingUnsafe(_ key: Key) -> RawMutableIterator
 
   /// Do not implement this function manually in Swift.

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -14,7 +14,7 @@
 ///
 /// C++ standard library types such as `std::map` and `std::unordered_map`
 /// conform to this protocol.
-public protocol CxxDictionary where Key: Hashable {
+public protocol CxxDictionary<Key, Value> {
   associatedtype Key
   associatedtype Value
   associatedtype Element: CxxPair<Key, Value>

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -30,7 +30,7 @@ public protocol CxxDictionary<Key, Value> {
 
   /// Do not implement this function manually in Swift.
   func __beginUnsafe() -> RawIterator
-  
+
   /// Do not implement this function manually in Swift.
   mutating func __findMutatingUnsafe(_ key: Key) -> RawMutableIterator
 

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -41,11 +41,23 @@ public protocol CxxDictionary<Key, Value> {
 
   /// Do not implement this function manually in Swift.
   func __endUnsafe() -> RawIterator
+}
 
-<<<<<<< HEAD
   /// Do not implement this function manually in Swift.
   mutating func __endMutatingUnsafe() -> RawMutableIterator
-=======
+
+extension CxxDictionary {
+  @inlinable
+  public subscript(key: Key) -> Value? {
+    get {
+      let iter = __findUnsafe(key)
+      guard iter != __endUnsafe() else {
+        return nil
+      }
+      return iter.pointee.second
+    }
+  }
+  
   func filter(
     _ isIncluded: (Key, Value) throws -> Bool
   ) rethrows -> [Key: Value] {
@@ -61,7 +73,6 @@ public protocol CxxDictionary<Key, Value> {
       iterator.successor()
     }
   }
->>>>>>> 2dccec95be3 (Add filter method for ordered and unordered map)
 }
 
 extension CxxDictionary {

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -2,8 +2,8 @@
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H
 
 #include <map>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 using Map = std::map<int, int>;
 using MapStrings = std::map<std::string, std::string>;
@@ -12,5 +12,7 @@ using UnorderedMap = std::unordered_map<int, int>;
 
 inline Map initMap() { return {{1, 3}, {2, 2}, {3, 3}}; }
 inline UnorderedMap initUnorderedMap() { return {{1, 3}, {3, 3}, {2, 2}}; }
+inline Map initEmptyMap() { return {}; }
+inline UnorderedMap initEmptyUnorderedMap() { return {}; }
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -90,34 +90,34 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
 
 StdMapTestSuite.test("Map.filter") {
   var m = initMap()
-  var n: [Int: Int] = [:]
+  var n = initEmptyMap()
 
   expectNotNil(m[1])
-  expectEqual(n.count, 0)
+  expectEqual(n.size(), 0)
 
   m = m.filter { k, v in k != 1 }
-  n = n.filter { k, v in k != 1 }
-
+  n = n.filter { k, v in false }
+ 
   expectNil(m[1])
   expectEqual(m[2], 2)
   expectEqual(m[3], 3)
-  expectEqual(n.count, 0)
+  expectTrue(n.empty())
 }
 
 StdMapTestSuite.test("UnorderedMap.filter") {
   var m = initUnorderedMap()
-  var n: [Int: Int] = [:]
+  var n = initEmptyUnorderedMap()
 
   expectNotNil(m[1])
-  expectEqual(n.count, 0)
+  expectEqual(n.size(), 0)
 
   m = m.filter { k, v in k != 1 }
-  n = n.filter { k, v in k != 1 }
+  n = n.filter { k, v in false }
 
   expectNil(m[1])
   expectEqual(m[2], 2)
   expectEqual(m[3], 3)
-  expectEqual(n.count, 0)
+  expectTrue(n.empty())
 }
 
 StdMapTestSuite.test("Map.erase") {

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -88,6 +88,30 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
   expectNil(m[-1])
 }
 
+StdMapTestSuite.test("Map.filter") {
+  var m = initMap()
+
+  expectNotNil(m[1])
+
+  m = m.filter { k, v in k != 1 }
+
+  expectNil(m[1])
+  expectEqual(m[2], 2)
+  expectEqual(m[3], 3)
+}
+
+StdMapTestSuite.test("UnorderedMap.filter") {
+  var m = initUnorderedMap()
+
+  expectNotNil(m[1])
+
+  m = m.filter { k, v in k != 1 }
+
+  expectNil(m[1])
+  expectEqual(m[2], 2)
+  expectEqual(m[3], 3)
+}
+
 StdMapTestSuite.test("Map.erase") {
   var m = initMap()
   expectNotNil(m[1])

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -90,26 +90,34 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
 
 StdMapTestSuite.test("Map.filter") {
   var m = initMap()
+  var n: [Int: Int] = [:]
 
   expectNotNil(m[1])
+  expectEqual(n.count, 0)
 
   m = m.filter { k, v in k != 1 }
+  n = n.filter { k, v in k != 1 }
 
   expectNil(m[1])
   expectEqual(m[2], 2)
   expectEqual(m[3], 3)
+  expectEqual(n.count, 0)
 }
 
 StdMapTestSuite.test("UnorderedMap.filter") {
   var m = initUnorderedMap()
+  var n: [Int: Int] = [:]
 
   expectNotNil(m[1])
+  expectEqual(n.count, 0)
 
   m = m.filter { k, v in k != 1 }
+  n = n.filter { k, v in k != 1 }
 
   expectNil(m[1])
   expectEqual(m[2], 2)
   expectEqual(m[3], 3)
+  expectEqual(n.count, 0)
 }
 
 StdMapTestSuite.test("Map.erase") {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Implemented a filter method like the [Swift stdlib one ](https://developer.apple.com/documentation/swift/dictionary/filter(_:))
Resolves #67400

