### PR TITLE
[CS] NFC: Store ContextualTypeInfo in SyntacticElementTarget

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -25,6 +25,7 @@
 #include "swift/AST/TypeLoc.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Sema/ConstraintLocator.h"
+#include "swift/Sema/ContextualTypeInfo.h"
 #include "swift/Sema/OverloadChoice.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/ilist.h"
@@ -49,23 +50,6 @@ class ConstraintFix;
 class ConstraintLocator;
 class ConstraintSystem;
 enum class TrailingClosureMatching;
-
-/// Describes contextual type information about a particular element
-/// (expression, statement etc.) within a constraint system.
-struct ContextualTypeInfo {
-  TypeLoc typeLoc;
-  ContextualTypePurpose purpose;
-
-  ContextualTypeInfo() : typeLoc(TypeLoc()), purpose(CTP_Unused) {}
-
-  ContextualTypeInfo(Type contextualTy, ContextualTypePurpose purpose)
-      : typeLoc(TypeLoc::withoutLoc(contextualTy)), purpose(purpose) {}
-
-  ContextualTypeInfo(TypeLoc typeLoc, ContextualTypePurpose purpose)
-      : typeLoc(typeLoc), purpose(purpose) {}
-
-  Type getType() const { return typeLoc.getType(); }
-};
 
 /// Describes the kind of constraint placed on one or more types.
 enum class ConstraintKind : char {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3114,12 +3114,11 @@ public:
     return E;
   }
 
-  void setContextualType(ASTNode node, TypeLoc T,
-                         ContextualTypePurpose purpose) {
+  void setContextualInfo(ASTNode node, ContextualTypeInfo info) {
     assert(bool(node) && "Expected non-null expression!");
     assert(contextualTypes.count(node) == 0 &&
            "Already set this contextual type");
-    contextualTypes[node] = {{T, purpose}, Type()};
+    contextualTypes[node] = {info, Type()};
   }
 
   llvm::Optional<ContextualTypeInfo> getContextualTypeInfo(ASTNode node) const {

--- a/include/swift/Sema/ContextualTypeInfo.h
+++ b/include/swift/Sema/ContextualTypeInfo.h
@@ -1,0 +1,55 @@
+//===--- ContextualTypeInfo.h - Contextual Type Info ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides the \c ContextualTypeInfo class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_CONTEXTUAL_TYPE_INFO_H
+#define SWIFT_SEMA_CONTEXTUAL_TYPE_INFO_H
+
+#include "swift/AST/TypeLoc.h"
+#include "swift/Sema/ConstraintLocator.h"
+
+namespace swift {
+namespace constraints {
+
+/// Describes contextual type information about a particular element
+/// (expression, statement etc.) within a constraint system.
+struct ContextualTypeInfo {
+  TypeLoc typeLoc;
+  ContextualTypePurpose purpose;
+
+  /// The locator for the contextual type conversion constraint, or
+  /// \c nullptr to use the default locator which is anchored directly on
+  /// the expression.
+  ConstraintLocator *locator;
+
+  ContextualTypeInfo()
+      : typeLoc(TypeLoc()), purpose(CTP_Unused), locator(nullptr) {}
+
+  ContextualTypeInfo(Type contextualTy, ContextualTypePurpose purpose,
+                     ConstraintLocator *locator = nullptr)
+      : typeLoc(TypeLoc::withoutLoc(contextualTy)), purpose(purpose),
+        locator(locator) {}
+
+  ContextualTypeInfo(TypeLoc typeLoc, ContextualTypePurpose purpose,
+                     ConstraintLocator *locator = nullptr)
+      : typeLoc(typeLoc), purpose(purpose), locator(locator) {}
+
+  Type getType() const { return typeLoc.getType(); }
+};
+
+} // end namespace constraints
+} // end namespace swift
+
+#endif // SWIFT_SEMA_CONTEXTUAL_TYPE_INFO_H

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4334,8 +4334,9 @@ bool ConstraintSystem::generateWrappedPropertyTypeConstraints(
       ConstraintKind::Equal, propertyType, wrappedValueType,
       getConstraintLocator(
           wrappedVar, LocatorPathElt::ContextualType(CTP_WrappedProperty)));
-  setContextualType(wrappedVar, TypeLoc::withoutLoc(wrappedValueType),
-                    CTP_WrappedProperty);
+
+  ContextualTypeInfo contextInfo(wrappedValueType, CTP_WrappedProperty);
+  setContextualInfo(wrappedVar, contextInfo);
   return false;
 }
 
@@ -4419,10 +4420,9 @@ generateForEachStmtConstraints(ConstraintSystem &cs,
         makeIteratorCall, dc, /*patternType=*/Type(), PB, /*index=*/0,
         /*shouldBindPatternsOneWay=*/false);
 
-    cs.setContextualType(
-        sequenceExpr,
-        TypeLoc::withoutLoc(sequenceProto->getDeclaredInterfaceType()),
-        CTP_ForEachSequence);
+    ContextualTypeInfo contextInfo(sequenceProto->getDeclaredInterfaceType(),
+                                   CTP_ForEachSequence);
+    cs.setContextualInfo(sequenceExpr, contextInfo);
 
     if (cs.generateConstraints(makeIteratorTarget))
       return llvm::None;
@@ -4480,10 +4480,9 @@ generateForEachStmtConstraints(ConstraintSystem &cs,
       if (!iteratorProto)
         return llvm::None;
 
-      cs.setContextualType(
-          nextRef->getBase(),
-          TypeLoc::withoutLoc(iteratorProto->getDeclaredInterfaceType()),
-          CTP_ForEachSequence);
+      ContextualTypeInfo contextInfo(iteratorProto->getDeclaredInterfaceType(),
+                                     CTP_ForEachSequence);
+      cs.setContextualInfo(nextRef->getBase(), contextInfo);
     }
 
     SyntacticElementTarget nextTarget(nextCall, dc, CTP_Unused,
@@ -4549,8 +4548,9 @@ generateForEachStmtConstraints(ConstraintSystem &cs,
       return llvm::None;
 
     cs.setTargetFor(whereExpr, whereTarget);
-    cs.setContextualType(whereExpr, TypeLoc::withoutLoc(boolType),
-                         CTP_Condition);
+
+    ContextualTypeInfo contextInfo(boolType, CTP_Condition);
+    cs.setContextualInfo(whereExpr, contextInfo);
   }
 
   // Populate all of the information for a for-each loop.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -323,10 +323,8 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   // Add the contextual types.
   for (const auto &contextualType : solution.contextualTypes) {
-    if (!getContextualTypeInfo(contextualType.first)) {
-      setContextualType(contextualType.first, contextualType.second.typeLoc,
-                        contextualType.second.purpose);
-    }
+    if (!getContextualTypeInfo(contextualType.first))
+      setContextualInfo(contextualType.first, contextualType.second);
   }
 
   // Register the statement condition targets.
@@ -1731,8 +1729,7 @@ bool ConstraintSystem::solveForCodeCompletion(
     SyntacticElementTarget &target, SmallVectorImpl<Solution> &solutions) {
   if (auto *expr = target.getAsExpr()) {
     // Tell the constraint system what the contextual type is.
-    setContextualType(expr, target.getExprContextualTypeLoc(),
-                      target.getExprContextualTypePurpose());
+    setContextualInfo(expr, target.getExprContextualTypeInfo());
 
     // Set up the expression type checker timer.
     Timer.emplace(expr, *this);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -458,8 +458,7 @@ TypeChecker::typeCheckTarget(SyntacticElementTarget &target,
   if (auto *expr = target.getAsExpr()) {
     // Tell the constraint system what the contextual type is.  This informs
     // diagnostics and is a hint for various performance optimizations.
-    cs.setContextualType(expr, target.getExprContextualTypeLoc(),
-                         target.getExprContextualTypePurpose());
+    cs.setContextualInfo(expr, target.getExprContextualTypeInfo());
 
     // Try to shrink the system by reducing disjunction domains. This
     // goes through every sub-expression and generate its own sub-system, to
@@ -751,9 +750,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
   }
 
   defaultExprTarget.setExprConversionType(contextualTy);
-  cs.setContextualType(defaultValue,
-                       defaultExprTarget.getExprContextualTypeLoc(),
-                       defaultExprTarget.getExprContextualTypePurpose());
+  cs.setContextualInfo(defaultValue,
+                       defaultExprTarget.getExprContextualTypeInfo());
 
   auto viable = cs.solve(defaultExprTarget, FreeTypeVariableBinding::Disallow);
   if (!viable)

--- a/unittests/Sema/PlaceholderTypeInferenceTests.cpp
+++ b/unittests/Sema/PlaceholderTypeInferenceTests.cpp
@@ -36,7 +36,8 @@ TEST_F(SemaTest, TestPlaceholderInferenceForArrayLiteral) {
       arrayExpr, DC, arrayTy, typedPattern, /*bindPatternVarsOneWay=*/false);
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());
-  cs.setContextualType(arrayExpr, {arrayRepr, arrayTy}, CTP_Initialization);
+  ContextualTypeInfo contextualInfo({arrayRepr, arrayTy}, CTP_Initialization);
+  cs.setContextualInfo(arrayExpr, contextualInfo);
   auto failed = cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
   ASSERT_FALSE(failed);
 
@@ -78,7 +79,8 @@ TEST_F(SemaTest, TestPlaceholderInferenceForDictionaryLiteral) {
       dictExpr, DC, dictTy, typedPattern, /*bindPatternVarsOneWay=*/false);
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());
-  cs.setContextualType(dictExpr, {dictRepr, dictTy}, CTP_Initialization);
+  ContextualTypeInfo contextualInfo({dictRepr, dictTy}, CTP_Initialization);
+  cs.setContextualInfo(dictExpr, contextualInfo);
   auto failed = cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
   ASSERT_FALSE(failed);
 


### PR DESCRIPTION
Move the contextual type locator onto ContextualTypeInfo, and consolidate the separate fields in SyntacticElementTarget into storing a ContextualTypeInfo. This then lets us plumb down the locator for the branch contextual type of an if/switch expression from the initial constraint generation, rather than introducing it later. This should be NFC.
