### PR TITLE
Enable large generic structs in statically initialized global variables

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -81,7 +81,7 @@ private extension BuiltinInst {
     // because memory effects are not computed in the Onone pipeline, yet.
     // This is no problem because the callee (usually a global init function )is mostly very small,
     // or contains the side-effect instruction `alloc_global` right at the beginning.
-    if callee.instructions.contains(where: { $0.mayReadOrWriteMemory || $0.hasUnspecifiedSideEffects }) {
+    if callee.instructions.contains(where: hasSideEffectForBuiltinOnce) {
       return
     }
     context.erase(instruction: self)
@@ -130,6 +130,16 @@ private extension BuiltinInst {
     }
     uses.replaceAll(with: literal, context)
     context.erase(instruction: self)
+  }
+}
+
+private func hasSideEffectForBuiltinOnce(_ instruction: Instruction) -> Bool {
+  switch instruction {
+  case is DebugStepInst, is DebugValueInst:
+    return false
+  default:
+    return instruction.mayReadOrWriteMemory ||
+           instruction.hasUnspecifiedSideEffects
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -293,6 +293,13 @@ struct AccessPath : CustomStringConvertible {
     return getProjection(to: other) != nil
   }
 
+  var materializableProjectionPath: SmallProjectionPath? {
+    if projectionPath.isMaterializable {
+      return projectionPath
+    }
+    return nil
+  }
+
   /// Returns the projection path to `other` if this access path is equal or contains `other`.
   ///
   /// For example,

--- a/test/SILOptimizer/init_static_globals.sil
+++ b/test/SILOptimizer/init_static_globals.sil
@@ -31,6 +31,11 @@ struct GenericStruct<T> {
   var x: T
 }
 
+struct TwoFields {
+  let a: Int32
+  let b: Int32
+}
+
 let nontrivialglobal: TClass
 
 // CHECK-LABEL: sil_global hidden [let] @$trivialglobal : $TStruct = {
@@ -74,6 +79,17 @@ sil_global private @g3_token : $Builtin.Word
 sil_global [let] @g4 : $Optional<UnsafeMutablePointer<Int>>
 sil_global private @g4_token : $Builtin.Word
 
+// CHECK-LABEL: sil_global [let] @g5 : $TwoFields = {
+// CHECK-NEXT:    %0 = integer_literal $Builtin.Int32, 11
+// CHECK-NEXT:    %1 = struct $Int32 (%0 : $Builtin.Int32)
+// CHECK-NEXT:    %2 = integer_literal $Builtin.Int32, 10
+// CHECK-NEXT:    %3 = struct $Int32 (%2 : $Builtin.Int32)
+// CHECK-NEXT:    %initval = struct $TwoFields (%1 : $Int32, %3 : $Int32)
+// CHECK-NEXT:  }
+sil_global [let] @g5 : $TwoFields
+
+sil_global [let] @g6 : $TwoFields
+sil_global [let] @g7 : $TwoFields
 
 // CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_trivialglobal_func :
 // CHECK-NOT:     alloc_global
@@ -189,3 +205,44 @@ bb0:
   %10 = tuple ()
   return %10 : $()
 }
+
+// CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_separate_stores :
+// CHECK-NOT:     alloc_global
+// CHECK-NOT:     store
+// CHECK:       } // end sil function 'globalinit_separate_stores'
+sil [global_init_once_fn] [ossa] @globalinit_separate_stores : $@convention(c) () -> () {
+bb0:
+  alloc_global @g5
+  %1 = global_addr @g5 : $*TwoFields
+  %2 = integer_literal $Builtin.Int32, 10
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  %4 = struct_element_addr %1 : $*TwoFields, #TwoFields.b
+  store %3 to [trivial] %4 : $*Int32
+  %6 = integer_literal $Builtin.Int32, 11
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  %8 = struct_element_addr %1 : $*TwoFields, #TwoFields.a
+  store %7 to [trivial] %8 : $*Int32
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_wrong_separate_stores :
+// CHECK:         alloc_global
+// CHECK:         store
+// CHECK:         store
+// CHECK:       } // end sil function 'globalinit_wrong_separate_stores'
+sil [global_init_once_fn] [ossa] @globalinit_wrong_separate_stores : $@convention(c) () -> () {
+bb0:
+  alloc_global @g5
+  %1 = global_addr @g5 : $*TwoFields
+  %2 = integer_literal $Builtin.Int32, 10
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  %4 = struct_element_addr %1 : $*TwoFields, #TwoFields.b
+  store %3 to [trivial] %4 : $*Int32
+  %6 = integer_literal $Builtin.Int32, 11
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  store %7 to [trivial] %4 : $*Int32
+  %10 = tuple ()
+  return %10 : $()
+}
+

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -experimental-performance-annotations -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -parse-as-library -emit-sil %s -o /dev/null -verify
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
 
@@ -11,7 +11,7 @@ open class Cl {
   final func finalMethod() {}
 }
 
-func initFunc() -> Int { return 3 }
+func initFunc() -> Int { return Int.random(in: 0..<10) }
 
 struct Str : P {
   let x: Int
@@ -163,8 +163,8 @@ class H {
 }
 
 struct MyStruct {
-  static var v: Int = {  // expected-note {{called from here}}
-    return H().hash      // expected-error {{Using type 'H' can cause metadata allocation or locks}}
+  static var v: Int = {      // expected-error {{Using type 'H' can cause metadata allocation or locks}}
+    return H().hash
   }()
 }
 
@@ -328,5 +328,52 @@ extension Y {
 @_noLocks
 public func testClosurePassing(a: inout Y) -> Int {
     return a.Xsort()
+}
+
+struct LargeGenericStruct<T> {
+  var a: T
+  var b: T
+  var c: T
+  var d: T
+  var e: T
+  var f: T
+  var g: T
+  var h: T
+}
+
+var largeGeneric = LargeGenericStruct<Int>(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8)
+
+@_noLocks
+func testLargeGenericStruct() -> LargeGenericStruct<Int> {
+  return largeGeneric
+}
+
+struct ContainsLargeGenericStruct {
+  var s: LargeGenericStruct<Int>
+}
+
+var clgs = ContainsLargeGenericStruct(s: LargeGenericStruct<Int>(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8))
+
+@_noLocks
+func testClgs() -> ContainsLargeGenericStruct {
+  return clgs
+}
+
+struct NestedGenericStruct<T> {
+  var a: T
+  var b: T
+  var c: LargeGenericStruct<T>
+  var d: T
+  var e: T
+  var f: T
+  var g: T
+  var h: T
+}
+
+var nestedGeneric = NestedGenericStruct(a: 1, b: 2, c: LargeGenericStruct<Int>(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8), d: 4, e: 5, f: 6, g: 7, h: 8)
+
+@_noLocks
+func testNestedGenericStruct() -> NestedGenericStruct<Int> {
+  return nestedGeneric
 }
 

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -274,6 +274,8 @@ bb0:
   %1 = global_addr @g : $*Int32
   %2 = integer_literal $Builtin.Int32, 10
   %3 = struct $Int32 (%2 : $Builtin.Int32)
+  debug_step
+  debug_value %1 : $*Int32
   %6 = tuple ()
   return %6 : $()
 }


### PR DESCRIPTION
Initializers of large generic structs are not re-abstracted when specialized. This means they return their result as an indirect out instead of a direct return value.
This PR adds some improvements  in MandatoryPerformanceOptimizations and InitializeStaticGlobals to be able to put such generic structs into statically initialized global variables.
* add a peephole to merge element stores to a single store
* ignore `debug_step` and `debug_value` when checking for side-effects in the callee of a `builtin.once`
* refine the inlining decisions in global initializers
For details see the commit messages.