### PR TITLE
More commits working toward getting rebranch building

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -122,7 +122,7 @@ public:
   /// collecting the identifiers in \p spiGroups.
   virtual void lookupImportedSPIGroups(
                             const ModuleDecl *importedModule,
-                            SmallSetVector<Identifier, 4> &spiGroups) const {};
+                            llvm::SmallSetVector<Identifier, 4> &spiGroups) const {};
 
   /// Checks whether this file imports \c module as \c @_weakLinked.
   virtual bool importsModuleAsWeakLinked(const ModuleDecl *module) const {

--- a/include/swift/AST/ResilienceExpansion.h
+++ b/include/swift/AST/ResilienceExpansion.h
@@ -14,6 +14,7 @@
 #define SWIFT_AST_RESILIENCE_EXPANSION_H
 
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace swift {
 

--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -25,7 +25,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/PrefixMap.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Host.h"
+#include "llvm/TargetParser/Host.h"
 #include "llvm/Support/TrailingObjects.h"
 #include <climits>
 

--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -48,10 +48,11 @@
 #ifndef SWIFT_BASIC_IMMUTABLEPOINTERSET_H
 #define SWIFT_BASIC_IMMUTABLEPOINTERSET_H
 
-#include "swift/Basic/STLExtras.h"
 #include "swift/Basic/NullablePtr.h"
-#include "llvm/Support/Allocator.h"
+#include "swift/Basic/STLExtras.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/Support/Allocator.h"
 #include <algorithm>
 #include <type_traits>
 

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -53,7 +53,6 @@ namespace llvm {
   template <typename T, unsigned N> class SmallVector;
 #endif
   template <unsigned N> class SmallString;
-  template <typename T, unsigned N> class SmallSetVector;
 #if SWIFT_LLVM_ODR_SAFE
   template<typename T> class ArrayRef;
   template<typename T> class MutableArrayRef;
@@ -93,7 +92,6 @@ namespace swift {
   using llvm::SmallBitVector;
   using llvm::SmallPtrSet;
   using llvm::SmallPtrSetImpl;
-  using llvm::SmallSetVector;
   using llvm::SmallString;
 #if SWIFT_LLVM_ODR_SAFE
   using llvm::SmallVector;

--- a/include/swift/Basic/LLVMExtras.h
+++ b/include/swift/Basic/LLVMExtras.h
@@ -1,0 +1,36 @@
+//===--- LLVMExtras.h -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides additional functionality on top of LLVM types
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_LLVMEXTRAS_H
+#define SWIFT_BASIC_LLVMEXTRAS_H
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+
+/// A SetVector that does no allocations under the specified size
+///
+/// swift::SmallSetVector provides the old SmallSetVector semantics that allow
+/// storing types that don't have `operator==`.
+template <typename T, unsigned N>
+using SmallSetVector = llvm::SetVector<T, llvm::SmallVector<T, N>,
+      llvm::SmallDenseSet<T, N, llvm::DenseMapInfo<T>>>;
+
+} // namespace swift
+
+#endif // SWIFT_BASIC_LLVMEXTRAS_H

--- a/include/swift/Basic/MultiMapCache.h
+++ b/include/swift/Basic/MultiMapCache.h
@@ -16,6 +16,9 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/None.h"
+#include "swift/Basic/STLExtras.h"
 
 namespace swift {
 
@@ -61,7 +64,8 @@ public:
 
     // If we already have a cached value, just return the cached value.
     if (!iter.second) {
-      return iter.first->second.transform(
+
+      return swift::transform(iter.first->second,
           [&](std::tuple<unsigned, unsigned> startLengthRange) {
             return llvm::makeArrayRef(data).slice(
                 std::get<ArrayStartOffset>(startLengthRange),

--- a/include/swift/ClangImporter/CXXMethodBridging.h
+++ b/include/swift/ClangImporter/CXXMethodBridging.h
@@ -26,7 +26,7 @@ struct CXXMethodBridging {
         nameKind != NameKind::lower && nameKind != NameKind::snake)
       return Kind::unknown;
 
-    if (getClangName().startswith_insensitive("set")) {
+    if (getClangName().starts_with_insensitive("set")) {
       // Setters only have one parameter.
       if (method->getNumParams() != 1)
         return Kind::unknown;
@@ -43,7 +43,7 @@ struct CXXMethodBridging {
     if (method->getReturnType()->isVoidType())
       return Kind::unknown;
 
-    if (getClangName().startswith_insensitive("get")) {
+    if (getClangName().starts_with_insensitive("get")) {
       // Getters cannot take arguments.
       if (method->getNumParams() != 0)
         return Kind::unknown;

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -770,13 +770,13 @@ class DiagnosticPrunedLiveness : public SSAPrunedLiveness {
   /// A side array that stores any non lifetime ending uses we find in live out
   /// blocks. This is used to enable our callers to emit errors on non-lifetime
   /// ending uses that extend liveness into a loop body.
-  SmallSetVector<SILInstruction *, 8> *nonLifetimeEndingUsesInLiveOut;
+  llvm::SmallSetVector<SILInstruction *, 8> *nonLifetimeEndingUsesInLiveOut;
 
 public:
   DiagnosticPrunedLiveness(
       SILFunction *function,
       SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr,
-      SmallSetVector<SILInstruction *, 8> *nonLifetimeEndingUsesInLiveOut =
+      llvm::SmallSetVector<SILInstruction *, 8> *nonLifetimeEndingUsesInLiveOut =
           nullptr)
       : SSAPrunedLiveness(function, discoveredBlocks),
         nonLifetimeEndingUsesInLiveOut(nonLifetimeEndingUsesInLiveOut) {}

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -219,7 +219,7 @@ public:
           return llvm::None;
         if ((*ID).IsNonLocal)
           return llvm::None;
-        return (*ID).ID;
+        return static_cast<unsigned>((*ID).ID);
       }
     };
 
@@ -230,7 +230,7 @@ public:
           return llvm::None;
         if (!(*ID).IsNonLocal)
           return llvm::None;
-        return (*ID).ID;
+        return static_cast<unsigned>((*ID).ID);
       }
     };
   };

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -247,7 +247,7 @@ public:
     /// reachability may extend.
     BasicBlockSetVector discoveredBlocks;
     /// The sublist of gens which are killed within the blocks where they occur.
-    SmallSetVector<SILInstruction *, 32> localGens;
+    llvm::SmallSetVector<SILInstruction *, 32> localGens;
 
     /// Construct a result for running IterativeBackwardReachability in a given
     /// function.

--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -138,7 +138,7 @@ class SinkAddressProjections {
   SmallVector<SingleValueInstruction *, 4> oldProjections;
   // Cloned projections to avoid address phis.
   SmallVectorImpl<SingleValueInstruction *> *newProjections;
-  SmallSetVector<SILValue, 4> inBlockDefs;
+  llvm::SmallSetVector<SILValue, 4> inBlockDefs;
 
   // Transient per-projection data for use during cloning.
   SmallVector<Operand *, 4> usesToReplace;

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -241,7 +241,7 @@ private:
   ///
   /// These blocks are not necessarily in the pruned live blocks since
   /// pruned liveness does not consider destroy_values.
-  SmallSetVector<SILBasicBlock *, 8> consumingBlocks;
+  llvm::SmallSetVector<SILBasicBlock *, 8> consumingBlocks;
 
   /// Record all interesting debug_value instructions here rather then treating
   /// them like a normal use. An interesting debug_value is one that may lie

--- a/include/swift/SILOptimizer/Utils/InstructionDeleter.h
+++ b/include/swift/SILOptimizer/Utils/InstructionDeleter.h
@@ -113,7 +113,7 @@ class InstructionDeleter {
   /// instructions in this set is important as when a dead instruction is
   /// removed, new instructions will be generated to fix the lifetime of the
   /// instruction's operands. This has to be deterministic.
-  SmallSetVector<SILInstruction *, 8> deadInstructions;
+  llvm::SmallSetVector<SILInstruction *, 8> deadInstructions;
 
   /// Callbacks used when adding/deleting instructions.
   InstModCallbacks callbacks;

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -192,7 +192,7 @@ bool extractSeparatedParams(
     auto ParagraphContent = ParagraphText->getLiteralContent();
     auto PotentialMatch = ParagraphContent.substr(0, ParameterPrefix.size());
 
-    if (!PotentialMatch.startswith_insensitive(ParameterPrefix)) {
+    if (!PotentialMatch.starts_with_insensitive(ParameterPrefix)) {
       NormalItems.push_back(Child);
       continue;
     }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -568,8 +568,8 @@ GenericSignatureImpl::haveSameShape(Type type1, Type type2) const {
   return getRequirementMachine()->haveSameShape(type1, type2);
 }
 
-SmallVector<CanType, 2> GenericSignatureImpl::getShapeClasses() const {
-  SmallSetVector<CanType, 2> result;
+llvm::SmallVector<CanType, 2> GenericSignatureImpl::getShapeClasses() const {
+  llvm::SmallSetVector<CanType, 2> result;
 
   forEachParam([&](GenericTypeParamType *gp, bool canonical) {
     if (!canonical || !gp->isParameterPack())

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -626,7 +626,7 @@ void SourceLookupCache::lookupVisibleDecls(ImportPath::Access AccessPath,
   // 'names' in macro role attributes). Since expansions are cached, it doesn't
   // cause duplicated expansions, but different 'unexpandedDecl' may report the
   // same 'ValueDecl'.
-  SmallSetVector<ValueDecl *, 4> macroExpandedDecls;
+  llvm::SmallSetVector<ValueDecl *, 4> macroExpandedDecls;
   for (MissingDecl *unexpandedDecl : unexpandedDecls) {
     unexpandedDecl->forEachMacroExpandedDecl([&](ValueDecl *vd) {
       macroExpandedDecls.insert(vd);

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -1135,7 +1135,7 @@ ArrayRef<ProtocolDecl *>
 ProtocolDependenciesRequest::evaluate(Evaluator &evaluator,
                                       ProtocolDecl *proto) const {
   auto &ctx = proto->getASTContext();
-  SmallSetVector<ProtocolDecl *, 4> result;
+  llvm::SmallSetVector<ProtocolDecl *, 4> result;
 
   // If we have a serialized requirement signature, deserialize it and
   // look at conformance requirements.

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -398,7 +398,7 @@ static bool matchNameWordToTypeWord(StringRef nameWord, StringRef typeWord) {
     // We can match the suffix of the type so long as everything preceding the
     // match is neither a lowercase letter nor a '_'. This ignores type
     // prefixes for acronyms, e.g., the 'NS' in 'NSURL'.
-    if (typeWord.endswith_insensitive(nameWord) &&
+    if (typeWord.ends_with_insensitive(nameWord) &&
         !clang::isLowercase(typeWord[typeWord.size() - nameWord.size()])) {
       // Check that everything preceding the match is neither a lowercase letter
       // nor a '_'.
@@ -411,7 +411,7 @@ static bool matchNameWordToTypeWord(StringRef nameWord, StringRef typeWord) {
 
     // We can match a prefix so long as everything following the match is
     // a number.
-    if (typeWord.startswith_insensitive(nameWord)) {
+    if (typeWord.starts_with_insensitive(nameWord)) {
       for (unsigned i = nameWord.size(), n = typeWord.size(); i != n; ++i) {
         if (!clang::isDigit(typeWord[i])) return false;
       }

--- a/lib/DriverTool/swift_llvm_opt_main.cpp
+++ b/lib/DriverTool/swift_llvm_opt_main.cpp
@@ -227,19 +227,16 @@ int swift_llvm_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   llvm::PassRegistry &Registry = *llvm::PassRegistry::getPassRegistry();
   initializeCore(Registry);
   initializeScalarOpts(Registry);
-  initializeObjCARCOpts(Registry);
   initializeVectorization(Registry);
   initializeIPO(Registry);
   initializeAnalysis(Registry);
   initializeTransformUtils(Registry);
   initializeInstCombine(Registry);
-  initializeInstrumentation(Registry);
   initializeTarget(Registry);
   // For codegen passes, only passes that do IR to IR transformation are
   // supported.
   initializeCodeGenPreparePass(Registry);
   initializeAtomicExpandPass(Registry);
-  initializeRewriteSymbolsLegacyPassPass(Registry);
   initializeWinEHPreparePass(Registry);
   initializeDwarfEHPrepareLegacyPassPass(Registry);
   initializeSjLjEHPreparePass(Registry);

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -43,9 +43,6 @@ public:
     if (addr == llvm::DenseMapInfo<llvm::Value *>::getEmptyKey() ||
         llvm::DenseMapInfo<llvm::Value *>::getTombstoneKey())
       return;
-    assert(llvm::cast<llvm::PointerType>(addr->getType())
-               ->isOpaqueOrPointeeTypeMatches(elementType) &&
-           "Incorrect pointer element type");
     assert(addr != nullptr && "building an invalid address");
   }
 

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -72,6 +72,7 @@ add_swift_host_library(swiftIRGen STATIC
     target
     targetparser
     transformutils
+    irprinter
 )
 target_link_libraries(swiftIRGen INTERFACE
   clangCodeGen

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -358,9 +358,6 @@ namespace irgen {
                              llvm::Type *awaitSignature = nullptr)
         : kind(kind), Value(value), SecondaryValue(secondaryValue),
           AuthInfo(authInfo), Sig(signature), awaitSignature(awaitSignature) {
-      // The function pointer should have function type.
-      assert(!value->getContext().supportsTypedPointers() ||
-             value->getType()->getNonOpaquePointerElementType()->isFunctionTy());
       // TODO: maybe assert similarity to signature.getType()?
       if (authInfo) {
         if (kind == Kind::Function) {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4625,10 +4625,10 @@ irgen::allocateForCoercion(IRGenFunction &IGF,
     ? fromTy
     : toTy;
 
-  auto alignment = std::max(DL.getABITypeAlignment(fromTy),
-                            DL.getABITypeAlignment(toTy));
+  llvm::Align alignment =
+      std::max(DL.getABITypeAlign(fromTy), DL.getABITypeAlign(toTy));
 
-  auto buffer = IGF.createAlloca(bufferTy, Alignment(alignment),
+  auto buffer = IGF.createAlloca(bufferTy, Alignment(alignment.value()),
                                  basename + ".coerced");
   
   Size size(std::max(fromSize, toSize));

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -721,12 +721,12 @@ void DistributedAccessor::emit() {
     for (unsigned index = 0; index < expandedSignature.numTypeMetadataPtrs; ++index) {
       auto offset =
           Size(index * IGM.DataLayout.getTypeAllocSize(IGM.TypeMetadataPtrTy));
-      auto alignment =
-          IGM.DataLayout.getABITypeAlignment(IGM.TypeMetadataPtrTy);
+      llvm::Align alignment =
+          IGM.DataLayout.getABITypeAlign(IGM.TypeMetadataPtrTy);
 
-      auto substitution =
-          IGF.emitAddressAtOffset(substitutionBuffer, Offset(offset),
-                                  IGM.TypeMetadataPtrTy, Alignment(alignment));
+      auto substitution = IGF.emitAddressAtOffset(
+          substitutionBuffer, Offset(offset), IGM.TypeMetadataPtrTy,
+          Alignment(alignment.value()));
       arguments.add(IGF.Builder.CreateLoad(substitution, "substitution"));
     }
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2171,7 +2171,7 @@ convertPrimitiveBuiltin(IRGenModule &IGM, CanType canTy) {
     case BuiltinFloatType::IEEE80: {
       llvm::Type *floatTy = llvm::Type::getX86_FP80Ty(ctx);
       uint64_t ByteSize = IGM.DataLayout.getTypeAllocSize(floatTy);
-      unsigned align = IGM.DataLayout.getABITypeAlignment(floatTy);
+      unsigned align = IGM.DataLayout.getABITypeAlign(floatTy).value();
       return RetTy{ floatTy, Size(ByteSize), Alignment(align) };
     }
     case BuiltinFloatType::IEEE128:

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -934,7 +934,7 @@ FixedTypeInfo::storeSpareBitExtraInhabitant(IRGenFunction &IGF,
     occupiedIndex = index;
     spareIndex = spareBitBias;
   } else {
-    auto occupiedBitMask = APInt::getAllOnesValue(occupiedBitCount);
+    auto occupiedBitMask = APInt::getAllOnes(occupiedBitCount);
     occupiedBitMask = occupiedBitMask.zext(32);
     auto occupiedBitMaskValue = llvm::ConstantInt::get(C, occupiedBitMask);
     occupiedIndex = IGF.Builder.CreateAnd(index, occupiedBitMaskValue);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -232,9 +232,9 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   PrintPassOptions PrintPassOpts;
   PrintPassOpts.Indent = DebugPassStructure;
   PrintPassOpts.SkipAnalyses = DebugPassStructure;
-  StandardInstrumentations SI(DebugPassStructure, /*VerifyEach*/ false,
-                              PrintPassOpts);
-  SI.registerCallbacks(PIC, &FAM);
+  StandardInstrumentations SI(Module->getContext(), DebugPassStructure,
+                              /*VerifyEach*/ false, PrintPassOpts);
+  SI.registerCallbacks(PIC, &MAM);
 
   PassBuilder PB(TargetMachine, PTO, PGOOpt, &PIC);
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -56,7 +56,7 @@
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
-#include "llvm/IR/IRPrintingPasses.h"
+#include "llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
@@ -81,7 +81,6 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/IPO/ThinLTOBitcodeWriter.h"
 #include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
@@ -374,7 +373,9 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   case IRGenOutputKind::Module:
     break;
   case IRGenOutputKind::LLVMAssemblyAfterOptimization:
-    PassManagerToRun.addPass(PrintModulePass(*out, "", false));
+    PassManagerToRun.addPass(
+        llvm::PrintModulePass(*out, "", /*ShouldPreserveUseListOrder=*/false,
+                              /*EmitSummaryIndex=*/false));
     break;
   case IRGenOutputKind::LLVMBitcode: {
     // Emit a module summary by default for Regular LTO except ld64-based ones

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -493,11 +493,11 @@ static void countStatsPostIRGen(UnifiedStatsReporter &Stats,
                                 const llvm::Module& Module) {
   auto &C = Stats.getFrontendCounters();
   // FIXME: calculate these in constant time if possible.
-  C.NumIRGlobals += Module.getGlobalList().size();
+  C.NumIRGlobals += Module.global_size();
   C.NumIRFunctions += Module.getFunctionList().size();
-  C.NumIRAliases += Module.getAliasList().size();
-  C.NumIRIFuncs += Module.getIFuncList().size();
-  C.NumIRNamedMetaData += Module.getNamedMDList().size();
+  C.NumIRAliases += Module.alias_size();
+  C.NumIRIFuncs += Module.ifunc_size();
+  C.NumIRNamedMetaData += Module.named_metadata_size();
   C.NumIRValueSymbols += Module.getValueSymbolTable().size();
   C.NumIRComdatSymbols += Module.getComdatSymbolTable().size();
   for (auto const &Func : Module) {
@@ -1472,13 +1472,13 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
         G.setLinkage(GlobalValue::ExternalLinkage);
       }
     };
-    for (llvm::GlobalVariable &G : M->getGlobalList()) {
+    for (llvm::GlobalVariable &G : M->globals()) {
       collectReference(G);
     }
     for (llvm::Function &F : M->getFunctionList()) {
       collectReference(F);
     }
-    for (llvm::GlobalAlias &A : M->getAliasList()) {
+    for (llvm::GlobalAlias &A : M->aliases()) {
       collectReference(A);
     }
   }
@@ -1498,13 +1498,13 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
         G.setLinkage(GlobalValue::WeakODRLinkage);
       }
     };
-    for (llvm::GlobalVariable &G : M->getGlobalList()) {
+    for (llvm::GlobalVariable &G : M->globals()) {
       updateLinkage(G);
     }
     for (llvm::Function &F : M->getFunctionList()) {
       updateLinkage(F);
     }
-    for (llvm::GlobalAlias &A : M->getAliasList()) {
+    for (llvm::GlobalAlias &A : M->aliases()) {
       updateLinkage(A);
     }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -29,6 +29,7 @@
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/MD5Stream.h"
 #include "swift/Basic/Platform.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -1116,7 +1117,7 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
   if (!SILMod) {
     auto loweringDesc = ASTLoweringDescriptor{
         desc.Ctx, desc.Conv, desc.SILOpts, nullptr,
-        symsToEmit.transform([](const auto &x) { return x.silRefsToEmit; })};
+        swift::transform(symsToEmit, [](const auto &x) { return x.silRefsToEmit; })};
     SILMod = llvm::cantFail(Ctx.evaluator(LoweredSILRequest{loweringDesc}));
 
     // If there was an error, bail.

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2745,7 +2745,7 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
       // Advance the offset for the next piece.
       OffsetInBits += SizeInBits;
       SizeInBits = IGM.DataLayout.getTypeSizeInBits(Piece->getType());
-      AlignInBits = IGM.DataLayout.getABITypeAlignment(Piece->getType());
+      AlignInBits = IGM.DataLayout.getABITypeAlign(Piece->getType()).value();
       if (!AlignInBits)
         AlignInBits = SizeOfByte;
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1179,7 +1179,7 @@ private:
       return createPointerSizedStruct(Scope, Name, FwdDecl, File, Line, Flags,
                                       MangledName);
     } else {
-      unsigned SizeInBits = CI.getTargetInfo().getPointerWidth(0);
+      unsigned SizeInBits = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
       return createOpaqueStruct(Scope, Name, File, Line, SizeInBits, 0, Flags,
                                 MangledName);
     }
@@ -1190,7 +1190,7 @@ private:
                                          llvm::DIFile *File, unsigned Line,
                                          llvm::DINode::DIFlags Flags,
                                          StringRef MangledName) {
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
     auto PtrTy = DBuilder.createPointerType(PointeeTy, PtrSize, 0);
     llvm::Metadata *Elements[] = {DBuilder.createMemberType(
         Scope, "ptr", File, 0, PtrSize, 0, 0, Flags, PtrTy)};
@@ -1205,7 +1205,7 @@ private:
                                  llvm::DIType *PointeeTy, llvm::DIFile *File,
                                  unsigned Line, llvm::DINode::DIFlags Flags,
                                  StringRef MangledName) {
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
     llvm::Metadata *Elements[] = {
         DBuilder.createMemberType(
             Scope, "ptr", File, 0, PtrSize, 0, 0, Flags,
@@ -1221,7 +1221,7 @@ private:
 
   llvm::DIType *createFixedValueBufferStruct(llvm::DIType *PointeeTy) {
     unsigned Line = 0;
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
     llvm::DINode::DIFlags Flags = llvm::DINode::FlagArtificial;
     llvm::DIFile *File = MainFile;
     llvm::DIScope *Scope = TheCU;
@@ -1265,7 +1265,7 @@ private:
     auto FnTy = DBuilder.createSubroutineType(Params, Flags);
     llvm::DIType *DITy;
     if (FunTy->getRepresentation() == SILFunctionType::Representation::Thick) {
-      if (SizeInBits == 2 * CI.getTargetInfo().getPointerWidth(0))
+      if (SizeInBits == 2 * CI.getTargetInfo().getPointerWidth(clang::LangAS::Default))
         // This is a FunctionPairTy: { i8*, %swift.refcounted* }.
         DITy = createDoublePointerSizedStruct(Scope, MangledName, FnTy,
                                               MainFile, 0, Flags, MangledName);
@@ -1274,7 +1274,7 @@ private:
         DITy = createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
                                   AlignInBits, Flags, MangledName);
     } else {
-      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(clang::LangAS::Default));
       DITy = createPointerSizedStruct(Scope, MangledName, FnTy, MainFile, 0,
                                       Flags, MangledName);
     }
@@ -1394,7 +1394,7 @@ private:
     }
 
     case TypeKind::BuiltinNativeObject: {
-      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
       auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0,
                                             /* DWARFAddressSpace */ llvm::None,
                                             MangledName);
@@ -1402,7 +1402,7 @@ private:
     }
 
     case TypeKind::BuiltinBridgeObject: {
-      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
       auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0,
                                             /* DWARFAddressSpace */ llvm::None,
                                             MangledName);
@@ -1410,21 +1410,21 @@ private:
     }
 
     case TypeKind::BuiltinRawPointer: {
-      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
       return DBuilder.createPointerType(nullptr, PtrSize, 0,
                                         /* DWARFAddressSpace */ llvm::None,
                                         MangledName);
     }
 
     case TypeKind::BuiltinRawUnsafeContinuation: {
-      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
       return DBuilder.createPointerType(nullptr, PtrSize, 0,
                                         /* DWARFAddressSpace */ llvm::None,
                                         MangledName);
     }
 
     case TypeKind::BuiltinJob: {
-      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
       return DBuilder.createPointerType(nullptr, PtrSize, 0,
                                         /* DWARFAddressSpace */ llvm::None,
                                         MangledName);
@@ -1483,7 +1483,7 @@ private:
       auto L = getFilenameAndLocation(*this, Decl);
       auto *File = getOrCreateFile(L.filename);
       unsigned FwdDeclLine = 0;
-      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(clang::LangAS::Default));
       return createPointerSizedStruct(Scope, Decl->getNameStr(), File,
                                       FwdDeclLine, Flags, MangledName);
     }
@@ -1518,7 +1518,7 @@ private:
       auto L = getFilenameAndLocation(*this, Decl);
       auto *File = getOrCreateFile(L.filename);
       unsigned FwdDeclLine = 0;
-      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(clang::LangAS::Default));
       return createPointerSizedStruct(Scope,
                                       Decl ? Decl->getNameStr() : MangledName,
                                       File, FwdDeclLine, Flags, MangledName);
@@ -1544,7 +1544,7 @@ private:
 
       // TODO: We may want to peek at Decl->isObjC() and set this
       // attribute accordingly.
-      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(clang::LangAS::Default));
       return createPointerSizedStruct(Scope,
                                       Decl ? Decl->getNameStr() : MangledName,
                                       File, FwdDeclLine, Flags, MangledName);
@@ -3039,12 +3039,12 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
   static const char *Tau = u8"\u03C4";
   llvm::raw_svector_ostream OS(Buf);
   OS << '$' << Tau << '_' << Depth << '_' << Index;
-  uint64_t PtrWidthInBits = CI.getTargetInfo().getPointerWidth(0);
+  uint64_t PtrWidthInBits = CI.getTargetInfo().getPointerWidth(clang::LangAS::Default);
   assert(PtrWidthInBits % 8 == 0);
   auto DbgTy = DebugTypeInfo::getTypeMetadata(
       getMetadataType(Name)->getDeclaredInterfaceType().getPointer(),
       Metadata->getType(), Size(PtrWidthInBits / 8),
-      Alignment(CI.getTargetInfo().getPointerAlign(0)));
+      Alignment(CI.getTargetInfo().getPointerAlign(clang::LangAS::Default)));
   emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
                           {}, {OS.str().str(), 0, false},
                           // swift.type is already a pointer type,
@@ -3065,7 +3065,7 @@ void IRGenDebugInfoImpl::emitPackCountParameter(IRGenFunction &IGF,
   if (!DS || DS->getInlinedFunction()->isTransparent())
     return;
 
-  Type IntTy = BuiltinIntegerType::get(CI.getTargetInfo().getPointerWidth(0),
+  Type IntTy = BuiltinIntegerType::get(CI.getTargetInfo().getPointerWidth(clang::LangAS::Default),
                                        IGM.getSwiftModule()->getASTContext());
   auto &TI = IGM.getTypeInfoForUnlowered(IntTy);
   auto DbgTy = *CompletedDebugTypeInfo::getFromTypeInfo(IntTy, TI, IGM);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -96,12 +96,6 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   auto &ClangContext = Importer->getClangASTContext();
 
   auto &CGO = Importer->getCodeGenOpts();
-  if (CGO.OpaquePointers) {
-    LLVMContext.setOpaquePointers(true);
-  } else {
-    LLVMContext.setOpaquePointers(false);
-  }
-
   CGO.OptimizationLevel = Opts.shouldOptimize() ? 3 : 0;
 
   CGO.DebugTypeExtRefs = !Opts.DisableClangModuleSkeletonCUs;

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1430,7 +1430,7 @@ llvm::SmallString<32> getTargetDependentLibraryOption(const llvm::Triple &T,
     if (quote)
       buffer += '"';
     buffer += library;
-    if (!library.endswith_insensitive(".lib"))
+    if (!library.ends_with_insensitive(".lib"))
       buffer += ".lib";
     if (quote)
       buffer += '"';

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -40,7 +40,7 @@
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/HeaderSearchOptions.h"
-#include "clang/Basic/CodeGenOptions.h"
+#include "llvm/Frontend/Debug/Options.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
@@ -102,14 +102,14 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   CGO.DiscardValueNames = !Opts.shouldProvideValueNames();
   switch (Opts.DebugInfoLevel) {
   case IRGenDebugInfoLevel::None:
-    CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::NoDebugInfo);
+    CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::NoDebugInfo);
     break;
   case IRGenDebugInfoLevel::LineTables:
-    CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
+    CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
     break;
   case IRGenDebugInfoLevel::ASTTypes:
   case IRGenDebugInfoLevel::DwarfTypes:
-    CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::FullDebugInfo);
+    CGO.setDebugInfo(llvm::codegenoptions::DebugInfoKind::FullDebugInfo);
     break;
   }
   switch (Opts.DebugInfoFormat) {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1183,8 +1183,7 @@ public:
     if (!FailBBs.empty()) {
       // Move the trap basic blocks to the end of the function.
       for (auto *FailBB : FailBBs) {
-        auto &BlockList = CurFn->getBasicBlockList();
-        BlockList.splice(BlockList.end(), BlockList, FailBB);
+        CurFn->splice(CurFn->end(), CurFn, llvm::Function::iterator(FailBB));
       }
     }
   }
@@ -2417,7 +2416,7 @@ void IRGenSILFunction::emitSILFunction() {
     // FIXME: Use the SIL basic block's name.
     llvm::BasicBlock *llBB = llvm::BasicBlock::Create(IGM.getLLVMContext());
     auto phis = emitPHINodesForBBArgs(*this, &*bi, llBB);
-    CurFn->getBasicBlockList().push_back(llBB);
+    CurFn->insert(CurFn->end(), llBB);
     LoweredBBs[&*bi] = LoweredBB(llBB, std::move(phis));
   }
 

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -335,7 +335,7 @@ void StructLayoutBuilder::addFixedSizeElement(ElementLayout &elt) {
 
       // The padding can be used as spare bits by enum layout.
       auto numBits = Size(paddingRequired).getValueInBits();
-      auto mask = llvm::APInt::getAllOnesValue(numBits);
+      auto mask = llvm::APInt::getAllOnes(numBits);
       CurSpareBits.push_back(SpareBitVector::fromAPInt(mask));
     }
   }

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2242,13 +2242,13 @@ bool EnumTypeLayoutEntry::buildSinglePayloadRefCountString(
       auto tzCount = mask.countTrailingZeros();
       auto shiftedMask = mask.lshr(tzCount);
       auto toCount = shiftedMask.countTrailingOnes();
-      if (mask.countPopulation() > 64 || toCount != mask.countPopulation() ||
+      if (mask.popcount() > 64 || toCount != mask.popcount() ||
           (tzCount % toCount != 0)) {
         // We currently don't handle cases with non-contiguous or > 64 bits of
         // extra inhabitants
         isSimple = false;
       } else {
-        xiBitCount = std::min(64u, mask.countPopulation());
+        xiBitCount = std::min(64u, mask.popcount());
         xiBitOffset = mask.countTrailingZeros();
         zeroTagValue = lowValue.extractBitsAsZExtValue(xiBitCount, xiBitOffset);
       }

--- a/lib/Option/Options.cpp
+++ b/lib/Option/Options.cpp
@@ -19,11 +19,14 @@
 using namespace swift::options;
 using namespace llvm::opt;
 
-#define PREFIX(NAME, VALUE) static const char *const NAME[] = VALUE;
+#define PREFIX(NAME, VALUE)                                                    \
+  constexpr llvm::StringLiteral NAME##_init[] = VALUE;                         \
+  constexpr llvm::ArrayRef<llvm::StringLiteral> NAME(                          \
+      NAME##_init, std::size(NAME##_init) - 1);
 #include "swift/Option/Options.inc"
 #undef PREFIX
 
-static const OptTable::Info InfoTable[] = {
+static const llvm::opt::GenericOptTable::Info InfoTable[] = {
 #define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
                HELPTEXT, METAVAR, VALUES)                                      \
   {PREFIX, NAME,  HELPTEXT,    METAVAR,     OPT_##ID,  Option::KIND##Class,    \
@@ -34,13 +37,13 @@ static const OptTable::Info InfoTable[] = {
 
 namespace {
 
-class SwiftOptTable : public OptTable {
+class SwiftOptTable : public llvm::opt::GenericOptTable {
 public:
-  SwiftOptTable() : OptTable(InfoTable) {}
+  SwiftOptTable() : GenericOptTable(InfoTable) {}
 };
 
 } // end anonymous namespace
 
 std::unique_ptr<OptTable> swift::createSwiftOptTable() {
-  return std::unique_ptr<OptTable>(new SwiftOptTable());
+  return std::unique_ptr<GenericOptTable>(new SwiftOptTable());
 }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/ADT/bit.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -60,7 +61,7 @@ using clang::isWhitespace;
 static bool EncodeToUTF8(unsigned CharValue,
                          SmallVectorImpl<char> &Result) {
   // Number of bits in the value, ignoring leading zeros.
-  unsigned NumBits = 32-llvm::countLeadingZeros(CharValue);
+  unsigned NumBits = 32-llvm::countl_zero(CharValue);
 
   // Handle the leading byte, based on the number of bits in the value.
   unsigned NumTrailingBytes;
@@ -100,7 +101,7 @@ static bool EncodeToUTF8(unsigned CharValue,
 
 /// CLO8 - Return the number of leading ones in the specified 8-bit value.
 static unsigned CLO8(unsigned char C) {
-  return llvm::countLeadingOnes(uint32_t(C) << 24);
+  return llvm::countl_zero(uint32_t(C) << 24);
 }
 
 /// isStartOfUTF8Character - Return true if this isn't a UTF8 continuation
@@ -162,7 +163,7 @@ uint32_t swift::validateUTF8CharacterAndAdvance(const char *&Ptr,
   // If we got here, we read the appropriate number of accumulated bytes.
   // Verify that the encoding was actually minimal.
   // Number of bits in the value, ignoring leading zeros.
-  unsigned NumBits = 32-llvm::countLeadingZeros(CharValue);
+  unsigned NumBits = 32-llvm::countl_zero(CharValue);
   
   if (NumBits <= 5+6)
     return EncodedBytes == 2 ? CharValue : ~0U;

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/Type.h"
 #include "swift/IRGen/IRABIDetailsProvider.h"
 #include "swift/IRGen/Linking.h"
+#include "clang/Basic/AddressSpaces.h"
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/STLExtras.h"
 
@@ -178,7 +179,7 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   auto &clangTI =
       astContext.getClangModuleLoader()->getClangASTContext().getTargetInfo();
   bool isSwiftIntLong =
-      clangTI.getPtrDiffType(0) == clang::TransferrableTargetInfo::SignedLong;
+      clangTI.getPtrDiffType(clang::LangAS::Default) == clang::TransferrableTargetInfo::SignedLong;
   bool isInt64Long =
       clangTI.getInt64Type() == clang::TransferrableTargetInfo::SignedLong;
   if (!(isSwiftIntLong && !isInt64Long))

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -814,7 +814,7 @@ DifferentiableFunctionInst *DifferentiableFunctionInst::create(
   auto derivativeFunctions =
       VJPAndJVPFunctions.has_value()
           ? ArrayRef<SILValue>(
-                reinterpret_cast<SILValue *>(VJPAndJVPFunctions.getPointer()),
+                reinterpret_cast<SILValue *>(&*VJPAndJVPFunctions),
                 2)
           : ArrayRef<SILValue>();
   size_t size = totalSizeToAlloc<Operand>(1 + derivativeFunctions.size());
@@ -841,7 +841,7 @@ LinearFunctionInst::LinearFunctionInst(
     : InstructionBaseWithTrailingOperands(
           OriginalFunction,
           TransposeFunction.has_value()
-              ? ArrayRef<SILValue>(TransposeFunction.getPointer(), 1)
+              ? ArrayRef<SILValue>(&*TransposeFunction, 1)
               : ArrayRef<SILValue>(),
           Loc, getLinearFunctionType(OriginalFunction, ParameterIndices),
           forwardingOwnershipKind),

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1068,7 +1068,7 @@ IntegerLiteralInst *IntegerLiteralInst::create(SILDebugLocation Loc,
            "IntegerLiteralInst APInt value's bit width doesn't match type");
   } else {
     assert(Ty.is<BuiltinIntegerLiteralType>());
-    assert(Value.getBitWidth() == Value.getMinSignedBits());
+    assert(Value.getBitWidth() == Value.getSignificantBits());
   }
 #endif
 
@@ -1085,7 +1085,7 @@ static APInt getAPInt(AnyBuiltinIntegerType *anyIntTy, intmax_t value) {
   // Otherwise, build using the size of the type and then truncate to the
   // minimum width necessary.
   APInt result(8 * sizeof(value), value, /*signed*/ true);
-  result = result.trunc(result.getMinSignedBits());
+  result = result.trunc(result.getSignificantBits());
   return result;
 }
 

--- a/lib/SIL/Utils/LoopInfo.cpp
+++ b/lib/SIL/Utils/LoopInfo.cpp
@@ -12,7 +12,7 @@
 
 #include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/Dominance.h"
-#include "llvm/Analysis/LoopInfoImpl.h"
+#include "llvm/Support/GenericLoopInfoImpl.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -490,7 +490,7 @@ bool swift::visitGuaranteedForwardingPhisForSSAValue(
   // guaranteedForwardingOps is a collection of all transitive
   // GuaranteedForwarding uses of \p value. It is a set, to avoid repeated
   // processing of structs and tuples which are GuaranteedForwarding.
-  SmallSetVector<Operand *, 4> guaranteedForwardingOps;
+  llvm::SmallSetVector<Operand *, 4> guaranteedForwardingOps;
   // Collect first-level GuaranteedForwarding uses, and call the visitor on any
   // GuaranteedForwardingPhi uses.
   for (auto *use : value->getUses()) {
@@ -1151,7 +1151,7 @@ bool swift::getAllBorrowIntroducingValues(SILValue inputValue,
   if (inputValue->getOwnershipKind() != OwnershipKind::Guaranteed)
     return false;
 
-  SmallSetVector<SILValue, 32> worklist;
+  llvm::SmallSetVector<SILValue, 32> worklist;
   worklist.insert(inputValue);
 
   // worklist grows in this loop.
@@ -1546,7 +1546,7 @@ void swift::visitExtendedReborrowPhiBaseValuePairs(
   // paths.
   // For that reason, worklist stores (reborrow, base value) pairs.
   // We need a SetVector to make sure we don't revisit the same pair again.
-  SmallSetVector<std::tuple<PhiOperand, SILValue>, 4> worklist;
+  llvm::SmallSetVector<std::tuple<PhiOperand, SILValue>, 4> worklist;
 
   // Find all reborrows of value and insert the (reborrow, base value) pair into
   // the worklist.
@@ -1602,7 +1602,7 @@ void swift::visitExtendedGuaranteedForwardingPhiBaseValuePairs(
   // For that reason, worklist stores (GuaranteedForwardingPhi operand, base
   // value) pairs. We need a SetVector to make sure we don't revisit the same
   // pair again.
-  SmallSetVector<std::tuple<PhiOperand, SILValue>, 4> worklist;
+  llvm::SmallSetVector<std::tuple<PhiOperand, SILValue>, 4> worklist;
 
   auto collectGuaranteedForwardingPhis = [&](SILValue value,
                                              SILValue baseValue) {

--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -103,7 +103,7 @@ struct State {
 
   /// A list of successor blocks that we must visit by the time the algorithm
   /// terminates.
-  SmallSetVector<SILBasicBlock *, 8> successorBlocksThatMustBeVisited;
+  llvm::SmallSetVector<SILBasicBlock *, 8> successorBlocksThatMustBeVisited;
 
   State(
       SILValue value, LinearLifetimeChecker::ErrorBuilder &errorBuilder,

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -30,6 +30,7 @@
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
@@ -300,9 +301,9 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       // Check for an error if the convention includes one.
       // Increment the error and flag indices if present.  They do not account
       // for the fact that they are preceded by the block_storage arguments.
-      auto errorIndex = convention.completionHandlerErrorParamIndex().transform(
+      auto errorIndex = swift::transform(convention.completionHandlerErrorParamIndex(),
           [](auto original) { return original + 1; });
-      auto flagIndex = convention.completionHandlerFlagParamIndex().transform(
+      auto flagIndex = swift::transform(convention.completionHandlerFlagParamIndex(),
           [](auto original) { return original + 1; });
 
       FuncDecl *resumeIntrinsic;

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -51,7 +51,7 @@ struct CallerAnalysis::ApplySiteFinderVisitor
 
 #ifndef NDEBUG
   SmallPtrSet<SILInstruction *, 8> visitedCallSites;
-  SmallSetVector<SILInstruction *, 8> callSitesThatMustBeVisited;
+  llvm::SmallSetVector<SILInstruction *, 8> callSitesThatMustBeVisited;
 #endif
 
   ApplySiteFinderVisitor(CallerAnalysis *analysis, SILFunction *callerFn)

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Basic/STLExtras.h"
 #define DEBUG_TYPE "differentiation"
 
 #include "swift/SILOptimizer/Differentiation/Common.h"
@@ -251,12 +252,12 @@ void collectMinimalIndicesForFunctionCall(
 llvm::Optional<std::pair<SILDebugLocation, SILDebugVariable>>
 findDebugLocationAndVariable(SILValue originalValue) {
   if (auto *asi = dyn_cast<AllocStackInst>(originalValue))
-    return asi->getVarInfo().transform([&](SILDebugVariable var) {
+    return swift::transform(asi->getVarInfo(),  [&](SILDebugVariable var) {
       return std::make_pair(asi->getDebugLocation(), var);
     });
   for (auto *use : originalValue->getUses()) {
     if (auto *dvi = dyn_cast<DebugValueInst>(use->getUser()))
-      return dvi->getVarInfo().transform([&](SILDebugVariable var) {
+      return swift::transform(dvi->getVarInfo(), [&](SILDebugVariable var) {
         // We need to drop `op_deref` here as we're transferring debug info
         // location from debug_value instruction (which describes how to get value)
         // into alloc_stack (which describes the location)

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -211,8 +211,8 @@ void collectMinimalIndicesForFunctionCall(
   results.reserve(calleeFnTy->getNumResults());
   unsigned dirResIdx = 0;
   unsigned indResIdx = calleeConvs.getSILArgIndexOfFirstIndirectResult();
-  for (auto &resAndIdx : enumerate(calleeConvs.getResults())) {
-    auto &res = resAndIdx.value();
+  for (const auto &resAndIdx : enumerate(calleeConvs.getResults())) {
+    const auto &res = resAndIdx.value();
     unsigned idx = resAndIdx.index();
     if (res.isFormalDirect()) {
       results.push_back(directResults[dirResIdx]);
@@ -229,8 +229,8 @@ void collectMinimalIndicesForFunctionCall(
   }
   // Record all `inout` parameters as results.
   auto inoutParamResultIndex = calleeFnTy->getNumResults();
-  for (auto &paramAndIdx : enumerate(calleeConvs.getParameters())) {
-    auto &param = paramAndIdx.value();
+  for (const auto &paramAndIdx : enumerate(calleeConvs.getParameters())) {
+    const auto &param = paramAndIdx.value();
     if (!param.isIndirectMutating())
       continue;
     unsigned idx = paramAndIdx.index() + calleeFnTy->getNumIndirectFormalResults();

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Basic/STLExtras.h"
 #define DEBUG_TYPE "differentiation"
 
 #include "swift/SILOptimizer/Differentiation/PullbackCloner.h"
@@ -579,7 +580,7 @@ private:
     llvm::SmallString<32> adjName;
     auto *newBuf = createFunctionLocalAllocation(
         bufType, loc, /*zeroInitialize*/ true,
-        debugInfo.transform(
+        swift::transform(debugInfo,
           [&](AdjointValue::DebugInfo di) {
             llvm::raw_svector_ostream adjNameStream(adjName);
             SILDebugVariable &dv = di.second;

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -110,7 +110,7 @@ private:
   /// Mapping from original basic blocks to local temporary values to be cleaned
   /// up. This is populated when pullback emission is run on one basic block and
   /// cleaned before processing another basic block.
-  llvm::DenseMap<SILBasicBlock *, SmallSetVector<SILValue, 64>>
+  llvm::DenseMap<SILBasicBlock *, llvm::SmallSetVector<SILValue, 32>>
       blockTemporaries;
 
   /// The scope cloner.

--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -159,7 +159,7 @@ class ArrayInfo {
   llvm::DenseMap<uint64_t, StoreInst *> elementStoreMap;
 
   /// List of Sequence.forEach calls invoked on the array.
-  SmallSetVector<TryApplyInst *, 4> forEachCalls;
+  llvm::SmallSetVector<TryApplyInst *, 4> forEachCalls;
 
   /// Indicates whether the array could be modified after initialization. Note
   /// that this not include modifications to the elements of the array. When

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -722,9 +722,9 @@ static SILValue tryRewriteToPartialApplyStack(
   SmallVector<SILBasicBlock *, 8> discoveredBlocks;
   SSAPrunedLiveness closureLiveness(cvt->getFunction(), &discoveredBlocks);
   closureLiveness.initializeDef(closureOp);
-  
-  SmallSetVector<SILValue, 4> borrowedOriginals;
-  
+
+  llvm::SmallSetVector<SILValue, 4> borrowedOriginals;
+
   for (unsigned i : indices(newPA->getArgumentOperands())) {
     auto &arg = newPA->getArgumentOperands()[i];
     SILValue copy = arg.get();

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -300,8 +300,8 @@ struct UseState {
   SILValue address;
   SmallVector<MarkUnresolvedMoveAddrInst *, 1> markMoves;
   SmallPtrSet<SILInstruction *, 1> seenMarkMoves;
-  SmallSetVector<SILInstruction *, 2> inits;
-  SmallSetVector<SILInstruction *, 4> livenessUses;
+  llvm::SmallSetVector<SILInstruction *, 2> inits;
+  llvm::SmallSetVector<SILInstruction *, 4> livenessUses;
   SmallBlotSetVector<DestroyAddrInst *, 4> destroys;
   llvm::SmallDenseMap<SILInstruction *, unsigned, 4> destroyToIndexMap;
   SmallBlotSetVector<SILInstruction *, 4> reinits;
@@ -2410,7 +2410,7 @@ class ConsumeOperatorCopyableAddressesCheckerPass
     assert(fn->getModule().getStage() == SILStage::Raw &&
            "Should only run on Raw SIL");
 
-    SmallSetVector<SILValue, 32> addressesToCheck;
+    llvm::SmallSetVector<SILValue, 32> addressesToCheck;
 
     for (auto *arg : fn->front().getSILFunctionArguments()) {
       if (arg->getType().isAddress() &&

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -55,8 +55,8 @@ namespace {
 
 struct CheckerLivenessInfo {
   GraphNodeWorklist<SILValue, 8> defUseWorklist;
-  SmallSetVector<Operand *, 8> consumingUse;
-  SmallSetVector<SILInstruction *, 8> nonLifetimeEndingUsesInLiveOut;
+  llvm::SmallSetVector<Operand *, 8> consumingUse;
+  llvm::SmallSetVector<SILInstruction *, 8> nonLifetimeEndingUsesInLiveOut;
   SmallVector<Operand *, 8> interiorPointerTransitiveUses;
   BitfieldRef<DiagnosticPrunedLiveness> liveness;
 
@@ -397,7 +397,7 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
 }
 
 bool ConsumeOperatorCopyableValuesChecker::check() {
-  SmallSetVector<SILValue, 32> valuesToCheck;
+  llvm::SmallSetVector<SILValue, 32> valuesToCheck;
 
   for (auto *arg : fn->getEntryBlock()->getSILFunctionArguments()) {
     if (arg->getOwnershipKind() == OwnershipKind::Owned &&

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -180,7 +180,7 @@ static void diagnosePoundAssert(const SILInstruction *I,
   APInt intValue = value.getIntegerValue();
   assert(intValue.getBitWidth() == 1 &&
          "sema prevents non-int1 #assert condition");
-  if (intValue.isNullValue()) {
+  if (intValue.isZero()) {
     auto *message = cast<StringLiteralInst>(builtinInst->getArguments()[1]);
     StringRef messageValue = message->getValue();
     if (messageValue.empty())

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2723,7 +2723,7 @@ static void updateControlVariable(SILLocation Loc,
   
   // If the mask is all ones, do a simple store, otherwise do a
   // load/or/store sequence to mask in the bits.
-  if (!Bitmask.isAllOnesValue()) {
+  if (!Bitmask.isAllOnes()) {
     SILValue Tmp =
         B.createLoad(Loc, ControlVariable, LoadOwnershipQualifier::Trivial);
     if (!OrFn.get())

--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -41,6 +41,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/Basic/LLVMExtras.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/BasicBlockData.h"
@@ -525,7 +526,7 @@ public:
   }
 };
 
-typedef SmallSetVector<Invariants, 4> InvariantsSet;
+typedef swift::SmallSetVector<Invariants, 4> InvariantsSet;
 
 /// Collect invariants with which we should try the analysis and return true if
 /// there is at least one recursive call in the function.

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -977,7 +977,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
     // The in-progress accesses for the current program point, represented
     // as map from storage locations to the accesses in progress for the
     // location.
-    State.Accesses = BBState.getPointer();
+    State.Accesses = &*BBState;
     for (auto &I : *BB)
       checkForViolationsAtInstruction(I, State);
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
@@ -95,7 +95,7 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
     auto *poa = getAnalysis<PostOrderAnalysis>();
 
     DiagnosticEmitter diagnosticEmitter(fn);
-    SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
     searchForCandidateAddressMarkMustChecks(fn, moveIntroducersToProcess,
                                             diagnosticEmitter);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -515,14 +515,14 @@ struct UseState {
   SmallFrozenMultiMap<SILInstruction *, SILValue, 8> reinitToValueMultiMap;
 
   /// The set of drop_deinits of this mark_must_check
-  SmallSetVector<SILInstruction *, 2> dropDeinitInsts;
+  llvm::SmallSetVector<SILInstruction *, 2> dropDeinitInsts;
 
   /// A "inout terminator use" is an implicit liveness use of the entire value
   /// placed on a terminator. We use this both so we add liveness for the
   /// terminator user and so that we can use the set to quickly identify later
   /// while emitting diagnostics that a liveness use is a terminator user and
   /// emit a specific diagnostic message.
-  SmallSetVector<SILInstruction *, 2> implicitEndOfLifetimeLivenessUses;
+  llvm::SmallSetVector<SILInstruction *, 2> implicitEndOfLifetimeLivenessUses;
 
   /// We add debug_values to liveness late after we diagnose, but before we
   /// hoist destroys to ensure that we do not hoist destroys out of access
@@ -595,7 +595,7 @@ struct UseState {
   /// and precedes a reinit instruction in that block.
   bool precedesReinitInSameBlock(SILInstruction *inst) const {
     SILBasicBlock *block = inst->getParent();
-    SmallSetVector<SILInstruction *, 8> sameBlockReinits;
+    llvm::SmallSetVector<SILInstruction *, 8> sameBlockReinits;
 
     // First, search for all reinits that are within the same block.
     for (auto &reinit : reinitInsts) {
@@ -1293,7 +1293,7 @@ struct MoveOnlyAddressCheckerPImpl {
   DominanceInfo *domTree;
 
   /// A set of mark_must_check that we are actually going to process.
-  SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+  llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
 
   /// The instruction deleter used by \p canonicalizer.
   InstructionDeleter deleter;
@@ -2562,7 +2562,7 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
     LLVM_DEBUG(llvm::dbgs() << "Performing forward traversal from errorUse "
                                "looking for the cause of liveness!\n");
 
-    SmallSetVector<SILInstruction *, 1> violatingInst;
+    llvm::SmallSetVector<SILInstruction *, 1> violatingInst;
     bool foundSingleBlockError = false;
     while (auto *block = worklist.pop()) {
       LLVM_DEBUG(llvm::dbgs()
@@ -3591,7 +3591,7 @@ static llvm::cl::opt<bool> DumpSILBeforeRemovingMarkMustCheck(
     llvm::cl::init(false));
 
 bool MoveOnlyAddressChecker::check(
-    SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess) {
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess) {
   assert(moveIntroducersToProcess.size() &&
          "Must have checks to process to call this function");
   MoveOnlyAddressCheckerPImpl pimpl(fn, diagnosticEmitter, domTree, poa,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
@@ -27,7 +27,7 @@ class DiagnosticEmitter;
 /// diagnosticEmitter.getDiagnosticCount().
 void searchForCandidateAddressMarkMustChecks(
     SILFunction *fn,
-    SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
     DiagnosticEmitter &diagnosticEmitter);
 
 struct MoveOnlyAddressChecker {
@@ -39,7 +39,7 @@ struct MoveOnlyAddressChecker {
 
   /// \returns true if we changed the IR. To see if we emitted a diagnostic, use
   /// \p diagnosticEmitter.getDiagnosticCount().
-  bool check(SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess);
+  bool check(llvm::SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess);
 };
 
 } // namespace siloptimizer

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTester.cpp
@@ -88,7 +88,7 @@ class MoveOnlyBorrowToDestructureTransformPass : public SILFunctionTransform {
 
     auto *postOrderAnalysis = getAnalysis<PostOrderAnalysis>();
 
-    SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
     DiagnosticEmitter diagnosticEmitter(getFunction());
 
     unsigned diagCount = diagnosticEmitter.getDiagnosticCount();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -92,7 +92,7 @@ struct MoveOnlyChecker {
 } // namespace
 
 void MoveOnlyChecker::checkObjects() {
-  SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+  llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
   unsigned diagCount = diagnosticEmitter.getDiagnosticCount();
   madeChange |= searchForCandidateObjectMarkMustChecks(
       fn, moveIntroducersToProcess, diagnosticEmitter);
@@ -115,7 +115,7 @@ void MoveOnlyChecker::checkObjects() {
 
 void MoveOnlyChecker::checkAddresses() {
   unsigned diagCount = diagnosticEmitter.getDiagnosticCount();
-  SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+  llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
   searchForCandidateAddressMarkMustChecks(fn, moveIntroducersToProcess,
                                           diagnosticEmitter);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerTester.cpp
@@ -97,7 +97,7 @@ class MoveOnlyObjectCheckerTesterPass : public SILFunctionTransform {
     borrowtodestructure::IntervalMapAllocator allocator;
 
     unsigned diagCount = diagnosticEmitter.getDiagnosticCount();
-    SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
     bool madeChange = searchForCandidateObjectMarkMustChecks(
         fn, moveIntroducersToProcess, diagnosticEmitter);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -69,7 +69,7 @@ using namespace swift::siloptimizer;
 
 bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
     SILFunction *fn,
-    SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
     DiagnosticEmitter &emitter) {
   bool localChanged = false;
   for (auto &block : *fn) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -168,7 +168,7 @@ struct OSSACanonicalizer {
 /// must checks to process.
 bool searchForCandidateObjectMarkMustChecks(
     SILFunction *fn,
-    SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
     DiagnosticEmitter &diagnosticEmitter);
 
 struct MoveOnlyObjectChecker {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTempAllocationFromLetTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTempAllocationFromLetTester.cpp
@@ -49,7 +49,7 @@ struct MoveOnlyTempAllocationFromLetTester : SILFunctionTransform {
                << "===> MoveOnlyTempAllocationFromLetTester. Visiting: "
                << fn->getName() << '\n');
 
-    SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
+    llvm::SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
     DiagnosticEmitter diagnosticEmitter(getFunction());
 
     unsigned diagCount = diagnosticEmitter.getDiagnosticCount();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -51,10 +51,10 @@ namespace {
 
 struct SILMoveOnlyWrappedTypeEliminatorVisitor
     : SILInstructionVisitor<SILMoveOnlyWrappedTypeEliminatorVisitor, bool> {
-  const SmallSetVector<SILArgument *, 8> &touchedArgs;
+  const llvm::SmallSetVector<SILArgument *, 8> &touchedArgs;
 
   SILMoveOnlyWrappedTypeEliminatorVisitor(
-      const SmallSetVector<SILArgument *, 8> &touchedArgs)
+      const llvm::SmallSetVector<SILArgument *, 8> &touchedArgs)
       : touchedArgs(touchedArgs) {}
 
   bool visitSILInstruction(SILInstruction *inst) {
@@ -294,8 +294,8 @@ static bool isMoveOnlyWrappedTrivial(SILValue value) {
 bool SILMoveOnlyWrappedTypeEliminator::process() {
   bool madeChange = true;
 
-  SmallSetVector<SILArgument *, 8> touchedArgs;
-  SmallSetVector<SILInstruction *, 8> touchedInsts;
+  llvm::SmallSetVector<SILArgument *, 8> touchedArgs;
+  llvm::SmallSetVector<SILInstruction *, 8> touchedInsts;
 
   for (auto &bb : *fn) {
     for (auto *arg : bb.getArguments()) {

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -196,7 +196,7 @@ public:
   SILInstruction *beginInstruction;
 
   /// Instructions that mark the end points of constant evaluation.
-  SmallSetVector<SILInstruction *, 2> endInstructions;
+  llvm::SmallSetVector<SILInstruction *, 2> endInstructions;
 
 private:
   /// SIL values that were found to be constants during

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -187,7 +187,7 @@ struct AvailableValue {
 
   /// If this gets too expensive in terms of copying, we can use an arena and a
   /// FrozenPtrSet like we do in ARC.
-  SmallSetVector<StoreInst *, 1> InsertionPoints;
+  llvm::SmallSetVector<StoreInst *, 1> InsertionPoints;
 
   /// Just for updating.
   SmallVectorImpl<PMOMemoryUse> *Uses;

--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -181,7 +181,7 @@ static void emitInitAccessorInitialValueArgument(
 static void
 lowerAssignByWrapperInstruction(SILBuilderWithScope &b,
                                 AssignByWrapperInst *inst,
-                                SmallSetVector<SILValue, 8> &toDelete) {
+                                llvm::SmallSetVector<SILValue, 8> &toDelete) {
   LLVM_DEBUG(llvm::dbgs() << "  *** Lowering " << *inst << "\n");
 
   ++numAssignRewritten;
@@ -263,7 +263,7 @@ lowerAssignByWrapperInstruction(SILBuilderWithScope &b,
 static void
 lowerAssignOrInitInstruction(SILBuilderWithScope &b,
                              AssignOrInitInst *inst,
-                             SmallSetVector<SILValue, 8> &toDelete) {
+                             llvm::SmallSetVector<SILValue, 8> &toDelete) {
   LLVM_DEBUG(llvm::dbgs() << "  *** Lowering " << *inst << "\n");
 
   ++numAssignRewritten;
@@ -422,7 +422,7 @@ static bool lowerRawSILOperations(SILFunction &fn) {
   bool changed = false;
 
   for (auto &bb : fn) {
-    SmallSetVector<SILValue, 8> toDelete;
+    llvm::SmallSetVector<SILValue, 8> toDelete;
 
     auto i = bb.begin(), e = bb.end();
     while (i != e) {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -298,7 +298,7 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
   if (!enableCopyPropagation || !Builder.hasOwnership())
     return;
 
-  SmallSetVector<SILValue, 16> defsToCanonicalize;
+  llvm::SmallSetVector<SILValue, 16> defsToCanonicalize;
 
   // copyInst was either optimized by a SILCombine visitor or is a copy_value
   // produced by the visitor. Find the canonical def.

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -301,7 +301,7 @@ static bool onlyStoresToTailObjects(BuiltinInst *destroyArray,
                                     AllocRefInstBase *allocRef) {
   // Get the number of destroyed elements.
   auto *literal = dyn_cast<IntegerLiteralInst>(destroyArray->getArguments()[2]);
-  if (!literal || literal->getValue().getMinSignedBits() > 32)
+  if (!literal || literal->getValue().getSignificantBits() > 32)
     return false;
   int numDestroyed = literal->getValue().getSExtValue();
   

--- a/lib/SILOptimizer/Transforms/DestroyAddrHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyAddrHoisting.cpp
@@ -113,7 +113,7 @@ struct KnownStorageUses : UniqueStorageUseVisitor {
   bool preserveDebugInfo;
 
   SmallPtrSet<SILInstruction *, 16> storageUsers;
-  SmallSetVector<SILInstruction *, 4> originalDestroys;
+  llvm::SmallSetVector<SILInstruction *, 4> originalDestroys;
   SmallPtrSet<SILInstruction *, 4> debugInsts;
 
   KnownStorageUses(AccessStorage storage, SILFunction *function)
@@ -199,17 +199,17 @@ class DeinitBarriers final {
 public:
   // Instructions beyond which a destroy_addr cannot be hoisted, reachable from
   // a destroy_addr.  Deinit barriers or storage uses.
-  SmallSetVector<SILInstruction *, 4> barrierInstructions;
+  llvm::SmallSetVector<SILInstruction *, 4> barrierInstructions;
 
   // Phis beyond which a destroy_addr cannot be hoisted, reachable from a
   // destroy_addr.
-  SmallSetVector<SILBasicBlock *, 4> barrierPhis;
+  llvm::SmallSetVector<SILBasicBlock *, 4> barrierPhis;
 
   // Blocks beyond the end of which a destroy_addr cannot be hoisted.
-  SmallSetVector<SILBasicBlock *, 4> barrierBlocks;
+  llvm::SmallSetVector<SILBasicBlock *, 4> barrierBlocks;
 
   // Debug instructions that are no longer within this lifetime after shrinking.
-  SmallSetVector<SILInstruction *, 4> deadUsers;
+  llvm::SmallSetVector<SILInstruction *, 4> deadUsers;
 
   // The access scopes which are hoisting barriers.
   //

--- a/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
+++ b/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
@@ -95,7 +95,7 @@ void RedundantPhiEliminationPass::run() {
 
 #ifndef NDEBUG
 static bool hasOnlyNoneOwnershipIncomingValues(SILPhiArgument *phi) {
-  SmallSetVector<SILPhiArgument *, 4> worklist;
+  llvm::SmallSetVector<SILPhiArgument *, 4> worklist;
   SmallVector<SILValue, 4> incomingValues;
   worklist.insert(phi);
 

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -819,7 +819,7 @@ void BBEnumTagDataflowState::dump() const {
   llvm::dbgs() << "Dumping state for BB" << BB.get()->getDebugID() << "\n";
   llvm::dbgs() << "Block States:\n";
   for (auto &P : ValueToCaseMap) {
-    if (!P.hasValue()) {
+    if (!P) {
       llvm::dbgs() << "  Skipping blotted value.\n";
       continue;
     }
@@ -835,7 +835,7 @@ void BBEnumTagDataflowState::dump() const {
   llvm::dbgs() << "Predecessor States:\n";
   // For each (EnumValue, [(BB, EnumTag)]) that we are tracking...
   for (auto &P : EnumToEnumBBCaseListMap) {
-    if (!P.hasValue()) {
+    if (!P) {
       llvm::dbgs() << "  Skipping blotted value.\n";
       continue;
     }

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -768,7 +768,7 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
 
       // Return a statically diagnosed overflow if the operation is supposed to
       // trap on overflow.
-      if (overflowed && !operand2.getIntegerValue().isNullValue())
+      if (overflowed && !operand2.getIntegerValue().isZero())
         return getUnknown(evaluator, SILValue(inst), UnknownReason::Overflow);
 
       auto &allocator = evaluator.getAllocator();

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2938,7 +2938,7 @@ bool usePrespecialized(
       }
 
       unsigned score = 0;
-      for (auto &entry :
+      for (const auto &entry :
            llvm::enumerate(apply.getSubstitutionMap().getReplacementTypes())) {
 
         auto genericParam = specializedSig.getGenericParams()[entry.index()];

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1173,7 +1173,7 @@ static bool hasNonSelfContainedRequirements(ArchetypeType *Archetype,
       // we should return true.
       auto First = Req.getFirstType()->getCanonicalType();
       auto Second = Req.getSecondType()->getCanonicalType();
-      SmallSetVector<TypeBase *, 2> UsedGenericParams;
+      llvm::SmallSetVector<TypeBase *, 2> UsedGenericParams;
       First.visit([&](Type Ty) {
         if (auto *GP = Ty->getAs<GenericTypeParamType>()) {
           UsedGenericParams.insert(GP);
@@ -1225,7 +1225,7 @@ static void collectRequirements(ArchetypeType *Archetype, GenericSignature Sig,
       // we should return true.
       auto First = Req.getFirstType()->getCanonicalType();
       auto Second = Req.getSecondType()->getCanonicalType();
-      SmallSetVector<GenericTypeParamType *, 2> UsedGenericParams;
+      llvm::SmallSetVector<GenericTypeParamType *, 2> UsedGenericParams;
       First.visit([&](Type Ty) {
         if (auto *GP = Ty->getAs<GenericTypeParamType>()) {
           UsedGenericParams.insert(GP);

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -43,7 +43,7 @@ void swift::extendOwnedLifetime(SILValue ownedValue,
                                 PrunedLivenessBoundary &lifetimeBoundary,
                                 InstructionDeleter &deleter) {
   // Gather the current set of destroy_values, which may die.
-  SmallSetVector<Operand *, 4> extraConsumes;
+  llvm::SmallSetVector<Operand *, 4> extraConsumes;
   SmallPtrSet<SILInstruction *, 4> extraConsumers;
   for (Operand *use : ownedValue->getUses()) {
     if (use->isConsuming()) {
@@ -1697,7 +1697,7 @@ SILBasicBlock::iterator OwnershipReplaceSingleUseHelper::perform() {
 class GuaranteedPhiBorrowFixup {
   // A phi in mustConvertPhis has already been determined to be part of this
   // new nested borrow scope.
-  SmallSetVector<SILPhiArgument *, 8> mustConvertPhis;
+  llvm::SmallSetVector<SILPhiArgument *, 8> mustConvertPhis;
 
   // Phi operands that are already within the new nested borrow scope.
   llvm::SmallDenseSet<PhiOperand, 8> nestedPhiOperands;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -316,7 +316,7 @@ void BindingSet::inferTransitiveProtocolRequirements(
     // class, make it a "representative" and let it infer
     // supertypes and direct protocol requirements from
     // other members and their equivalence classes.
-    SmallSetVector<TypeVariableType *, 4> equivalenceClass;
+    llvm::SmallSetVector<TypeVariableType *, 4> equivalenceClass;
     {
       SmallVector<TypeVariableType *, 4> workList;
       workList.push_back(currentVar);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4537,7 +4537,7 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     auto *typeVar = entry.first;
     auto GP = entry.second;
 
-    llvm::SmallSetVector<Type, 4> arguments;
+    swift::SmallSetVector<Type, 4> arguments;
     for (const auto &solution : solutions) {
       auto type = solution.typeBindings.lookup(typeVar);
       // Type variables gathered from a solution's type binding context may not
@@ -5083,7 +5083,7 @@ static bool diagnoseContextualFunctionCallGenericAmbiguity(
   // So let's try to collect the set of fixed types for the generic parameter
   // from all the closure contextual fix/solutions and if there are more than
   // one fixed type diagnose it.
-  llvm::SmallSetVector<Type, 4> genericParamInferredTypes;
+  swift::SmallSetVector<Type, 4> genericParamInferredTypes;
   for (auto &fix : contextualFixes)
     genericParamInferredTypes.insert(fix.first->getFixedType(resultTypeVar));
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -167,7 +167,7 @@ class ImportResolver final : public DeclVisitor<ImportResolver> {
   /// We use a \c SmallSetVector here because this doubles as the worklist for
   /// cross-importing, so we want to keep it in order; this is feasible
   /// because this set is usually fairly small.
-  SmallSetVector<AttributedImport<ImportedModule>, 64> crossImportableModules;
+  llvm::SmallSetVector<AttributedImport<ImportedModule>, 32> crossImportableModules;
 
   /// The subset of \c crossImportableModules which may declare cross-imports.
   ///

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2872,7 +2872,7 @@ class ObjCImplementationChecker {
     return diag;
   }
 
-  SmallSetVector<ValueDecl *, 16> unmatchedRequirements;
+  llvm::SmallSetVector<ValueDecl *, 16> unmatchedRequirements;
 
   /// Candidates with their explicit ObjC names, if any.
   llvm::SmallDenseMap<ValueDecl *, ObjCSelector, 16> unmatchedCandidates;
@@ -3087,8 +3087,8 @@ private:
 
     // Requirements and candidates that have been matched (even ambiguously) and
     // should be removed from our unmatched lists.
-    SmallSetVector<ValueDecl *, 16> requirementsToRemove;
-    SmallSetVector<ValueDecl *, 16> candidatesToRemove;
+    llvm::SmallSetVector<ValueDecl *, 16> requirementsToRemove;
+    llvm::SmallSetVector<ValueDecl *, 16> candidatesToRemove;
 
     // First, loop through unsatisfied candidates and try the requirements.
     for (const auto &pair : unmatchedCandidates) {

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -17,6 +17,7 @@
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/Module.h"
 #include "swift/Serialization/Validation.h"
+#include "llvm/ADT/bit.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 
 namespace llvm {
@@ -124,7 +125,7 @@ public:
     const unsigned IsScoped : 1;
 
     static unsigned rawControlFromKind(ImportFilterKind importKind) {
-      return llvm::countTrailingZeros(static_cast<unsigned>(importKind));
+      return llvm::countr_zero(static_cast<unsigned>(importKind));
     }
     ImportFilterKind getImportControl() const {
       return static_cast<ImportFilterKind>(1 << RawImportControl);
@@ -137,7 +138,7 @@ public:
           RawImportControl(rawControlFromKind(importControl)),
           IsHeader(isHeader),
           IsScoped(isScoped) {
-      assert(llvm::countPopulation(static_cast<unsigned>(importControl)) == 1 &&
+      assert(llvm::popcount(static_cast<unsigned>(importControl)) == 1 &&
              "must be a particular filter option, not a bitset");
       assert(getImportControl() == importControl && "not enough bits");
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -41,6 +41,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/FileSystem.h"
+#include "swift/Basic/LLVMExtras.h"
 #include "swift/Basic/PathRemapper.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Version.h"
@@ -2596,7 +2597,7 @@ static bool contextDependsOn(const NominalTypeDecl *decl,
   return false;
 }
 
-static void collectDependenciesFromType(llvm::SmallSetVector<Type, 4> &seen,
+static void collectDependenciesFromType(swift::SmallSetVector<Type, 4> &seen,
                                         Type ty,
                                         const DeclContext *excluding) {
   if (!ty)
@@ -2612,7 +2613,7 @@ static void collectDependenciesFromType(llvm::SmallSetVector<Type, 4> &seen,
 }
 
 static void
-collectDependenciesFromRequirement(llvm::SmallSetVector<Type, 4> &seen,
+collectDependenciesFromRequirement(swift::SmallSetVector<Type, 4> &seen,
                                    const Requirement &req,
                                    const DeclContext *excluding) {
   collectDependenciesFromType(seen, req.getFirstType(), excluding);
@@ -2621,7 +2622,7 @@ collectDependenciesFromRequirement(llvm::SmallSetVector<Type, 4> &seen,
 }
 
 static SmallVector<Type, 4> collectDependenciesFromType(Type ty) {
-  llvm::SmallSetVector<Type, 4> result;
+  swift::SmallSetVector<Type, 4> result;
   collectDependenciesFromType(result, ty, /*excluding*/nullptr);
   return result.takeVector();
 }
@@ -3827,7 +3828,7 @@ public:
     size_t numInherited = addInherited(
         extension->getInherited(), data);
 
-    llvm::SmallSetVector<Type, 4> dependencies;
+    swift::SmallSetVector<Type, 4> dependencies;
     collectDependenciesFromType(
       dependencies, extendedType, /*excluding*/nullptr);
     for (Requirement req : extension->getGenericRequirements()) {
@@ -3982,7 +3983,7 @@ public:
 
     auto underlying = typeAlias->getUnderlyingType();
 
-    llvm::SmallSetVector<Type, 4> dependencies;
+    swift::SmallSetVector<Type, 4> dependencies;
     collectDependenciesFromType(dependencies, underlying->getCanonicalType(),
                                 /*excluding*/nullptr);
     for (Requirement req : typeAlias->getGenericRequirements()) {
@@ -4059,7 +4060,7 @@ public:
 
     unsigned numInherited = addInherited(theStruct->getInherited(), data);
 
-    llvm::SmallSetVector<Type, 4> dependencyTypes;
+    swift::SmallSetVector<Type, 4> dependencyTypes;
     for (Requirement req : theStruct->getGenericRequirements()) {
       collectDependenciesFromRequirement(dependencyTypes, req,
                                          /*excluding*/nullptr);
@@ -4103,7 +4104,7 @@ public:
 
     unsigned numInherited = addInherited(theEnum->getInherited(), data);
 
-    llvm::SmallSetVector<Type, 4> dependencyTypes;
+    swift::SmallSetVector<Type, 4> dependencyTypes;
     for (const EnumElementDecl *nextElt : theEnum->getAllElements()) {
       if (!nextElt->hasAssociatedValues())
         continue;
@@ -4160,7 +4161,7 @@ public:
 
     unsigned numInherited = addInherited(theClass->getInherited(), data);
 
-    llvm::SmallSetVector<Type, 4> dependencyTypes;
+    swift::SmallSetVector<Type, 4> dependencyTypes;
     if (theClass->hasSuperclass()) {
       // FIXME: Nested types can still be a problem here: it's possible that (for
       // whatever reason) they won't be able to be deserialized, in which case
@@ -4210,7 +4211,7 @@ public:
     auto contextID = S.addDeclContextRef(proto->getDeclContext());
 
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
-    llvm::SmallSetVector<Type, 4> dependencyTypes;
+    swift::SmallSetVector<Type, 4> dependencyTypes;
 
     unsigned numInherited = addInherited(
         proto->getInherited(), inheritedAndDependencyTypes);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3456,10 +3456,15 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
   void writeForeignAsyncConvention(const ForeignAsyncConvention &fac) {
     using namespace decls_block;
     TypeID completionHandlerTypeID = S.addTypeRef(fac.completionHandlerType());
-    unsigned rawErrorParameterIndex = fac.completionHandlerErrorParamIndex()
-      .transform([](unsigned index) { return index + 1; }).value_or(0);
-    unsigned rawErrorFlagParameterIndex = fac.completionHandlerFlagParamIndex()
-      .transform([](unsigned index) { return index + 1; }).value_or(0);
+
+    unsigned rawErrorParameterIndex =
+        swift::transform(fac.completionHandlerErrorParamIndex(),
+                         [](unsigned index) { return index + 1; })
+            .value_or(0);
+    unsigned rawErrorFlagParameterIndex =
+        swift::transform(fac.completionHandlerFlagParamIndex(),
+                         [](unsigned index) { return index + 1; })
+            .value_or(0);
     auto abbrCode = S.DeclTypeAbbrCodes[ForeignAsyncConventionLayout::Code];
     ForeignAsyncConventionLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                              completionHandlerTypeID,

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -18,6 +18,7 @@
 #define SWIFT_SERIALIZATION_SERIALIZATION_H
 
 #include "ModuleFormat.h"
+#include "swift/Basic/LLVMExtras.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/Identifier.h"
@@ -287,7 +288,7 @@ public:
   // constructed, and then converted to a `DerivativeFunctionConfigTableData`.
   using UniquedDerivativeFunctionConfigTable = llvm::MapVector<
       Identifier,
-      llvm::SmallSetVector<std::pair<Identifier, GenericSignature>, 4>>;
+      swift::SmallSetVector<std::pair<Identifier, GenericSignature>, 4>>;
 
   // In-memory representation of what will eventually be an on-disk
   // hash table of the fingerprint associated with a serialized

--- a/unittests/Basic/STLExtrasTest.cpp
+++ b/unittests/Basic/STLExtrasTest.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/STLExtras.h"
+#include "swift/Basic/LLVMExtras.h"
 #include "gtest/gtest.h"
 
 using namespace swift;
@@ -180,4 +181,22 @@ TEST(RemoveAdjacentIf, MultipleRuns) {
                                    std::equal_to<int>());
     EXPECT_EQ(result, &items[0]);
   }
+}
+
+TEST(SmallSetVector, operator_equals) {
+
+  struct EquatableThing {
+    int value;
+    bool operator==(EquatableThing other) {
+      return value == other.value;
+    }
+  };
+
+  struct NonEquatableThing {
+    int value;
+    bool operator==() = delete;
+  };
+
+  EXPECT_TRUE(isEquatable<EquatableThing>());
+  EXPECT_FALSE(isEquatable<NonEquatableThing>());
 }


### PR DESCRIPTION
This PR is a concoction of fixes working toward getting the rebranch compiler building.
A lot of the commits are not terribly remarkable and parts have already been reviewed,
but here is a listing of the riskier commits that I would like folks to take a closer look at.
I've tried to split the commits into related sets of changes.

### Add SmallSetVector replacement

llvm::SmallSetVector changed semantics
(https://reviews.llvm.org/D152497) resulting in build failures in Swift.
The old semantics allowed usage of types that did not have an
`operator==` because `SmallDenseSet` uses `DenseSetInfo<T>::isEqual` to
determine equality. The new implementation switched to using
`std::find`, which internally uses `operator==`. This type is used
pretty frequently with `swift::Type`, which intentionally deletes
`operator==` as it is not the canonical type and therefore cannot be
compared in normal circumstances.

This patch adds a new type-alias to the Swift namespace that provides
the old semantic behavior for `SmallSetVector`. I've also gone through
and replaced usages of `llvm::SmallSetVector` with the
`Swift::SmallSetVector` in places where we're storing a type that
doesn't implement or explicitly deletes `operator==`. The changes to
`llvm::SmallSetVector` should improve compile-time performance, so I
left the `llvm::SmallSetVector` where possible.

Note that for things that do have an `operator==`, the LLVM changes should help improve the compile-time performance, so I didn't go through and whole-sale search-and-replace change things to use the swift SmallSetVector.

### Removing deleted legacy pass inits

The legacy pass manager is being taken down in LLVM. This patch removes
the initializers that were removed from LLVM from the
`swift_llvm_opt_main` tool. The rest of the compiler has already been
migrated to the new pass manager, so I don't think this will break the
main parts of the compiler.

@eeckstein, `swift_llvm_opt_main.cpp` appears to be using the legacy pass manager still to some extent?
The rest of the compiler looks like it has already been migrated. This sub-program seems to be mostly your work; could you look into migrating it or doing something. I removed the initialization of the removed passes to get it building, but it would be better to transition this entirely to the new pass manager. Thanks.

### Remove Typed-Pointer cutouts

This removes some of the typed pointer cutouts in IRGen.
LLVM has removed the typed pointers, so `LLVMContext.setOpaquePointers`
doesn't make sense. Clang doesn't have opaque pointers either.

Also removing defunct assertions in IRGen were checking pointer-type
information. With llvm moving to opaque pointer types, these functions
are no longer returning useful information and are deprecated.

Specifically
 - `isOpaqueOrPointeeTypeMatches` always returns true
 - `supportsTypedPointers()` always returns false
 - `getNonOpaquePointerElementType()->isFunctionTy()` will never get hit

