### PR TITLE
[Tests] NFC: Disable test/IRGen/raw_layout.swift on WatchOS armv7k

### DIFF
--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -2,6 +2,8 @@
 // RUN: %{python} %utils/chex.py < %s > %t/raw_layout.sil
 // RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir %t/raw_layout.sil | %FileCheck %t/raw_layout.sil
 
+// UNSUPPORTED: OS=watchos && (CPU=armv7k || CPU=arm64_32)
+
 import Swift
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}4LockVWV" = {{.*}} %swift.vwtable


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
