### PR TITLE
TypeDecoder: Push one-element tuple unwrapping down into createTupleType() implementations

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1052,13 +1052,6 @@ protected:
           return *optError;
       }
 
-      // Unwrap unlabeled one-element tuples.
-      //
-      // FIXME: The behavior of one-element labeled tuples is inconsistent throughout
-      // the different re-implementations of type substitution and pack expansion.
-      if (elements.size() == 1 && labels[0].empty())
-        return elements[0];
-
       return Builder.createTupleType(elements, labels);
     }
     case NodeKind::TupleElement:

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -328,6 +328,17 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
 }
 
 Type ASTBuilder::createTupleType(ArrayRef<Type> eltTypes, ArrayRef<StringRef> labels) {
+  // Unwrap unlabeled one-element tuples.
+  //
+  // FIXME: The behavior of one-element labeled tuples is inconsistent
+  // throughout the different re-implementations of type substitution
+  // and pack expansion.
+  if (eltTypes.size() == 1 &&
+      !eltTypes[0]->is<PackExpansionType>() &&
+      labels[0].empty()) {
+    return eltTypes[0];
+  }
+
   SmallVector<TupleTypeElt, 4> elements;
   elements.reserve(eltTypes.size());
   for (unsigned i : indices(eltTypes)) {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1965,6 +1965,14 @@ public:
   TypeLookupErrorOr<BuiltType>
   createTupleType(llvm::ArrayRef<BuiltType> elements,
                   llvm::ArrayRef<StringRef> labels) const {
+    // Unwrap unlabeled one-element tuples.
+    //
+    // FIXME: The behavior of one-element labeled tuples is inconsistent
+    // throughout the different re-implementations of type substitution
+    // and pack expansion.
+    if (elements.size() == 1 && labels[0].empty())
+      return elements[0];
+
     for (auto element : elements) {
       if (!element.isMetadata()) {
         return TYPE_LOOKUP_ERROR_FMT("Tried to build a tuple type where "

--- a/test/DebugInfo/variadic-generics.swift
+++ b/test/DebugInfo/variadic-generics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -o - \
-// RUN:    -parse-as-library -module-name a | %IRGenFileCheck %s
+// RUN:    -parse-as-library -module-name a -disable-availability-checking | %IRGenFileCheck %s
 
 public func foo<each T>(args: repeat each T) {
   // CHECK: define {{.*}} @"$s1a3foo4argsyxxQp_tRvzlF"
@@ -22,3 +22,35 @@ public func foo<each T>(args: repeat each T) {
   // CHECK-DAG: ![[TYPE_PACK_TY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD"
 }
 
+// Test ASTDemangler round-tripping of various pack expansion types
+
+public func paramExpansionWithPattern<each T>(args: repeat Array<each T>) {}
+
+public func paramExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: repeat (each T).Element) {}
+
+public func tupleExpansion<each T>(args: (repeat each T)) {}
+
+public func tupleExpansionWithPattern<each T>(args: (repeat Array<each T>)) {}
+
+// FIXME: Crashes due to unrelated bug
+// public func tupleExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: (repeat (each T).Element)) {}
+
+public func functionExpansion<each T>(args: (repeat each T) -> ()) {}
+
+public func functionExpansionWithPattern<each T>(args: (repeat Array<each T>) -> ()) {}
+
+public func functionExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: (repeat (each T).Element) -> ()) {}
+
+public struct G<each T> {}
+
+public func nominalExpansion<each T>(args: G<repeat each T>) {}
+
+public func nominalExpansionWithPattern<each T>(args: G<repeat Array<each T>>) {}
+
+public func nominalExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: G<repeat (each T).Element>) {}
+
+//
+
+public typealias First<T, U> = T
+
+public func concreteExpansion<each T>(args: repeat each T, concrete: repeat First<Int, each T>) {}


### PR DESCRIPTION
The old behavior was only correct when building substituted types, ie, if createTupleType() was never called with a pack expansion type.

This was the case in the runtime's MetadataLookup which applies substitutions to an interface type to ultimately construct metadata for a fully-concrete type, but not in the ASTDemangler, where we actually build interface types.

Since TypeDecoder doesn't have any way to query the kind of type it just built, let's just instead make this decision inside the implementation of the type builder concept.

Fixes https://github.com/apple/swift/issues/67322.