### PR TITLE
[cxx-interop] Add tests for `std::map::erase` and `std::set::erase`

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -39,4 +39,22 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
   expectNil(m[5])
 }
 
+StdMapTestSuite.test("Map.erase") {
+  var m = initMap()
+  expectNotNil(m[1])
+  m.erase(1)
+  expectNil(m[1])
+  m.erase(1)
+  expectNil(m[1])
+}
+
+StdMapTestSuite.test("UnorderedMap.erase") {
+  var m = initUnorderedMap()
+  expectNotNil(m[2])
+  m.erase(2)
+  expectNil(m[2])
+  m.erase(2)
+  expectNil(m[2])
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -89,4 +89,22 @@ StdSetTestSuite.test("UnorderedSetOfCInt.insert") {
 }
 #endif
 
+StdSetTestSuite.test("SetOfCInt.erase") {
+    var s = initSetOfCInt()
+    expectTrue(s.contains(1))
+    s.erase(1)
+    expectFalse(s.contains(1))
+    s.erase(1)
+    expectFalse(s.contains(1))
+}
+
+StdSetTestSuite.test("UnorderedSetOfCInt.erase") {
+    var s = initUnorderedSetOfCInt()
+    expectTrue(s.contains(2))
+    s.erase(2)
+    expectFalse(s.contains(2))
+    s.erase(2)
+    expectFalse(s.contains(2))
+}
+
 runAllTests()


### PR DESCRIPTION
We're going to need the ability to remove an element from a map to support mutation in `CxxDictionary.subscript`.

rdar://105399019