### PR TITLE
test: adjust IRGen tests for Windows ARM64

### DIFF
--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -11,7 +11,7 @@ import Swift
 // CHECK-x86_64:      {{.cfi_startproc|Lfunc_begin}}
 // CHECK-i386:        .cfi_startproc
 // CHECK-arm64:       .cfi_startproc
-// CHECK-aarch64:     .cfi_startproc
+// CHECK-aarch64:     {{.cfi_startproc|Lfunc_begin}}
 // CHECK-armv7:       Lfunc_begin
 // CHECK-armv7s:      Lfunc_begin
 // CHECK-powerpc64:   .cfi_startproc
@@ -79,7 +79,7 @@ import Swift
 // CHECK-x86_64:      {{.cfi_endproc|Lfunc_end}}
 // CHECK-i386:        .cfi_endproc
 // CHECK-arm64:       .cfi_endproc
-// CHECK-aarch64:     .cfi_endproc
+// CHECK-aarch64:     {{.cfi_endproc|Lfunc_end}}
 // CHECK-armv7:       Lfunc_end
 // CHECK-armv7s:      Lfunc_end
 // CHECK-powerpc64:   .cfi_endproc

--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -46,9 +46,9 @@ import empty
 // CHECK-ELF-MERGE-DAG: !{{[0-9]+}} = !{!"autolink-module-map-link"}
 
 
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-COFF
-// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-COFF
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-COFF
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-COFF
 
 // CHECK-COFF-MERGE-DAG: !llvm.linker.options = !{
 // CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:empty.lib"}

--- a/test/IRGen/static-library.swift
+++ b/test/IRGen/static-library.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %swiftc_driver_plain -target x86_64-unknown-windows-msvc -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -o %t/library.lib -emit-module-path %t
-// RUN: %swiftc_driver_plain -target x86_64-unknown-windows-msvc -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -S -emit-ir -o - | %FileCheck -check-prefix CHECK-LIBRARY %s
-// RUN: %swiftc_driver_plain -target x86_64-unknown-windows-msvc -I %t -emit-library -S -emit-ir -o - %s | %FileCheck -check-prefix CHECK-EMBEDDING %s
+// RUN: %target-swiftc_driver_plain -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -o %t/library.lib -emit-module-path %t
+// RUN: %target-swiftc_driver_plain -DLIBRARY -module-name Library -emit-library -static -autolink-force-load -module-link-name Library %s -S -emit-ir -o - | %FileCheck -check-prefix CHECK-LIBRARY %s
+// RUN: %target-swiftc_driver_plain -I %t -emit-library -S -emit-ir -o - %s | %FileCheck -check-prefix CHECK-EMBEDDING %s
 
 // REQUIRES: OS=windows-msvc
 


### PR DESCRIPTION
This repairs a few tests by making them more portable to other CPU architectures.