### PR TITLE
[Macros] Don't allow types to shadow freestanding macros.

### DIFF
--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -56,6 +56,9 @@ enum NLOptions : unsigned {
   /// Exclude names introduced by macro expansions in the top-level module.
   NL_ExcludeMacroExpansions = 1 << 7,
 
+  /// This lookup should only return macro declarations.
+  NL_OnlyMacros = 1 << 8,
+
   /// The default set of options used for qualified name lookup.
   ///
   /// FIXME: Eventually, add NL_ProtocolMembers to this, once all of the

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -116,12 +116,6 @@ StringRef getMacroIntroducedDeclNameString(
 
 class CustomAttr;
 
-/// Perform lookup to determine whether the given custom attribute refers to
-/// a macro declaration, and populate the \c macros vector with the lookup
-/// results that are attached macros.
-void findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc,
-                            llvm::TinyPtrVector<ValueDecl *> &macros);
-
 class MacroIntroducedDeclName {
 public:
   using Kind = MacroIntroducedDeclNameKind;

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -36,7 +36,10 @@ enum class ResolutionKind {
   Overloadable,
 
   /// Lookup should match a single decl that declares a type.
-  TypesOnly
+  TypesOnly,
+
+  /// Lookup should only match macros.
+  MacrosOnly,
 };
 
 void simple_display(llvm::raw_ostream &out, ResolutionKind kind);

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -242,6 +242,8 @@ enum class UnqualifiedLookupFlags {
   IncludeUsableFromInline = 1 << 5,
   /// This lookup should exclude any names introduced by macro expansions.
   ExcludeMacroExpansions = 1 << 6,
+  /// This lookup should only return macros.
+  MacroLookup            = 1 << 7,
 };
 
 using UnqualifiedLookupOptions = OptionSet<UnqualifiedLookupFlags>;

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -162,6 +162,8 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
       [&](ValueDecl *VD) {
         if (resolutionKind == ResolutionKind::TypesOnly && !isa<TypeDecl>(VD))
           return true;
+        if (resolutionKind == ResolutionKind::MacrosOnly && !isa<MacroDecl>(VD))
+          return true;
         if (respectAccessControl &&
             !VD->isAccessibleFrom(moduleScopeContext, false,
                                   includeUsableFromInline))
@@ -310,6 +312,9 @@ void namelookup::simple_display(llvm::raw_ostream &out, ResolutionKind kind) {
     return;
   case ResolutionKind::TypesOnly:
     out << "TypesOnly";
+    return;
+  case ResolutionKind::MacrosOnly:
+    out << "MacrosOnly";
     return;
   }
   llvm_unreachable("Unhandled case in switch");

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3474,40 +3474,19 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
       parsedGenericParams->getRAngleLoc());
 }
 
-void swift::findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc,
-                                   llvm::TinyPtrVector<ValueDecl *> &macros) {
-  auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
-  if (!identTypeRepr)
-    return;
-
-  // Look for macros at module scope. They can only occur at module scope, and
-  // we need to be sure not to trigger name lookup into type contexts along
-  // the way.
-  auto moduleScopeDC = dc->getModuleScopeContext();
-  ASTContext &ctx = moduleScopeDC->getASTContext();
-  UnqualifiedLookupDescriptor descriptor(
-      identTypeRepr->getNameRef(), moduleScopeDC
-  );
-  auto lookup = evaluateOrDefault(
-      ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});
-  for (const auto &result : lookup.allResults()) {
-    // Only keep attached macros, which can be spelled as custom attributes.
-    if (auto macro = dyn_cast<MacroDecl>(result.getValueDecl()))
-      if (isAttachedMacro(macro->getMacroRoles()))
-        macros.push_back(macro);
-  }
-}
-
 NominalTypeDecl *
 CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                                    CustomAttr *attr, DeclContext *dc) const {
   // Look for names at module scope, so we don't trigger name lookup for
   // nested scopes. At this point, we're looking to see whether there are
   // any suitable macros.
-  llvm::TinyPtrVector<ValueDecl *> macros;
-  findMacroForCustomAttr(attr, dc, macros);
-  if (!macros.empty())
-    return nullptr;
+  if (auto *identTypeRepr =
+          dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr())) {
+    auto macros = namelookup::lookupMacros(
+        dc, identTypeRepr->getNameRef(), getAttachedMacroRoles());
+    if (!macros.empty())
+      return nullptr;
+  }
 
   // Find the types referenced by the custom attribute.
   auto &ctx = dc->getASTContext();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -112,6 +112,7 @@ void swift::simple_display(llvm::raw_ostream &out,
       {UnqualifiedLookupFlags::IgnoreAccessControl, "IgnoreAccessControl"},
       {UnqualifiedLookupFlags::IncludeOuterResults, "IncludeOuterResults"},
       {UnqualifiedLookupFlags::TypeLookup, "TypeLookup"},
+      {UnqualifiedLookupFlags::MacroLookup, "MacroLookup"},
   };
 
   auto flagsToPrint = llvm::make_filter_range(
@@ -1618,6 +1619,11 @@ namelookup::lookupMacros(DeclContext *dc, DeclNameRef macroName,
   auto moduleScopeDC = dc->getModuleScopeContext();
   ASTContext &ctx = moduleScopeDC->getASTContext();
 
+  // When performing lookup for freestanding macro roles, only consider
+  // macro names, ignoring types.
+  bool onlyMacros = static_cast<bool>(roles & getFreestandingMacroRoles()) &&
+      !(roles - getFreestandingMacroRoles());
+
   // Macro lookup should always exclude macro expansions; macro
   // expansions cannot introduce new macro declarations. Note that
   // the source location here doesn't matter.
@@ -1626,8 +1632,12 @@ namelookup::lookupMacros(DeclContext *dc, DeclNameRef macroName,
     UnqualifiedLookupFlags::ExcludeMacroExpansions
   };
 
+  if (onlyMacros)
+    descriptor.Options |= UnqualifiedLookupFlags::MacroLookup;
+
   auto lookup = evaluateOrDefault(
       ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});
+
   for (const auto &found : lookup.allResults()) {
     if (auto macro = dyn_cast<MacroDecl>(found.getValueDecl())) {
       auto candidateRoles = macro->getMacroRoles();
@@ -1638,6 +1648,7 @@ namelookup::lookupMacros(DeclContext *dc, DeclNameRef macroName,
       }
     }
   }
+
   return choices;
 }
 
@@ -2408,6 +2419,11 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       if ((options & NL_OnlyTypes) && !isa<TypeDecl>(decl))
         continue;
 
+      // If we're performing a macro lookup, don't even attempt to validate
+      // the decl if its not a macro.
+      if ((options & NL_OnlyMacros) && !isa<MacroDecl>(decl))
+        continue;
+
       if (isAcceptableLookupResult(DC, options, decl, onlyCompleteObjectInits))
         decls.push_back(decl);
     }
@@ -2491,8 +2507,8 @@ ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
   using namespace namelookup;
   QualifiedLookupResult decls;
 
-  auto kind = (options & NL_OnlyTypes
-               ? ResolutionKind::TypesOnly
+  auto kind = (options & NL_OnlyTypes ? ResolutionKind::TypesOnly
+               : options & NL_OnlyMacros ? ResolutionKind::MacrosOnly
                : ResolutionKind::Overloadable);
   auto topLevelScope = DC->getModuleScopeContext();
   if (module == topLevelScope->getParentModule()) {
@@ -2534,8 +2550,8 @@ AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
   using namespace namelookup;
   QualifiedLookupResult decls;
 
-  // Type-only lookup won't find anything on AnyObject.
-  if (options & NL_OnlyTypes)
+  // Type-only and macro lookup won't find anything on AnyObject.
+  if (options & (NL_OnlyTypes | NL_OnlyMacros))
     return decls;
 
   // Collect all of the visible declarations.
@@ -4027,6 +4043,7 @@ void swift::simple_display(llvm::raw_ostream &out, NLOptions options) {
     FLAG(NL_RemoveOverridden)
     FLAG(NL_IgnoreAccessControl)
     FLAG(NL_OnlyTypes)
+    FLAG(NL_OnlyMacros)
     FLAG(NL_IncludeAttributeImplements)
 #undef FLAG
   };

--- a/test/IDE/complete_macro_declaration.swift
+++ b/test/IDE/complete_macro_declaration.swift
@@ -7,7 +7,7 @@ macro expect(file: Int = #^DEFAULT_ARG^#) = #externalMacro(module: "MyModule", t
 // DEFAULT_ARG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: globalVar[#Int#]; name=globalVar
 
 @freestanding(expression)
-macro externalMacro() = ##^EXTERNAL_MACRO^#
+macro otherExternalMacro() = ##^EXTERNAL_MACRO^#
 // EXTERNAL_MACRO: Decl[Macro]/OtherModule[Swift]/IsSystem: externalMacro({#module: String#}, {#type: String#})[#T#]; name=externalMacro(module:type:)
 
 @freestanding(expression)

--- a/test/Macros/macro_shadowing.swift
+++ b/test/Macros/macro_shadowing.swift
@@ -1,0 +1,20 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+
+// Build macro implementations
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+
+// Build library that declares macros
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library.swiftmodule %S/Inputs/freestanding_macro_library.swift -module-name freestanding_macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+
+// 
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -I %t
+
+import freestanding_macro_library
+
+struct stringify<T> { }
+
+func testStringify(a: Int, b: Int) {
+  _ = #stringify(a + b)
+}


### PR DESCRIPTION
When performing name lookup for freestanding macros (e.g., after the `#`), don't allow types to shadow macros from imported libraries.

Fixes rdar://110429368.
