### PR TITLE
[Mem2Reg] Canonicalize promoted lifetimes.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1927,7 +1927,7 @@ class MemoryToRegisters {
   /// Attempt to promote the specified stack allocation, returning true if so
   /// or false if not.  On success, all uses of the AllocStackInst have been
   /// removed, but the ASI itself is still in the program.
-  bool promoteSingleAllocation(AllocStackInst *asi);
+  bool promoteAllocation(AllocStackInst *asi);
 
 public:
   /// C'tor
@@ -2128,7 +2128,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
 /// or false if not.  On success, this returns true and usually drops all of the
 /// uses of the AllocStackInst, but never deletes the ASI itself.  Callers
 /// should check to see if the ASI is dead after this and remove it if so.
-bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc) {
+bool MemoryToRegisters::promoteAllocation(AllocStackInst *alloc) {
   LLVM_DEBUG(llvm::dbgs() << "*** Memory to register looking at: " << *alloc);
   ++NumAllocStackFound;
 
@@ -2190,7 +2190,7 @@ bool MemoryToRegisters::run() {
       if (!asi)
         continue;
 
-      if (promoteSingleAllocation(asi)) {
+      if (promoteAllocation(asi)) {
         for (auto *inst : instructionsToDelete) {
           deleter.forceDelete(inst);
         }

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1918,15 +1918,18 @@ class MemoryToRegisters {
     return *domTreeLevels;
   }
 
-  /// Promote all of the AllocStacks in a single basic block in one
-  /// linear scan. Note: This function deletes all of the users of the
-  /// AllocStackInst, including the DeallocStackInst but it does not remove the
-  /// AllocStackInst itself!
+  /// Promote the specified stack location whose uses are all within a single
+  /// block.
+  ///
+  /// Note: Deletes all of the users of the alloc_stack, including the
+  ///       dealloc_stack but it does not remove the alloc_stack itself.
   void removeSingleBlockAllocation(AllocStackInst *asi);
 
-  /// Attempt to promote the specified stack allocation, returning true if so
-  /// or false if not.  On success, all uses of the AllocStackInst have been
-  /// removed, but the ASI itself is still in the program.
+  /// Attempt to promote the specified stack allocation.  Its uses may be in a
+  /// single block or in multiple blocks.
+  ///
+  /// Note: Populates instructionsToDelete with the instructions the caller is
+  ///       responsible for deleting.
   bool promoteAllocation(AllocStackInst *asi);
 
 public:

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -311,8 +311,9 @@ bb2:
 // CHECK: bb3([[ARG:%.*]] : @owned $@callee_owned () -> Int):
 bb3:
   %13 = load [copy] %1 : $*@callee_owned () -> Int
-// CHECK: [[COPY:%.*]] = copy_value [[ARG]]
-// CHECK: [[RESULT:%.*]] = apply [[COPY]]
+//      : [[COPY:%.*]] = copy_value [[ARG]]
+// The above copy is eliminated by owned value canonicalization.
+// CHECK: [[RESULT:%.*]] = apply [[ARG]]
   %15 = apply %13() : $@callee_owned () -> Int
   br bb4
 
@@ -321,7 +322,8 @@ bb3:
   //       block.
 // CHECK: bb4
 bb4:
-// CHECK: destroy_value [[ARG]]
+//      : destroy_value [[ARG]]
+// The above destroy is eliminated by owned value canonicalization.
   destroy_addr %1 : $*@callee_owned () -> Int
   dealloc_stack %1 : $*@callee_owned () -> Int
   return %15 : $Int

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -325,8 +325,9 @@ bb2:
 bb3:
 // CHECK-NOT: load
   %13 = load [copy] %1 : $*@callee_owned () -> Int
-// CHECK: [[COPY:%.*]] = copy_value [[ARG]]
-// CHECK: [[RESULT:%.*]] = apply [[COPY]]
+//      : [[COPY:%.*]] = copy_value [[ARG]]
+// The above copy is eliminated by owned value canonicalization.
+// CHECK: [[RESULT:%.*]] = apply [[ARG]]
   %15 = apply %13() : $@callee_owned () -> Int
   br bb4
 

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -336,7 +336,8 @@ bb3:
 // CHECK: bb4
 bb4:
 // CHECK-NOT: destroy_addr
-// CHECK: destroy_value [[ARG]]
+//      : destroy_value [[ARG]]
+// The above destroy is eliminated by owned value canonicalization.
   destroy_addr %1 : $*@callee_owned () -> Int
 // CHECK-NOT: dealloc_stack
   dealloc_stack %1 : $*@callee_owned () -> Int
@@ -437,13 +438,13 @@ bb0(%0 : @owned $SmallCodesizeStruct):
 // CHECK-LABEL: sil [ossa] @small_struct_multi_test :
 // CHECK-NOT: alloc_stack
 // CHECK: [[COPY:%.*]] = copy_value %0
-// CHECK-NEXT: destructure_struct %0
+// CHECK-NEXT: destructure_struct %2
 // CHECK-NEXT: destroy_value
 // CHECK-NEXT: destroy_value
-// CHECK-NEXT: begin_borrow [[COPY]]
+// CHECK-NEXT: begin_borrow %0
 // CHECK-NEXT: debug_value
 // CHECK-NEXT: end_borrow
-// CHECK-NEXT: destroy_value [[COPY]]
+// CHECK-NEXT: destroy_value %0
 // CHECK: bb2:
 // CHECK-NEXT: destructure_struct %0
 // CHECK-NEXT: destroy_value

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -145,9 +145,10 @@ bb0(%0 : @owned $Klass, %1 : @owned $Klass):
 
 // CHECK-LABEL: sil [ossa] @multiple_store_vals3 :
 // CHECK-NOT: alloc_stack
-// CHECK: [[COPY0:%.*]] = copy_value %0 : $Klass
+// The COPY0 copy/destroy is eliminated by owned value canonicalization.
+//      : [[COPY0:%.*]] = copy_value %0 : $Klass
 // CHECK: [[COPY1:%.*]] = copy_value %1 : $Klass
-// CHECK: destroy_value [[COPY0]] : $Klass
+//      : destroy_value [[COPY0]] : $Klass
 // CHECK: [[FUNC:%.*]] = function_ref @blackhole_spl :
 // CHECK: apply [[FUNC]]([[COPY1]]) : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK: destroy_value [[COPY1]] : $Klass
@@ -353,8 +354,9 @@ bb0(%0 : @owned $Klass, %1 : @owned $Klass):
 
 // CHECK-LABEL: sil [ossa] @basic_block_with_loads_copy_and_take :
 // CHECK-NOT: alloc_stack
-// CHECK: [[COPY:%.*]] = copy_value %0 : $Klass
-// CHECK: destroy_value [[COPY]] : $Klass
+// The COPY/destroy pair is eliminated by owned value canonicalization.
+//      : [[COPY:%.*]] = copy_value %0 : $Klass
+//      : destroy_value [[COPY]] : $Klass
 // CHECK: destroy_value %0 : $Klass
 // CHECK-LABEL: } // end sil function 'basic_block_with_loads_copy_and_take'
 sil [ossa] @basic_block_with_loads_copy_and_take : $@convention(thin) (@owned Klass) -> () {


### PR DESCRIPTION
Canonicalize the lifetimes of values which were stored to the promoted `alloc_stack` and of the newly created phis.
