### PR TITLE
[cxx-interop] Fix assertion failure in IRGen with mutable dereference operators

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1921,7 +1921,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       if (auto cxxMethod = dyn_cast<clang::CXXMethodDecl>(functionDecl)) {
         if (op == clang::OverloadedOperatorKind::OO_Star &&
             cxxMethod->param_empty()) {
-          if (cxxMethod->isConst())
+          auto returnType = functionDecl->getReturnType();
+          if ((!returnType->isReferenceType() &&
+               !returnType->isAnyPointerType()) ||
+              returnType->isAnyPointerType() ||
+              returnType->getPointeeType().isConstQualified())
             result.info.accessorKind = ImportedAccessorKind::DereferenceGetter;
           else
             result.info.accessorKind = ImportedAccessorKind::DereferenceSetter;

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1691,7 +1691,6 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
               getterImpl->getStartLoc(), ctx.getIdentifier("pointee"), dc);
   result->setInterfaceType(elementTy);
   result->setAccess(AccessLevel::Public);
-  result->setImplInfo(StorageImplInfo::getImmutableComputed());
 
   AccessorDecl *getterDecl = AccessorDecl::create(
       ctx, getterImpl->getLoc(), getterImpl->getLoc(), AccessorKind::Get,
@@ -1709,6 +1708,9 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
   if (getterImpl->isMutating()) {
     getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
     result->setIsGetterMutating(true);
+  } else {
+    getterDecl->setSelfAccessKind(SelfAccessKind::NonMutating);
+    result->setIsGetterMutating(false);
   }
 
   AccessorDecl *setterDecl = nullptr;
@@ -1737,6 +1739,9 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
     if (setterImpl->isMutating()) {
       setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
       result->setIsSetterMutating(true);
+    } else {
+      setterDecl->setSelfAccessKind(SelfAccessKind::NonMutating);
+      result->setIsSetterMutating(false);
     }
   }
 

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -839,14 +839,15 @@ public:
                              std::output_iterator_tag {};
   using value_type = int;
   using pointer = int *;
-  using reference = const int &;
+  using reference = int &;
+  using const_reference = const int &;
   using difference_type = int;
 
   InputOutputIterator(int value) : value(value) {}
   InputOutputIterator(const InputOutputIterator &other) = default;
 
-  const int &operator*() const { return value; }
-  int &operator*() { return value; }
+  const_reference operator*() const { return value; }
+  reference operator*() { return value; }
 
   InputOutputIterator &operator++() {
     value++;
@@ -862,6 +863,41 @@ public:
     return value == other.value;
   }
   bool operator!=(const InputOutputIterator &other) const {
+    return value != other.value;
+  }
+};
+
+struct InputOutputConstIterator {
+private:
+  int *value;
+
+public:
+  struct iterator_category : std::input_iterator_tag,
+                             std::output_iterator_tag {};
+  using value_type = int;
+  using pointer = int *;
+  using reference = int &;
+  using difference_type = int;
+
+  InputOutputConstIterator(int *value) : value(value) {}
+  InputOutputConstIterator(const InputOutputConstIterator &other) = default;
+
+  reference operator*() const { return *value; }
+
+  InputOutputConstIterator &operator++() {
+    value++;
+    return *this;
+  }
+  InputOutputConstIterator operator++(int) {
+    auto tmp = InputOutputConstIterator(value);
+    value++;
+    return tmp;
+  }
+
+  bool operator==(const InputOutputConstIterator &other) const {
+    return value == other.value;
+  }
+  bool operator!=(const InputOutputConstIterator &other) const {
     return value != other.value;
   }
 };

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -135,4 +135,13 @@ public:
 typedef HasInheritedTemplatedConstIterator<int>
     HasInheritedTemplatedConstIteratorInt;
 
+struct HasInputOutputConstIterator {
+  typedef InputOutputConstIterator iterator;
+
+  mutable int x[5] = {5, 4, 3, 2, 1};
+
+  iterator begin() const { return iterator(x); }
+  iterator end() const { return iterator(x + 5); }
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_SEQUENCE_H

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -71,4 +71,10 @@ CxxSequenceTestSuite.test("HasInheritedTemplatedConstIterator to Swift.Array") {
   expectEqual([1, 2, 3, 4, 5, 6] as [Int32], array)
 }
 
+CxxSequenceTestSuite.test("HasInputOutputConstIterator to Swift.Array") {
+  let seq = HasInputOutputConstIterator()
+  let array = Array(seq)
+  expectEqual([5, 4, 3, 2, 1] as [Int32], array)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -132,6 +132,12 @@
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
+// CHECK: struct InputOutputConstIterator : UnsafeCxxMutableInputIterator {
+// CHECK:   func successor() -> InputOutputConstIterator
+// CHECK:   var pointee: Int32 { get nonmutating set }
+// CHECK:   typealias Pointee = Int32
+// CHECK: }
+
 // CHECK: struct MutableRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxMutableInputIterator {
 // CHECK:   func successor() -> MutableRACIterator
 // CHECK:   var pointee: Int32

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -56,3 +56,9 @@
 // CHECK-NOT:   typealias RawIterator
 // CHECK: }
 // CHECK: typealias HasUninstantiatableIterator = HasTemplatedIterator<Int32, NoDefinition<Int32>>
+
+// CHECK: struct HasInputOutputConstIterator : CxxConvertibleToCollection {
+// CHECK:   typealias Element = InputOutputConstIterator.Pointee
+// CHECK:   typealias Iterator = CxxIterator<HasInputOutputConstIterator>
+// CHECK:   typealias RawIterator = HasInputOutputConstIterator.iterator
+// CHECK: }


### PR DESCRIPTION
I discovered this when experimenting with `std::map::iterator`, which has a const overload of `operator*` that returns a non-const reference, and does not have a const overload of `operator*`.

rdar://112471779