### PR TITLE
[Prototype] Import ObjC Bridging Header as module

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -914,6 +914,9 @@ namespace swift {
     /// Enable ClangIncludeTree for explicit module builds.
     bool UseClangIncludeTree = false;
 
+    /// Import clang bridging header as module.
+    bool BridgingHeaderAsModule = false;
+
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.
     llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -192,6 +192,10 @@ def clang_build_session_file : Separate<["-"], "clang-build-session-file">,
   Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Use the last modification time of <file> as the underlying Clang build session timestamp">;
 
+def clang_module_map : Separate<["-"], "clang-module-map">,
+  Flags<[FrontendOption, ArgumentIsPath]>,
+  HelpText<"clang module map path">, MetaVarName<"<path>">;
+
 def disallow_forwarding_driver :
   Flag<["-"], "disallow-use-new-driver">, Flags<[]>,
   HelpText<"Disable using new swift-driver">;
@@ -1837,6 +1841,10 @@ def cas_plugin_path: Separate<["-"], "cas-plugin-path">,
 def cas_plugin_option: Separate<["-"], "cas-plugin-option">,
   Flags<[FrontendOption, NewDriverOnlyOption]>,
   HelpText<"Option pass to CAS Plugin">, MetaVarName<"<name>=<option>">;
+
+def experimental_bridging_header_as_module: Flag<["-"], "experimental-bridging-header-as-module">,
+  Flags<[FrontendOption, NewDriverOnlyOption]>,
+  HelpText<"Import bridging header as module">;
 
 
 // END ONLY SUPPORTED IN NEW DRIVER

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1547,6 +1547,12 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     Opts.PrecompiledHeaderOutputDir = A->getValue();
     Opts.PCHDisableValidation |= Args.hasArg(OPT_pch_disable_validation);
   }
+  Opts.BridgingHeaderAsModule |=
+      Args.hasArg(OPT_experimental_bridging_header_as_module);
+
+  // Forward clang module map to clang importer through ExtraArgs.
+  for (const Arg *A : Args.filtered(OPT_clang_module_map))
+    Opts.ExtraArgs.push_back(std::string("-fmodule-map-file=") + A->getValue());
 
   if (FrontendOpts.DisableImplicitModules)
     Opts.DisableImplicitClangModules = true;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1192,6 +1192,9 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
     pushImport(CXX_SHIM_NAME, {ImportFlags::ImplementationOnly});
   }
 
+  if (Invocation.getClangImporterOptions().BridgingHeaderAsModule)
+    pushImport(CLANG_HEADER_MODULE_NAME, {ImportFlags::ImplementationOnly});
+
   imports.ShouldImportUnderlyingModule = frontendOpts.ImportUnderlyingModule;
   imports.BridgingHeaderPath = frontendOpts.ImplicitObjCHeaderPath;
   return imports;


### PR DESCRIPTION
Add a flag to import ObjC Bridging header as module. The function relies on the build system or driver pass in a clang module map that contains the bridging header module and `swift-frontend` will implementationOnly import the bridging header module.
