### PR TITLE
Platform: improve module definitions for Windows

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -163,6 +163,11 @@ module corecrt [system] {
     export *
   }
 
+  module stdlib {
+    header "corecrt_wstdlib.h"
+    export *
+  }
+
   module string {
     header "corecrt_wstring.h"
     export *

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -355,6 +355,12 @@ module std [system] {
     export *
   }
 
+  module expected {
+    requires cplusplus23
+    header "expected"
+    export *
+  }
+
   module filesystem {
     requires cplusplus17
     header "filesystem"
@@ -573,13 +579,11 @@ module std [system] {
     export *
   }
 
-/*
   module spanstream {
     requires cpluplus23
     header "spanstream"
     export *
   }
-*/
 
   module sstream {
     header "sstream"
@@ -588,6 +592,12 @@ module std [system] {
 
   module stack {
     header "stack"
+    export *
+  }
+
+  module stacktrace {
+    requires cplusplus23
+    header "stacktrace"
     export *
   }
 

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -409,6 +409,11 @@ module std [system] {
     export *
   }
 
+  module iomanip {
+    header "iomanip"
+    export *
+  }
+
   module ios {
     header "ios"
     export *

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -707,6 +707,10 @@ module std [system] {
       export *
     }
 
+    explicit module xstddef {
+      header "xstddef"
+      export *
+    }
 
     explicit module xstring {
       header "xstring"
@@ -725,6 +729,16 @@ module std [system] {
 
     explicit module xutility {
       header "xutility"
+      export *
+    }
+
+    explicit module yvals {
+      header "yvals.h"
+      export *
+    }
+
+    explicit module yvals_core {
+      header "yvals_core.h"
       export *
     }
   }

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -703,23 +703,27 @@ module std [system] {
     export *
   }
 
-  explicit module xmemory {
-    header "xmemory"
-    export *
-  }
+  module _Private [system] {
+    requires cplusplus
 
-  explicit module xtr1common {
-    header "xtr1common"
-    export *
-  }
+    explicit module xmemory {
+      header "xmemory"
+      export *
+    }
 
-  explicit module xstring {
-    header "xstring"
-    export *
-  }
+    explicit module xtr1common {
+      header "xtr1common"
+      export *
+    }
 
-  explicit module xtree {
-    header "xtree"
-    export *
+    explicit module xstring {
+      header "xstring"
+      export *
+    }
+
+    explicit module xtree {
+      header "xtree"
+      export *
+    }
   }
 }

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -237,6 +237,7 @@ module std [system] {
     }
 
     module cuchar {
+      requires cplusplus11
       header "cuchar"
       export *
     }
@@ -258,26 +259,31 @@ module std [system] {
   }
 
   module any {
+    requires cpluplus17
     header "any"
     export *
   }
 
   module array {
+    requires cplusplus11
     header "array"
     export *
   }
 
   module atomic {
+    requires cplusplus11
     header "atomic"
     export *
   }
 
   module barrier {
+    requires cplusplus20
     header "barrier"
     export *
   }
 
   module bit {
+    requires cplusplus20
     header "bit"
     export *
   }
@@ -288,11 +294,13 @@ module std [system] {
   }
 
   module charconv {
+    requires cplusplus17
     header "charconv"
     export *
   }
 
   module chrono {
+    requires cplusplus11
     header "chrono"
     export *
   }
@@ -303,6 +311,7 @@ module std [system] {
   }
 
   module compare {
+    requires cplusplus20
     header "compare"
     export *
   }
@@ -313,16 +322,19 @@ module std [system] {
   }
 
   module concepts {
+    requires cplusplus20
     header "concepts"
     export *
   }
 
   module condition_variable {
+    requires cplusplus11
     header "condition_variable"
     export *
   }
 
   module coroutine {
+    requires cplusplus20
     header "coroutine"
     export *
   }
@@ -338,21 +350,25 @@ module std [system] {
   }
 
   module execution {
+    requires cplusplus17
     header "execution"
     export *
   }
 
   module filesystem {
+    requires cplusplus17
     header "filesystem"
     export *
   }
 
   module format {
+    requires cplusplus20
     header "format"
     export *
   }
 
   module forward_list {
+    requires cplusplus11
     header "forward_list"
     export *
   }
@@ -368,6 +384,7 @@ module std [system] {
   }
 
   module future {
+    requires cplusplus11
     header "future"
     export *
   }
@@ -387,6 +404,7 @@ module std [system] {
 */
 
   module initializer_list {
+    requires cplusplus11
     header "initializer_list"
     export *
   }
@@ -417,6 +435,7 @@ module std [system] {
   }
 
   module latch {
+    requires cplusplus20
     header "latch"
     export *
   }
@@ -447,11 +466,13 @@ module std [system] {
   }
 
   module memory_resource {
+    requires cplusplus17
     header "memory_resource"
     export *
   }
 
   module mutex {
+    requires cplusplus11
     header "mutex"
     export *
   }
@@ -462,6 +483,7 @@ module std [system] {
   }
 
   module numbers {
+    requires cplusplus20
     header "numbers"
     export *
   }
@@ -472,6 +494,7 @@ module std [system] {
   }
 
   module optional {
+    requires cplusplus17
     header "optional"
     export *
   }
@@ -487,31 +510,37 @@ module std [system] {
   }
 
   module random {
+    requires cplusplus11
     header "random"
     export *
   }
 
   module ranges {
+    requires cplusplus20
     header "ranges"
     export *
   }
 
   module ratio {
+    requires cplusplus11
     header "ratio"
     export *
   }
 
   module regex {
+    requires cplusplus11
     header "regex"
     export *
   }
 
   module scoped_allocator {
+    requires cplusplus11
     header "scoped_allocator"
     export *
   }
 
   module semaphore {
+    requires cplusplus20
     header "semaphore"
     export *
   }
@@ -522,22 +551,26 @@ module std [system] {
   }
 
   module shared_mutex {
+    requires cplusplus14
     header "shared_mutex"
     export *
   }
 
   module source_location {
+    requires cplusplus20
     header "source_location"
     export *
   }
 
   module span {
+    requires cplusplus20
     header "span"
     export *
   }
 
 /*
   module spanstream {
+    requires cpluplus23
     header "spanstream"
     export *
   }
@@ -559,6 +592,7 @@ module std [system] {
   }
 
   module stop_token {
+    requires cplusplus20
     header "stop_token"
     export *
   }
@@ -574,6 +608,7 @@ module std [system] {
   }
 
   module string_view {
+    requires cplusplus17
     header "string_view"
     export *
   }
@@ -584,31 +619,37 @@ module std [system] {
   }
 
   module syncstream {
+    requires cplusplus20
     header "syncstream"
     export *
   }
 
   module system_error {
+    requires cplusplus11
     header "system_error"
     export *
   }
 
   module thread {
+    requires cplusplus11
     header "thread"
     export *
   }
 
   module tuple {
+    requires cplusplus11
     header "tuple"
     export *
   }
 
   module type_traits {
+    requires cplusplus11
     header "type_traits"
     export *
   }
 
   module typeindex {
+    requires cplusplus11
     header "typeindex"
     export *
   }
@@ -619,11 +660,13 @@ module std [system] {
   }
 
   module unordered_map {
+    requires cplusplus11
     header "unordered_map"
     export *
   }
 
   module unordered_set {
+    requires unordered_set
     header "unordered_set"
     export *
   }
@@ -639,6 +682,7 @@ module std [system] {
   }
 
   module variant {
+    requires cplusplus17
     header "variant"
     export *
   }
@@ -649,6 +693,7 @@ module std [system] {
   }
 
   module version {
+    requires cplusplus20
     header "version"
     export *
   }

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -395,20 +395,6 @@ module std [system] {
     export *
   }
 
-/*
-  module hash_map {
-    header "hash_map"
-    export *
-  }
-*/
-
-/*
-  module hash_set {
-    header "hash_set"
-    export *
-  }
-*/
-
   module initializer_list {
     requires cplusplus11
     header "initializer_list"

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -711,10 +711,6 @@ module std [system] {
       export *
     }
 
-    explicit module xtr1common {
-      header "xtr1common"
-      export *
-    }
 
     explicit module xstring {
       header "xstring"
@@ -723,6 +719,16 @@ module std [system] {
 
     explicit module xtree {
       header "xtree"
+      export *
+    }
+
+    explicit module xtr1common {
+      header "xtr1common"
+      export *
+    }
+
+    explicit module xutility {
+      header "xutility"
       export *
     }
   }


### PR DESCRIPTION
Rework a number of items within the platform specific module definitions for corecrt and MSVCPRT.  This was done to try to find a modularisation failure.