### PR TITLE
[Rebranch] More header include fixes

### DIFF
--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include <unordered_map>
 
 namespace swift {

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -19,6 +19,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/MapVector.h"
+#include "LocalTypeDataKind.h"
 
 namespace llvm {
   class Value;
@@ -37,7 +38,6 @@ class Address;
 class Explosion;
 class IRGenFunction;
 class IRGenModule;
-class LocalTypeDataKey;
 class TypeInfo;
 
 /// A helper class for emitting outlined value operations.


### PR DESCRIPTION
MapVector started querying for constructability of stored types with templates. As such, we need the definition of `LocalTypeDataKey` so that it can instantiate the template.

We also lost a transitive include of `TinyPtrVector`, which we use, so including it in `ConformanceLookupTable.h`.