### PR TITLE
test/stdlib/UnsafePointer.swift.gyb: disable crashing test on WASI

### DIFF
--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -537,6 +537,7 @@ ${SelfName}TestSuite.test("pointer(to:)") {
 % end
 }
 
+#if !os(WASI)
 ${SelfName}TestSuite.test("pointer(to:).overflow") {
   struct Example {
     var a = false
@@ -558,6 +559,7 @@ ${SelfName}TestSuite.test("pointer(to:).overflow") {
   let doublePointer = p.pointer(to: \.d)
   expectNotNil(doublePointer)
 }
+#endif
 
 % end
 


### PR DESCRIPTION
WASI doesn't support spawning a subprocess, so crash tests crashes the test harness itself. Those should be skipped until proper subprocess support is available.
