### PR TITLE
[🌲] Move to llvm::MemoryEffects

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -29,6 +29,7 @@
 ///     list of expressions meant to be looked up in IRGenModule.
 ///   Attrs is a parenthesized list of attributes.
 ///   Effect is a list of runtime effects as defined by RuntimeEffect.
+///   MemEffects is a list of memory effects
 ///
 ///   By default, passes Id to FUNCTION_ID.  Therefore, the valid uses of
 ///   this database define either:
@@ -40,8 +41,11 @@
 ///     NO_ARGS
 ///     ATTRS
 ///     NO_ATTRS
+///     MEMEFFECTS
+///     NO_MEMEFFECTS
+
 #ifndef FUNCTION
-#define FUNCTION(Id, Name, CC, Availability, ReturnTys, ArgTys, Attrs, Effect) \
+#define FUNCTION(Id, Name, CC, Availability, ReturnTys, ArgTys, Attrs, Effect, MemEffects) \
   FUNCTION_ID(Id)
 #endif
 
@@ -49,7 +53,8 @@ FUNCTION(AllocBox, swift_allocBox, SwiftCC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy, OpaquePtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 
 //  BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata *type, size_t alignMask);
 FUNCTION(MakeBoxUnique,
@@ -58,33 +63,38 @@ FUNCTION(MakeBoxUnique,
          RETURNS(RefCountedPtrTy, OpaquePtrTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 
 FUNCTION(DeallocBox, swift_deallocBox, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // swift_projectBox reads object metadata so cannot be marked ReadNone.
 FUNCTION(ProjectBox, swift_projectBox, C_CC, AlwaysAvailable,
          RETURNS(OpaquePtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind, ReadOnly, ArgMemOnly, WillReturn),
-         EFFECT(NoEffect))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(NoEffect),
+         MEMEFFECTS(ReadOnly, ArgMemOnly))
 
 FUNCTION(AllocEmptyBox, swift_allocEmptyBox, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // RefCounted *swift_allocObject(Metadata *type, size_t size, size_t alignMask);
 FUNCTION(AllocObject, swift_allocObject, C_CC,  AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 
 // HeapObject *swift_initStackObject(HeapMetadata const *metadata,
 //                                   HeapObject *object);
@@ -92,7 +102,8 @@ FUNCTION(InitStackObject, swift_initStackObject, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(TypeMetadataPtrTy, RefCountedPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // HeapObject *swift_initStaticObject(HeapMetadata const *metadata,
 //                                    HeapObject *object);
@@ -100,21 +111,24 @@ FUNCTION(InitStaticObject, swift_initStaticObject, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(TypeMetadataPtrTy, RefCountedPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(Locking))
+         EFFECT(Locking),
+         NO_MEMEFFECTS)
 
 // void swift_verifyEndOfLifetime(HeapObject *object);
 FUNCTION(VerifyEndOfLifetime, swift_verifyEndOfLifetime, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_deallocObject(HeapObject *obj, size_t size, size_t alignMask);
 FUNCTION(DeallocObject, swift_deallocObject, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_deallocUninitializedObject(HeapObject *obj, size_t size, size_t alignMask);
 FUNCTION(DeallocUninitializedObject, swift_deallocUninitializedObject,
@@ -122,14 +136,16 @@ FUNCTION(DeallocUninitializedObject, swift_deallocUninitializedObject,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_deallocClassInstance(HeapObject *obj, size_t size, size_t alignMask);
 FUNCTION(DeallocClassInstance, swift_deallocClassInstance, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_deallocPartialClassInstance(HeapObject *obj, HeapMetadata *type, size_t size, size_t alignMask);
 FUNCTION(DeallocPartialClassInstance, swift_deallocPartialClassInstance,
@@ -137,77 +153,88 @@ FUNCTION(DeallocPartialClassInstance, swift_deallocPartialClassInstance,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, TypeMetadataPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_slowAlloc(size_t size, size_t alignMask);
 FUNCTION(SlowAlloc, swift_slowAlloc, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 
 // void swift_slowDealloc(void *ptr, size_t size, size_t alignMask);
 FUNCTION(SlowDealloc, swift_slowDealloc, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_willThrow(error *ptr);
 FUNCTION(WillThrow, swift_willThrow, SwiftCC,  AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, ErrorPtrTy->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_errorInMain(error *ptr);
 FUNCTION(ErrorInMain, swift_errorInMain, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_unexpectedError(error *ptr);
 FUNCTION(UnexpectedError, swift_unexpectedError, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind, NoReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void *swift_copyPOD(void *dest, void *src, Metadata *self);
 FUNCTION(CopyPOD, swift_copyPOD, C_CC, AlwaysAvailable,
          RETURNS(OpaquePtrTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void *swift_retain(void *ptr);
 FUNCTION(NativeStrongRetain, swift_retain, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_release(void *ptr);
 FUNCTION(NativeStrongRelease, swift_release, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_retain_n(void *ptr, int32_t n);
 FUNCTION(NativeStrongRetainN, swift_retain_n, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void *swift_release_n(void *ptr, int32_t n);
 FUNCTION(NativeStrongReleaseN, swift_release_n, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_setDeallocating(void *ptr);
 FUNCTION(NativeSetDeallocating, swift_setDeallocating,
@@ -215,21 +242,24 @@ FUNCTION(NativeSetDeallocating, swift_setDeallocating,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void *swift_nonatomic_retain_n(void *ptr, int32_t n);
 FUNCTION(NativeNonAtomicStrongRetainN, swift_nonatomic_retain_n, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_release_n(void *ptr, int32_t n);
 FUNCTION(NativeNonAtomicStrongReleaseN, swift_nonatomic_release_n, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_unknownObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(UnknownObjectRetainN, swift_unknownObjectRetain_n,
@@ -237,7 +267,8 @@ FUNCTION(UnknownObjectRetainN, swift_unknownObjectRetain_n,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_unknownObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(UnknownObjectReleaseN, swift_unknownObjectRelease_n,
@@ -245,7 +276,8 @@ FUNCTION(UnknownObjectReleaseN, swift_unknownObjectRelease_n,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_nonatomic_unknownObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnknownObjectRetainN, swift_nonatomic_unknownObjectRetain_n,
@@ -253,7 +285,8 @@ FUNCTION(NonAtomicUnknownObjectRetainN, swift_nonatomic_unknownObjectRetain_n,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_unknownObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnknownObjectReleaseN, swift_nonatomic_unknownObjectRelease_n,
@@ -261,7 +294,8 @@ FUNCTION(NonAtomicUnknownObjectReleaseN, swift_nonatomic_unknownObjectRelease_n,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_bridgeObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(BridgeObjectRetainN, swift_bridgeObjectRetain_n,
@@ -269,7 +303,8 @@ FUNCTION(BridgeObjectRetainN, swift_bridgeObjectRetain_n,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_bridgeObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(BridgeObjectReleaseN, swift_bridgeObjectRelease_n,
@@ -277,7 +312,8 @@ FUNCTION(BridgeObjectReleaseN, swift_bridgeObjectRelease_n,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_bridgeObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicBridgeObjectRetainN, swift_nonatomic_bridgeObjectRetain_n,
@@ -285,7 +321,8 @@ FUNCTION(NonAtomicBridgeObjectRetainN, swift_nonatomic_bridgeObjectRetain_n,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_bridgeObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicBridgeObjectReleaseN, swift_nonatomic_bridgeObjectRelease_n,
@@ -293,7 +330,8 @@ FUNCTION(NonAtomicBridgeObjectReleaseN, swift_nonatomic_bridgeObjectRelease_n,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_nonatomic_retain(void *ptr);
 FUNCTION(NativeNonAtomicStrongRetain, swift_nonatomic_retain,
@@ -301,7 +339,8 @@ FUNCTION(NativeNonAtomicStrongRetain, swift_nonatomic_retain,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_release(void *ptr);
 FUNCTION(NativeNonAtomicStrongRelease, swift_nonatomic_release,
@@ -309,28 +348,32 @@ FUNCTION(NativeNonAtomicStrongRelease, swift_nonatomic_release,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_tryRetain(void *ptr);
 FUNCTION(NativeTryRetain, swift_tryRetain, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(RefCounting, Locking))
+         EFFECT(RefCounting, Locking),
+         NO_MEMEFFECTS)
 
 // bool swift_isDeallocating(void *ptr);
 FUNCTION(IsDeallocating, swift_isDeallocating, C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void *swift_unknownObjectRetain(void *ptr);
 FUNCTION(UnknownObjectRetain, swift_unknownObjectRetain, C_CC, AlwaysAvailable,
          RETURNS(UnknownRefCountedPtrTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_unknownObjectRelease(void *ptr);
 FUNCTION(UnknownObjectRelease, swift_unknownObjectRelease,
@@ -338,7 +381,8 @@ FUNCTION(UnknownObjectRelease, swift_unknownObjectRelease,
          RETURNS(VoidTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_nonatomic_unknownObjectRetain(void *ptr);
 FUNCTION(NonAtomicUnknownObjectRetain, swift_nonatomic_unknownObjectRetain,
@@ -346,7 +390,8 @@ FUNCTION(NonAtomicUnknownObjectRetain, swift_nonatomic_unknownObjectRetain,
          RETURNS(UnknownRefCountedPtrTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_unknownObjectRelease(void *ptr);
 FUNCTION(NonAtomicUnknownObjectRelease, swift_nonatomic_unknownObjectRelease,
@@ -354,7 +399,8 @@ FUNCTION(NonAtomicUnknownObjectRelease, swift_nonatomic_unknownObjectRelease,
          RETURNS(VoidTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_bridgeObjectRetain(void *ptr);
 FUNCTION(BridgeObjectStrongRetain, swift_bridgeObjectRetain,
@@ -362,7 +408,8 @@ FUNCTION(BridgeObjectStrongRetain, swift_bridgeObjectRetain,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_bridgeRelease(void *ptr);
 FUNCTION(BridgeObjectStrongRelease, swift_bridgeObjectRelease,
@@ -370,7 +417,8 @@ FUNCTION(BridgeObjectStrongRelease, swift_bridgeObjectRelease,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_nonatomic_bridgeObjectRetain(void *ptr);
 FUNCTION(NonAtomicBridgeObjectStrongRetain, swift_nonatomic_bridgeObjectRetain,
@@ -378,7 +426,8 @@ FUNCTION(NonAtomicBridgeObjectStrongRetain, swift_nonatomic_bridgeObjectRetain,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, FirstParamReturned),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_nonatomic_bridgeRelease(void *ptr);
 FUNCTION(NonAtomicBridgeObjectStrongRelease,
@@ -387,7 +436,8 @@ FUNCTION(NonAtomicBridgeObjectStrongRelease,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 
 // error *swift_errorRetain(error *ptr);
@@ -396,7 +446,8 @@ FUNCTION(ErrorStrongRetain, swift_errorRetain,
          RETURNS(ErrorPtrTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_errorRelease(void *ptr);
 FUNCTION(ErrorStrongRelease, swift_errorRelease,
@@ -404,7 +455,8 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Nativeness, SymName, UnknownPrefix) \
   /* void swift_##SymName##Destroy(Name##Reference *object); */ \
@@ -413,63 +465,73 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease,
            RETURNS(VoidTy), \
            ARGS(Name##ReferencePtrTy), \
            ATTRS(NoUnwind), \
-           EFFECT(RefCounting, Deallocating)) \
+           EFFECT(RefCounting, Deallocating), \
+           NO_MEMEFFECTS) \
   /* void swift_##SymName##Init(Name##Reference *object, void *value); */ \
   FUNCTION(Nativeness##Name##Init, swift_##SymName##Init, \
            C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, UnknownPrefix##RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned, WillReturn), \
-           EFFECT(NoEffect)) \
+           EFFECT(NoEffect), \
+           NO_MEMEFFECTS) \
   /* Name##Reference *swift_##SymName##Assign(Name##Reference *object, void *value); */ \
   FUNCTION(Nativeness##Name##Assign, swift_##SymName##Assign, \
            C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, UnknownPrefix##RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned), \
-           EFFECT(RefCounting, Deallocating)) \
+           EFFECT(RefCounting, Deallocating), \
+           NO_MEMEFFECTS) \
   /* void *swift_##SymName##Load(Name##Reference *object); */ \
   FUNCTION(Nativeness##Name##LoadStrong, swift_##SymName##LoadStrong, \
            C_CC, AlwaysAvailable, \
            RETURNS(UnknownPrefix##RefCountedPtrTy), \
            ARGS(Name##ReferencePtrTy), \
            ATTRS(NoUnwind, WillReturn), \
-           EFFECT(NoEffect)) \
+           EFFECT(NoEffect), \
+           NO_MEMEFFECTS) \
   /* void *swift_##SymName##Take(Name##Reference *object); */ \
   FUNCTION(Nativeness##Name##TakeStrong, swift_##SymName##TakeStrong, \
            C_CC, AlwaysAvailable, \
            RETURNS(UnknownPrefix##RefCountedPtrTy), \
            ARGS(Name##ReferencePtrTy), \
            ATTRS(NoUnwind, WillReturn), \
-           EFFECT(NoEffect)) \
+           EFFECT(NoEffect), \
+           NO_MEMEFFECTS) \
   /* Name##Reference *swift_##SymName##CopyInit(Name##Reference *dest, Name##Reference *src); */ \
   FUNCTION(Nativeness##Name##CopyInit, swift_##SymName##CopyInit, \
            C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned, WillReturn), \
-           EFFECT(RefCounting)) \
+           EFFECT(RefCounting), \
+           NO_MEMEFFECTS) \
   /* void *swift_##SymName##TakeInit(Name##Reference *dest, Name##Reference *src); */ \
   FUNCTION(Nativeness##Name##TakeInit, swift_##SymName##TakeInit, \
            C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned, WillReturn), \
-           EFFECT(NoEffect)) \
+           EFFECT(NoEffect), \
+           NO_MEMEFFECTS) \
   /* Name##Reference *swift_##SymName##CopyAssign(Name##Reference *dest, Name##Reference *src); */ \
   FUNCTION(Nativeness##Name##CopyAssign, swift_##SymName##CopyAssign, \
            C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned), \
-           EFFECT(RefCounting, Deallocating)) \
+           EFFECT(RefCounting, Deallocating), \
+           NO_MEMEFFECTS) \
   /* Name##Reference *swift_##SymName##TakeAssign(Name##Reference *dest, Name##Reference *src); */ \
   FUNCTION(Nativeness##Name##TakeAssign, swift_##SymName##TakeAssign, \
            C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned), \
-           EFFECT(RefCounting, Deallocating))
+           EFFECT(RefCounting, Deallocating), \
+           NO_MEMEFFECTS)
+
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Native, name, ) \
   NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Unknown, unknownObject##Name, Unknown)
@@ -480,21 +542,24 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease,
            RETURNS(RefCountedPtrTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned, WillReturn), \
-           EFFECT(RefCounting)) \
+           EFFECT(RefCounting), \
+           NO_MEMEFFECTS) \
   /* void swift_##prefix##name##Release(void *ptr); */ \
   FUNCTION(Prefix##Name##Release, swift_##prefix##name##Release, \
            C_CC, AlwaysAvailable, \
            RETURNS(VoidTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind), \
-           EFFECT(RefCounting, Deallocating)) \
+           EFFECT(RefCounting, Deallocating), \
+           NO_MEMEFFECTS) \
   /* void *swift_##prefix##name##RetainStrong(void *ptr); */ \
   FUNCTION(Prefix##StrongRetain##Name, swift_##prefix##name##RetainStrong, \
            C_CC, AlwaysAvailable, \
            RETURNS(RefCountedPtrTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned, WillReturn), \
-           EFFECT(RefCounting)) \
+           EFFECT(RefCounting), \
+           NO_MEMEFFECTS) \
   /* void swift_##prefix##name##RetainStrongAndRelease(void *ptr); */ \
   FUNCTION(Prefix##StrongRetainAnd##Name##Release, \
            swift_##prefix##name##RetainStrongAndRelease, \
@@ -502,7 +567,8 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease,
            RETURNS(VoidTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind), \
-           EFFECT(RefCounting))
+           EFFECT(RefCounting), \
+           NO_MEMEFFECTS)
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Unknown, unknownObject##Name, Unknown) \
   LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name, Native, ) \
@@ -520,7 +586,8 @@ FUNCTION(IsUniquelyReferencedNonObjC, swift_isUniquelyReferencedNonObjC,
          RETURNS(Int1Ty),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferencedNonObjC_nonNull(const void *);
 FUNCTION(IsUniquelyReferencedNonObjC_nonNull,
@@ -529,7 +596,8 @@ FUNCTION(IsUniquelyReferencedNonObjC_nonNull,
          RETURNS(Int1Ty),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferencedNonObjC_nonNull_bridgeObject(
 //   uintptr_t bits);
@@ -539,7 +607,8 @@ FUNCTION(IsUniquelyReferencedNonObjC_nonNull_bridgeObject,
          RETURNS(Int1Ty),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferenced(const void *);
 FUNCTION(IsUniquelyReferenced, swift_isUniquelyReferenced,
@@ -547,7 +616,8 @@ FUNCTION(IsUniquelyReferenced, swift_isUniquelyReferenced,
          RETURNS(Int1Ty),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferenced_nonNull(const void *);
 FUNCTION(IsUniquelyReferenced_nonNull,
@@ -556,7 +626,8 @@ FUNCTION(IsUniquelyReferenced_nonNull,
          RETURNS(Int1Ty),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferenced_nonNull_bridgeObject(
 //   uintptr_t bits);
@@ -566,7 +637,8 @@ FUNCTION(IsUniquelyReferenced_nonNull_bridgeObject,
          RETURNS(Int1Ty),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferenced_native(const struct HeapObject *);
 FUNCTION(IsUniquelyReferenced_native, swift_isUniquelyReferenced_native,
@@ -574,7 +646,8 @@ FUNCTION(IsUniquelyReferenced_native, swift_isUniquelyReferenced_native,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isUniquelyReferenced_nonNull_native(const struct HeapObject *);
 FUNCTION(IsUniquelyReferenced_nonNull_native,
@@ -583,7 +656,8 @@ FUNCTION(IsUniquelyReferenced_nonNull_native,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // bool swift_isEscapingClosureAtFileLocation(const struct HeapObject *object,
 //                                            const unsigned char *filename,
@@ -596,7 +670,8 @@ FUNCTION(IsEscapingClosureAtFileLocation, swift_isEscapingClosureAtFileLocation,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy, Int8PtrTy, Int32Ty, Int32Ty, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ZExt),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_arrayInitWithCopy(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayInitWithCopy, swift_arrayInitWithCopy,
@@ -604,7 +679,8 @@ FUNCTION(ArrayInitWithCopy, swift_arrayInitWithCopy,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_arrayInitWithTakeNoAlias(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayInitWithTakeNoAlias, swift_arrayInitWithTakeNoAlias,
@@ -612,7 +688,8 @@ FUNCTION(ArrayInitWithTakeNoAlias, swift_arrayInitWithTakeNoAlias,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_arrayInitWithTakeFrontToBack(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayInitWithTakeFrontToBack, swift_arrayInitWithTakeFrontToBack,
@@ -620,7 +697,8 @@ FUNCTION(ArrayInitWithTakeFrontToBack, swift_arrayInitWithTakeFrontToBack,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_arrayInitWithTakeBackToFront(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayInitWithTakeBackToFront, swift_arrayInitWithTakeBackToFront,
@@ -628,7 +706,8 @@ FUNCTION(ArrayInitWithTakeBackToFront, swift_arrayInitWithTakeBackToFront,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_arrayAssignWithCopyNoAlias(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithCopyNoAlias, swift_arrayAssignWithCopyNoAlias,
@@ -636,7 +715,8 @@ FUNCTION(ArrayAssignWithCopyNoAlias, swift_arrayAssignWithCopyNoAlias,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_arrayAssignWithCopyFrontToBack(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithCopyFrontToBack, swift_arrayAssignWithCopyFrontToBack,
@@ -644,7 +724,8 @@ FUNCTION(ArrayAssignWithCopyFrontToBack, swift_arrayAssignWithCopyFrontToBack,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_arrayAssignWithCopyBackToFront(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithCopyBackToFront, swift_arrayAssignWithCopyBackToFront,
@@ -652,21 +733,24 @@ FUNCTION(ArrayAssignWithCopyBackToFront, swift_arrayAssignWithCopyBackToFront,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_arrayAssignWithTake(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithTake, swift_arrayAssignWithTake, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void swift_arrayDestroy(opaque*, size_t, type*);
 FUNCTION(ArrayDestroy, swift_arrayDestroy, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(RefCounting, Deallocating))
+         EFFECT(RefCounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getFunctionTypeMetadata(unsigned long flags,
 //                                         const Metadata **parameters,
@@ -679,8 +763,9 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata,
               TypeMetadataPtrTy->getPointerTo(0),
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // Metadata *
 // swift_getFunctionTypeMetadataDifferentiable(unsigned long flags,
@@ -697,8 +782,9 @@ FUNCTION(GetFunctionMetadataDifferentiable,
               TypeMetadataPtrTy->getPointerTo(0),
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // Metadata *
 // swift_getFunctionTypeMetadataGlobalActor(unsigned long flags,
@@ -717,8 +803,9 @@ FUNCTION(GetFunctionMetadataGlobalActor,
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy,
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // Metadata *
 // swift_getFunctionTypeMetadataGlobalActorBackDeploy(unsigned long flags,
@@ -737,8 +824,9 @@ FUNCTION(GetFunctionMetadataGlobalActorBackDeploy,
               Int32Ty->getPointerTo(0),
               TypeMetadataPtrTy,
               TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // Metadata *swift_getFunctionTypeMetadata0(unsigned long flags,
 //                                          const Metadata *resultMetadata);
@@ -747,7 +835,8 @@ FUNCTION(GetFunctionMetadata0, swift_getFunctionTypeMetadata0,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
 //                                          const Metadata *arg0,
@@ -757,7 +846,8 @@ FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1,
         RETURNS(TypeMetadataPtrTy),
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone),
-        EFFECT(MetaData))
+        EFFECT(MetaData),
+        NO_MEMEFFECTS)
 
 // Metadata *swift_getFunctionTypeMetadata2(unsigned long flags,
 //                                          const Metadata *arg0,
@@ -768,7 +858,8 @@ FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
         RETURNS(TypeMetadataPtrTy),
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone),
-        EFFECT(MetaData))
+        EFFECT(MetaData),
+        NO_MEMEFFECTS)
 
 // Metadata *swift_getFunctionTypeMetadata3(unsigned long flags,
 //                                          const Metadata *arg0,
@@ -781,7 +872,8 @@ FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
              TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone),
-        EFFECT(MetaData))
+        EFFECT(MetaData),
+        NO_MEMEFFECTS)
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);
 FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata,
@@ -789,7 +881,8 @@ FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone), // only writes to runtime-private fields
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // SWIFT_RUNTIME_EXPORT
 // SWIFT_CC(swift)
@@ -802,7 +895,8 @@ FUNCTION(CompareTypeContextDescriptors,
          ARGS(TypeContextDescriptorPtrTy, 
               TypeContextDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(NoEffect)) // ?
+         EFFECT(NoEffect), // ?
+         NO_MEMEFFECTS)
 
 // MetadataResponse swift_getSingletonMetadata(MetadataRequest request,
 //                                             TypeContextDescriptor *type);
@@ -811,7 +905,8 @@ FUNCTION(GetSingletonMetadata, swift_getSingletonMetadata,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeContextDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // MetadataResponse swift_getGenericMetadata(MetadataRequest request,
 //                                           const void * const *arguments,
@@ -820,8 +915,9 @@ FUNCTION(GetGenericMetadata, swift_getGenericMetadata,
          SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, TypeContextDescriptorPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // MetadataResponse swift_getCanonicalSpecializedMetadata(MetadataRequest request,
 //                                                        Metadata *candidate);
@@ -829,8 +925,9 @@ FUNCTION(GetCanonicalSpecializedMetadata, swift_getCanonicalSpecializedMetadata,
          SwiftCC, GetCanonicalSpecializedMetadataAvailability,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // MetadataResponse
 // swift_getCanonicalPrespecializedGenericMetadata(MetadataRequest request,
@@ -842,8 +939,9 @@ FUNCTION(GetCanonicalPrespecializedGenericMetadata,
          SwiftCC, GetCanonicalPrespecializedGenericMetadataAvailability,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, TypeContextDescriptorPtrTy, OnceTy->getPointerTo()),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // MetadataResponse swift_getOpaqueTypeMetadata(MetadataRequest request,
 //                                     const void * const *arguments,
@@ -853,8 +951,10 @@ FUNCTION(GetOpaqueTypeMetadata, swift_getOpaqueTypeMetadata,
          SwiftCC, OpaqueTypeAvailability,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
+
 
 // MetadataResponse swift_getOpaqueTypeMetadata2(MetadataRequest request,
 //                                     const void * const *arguments,
@@ -864,8 +964,10 @@ FUNCTION(GetOpaqueTypeMetadata2, swift_getOpaqueTypeMetadata2,
          SwiftCC, SignedDescriptorAvailability,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
+
 
 // const WitnessTable *swift_getOpaqueTypeConformance(const void * const *arguments,
 //                                     const OpaqueTypeDescriptor *descriptor,
@@ -874,8 +976,9 @@ FUNCTION(GetOpaqueTypeConformance, swift_getOpaqueTypeConformance,
          SwiftCC, OpaqueTypeAvailability,
          RETURNS(WitnessTablePtrTy),
          ARGS(Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // const WitnessTable *swift_getOpaqueTypeConformance2(const void * const *arguments,
 //                                     const OpaqueTypeDescriptor *descriptor,
@@ -884,8 +987,9 @@ FUNCTION(GetOpaqueTypeConformance2, swift_getOpaqueTypeConformance2,
          SwiftCC, SignedDescriptorAvailability,
          RETURNS(WitnessTablePtrTy),
          ARGS(Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // Metadata *swift_allocateGenericClassMetadata(ClassDescriptor *type,
 //                                              const void * const *arguments,
@@ -895,7 +999,8 @@ FUNCTION(AllocateGenericClassMetadata, swift_allocateGenericClassMetadata,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_allocateGenericClassMetadataWithLayoutString(
 //     ClassDescriptor *type,
@@ -907,7 +1012,8 @@ FUNCTION(AllocateGenericClassMetadataWithLayoutString,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_allocateGenericValueMetadata(ValueTypeDescriptor *type,
 //                                              const void * const *arguments,
@@ -918,7 +1024,8 @@ FUNCTION(AllocateGenericValueMetadata, swift_allocateGenericValueMetadata,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_allocateGenericValueMetadataWithLayoutString(
 //     ValueTypeDescriptor *type,
@@ -931,7 +1038,8 @@ FUNCTION(AllocateGenericValueMetadataWithLayoutString,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // MetadataResponse swift_checkMetadataState(MetadataRequest request,
 //                                           const Metadata *type);
@@ -939,8 +1047,10 @@ FUNCTION(CheckMetadataState, swift_checkMetadataState,
          SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ReadOnly))
+
 
 // const ProtocolWitnessTable *
 // swift_getWitnessTable(const ProtocolConformanceDescriptor *conf,
@@ -951,15 +1061,18 @@ FUNCTION(GetWitnessTable, swift_getWitnessTable, C_CC, AlwaysAvailable,
          ARGS(ProtocolConformanceDescriptorPtrTy,
               TypeMetadataPtrTy,
               WitnessTablePtrPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ReadOnly))
+
 FUNCTION(GetWitnessTableRelative, swift_getWitnessTableRelative, C_CC, AlwaysAvailable,
          RETURNS(WitnessTablePtrTy),
          ARGS(ProtocolConformanceDescriptorPtrTy,
               TypeMetadataPtrTy,
               WitnessTablePtrPtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ReadOnly))
 
 // MetadataResponse swift_getAssociatedTypeWitness(
 //                                            MetadataRequest request,
@@ -976,7 +1089,8 @@ FUNCTION(GetAssociatedTypeWitness, swift_getAssociatedTypeWitness,
               ProtocolRequirementStructTy->getPointerTo(),
               ProtocolRequirementStructTy->getPointerTo()),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 FUNCTION(GetAssociatedTypeWitnessRelative, swift_getAssociatedTypeWitnessRelative,
          SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
@@ -986,7 +1100,8 @@ FUNCTION(GetAssociatedTypeWitnessRelative, swift_getAssociatedTypeWitnessRelativ
               ProtocolRequirementStructTy->getPointerTo(),
               ProtocolRequirementStructTy->getPointerTo()),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 // const WitnessTable *swift_getAssociatedConformanceWitness(
@@ -1004,7 +1119,8 @@ FUNCTION(GetAssociatedConformanceWitness,
               ProtocolRequirementStructTy->getPointerTo(),
               ProtocolRequirementStructTy->getPointerTo()),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 FUNCTION(GetAssociatedConformanceWitnessRelative,
          swift_getAssociatedConformanceWitnessRelative, SwiftCC, AlwaysAvailable,
          RETURNS(WitnessTablePtrTy),
@@ -1014,7 +1130,8 @@ FUNCTION(GetAssociatedConformanceWitnessRelative,
               ProtocolRequirementStructTy->getPointerTo(),
               ProtocolRequirementStructTy->getPointerTo()),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // SWIFT_RUNTIME_EXPORT
 //     SWIFT_CC(swift) bool swift_compareProtocolConformanceDescriptors(
@@ -1027,7 +1144,8 @@ FUNCTION(CompareProtocolConformanceDescriptors,
          ARGS(ProtocolConformanceDescriptorPtrTy, 
               ProtocolConformanceDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(NoEffect)) // ?
+         EFFECT(NoEffect), // ?
+         NO_MEMEFFECTS)
 
 // SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 // const Metadata * const *
@@ -1038,7 +1156,8 @@ FUNCTION(AllocateMetadataPack,
          RETURNS(TypeMetadataPtrPtrTy),
          ARGS(TypeMetadataPtrPtrTy, SizeTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 // const WitnessTable * const *
@@ -1049,14 +1168,16 @@ FUNCTION(AllocateWitnessTablePack,
          RETURNS(WitnessTablePtrPtrTy),
          ARGS(WitnessTablePtrPtrTy, SizeTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getMetatypeMetadata(Metadata *instanceTy);
 FUNCTION(GetMetatypeMetadata, swift_getMetatypeMetadata, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getExistentialMetatypeMetadata(Metadata *instanceTy);
 FUNCTION(GetExistentialMetatypeMetadata,
@@ -1064,7 +1185,8 @@ FUNCTION(GetExistentialMetatypeMetadata,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getObjCClassMetadata(objc_class *theClass);
 FUNCTION(GetObjCClassMetadata, swift_getObjCClassMetadata,
@@ -1072,7 +1194,8 @@ FUNCTION(GetObjCClassMetadata, swift_getObjCClassMetadata,
          RETURNS(TypeMetadataPtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData)) // ?
+         EFFECT(MetaData), // ?
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getObjCClassFromMetadata(objc_class *theClass);
 FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata,
@@ -1080,7 +1203,8 @@ FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata,
          RETURNS(ObjCClassPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(NoEffect)) // ?
+         EFFECT(NoEffect), // ?
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getObjCClassFromObject(id object);
 // This reads object metadata so cannot be marked ReadNone.
@@ -1088,8 +1212,9 @@ FUNCTION(GetObjCClassFromObject, swift_getObjCClassFromObject,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCPtrTy),
-         ATTRS(NoUnwind, ReadOnly, ArgMemOnly, WillReturn),
-         EFFECT(NoEffect)) // ?
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(NoEffect), // ?
+         MEMEFFECTS(ReadOnly, ArgMemOnly))
 
 // MetadataResponse swift_getTupleTypeMetadata(MetadataRequest request,
 //                                             TupleTypeFlags flags,
@@ -1100,8 +1225,9 @@ FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, SizeTy, TypeMetadataPtrTy->getPointerTo(0),
               Int8PtrTy, WitnessTablePtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // MetadataResponse swift_getTupleTypeMetadata2(MetadataRequest request,
 //                                              Metadata *elt0, Metadata *elt1,
@@ -1111,8 +1237,9 @@ FUNCTION(GetTupleMetadata2, swift_getTupleTypeMetadata2, SwiftCC, AlwaysAvailabl
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               Int8PtrTy, WitnessTablePtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // MetadataResponse swift_getTupleTypeMetadata3(MetadataRequest request,
 //                                              Metadata *elt0, Metadata *elt1,
@@ -1123,8 +1250,9 @@ FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, SwiftCC, AlwaysAvailabl
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               Int8PtrTy, WitnessTablePtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // void swift_getTupleTypeLayout(TypeLayout *result,
 //                               uint32_t offsets,
@@ -1135,7 +1263,8 @@ FUNCTION(GetTupleLayout, swift_getTupleTypeLayout, SwiftCC, AlwaysAvailable,
          ARGS(FullTypeLayoutTy->getPointerTo(0), Int32Ty->getPointerTo(0),
               SizeTy, Int8PtrPtrTy->getPointerTo(0)),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // size_t swift_getTupleTypeLayout2(TypeLayout *layout,
 //                                  const TypeLayout *elt0,
@@ -1144,7 +1273,8 @@ FUNCTION(GetTupleLayout2, swift_getTupleTypeLayout2, SwiftCC, AlwaysAvailable,
          RETURNS(SizeTy),
          ARGS(FullTypeLayoutTy->getPointerTo(0), Int8PtrPtrTy, Int8PtrPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // OffsetPair swift_getTupleTypeLayout3(TypeLayout *layout,
 //                                      const TypeLayout *elt0,
@@ -1155,7 +1285,8 @@ FUNCTION(GetTupleLayout3, swift_getTupleTypeLayout3, SwiftCC, AlwaysAvailable,
          ARGS(FullTypeLayoutTy->getPointerTo(0),
               Int8PtrPtrTy, Int8PtrPtrTy, Int8PtrPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getExistentialTypeMetadata(
 //                              ProtocolClassConstraint classConstraint,
@@ -1170,8 +1301,10 @@ FUNCTION(GetExistentialMetadata,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int1Ty, TypeMetadataPtrTy, SizeTy,
               ProtocolDescriptorRefTy->getPointerTo()),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ReadOnly))
+
 
 // const ExtendedExistentialTypeShape *
 // swift_getExtendedExistentialTypeShape(
@@ -1180,8 +1313,9 @@ FUNCTION(GetExtendedExistentialTypeShape,
          swift_getExtendedExistentialTypeShape, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int8PtrTy, Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly, WillReturn),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ArgMemOnly))
 
 // Metadata *swift_getExtendedExistentialTypeMetadata(
 //             const NonUniqueExtendedExistentialTypeShape *shape,
@@ -1190,8 +1324,9 @@ FUNCTION(GetExtendedExistentialTypeMetadata,
          swift_getExtendedExistentialTypeMetadata, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int8PtrTy, Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly, WillReturn),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ArgMemOnly))
 
 // Metadata *swift_getExtendedExistentialTypeMetadata_unique(
 //             const ExtendedExistentialTypeShape *shape,
@@ -1200,8 +1335,9 @@ FUNCTION(GetExtendedExistentialTypeMetadataUnique,
          swift_getExtendedExistentialTypeMetadata_unique, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int8PtrTy, Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly, WillReturn),
-         EFFECT(MetaData)) // ?
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData), // ?
+         MEMEFFECTS(ArgMemOnly))
 
 // Metadata *swift_relocateClassMetadata(TypeContextDescriptor *descriptor,
 //                                       const void *pattern);
@@ -1210,7 +1346,8 @@ FUNCTION(RelocateClassMetadata,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initClassMetadata(Metadata *self,
 //                              ClassLayoutFlags flags,
@@ -1224,7 +1361,8 @@ FUNCTION(InitClassMetadata,
               Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_updateClassMetadata(Metadata *self,
 //                                ClassLayoutFlags flags,
@@ -1238,7 +1376,8 @@ FUNCTION(UpdateClassMetadata,
               Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // MetadataDependency swift_initClassMetadata2(Metadata *self,
 //                                             ClassLayoutFlags flags,
@@ -1252,7 +1391,8 @@ FUNCTION(InitClassMetadata2,
               Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // MetadataDependency swift_updateClassMetadata2(Metadata *self,
 //                                               ClassLayoutFlags flags,
@@ -1266,7 +1406,8 @@ FUNCTION(UpdateClassMetadata2,
               Int8PtrPtrTy->getPointerTo(),
               SizeTy->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void *swift_lookUpClassMethod(Metadata *metadata,
 //                               ClassDescriptor *description,
@@ -1278,7 +1419,8 @@ FUNCTION(LookUpClassMethod,
               MethodDescriptorStructTy->getPointerTo(),
               TypeContextDescriptorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_initStructMetadata(Metadata *structType,
 //                               StructLayoutFlags flags,
@@ -1292,7 +1434,8 @@ FUNCTION(InitStructMetadata,
               Int8PtrPtrTy->getPointerTo(0),
               Int32Ty->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initStructMetadataWithLayoutString(Metadata *structType,
 //                                               StructLayoutFlags flags,
@@ -1308,7 +1451,8 @@ FUNCTION(InitStructMetadataWithLayoutString,
               Int8PtrTy,
               Int32Ty->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initEnumMetadataSingleCase(Metadata *enumType,
 //                                       EnumLayoutFlags flags,
@@ -1319,7 +1463,8 @@ FUNCTION(InitEnumMetadataSingleCase,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initEnumMetadataSingleCaseWithLayoutString(Metadata *enumType,
 //                                                       EnumLayoutFlags flags,
@@ -1330,7 +1475,8 @@ FUNCTION(InitEnumMetadataSingleCaseWithLayoutString,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initEnumMetadataSinglePayload(Metadata *enumType,
 //                                          EnumLayoutFlags flags,
@@ -1342,7 +1488,8 @@ FUNCTION(InitEnumMetadataSinglePayload,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy, Int32Ty),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initEnumMetadataSinglePayloadWithLayoutString(Metadata *enumType,
 //                                                        EnumLayoutFlags flags,
@@ -1354,7 +1501,8 @@ FUNCTION(InitEnumMetadataSinglePayloadWithLayoutString,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, TypeMetadataPtrTy, Int32Ty),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_initEnumMetadataMultiPayload(Metadata *enumType,
 //                                         EnumLayoutFlags layoutFlags,
@@ -1366,7 +1514,8 @@ FUNCTION(InitEnumMetadataMultiPayload,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy, Int8PtrPtrTy->getPointerTo(0)),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void
 // swift_initEnumMetadataMultiPayloadWithLayoutString(Metadata *enumType,
@@ -1379,7 +1528,8 @@ FUNCTION(InitEnumMetadataMultiPayloadWithLayoutString,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy, TypeMetadataPtrPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // int swift_getEnumCaseMultiPayload(opaque_t *obj, Metadata *enumTy);
 FUNCTION(GetEnumCaseMultiPayload,
@@ -1387,8 +1537,9 @@ FUNCTION(GetEnumCaseMultiPayload,
          C_CC, AlwaysAvailable,
          RETURNS(Int32Ty),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(NoEffect))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(NoEffect),
+         MEMEFFECTS(ReadOnly))
 
 // int swift_getEnumTagSinglePayloadGeneric(opaque_t *obj,
 //                                          unsigned num_empty_cases,
@@ -1404,8 +1555,9 @@ FUNCTION(GetEnumTagSinglePayloadGeneric,
               llvm::FunctionType::get(Int32Ty, {OpaquePtrTy, Int32Ty,
                                                 TypeMetadataPtrTy},
                                       false)->getPointerTo()),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(NoEffect))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(NoEffect),
+         MEMEFFECTS(ReadOnly))
 
 
 // void swift_storeEnumTagSinglePayloadGeneric(opaque_t *obj,
@@ -1425,7 +1577,8 @@ FUNCTION(StoreEnumTagSinglePayloadGeneric,
                                                TypeMetadataPtrTy},
                                       false)->getPointerTo()),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_storeEnumTagMultiPayload(opaque_t *obj, Metadata *enumTy,
 //                                     int case_index);
@@ -1435,7 +1588,8 @@ FUNCTION(StoreEnumTagMultiPayload,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, Int32Ty),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // Class object_getClass(id object);
 //
@@ -1444,82 +1598,94 @@ FUNCTION(StoreEnumTagMultiPayload,
 FUNCTION(GetObjectClass, object_getClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCPtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(ObjectiveC))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(ObjectiveC),
+         MEMEFFECTS(ReadOnly))
+
 
 // id object_dispose(id object);
 FUNCTION(ObjectDispose, object_dispose, C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy),
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC, Deallocating))
+         EFFECT(ObjectiveC, Deallocating),
+         NO_MEMEFFECTS)
 
 // Class objc_lookUpClass(const char *name);
 FUNCTION(LookUpClass, objc_lookUpClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // Class objc_setSuperclass(Class cls, Class newSuper);
 FUNCTION(SetSuperclass, class_setSuperclass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy, ObjCClassPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 
 // Metadata *swift_getObjectType(id object);
 FUNCTION(GetObjectType, swift_getObjectType, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(ObjCPtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // Metadata *swift_getDynamicType(opaque_t *obj, Metadata *self);
 FUNCTION(GetDynamicType, swift_getDynamicType, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, Int1Ty),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(MetaData),
+         MEMEFFECTS(ReadOnly))
 
 // void *swift_dynamicCastClass(void*, void*);
 FUNCTION(DynamicCastClass, swift_dynamicCastClass, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(Casting))
+         ATTRS(NoUnwind),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // void *swift_dynamicCastClassUnconditional(void*, void*);
 FUNCTION(DynamicCastClassUnconditional, swift_dynamicCastClassUnconditional,
          C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(Casting))
+         ATTRS(NoUnwind),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // void *swift_dynamicCastObjCClass(void*, void*);
 FUNCTION(DynamicCastObjCClass, swift_dynamicCastObjCClass,
          C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(Casting))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // void *swift_dynamicCastObjCClassUnconditional(void*, void*);
 FUNCTION(DynamicCastObjCClassUnconditional,
          swift_dynamicCastObjCClassUnconditional, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(Casting))
+         ATTRS(NoUnwind),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // void *swift_dynamicCastUnknownClass(void*, void*);
 FUNCTION(DynamicCastUnknownClass, swift_dynamicCastUnknownClass,
          C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(Casting))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // void *swift_dynamicCastUnknownClassUnconditional(void*, void*);
 FUNCTION(DynamicCastUnknownClassUnconditional,
@@ -1527,16 +1693,18 @@ FUNCTION(DynamicCastUnknownClassUnconditional,
          C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(Casting))
+         ATTRS(NoUnwind),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // type *swift_dynamicCastMetatype(type*, type*);
 FUNCTION(DynamicCastMetatype, swift_dynamicCastMetatype,
          C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(Casting))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // type *swift_dynamicCastMetatypeUnconditional(type*, type*);
 FUNCTION(DynamicCastMetatypeUnconditional,
@@ -1544,16 +1712,18 @@ FUNCTION(DynamicCastMetatypeUnconditional,
          C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(Casting))
+         ATTRS(NoUnwind),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // objc_class *swift_dynamicCastObjCClassMetatype(objc_class*, objc_class*);
 FUNCTION(DynamicCastObjCClassMetatype, swift_dynamicCastObjCClassMetatype,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy, ObjCClassPtrTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(Casting))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // objc_class *swift_dynamicCastObjCClassMetatypeUnconditional(objc_class*, objc_class*);
 FUNCTION(DynamicCastObjCClassMetatypeUnconditional,
@@ -1561,8 +1731,9 @@ FUNCTION(DynamicCastObjCClassMetatypeUnconditional,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy, ObjCClassPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
-         ATTRS(NoUnwind, ReadOnly),
-         EFFECT(Casting))
+         ATTRS(NoUnwind),
+         EFFECT(Casting),
+         MEMEFFECTS(ReadOnly))
 
 // bool swift_dynamicCast(opaque*, opaque*, type*, type*, size_t);
 FUNCTION(DynamicCast, swift_dynamicCast, C_CC, AlwaysAvailable,
@@ -1570,7 +1741,8 @@ FUNCTION(DynamicCast, swift_dynamicCast, C_CC, AlwaysAvailable,
          ARGS(OpaquePtrTy, OpaquePtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               SizeTy),
          ATTRS(ZExt, NoUnwind),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // type* swift_dynamicCastTypeToObjCProtocolUnconditional(type* object,
 //                                               size_t numProtocols,
@@ -1581,7 +1753,8 @@ FUNCTION(DynamicCastTypeToObjCProtocolUnconditional,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // type* swift_dynamicCastTypeToObjCProtocolConditional(type* object,
 //                                             size_t numProtocols,
@@ -1592,7 +1765,8 @@ FUNCTION(DynamicCastTypeToObjCProtocolConditional,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // id swift_dynamicCastObjCProtocolUnconditional(id object,
 //                                               size_t numProtocols,
@@ -1602,7 +1776,8 @@ FUNCTION(DynamicCastObjCProtocolUnconditional,
          RETURNS(ObjCPtrTy),
          ARGS(ObjCPtrTy, SizeTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // id swift_dynamicCastObjCProtocolConditional(id object,
 //                                             size_t numProtocols,
@@ -1612,7 +1787,8 @@ FUNCTION(DynamicCastObjCProtocolConditional,
          RETURNS(ObjCPtrTy),
          ARGS(ObjCPtrTy, SizeTy, Int8PtrPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // id swift_dynamicCastMetatypeToObjectUnconditional(type *type);
 FUNCTION(DynamicCastMetatypeToObjectUnconditional,
@@ -1620,7 +1796,8 @@ FUNCTION(DynamicCastMetatypeToObjectUnconditional,
          RETURNS(ObjCPtrTy),
          ARGS(TypeMetadataPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadNone),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // id swift_dynamicCastMetatypeToObjectConditional(type *type);
 FUNCTION(DynamicCastMetatypeToObjectConditional,
@@ -1628,7 +1805,8 @@ FUNCTION(DynamicCastMetatypeToObjectConditional,
          RETURNS(ObjCPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // witness_table* swift_conformsToProtocol(type*, protocol*);
 FUNCTION(ConformsToProtocol,
@@ -1636,7 +1814,8 @@ FUNCTION(ConformsToProtocol,
          RETURNS(WitnessTablePtrTy),
          ARGS(TypeMetadataPtrTy, ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // witness_table* swift_conformsToProtocol2(type*, protocol*);
 FUNCTION(ConformsToProtocol2,
@@ -1644,7 +1823,8 @@ FUNCTION(ConformsToProtocol2,
          RETURNS(WitnessTablePtrTy),
          ARGS(TypeMetadataPtrTy, ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // bool swift_isClassType(type*);
 FUNCTION(IsClassType,
@@ -1652,7 +1832,8 @@ FUNCTION(IsClassType,
          RETURNS(Int1Ty),
          ARGS(TypeMetadataPtrTy),
          ATTRS(ZExt, NoUnwind, ReadNone, WillReturn),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // bool swift_isOptionalType(type*);
 FUNCTION(IsOptionalType,
@@ -1660,7 +1841,8 @@ FUNCTION(IsOptionalType,
          RETURNS(Int1Ty),
          ARGS(TypeMetadataPtrTy),
          ATTRS(ZExt, NoUnwind, ReadNone, WillReturn),
-         EFFECT(Casting))
+         EFFECT(Casting),
+         NO_MEMEFFECTS)
 
 // void swift_once(swift_once_t *predicate,
 //                 void (*function_code)(RefCounted*),
@@ -1669,7 +1851,8 @@ FUNCTION(Once, swift_once, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OnceTy->getPointerTo(), Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Locking))
+         EFFECT(Locking),
+         NO_MEMEFFECTS)
 
 // void swift_registerProtocols(const ProtocolRecord *begin,
 //                              const ProtocolRecord *end)
@@ -1678,7 +1861,8 @@ FUNCTION(RegisterProtocols,
          RETURNS(VoidTy),
          ARGS(ProtocolRecordPtrTy, ProtocolRecordPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Locking))
+         EFFECT(Locking),
+         NO_MEMEFFECTS)
 
 // void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
 //                                         const ProtocolConformanceRecord *end)
@@ -1687,189 +1871,224 @@ FUNCTION(RegisterProtocolConformances,
          RETURNS(VoidTy),
          ARGS(RelativeAddressPtrTy, RelativeAddressPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Locking))
+         EFFECT(Locking),
+         NO_MEMEFFECTS)
 FUNCTION(RegisterTypeMetadataRecords,
          swift_registerTypeMetadataRecords, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataRecordPtrTy, TypeMetadataRecordPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Locking))
+         EFFECT(Locking),
+         NO_MEMEFFECTS)
 
 // void swift_beginAccess(void *pointer, ValueBuffer *scratch, size_t flags);
 FUNCTION(BeginAccess, swift_beginAccess, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, getFixedBufferTy()->getPointerTo(), SizeTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ExclusivityChecking))
+         EFFECT(ExclusivityChecking),
+         NO_MEMEFFECTS)
 
 // void swift_endAccess(ValueBuffer *scratch);
 FUNCTION(EndAccess, swift_endAccess, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(getFixedBufferTy()->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(ExclusivityChecking))
+         EFFECT(ExclusivityChecking),
+         NO_MEMEFFECTS)
 
 FUNCTION(GetOrigOfReplaceable, swift_getOrigOfReplaceable, C_CC,
          DynamicReplacementAvailability,
          RETURNS(FunctionPtrTy),
          ARGS(FunctionPtrTy->getPointerTo()),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 FUNCTION(GetReplacement, swift_getFunctionReplacement, C_CC,
          DynamicReplacementAvailability,
          RETURNS(FunctionPtrTy),
          ARGS(FunctionPtrTy->getPointerTo(), FunctionPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 FUNCTION(InstantiateObjCClass, swift_instantiateObjCClass,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCAllocWithZone, objc_allocWithZone,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy), ARGS(ObjCClassPtrTy), ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCMsgSend, objc_msgSend,
          C_CC, AlwaysAvailable,
-         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC))
+         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCMsgSendStret, objc_msgSend_stret,
          C_CC, AlwaysAvailable,
-         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC))
+         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCMsgSendSuper, objc_msgSendSuper,
          C_CC, AlwaysAvailable,
-         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC))
+         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCMsgSendSuperStret, objc_msgSendSuper_stret,
          C_CC, AlwaysAvailable,
-         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC))
+         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCMsgSendSuper2, objc_msgSendSuper2,
          C_CC, AlwaysAvailable,
-         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC))
+         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCMsgSendSuperStret2, objc_msgSendSuper2_stret,
          C_CC, AlwaysAvailable,
-         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC))
+         RETURNS(VoidTy), NO_ARGS, NO_ATTRS, EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCSelRegisterName, sel_registerName,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCSELTy), ARGS(Int8PtrTy), ATTRS(NoUnwind, ReadNone),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ClassReplaceMethod, class_replaceMethod,
          C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(ObjCClassPtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ClassAddProtocol, class_addProtocol,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ObjCClassPtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCGetClass, objc_getClass, C_CC,  AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCGetRequiredClass, objc_getRequiredClass, C_CC,  AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCGetMetaClass, objc_getMetaClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ObjCClassGetName, class_getName, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 
 FUNCTION(GetObjCProtocol, objc_getProtocol, C_CC, AlwaysAvailable,
          RETURNS(ProtocolDescriptorPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(AllocateObjCProtocol, objc_allocateProtocol, C_CC, AlwaysAvailable,
          RETURNS(ProtocolDescriptorPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC, Allocating))
+         EFFECT(ObjectiveC, Allocating),
+         NO_MEMEFFECTS)
 FUNCTION(RegisterObjCProtocol, objc_registerProtocol, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ProtocolAddMethodDescription, protocol_addMethodDescription,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolDescriptorPtrTy, Int8PtrTy, Int8PtrTy,
               ObjCBoolTy, ObjCBoolTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 FUNCTION(ProtocolAddProtocol, protocol_addProtocol,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolDescriptorPtrTy, ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 
 FUNCTION(ObjCOptSelf, objc_opt_self,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC))
+         EFFECT(ObjectiveC),
+         NO_MEMEFFECTS)
 
 FUNCTION(Malloc, malloc, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy),
          NO_ATTRS,
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 FUNCTION(Free, free, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          NO_ATTRS,
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 // void *_Block_copy(void *block);
 FUNCTION(BlockCopy, _Block_copy, C_CC, AlwaysAvailable,
          RETURNS(ObjCBlockPtrTy),
          ARGS(ObjCBlockPtrTy),
          NO_ATTRS,
-         EFFECT(RefCounting))
+         EFFECT(RefCounting),
+         NO_MEMEFFECTS)
 // void _Block_release(void *block);
 FUNCTION(BlockRelease, _Block_release, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ObjCBlockPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating, RefCounting))
+         EFFECT(Deallocating, RefCounting),
+         NO_MEMEFFECTS)
 
 // void swift_deletedMethodError();
 FUNCTION(DeletedMethodError, swift_deletedMethodError, C_CC, AlwaysAvailable,
         RETURNS(VoidTy),
         ARGS(),
         ATTRS(NoUnwind),
-        EFFECT(NoEffect))
+        EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 FUNCTION(AllocError, swift_allocError, SwiftCC, AlwaysAvailable,
          RETURNS(ErrorPtrTy, OpaquePtrTy),
          ARGS(TypeMetadataPtrTy, WitnessTablePtrTy, OpaquePtrTy, Int1Ty),
          ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 FUNCTION(DeallocError, swift_deallocError, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 FUNCTION(GetErrorValue, swift_getErrorValue, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy, Int8PtrPtrTy, OpenedErrorTriplePtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void __tsan_external_write(void *addr, void *caller_pc, void *tag);
 // This is a Thread Sanitizer instrumentation entry point in compiler-rt.
@@ -1877,7 +2096,8 @@ FUNCTION(TSanInoutAccess, __tsan_external_write, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // int32 __isPlatformVersionAtLeast(uint32_t platform, uint32_t major,
 //                                  uint32_t minor, uint32_t patch);
@@ -1887,26 +2107,30 @@ FUNCTION(PlatformVersionAtLeast, __isPlatformVersionAtLeast,
          RETURNS(Int32Ty),
          ARGS(Int32Ty, Int32Ty, Int32Ty, Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 FUNCTION(GetKeyPath, swift_getKeyPath, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Allocating))
+         EFFECT(Allocating),
+         NO_MEMEFFECTS)
 FUNCTION(CopyKeyPathTrivialIndices, swift_copyKeyPathTrivialIndices,
          C_CC,  AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 FUNCTION(GetInitializedObjCClass, swift_getInitializedObjCClass,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 // void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector)
 FUNCTION(Swift3ImplicitObjCEntrypoint, swift_objc_swift3ImplicitObjCEntrypoint,
@@ -1914,26 +2138,31 @@ FUNCTION(Swift3ImplicitObjCEntrypoint, swift_objc_swift3ImplicitObjCEntrypoint,
          RETURNS(VoidTy),
          ARGS(ObjCPtrTy, ObjCSELTy, Int8PtrTy, SizeTy, SizeTy, SizeTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(ObjectiveC, Allocating))
+         EFFECT(ObjectiveC, Allocating),
+         NO_MEMEFFECTS)
 
 FUNCTION(VerifyTypeLayoutAttribute, _swift_debug_verifyTypeLayoutAttribute,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, Int8PtrTy, Int8PtrTy, SizeTy, Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // float swift_intToFloat32(const size_t *data, IntegerLiteralFlags flags);
 FUNCTION(IntToFloat32, swift_intToFloat32, SwiftCC, AlwaysAvailable,
          RETURNS(FloatTy),
          ARGS(SizeTy->getPointerTo(), SizeTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(NoEffect))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(NoEffect),
+         MEMEFFECTS(ReadOnly))
+
 FUNCTION(IntToFloat64, swift_intToFloat64, SwiftCC, AlwaysAvailable,
          RETURNS(DoubleTy),
          ARGS(SizeTy->getPointerTo(), SizeTy),
-         ATTRS(NoUnwind, ReadOnly, WillReturn),
-         EFFECT(NoEffect))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(NoEffect),
+         MEMEFFECTS(ReadOnly))
 
 // const Metadata *swift_getTypeByMangledNameInContext(
 //                        const char *typeNameStart,
@@ -1944,8 +2173,9 @@ FUNCTION(GetTypeByMangledNameInContext, swift_getTypeByMangledNameInContext,
          SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int8PtrTy, SizeTy, TypeContextDescriptorPtrTy, Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ArgMemOnly))
 
 // const Metadata *swift_getTypeByMangledNameInContext2(
 //                        const char *typeNameStart,
@@ -1956,8 +2186,9 @@ FUNCTION(GetTypeByMangledNameInContext2, swift_getTypeByMangledNameInContext2,
          SwiftCC, SignedDescriptorAvailability,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int8PtrTy, SizeTy, TypeContextDescriptorPtrTy, Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ArgMemOnly))
 
 // const Metadata *swift_getTypeByMangledNameInContextInMetadataState(
 //                        size_t metadataState,
@@ -1971,8 +2202,9 @@ FUNCTION(GetTypeByMangledNameInContextInMetadataState,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy, Int8PtrTy, SizeTy, TypeContextDescriptorPtrTy,
               Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ArgMemOnly))
 
 // const Metadata *swift_getTypeByMangledNameInContextInMetadataState2(
 //                        size_t metadataState,
@@ -1986,8 +2218,9 @@ FUNCTION(GetTypeByMangledNameInContextInMetadataState2,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy, Int8PtrTy, SizeTy, TypeContextDescriptorPtrTy,
               Int8PtrPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(MetaData))
+         ATTRS(NoUnwind),
+         EFFECT(MetaData),
+         MEMEFFECTS(ArgMemOnly))
 
 // AsyncTask *swift_task_getCurrent();s
 FUNCTION(GetCurrentTask,
@@ -1996,7 +2229,8 @@ FUNCTION(GetCurrentTask,
          RETURNS(SwiftTaskPtrTy),
          ARGS(),
          ATTRS(NoUnwind, ReadNone, WillReturn),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void *swift_task_alloc(size_t size);
 FUNCTION(TaskAlloc,
@@ -2004,8 +2238,9 @@ FUNCTION(TaskAlloc,
          ConcurrencyAvailability,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // void swift_task_dealloc(void *ptr);
 FUNCTION(TaskDealloc,
@@ -2013,8 +2248,9 @@ FUNCTION(TaskDealloc,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // void swift_task_cancel(AsyncTask *task);
 FUNCTION(TaskCancel,
@@ -2022,8 +2258,9 @@ FUNCTION(TaskCancel,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
          ARGS(SwiftTaskPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create(
 //     size_t taskCreateFlags,
@@ -2039,8 +2276,9 @@ FUNCTION(TaskCreate,
               TypeMetadataPtrTy,
               Int8PtrTy,
               RefCountedPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // void swift_task_switch(AsyncContext *resumeContext,
 //                        TaskContinuationFunction *resumeFunction,
@@ -2051,7 +2289,8 @@ FUNCTION(TaskSwitchFunc,
          RETURNS(VoidTy),
          ARGS(SwiftContextPtrTy, Int8PtrTy, ExecutorFirstTy, ExecutorSecondTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // AsyncTask *swift_continuation_init(AsyncContext *continuationContext,
 //                                    AsyncContinuationFlags);
@@ -2061,7 +2300,8 @@ FUNCTION(ContinuationInit,
          RETURNS(SwiftTaskPtrTy),
          ARGS(ContinuationAsyncContextPtrTy, SizeTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_continuation_await(AsyncContext *continuationContext);
 FUNCTION(ContinuationAwait,
@@ -2070,7 +2310,8 @@ FUNCTION(ContinuationAwait,
          RETURNS(VoidTy),
          ARGS(ContinuationAsyncContextPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_continuation_resume(AsyncTask *continuation);
 FUNCTION(ContinuationResume,
@@ -2079,7 +2320,8 @@ FUNCTION(ContinuationResume,
          RETURNS(VoidTy),
          ARGS(SwiftTaskPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_continuation_throwingResume(AsyncTask *continuation);
 FUNCTION(ContinuationThrowingResume,
@@ -2088,7 +2330,8 @@ FUNCTION(ContinuationThrowingResume,
          RETURNS(VoidTy),
          ARGS(SwiftTaskPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_continuation_throwingResumeWithError(AsyncTask *continuation,
 //                                                 SwiftError *error);
@@ -2098,7 +2341,8 @@ FUNCTION(ContinuationThrowingResumeWithError,
          RETURNS(VoidTy),
          ARGS(SwiftTaskPtrTy, ErrorPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // ExecutorRef swift_task_getCurrentExecutor();
 FUNCTION(TaskGetCurrentExecutor,
@@ -2106,8 +2350,9 @@ FUNCTION(TaskGetCurrentExecutor,
          ConcurrencyAvailability,
          RETURNS(SwiftExecutorTy),
          ARGS(),
-         ATTRS(NoUnwind, ArgMemOnly, WillReturn),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // ExecutorRef swift_task_getMainExecutor();
 FUNCTION(TaskGetMainExecutor,
@@ -2115,8 +2360,9 @@ FUNCTION(TaskGetMainExecutor,
          ConcurrencyAvailability,
          RETURNS(SwiftExecutorTy),
          ARGS(),
-         ATTRS(NoUnwind, ArgMemOnly, WillReturn),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // void swift_defaultActor_initialize(DefaultActor *actor);
 FUNCTION(DefaultActorInitialize,
@@ -2125,7 +2371,8 @@ FUNCTION(DefaultActorInitialize,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_defaultActor_destroy(DefaultActor *actor);
 FUNCTION(DefaultActorDestroy,
@@ -2134,7 +2381,8 @@ FUNCTION(DefaultActorDestroy,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_defaultActor_deallocate(DefaultActor *actor);
 FUNCTION(DefaultActorDeallocate,
@@ -2143,7 +2391,8 @@ FUNCTION(DefaultActorDeallocate,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_defaultActor_deallocateResilient(HeapObject *actor);
 FUNCTION(DefaultActorDeallocateResilient,
@@ -2152,7 +2401,8 @@ FUNCTION(DefaultActorDeallocateResilient,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_nonDefaultDistributedActor_initialize(NonDefaultDistributedActor *actor);
 FUNCTION(NonDefaultDistributedActorInitialize,
@@ -2161,7 +2411,8 @@ FUNCTION(NonDefaultDistributedActorInitialize,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // OpaqueValue* swift_distributedActor_remote_initialize(
 //    const Metadata *actorType
@@ -2172,7 +2423,8 @@ FUNCTION(DistributedActorInitializeRemote,
          RETURNS(OpaquePtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 /// void swift_asyncLet_start(
 ///     AsyncLet *alet,
@@ -2191,8 +2443,9 @@ FUNCTION(AsyncLetStart,
               Int8PtrTy,                  // closureEntry
               OpaquePtrTy                 // closureContext
          ),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 /// void swift_asyncLet_begin(
 ///     AsyncLet *alet,
@@ -2213,8 +2466,9 @@ FUNCTION(AsyncLetBegin,
               OpaquePtrTy,                // closureContext
               Int8PtrTy
          ),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(Concurrency))
+         ATTRS(NoUnwind),
+         EFFECT(Concurrency),
+         MEMEFFECTS(ArgMemOnly))
 
 // void swift_asyncLet_end(AsyncLet *alet);
 FUNCTION(EndAsyncLet,
@@ -2223,7 +2477,8 @@ FUNCTION(EndAsyncLet,
          RETURNS(VoidTy),
          ARGS(SwiftAsyncLetPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 /// void swift_task_run_inline(
 ///     OpaqueValue *result,
@@ -2241,7 +2496,8 @@ FUNCTION(TaskRunInline,
               TypeMetadataPtrTy, // const Metadata *futureResultType
          ),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_taskGroup_initialize(TaskGroup *group);
 FUNCTION(TaskGroupInitialize,
@@ -2250,7 +2506,8 @@ FUNCTION(TaskGroupInitialize,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_taskGroup_initializeWithFlags(size_t flags, TaskGroup *group);
 FUNCTION(TaskGroupInitializeWithFlags,
@@ -2262,7 +2519,8 @@ FUNCTION(TaskGroupInitializeWithFlags,
               TypeMetadataPtrTy // T.Type
          ),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // void swift_taskGroup_destroy(TaskGroup *group);
 FUNCTION(TaskGroupDestroy,
@@ -2271,7 +2529,8 @@ FUNCTION(TaskGroupDestroy,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Concurrency))
+         EFFECT(Concurrency),
+         NO_MEMEFFECTS)
 
 // AutoDiffLinearMapContext *swift_autoDiffCreateLinearMapContext(size_t);
 FUNCTION(AutoDiffCreateLinearMapContext,
@@ -2279,8 +2538,9 @@ FUNCTION(AutoDiffCreateLinearMapContext,
          DifferentiationAvailability,
          RETURNS(RefCountedPtrTy),
          ARGS(SizeTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(AutoDiff))
+         ATTRS(NoUnwind),
+         EFFECT(AutoDiff),
+         MEMEFFECTS(ArgMemOnly))
 
 // void *swift_autoDiffProjectTopLevelSubcontext(AutoDiffLinearMapContext *);
 FUNCTION(AutoDiffProjectTopLevelSubcontext,
@@ -2288,8 +2548,9 @@ FUNCTION(AutoDiffProjectTopLevelSubcontext,
          DifferentiationAvailability,
          RETURNS(Int8PtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(AutoDiff))
+         ATTRS(NoUnwind),
+         EFFECT(AutoDiff),
+         MEMEFFECTS(ArgMemOnly))
 
 // void *swift_autoDiffAllocateSubcontext(AutoDiffLinearMapContext *, size_t);
 FUNCTION(AutoDiffAllocateSubcontext,
@@ -2297,8 +2558,9 @@ FUNCTION(AutoDiffAllocateSubcontext,
          DifferentiationAvailability,
          RETURNS(Int8PtrTy),
          ARGS(RefCountedPtrTy, SizeTy),
-         ATTRS(NoUnwind, ArgMemOnly),
-         EFFECT(AutoDiff))
+         ATTRS(NoUnwind),
+         EFFECT(AutoDiff),
+         MEMEFFECTS(ArgMemOnly))
 
 // SWIFT_RUNTIME_EXPORT
 // unsigned swift_getMultiPayloadEnumTagSinglePayload(const OpaqueValue *value,
@@ -2310,7 +2572,8 @@ FUNCTION(GetMultiPayloadEnumTagSinglePayload,
          RETURNS(Int32Ty),
          ARGS(OpaquePtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // SWIFT_RUNTIME_EXPORT 
 // void swift_storeMultiPayloadEnumTagSinglePayload(OpaqueValue *value,
@@ -2323,7 +2586,8 @@ FUNCTION(StoreMultiPayloadEnumTagSinglePayload,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, Int32Ty, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_generic_destroy(opaque*, const Metadata* type);
 FUNCTION(GenericDestroy,
@@ -2332,7 +2596,8 @@ FUNCTION(GenericDestroy,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Deallocating))
+         EFFECT(Deallocating),
+         NO_MEMEFFECTS)
 
 
 // void *swift_generic_assignWithCopy(opaque* dest, opaque* src, const Metadata* type);
@@ -2342,7 +2607,8 @@ FUNCTION(GenericAssignWithCopy,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Refcounting, Deallocating))
+         EFFECT(Refcounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_generic_assignWithTake(opaque* dest, opaque* src, const Metadata* type);
 FUNCTION(GenericAssignWithTake,
@@ -2351,7 +2617,8 @@ FUNCTION(GenericAssignWithTake,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Refcounting, Deallocating))
+         EFFECT(Refcounting, Deallocating),
+         NO_MEMEFFECTS)
 
 // void *swift_generic_initWithCopy(opaque* dest, opaque* src, const Metadata* type);
 FUNCTION(GenericInitWithCopy,
@@ -2360,7 +2627,8 @@ FUNCTION(GenericInitWithCopy,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Refcounting))
+         EFFECT(Refcounting),
+         NO_MEMEFFECTS)
 
 // void *swift_generic_initWithTake(opaque* dest, opaque* src, const Metadata* type);
 FUNCTION(GenericInitWithTake,
@@ -2369,7 +2637,8 @@ FUNCTION(GenericInitWithTake,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Refcounting))
+         EFFECT(Refcounting),
+         NO_MEMEFFECTS)
 
 // void *swift_generic_initializeBufferWithCopyOfBuffer(ValueBuffer* dest, ValueBuffer* src, const Metadata* type);
 FUNCTION(GenericInitializeBufferWithCopyOfBuffer,
@@ -2380,7 +2649,8 @@ FUNCTION(GenericInitializeBufferWithCopyOfBuffer,
               getFixedBufferTy()->getPointerTo(),
               TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(Refcounting))
+         EFFECT(Refcounting),
+         NO_MEMEFFECTS)
 
 // unsigned swift_singletonEnum_getEnumTag(swift::OpaqueValue *address,
 //                                         const Metadata *metadata);
@@ -2390,7 +2660,8 @@ FUNCTION(SingletonEnumGetEnumTag,
          RETURNS(Int32Ty),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_singletonEnum_destructiveInjectEnumTag(swift::OpaqueValue *address,
 //                                                   unsigned tag,
@@ -2401,7 +2672,8 @@ FUNCTION(SingletonEnumDestructiveInjectEnumTag,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // unsigned swift_enumSimple_getEnumTag(swift::OpaqueValue *address,
 //                                      const Metadata *metadata);
@@ -2411,7 +2683,8 @@ FUNCTION(EnumSimpleGetEnumTag,
          RETURNS(Int32Ty),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // unsigned swift_enumSimple_destructiveInjectEnumTag(swift::OpaqueValue *address,
 //                                                    unsigned tag,
@@ -2422,7 +2695,8 @@ FUNCTION(EnumSimpleDestructiveInjectEnumTag,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // unsigned swift_enumFn_getEnumTag(swift::OpaqueValue *address,
 //                                  const Metadata *metadata);
@@ -2432,7 +2706,8 @@ FUNCTION(EnumFnGetEnumTag,
          RETURNS(Int32Ty),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // unsigned swift_multiPayloadEnumGeneric_getEnumTag(opaque* address,
 //                                                   const Metadata *type);
@@ -2442,7 +2717,8 @@ FUNCTION(MultiPayloadEnumGenericGetEnumTag,
          RETURNS(Int32Ty),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_multiPayloadEnumGeneric_destructiveInjectEnumTag(swift::OpaqueValue *address,
 //                                                             unsigned tag,
@@ -2453,7 +2729,8 @@ FUNCTION(MultiPayloadEnumGenericDestructiveInjectEnumTag,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // unsigned swift_singlePayloadEnumGeneric_getEnumTag(swift::OpaqueValue *address,
 //                                                    const Metadata *metadata);
@@ -2463,7 +2740,8 @@ FUNCTION(SinglePayloadEnumGenericGetEnumTag,
          RETURNS(Int32Ty),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_singlePayloadEnumGeneric_destructiveInjectEnumTag(swift::OpaqueValue *address,
 //                                                              unsigned tag,
@@ -2474,7 +2752,8 @@ FUNCTION(SinglePayloadEnumGenericDestructiveInjectEnumTag,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int32Ty, TypeMetadataPtrTy),
          ATTRS(NoUnwind, WillReturn),
-         EFFECT(NoEffect))
+         EFFECT(NoEffect),
+         NO_MEMEFFECTS)
 
 // void swift_generic_instantiateLayoutString(const uint8_t* layoutStr,
 //                                            Metadata* type);
@@ -2484,7 +2763,8 @@ FUNCTION(GenericInstantiateLayoutString,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         NO_MEMEFFECTS)
 
 #undef RETURNS
 #undef ARGS

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -14,20 +14,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/Availability.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/Module.h"
+#include "swift/AST/Availability.h"
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/IRGenRequests.h"
+#include "swift/AST/Module.h"
 #include "swift/Basic/Dwarf.h"
-#include "swift/Demangling/ManglingMacros.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/IRGen/IRGenPublic.h"
 #include "swift/IRGen/Linking.h"
-#include "swift/Runtime/RuntimeFnWrappersGen.h"
 #include "swift/Runtime/Config.h"
+#include "swift/Runtime/RuntimeFnWrappersGen.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/CharInfo.h"
@@ -36,22 +36,25 @@
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "clang/CodeGen/SwiftCallingConv.h"
 #include "clang/Frontend/CompilerInstance.h"
-#include "clang/Lex/Preprocessor.h"
-#include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/HeaderSearchOptions.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/PreprocessorOptions.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/PointerUnion.h"
 #include "llvm/Frontend/Debug/Options.h"
-#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
-#include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MD5.h"
+#include "llvm/Support/ModRef.h"
 
 #include "Callee.h"
 #include "ConformanceDescription.h"
@@ -747,8 +750,8 @@ IRGenModule::~IRGenModule() {
 // a particular x-macro expansion doesn't use one.
 namespace RuntimeConstants {
   const auto ReadNone = llvm::Attribute::ReadNone;
-  const auto ReadOnly = llvm::Attribute::ReadOnly;
-  const auto ArgMemOnly = llvm::Attribute::ArgMemOnly;
+  const auto ReadOnly = llvm::MemoryEffects::readOnly();
+  const auto ArgMemOnly = llvm::MemoryEffects::argMemOnly();
   const auto NoReturn = llvm::Attribute::NoReturn;
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;
@@ -1088,9 +1091,10 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
 #define QUOTE(...) __VA_ARGS__
 #define STR(X)     #X
 
-#define FUNCTION(ID, NAME, CC, AVAILABILITY, RETURNS, ARGS, ATTRS, EFFECT) \
-  FUNCTION_IMPL(ID, NAME, CC, AVAILABILITY, QUOTE(RETURNS), QUOTE(ARGS), \
-                QUOTE(ATTRS), QUOTE(EFFECT))
+#define FUNCTION(ID, NAME, CC, AVAILABILITY, RETURNS, ARGS, ATTRS, EFFECT,     \
+                 MEMEFFECTS)                                                   \
+  FUNCTION_IMPL(ID, NAME, CC, AVAILABILITY, QUOTE(RETURNS), QUOTE(ARGS),       \
+                QUOTE(ATTRS), QUOTE(EFFECT), QUOTE(MEMEFFECTS))
 
 #define RETURNS(...) { __VA_ARGS__ }
 #define ARGS(...) { __VA_ARGS__ }
@@ -1098,9 +1102,13 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
 #define ATTRS(...) { __VA_ARGS__ }
 #define NO_ATTRS {}
 #define EFFECT(...) { __VA_ARGS__ }
+#define NO_MEMEFFECTS                                                          \
+  { llvm::MemoryEffects::none() }
+#define MEMEFFECTS(...)                                                        \
+  { __VA_ARGS__ }
 
 #define FUNCTION_IMPL(ID, NAME, CC, AVAILABILITY, RETURNS, ARGS, ATTRS,        \
-                      EFFECT)                                                  \
+                      EFFECT, MEMEFFECTS)                                      \
   llvm::Constant *IRGenModule::get##ID##Fn() {                                 \
     using namespace RuntimeConstants;                                          \
     registerRuntimeEffect(EFFECT, #NAME);                                      \
@@ -1112,6 +1120,9 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
     using namespace RuntimeConstants;                                          \
     auto fn = get##ID##Fn();                                                   \
     auto fnTy = get##ID##FnType();                                             \
+    llvm::MemoryEffects effects = llvm::MemoryEffects::none();                 \
+    for (auto effect : MEMEFFECTS)                                             \
+      effects |= effect;                                                       \
     llvm::AttributeList attrs;                                                 \
     SmallVector<llvm::Attribute::AttrKind, 8> theAttrs(ATTRS);                 \
     for (auto Attr : theAttrs) {                                               \
@@ -1122,6 +1133,9 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
       else                                                                     \
         attrs = attrs.addFnAttribute(getLLVMContext(), Attr);                  \
     }                                                                          \
+    attrs = attrs.addFnAttribute(                                              \
+        getLLVMContext(),                                                      \
+        llvm::Attribute::getWithMemoryEffects(getLLVMContext(), effects));     \
     auto sig = Signature(fnTy, attrs, CC);                                     \
     return FunctionPointer::forDirect(FunctionPointer::Kind::Function, fn,     \
                                       nullptr, sig);                           \
@@ -1164,7 +1178,7 @@ IRGenModule::createStringConstant(StringRef Str, bool willBeRelativelyAddressed,
   llvm::Constant *IRGenModule::get##NAME() {                                   \
     if (NAME)                                                                  \
       return NAME;                                                             \
-    NAME = Module.getOrInsertGlobal(SYM, FullExistentialTypeMetadataStructTy);            \
+    NAME = Module.getOrInsertGlobal(SYM, FullExistentialTypeMetadataStructTy); \
     if (useDllStorage() && !isStandardLibrary())                               \
       ApplyIRLinkage(IRLinkage::ExternalImport)                                \
           .to(cast<llvm::GlobalVariable>(NAME));                               \

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -45,12 +45,13 @@
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/TypeLowering.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/ModRef.h"
 #include <algorithm>
 
 using namespace swift;
@@ -2324,9 +2325,9 @@ IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
                                  accessFunction, callArgs);
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
-  call->addFnAttr(allocatedArgsBuffer
-                      ? llvm::Attribute::InaccessibleMemOrArgMemOnly
-                      : llvm::Attribute::ReadNone);
+  call->setMemoryEffects(allocatedArgsBuffer
+                             ? llvm::MemoryEffects::inaccessibleOrArgMemOnly()
+                             : llvm::MemoryEffects::none());
 
   // If we allocated a buffer for the arguments, end its lifetime.
   if (allocatedArgsBuffer)


### PR DESCRIPTION
The memory effects are no longer represented as raw attributes, but as its own type. This patch migrates IRGen over to using the new unified memory effect type.

rdar://112978659