### PR TITLE
Update rebranch llvm checkout version

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -137,8 +137,8 @@
         "rebranch": {
             "aliases": ["rebranch"],
             "repos": {
-                "llvm-project": "stable/20221013",
-                "swift-llvm-bindings": "stable/20221013",
+                "llvm-project": "stable/20230725",
+                "swift-llvm-bindings": "stable/20230725",
                 "swift": "rebranch",
                 "cmark": "gfm",
                 "llbuild": "main",


### PR DESCRIPTION
Updating the llvm version for the rebranch configuration in update-checkout.
Pointing it at the new `stable/20230725` branch.