### PR TITLE
[🌲] Get the frontend building

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -697,13 +697,6 @@ protected:
     return var;
   }
 
-  // Helpers to guide the C++ type system into converting lambda arguments
-  // to llvm::Optional<function_ref>
-  llvm::GlobalVariable *emit(llvm::function_ref<GetAddrOfEntityFn> getAddr,
-                             const char *section) {
-    return emit(llvm::Optional<llvm::function_ref<GetAddrOfEntityFn>>(getAddr),
-                section);
-  }
   llvm::GlobalVariable *emit(llvm::NoneType none, const char *section) {
     return emit(llvm::Optional<llvm::function_ref<GetAddrOfEntityFn>>(),
                 section);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/IRGenRequests.h"
 #include "swift/AST/Module.h"
 #include "swift/Basic/Dwarf.h"
+#include "swift/Basic/LLVMExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/IRGen/IRGenPublic.h"
@@ -1770,7 +1771,7 @@ void IRGenModule::emitAutolinkInfo() {
   StringRef AutolinkSectionName = Autolink.getSectionNameMetadata();
 
   auto *Metadata = Module.getOrInsertNamedMetadata(AutolinkSectionName);
-  llvm::SmallSetVector<llvm::MDNode *, 4> Entries;
+  swift::SmallSetVector<llvm::MDNode *, 4> Entries;
 
   // Collect the linker options already in the module (from ClangCodeGen).
   for (auto Entry : Metadata->operands()) {


### PR DESCRIPTION
Just a couple changes left to get the swift-frontend building.

- `std::optional` allows types to implicitly convert to it, unlike `llvm::Optional`, making the `ReflectionMetadataBuilder::emit` overloads ambiguous. I removed the non-optional version, which explicitly wrapped the function ref in an optional before calling the optional overload.
- `llvm::SmallSetVector` is no longer an `llvm::SetVector`, so we can't pass an `llvm::SmallSetVector` to a function that takes an `llvm::SetVector`. A `swift::SmallSetVector` on the other hand is an `llvm::SetVector`, so I just changed the type to use the `swift::SmallSetVector` instead.
