### PR TITLE
noncopyable diagnostics fix to correct error message wording

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -547,6 +547,9 @@ void DiagnosticEmitter::emitObjectDiagnosticsForPartialApplyUses(
 static bool isClosureCapture(MarkMustCheckInst *markedValue) {
   SILValue val = markedValue->getOperand();
 
+  // Sometimes we've mark-must-check'd a begin_access.
+  val = stripAccessMarkers(val);
+
   // look past any project-box
   if (auto *pbi = dyn_cast<ProjectBoxInst>(val))
     val = pbi->getOperand();

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -3862,6 +3862,22 @@ func blackHoleKlassTestCase2(_ k: consuming Klass) {
     // expected-note @-1 {{consumed again here}}
 }
 
+// rdar://109908383
+struct NonCopyableStruct: ~Copyable {}
+var globFn: () -> () = {}
+func forceEscaping(_ esc: @escaping () -> ()) {
+    globFn = esc
+}
+func closureDiagnosticsSimple() {
+    var s = NonCopyableStruct()
+    let f = {
+        _ = consume s  // expected-error {{missing reinitialization of closure capture 's' after consume}} // expected-note {{consumed here}}
+        s = NonCopyableStruct()
+    }
+    forceEscaping(f)
+    f()
+}
+
 ///////////////////////////////////////
 // Copyable Type in a Move Only Type //
 ///////////////////////////////////////


### PR DESCRIPTION
Turns out if you write `_ = consume s` you get different enough SIL than `_ = s` that it fools the ad-hoc test for whether we've mark-must-check'd a closure capture, since the former will have a begin_access. There doesn't appear to be a simple way to reuse the existing information or checking routine for this that was used by the checker itself to flag this.