### PR TITLE
[Linux] Fix installation of swift-backtrace binary

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2972,7 +2972,7 @@ function(add_swift_target_executable name)
       add_dependencies(${install_in_component} ${lipo_target})
 
       set(install_dest "libexec${LLVM_LIBDIR_SUFFIX}/swift/${resource_dir_sdk_subdir}")
-      swift_install_in_component(FILES "${UNIVERSAL_LIBRARY_NAME}"
+      swift_install_in_component(FILES "${UNIVERSAL_NAME}"
                                    DESTINATION ${install_dest}
                                    COMPONENT "${install_in_component}"
                                  PERMISSIONS

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -824,7 +824,7 @@ no-swift-stdlib-assertions
 #===------------------------------------------------------------------------===#
 [preset: mixin_linux_install_components_with_clang]
 
-swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
 llvm-install-components=llvm-ar;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
@@ -1090,7 +1090,7 @@ install-swift-driver
 install-swiftsyntax
 install-xctest
 install-prefix=/usr
-swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;dev
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;libexec;stdlib;swift-remote-mirror;sdk-overlay;dev
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 
@@ -2774,7 +2774,7 @@ xctest
 install-foundation
 install-libdispatch
 install-xctest
-swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
 [preset: source_compat_suite_macos_DA]
 mixin-preset=source_compat_suite_macos_base


### PR DESCRIPTION
We weren't installing the `swift-backtrace` binary on Linux because (a) we weren't installing the `libexec` component, and (b) there was a bug in the CMake scripts that made it not work anyway.