### PR TITLE
GenericSpecializer: don't re-abstract a specialized function if it has a dead indirect in-argument

### DIFF
--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -211,6 +211,8 @@ public:
     return Serialized;
   }
 
+  bool isReabstracted() const { return ConvertIndirectToDirect; }
+
   unsigned param2ArgIndex(unsigned ParamIdx) const  {
     return ParamIdx + NumFormalIndirectResults;
   }

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -440,7 +440,7 @@ bb0(%0 : $*T, %1 : $*T, %2 : $@thin T.Type):
 }
 
 // CHECK-LABEL: sil @return_generic_nonthrowing_closure
-// CHECK: [[F:%[0-9]+]] = function_ref @$s39specialized_generic_nonthrowing_closures5Int32V_Tg5
+// CHECK: [[F:%[0-9]+]] = function_ref @$s39specialized_generic_nonthrowing_closures5Int32V_TG5
 // CHECK: [[R:%[0-9]+]] = thin_to_thick_function [[F]]
 // CHECK: return [[R]]
 sil @return_generic_nonthrowing_closure : $@convention(thin) () -> @owned @callee_owned (@in Int32, @in Int32) -> Bool {

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -27,17 +27,16 @@ bb0(%0 : $Int, %1 : $Int):
 
   // CHECK: [[STACK:%[0-9]+]] = alloc_stack $MMString
   %37 = alloc_stack $MMString
-  // CHECK: [[ID:%[0-9]+]] = function_ref @$s6callee7inherit8MMStringC_AB6MMFontCSgTg5 : $@convention(method) (@owned MMString, Int, @owned MMStorage<MMString, Optional<MMFont>>) -> Bool
+  // CHECK: [[ID:%[0-9]+]] = function_ref @$s6callee7inherit8MMStringC_AB6MMFontCSgTG5 : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, Optional<MMFont>>) -> Bool
   %34 = function_ref @callee : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in τ_0_0, Int, @owned MMStorage<τ_0_0, τ_0_1>) -> Bool
-  // CHECK: [[LOAD:%[0-9]+]] = load [[STACK]]
-  // CHECK: apply [[ID]]([[LOAD]], %1, %{{[0-9]+}}) : $@convention(method) (@owned MMString, Int, @owned MMStorage<MMString, Optional<MMFont>>) -> Bool
+  // CHECK: apply [[ID]]([[STACK]], %1, %{{[0-9]+}}) : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, Optional<MMFont>>) -> Bool
   %45 = apply %34<MMString, MMFont?>(%37, %1, %14) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in τ_0_0, Int, @owned MMStorage<τ_0_0, τ_0_1>) -> Bool
   dealloc_stack %37 : $*MMString
 
   return %14 : $MMStorage<MMString, Optional<MMFont>>
 }
 
-// CHECK-LABEL: @$s6callee7inherit8MMStringC_AB6MMFontCSgTg5 : $@convention(method) (@owned MMString, Int, @owned MMStorage<MMString, Optional<MMFont>>) -> Bool {
+// CHECK-LABEL: sil shared [noinline] @$s6callee7inherit8MMStringC_AB6MMFontCSgTG5 : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, Optional<MMFont>>) -> Bool {
 // CHECK: [[META:%[0-9]+]] = metatype $@thick MMString.Type
 // CHECK: [[ID3:%[0-9]+]] = witness_method $MMString, #Equatable."==" :
 // CHECK: [[STACK2:%[0-9]+]] = alloc_stack $MMString


### PR DESCRIPTION
If an indirect in-argument is not used in the callee, dead store elimination might have removed the preceding store to the memory location. If we would convert such an argument to a _direct_ argument, we would insert a load before the call - but this load would load an undefined value, because the store is missing. We want to avoid this undefined behavior. Also SILMem2Reg cannot handle it.

Usually this is no problem because there are no dead-store elimination passes before the specializer in the pipeline. But in theory, it can happen.

Add a check, which only covers the common pattern of a stack location with no stores. This is a bad hack and the real solution would be to allow re-abstraction and pass an `undef` as direct argument. But currently undefs are not handled very well in optimizations.
