### PR TITLE
Sema: Fix two problems in checkReferencedGenericParams() analysis

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -341,6 +341,25 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
         ReferencedGenericParams.insert(ty->getCanonicalType());
         return Action::SkipChildren;
       }
+
+      // Skip the count type, which is always a generic parameter;
+      // we don't consider it a reference because it only binds the
+      // shape and not the metadata.
+      if (auto *expansionTy = ty->getAs<PackExpansionType>()) {
+        expansionTy->getPatternType().walk(*this);
+        return Action::SkipChildren;
+      }
+
+      // Don't walk into generic type alias substitutions. This does
+      // not constrain `T`:
+      //
+      //   typealias Foo<T> = Int
+      //   func foo<T>(_: Foo<T>) {}
+      if (auto *aliasTy = dyn_cast<TypeAliasType>(ty.getPointer())) {
+        Type(aliasTy->getSinglyDesugaredType()).walk(*this);
+        return Action::SkipChildren;
+      }
+
       return Action::Continue;
     }
 

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -65,6 +65,7 @@ struct Outer<each T> {
 func packRef<each T>(_: repeat each T) where repeat each T: P {}
 
 func packMemberRef<each T>(_: repeat (each T).T) where repeat each T: P {}
+// expected-error@-1 {{generic parameter 'T' is not used in function signature}}
 
 // expected-error@+1 {{'each' cannot be applied to non-pack type 'Int'}}{{31-35=}}
 func invalidPackRefEachInt(_: each Int) {}
@@ -98,3 +99,11 @@ func golden<Z>(_ z: Z) {}
 func hour<each T>(_ t: repeat each T)  {
   _ = (repeat golden(each t))
 }
+
+func unusedParameterPack1<each T: Sequence>(_: repeat (each T).Element) {}
+// expected-error@-1 {{generic parameter 'T' is not used in function signature}}
+
+typealias First<T, U> = T
+
+func unusedParameterPack2<each T>(_: repeat First<Int, each T>) {}
+// expected-error@-1 {{generic parameter 'T' is not used in function signature}}


### PR DESCRIPTION
- Don't walk into the count type of a PackExpansionType, because when matching two PackExpansionTypes, the solver only introduces a shape constraint between the count types, which does not fix it to a concrete type.

- Similarly, don't walk into type alias substitutions, because only the desugared type is considered by the constraint solver.

This is mildly source breaking, in that before we let you declare generic functions that could not be called.