### PR TITLE
[IRGen] alloc_stack may allocate pack metadata.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -180,10 +180,13 @@ public:
     /// they have a type variable originator.
     SolverAllocated = 0x8000,
 
-    /// This type contains a concrete pack.
-    HasConcretePack = 0x10000,
+    /// Contains a PackType.
+    HasPack = 0x10000,
 
-    Last_Property = HasConcretePack
+    /// Contains a PackArchetypeType.
+    HasPackArchetype = 0x20000,
+
+    Last_Property = HasPackArchetype
   };
   enum { BitWidth = countBitsUsed(Property::Last_Property) };
 
@@ -259,7 +262,9 @@ public:
 
   bool hasParameterPack() const { return Bits & HasParameterPack; }
 
-  bool hasConcretePack() const { return Bits & HasConcretePack; }
+  bool hasPack() const { return Bits & HasPack; }
+
+  bool hasPackArchetype() const { return Bits & HasPackArchetype; }
 
   /// Does a type with these properties structurally contain a
   /// parameterized existential type?
@@ -420,12 +425,12 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+30,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 7+29,
     /// Type variable options.
     Options : 7,
     : NumPadBits,
     /// The unique number assigned to this type variable.
-    ID : 30
+    ID : 29
   );
 
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+1+4+1+2+1+1,
@@ -689,16 +694,26 @@ public:
     return getRecursiveProperties().hasLocalArchetype();
   }
 
+  /// Whether the type contains a generic parameter declared as a parameter
+  /// pack.
   bool hasParameterPack() const {
     return getRecursiveProperties().hasParameterPack();
   }
 
-  bool hasConcretePack() const {
-    return getRecursiveProperties().hasConcretePack();
+  /// Whether the type contains a PackType.
+  bool hasPack() const {
+    return getRecursiveProperties().hasPack();
   }
 
-  /// Whether the type has some flavor of pack.
-  bool hasPack() const { return hasParameterPack() || hasConcretePack(); }
+  /// Whether the type contains a PackArchetypeType.
+  bool hasPackArchetype() const {
+    return getRecursiveProperties().hasPackArchetype();
+  }
+
+  /// Whether the type has any flavor of pack.
+  bool hasAnyPack() const {
+    return hasParameterPack() || hasPack() || hasPackArchetype();
+  }
 
   /// Determine whether the type involves a parameterized existential type.
   bool hasParameterizedExistential() const {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -377,11 +377,14 @@ public:
   /// pack.
   bool hasParameterPack() const { return getASTType()->hasParameterPack(); }
 
-  /// Whether the type contains a concrete pack.
-  bool hasConcretePack() const { return getASTType()->hasConcretePack(); }
-
-  /// Whether the type contains some flavor of pack.
+  /// Whether the type contains a PackType.
   bool hasPack() const { return getASTType()->hasPack(); }
+
+  /// Whether the type contains a PackArchetypeType.
+  bool hasPackArchetype() const { return getASTType()->hasPackArchetype(); }
+
+  /// Whether the type contains any flavor of pack.
+  bool hasAnyPack() const { return getASTType()->hasAnyPack(); }
 
   /// True if the type is an empty tuple or an empty struct or a tuple or
   /// struct containing only empty types.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3415,7 +3415,7 @@ CanPackType CanPackType::get(const ASTContext &C,
 }
 
 PackType *PackType::get(const ASTContext &C, ArrayRef<Type> elements) {
-  RecursiveTypeProperties properties = RecursiveTypeProperties::HasConcretePack;
+  RecursiveTypeProperties properties = RecursiveTypeProperties::HasPack;
   bool isCanonical = true;
   for (Type eltTy : elements) {
     assert(!eltTy->is<PackType>() &&
@@ -3455,7 +3455,7 @@ void PackType::Profile(llvm::FoldingSetNodeID &ID, ArrayRef<Type> Elements) {
 
 CanSILPackType SILPackType::get(const ASTContext &C, ExtInfo info,
                                 ArrayRef<CanType> elements) {
-  RecursiveTypeProperties properties = RecursiveTypeProperties::HasConcretePack;
+  RecursiveTypeProperties properties;
   for (CanType eltTy : elements) {
     assert(!isa<SILPackType>(eltTy) &&
            "Cannot have pack directly inside another pack");
@@ -4047,7 +4047,7 @@ isAnyFunctionTypeCanonical(ArrayRef<AnyFunctionType::Param> params,
 static RecursiveTypeProperties
 getGenericFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
                                       Type result) {
-  static_assert(RecursiveTypeProperties::BitWidth == 17,
+  static_assert(RecursiveTypeProperties::BitWidth == 18,
                 "revisit this if you add new recursive type properties");
   RecursiveTypeProperties properties;
 
@@ -4689,7 +4689,7 @@ CanSILFunctionType SILFunctionType::get(
   void *mem = ctx.Allocate(bytes, alignof(SILFunctionType));
 
   RecursiveTypeProperties properties;
-  static_assert(RecursiveTypeProperties::BitWidth == 17,
+  static_assert(RecursiveTypeProperties::BitWidth == 18,
                 "revisit this if you add new recursive type properties");
   for (auto &param : params)
     properties |= param.getInterfaceType()->getRecursiveProperties();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3704,7 +3704,7 @@ PackArchetypeType::PackArchetypeType(
     LayoutConstraint Layout, PackShape Shape)
     : ArchetypeType(TypeKind::PackArchetype, Ctx,
                     RecursiveTypeProperties::HasArchetype |
-                        RecursiveTypeProperties::HasConcretePack,
+                        RecursiveTypeProperties::HasPackArchetype,
                     InterfaceType, ConformsTo, Superclass, Layout, GenericEnv) {
   assert(InterfaceType->isParameterPack());
   *getTrailingObjects<PackShape>() = Shape;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3703,8 +3703,9 @@ PackArchetypeType::PackArchetypeType(
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,
     LayoutConstraint Layout, PackShape Shape)
     : ArchetypeType(TypeKind::PackArchetype, Ctx,
-                    RecursiveTypeProperties::HasArchetype, InterfaceType,
-                    ConformsTo, Superclass, Layout, GenericEnv) {
+                    RecursiveTypeProperties::HasArchetype |
+                        RecursiveTypeProperties::HasConcretePack,
+                    InterfaceType, ConformsTo, Superclass, Layout, GenericEnv) {
   assert(InterfaceType->isParameterPack());
   *getTrailingObjects<PackShape>() = Shape;
 }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1287,11 +1287,11 @@ bool SILInstruction::mayRequirePackMetadata() const {
   case SILInstructionKind::TryApplyInst: {
     // Check the function type for packs.
     auto apply = ApplySite::isa(const_cast<SILInstruction *>(this));
-    if (apply.getCallee()->getType().hasPack())
+    if (apply.getCallee()->getType().hasAnyPack())
       return true;
     // Check the substituted types for packs.
     for (auto ty : apply.getSubstitutionMap().getReplacementTypes()) {
-      if (ty->hasPack())
+      if (ty->hasAnyPack())
         return true;
     }
     return false;
@@ -1302,20 +1302,20 @@ bool SILInstruction::mayRequirePackMetadata() const {
   case SILInstructionKind::DestroyValueInst:
   // Unary instructions.
   {
-    return getOperand(0)->getType().hasPack();
+    return getOperand(0)->getType().hasAnyPack();
   }
   case SILInstructionKind::AllocStackInst: {
     auto *asi = cast<AllocStackInst>(this);
-    return asi->getType().hasPack();
+    return asi->getType().hasAnyPack();
   }
   case SILInstructionKind::MetatypeInst: {
     auto *mi = cast<MetatypeInst>(this);
-    return mi->getType().hasPack();
+    return mi->getType().hasAnyPack();
   }
   case SILInstructionKind::WitnessMethodInst: {
     auto *wmi = cast<WitnessMethodInst>(this);
     auto ty = wmi->getLookupType();
-    return ty->hasPack();
+    return ty->hasAnyPack();
   }
   default:
     return false;

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1304,6 +1304,10 @@ bool SILInstruction::mayRequirePackMetadata() const {
   {
     return getOperand(0)->getType().hasPack();
   }
+  case SILInstructionKind::AllocStackInst: {
+    auto *asi = cast<AllocStackInst>(this);
+    return asi->getType().hasPack();
+  }
   case SILInstructionKind::MetatypeInst: {
     auto *mi = cast<MetatypeInst>(this);
     return mi->getType().hasPack();

--- a/test/IRGen/pack_marker_insertion.swift
+++ b/test/IRGen/pack_marker_insertion.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+// Verify that we don't hit the `Instruction missing on-stack pack metadata cleanups!` assertion.
+
+// For alloc_stacks of tuples featuring a pack.
+public func tupleExpansionWithMemberType<each T: Sequence>(seqs: (repeat each T), elts: (repeat (each T).Element)) {}


### PR DESCRIPTION
Add alloc_stack to the list of instructions that may allocate pack metadata and make PackArchetypeTypes have the HasConcretePack recursive property.
