### PR TITLE
[5.9][Macros] Suppress the conformance macro diagnostic in swiftinterfaces.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7121,11 +7121,17 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
       break;
     case MacroRole::Peer:
       break;
-    case MacroRole::Conformance:
+    case MacroRole::Conformance: {
+      // Suppress the conformance macro error in swiftinterfaces.
+      SourceFile *file = D->getDeclContext()->getParentSourceFile();
+      if (file && file->Kind == SourceFileKind::Interface)
+        break;
+
       diagnoseAndRemoveAttr(attr, diag::conformance_macro)
           .fixItReplace(attr->getRange(),
                         "@attached(extension, conformances: <#Protocol#>)");
       break;
+    }
     case MacroRole::Extension:
       break;
     default:

--- a/test/Macros/Inputs/ConformanceMacroLib.swiftinterface
+++ b/test/Macros/Inputs/ConformanceMacroLib.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ConformanceMacroLib
+
+@attached(conformance)
+public macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")

--- a/test/Macros/imported_conformance_macro.swift
+++ b/test/Macros/imported_conformance_macro.swift
@@ -1,0 +1,18 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name ConformanceMacroLib %S/Inputs/ConformanceMacroLib.swiftinterface -o %t/ConformanceMacroLib.swiftmodule
+
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -I%t -verify %s -verify-ignore-unknown  -load-plugin-library %t/%target-library-name(MacroDefinition) -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
+
+import ConformanceMacroLib
+
+@Equatable
+struct S {}
+
+// CHECK-DUMP: extension S: Equatable  {
+// CHECK-DUMP: }


### PR DESCRIPTION
* **Explanation**: Programmers cannot fix compiler errors in swiftinterfaces, so suppress the error for `@attached(conformance)` attributes if they appear in swiftinterfaces.
* **Scope**: Only impacts `@attached(conformance)` attributes in swiftinterfaces. The compiler cannot produce new interfaces with this attribute, but existing swiftinterfaces containing this attribute will continue to build.
* **Risk**: Very low.
* **Testing**: Added a test that builds a swift module from a swiftinterface containing an `@attached(conformance)` macro declaration.
* **Issue**: rdar://112867079
* **Reviewer**: @tshortli 
* **Main branch PR**: https://github.com/apple/swift/pull/67524