### PR TITLE
Update documentation links to the Observable macro and protocol (112678394)

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -15,7 +15,7 @@
 /// Conforming to this protocol signals to other APIs that the type supports
 /// observation. However, applying the `Observable` protocol by itself to a
 /// type doesn't add observation functionality to the type. Instead, always use
-/// the ``Observation/Observable-swift.macro`` macro when adding observation
+/// the ``Observation/Observable()`` macro when adding observation
 /// support to a type.
 @available(SwiftStdlib 5.9, *)
 public protocol Observable { }
@@ -25,9 +25,8 @@ public protocol Observable { }
 /// Defines and implements conformance of the Observable protocol.
 ///
 /// This macro adds observation support to a custom type and conforms the type
-/// to the ``Observation/Observable-swift.protocol`` protocol. For example, the
-/// following code applies the `Observable` macro to the type `Car` making it
-/// observable:
+/// to the ``Observation/Observable`` protocol. For example, the following code
+/// applies the `Observable` macro to the type `Car` making it observable:
 ///
 ///     @Observable 
 ///     class Car {

--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -12,8 +12,7 @@
 /// Provides storage for tracking and access to data changes.
 ///
 /// You don't need to create an instance of `ObservationRegistrar` when using
-/// the ``Observation/Observable-swift.macro`` macro to indicate observability
-/// of a type.
+/// the ``Observation/Observable()`` macro to indicate observability of a type.
 @available(SwiftStdlib 5.9, *)
 public struct ObservationRegistrar: Sendable {
   internal class ValueObservationStorage {
@@ -301,7 +300,7 @@ public struct ObservationRegistrar: Sendable {
   ///
   /// You don't need to create an instance of
   /// ``Observation/ObservationRegistrar`` when using the
-  /// ``Observation/Observable-swift.macro`` macro to indicate observably
+  /// ``Observation/Observable()`` macro to indicate observably
   /// of a type.
   public init() {
   }


### PR DESCRIPTION
Update documentation links to the `Observable` macro and protocol to confirm to new DocC treatment of macro names.

Resolves rdar://112678394
