### PR TITLE
IRGen: fix a problem with 24-bit enum payloads in statically initialized global variables

### DIFF
--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -171,6 +171,16 @@ public let success: R = .success(27)
 // CHECK-LABEL: sil_global hidden @$s4test10optSuccessAA1ROSgvp : $Optional<R> = {
 var optSuccess: R? = success
 
+public enum Color {
+  case black
+  case rgb(r: UInt8, g: UInt8, b: UInt8)
+}
+
+// CHECK-LABEL: sil_global hidden @$s4test8optBlackAA5ColorOSgvp : $Optional<Color> = {
+var optBlack: Color? = Color.black
+// CHECK-LABEL: sil_global hidden @$s4test9optSalmonAA5ColorOSgvp : $Optional<Color> = {
+var optSalmon: Color? = Color.rgb(r: 0xfa, g: 0x80, b: 0x72)
+
 // CHECK-LABEL: sil_global private @$s4test9createArrSaySiSgGyFTv_ : $_ContiguousArrayStorage<Optional<Int>> = {
 @inline(never)
 func createArr() -> [Int?] {
@@ -246,6 +256,10 @@ struct Main {
     print("stringGen3: \(getStringGen(sg3))")
     // CHECK-OUTPUT: optSuccess: Optional(test.R.success(27))
     print("optSuccess:", optSuccess as Any)
+    // CHECK-OUTPUT: optBlack: Optional(test.Color.black)
+    print("optBlack:", optBlack as Any)
+    // CHECK-OUTPUT: optSalmon: Optional(test.Color.rgb(r: 250, g: 128, b: 114))
+    print("optSalmon:", optSalmon as Any)
   }
 }
 

--- a/validation-test/SILOptimizer/static_enums_fuzzing.swift
+++ b/validation-test/SILOptimizer/static_enums_fuzzing.swift
@@ -79,6 +79,11 @@ var typeDefinitions: String {
       case C
     }
 
+    public enum E24 {
+      case A
+      case B(UInt8, UInt8, UInt8)
+    }
+
     public func fn() {}
 
     public typealias Func = () -> ()
@@ -322,6 +327,42 @@ struct MultiPayloadEnum : Value {
   var containsEnum: Bool { true }
 }
 
+struct Size24Enum : Value {
+  let caseIdx: Int
+  
+  init(generator: inout RandomGenerator, depth: Int) {
+    self.caseIdx = Int.random(in: 0..<2, using: &generator)
+  }
+  
+  func getType() -> String {
+    "E24"
+  }
+
+  func getInitValue() -> String  {
+    switch caseIdx {
+      case 0: return "E24.A"
+      case 1: return "E24.B(250, 128, 114)"
+      default: fatalError()
+    }
+  }
+
+  func getExpectedOutput(topLevel: Bool) -> String  {
+    let prefix = topLevel ? "" : "\(getRuntimeTypeName(topLevel: topLevel))."
+    switch caseIdx {
+      case 0: return "\(prefix)A"
+      case 1: return "\(prefix)B(250, 128, 114)"
+      default: fatalError()
+    }
+  }
+
+  func getRuntimeTypeName(topLevel: Bool) -> String {
+    let prefix = topLevel ? "" : "test."
+    return "\(prefix)E24"
+  }
+
+  var containsEnum: Bool { true }
+}
+
 // Can't use the default random generator becaus we need deterministic results
 struct RandomGenerator : RandomNumberGenerator {
   var state: (UInt64, UInt64, UInt64, UInt64) = (15042304078070129153, 10706435816813474385, 14710304063852993123, 11070704559760783939)
@@ -360,7 +401,8 @@ struct RandomGenerator : RandomNumberGenerator {
     SmallString.self,
     LargeString.self,
     Function.self,
-    Enum.self
+    Enum.self,
+    Size24Enum.self
   ]
   private static let allValueTypes: [any Value.Type] = allTerminalTypes + [
     OptionalValue.self,


### PR DESCRIPTION
IRGen crashed in case an enum, which has a 24 bit payload (e.g. three `UInt8`), is used as a payload of another enum, e.g. `Optional`, in a statically initialized global variable.

rdar://112823823
