### PR TITLE
[5.9][Stdlib] Add some prespecializations to the stdlib (#66446)

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -861,6 +861,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_enable_builtin_module))
     Opts.Features.insert(Feature::BuiltinModule);
 
+  Opts.Features.insert(Feature::LayoutPrespecialization);
+
   Opts.EnableAppExtensionRestrictions |= Args.hasArg(OPT_enable_app_extension);
 
   Opts.EnableSwift3ObjCInference =

--- a/stdlib/public/core/Prespecialize.swift
+++ b/stdlib/public/core/Prespecialize.swift
@@ -117,3 +117,147 @@ internal func _prespecialize() {
   consume(UnsafeBufferPointer<Int8>.self)
   consume(UnsafePointer<Int8>.self)
 }
+
+@_specializeExtension
+extension Array {
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _endMutation(),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__endMutation(){ Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__createNewBuffer(bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool) { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _makeUniqueAndReserveCapacityIfNotUnique(),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__makeUniqueAndReserveCapacityIfNotUnique() { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _appendElementAssumeUniqueAndCapacity(_:newElement:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__appendElementAssumeUniqueAndCapacity(_: Int, newElement: __owned Element) { Builtin.unreachable() }
+}
+
+#if _runtime(_ObjC)
+@_specializeExtension
+extension _ArrayBuffer {
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _consumeAndCreateNew(bufferIsUnique:minimumCapacity:growForAppend:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  func __specialize_class__consumeAndCreateNew(bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool) -> _ArrayBuffer<Element> { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _copyContents(initializing:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  __consuming func __specialize_class__copyContents(
+    initializing buffer: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _copyContents(subRange:initializing:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  __consuming func __specialize_class__copyContents(subRange: Range<Int>, initializing: Swift.UnsafeMutablePointer<Element>) -> Swift.UnsafeMutablePointer<Element> { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _getElementSlowPath(_:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  func __specialize_class__getElementSlowPath(_ i: Int) -> AnyObject { Builtin.unreachable() }
+}
+#endif
+
+@_specializeExtension
+extension ContiguousArray {
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _endMutation(),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__endMutation(){ Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__createNewBuffer(bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool) { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _makeUniqueAndReserveCapacityIfNotUnique(),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__makeUniqueAndReserveCapacityIfNotUnique() { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _appendElementAssumeUniqueAndCapacity(_:newElement:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__appendElementAssumeUniqueAndCapacity(_: Int, newElement: __owned Element) { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+              target: _reserveCapacityImpl(minimumCapacity:growForAppend:),
+              where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__reserveCapacityImpl(minimumCapacity: Int, growForAppend: Bool) { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+              target: _reserveCapacityAssumingUniqueBuffer(oldCount:),
+              where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__reserveCapacityAssumingUniqueBuffer(oldCount: Int) { Builtin.unreachable() }
+
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+              target: reserveCapacity(_:),
+              where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  mutating func __specialize_class__reserveCapacity(_ minimumCapacity: Int) { Builtin.unreachable() }
+}
+
+@_specializeExtension
+extension _ContiguousArrayBuffer {
+  @_specialize(exported: true,
+               availability: SwiftStdlib 5.9, *;
+               target: _consumeAndCreateNew(bufferIsUnique:minimumCapacity:growForAppend:),
+               where @_noMetadata Element : _Class)
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  func __specialize_class__consumeAndCreateNew(bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool) -> _ContiguousArrayBuffer<Element> { Builtin.unreachable() }
+}

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -69,7 +69,6 @@ public func mutateBaseArray(_ arr: inout [Base], _ x: Base) {
 // Check if all specializations from stdlib functions are created in the same LLVM module.
 
 // CHECK-MAINLL-DAG: define {{.*}} @"$ss{{(12_|22_Contiguous)}}ArrayBufferV20_consumeAndCreateNew14bufferIsUnique15minimumCapacity13growForAppendAByxGSb_SiSbtF4test8MyStructV_Tg5"
-// CHECK-MAINLL-DAG: define {{.*}} @"$ss{{(12_|22_Contiguous)}}ArrayBufferV20_consumeAndCreateNew14bufferIsUnique15minimumCapacity13growForAppendAByxGSb_SiSbtF4test4BaseC_Tg5"
 
 // Check if the DI filename is correct and not "<unknown>".
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -124,4 +124,13 @@ Var _StringGuts._isContiguousUTF16 has been removed
 Var _StringGuts.startUTF16 has been removed
 Func _persistCString(_:) has been removed
 
+// These functions have not been renamed, they are pre-specialized versions and purely additive.
+// These seem to be false positives in the ABI checker. The original symbols are still present.
+Func Array._createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:) has been renamed to Func __specialize_class__createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:)
+Func Array._createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:) has mangled name changing from 'Swift.Array._createNewBuffer(bufferIsUnique: Swift.Bool, minimumCapacity: Swift.Int, growForAppend: Swift.Bool) -> ()' to 'Swift.Array.__specialize_class__createNewBuffer(bufferIsUnique: Swift.Bool, minimumCapacity: Swift.Int, growForAppend: Swift.Bool) -> ()'
+Func ContiguousArray._createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:) has been renamed to Func __specialize_class__createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:)
+Func ContiguousArray._createNewBuffer(bufferIsUnique:minimumCapacity:growForAppend:) has mangled name changing from 'Swift.ContiguousArray._createNewBuffer(bufferIsUnique: Swift.Bool, minimumCapacity: Swift.Int, growForAppend: Swift.Bool) -> ()' to 'Swift.ContiguousArray.__specialize_class__createNewBuffer(bufferIsUnique: Swift.Bool, minimumCapacity: Swift.Int, growForAppend: Swift.Bool) -> ()'
+Func ContiguousArray._reserveCapacityImpl(minimumCapacity:growForAppend:) has been renamed to Func __specialize_class__reserveCapacityImpl(minimumCapacity:growForAppend:)
+Func ContiguousArray._reserveCapacityImpl(minimumCapacity:growForAppend:) has mangled name changing from 'Swift.ContiguousArray._reserveCapacityImpl(minimumCapacity: Swift.Int, growForAppend: Swift.Bool) -> ()' to 'Swift.ContiguousArray.__specialize_class__reserveCapacityImpl(minimumCapacity: Swift.Int, growForAppend: Swift.Bool) -> ()'
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -589,6 +589,9 @@ int main(int argc, char **argv) {
       toOptionalBool(EnableExperimentalMoveOnly);
   if (enableExperimentalMoveOnly && *enableExperimentalMoveOnly)
     Invocation.getLangOptions().Features.insert(Feature::MoveOnly);
+
+  Invocation.getLangOptions().Features.insert(Feature::LayoutPrespecialization);
+
   for (auto &featureName : ExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureName)) {
       Invocation.getLangOptions().Features.insert(*feature);


### PR DESCRIPTION
Explanation: This adds prespecializations for commonly used types to the stdlib
Scope: Code size and performance for arrays of reference types.
Issue: rdar://112931774
Cherry-picked from: https://github.com/apple/swift/pull/66446
Risk: Low. 
Testing: Covered by existing tests.
Reviewer: @mikeash 