### PR TITLE
[SymbolGraphGen] don't emit symbols and protocols from unconditionally unavailable extensions

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -493,6 +493,13 @@ void SymbolGraph::recordConformanceRelationships(Symbol S) {
       });
     } else {
       for (const auto *Conformance : NTD->getAllConformances()) {
+        // Check to make sure that this conformance wasn't declared via an
+        // unconditionally-unavailable extension. If so, don't add that to the graph.
+        if (const auto *ED = dyn_cast_or_null<ExtensionDecl>(Conformance->getDeclContext())) {
+          if (isUnconditionallyUnavailableOnAllPlatforms(ED)) {
+            continue;
+          }
+        }
         recordEdge(
             S, Symbol(this, Conformance->getProtocol(), nullptr),
             RelationshipKind::ConformsTo(),

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -162,6 +162,10 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
       return false;
     }
 
+    if (SG->isUnconditionallyUnavailableOnAllPlatforms(Extension)) {
+      return false;
+    }
+
     if (isUnavailableOrObsoleted(ExtendedNominal)) {
       return false;
     }

--- a/test/SymbolGraph/Relationships/ConformsTo/Unavailable.swift
+++ b/test/SymbolGraph/Relationships/ConformsTo/Unavailable.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Unavailable -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name Unavailable -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Unavailable.symbols.json
+
+public class MyClass {}
+
+@available(*, unavailable)
+extension MyClass: Sendable {}
+
+// CHECK-NOT: conformsTo

--- a/test/SymbolGraph/Relationships/MemberOf/UnavailableExtension.swift
+++ b/test/SymbolGraph/Relationships/MemberOf/UnavailableExtension.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name UnavailableExtension -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name UnavailableExtension -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/UnavailableExtension.symbols.json 
+
+public class MyClass {}
+
+@available(*, unavailable)
+public extension MyClass {
+    func myFunc() {}
+}
+
+// CHECK-NOT: myFunc


### PR DESCRIPTION
Resolves rdar://112137607

When a protocol conformance is supplied via an extension tagged with `@available(*, unavailable)`, that protocol shouldn't be considered part of that type's API. This PR updates SymbolGraphGen to skip unconditionally-unavailable extension blocks and protocol conformances that come from them.