### PR TITLE
RequirementMachine: Fix some edge cases with shape requirements

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -214,7 +214,7 @@ enum class ForeignRepresentableKind : uint8_t {
 /// therefore, the result type is in covariant position relative to the function
 /// type.
 struct TypePosition final {
-  enum : uint8_t { Covariant, Contravariant, Invariant };
+  enum : uint8_t { Covariant, Contravariant, Invariant, Shape };
 
 private:
   decltype(Covariant) kind;
@@ -224,6 +224,7 @@ public:
 
   TypePosition flipped() const {
     switch (kind) {
+    case Shape:
     case Invariant:
       return *this;
     case Covariant:

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -24,7 +24,6 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/AST/LayoutConstraint.h"
-#include "swift/AST/TypeMatcher.h"
 #include "swift/AST/Types.h"
 #include <algorithm>
 #include <vector>

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -57,7 +57,7 @@ class Term;
 /// This transformation allows DependentMemberTypes to be manipulated as
 /// terms, with the actual concrete type structure remaining opaque to
 /// the requirement machine. This transformation is implemented in
-/// RewriteContext::getConcreteSubstitutionSchema().
+/// RewriteContext::getSubstitutionSchemaFromType().
 ///
 /// For example, the superclass requirement
 /// "T : MyClass<U.X, (Int) -> V.A.B>" is denoted with a symbol

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -159,6 +159,9 @@ namespace {
       bool rhsAbstract = rhsType->isTypeParameter();
 
       if (lhsAbstract && rhsAbstract) {
+        // FIXME: same-element requirements
+        assert(lhsType->isParameterPack() == rhsType->isParameterPack());
+
         unsigned lhsIndex = RewriteContext::getGenericParamIndex(lhsType);
         unsigned rhsIndex = RewriteContext::getGenericParamIndex(rhsType);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4677,7 +4677,7 @@ case TypeKind::Id:
       return Type();
 
     Type transformedCount =
-        expand->getCountType().transformWithPosition(pos, fn);
+        expand->getCountType().transformWithPosition(TypePosition::Shape, fn);
     if (!transformedCount)
       return Type();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2199,6 +2199,7 @@ static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
 
           case TypePosition::Contravariant:
           case TypePosition::Invariant:
+          case TypePosition::Shape:
             return Type(t);
           }
 

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -107,3 +107,22 @@ func sameTypeDesugar1<each T, each U>(t: repeat each T, u: repeat each U)
 func sameTypeDesugar2<each T: P, each U: P>(t: repeat each T, u: repeat each U)
   where Shape<repeat (each T).A> == Shape<repeat (each U).A> {}
 
+/// More complex example involving concrete type matching in
+/// property map construction
+
+protocol PP {
+  associatedtype A
+}
+
+struct G<each T> {}
+
+// CHECK-LABEL: sameTypeMatch1
+// CHECK-NEXT: <T, each U, each V where T : PP, repeat each U : PP, repeat each V : PP, T.[PP]A == G<repeat (each U).[PP]A>, repeat (each U).[PP]A == (each V).[PP]A>
+func sameTypeMatch1<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: repeat each V)
+  where T.A == G<repeat (each U).A>, T.A == G<repeat (each V).A>,
+        (repeat (each U, each V)) : Any {}
+
+// CHECK-LABEL: sameTypeMatch2
+// CHECK-NEXT: <T, each U, each V where T : PP, repeat each U : PP, (repeat (each U, each V)) : Any, repeat each V : PP, T.[PP]A == (/* shape: each U */ repeat ())>
+func sameTypeMatch2<T: PP, each U: PP, each V: PP>(t: T, u: repeat each U, v: repeat each V)
+  where T.A == Shape<repeat each U>, T.A == Shape<repeat each V> {}

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -83,3 +83,27 @@ protocol Q: P where A: Q {}
 // CHECK-LABEL: sameType2
 // CHECK-NEXT: Generic signature: <each T, each U where repeat each T : Q, repeat each U : Q, repeat (each T).[P]A.[P]A == (each U).[P]A.[P]A>
 func sameType2<each T, each U>(_: repeat (each T, each U)) where repeat each T: Q, repeat each U: Q, repeat (each T).A.A == (each U).A.A {}
+
+
+//////
+///
+/// A same-type requirement between two pack expansion types
+/// should desugar to a same-shape requirement between their
+/// count types and a same-type requirement between their
+/// element types.
+///
+//////
+
+typealias First<T, U> = T
+typealias Shape<each T> = (repeat First<(), each T>)
+
+// CHECK-LABEL: sameTypeDesugar1
+// CHECK-NEXT: Generic signature: <each T, each U where (repeat (each T, each U)) : Any>
+func sameTypeDesugar1<each T, each U>(t: repeat each T, u: repeat each U)
+  where Shape<repeat each T> == Shape<repeat each U> {}
+
+// CHECK-LABEL: sameTypeDesugar2
+// CHECK-NEXT: Generic signature: <each T, each U where repeat each T : P, (repeat (each T, each U)) : Any, repeat each U : P>
+func sameTypeDesugar2<each T: P, each U: P>(t: repeat each T, u: repeat each U)
+  where Shape<repeat (each T).A> == Shape<repeat (each U).A> {}
+


### PR DESCRIPTION
Conceptually, a same-type requirement between two PackExpansionTypes breaks down into a same-type requirement between pattern types, and a _same-shape_ requirement between their counts. We didn't do this properly in two places:

- Requirement desugaring, where we break down same-type requirements with concrete types on both sides before constructing rules.
- Property unification, where we match concrete types subject to pairs of requirements such as `T == C1`, `T == C2`.