### PR TITLE
[Runtime] Gracefully handle null genericArgs in SubstGenericParametersFromMetadata.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -3063,6 +3063,10 @@ void SubstGenericParametersFromMetadata::setup() const {
 MetadataOrPack
 SubstGenericParametersFromMetadata::getMetadata(
                                         unsigned depth, unsigned index) const {
+  // Don't attempt anything if we have no generic parameters.
+  if (genericArgs == nullptr)
+    return MetadataOrPack();
+
   // On first access, compute the descriptor path.
   setup();
 
@@ -3104,6 +3108,10 @@ SubstGenericParametersFromMetadata::getMetadata(
 const WitnessTable *
 SubstGenericParametersFromMetadata::getWitnessTable(const Metadata *type,
                                                     unsigned index) const {
+  // Don't attempt anything if we have no generic parameters.
+  if (genericArgs == nullptr)
+    return nullptr;
+
   // On first access, compute the descriptor path.
   setup();
 


### PR DESCRIPTION
If a caller passes NULL generic parameters when looking up a generic type, we'll error and return NULL instead of crashing.

rdar://112153818