### PR TITLE
[🌲] Fix off-by-one in `DefaultAndMaxAccessLevelRequest::getCachedResult`

### DIFF
--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -337,8 +337,8 @@ DefaultAndMaxAccessLevelRequest::getCachedResult() const {
                                    (std::numeric_limits<uint8_t>::digits - 1));
     uint8_t firstSet = Bits == 0 ? std::numeric_limits<uint8_t>::max()
                                  : llvm::countr_zero(Bits);
-    AccessLevel Max = static_cast<AccessLevel>(lastSet);
-    AccessLevel Default = static_cast<AccessLevel>(firstSet);
+    AccessLevel Max = static_cast<AccessLevel>(lastSet + 1);
+    AccessLevel Default = static_cast<AccessLevel>(firstSet + 1);
 
     assert(Max >= Default);
     return std::make_pair(Default, Max);


### PR DESCRIPTION
I had an off-by-one in `DefaultAndMaxAccessLevelRequest::getCachedResult`. The original code added 1 to the last and first set bits when computing the `Max` and `Default` access levels:

```
AccessLevel Max = static_cast<AccessLevel>(llvm::findLastSet(Bits) + 1);
AccessLevel Default = static_cast<AccessLevel>(llvm::findFirstSet(Bits) + 1);
```

LLVM got rid of `findLastSet`, so in the fun of figuring out the replacements (`llvm::countl_zero` and `llvm::countl_zero`), I missed adding the one to the result.

This was caught in an assert while trying to build the stdlib in the new compiler.

rdar://112988778